### PR TITLE
Collect web vitals via Events Collector

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,6 +43,7 @@
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "19.8.0",
 		"@guardian/core-web-vitals": "6.0.0",
+		"@guardian/core-web-vitals-attribution": "npm:@guardian/core-web-vitals@0.0.0-canary-20240627122902",
 		"@guardian/eslint-config": "7.0.1",
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "2.1.0",

--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -8,6 +8,10 @@ import {
 	bypassCoreWebVitalsSampling,
 	initCoreWebVitals,
 } from '@guardian/core-web-vitals';
+import {
+	bypassCoreWebVitalsSampling as bypassCoreWebVitalsSamplingAttribution,
+	initCoreWebVitals as initCoreWebVitalsAttribution,
+} from '@guardian/core-web-vitals-attribution';
 import { getCookie, isString, isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
 import { adBlockAsk } from '../experiments/tests/ad-block-ask';
@@ -134,8 +138,17 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 				team: 'dotcom',
 			});
 
+			void initCoreWebVitalsAttribution({
+				browserId,
+				pageViewId,
+				isDev,
+				sampling: nearZeroSampling,
+				team: 'dotcom',
+			});
+
 			if (bypassSampling || isDev) {
 				void bypassCoreWebVitalsSampling('commercial');
+				void bypassCoreWebVitalsSamplingAttribution('dotcom');
 			}
 		},
 		[abTestApi, browserId, isDev, pageViewId, shouldBypassSampling],

--- a/dotcom-rendering/src/experiments/utils.ts
+++ b/dotcom-rendering/src/experiments/utils.ts
@@ -1,7 +1,9 @@
 import { bypassCommercialMetricsSampling } from '@guardian/commercial';
 import { bypassCoreWebVitalsSampling } from '@guardian/core-web-vitals';
