### PR TITLE
Fix MatchNav crest images

### DIFF
--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -132,21 +132,23 @@ const Crest = ({ crest }: { crest: string }) => (
 			z-index: 1;
 		`}
 	>
-		<img
-			css={css`
-				position: absolute;
-				left: 0.5rem;
-				right: 0.5rem;
-				bottom: 0.5rem;
-				top: 0.5rem;
-				max-width: calc(100% - 1rem);
-				max-height: calc(100% - 1rem);
-				margin: auto;
-				display: block;
-			`}
-			src={crest}
-			alt=""
-		/>
+		{crest.trim() === '' ? null : (
+			<img
+				css={css`
+					position: absolute;
+					left: 0.5rem;
+					right: 0.5rem;
+					bottom: 0.5rem;
+					top: 0.5rem;
+					max-width: calc(100% - 1rem);
+					max-height: calc(100% - 1rem);
+					margin: auto;
+					display: block;
+				`}
+				src={crest}
+				alt=""
+			/>
+		)}
 	</div>
 );
 


### PR DESCRIPTION
## What does this change?

Stop rendering an `<img src="">` tag on the server without a valid source URL.

## Why?

Prevent rendering bugs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/604595da-87dd-4092-b0b3-7e52455db865
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/365fd8c5-4c74-4f42-bd68-fc0cec556287