### PR TITLE
Fix original choice card selection params

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -507,6 +507,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					amountsTestName={choiceCardAmounts?.testName}
 					amountsVariantName={choiceCardAmounts?.variantName}
 					choiceCardSelection={choiceCardSelection}
+					showThreeTierChoiceCards={showThreeTierChoiceCards}
 					threeTierChoiceCardSelectedAmount={
 						threeTierChoiceCardSelectedAmount
 					}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -142,6 +142,7 @@ interface ContributionsEpicButtonsProps {
 	amountsTestName?: string;
 	amountsVariantName?: string;
 	choiceCardSelection?: ChoiceCardSelection;
+	showThreeTierChoiceCards?: boolean;
 	threeTierChoiceCardSelectedAmount?: number;
 	numArticles: number;
 }
@@ -156,6 +157,7 @@ export const ContributionsEpicButtons = ({
 	isSignedIn,
 	showChoiceCards,
 	choiceCardSelection,
+	showThreeTierChoiceCards,
 	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
@@ -182,7 +184,10 @@ export const ContributionsEpicButtons = ({
 	}
 
 	const getChoiceCardCta = (cta: Cta): Cta => {
-		if (threeTierChoiceCardSelectedAmount != undefined) {
+		if (
+			showThreeTierChoiceCards &&
+			threeTierChoiceCardSelectedAmount != undefined
+		) {
 			return {
 				text: cta.text,
 				baseUrl: addChoiceCardsParams(

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
@@ -17,6 +17,7 @@ interface OnReminderOpen {
 type ContributionsEpicCtasProps = EpicProps & {
 	showChoiceCards?: boolean;
 	choiceCardSelection?: ChoiceCardSelection;
+	showThreeTierChoiceCards?: boolean;
 	threeTierChoiceCardSelectedAmount?: number;
 	amountsTestName?: string;
 	amountsVariantName?: string;
@@ -34,6 +35,7 @@ export const ContributionsEpicCtas: ReactComponent<
 	fetchEmail,
 	showChoiceCards,
 	choiceCardSelection,
+	showThreeTierChoiceCards,
 	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
@@ -82,6 +84,7 @@ export const ContributionsEpicCtas: ReactComponent<
 				isSignedIn={Boolean(fetchedEmail)}
 				showChoiceCards={showChoiceCards}
 				choiceCardSelection={choiceCardSelection}
+				showThreeTierChoiceCards={showThreeTierChoiceCards}
 				threeTierChoiceCardSelectedAmount={
 					threeTierChoiceCardSelectedAmount
 				}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -265,6 +265,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 							submitComponentEvent={submitComponentEvent}
 							showChoiceCards={showChoiceCards}
 							choiceCardSelection={choiceCardSelection}
+							showThreeTierChoiceCards={showThreeTierChoiceCards}
 							threeTierChoiceCardSelectedAmount={
 								threeTierChoiceCardSelectedAmount
 							}


### PR DESCRIPTION
## What does this change?

Use the three tier choice card selected amount in CTA URL params, only if the three tier choice cards are visible.

## Why?

Fix a bug where the existing choice card selection was not being passed through to the CTA URL, because the default amount for the three tier selection was set

## Screenshots

### Before
Choice card
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/64d6cf23-7af4-45af-b6d7-fe4360fdd7c2)

Selection not reflected on checkout
![image](https://github.com/guardian/dotcom-rendering/assets/114918544/98968cbd-a118-4318-9ad9-807a5654c8a5)

### After

![image](https://github.com/guardian/dotcom-rendering/assets/114918544/eb346062-bac2-4025-97d2-c7969eaa029f)


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