+import { bypassCoreWebVitalsSampling as bypassCoreWebVitalsSamplingAttribution } from '@guardian/core-web-vitals-attribution';
 
 export const bypassMetricsSampling = (): void => {
 	void bypassCommercialMetricsSampling();
 	void bypassCoreWebVitalsSampling();
+	void bypassCoreWebVitalsSamplingAttribution();
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 2.0.16
       '@storybook/addon-essentials':
         specifier: 8.1.8
-        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: 3.0.3
         version: 3.0.3(webpack@5.91.0)
@@ -117,10 +117,10 @@ importers:
         version: 8.1.8
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: 8.1.8
-        version: 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+        version: 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
       '@storybook/theming':
         specifier: 8.1.8
         version: 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -346,6 +346,9 @@ importers:
       '@guardian/core-web-vitals':
         specifier: 6.0.0
         version: 6.0.0(@guardian/libs@17.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
+      '@guardian/core-web-vitals-attribution':
+        specifier: npm:@guardian/core-web-vitals@0.0.0-canary-20240627122902
+        version: /@guardian/core-web-vitals@0.0.0-canary-20240627122902(@guardian/libs@17.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1)
       '@guardian/eslint-config':
         specifier: 7.0.1
         version: 7.0.1(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(tslib@2.6.2)
@@ -390,7 +393,7 @@ importers:
         version: 7.75.1
       '@storybook/addon-essentials':
         specifier: 8.1.8
-        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: 8.1.8
         version: 8.1.8(@types/jest@29.5.12)(jest@29.7.0)
@@ -411,10 +414,10 @@ importers:
         version: 8.1.8
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-webpack5':
         specifier: 8.1.8
-        version: 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+        version: 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
       '@storybook/test':
         specifier: 8.1.8
         version: 8.1.8(@types/jest@29.5.12)(jest@29.7.0)
@@ -4132,6 +4135,23 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@guardian/core-web-vitals@0.0.0-canary-20240627122902(@guardian/libs@17.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1):
+    resolution: {integrity: sha512-ueBE17UXabSKzkix3poagnP6PLv1f0HnvmaOFhi1mbXHXbjRyBzRDZh+gY4f7aC7fTOPKJW4GAAAD3kElfpLEw==}
+    peerDependencies:
+      '@guardian/libs': ^16.0.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+      web-vitals: ^3.5.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@guardian/libs': 17.0.1(tslib@2.6.2)(typescript@5.3.3)
+      tslib: 2.6.2
+      typescript: 5.3.3
+      web-vitals: 3.5.1
+    dev: false
+
   /@guardian/core-web-vitals@6.0.0(@guardian/libs@17.0.1)(tslib@2.6.2)(typescript@5.3.3)(web-vitals@3.5.1):
     resolution: {integrity: sha512-kwH1VsQQMn+sPZis1zYYcCYzedNpen6tk3CtVjJlmtHV4nK6i6FnMfhHgbtqECDsqrHdTzRbwN2Lodh1f8D5lA==}
     peerDependencies:
@@ -4161,7 +4181,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -5781,10 +5801,10 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/addon-controls@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/addon-controls@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-o/0WUSlWd6Erf37D9xOnRk7GYMOYf0eI1O7MQdPBSOpI+I77684vCp35D/WcamK3lqz0sAewF5tM14tuo3ATZw==}
     dependencies:
-      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
       dequal: 2.0.3
       lodash: 4.17.21
       ts-dedent: 2.2.0
@@ -5798,12 +5818,12 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/addon-docs@8.1.8(@types/react-dom@18.3.0)(prettier@3.3.2):
+  /@storybook/addon-docs@8.1.8(@types/react-dom@18.3.0)(prettier@3.0.3):
     resolution: {integrity: sha512-zTQxrO53TxDNUn/laK4BCBHp1nO2DABq4BIuNAapYq+DuQ3w981/Jcb9Qwr8TrGGb0hmT1vV2ZGP1m0KfA8OQg==}
     dependencies:
       '@babel/core': 7.24.5
       '@mdx-js/react': 3.0.1(@types/react@18.3.1)(react@18.3.1)
-      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/blocks': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/client-logger': 8.1.8
       '@storybook/components': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-plugin': 8.1.8
@@ -5828,19 +5848,19 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/addon-essentials@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/addon-essentials@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-qAVuighthkhYEgM977vj3sk4mZEOP+JGt+qYLT4nIjuucNm9aXyUOQovIiLQeAwtj+zvwSJ7diFDlQW3eYq+hQ==}
     dependencies:
       '@storybook/addon-actions': 8.1.8
       '@storybook/addon-backgrounds': 8.1.8
-      '@storybook/addon-controls': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@storybook/addon-docs': 8.1.8(@types/react-dom@18.3.0)(prettier@3.3.2)
+      '@storybook/addon-controls': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/addon-docs': 8.1.8(@types/react-dom@18.3.0)(prettier@3.0.3)
       '@storybook/addon-highlight': 8.1.8
       '@storybook/addon-measure': 8.1.8
       '@storybook/addon-outline': 8.1.8
       '@storybook/addon-toolbars': 8.1.8
       '@storybook/addon-viewport': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -5924,7 +5944,7 @@ packages:
       - webpack
     dev: false
 
-  /@storybook/blocks@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/blocks@8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-nx18ism4YCuLFOmI6mQ+EJD1XABcbDdAyeheZPwkwB+fKkseNiOy7C/Mqio7ReYIncvlML6CCUyFm/OSEZkHkQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -5940,7 +5960,7 @@ packages:
       '@storybook/components': 8.1.8(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/core-events': 8.1.8
       '@storybook/csf': 0.1.8
-      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.3.1)
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -5969,11 +5989,11 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/builder-manager@8.1.8(prettier@3.3.2):
+  /@storybook/builder-manager@8.1.8(prettier@3.0.3):
     resolution: {integrity: sha512-M4qpETmQNUTg6KEt4nVONjF2dXlVV1V+Mxf9saiinoj+PCyHdz+BmYYmiGtopUPxJ2YGvTL1nGykkyH57HutrQ==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/manager': 8.1.8
       '@storybook/node-logger': 8.1.8
       '@types/ejs': 3.1.5
@@ -5992,7 +6012,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/builder-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/builder-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==}
     peerDependencies:
       typescript: '*'
@@ -6002,9 +6022,9 @@ packages:
     dependencies:
       '@storybook/channels': 8.1.8
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
+      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -6046,7 +6066,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/builder-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/builder-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==}
     peerDependencies:
       typescript: '*'
