### PR TITLE
Edition switcher banner

### DIFF
--- a/dotcom-rendering/playwright/tests/edition-switcher-banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/edition-switcher-banner.e2e.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { disableCMP } from '../lib/cmp';
+import { addCookie } from '../lib/cookies';
+import { loadPage } from '../lib/load-page';
+
+const scenarios = [
+	{ pageId: 'uk', edition: 'AU', showBanner: true },
+	{ pageId: 'europe', edition: 'US', showBanner: true },
+	{ pageId: 'uk', edition: 'UK', showBanner: false },
+	{ pageId: 'us', edition: 'US', showBanner: false },
+];
+
+test.describe('Edition Switcher Banner', () => {
+	for (const { pageId, edition } of scenarios.filter(
+		({ showBanner }) => showBanner,
+	)) {
+		test.describe("the page ID doesn't match the edition", () => {
+			test(`It shows the banner when the edition is ${edition} and the page is /${pageId}`, async ({
+				context,
+				page,
+			}) => {
+				await addCookie(context, {
+					name: 'GU_EDITION',
+					value: `${edition}`,
+				});
+
+				await disableCMP(context);
+				await loadPage(
+					page,
+					`/Front/https://www.theguardian.com/${pageId}`,
+				);
+
+				await expect(
+					page.locator('[data-component="edition-switcher-banner"]'),
+				).toBeVisible();
+			});
+		});
+	}
+
+	for (const { pageId, edition } of scenarios.filter(
+		({ showBanner }) => !showBanner,
+	)) {
+		test.describe('the page ID matches the edition', () => {
+			test(`It does NOT show the banner when the edition is ${edition} and the page is /${pageId}`, async ({
+				context,
+				page,
+			}) => {
+				await addCookie(context, {
+					name: 'GU_EDITION',
+					value: `${edition}`,
+				});
+
+				await disableCMP(context);
+				await loadPage(
+					page,
+					`/Front/https://www.theguardian.com/${pageId}`,
+				);
+
+				await expect(
+					page.locator('[data-component="edition-switcher-banner"]'),
+				).not.toBeVisible();
+			});
+		});
+	}
+
+	test.describe('the page is not a network front', () => {
+		test(`It does NOT show the banner on a section front`, async ({
+			context,
+			page,
+		}) => {
+			await addCookie(context, {
+				name: 'GU_EDITION',
+				value: 'US',
+			});
+
+			await disableCMP(context);
+			await loadPage(page, `/Front/https://www.theguardian.com/uk/sport`);
+
+			await expect(
+				page.locator('[data-component="edition-switcher-banner"]'),
+			).not.toBeVisible();
+		});
+
+		test(`It does NOT show the banner on an article`, async ({
+			context,
+			page,
+		}) => {
+			await addCookie(context, {
+				name: 'GU_EDITION',
+				value: 'US',
+			});
+
+			await disableCMP(context);
+			await loadPage(
+				page,
+				`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
+			);
+
+			await expect(
+				page.locator('[data-component="edition-switcher-banner"]'),
+			).not.toBeVisible();
+		});
+	});
+});

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -102,7 +102,7 @@ export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
 				<div css={textAndLink}>
 					<p>You are viewing the {defaultEditionName} homepage</p>
 					<LinkButton
-						href={`https://www.theguardian.com/${suggestedPageId}`}
+						href={`/${suggestedPageId}`}
 						priority="primary"
 						size="xsmall"
 						// larger screen sizes should have size="small", which is why we need a css override

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -4,6 +4,7 @@ import { LinkButton } from '@guardian/source/react-components';
 import useSWR from 'swr';
 import { center } from '../lib/center';
 import {
+	type Edition,
 	type EditionId,
 	getEditionFromId,
 	getEditionFromPageId,
@@ -14,7 +15,6 @@ import {
 	useEditionSwitcherBanner,
 } from '../lib/useUserPreferredEdition';
 import XIcon from '../static/icons/x.svg';
-import type { NetworkFrontPageId } from '../types/front';
 
 const container = css`
 	position: sticky;
@@ -74,7 +74,7 @@ const apiPromise = new Promise<{ hidden: boolean }>(() => {
 });
 
 type Props = {
-	pageId: NetworkFrontPageId;
+	pageId: Edition['pageId'];
 	edition: EditionId;
 };
 

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette, space, textSans14 } from '@guardian/source/foundations';
 import { LinkButton } from '@guardian/source/react-components';
-import useSWR from 'swr';
 import { center } from '../lib/center';
 import {
 	type Edition,
@@ -68,11 +67,6 @@ const closeButton = css`
 	border: none;
 `;
 
-const key = 'edition-switcher-banner';
-const apiPromise = new Promise<{ hidden: boolean }>(() => {
-	/* this never resolves */
-});
-
 type Props = {
 	pageId: Edition['pageId'];
 	edition: EditionId;
@@ -85,10 +79,11 @@ type Props = {
  * See PR for details: https://github.com/guardian/dotcom-rendering/pull/11763
  */
 export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
-	const [showBanner] = useEditionSwitcherBanner(pageId, edition);
+	const [showBanner, isBannerClosed] = useEditionSwitcherBanner(
+		pageId,
+		edition,
+	);
 
-	const { data } = useSWR(key, () => apiPromise);
-	const isBannerClosed = !!data?.hidden;
 	const suggestedPageId = getEditionFromId(edition).pageId;
 	const suggestedEdition = getEditionFromId(edition).title.replace(
 		' edition',

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -79,7 +79,7 @@ type Props = {
  * See PR for details: https://github.com/guardian/dotcom-rendering/pull/11763
  */
 export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
-	const [showBanner, isBannerClosed] = useEditionSwitcherBanner(
+	const { showBanner, isBannerClosed } = useEditionSwitcherBanner(
 		pageId,
 		edition,
 	);

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -105,7 +105,6 @@ export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
 						href={`/${suggestedPageId}`}
 						priority="primary"
 						size="xsmall"
-						// larger screen sizes should have size="small", which is why we need a css override
 						cssOverrides={linkButton}
 						data-link-name="edition-switcher-banner switch-edition"
 					>

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -14,6 +14,7 @@ import {
 	useEditionSwitcherBanner,
 } from '../lib/useUserPreferredEdition';
 import XIcon from '../static/icons/x.svg';
+import type { NetworkFrontPageId } from '../types/front';
 
 const container = css`
 	position: sticky;
@@ -73,7 +74,7 @@ const apiPromise = new Promise<{ hidden: boolean }>(() => {
 });
 
 type Props = {
-	pageId: string;
+	pageId: NetworkFrontPageId;
 	edition: EditionId;
 };
 

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -1,0 +1,115 @@
+import { css } from '@emotion/react';
+import { from, palette, space, textSans14 } from '@guardian/source/foundations';
+import { LinkButton } from '@guardian/source/react-components';
+import useSWR from 'swr';
+import { center } from '../lib/center';
+import { type EditionId, getEditionFromPageId } from '../lib/edition';
+import { getZIndex } from '../lib/getZIndex';
+import {
+	hideEditionSwitcherBanner,
+	useEditionSwitcherBanner,
+} from '../lib/useUserPreferredEdition';
+import XIcon from '../static/icons/x.svg';
+
+const container = css`
+	position: sticky;
+	top: 0;
+	background-color: ${palette.brand[800]};
+	${getZIndex('banner')};
+`;
+
+const content = css`
+	display: flex;
+	justify-content: space-between;
+	padding: 10px;
+	align-items: flex-start;
+	${center}
+
+	${from.mobileLandscape} {
+		padding: 10px ${space[5]}px;
+	}
+
+	${from.phablet} {
+		align-items: center;
+	}
+`;
+
+const text = css`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 10px;
+	${textSans14};
+
+	${from.phablet} {
+		flex-direction: row;
+		align-items: center;
+		gap: ${space[5]}px;
+	}
+`;
+
+const button = css`
+	${from.phablet} {
+		padding: 18px ${space[4]}px;
+	}
+`;
+
+const icon = css`
+	cursor: pointer;
+	display: flex;
+	justify-content: center;
+	padding: 0;
+	background-color: unset;
+	border: none;
+`;
+
+const key = 'edition-switcher-banner';
+const apiPromise = new Promise<{ hidden: boolean }>(() => {
+	/* this never resolves */
+});
+
+type Props = {
+	pageId: string;
+	edition: EditionId;
+};
+
+export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
+	const [shouldShowBanner] = useEditionSwitcherBanner(pageId, edition);
+	const { data } = useSWR(key, () => apiPromise);
+
+	if (data?.hidden ?? !shouldShowBanner) {
+		return null;
+	}
+
+	const defaultEditionForPage = getEditionFromPageId(pageId)?.editionId;
+	const suggestedUrl = `https://www.theguardian.com/${pageId}`;
+
+	return (
+		<aside data-component="edition-switcher-banner" css={container}>
+			<div css={content}>
+				<div css={text}>
+					<p>You are viewing the {defaultEditionForPage} homepage</p>
+					<LinkButton
+						href={suggestedUrl}
+						priority="primary"
+						size="xsmall"
+						cssOverrides={button}
+						data-link-name="edition-switcher-banner switch-edition"
+					>
+						View the {edition} homepage
+					</LinkButton>
+				</div>
+				<button
+					type="button"
+					css={icon}
+					data-link-name="edition-switcher-banner close-banner"
+					onClick={() => {
+						hideEditionSwitcherBanner();
+					}}
+				>
+					<XIcon />
+				</button>
+			</div>
+		</aside>
+	);
+};

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.stories.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EditionSwitcherBanner as EditionSwitcherBannerComponent } from './EditionSwitcherBanner.importable';
+
+const meta = {
+	title: 'Components/EditionSwitcherBanner',
+	component: EditionSwitcherBannerComponent,
+} satisfies Meta<typeof EditionSwitcherBannerComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const EditionSwitcherBanner = {
+	args: {
+		pageId: 'UK',
+		edition: 'US',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.stories.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export const EditionSwitcherBanner = {
 	args: {
-		pageId: 'UK',
+		pageId: 'uk',
 		edition: 'US',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.test.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.test.tsx
@@ -10,7 +10,7 @@ describe('EditionSwitcherBanner', () => {
 		screen.getByText('You are viewing the US homepage');
 
 		const link = screen.getByRole('link', { name: 'View the UK homepage' });
-		expect(link).toHaveAttribute('href', 'https://www.theguardian.com/uk');
+		expect(link).toHaveAttribute('href', '/uk');
 	});
 
 	test('should no longer be present in DOM after clicking the close button', async () => {

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.test.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.test.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom';
+import { userEvent } from '@storybook/test';
+import { act, render, screen } from '@testing-library/react';
+import { EditionSwitcherBanner } from './EditionSwitcherBanner.importable';
+
+describe('EditionSwitcherBanner', () => {
+	it('should display the correct text', () => {
+		render(<EditionSwitcherBanner pageId="us" edition="UK" />);
+
+		screen.getByText('You are viewing the US homepage');
+
+		const link = screen.getByRole('link', { name: 'View the UK homepage' });
+		expect(link).toHaveAttribute('href', 'https://www.theguardian.com/uk');
+	});
+
+	test('should no longer be present in DOM after clicking the close button', async () => {
+		const { container } = render(
+			<EditionSwitcherBanner pageId="us" edition="UK" />,
+		);
+		container.querySelector('[data-component="edition-switcher-banner"]');
+
+		const closeButton = screen.getByRole('button');
+		await act(async () => {
+			await userEvent.click(closeButton);
+		});
+
+		expect(
+			container.querySelector(
+				'[data-component="edition-switcher-banner"]',
+			),
+		).toBeNull();
+	});
+});

--- a/dotcom-rendering/src/components/FrontSubNav.importable.tsx
+++ b/dotcom-rendering/src/components/FrontSubNav.importable.tsx
@@ -1,16 +1,10 @@
 import { css } from '@emotion/react';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
-import useSWR from 'swr';
 import type { EditionId } from '../lib/edition';
 import { useEditionSwitcherBanner } from '../lib/useUserPreferredEdition';
 import type { SubNavType } from '../model/extract-nav';
 import { Section } from './Section';
 import { SubNav } from './SubNav.importable';
-
-const key = 'edition-switcher-banner';
-const apiPromise = new Promise<{ hidden: boolean }>(() => {
-	/* this never resolves */
-});
 
 type Props = {
 	subNavSections: SubNavType;
@@ -29,9 +23,10 @@ export const FrontSubNav = ({
 	userEdition,
 	currentPillarTitle,
 }: Props) => {
-	const [showBanner] = useEditionSwitcherBanner(pageId, userEdition);
-	const { data } = useSWR(key, () => apiPromise);
-	const isBannerClosed = !!data?.hidden;
+	const [showBanner, isBannerClosed] = useEditionSwitcherBanner(
+		pageId,
+		userEdition,
+	);
 
 	if (showBanner && !isBannerClosed) {
 		return null;

--- a/dotcom-rendering/src/components/FrontSubNav.importable.tsx
+++ b/dotcom-rendering/src/components/FrontSubNav.importable.tsx
@@ -31,8 +31,9 @@ export const FrontSubNav = ({
 }: Props) => {
 	const [showBanner] = useEditionSwitcherBanner(pageId, userEdition);
 	const { data } = useSWR(key, () => apiPromise);
+	const isBannerClosed = !!data?.hidden;
 
-	if (showBanner && !data?.hidden) {
+	if (showBanner && !isBannerClosed) {
 		return null;
 	}
 

--- a/dotcom-rendering/src/components/FrontSubNav.importable.tsx
+++ b/dotcom-rendering/src/components/FrontSubNav.importable.tsx
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import useSWR from 'swr';
+import type { EditionId } from '../lib/edition';
+import { useEditionSwitcherBanner } from '../lib/useUserPreferredEdition';
+import type { SubNavType } from '../model/extract-nav';
+import { Section } from './Section';
+import { SubNav } from './SubNav.importable';
+
+const key = 'edition-switcher-banner';
+const apiPromise = new Promise<{ hidden: boolean }>(() => {
+	/* this never resolves */
+});
+
+type Props = {
+	subNavSections: SubNavType;
+	currentNavLink: string;
+	hasPageSkin: boolean;
+	pageId: string;
+	userEdition: EditionId;
+	currentPillarTitle?: string;
+};
+
+export const FrontSubNav = ({
+	subNavSections,
+	currentNavLink,
+	hasPageSkin,
+	pageId,
+	userEdition,
+	currentPillarTitle,
+}: Props) => {
+	const [showBanner] = useEditionSwitcherBanner(pageId, userEdition);
+	const { data } = useSWR(key, () => apiPromise);
+
+	if (showBanner && !data?.hidden) {
+		return null;
+	}
+
+	return (
+		<>
+			<Section
+				fullWidth={true}
+				padSides={false}
+				element="aside"
+				hasPageSkin={hasPageSkin}
+			>
+				<SubNav
+					subNavSections={subNavSections}
+					currentNavLink={currentNavLink}
+					position="header"
+					currentPillarTitle={currentPillarTitle}
+				/>
+			</Section>
+			<Section
+				fullWidth={true}
+				padSides={false}
+				showTopBorder={false}
+				hasPageSkin={hasPageSkin}
+			>
+				<StraightLines
+					cssOverrides={css`
+						display: block;
+					`}
+					count={4}
+				/>
+			</Section>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/FrontSubNav.importable.tsx
+++ b/dotcom-rendering/src/components/FrontSubNav.importable.tsx
@@ -23,7 +23,7 @@ export const FrontSubNav = ({
 	userEdition,
 	currentPillarTitle,
 }: Props) => {
-	const [showBanner, isBannerClosed] = useEditionSwitcherBanner(
+	const { showBanner, isBannerClosed } = useEditionSwitcherBanner(
 		pageId,
 		userEdition,
 	);

--- a/dotcom-rendering/src/components/Header.tsx
+++ b/dotcom-rendering/src/components/Header.tsx
@@ -39,6 +39,7 @@ type Props = {
 	idApiUrl: string;
 	headerTopBarSearchCapiSwitch: boolean;
 	hasPageSkin?: boolean;
+	pageId?: string;
 };
 
 export const Header = ({
@@ -52,6 +53,7 @@ export const Header = ({
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
 	hasPageSkin = false,
+	pageId,
 }: Props) => (
 	<div css={headerStyles} data-component="nav3">
 		<Island priority="critical">
@@ -68,6 +70,7 @@ export const Header = ({
 				idApiUrl={idApiUrl}
 				headerTopBarSearchCapiSwitch={headerTopBarSearchCapiSwitch}
 				hasPageSkin={hasPageSkin}
+				pageId={pageId}
 			/>
 		</Island>
 

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -4,6 +4,7 @@ import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
 import type { EditionId } from '../lib/edition';
 import { useAuthStatus } from '../lib/useAuthStatus';
+import { useEditionSwitcherBanner } from '../lib/useUserPreferredEdition';
 import { HeaderTopBarEditionDropdown } from './HeaderTopBarEditionDropdown';
 import { MyAccount } from './HeaderTopBarMyAccount';
 import { HeaderTopBarPrintSubscriptions } from './HeaderTopBarPrintSubscriptions';
@@ -21,6 +22,7 @@ interface HeaderTopBarProps {
 	idApiUrl: string;
 	headerTopBarSearchCapiSwitch: boolean;
 	hasPageSkin?: boolean;
+	pageId?: string;
 }
 
 const topBarStylesUntilLeftCol = css`
@@ -70,8 +72,10 @@ export const HeaderTopBar = ({
 	idApiUrl,
 	headerTopBarSearchCapiSwitch,
 	hasPageSkin = false,
+	pageId = '',
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
+	const [shouldShowBanner] = useEditionSwitcherBanner(pageId, editionId);
 
 	return (
 		<div
@@ -107,6 +111,7 @@ export const HeaderTopBar = ({
 					<HeaderTopBarEditionDropdown
 						editionId={editionId}
 						dataLinkName={dataLinkName}
+						showActiveEdition={!shouldShowBanner}
 					/>
 				</Hide>
 			</div>

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -76,7 +76,7 @@ export const HeaderTopBar = ({
 	pageId = '',
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
-	const [shouldShowBanner] = useEditionSwitcherBanner(pageId, editionId);
+	const [showBanner] = useEditionSwitcherBanner(pageId, editionId);
 
 	return (
 		<div
@@ -112,7 +112,7 @@ export const HeaderTopBar = ({
 					<HeaderTopBarEditionDropdown
 						editionId={editionId}
 						dataLinkName={dataLinkName}
-						showActiveEdition={!shouldShowBanner}
+						showActiveEdition={!showBanner}
 					/>
 				</Hide>
 			</div>

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -55,9 +55,10 @@ const topBarStylesFromLeftCol = css`
  *
  * ## Why does this need to be an Island?
  *
- * - We need to check if a user is signed in to show them the right header.
+ * - We need to check if a user is signed in to show them the right header
  * - We track clicks on print subscription with a page view ID
  * - We (sometimes) have a dynamic search
+ * - We change the text of the edition dropdown if we show the edition switcher banner
  *
  * ---
  *

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -76,7 +76,7 @@ export const HeaderTopBar = ({
 	pageId = '',
 }: HeaderTopBarProps) => {
 	const authStatus = useAuthStatus();
-	const [showBanner] = useEditionSwitcherBanner(pageId, editionId);
+	const { showBanner } = useEditionSwitcherBanner(pageId, editionId);
 
 	return (
 		<div

--- a/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBar.importable.tsx
@@ -112,7 +112,7 @@ export const HeaderTopBar = ({
 					<HeaderTopBarEditionDropdown
 						editionId={editionId}
 						dataLinkName={dataLinkName}
-						showActiveEdition={!showBanner}
+						showCurrentEdition={!showBanner}
 					/>
 				</Hide>
 			</div>

--- a/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
@@ -12,7 +12,7 @@ import { dropDownOverrides } from './HeaderTopBarMyAccount';
 interface HeaderTopBarEditionDropdownProps {
 	editionId: EditionId;
 	dataLinkName: string;
-	showActiveEdition?: boolean;
+	showCurrentEdition?: boolean;
 }
 
 const editionDropdownStyles = css`
@@ -29,7 +29,7 @@ const editionDropdownStyles = css`
 export const HeaderTopBarEditionDropdown = ({
 	editionId,
 	dataLinkName,
-	showActiveEdition = true,
+	showCurrentEdition = true,
 }: HeaderTopBarEditionDropdownProps) => {
 	const editionToDropdownLink = (edition: EditionLinkType) => ({
 		id: edition.editionId,
@@ -47,7 +47,7 @@ export const HeaderTopBarEditionDropdown = ({
 		getEditionFromId(editionId),
 	);
 
-	const label = showActiveEdition ? activeEdition.title : 'Edition';
+	const label = showCurrentEdition ? activeEdition.title : 'Edition';
 
 	const dropdownItems: DropdownLinkType[] = editionList.map(
 		editionToDropdownLink,

--- a/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
+++ b/dotcom-rendering/src/components/HeaderTopBarEditionDropdown.tsx
@@ -12,6 +12,7 @@ import { dropDownOverrides } from './HeaderTopBarMyAccount';
 interface HeaderTopBarEditionDropdownProps {
 	editionId: EditionId;
 	dataLinkName: string;
+	showActiveEdition?: boolean;
 }
 
 const editionDropdownStyles = css`
@@ -28,6 +29,7 @@ const editionDropdownStyles = css`
 export const HeaderTopBarEditionDropdown = ({
 	editionId,
 	dataLinkName,
+	showActiveEdition = true,
 }: HeaderTopBarEditionDropdownProps) => {
 	const editionToDropdownLink = (edition: EditionLinkType) => ({
 		id: edition.editionId,
@@ -45,6 +47,8 @@ export const HeaderTopBarEditionDropdown = ({
 		getEditionFromId(editionId),
 	);
 
+	const label = showActiveEdition ? activeEdition.title : 'Edition';
+
 	const dropdownItems: DropdownLinkType[] = editionList.map(
 		editionToDropdownLink,
 	);
@@ -58,7 +62,7 @@ export const HeaderTopBarEditionDropdown = ({
 	return (
 		<div css={editionDropdownStyles}>
 			<Dropdown
-				label={activeEdition.title}
+				label={label}
 				links={linksToDisplay}
 				id="edition"
 				dataLinkName={dataLinkName}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -39,17 +39,14 @@ import { badgeFromBranding, isPaidContentSameBranding } from '../lib/branding';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideContainerOverrides } from '../lib/decideContainerOverrides';
+import { editionList } from '../lib/edition';
 import {
 	getFrontsBannerAdPositions,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import type { NavType } from '../model/extract-nav';
-import {
-	type DCRCollectionType,
-	type DCRFrontType,
-	NetworkFrontPageIds,
-} from '../types/front';
+import { type DCRCollectionType, type DCRFrontType } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -63,7 +60,7 @@ const spaces = / /g;
 const ophanComponentId = (name: string) =>
 	name.toLowerCase().replace(spaces, '-');
 
-const isNetworkFrontPageId = isOneOf(NetworkFrontPageIds);
+const isNetworkFrontPageId = isOneOf(editionList.map(({ pageId }) => pageId));
 
 const isNavList = (collection: DCRCollectionType) => {
 	return (

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -1,4 +1,4 @@
-import { ArticleDisplay } from '@guardian/libs';
+import { ArticleDisplay, isOneOf } from '@guardian/libs';
 import {
 	background,
 	brandBackground,
@@ -45,7 +45,11 @@ import {
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import type { NavType } from '../model/extract-nav';
-import type { DCRCollectionType, DCRFrontType } from '../types/front';
+import {
+	type DCRCollectionType,
+	type DCRFrontType,
+	NetworkFrontPageIds,
+} from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -58,6 +62,8 @@ const spaces = / /g;
 /** TODO: Confirm with is a valid way to generate component IDs. */
 const ophanComponentId = (name: string) =>
 	name.toLowerCase().replace(spaces, '-');
+
+const isNetworkFrontPageId = isOneOf(NetworkFrontPageIds);
 
 const isNavList = (collection: DCRCollectionType) => {
 	return (
@@ -99,9 +105,7 @@ const decideLeftContent = (
 	// show weather?
 	if (
 		front.config.switches['weather'] &&
-		['uk', 'us', 'au', 'international', 'europe'].includes(
-			front.config.pageId,
-		) &&
+		isNetworkFrontPageId(front.config.pageId) &&
 		// based on https://github.com/guardian/frontend/blob/473aafd168fec7f2a578a52c8e84982e3ec10fea/common/app/views/support/GetClasses.scala#L107
 		collection.displayName.toLowerCase() === 'headlines' &&
 		!hasPageSkin
@@ -313,12 +317,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				id="maincontent"
 				css={hasPageSkin && pageSkinContainer}
 			>
-				<Island priority="enhancement" defer={{ until: 'idle' }}>
-					<EditionSwitcherBanner
-						pageId={pageId}
-						edition={editionId}
-					/>
-				</Island>
+				{isNetworkFrontPageId(pageId) && (
+					<Island priority="enhancement" defer={{ until: 'idle' }}>
+						<EditionSwitcherBanner
+							pageId={pageId}
+							edition={editionId}
+						/>
+					</Island>
+				)}
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { ArticleDisplay } from '@guardian/libs';
 import {
 	background,
@@ -7,7 +6,6 @@ import {
 	brandLine,
 	palette as sourcePalette,
 } from '@guardian/source/foundations';
-import { StraightLines } from '@guardian/source-development-kitchen/react-components';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
 import { Carousel } from '../components/Carousel.importable';
@@ -18,9 +16,11 @@ import {
 	decideMerchandisingSlot,
 	decideMerchHighAndMobileAdSlots,
 } from '../components/DecideFrontsAdSlots';
+import { EditionSwitcherBanner } from '../components/EditionSwitcherBanner.importable';
 import { Footer } from '../components/Footer';
 import { FrontMostViewed } from '../components/FrontMostViewed';
 import { FrontSection } from '../components/FrontSection';
+import { FrontSubNav } from '../components/FrontSubNav.importable';
 import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
@@ -248,6 +248,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												.headerTopBarSearchCapi
 										}
 										hasPageSkin={hasPageSkin}
+										pageId={pageId}
 									/>
 								</Section>
 							)}
@@ -274,45 +275,21 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								/>
 							</Section>
 							{NAV.subNavSections && (
-								<>
-									<Section
-										fullWidth={true}
-										padSides={false}
-										element="aside"
+								<Island
+									priority="enhancement"
+									defer={{ until: 'idle' }}
+								>
+									<FrontSubNav
+										subNavSections={NAV.subNavSections}
+										currentNavLink={NAV.currentNavLink}
 										hasPageSkin={hasPageSkin}
-									>
-										<Island
-											priority="enhancement"
-											defer={{ until: 'idle' }}
-										>
-											<SubNav
-												subNavSections={
-													NAV.subNavSections
-												}
-												currentNavLink={
-													NAV.currentNavLink
-												}
-												position="header"
-												currentPillarTitle={
-													front.nav.currentPillarTitle
-												}
-											/>
-										</Island>
-									</Section>
-									<Section
-										fullWidth={true}
-										padSides={false}
-										showTopBorder={false}
-										hasPageSkin={hasPageSkin}
-									>
-										<StraightLines
-											cssOverrides={css`
-												display: block;
-											`}
-											count={4}
-										/>
-									</Section>
-								</>
+										pageId={pageId}
+										userEdition={editionId}
+										currentPillarTitle={
+											front.nav.currentPillarTitle
+										}
+									/>
+								</Island>
 							)}
 						</>
 					)}
@@ -330,13 +307,20 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 				</>
 			</div>
-
 			<main
 				data-layout="FrontLayout"
 				data-link-name={`Front | /${front.pressedPage.id}`}
 				id="maincontent"
 				css={hasPageSkin && pageSkinContainer}
 			>
+				{front.isNetworkFront && (
+					<Island priority="enhancement" defer={{ until: 'idle' }}>
+						<EditionSwitcherBanner
+							pageId={pageId}
+							edition={editionId}
+						/>
+					</Island>
+				)}
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -313,14 +313,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				id="maincontent"
 				css={hasPageSkin && pageSkinContainer}
 			>
-				{front.isNetworkFront && (
-					<Island priority="enhancement" defer={{ until: 'idle' }}>
-						<EditionSwitcherBanner
-							pageId={pageId}
-							edition={editionId}
-						/>
-					</Island>
-				)}
+				<Island priority="enhancement" defer={{ until: 'idle' }}>
+					<EditionSwitcherBanner
+						pageId={pageId}
+						edition={editionId}
+					/>
+				</Island>
 				{front.pressedPage.collections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -124,9 +124,6 @@ const isNetworkFront = (pageId: string): boolean =>
  * Checks:
  * a) the first section is a network front
  * b) the second section is an editionalised page
- *
- * @param pageId
- * @returns
  */
 const splitEditionalisedPage = (
 	pageId: string,

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,18 +2,19 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 27;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 26;');
-		expect(getZIndex('banner')).toBe('z-index: 25;');
-		expect(getZIndex('dropdown')).toBe('z-index: 24;');
-		expect(getZIndex('burger')).toBe('z-index: 23;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 22;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 21;');
-		expect(getZIndex('mobileSticky')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 19;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 18;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 17;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 16;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 28;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 27;');
+		expect(getZIndex('banner')).toBe('z-index: 26;');
+		expect(getZIndex('dropdown')).toBe('z-index: 25;');
+		expect(getZIndex('burger')).toBe('z-index: 24;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 23;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 22;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 20;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 19;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 18;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
+		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 16;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 15;');
 		expect(getZIndex('toast')).toBe('z-index: 14;');
 		expect(getZIndex('onwardsCarousel')).toBe('z-index: 13;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -45,6 +45,9 @@ const indices = [
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 
+	// The edition switcher banner needs to be below the Edition selector in nav
+	'editionSwitcherBanner',
+
 	// The content displayed by the Details component
 	'summaryDetails',
 

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -1,7 +1,11 @@
 import { getCookie, removeCookie, setCookie } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { mutate } from 'swr';
-import { type EditionId as Edition, getEditionFromPageId } from './edition';
+import {
+	type EditionId as Edition,
+	getEditionFromPageId,
+	isNetworkFront,
+} from './edition';
 
 const getBannerValueFromQueryParams = () => {
 	const queryParams = new URLSearchParams(window.location.search);
@@ -33,26 +37,29 @@ const hideBannerThroughUserOverride = () => {
 };
 
 /**
- * Show an "Edition Switcher" banner if the user's preferred edition is different from the current edition.
+ * Show an "Edition Switcher" banner if the user is on a network front
+ * which is different to their preferred or default edition.
  *
  * This allows a user to quickly identify that they are not on the network front
- * for their preferred edition and provides a link to switch to it.
+ * for their edition and gives them a link to switch to it.
  */
 export const useEditionSwitcherBanner = (
 	pageId: string,
 	userEdition: Edition,
 ): [boolean] => {
 	const pageEdition = getEditionFromPageId(pageId)?.editionId;
+	const isOnDifferentFrontToEdition =
+		isNetworkFront(pageId) && pageEdition !== userEdition;
 
 	const [shouldShowBanner, setShouldShowBanner] = useState(
-		pageEdition !== userEdition,
+		isOnDifferentFrontToEdition,
 	);
 
 	useEffect(() => {
 		setShouldShowBanner(
-			pageEdition !== userEdition && !hideBannerThroughUserOverride(),
+			isOnDifferentFrontToEdition && !hideBannerThroughUserOverride(),
 		);
-	}, [userEdition, pageId, pageEdition]);
+	}, [isOnDifferentFrontToEdition]);
 
 	useEffect(() => {
 		addOrRemoveCookie();

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -41,6 +41,11 @@ const hideBannerThroughUserOverride = () => {
 	);
 };
 
+type EditionSwitcherBanner = {
+	showBanner: boolean;
+	isBannerClosed: boolean;
+};
+
 /**
  * Show an "Edition Switcher" banner if the user is on a network front
  * which is different to their preferred or default edition.
@@ -51,7 +56,7 @@ const hideBannerThroughUserOverride = () => {
 export const useEditionSwitcherBanner = (
 	pageId: string,
 	userEdition: Edition,
-): [boolean, boolean] => {
+): EditionSwitcherBanner => {
 	const pageEdition = getEditionFromPageId(pageId)?.editionId;
 	const isOnMismatchedNetworkFront =
 		isNetworkFront(pageId) && pageEdition !== userEdition;
@@ -70,7 +75,7 @@ export const useEditionSwitcherBanner = (
 		addOrRemoveCookie();
 	}, []);
 
-	return [showBanner, isBannerClosed];
+	return { showBanner, isBannerClosed };
 };
 
 export const hideEditionSwitcherBanner = (): void => {

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -14,7 +14,7 @@ const apiPromise = new Promise<{ hidden: boolean }>(() => {
 
 const getBannerValueFromQueryParams = () => {
 	const queryParams = new URLSearchParams(window.location.search);
-	return queryParams.get('editionSwitcherBanner');
+	return queryParams.get('edition-switcher-banner');
 };
 
 const addOrRemoveCookie = () => {

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -49,14 +49,14 @@ export const useEditionSwitcherBanner = (
 	);
 
 	useEffect(() => {
-		addOrRemoveCookie();
-	}, []);
-
-	useEffect(() => {
 		setShouldShowBanner(
 			pageEdition !== userEdition && !hideBannerThroughUserOverride(),
 		);
 	}, [userEdition, pageId, pageEdition]);
+
+	useEffect(() => {
+		addOrRemoveCookie();
+	}, []);
 
 	return [shouldShowBanner];
 };

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -48,15 +48,15 @@ export const useEditionSwitcherBanner = (
 	userEdition: Edition,
 ): [boolean] => {
 	const pageEdition = getEditionFromPageId(pageId)?.editionId;
-	const isOnWrongNetworkFront =
+	const isOnMismatchedNetworkFront =
 		isNetworkFront(pageId) && pageEdition !== userEdition;
-	const [showBanner, setShowBanner] = useState(isOnWrongNetworkFront);
+	const [showBanner, setShowBanner] = useState(isOnMismatchedNetworkFront);
 
 	useEffect(() => {
 		setShowBanner(
-			isOnWrongNetworkFront && !hideBannerThroughUserOverride(),
+			isOnMismatchedNetworkFront && !hideBannerThroughUserOverride(),
 		);
-	}, [isOnWrongNetworkFront]);
+	}, [isOnMismatchedNetworkFront]);
 
 	useEffect(() => {
 		addOrRemoveCookie();

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -48,24 +48,21 @@ export const useEditionSwitcherBanner = (
 	userEdition: Edition,
 ): [boolean] => {
 	const pageEdition = getEditionFromPageId(pageId)?.editionId;
-	const isOnDifferentFrontToEdition =
+	const isOnWrongNetworkFront =
 		isNetworkFront(pageId) && pageEdition !== userEdition;
-
-	const [shouldShowBanner, setShouldShowBanner] = useState(
-		isOnDifferentFrontToEdition,
-	);
+	const [showBanner, setShowBanner] = useState(isOnWrongNetworkFront);
 
 	useEffect(() => {
-		setShouldShowBanner(
-			isOnDifferentFrontToEdition && !hideBannerThroughUserOverride(),
+		setShowBanner(
+			isOnWrongNetworkFront && !hideBannerThroughUserOverride(),
 		);
-	}, [isOnDifferentFrontToEdition]);
+	}, [isOnWrongNetworkFront]);
 
 	useEffect(() => {
 		addOrRemoveCookie();
 	}, []);
 
-	return [shouldShowBanner];
+	return [showBanner];
 };
 
 const key = 'edition-switcher-banner';

--- a/dotcom-rendering/src/lib/useUserPreferredEdition.ts
+++ b/dotcom-rendering/src/lib/useUserPreferredEdition.ts
@@ -1,0 +1,67 @@
+import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { useEffect, useState } from 'react';
+import { mutate } from 'swr';
+import { type EditionId as Edition, getEditionFromPageId } from './edition';
+
+const getBannerValueFromQueryParams = () => {
+	const queryParams = new URLSearchParams(window.location.search);
+	return queryParams.get('editionSwitcherBanner');
+};
+
+const addOrRemoveCookie = () => {
+	const value = getBannerValueFromQueryParams();
+	if (value === 'hide') {
+		setCookie({
+			name: 'gu_hide_edition_switcher_banner',
+			value: 'true',
+		});
+	} else if (value === 'unhide') {
+		removeCookie({ name: 'gu_hide_edition_switcher_banner' });
+	}
+};
+
+const hideBannerThroughUserOverride = () => {
+	const queryStringValue = getBannerValueFromQueryParams();
+	const cookieValue = getCookie({
+		name: 'gu_hide_edition_switcher_banner',
+	});
+
+	return (
+		queryStringValue === 'hide' ||
+		(cookieValue === 'true' && queryStringValue !== 'unhide')
+	);
+};
+
+/**
+ * Show an "Edition Switcher" banner if the user's preferred edition is different from the current edition.
+ *
+ * This allows a user to quickly identify that they are not on the network front
+ * for their preferred edition and provides a link to switch to it.
+ */
+export const useEditionSwitcherBanner = (
+	pageId: string,
+	userEdition: Edition,
+): [boolean] => {
+	const pageEdition = getEditionFromPageId(pageId)?.editionId;
+
+	const [shouldShowBanner, setShouldShowBanner] = useState(
+		pageEdition !== userEdition,
+	);
+
+	useEffect(() => {
+		addOrRemoveCookie();
+	}, []);
+
+	useEffect(() => {
+		setShouldShowBanner(
+			pageEdition !== userEdition && !hideBannerThroughUserOverride(),
+		);
+	}, [userEdition, pageId, pageEdition]);
+
+	return [shouldShowBanner];
+};
+
+const key = 'edition-switcher-banner';
+export const hideEditionSwitcherBanner = (): void => {
+	void mutate(key, { hidden: true }, false);
+};

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -560,3 +560,12 @@ export type TreatType = {
 	 */
 	pageId?: string;
 };
+
+export const NetworkFrontPageIds = [
+	'uk',
+	'us',
+	'au',
+	'international',
+	'europe',
+] as const;
+export type NetworkFrontPageId = (typeof NetworkFrontPageIds)[number];

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -560,12 +560,3 @@ export type TreatType = {
 	 */
 	pageId?: string;
 };
-
-export const NetworkFrontPageIds = [
-	'uk',
-	'us',
-	'au',
-	'international',
-	'europe',
-] as const;
-export type NetworkFrontPageId = (typeof NetworkFrontPageIds)[number];


### PR DESCRIPTION
Closes #11671

## What does this change?

Displays a banner which allows users to switch to their preferred or default network front. It is only displayed when the user is viewing any other network front. 

The banner is sticky to the top of the page as the user scrolls and can be dismissed by clicking the `X` button.

A user can indicate a preference for an edition by using the dropdown in the top-right on desktop pages and selecting their preferred edition. This stores a cookie `GU_EDITION` that remembers their edition preference. If the user _hasn't_ indicated a preference for an edition, their default edition will be decided in Fastly by their geolocation, which is likely to be the edition that is most relevant to them.

For example, a user that has selected the UK as their preferred edition and visits the US network front, `/us`, will be shown this banner. Similarly, a user that does not have this cookie but lives in the UK will also be shown this banner when visiting `/us`, or `/au`, `/europe` or `/international`.

The banner will show up every time the user goes to a network front different to their edition.

The subnav (with white background) and straight lines beneath it are not rendered when the banner is displayed. This is because the banner needs to be sticky over the main content and having the banner above the subnav isn't technically possible without updating the HTML of the page. This would undoubtedly affect other teams. For example, we don't want to risk interrupting the behaviour of the `top-above-nav` ad slot.

You can opt out of seeing the banner by visiting `https://www.theguardian.com/uk?editionSwitcherBanner=hide`. This will set a cookie that will hide the banner. Note that there may be a flash of content as the banner is rendered server-side. To remove this cookie, visit `https://www.theguardian.com/uk?editionSwitcherBanner=unhide`. I chose "unhide" rather than "show", as the latter may mislead users to think that it forces the banner to show, which it does not.

Tracking:
- Component: `data-component="edition-switcher-banner"`
- "View the ... homepage link: `data-link-name="edition-switcher-banner close-banner"`
- Close button: `data-link-name="edition-switcher-banner switch-edition"`

## Why?

We want to give users the option to go back to their default front if they've ended up on a different network front by accident (or been sent there incorrectly by a search engine).

This banner provides a visual indication to a user that has arrived on a different network front to their own, that there may be a network front with content more relevant to them.

## Screenshots

| <img width=400/> | UK edition on /uk | UK edition on /us |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| tablet | ![tablet-before] | ![tablet-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/25df77d5-4224-40b6-afd0-f18157080ba8
[tablet-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/519ff942-0d47-40e4-a365-1101a0cc6d53
[desktop-before]: https://github.com/guardian/dotcom-rendering/assets/9574885/2c09b7da-bd75-4194-af78-4a8fa4ed14dc
[mobile-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/890be06e-9099-47f5-b521-51d5792c5b97
[tablet-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/92c77cf6-0d0f-4406-991b-7ab3bdba43d9
[desktop-after]: https://github.com/guardian/dotcom-rendering/assets/9574885/983c20ab-3b78-4908-9b70-c6f8209422db


##  Screen recordings

https://github.com/guardian/dotcom-rendering/assets/9574885/57212231-ef55-4745-a775-56bff09d6388

https://github.com/guardian/dotcom-rendering/assets/9574885/0eb31e73-affe-4ecd-b714-2ef91f3a1b7b

