### PR TITLE
Increase `rendering` App Max Capacity

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -17,7 +17,7 @@ new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	app: 'rendering',
 	stage: 'PROD',
 	minCapacity: 3,
-	maxCapacity: 12,
+	maxCapacity: 24,
 	instanceType: 't4g.small',
 });
 new DotcomRendering(cdkApp, 'DotcomRendering-CODE', {


### PR DESCRIPTION
This app scales by doubling the number of boxes. This change temporarily increases the headroom, so that we still have space to deploy if it's scaled up.
