### PR TITLE
Fix Treats so they uses the palette properly

### DIFF
--- a/dotcom-rendering/src/components/Treats.stories.tsx
+++ b/dotcom-rendering/src/components/Treats.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { Treats } from './Treats';
 import { Pillar } from '@guardian/libs';
+import { Treats } from './Treats';
 
 export default {
 	component: Treats,

--- a/dotcom-rendering/src/components/Treats.stories.tsx
+++ b/dotcom-rendering/src/components/Treats.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { Treats } from './Treats';
+import { Pillar } from '@guardian/libs';
 
 export default {
 	component: Treats,
@@ -46,3 +47,28 @@ export const Default = () => {
 	);
 };
 Default.storyName = 'Default';
+
+export const US = () => {
+	return (
+		<Wrapper>
+			<Treats
+				treats={[
+					{
+						links: [
+							{
+								linkTo: '/us/wellness',
+								text: 'Read more on living a good life in a complex world.',
+							},
+						],
+						theme: Pillar.Lifestyle,
+						imageUrl:
+							'https://uploads.guim.co.uk/2023/10/30/Wellness_Treat.png',
+						altText: 'Well Actually logo',
+						pageId: 'us',
+						containerTitle: 'Spotlight',
+					},
+				]}
+			/>
+		</Wrapper>
+	);
+};

--- a/dotcom-rendering/src/components/Treats.tsx
+++ b/dotcom-rendering/src/components/Treats.tsx
@@ -3,15 +3,14 @@ import { ArticleDesign, ArticleDisplay } from '@guardian/libs';
 import {
 	from,
 	headlineMedium17,
-	palette as sourcePalette,
 	space,
 	textSans12,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { Fragment } from 'react';
-import { decidePalette } from '../lib/decidePalette';
-import { palette as schemePalette } from '../palette';
+import { palette } from '../palette';
 import type { TreatType } from '../types/front';
+import { FormatBoundary } from './FormatBoundary';
 import { generateSources, getFallbackSource } from './Picture';
 import { SvgCrossword } from './SvgCrossword';
 
@@ -30,9 +29,8 @@ const TextTreat = ({
 		css={css`
 			margin-top: ${space[3]}px;
 			border-left: 1px solid
-				${borderColour ?? schemePalette('--article-border')};
-			border-top: 1px solid
-				${borderColour ?? schemePalette('--article-border')};
+				${borderColour ?? palette('--article-border')};
+			border-top: 1px solid ${borderColour ?? palette('--article-border')};
 			padding-top: ${space[1]}px;
 			padding-left: ${space[2]}px;
 		`}
@@ -57,12 +55,10 @@ const ImageTreat = ({
 	imageUrl,
 	links,
 	altText,
-	backgroundColour,
 }: {
 	imageUrl: string;
 	links: { text: string; title?: string; linkTo: string }[];
 	altText?: string;
-	backgroundColour: string;
 }) => {
 	const sources = generateSources(imageUrl, [
 		{ breakpoint: 320, width: 130 },
@@ -137,15 +133,13 @@ const ImageTreat = ({
 								css={css`
 									${headlineMedium17};
 									font-size: 16px;
-									background-color: ${index % 2 === 0
-										? sourcePalette.neutral[0]
-										: backgroundColour};
+									background-color: ${palette(
+										'--treat-background',
+									)};
 									padding: 0 5px 4px;
 									box-decoration-break: clone;
 									position: relative;
-									color: ${schemePalette(
-										'--article-section-title',
-									)};
+									color: ${palette('--treat-text')};
 									text-decoration: none;
 									:hover {
 										text-decoration: underline;
@@ -215,19 +209,21 @@ export const Treats = ({
 					treat.altText &&
 					treat.theme !== undefined
 				) {
-					const palette = decidePalette({
-						display: ArticleDisplay.Standard,
-						design: ArticleDesign.Standard,
-						theme: treat.theme,
-					});
 					return (
-						<ImageTreat
+						<FormatBoundary
 							key={treat.imageUrl}
-							imageUrl={treat.imageUrl}
-							links={treat.links}
-							altText={treat.altText}
-							backgroundColour={palette.background.treat}
-						/>
+							format={{
+								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: treat.theme,
+							}}
+						>
+							<ImageTreat
+								imageUrl={treat.imageUrl}
+								links={treat.links}
+								altText={treat.altText}
+							/>
+						</FormatBoundary>
 					);
 				}
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6675,6 +6675,14 @@ const paletteColours = {
 		light: timelineEventBorderLight,
 		dark: timelineEventBorderDark,
 	},
+	'--treat-background': {
+		light: () => sourcePalette.neutral[0],
+		dark: () => sourcePalette.neutral[97],
+	},
+	'--treat-text': {
+		light: () => sourcePalette.neutral[97],
+		dark: () => sourcePalette.neutral[7],
+	},
 	'--trending-topics-background': {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[7],


### PR DESCRIPTION
## What does this change?

Ensure `Treats.tsx` uses the `palette.ts` declarations

## Why?

So it adequately responds to colour scheme and format, and is always readable.

Missed in #11372

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/dotcom-rendering/assets/76776/24a273a9-15d8-4f9d-918e-d2d5b455612c
[after]: https://github.com/guardian/dotcom-rendering/assets/76776/af6a9961-f413-4ace-b27d-d4355ce77fdc