### PR TITLE
Right column at wide breakpoint right to the edge

### DIFF
--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -90,7 +90,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 
 					${display === ArticleDisplay.Showcase
 						? css`

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -90,7 +90,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 80px 300px;
+					grid-template-columns: 219px 1px 620px 60px 320px;
 
 					${display === ArticleDisplay.Showcase
 						? css`

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -86,7 +86,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
-					grid-template-columns: 219px 1px 620px 80px 300px;
+					grid-template-columns: 219px 1px 620px 60px 320px;
 					grid-template-areas:
 						'caption    border      title      . right-column'
 						'.          border      headline   . right-column'

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -86,7 +86,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 					grid-template-areas:
 						'caption    border      title      . right-column'
 						'.          border      headline   . right-column'

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -87,7 +87,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 					grid-template-areas:
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -87,7 +87,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 80px 300px;
+					grid-template-columns: 219px 1px 620px 60px 320px;
 					grid-template-areas:
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -99,7 +99,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 80px 300px;
+					grid-template-columns: 219px 1px 620px 60px 320px;
 
 					${isMatchReport
 						? css`

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -99,7 +99,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 
 					${isMatchReport
 						? css`


### PR DESCRIPTION
## What does this change?

Upon a request from @HarryFischer, fix the location of the right column at wide breakpoints further to the right.

## Why?

The right column should only be 20px from the border, not 40px, as per the designs.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/ac8b28f3-913d-4a1b-a1d1-d8f3d601418f
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/3eb05084-3883-48d3-8366-5343d6764ba8