@@ -6056,9 +6076,9 @@ packages:
     dependencies:
       '@storybook/channels': 8.1.8
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
+      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview': 8.1.8
       '@storybook/preview-api': 8.1.8
@@ -6118,12 +6138,12 @@ packages:
       '@babel/types': 7.24.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-server': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/core-server': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-tools': 8.1.8
       '@storybook/node-logger': 8.1.8
-      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
+      '@storybook/telemetry': 8.1.8(prettier@3.0.3)
       '@storybook/types': 8.1.8
       '@types/semver': 7.5.6
       '@yarnpkg/fslib': 2.10.3
@@ -6211,7 +6231,7 @@ packages:
       - '@types/react-dom'
     dev: false
 
-  /@storybook/core-common@8.1.8(prettier@3.3.2):
+  /@storybook/core-common@8.1.8(prettier@3.0.3):
     resolution: {integrity: sha512-RcJUTGjvVCuGtz7GifY8sMHLUvmsg8moDOgwwkOJ+9QdgInyuZeqLzNI7BjOv2CYCK1sy7x0eU7B4CWD8LwnwA==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -6240,8 +6260,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.3.2
-      prettier-fallback: /prettier@3.3.2
+      prettier: 3.0.3
+      prettier-fallback: /prettier@3.0.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.4
@@ -6261,16 +6281,16 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/core-server@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/core-server@8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-v2V7FC/y/lrKPxcseIwPavjdCCDHphpj+A23Jmp822tqYn+I4nYRvE74QKyn5dfLrdn52nz8KrUFwjhuacj10Q==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.8(prettier@3.3.2)
+      '@storybook/builder-manager': 8.1.8(prettier@3.0.3)
       '@storybook/channels': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/core-events': 8.1.8
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.8
@@ -6280,7 +6300,7 @@ packages:
       '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
-      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
+      '@storybook/telemetry': 8.1.8(prettier@3.0.3)
       '@storybook/types': 8.1.8
       '@types/detect-port': 1.3.5
       '@types/diff': 5.2.1
@@ -6319,10 +6339,10 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@storybook/core-webpack@8.1.8(prettier@3.3.2):
+  /@storybook/core-webpack@8.1.8(prettier@3.0.3):
     resolution: {integrity: sha512-rT0Nn72Z6tDLM4EX9SWUmRtIWGxve/u1MBwckBuztzeQaGUl4ORMDtbo4Ahvfc1oEapHKmow+zvzeH0NWGCw5w==}
     dependencies:
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/node-logger': 8.1.8
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
@@ -6368,10 +6388,10 @@ packages:
     resolution: {integrity: sha512-t4syFIeSyufieNovZbLruPt2DmRKpbwL4fERCZ1MifWDRIORCKLc4NCEHy+IqvIqd71/SJV2k4B51nF7vlJfmQ==}
     dev: false
 
-  /@storybook/docs-tools@8.1.8(prettier@3.3.2):
+  /@storybook/docs-tools@8.1.8(prettier@3.0.3):
     resolution: {integrity: sha512-YdwuLKIiqNFfpfBucWXt+MDvqBYmBWdm3pADTYmC9P3BI+jQ4A88LhIHYVycq8JWLxFQHSKNvgJ+Z5MFbnijIQ==}
     dependencies:
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/core-events': 8.1.8
       '@storybook/preview-api': 8.1.8
       '@storybook/types': 8.1.8
@@ -6443,7 +6463,7 @@ packages:
     resolution: {integrity: sha512-7woDHnwd8HdssbEQnfpwZu+zNjp9X6vqdPHhxhwAYsYt3x+m0Y8LP0sMJk8w/gQygelUoJsZLFZsJ2pifLXLCg==}
     dev: false
 
-  /@storybook/preset-react-webpack@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/preset-react-webpack@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JS4XRqVmRqUY0i/NjkfKNZ08wvuBq2Lexs1Np/8CFrgenT5EeqZPQkvW955zkQT17jHQ8WgTyygVaXKh+TSSRQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6454,10 +6474,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
-      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
+      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
       '@storybook/node-logger': 8.1.8
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0)
       '@types/node': 18.18.14
       '@types/semver': 7.5.6
