### PR TITLE
UK election 2024 scaling

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -16,8 +16,8 @@ new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
 	app: 'rendering',
 	stage: 'PROD',
-	minCapacity: 3,
-	maxCapacity: 30,
+	minCapacity: 6,
+	maxCapacity: 60,
 	instanceType: 't4g.small',
 });
 new DotcomRendering(cdkApp, 'DotcomRendering-CODE', {
@@ -42,8 +42,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 36,
+		maximumInstances: 360,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s
@@ -77,8 +77,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 36,
+		maximumInstances: 360,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
@@ -112,8 +112,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 36,
+		maximumInstances: 360,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
@@ -147,8 +147,8 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'interactive-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 3,
-		maximumInstances: 30,
+		minimumInstances: 12,
+		maximumInstances: 120,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.2s


### PR DESCRIPTION
## What does this change?

Scale the ASG Min and Max in preparation for the UK Election 2024.

This is a precaution to handle expected increase of base traffic and traffic spikes.

All stacks have been doubled with the exception of the interactive stack which has been quadrupled as it is under-resourced when compared to the other stacks.

| stack | scaling |
|:-- |:-- |
|article, facia, tag-page, legacy-rendering | 2x |
| interactive | 4x |



