### PR TITLE
Only Log When The Video ID Is Missing

### DIFF
--- a/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoVimeoBlockComponent.amp.tsx
@@ -17,8 +17,10 @@ export const VideoVimeoBlockComponent = ({ element, pillar }: Props) => {
 	const url = element.url === '' ? element.originalUrl ?? '' : element.url;
 	const vimeoId = getIdFromUrl(url, true);
 
-	logger.log(levels.ERROR, `Could not get an id from: ${url}`);
-	if (!vimeoId) return null;
+	if (!vimeoId) {
+		logger.log(levels.WARN, `Could not get an id from: ${url}`);
+		return null;
+	}
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>

--- a/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/VideoYoutubeBlockComponent.amp.tsx
@@ -13,8 +13,10 @@ export const VideoYoutubeBlockComponent = ({ element, pillar }: Props) => {
 	const url = element.originalUrl || element.url;
 	const youtubeId = getIdFromUrl(url, true, 'v');
 
-	logger.log(levels.ERROR, `Could not get an id from: ${url}`);
-	if (!youtubeId) return null;
+	if (!youtubeId) {
+		logger.log(levels.WARN, `Could not get an id from: ${url}`);
+		return null;
+	}
 
 	return (
 		<Caption captionText={element.caption} pillar={pillar}>


### PR DESCRIPTION
This was always logging, regardless of whether the id was found.

Also switches from ERROR to WARN. We still render the page if this occurs, the video just isn't rendered. Therefore this could be a warning, which would mean it generates less noise in the logs, particularly when looking for other errors.
