### PR TITLE
Add partner code to weather widget link

### DIFF
--- a/dotcom-rendering/src/components/Weather.stories.tsx
+++ b/dotcom-rendering/src/components/Weather.stories.tsx
@@ -27,7 +27,7 @@ export default {
 				metric: 10,
 				imperial: 50,
 			},
-			link: 'https://www.accuweather.com/en/gb/llanfair-pwllgwyngyll/ll61-5/current-weather/328819?lang=en-us&partner=web_guardian_adc',
+			link: 'https://www.accuweather.com/en/gb/llanfair-pwllgwyngyll/ll61-5/current-weather/328819?lang=en-us',
 		},
 		forecast: [
 			{
@@ -175,6 +175,7 @@ export default {
 				dateTime: '2023-06-27T15:00:00.000Z',
 			},
 		],
+		link: 'https://www.accuweather.com/en/gb/llanfair-pwllgwyngyll/ll61-5/current-weather/328819?lang=en-us&partner=web_guardian_adc',
 	},
 };
 

--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -31,8 +31,8 @@ import {
 import { useId } from 'react';
 import type { EditionId } from '../lib/edition';
 import { palette as schemePalette } from '../palette';
+import type { WeatherApiData, WeatherData } from '../types/weather';
 import { WeatherSlot } from './WeatherSlot';
-import type { WeatherApiData, WeatherData } from './WeatherWrapper.importable';
 
 const visuallyHiddenCSS = css`
 	${visuallyHidden}

--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -192,6 +192,7 @@ export interface WeatherProps
 	extends Pick<WeatherApiData, 'location' | 'forecast'> {
 	now: WeatherData;
 	edition: EditionId;
+	link?: string;
 }
 
 const collapsibleStyles = css`
@@ -234,7 +235,13 @@ export const WeatherPlaceholder = () => (
 	<aside css={[collapsibleStyles, weatherCSS]}></aside>
 );
 
-export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
+export const Weather = ({
+	location,
+	now,
+	forecast,
+	edition,
+	link,
+}: WeatherProps) => {
 	const checkboxId = useId();
 
 	return (
@@ -273,11 +280,13 @@ export const Weather = ({ location, now, forecast, edition }: WeatherProps) => {
 				<WeatherSlot edition={edition} {...forecast[12]} />
 			</div>
 
-			<div css={linkCSS} className="collapsible">
-				<a href={now.link}>
-					View full forecast <ExternalLinkIcon />
-				</a>
-			</div>
+			{!!link && (
+				<div css={linkCSS} className="collapsible">
+					<a href={link}>
+						View full forecast <ExternalLinkIcon />
+					</a>
+				</div>
+			)}
 		</aside>
 	);
 };

--- a/dotcom-rendering/src/components/WeatherSlot.tsx
+++ b/dotcom-rendering/src/components/WeatherSlot.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/source/foundations';
 import { lazy, Suspense } from 'react';
 import { type EditionId, getEditionFromId } from '../lib/edition';
-import type { WeatherData } from './WeatherWrapper.importable';
+import type { WeatherData } from '../types/weather';
 
 interface IconProps {
 	size?: number;

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -6,14 +6,14 @@ import { Weather, WeatherPlaceholder } from './Weather';
 const appendPartnerCodeToUrl = (
 	url: string | undefined,
 ): string | undefined => {
-	if (!url) {
+	if (!url || !URL.canParse(url)) {
 		return undefined;
 	}
 
 	const link = new URL(url);
 	link.searchParams.append('partner', 'web_guardian_adc');
 
-	return link.toString();
+	return link.href;
 };
 
 type Props = {

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -1,37 +1,7 @@
 import type { EditionId } from '../lib/edition';
-import type { Tuple } from '../lib/tuple';
 import { useApi } from '../lib/useApi';
+import type { WeatherApiData } from '../types/weather';
 import { Weather, WeatherPlaceholder } from './Weather';
-
-/**
- * Our weather API returns 24 forecast.
- * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from Now.
- */
-export type WeatherForecast = [
-	...Tuple<WeatherData, 12>,
-	...Tuple<WeatherData, 12>,
-];
-
-export type WeatherData = {
-	description: string;
-	icon: number;
-	link?: string;
-	dateTime?: string;
-	temperature: {
-		metric: number;
-		imperial: number;
-	};
-};
-
-export type WeatherApiData = {
-	location: {
-		id: string;
-		city: string;
-		country: string;
-	};
-	weather: WeatherData;
-	forecast: WeatherForecast;
-};
 
 const appendPartnerCodeToUrl = (
 	url: string | undefined,

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -33,6 +33,19 @@ export type WeatherApiData = {
 	forecast: WeatherForecast;
 };
 
+const appendPartnerCodeToUrl = (
+	url: string | undefined,
+): string | undefined => {
+	if (!url) {
+		return undefined;
+	}
+
+	const link = new URL(url);
+	link.searchParams.append('partner', 'web_guardian_adc');
+
+	return link.toString();
+};
+
 type Props = {
 	ajaxUrl: string;
 	edition: EditionId;
@@ -53,6 +66,7 @@ export const WeatherWrapper = ({ ajaxUrl, edition }: Props) => {
 			now={data.weather}
 			forecast={data.forecast}
 			edition={edition}
+			link={appendPartnerCodeToUrl(data.weather.link)}
 		/>
 	);
 };

--- a/dotcom-rendering/src/types/weather.ts
+++ b/dotcom-rendering/src/types/weather.ts
@@ -13,7 +13,7 @@ export type WeatherData = {
 
 /**
  * Our weather API returns 24 forecast.
- * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from Now.
+ * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from now.
  */
 type WeatherForecast = [...Tuple<WeatherData, 12>, ...Tuple<WeatherData, 12>];
 

--- a/dotcom-rendering/src/types/weather.ts
+++ b/dotcom-rendering/src/types/weather.ts
@@ -1,0 +1,28 @@
+import type { Tuple } from '../lib/tuple';
+
+export type WeatherData = {
+	description: string;
+	icon: number;
+	link?: string;
+	dateTime?: string;
+	temperature: {
+		metric: number;
+		imperial: number;
+	};
+};
+
+/**
+ * Our weather API returns 24 forecast.
+ * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from Now.
+ */
+type WeatherForecast = [...Tuple<WeatherData, 12>, ...Tuple<WeatherData, 12>];
+
+export type WeatherApiData = {
+	location: {
+		id: string;
+		city: string;
+		country: string;
+	};
+	weather: WeatherData;
+	forecast: WeatherForecast;
+};


### PR DESCRIPTION
Closes #9561

## What does this change?

Adds our partner code to external links to AccuWeather. This used to exist in frontend but was missed off when migrating to DCR.

## Why?

£££