### PR TITLE
New polyfill URL

### DIFF
--- a/dotcom-rendering/src/lib/polyfill.io.ts
+++ b/dotcom-rendering/src/lib/polyfill.io.ts
@@ -1,4 +1,4 @@
-/** Polyfill.io script URL @see https://polyfill.io/ */
+/** Polyfill.io script URL @see https://polyfill-fastly.net/ */
 export const polyfillIO = `https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?${new URLSearchParams(
 	{
 		/** Undocumented; probably opting out of real user monitoring… */

--- a/dotcom-rendering/src/lib/polyfill.io.ts
+++ b/dotcom-rendering/src/lib/polyfill.io.ts
@@ -10,7 +10,7 @@ export const polyfillIO = `https://assets.guim.co.uk/polyfill.io/v3/polyfill.min
 		 *
 		 * Available feature names are shown on the [features page][].
 		 *
-		 * [features page]: https://polyfill.io/v3/url-builder
+		 * [features page]: https://polyfill-fastly.net/
 		 */
 		features: [
 			'es6',


### PR DESCRIPTION
## What does this change?

Link to [Fastly Polyfill](https://polyfill-fastly.io/) website.

## Why?

The previous, [malicious website](https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack) no longer works.