### PR TITLE
Prefer WARN To ERROR For YouTube ID

### DIFF
--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -13,7 +13,7 @@ export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const url = element.originalUrl || element.url;
 	const youtubeId = getIdFromUrl(url, true, 'v');
 
-	logger.log(levels.ERROR, `Could not get an id from: ${url}`);
+	logger.log(levels.WARN, `Could not get an id from: ${url}`);
 	if (!youtubeId) return null;
 
 	return (


### PR DESCRIPTION
We still render the page if this occurs, the video just isn't rendered. Therefore this could be a warning, which would mean it generates less noise in the logs, particularly when looking for other errors.
