### PR TITLE
Trigger Chromatic diff for `AdSlot` apps stories

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
 	decorators: [rightColumnDecorator],
 	parameters: {
 		chromatic: {
+			diffThreshold: 0.012,
 			modes: {
 				'vertical mobileMedium': allModes['vertical mobileMedium'],
 				'light desktop': allModes['light desktop'],


### PR DESCRIPTION
## What does this change?

- lower visual diff threshold

## Why?

Demonstrate a Chromatic bug, and ease @Jakeii’s mind with #11648 