### PR TITLE
Encapsulate logic for dark card backgrounds in libs

### DIFF
--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -119,7 +119,8 @@ const imgStyles = (lightLogoWidth: number) => css`
 	height: fit-content;
 `;
 
-function decideLogo(
+/** @todo Future improvement to align with src/lib/decideLogo.ts */
+function decideArticleLogo(
 	branding: BrandingType,
 	format: ArticleFormat,
 	darkModeAvailable: boolean,
@@ -259,7 +260,7 @@ export const Branding = ({ branding, format }: Props) => {
 					data-component={ophanComponentName}
 					data-link-name={ophanComponentLink}
 				>
-					{decideLogo(branding, format, darkModeAvailable)}
+					{decideArticleLogo(branding, format, darkModeAvailable)}
 				</a>
 			</div>
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -7,7 +7,7 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
-import { isUnsupportedFormatForCardWithoutBackground } from '../../lib/cardHelpers';
+import { isMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { palette as themePalette } from '../../palette';
@@ -343,9 +343,7 @@ export const Card = ({
 	 * Some cards in standard containers have contrasting background colours.
 	 * We need to add additional padding to these cards to keep the text readable.
 	 */
-	const hasBackgroundColour =
-		!containerPalette &&
-		isUnsupportedFormatForCardWithoutBackground(format);
+	const hasBackgroundColour = !containerPalette && isMediaCard(format);
 
 	return (
 		<CardWrapper

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { timeAgo } from '@guardian/libs';
 import { from, textSans12, textSansBold12 } from '@guardian/source/foundations';
-import { isUnsupportedFormatForCardWithoutBackground } from '../../../lib/cardHelpers';
+import { cardHasDarkBackground } from '../../../lib/cardHelpers';
 import { palette } from '../../../palette';
 import ClockIcon from '../../../static/icons/clock.svg';
 import { DateTime } from '../../DateTime';
@@ -48,9 +48,7 @@ const ageStyles = (format: ArticleFormat, isOnwardsContent?: boolean) => {
 		}
 
 		> time {
-			${isUnsupportedFormatForCardWithoutBackground(format)
-				? textSansBold12
-				: textSans12};
+			${cardHasDarkBackground(format) ? textSansBold12 : textSans12};
 		}
 	`;
 };

--- a/dotcom-rendering/src/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardBranding.tsx
@@ -4,7 +4,7 @@ import {
 	textSans12,
 	visuallyHidden,
 } from '@guardian/source/foundations';
-import { decideLogo } from '../../../lib/decideLogo';
+import { decideCardLogo } from '../../../lib/decideLogo';
 import { getZIndex } from '../../../lib/getZIndex';
 import { getOphanComponents } from '../../../lib/labs';
 import { palette as themePalette } from '../../../palette';
@@ -48,7 +48,7 @@ export const CardBranding = ({
 	onwardsSource,
 	containerPalette,
 }: Props) => {
-	const logo = decideLogo(format, branding, containerPalette);
+	const logo = decideCardLogo(branding, format, containerPalette);
 
 	/**
 	 * Only apply click tracking to branding on related content

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
 import { between, from, space } from '@guardian/source/foundations';
-import { isUnsupportedFormatForCardWithoutBackground } from '../lib/cardHelpers';
+import { isMediaCard } from '../lib/cardHelpers';
 import { palette } from '../palette';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
 import { CardHeadline } from './CardHeadline';
@@ -141,9 +141,7 @@ export const SupportingContent = ({
 				 * is not compatible with transparent backgrounds */
 				const subLinkFormat = {
 					...subLink.format,
-					design: isUnsupportedFormatForCardWithoutBackground(
-						subLink.format,
-					)
+					design: isMediaCard(subLink.format)
 						? ArticleDesign.Standard
 						: subLink.format.design,
 				};

--- a/dotcom-rendering/src/lib/cardHelpers.test.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.test.ts
@@ -1,26 +1,67 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { isUnsupportedFormatForCardWithoutBackground } from './cardHelpers';
+import type { DCRContainerPalette } from '../types/front';
+import { cardHasDarkBackground } from './cardHelpers';
 
-describe('isUnsupportedFormatForCardWithoutBackground', () => {
+describe('cardHasDarkBackground', () => {
 	const standardArticleFormat = {
 		design: ArticleDesign.Standard,
 		display: ArticleDisplay.Standard,
 		theme: Pillar.News,
 	};
 
-	it('should return false for ArticleDesign.Picture', () => {
-		const format = {
-			...standardArticleFormat,
-			design: ArticleDesign.Picture,
-		};
-		expect(isUnsupportedFormatForCardWithoutBackground(format)).toBe(false);
-	});
+	const pictureFormat = {
+		...standardArticleFormat,
+		design: ArticleDesign.Picture,
+	};
 
-	it('should return true for ArticleDesign.Gallery', () => {
-		const format = {
-			...standardArticleFormat,
-			design: ArticleDesign.Gallery,
-		};
-		expect(isUnsupportedFormatForCardWithoutBackground(format)).toBe(true);
-	});
+	const galleryFormat = {
+		...standardArticleFormat,
+		design: ArticleDesign.Gallery,
+	};
+
+	const testCases = [
+		{
+			format: pictureFormat,
+			containerPalette: undefined,
+			expectedResult: false,
+		},
+		{
+			format: galleryFormat,
+			containerPalette: undefined,
+			expectedResult: true,
+		},
+		{
+			format: pictureFormat,
+			containerPalette: 'Branded',
+			expectedResult: false,
+		},
+		{
+			format: galleryFormat,
+			containerPalette: 'Branded',
+			expectedResult: false,
+		},
+		{
+			format: pictureFormat,
+			containerPalette: 'SombrePalette',
+			expectedResult: true,
+		},
+		{
+			format: galleryFormat,
+			containerPalette: 'SombrePalette',
+			expectedResult: true,
+		},
+	] satisfies {
+		format: ArticleFormat;
+		containerPalette?: DCRContainerPalette;
+		expectedResult: boolean;
+	}[];
+
+	it.each(testCases)(
+		'returns $expectedResult for $format format, $containerPalette containerPalette',
+		({ format, containerPalette, expectedResult }) => {
+			expect(cardHasDarkBackground(format, containerPalette)).toBe(
+				expectedResult,
+			);
+		},
+	);
 });

--- a/dotcom-rendering/src/lib/cardHelpers.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.ts
@@ -1,8 +1,46 @@
 import { ArticleDesign } from '@guardian/libs';
+import type { DCRContainerPalette } from '../types/front';
 
-export const isUnsupportedFormatForCardWithoutBackground = (
+export const isMediaCard = (format: ArticleFormat): boolean => {
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+		case ArticleDesign.Audio:
+		case ArticleDesign.Video: {
+			return true;
+		}
+		default: {
+			return false;
+		}
+	}
+};
+
+export const cardHasDarkBackground = (
 	format: ArticleFormat,
-): boolean =>
-	[ArticleDesign.Video, ArticleDesign.Audio, ArticleDesign.Gallery].includes(
-		format.design,
-	);
+	containerPalette?: DCRContainerPalette,
+): boolean => {
+	switch (containerPalette) {
+		// Special palettes with dark background colours on containers
+		case 'BreakingPalette':
+		case 'SombrePalette':
+		case 'InvestigationPalette':
+		case 'SombreAltPalette':
+			return true;
+
+		// Special palettes with light background colours on containers
+		case 'Branded':
+		case 'EventAltPalette':
+		case 'EventPalette':
+		case 'LongRunningAltPalette':
+		case 'LongRunningPalette':
+		case 'SpecialReportAltPalette':
+			return false;
+
+		// Special palettes which act more like standard containers
+		case 'MediaPalette':
+		case 'PodcastPalette':
+		// If no containerPalette provided, card is in a standard container
+		case undefined: {
+			return isMediaCard(format);
+		}
+	}
+};

--- a/dotcom-rendering/src/lib/decideLogo.ts
+++ b/dotcom-rendering/src/lib/decideLogo.ts
@@ -1,50 +1,13 @@
-import { ArticleDesign } from '@guardian/libs';
 import type { Branding } from '../types/branding';
 import type { DCRContainerPalette } from '../types/front';
+import { cardHasDarkBackground } from './cardHelpers';
 
-const shouldUseLogoForDarkBackground = (
-	format: ArticleFormat,
-	containerPalette?: DCRContainerPalette,
-): boolean => {
-	switch (containerPalette) {
-		// Special palettes with dark background colours on containers
-		case 'BreakingPalette':
-		case 'SombrePalette':
-		case 'InvestigationPalette':
-		case 'SombreAltPalette':
-			return true;
-
-		// Special palettes with light background colours on containers
-		case 'Branded':
-		case 'EventAltPalette':
-		case 'EventPalette':
-		case 'LongRunningAltPalette':
-		case 'LongRunningPalette':
-		case 'SpecialReportAltPalette':
-			return false;
-
-		// Special palettes which act more like standard containers
-		case 'MediaPalette':
-		case 'PodcastPalette':
-		case undefined: {
-			switch (format.design) {
-				case ArticleDesign.Gallery:
-				case ArticleDesign.Audio:
-				case ArticleDesign.Video:
-					return true;
-				default:
-					return false;
-			}
-		}
-	}
-};
-
-export const decideLogo = (
-	format: ArticleFormat,
+export const decideCardLogo = (
 	branding: Branding,
+	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
 ): Branding['logo'] => {
-	return shouldUseLogoForDarkBackground(format, containerPalette) &&
+	return cardHasDarkBackground(format, containerPalette) &&
 		branding.logoForDarkBackground
 		? branding.logoForDarkBackground
 		: branding.logo;


### PR DESCRIPTION
## What does this change?

Follow-up PR for https://github.com/guardian/dotcom-rendering/pull/11772

- Moves the logic for whether a card has a "dark" background into a central `libs` location rather than living directly in the `decideLogo` directory
- Renames long, complicated `isUnsupportedFormatForCardWithoutBackground` in `cardHelpers.ts` to simply `isMediaCard` since this is what it really represents.
- Adds more tests to `cardHelpers` file since the introduction of `containerPalette` into the decision of whether the card has a "dark" background or not
- Renames `decideLogo` in two places to better indicate what they are designed for (articles and cards) with todo comment to hint at future improvement

## Why?

Avoids duplication of logic and centralises it so that other areas in the codebase can rely on consistent decision making.
