### PR TITLE
Improved `PinnedPost` gradient & dark scheme support

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -81,7 +81,6 @@ export const LiveBlogRenderer = ({
 					</Island>
 					<PinnedPost
 						pinnedPost={pinnedPost}
-						format={format}
 						absoluteServerTimes={absoluteServerTimes}
 					>
 						<LiveBlock

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -6,27 +7,37 @@ import {
 	Pillar,
 } from '@guardian/libs';
 import { breakpoints, from } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
 import { liveBlock } from '../../fixtures/manual/liveBlock';
+import { FormatBoundary } from './FormatBoundary';
 import { LiveBlock } from './LiveBlock';
 import { PinnedPost } from './PinnedPost';
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => {
+const Wrapper = ({
+	children,
+	format,
+}: {
+	children: React.ReactNode;
+	format: ArticleFormat;
+}) => {
 	return (
-		<div
-			css={css`
-				padding: 20px;
-				max-width: 700px;
-				${from.tablet} {
-					width: 700px;
-				}
-			`}
-		>
-			{children}
-		</div>
+		<FormatBoundary format={format}>
+			<div
+				css={css`
+					padding: 20px;
+					max-width: 700px;
+					${from.tablet} {
+						width: 700px;
+					}
+				`}
+			>
+				{children}
+			</div>
+		</FormatBoundary>
 	);
 };
 
-export default {
+const meta = {
 	component: PinnedPost,
 	title: 'Components/PinnedPost',
 	parameters: {
@@ -42,333 +53,288 @@ export default {
 			],
 		},
 	},
-};
+} satisfies Meta<typeof PinnedPost>;
 
-export const Sport = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: Pillar.Sport,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+export default meta;
 
-export const News = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: Pillar.News,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+type Story = StoryObj<typeof meta>;
 
-export const Culture = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: Pillar.Culture,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+const block = {
+	...liveBlock,
+	elements: [
+		{
+			elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
+			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+			html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
+		},
+		{
+			elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
+			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+			html: '<p>To recap:</p>',
+		},
+		{
+			elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
+			_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+			html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
+		},
+	],
+} satisfies Block;
 
-export const Lifestyle = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: Pillar.Lifestyle,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+export const Sport = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: Pillar.Sport,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
 
-export const Opinion = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: Pillar.Opinion,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+export const News = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: Pillar.News,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
 
-export const SpecialReport = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: ArticleSpecial.SpecialReport,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+export const Culture = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: Pillar.Culture,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
 
-export const Labs = () => {
-	const block: Block = {
-		...liveBlock,
-		elements: [
-			{
-				elementId: '14ffdfde-113a-4270-afca-d34436dca56e',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>That’s it for our live coverage of Nasa’s celebratory news conference and Q&amp;A following the successful landing of the rover Perseverance on Mars. </p>',
-			},
-			{
-				elementId: '1e877282-4d8f-45b0-8b2a-a27060dfc7f5',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<p>To recap:</p>',
-			},
-			{
-				elementId: 'b48f6547-8346-416d-a8be-2e0e6e254087',
-				_type: 'model.dotcomrendering.pageElements.TextBlockElement',
-				html: '<ul> \n <li>The rover is “healthy” and undergoing systems testing.</li> \n <li>It already has beamed back stunning photos from the surface of <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> promising significant scientific discoveries ahead.</li> \n <li>The images include the first color images beamed directly from <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> as opposed to images touched up later.</li> \n <li>The rover documented its own touchdown via an ingenious system of booster rockets and a “space crane”.</li> \n <li>It landed in a “pool-table flat” crater in a prime location for searching for traces of ancient life.</li> \n <li>The wheeled rover could begin to move around its new home as early as late February.</li> \n <li>The rover’s mini helicopter could launch as early as April.</li> \n <li>Its broad mission is to stay on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> for a couple years, gather data and harvest samples to be collected and returned to Earth on a future mission.</li> \n <li>The point is to determine whether there was life on <a href="https://www.theguardian.com/science/mars" data-component="auto-linked-tag">Mars</a> and subsidiary questions.</li> \n <li>The team at Nasa is very happy and excited, “on cloud nine” in a “weird, dreamlike state”... with lots of work ahead.</li> \n</ul>',
-			},
-		],
-	};
-	const format = {
-		theme: ArticleSpecial.Labs,
-		design: ArticleDesign.LiveBlog,
-		display: ArticleDisplay.Standard,
-	};
-	return (
-		<Wrapper>
-			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
-				<LiveBlock
-					format={format}
-					block={block}
-					pageId=""
-					webTitle=""
-					ajaxUrl=""
-					isAdFreeUser={false}
-					isSensitive={false}
-					abTests={{}}
-					switches={{}}
-					isPinnedPost={true}
-					editionId={'UK'}
-				/>
-			</PinnedPost>
-		</Wrapper>
-	);
-};
+export const Lifestyle = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: Pillar.Lifestyle,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
+
+export const Opinion = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: Pillar.Opinion,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
+
+export const SpecialReport = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: ArticleSpecial.SpecialReport,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;
+
+export const Labs = {
+	args: {
+		pinnedPost: block,
+		absoluteServerTimes: true,
+		children: null,
+	},
+	render: ({ pinnedPost, absoluteServerTimes }) => {
+		const format = {
+			theme: ArticleSpecial.Labs,
+			design: ArticleDesign.LiveBlog,
+			display: ArticleDisplay.Standard,
+		};
+		return (
+			<Wrapper format={format}>
+				<PinnedPost
+					pinnedPost={pinnedPost}
+					absoluteServerTimes={absoluteServerTimes}
+				>
+					<LiveBlock
+						format={format}
+						block={pinnedPost}
+						pageId=""
+						webTitle=""
+						ajaxUrl=""
+						isAdFreeUser={false}
+						isSensitive={false}
+						abTests={{}}
+						switches={{}}
+						isPinnedPost={true}
+						editionId={'UK'}
+					/>
+				</PinnedPost>
+			</Wrapper>
+		);
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -72,11 +72,7 @@ export const Sport = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -123,11 +119,7 @@ export const News = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -174,11 +166,7 @@ export const Culture = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -225,11 +213,7 @@ export const Lifestyle = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -276,11 +260,7 @@ export const Opinion = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -327,11 +307,7 @@ export const SpecialReport = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}
@@ -378,11 +354,7 @@ export const Labs = () => {
 	};
 	return (
 		<Wrapper>
-			<PinnedPost
-				pinnedPost={block}
-				format={format}
-				absoluteServerTimes={true}
-			>
+			<PinnedPost pinnedPost={block} absoluteServerTimes={true}>
 				<LiveBlock
 					format={format}
 					block={block}

--- a/dotcom-rendering/src/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.tsx
@@ -16,15 +16,14 @@ import {
 	SvgPinned,
 	SvgPlus,
 } from '@guardian/source/react-components';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
+import { palette } from '../palette';
 import { DateTime } from './DateTime';
 
-const pinnedPostContainer = (palette: Palette) => css`
-	border: 3px solid ${palette.border.pinnedPost};
+const pinnedPostContainer = css`
+	border: 3px solid ${palette('--pinned-post-border')};
 	padding-bottom: ${space[1]}px;
 	position: relative;
-	background: ${sourcePalette.neutral[100]};
+	background: ${palette('--pinned-post-background')};
 	${from.mobile} {
 		margin-bottom: 34px;
 	}
@@ -52,8 +51,8 @@ const pinnedPostContainer = (palette: Palette) => css`
 	}
 `;
 
-const rowStyles = (palette: Palette) => css`
-	background: ${palette.border.pinnedPost};
+const rowStyles = css`
+	background: ${palette('--pinned-post-border')};
 	height: 32px;
 	display: flex;
 	align-items: center;
@@ -76,8 +75,8 @@ const timeAgoStyles = css`
 const overlayStyles = css`
 	background-image: linear-gradient(
 		0deg,
-		${sourcePalette.neutral[100]},
-		${sourcePalette.neutral[100]} 40%,
+		${palette('--pinned-post-background')},
+		${palette('--pinned-post-background')} 40%,
 		rgba(255, 255, 255, 0)
 	);
 	height: 80px;
@@ -87,7 +86,7 @@ const overlayStyles = css`
 	display: block;
 `;
 
-const fakeButtonStyles = (palette: Palette) => css`
+const fakeButtonStyles = css`
 	display: inline-flex;
 	justify-content: space-between;
 	align-items: center;
@@ -103,7 +102,7 @@ const fakeButtonStyles = (palette: Palette) => css`
 	&:focus {
 		${focusHalo};
 	}
-	background: ${palette.border.pinnedPost};
+	background: ${palette('--pinned-post-border')};
 	margin-left: 10px;
 	position: absolute;
 	bottom: -24px;
@@ -140,21 +139,18 @@ const buttonIcon = css`
 type Props = {
 	pinnedPost: Block;
 	children: React.ReactNode;
-	format: ArticleFormat;
 	absoluteServerTimes: boolean;
 };
 
 export const PinnedPost = ({
 	pinnedPost,
 	children,
-	format,
 	absoluteServerTimes,
 }: Props) => {
-	const palette = decidePalette(format);
 	return (
 		<div
 			id="pinned-post"
-			css={pinnedPostContainer(palette)}
+			css={pinnedPostContainer}
 			data-gu-marker="pinned-post"
 			data-component="pinned-post"
 		>
@@ -169,7 +165,7 @@ export const PinnedPost = ({
 				tabIndex={-1}
 				key="PinnedPostCheckbox"
 			/>
-			<div css={rowStyles(palette)}>
+			<div css={rowStyles}>
 				<SvgPinned />
 				{!isUndefined(pinnedPost.blockFirstPublished) && (
 					<div css={timeAgoStyles}>
@@ -191,7 +187,7 @@ export const PinnedPost = ({
 			</div>
 			<div id="pinned-post-overlay" css={overlayStyles} />
 			<label
-				css={fakeButtonStyles(palette)}
+				css={fakeButtonStyles}
 				htmlFor="pinned-post-checkbox"
 				id="pinned-post-button"
 			>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -225,27 +225,6 @@ const fillGuardianLogo = (format: ArticleFormat): string => {
 	return WHITE;
 };
 
-const borderPinnedPost = (format: ArticleFormat): string => {
-	switch (format.theme) {
-		case Pillar.News:
-			return news[300];
-		case Pillar.Culture:
-			return culture[300];
-		case Pillar.Lifestyle:
-			return lifestyle[300];
-		case Pillar.Sport:
-			return sport[300];
-		case Pillar.Opinion:
-			return opinion[300];
-		case ArticleSpecial.Labs:
-			return labs[300];
-		case ArticleSpecial.SpecialReport:
-			return specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return news[300];
-	}
-};
-
 const borderStandfirstLink = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) {
 		switch (format.theme) {
@@ -571,7 +550,6 @@ export const decidePalette = (
 			guardianLogo: fillGuardianLogo(format),
 		},
 		border: {
-			pinnedPost: borderPinnedPost(format),
 			standfirstLink: borderStandfirstLink(format),
 			headline: borderHeadline(format),
 			navPillar: borderNavPillar(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5421,6 +5421,39 @@ const mastheadVeggieBurgerBackground: PaletteFunction = () =>
 const mastheadVeggieBurgerBackgroundHover: PaletteFunction = () =>
 	sourcePalette.brandAlt[300];
 
+const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 300);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[300];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[300];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[300];
+	}
+};
+const pinnedPostBorderDark: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.News:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+		case Pillar.Sport:
+		case Pillar.Opinion:
+			return pillarPalette(theme, 200);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[200];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[200];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.news[200];
+	}
+};
+
 const tagLinkBackground: PaletteFunction = () => sourcePalette.sport[800];
 const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
 	switch (design) {
@@ -6298,6 +6331,14 @@ const paletteColours = {
 	'--pagination-text': {
 		light: paginationTextLight,
 		dark: paginationTextDark,
+	},
+	'--pinned-post-background': {
+		light: liveBlockContainerBackgroundLight,
+		dark: liveBlockContainerBackgroundDark,
+	},
+	'--pinned-post-border': {
+		light: pinnedPostBorderLight,
+		dark: pinnedPostBorderDark,
 	},
 	'--privacy-text-regular': {
 		light: privacyTextRegularLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -36,7 +36,6 @@ export type Palette = {
 		guardianLogo: Colour;
 	};
 	border: {
-		pinnedPost: Colour;
 		standfirstLink: Colour;
 		headline: Colour;
 		navPillar: Colour;


### PR DESCRIPTION
## What does this change?

Make the PinnedPost more resilient to colour changes:
- no need for `format` being passed through
- no more dynamic styles
- follow-up on #11585

## Why?

Enable smooth transition for DCAR

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

<img width="738" alt="image" src="">



[before]: https://github.com/guardian/dotcom-rendering/assets/76776/9d5e8490-4595-41c1-a202-32c67c95691b
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/8a7d36fb-9997-4da7-bd0d-872d9f4740b1