@@ -6482,7 +6502,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/preset-react-webpack@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/preset-react-webpack@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JS4XRqVmRqUY0i/NjkfKNZ08wvuBq2Lexs1Np/8CFrgenT5EeqZPQkvW955zkQT17jHQ8WgTyygVaXKh+TSSRQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6493,10 +6513,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
-      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/core-webpack': 8.1.8(prettier@3.0.3)
+      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
       '@storybook/node-logger': 8.1.8
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.91.0)
       '@types/node': 18.18.14
       '@types/semver': 7.5.6
@@ -6558,7 +6578,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6573,7 +6593,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@storybook/react-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/react-webpack5@8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-XpZL2D7Zgl2iPcg3yTSiEGX6BuHQSOEeXNqDkWti2xqwGRYhczaSp3oi+P5cSUYAGY9hn3BBOzFNUpOMrBNG6Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6584,9 +6604,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.1.8(@swc/core@1.5.3)(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
       react: 18.3.1
@@ -6603,7 +6623,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/react-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
+  /@storybook/react-webpack5@8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-XpZL2D7Zgl2iPcg3yTSiEGX6BuHQSOEeXNqDkWti2xqwGRYhczaSp3oi+P5cSUYAGY9hn3BBOzFNUpOMrBNG6Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6614,9 +6634,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.18.20)(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.18.20)(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)(webpack-cli@5.1.4)
+      '@storybook/react': 8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3)
       '@storybook/types': 8.1.8
       '@types/node': 18.18.14
       react: 18.3.1
@@ -6633,7 +6653,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/react@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3):
+  /@storybook/react@8.1.8(prettier@3.0.3)(react-dom@18.3.1)(react@18.3.1)(typescript@5.3.3):
     resolution: {integrity: sha512-QFwyccbyZGcTpYk6BVChSSemeZ3mmnpp62Ca60j6JO+zbtZv3tTr4PFo79lkWwtz+jpfj0CX8hyYdT1p3r77YA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6645,7 +6665,7 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 8.1.8
-      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/docs-tools': 8.1.8(prettier@3.0.3)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.8
       '@storybook/react-dom-shim': 8.1.8(react-dom@18.3.1)(react@18.3.1)
@@ -6682,11 +6702,11 @@ packages:
       qs: 6.11.2
     dev: false
 
-  /@storybook/telemetry@8.1.8(prettier@3.3.2):
+  /@storybook/telemetry@8.1.8(prettier@3.0.3):
     resolution: {integrity: sha512-Hr5QUVtn4BzQrqsv1dwlfKRj2yU8XRXmhwCbo0DFULpJasVsJB3VJXeuUOijwteWsGo2avKMZErwNZElJy2yXA==}
     dependencies:
       '@storybook/client-logger': 8.1.8
-      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-common': 8.1.8(prettier@3.0.3)
       '@storybook/csf-tools': 8.1.8
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -8369,8 +8389,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
     dev: false
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8380,8 +8400,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
     dev: false
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.91.0):
@@ -8395,8 +8415,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.91.0)
     dev: false
 
@@ -8947,7 +8967,7 @@ packages:
       '@babel/core': 7.24.5
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -10035,7 +10055,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /css-loader@7.1.1(webpack@5.91.0):
@@ -11075,7 +11095,7 @@ packages:
       enhanced-resolve: 5.16.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -12039,7 +12059,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.3.3
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /form-data@3.0.1:
@@ -17665,7 +17685,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -17992,7 +18012,6 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: false
 
-
   /thrift@0.20.0:
     resolution: {integrity: sha512-oSmJTaoIAGolpupVHFfsWcmdEKX81fcDI6ty0hhezzdgZvp0XyXgMe9+1YusI8Ahy0HK4n8jlNrkPjOPeHZjdQ==}
     engines: {node: '>= 10.18.0'}
@@ -18229,7 +18248,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.3.3
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.5.3)(@types/node@16.18.68)(typescript@4.9.5):
@@ -19049,7 +19068,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.2.1(webpack@5.91.0):
@@ -19111,8 +19130,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.91.0)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.91.0)
       webpack-dev-middleware: 7.2.1(webpack@5.91.0)
       ws: 8.17.1
     transitivePeerDependencies:
@@ -19157,7 +19176,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.91.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.5.3)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

Use the new `@guardian/core-web-vitals` library

## Why?

- #11688