### PR TITLE
Parse the Weather API response

### DIFF
--- a/dotcom-rendering/src/components/Weather.stories.tsx
+++ b/dotcom-rendering/src/components/Weather.stories.tsx
@@ -1,284 +1,68 @@
-import type { WeatherProps } from './Weather';
-import { Weather } from './Weather';
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { Weather as WeatherComponent } from './Weather';
 
-export default {
-	component: Weather,
+const meta: Meta<typeof WeatherComponent> = {
 	title: 'Components/Weather',
+	component: WeatherComponent,
+};
+
+type Story = StoryObj<typeof WeatherComponent>;
+export const Weather: Story = {
 	args: {
 		edition: 'UK',
 		location: {
-			key: '328819',
-			localizedName:
-				'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch',
-			country: {
-				id: 'GB',
-				localizedName: 'United Kingdom',
-			},
-			administrativeArea: {
-				id: 'GWN',
-				localizedName: 'Gwynedd',
-			},
-			type: 'city',
+			id: '712993',
+			city: 'Ickleford',
+			country: 'United Kingdom',
 		},
 		now: {
-			icon: 1,
 			description: 'Sunny',
-			temperature: {
-				metric: 10,
-				imperial: 50,
-			},
-			link: 'https://www.accuweather.com/en/gb/llanfair-pwllgwyngyll/ll61-5/current-weather/328819?lang=en-us',
+			icon: 1,
+			link: 'http://www.accuweather.com/en/gb/ickleford/sg5-3/current-weather/712993?lang=en-us',
+			dateTime: null,
+			temperature: { metric: 27, imperial: 81 },
 		},
-		forecast: [
-			{
-				icon: 19,
-				description: 'Sleet',
-				temperature: {
-					metric: 20,
-					imperial: 68,
-				},
-				dateTime: '2023-06-27T00:00:00.000Z',
+		forecast: {
+			'3h': {
+				description: 'Mostly sunny',
+				icon: 2,
+				link: '',
+				dateTime: '2024-07-31T20:00:00+01:00',
+				temperature: { metric: 23, imperial: 74 },
 			},
-			{
-				icon: 19,
-				description: 'Sleet',
-				temperature: {
-					metric: 20,
-					imperial: 68,
-				},
-				dateTime: '2023-06-27T01:00:00.000Z',
+			'6h': {
+				description: 'Partly cloudy',
+				icon: 35,
+				link: '',
+				dateTime: '2024-07-31T23:00:00+01:00',
+				temperature: { metric: 18, imperial: 65 },
 			},
-			{
-				icon: 19,
-				description: 'Sleet',
-				temperature: {
-					metric: 20,
-					imperial: 68,
-				},
-				dateTime: '2023-06-27T02:00:00.000Z',
+			'9h': {
+				description: 'Cloudy',
+				icon: 7,
+				link: '',
+				dateTime: '2024-08-01T02:00:00+01:00',
+				temperature: { metric: 15, imperial: 59 },
 			},
-			{
-				icon: 19,
-				description: 'Sleet',
-				temperature: {
-					metric: 20,
-					imperial: 68,
-				},
-				dateTime: '2023-06-27T03:00:00.000Z',
+			'12h': {
+				description: 'Intermittent clouds',
+				icon: 36,
+				link: '',
+				dateTime: '2024-08-01T05:00:00+01:00',
+				temperature: { metric: 16, imperial: 61 },
 			},
-			{
-				icon: 25,
-				description: 'Hail',
-				temperature: {
-					metric: 25,
-					imperial: 77,
-				},
-				dateTime: '2023-06-27T04:00:00.000Z',
-			},
-			{
-				icon: 25,
-				description: 'Hail',
-				temperature: {
-					metric: 25,
-					imperial: 77,
-				},
-				dateTime: '2023-06-27T05:00:00.000Z',
-			},
-			{
-				icon: 25,
-				description: 'Hail',
-				temperature: {
-					metric: 25,
-					imperial: 77,
-				},
-				dateTime: '2023-06-27T06:00:00.000Z',
-			},
-			{
-				icon: 25,
-				description: 'Hail',
-				temperature: {
-					metric: 25,
-					imperial: 77,
-				},
-				dateTime: '2023-06-27T07:00:00.000Z',
-			},
-			{
-				icon: 32,
-				description: 'Wind',
-				temperature: {
-					metric: 30,
-					imperial: 89,
-				},
-				dateTime: '2023-06-27T08:00:00.000Z',
-			},
-			{
-				icon: 32,
-				description: 'Wind',
-				temperature: {
-					metric: 30,
-					imperial: 89,
-				},
-				dateTime: '2023-06-27T09:00:00.000Z',
-			},
-			{
-				icon: 32,
-				description: 'Wind',
-				temperature: {
-					metric: 30,
-					imperial: 89,
-				},
-				dateTime: '2023-06-27T10:00:00.000Z',
-			},
-			{
-				icon: 32,
-				description: 'Wind',
-				temperature: {
-					metric: 30,
-					imperial: 89,
-				},
-				dateTime: '2023-06-27T11:00:00.000Z',
-			},
-			{
-				icon: 44,
-				description: 'Night snow',
-				temperature: {
-					metric: 40,
-					imperial: 104,
-				},
-				dateTime: '2023-06-27T12:00:00.000Z',
-			},
-			{
-				icon: 44,
-				description: 'Night snow',
-				temperature: {
-					metric: 40,
-					imperial: 104,
-				},
-				dateTime: '2023-06-27T13:00:00.000Z',
-			},
-			{
-				icon: 44,
-				description: 'Night snow',
-				temperature: {
-					metric: 40,
-					imperial: 104,
-				},
-				dateTime: '2023-06-27T14:00:00.000Z',
-			},
-			{
-				icon: 44,
-				description: 'Night snow',
-				temperature: {
-					metric: 40,
-					imperial: 104,
-				},
-				dateTime: '2023-06-27T15:00:00.000Z',
-			},
-		],
-		link: 'https://www.accuweather.com/en/gb/llanfair-pwllgwyngyll/ll61-5/current-weather/328819?lang=en-us&partner=web_guardian_adc',
+		},
+	},
+	decorators: [splitTheme()],
+};
+
+export const WeatherUS: Story = {
+	...Weather,
+	args: {
+		...Weather.args,
+		edition: 'US',
 	},
 };
 
-export const Mobile = (args: WeatherProps) => (
-	<div style={{ maxWidth: '320px', padding: '0 10px' }}>
-		<Weather {...args} />
-	</div>
-);
-Mobile.parameters = {
-	viewport: {
-		defaultViewport: 'mobile',
-	},
-};
-
-export const MobileMedium = (args: WeatherProps) => (
-	<div style={{ maxWidth: '375px', padding: '0 10px' }}>
-		<Weather {...args} />
-	</div>
-);
-MobileMedium.parameters = {
-	viewport: {
-		defaultViewport: 'mobileMedium',
-	},
-};
-
-export const MobileLandscape = (args: WeatherProps) => (
-	<div style={{ maxWidth: '480px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-MobileLandscape.parameters = {
-	viewport: {
-		defaultViewport: 'mobileLandscape',
-	},
-};
-
-export const Phablet = (args: WeatherProps) => (
-	<div style={{ maxWidth: '680px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-Phablet.parameters = {
-	viewport: {
-		defaultViewport: 'phablet',
-	},
-};
-
-export const Tablet = (args: WeatherProps) => (
-	<div style={{ maxWidth: '552px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-Tablet.parameters = {
-	viewport: {
-		defaultViewport: 'tablet',
-	},
-};
-
-export const Desktop = (args: WeatherProps) => (
-	<div style={{ maxWidth: '792px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-Desktop.parameters = {
-	viewport: {
-		defaultViewport: 'desktop',
-	},
-};
-
-export const LeftCol = (args: WeatherProps) => (
-	<div style={{ maxWidth: '180px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-LeftCol.parameters = {
-	viewport: {
-		defaultViewport: 'leftCol',
-	},
-};
-
-export const Wide = (args: WeatherProps) => (
-	<div style={{ maxWidth: '260px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-Wide.parameters = {
-	viewport: {
-		defaultViewport: 'wide',
-	},
-};
-
-// just checks US special case
-export const US = (args: WeatherProps) => (
-	<div style={{ maxWidth: '340px', padding: '0 20px' }}>
-		<Weather {...args} />
-	</div>
-);
-US.args = {
-	edition: 'US',
-};
-// make it easy to see on most screens
-US.parameters = {
-	viewport: {
-		defaultViewport: 'mobileLandscape',
-	},
-};
+export default meta;

--- a/dotcom-rendering/src/components/Weather.tsx
+++ b/dotcom-rendering/src/components/Weather.tsx
@@ -266,16 +266,19 @@ export const Weather = ({
 			</div>
 
 			<div css={slotCSS} className="forecast-1 collapsible">
-				<WeatherSlot edition={edition} {...forecast[3]} />
+				<WeatherSlot edition={edition} {...forecast['3h']} />
 			</div>
+
 			<div css={slotCSS} className="forecast-2 collapsible">
-				<WeatherSlot edition={edition} {...forecast[6]} />
+				<WeatherSlot edition={edition} {...forecast['6h']} />
 			</div>
+
 			<div css={slotCSS} className="forecast-3 collapsible">
-				<WeatherSlot edition={edition} {...forecast[9]} />
+				<WeatherSlot edition={edition} {...forecast['9h']} />
 			</div>
+
 			<div css={slotCSS} className="forecast-4 collapsible">
-				<WeatherSlot edition={edition} {...forecast[12]} />
+				<WeatherSlot edition={edition} {...forecast['12h']} />
 			</div>
 
 			{!!link && (

--- a/dotcom-rendering/src/types/weather.ts
+++ b/dotcom-rendering/src/types/weather.ts
@@ -1,28 +1,71 @@
-import type { Tuple } from '../lib/tuple';
+import type { Output } from 'valibot';
+import {
+	nullable,
+	number,
+	object,
+	optional,
+	safeParse,
+	string,
+	transform,
+	tuple,
+	unknown,
+} from 'valibot';
+import type { Result } from '../lib/result';
+import { error, ok } from '../lib/result';
 
-export type WeatherData = {
-	description: string;
-	icon: number;
-	link?: string;
-	dateTime?: string;
-	temperature: {
-		metric: number;
-		imperial: number;
-	};
-};
+const weatherDataSchema = object({
+	description: string(),
+	icon: number(),
+	link: nullable(string(), ''),
+	dateTime: nullable(string()),
+	temperature: object({
+		metric: number(),
+		imperial: number(),
+	}),
+});
+export type WeatherData = Output<typeof weatherDataSchema>;
 
-/**
- * Our weather API returns 24 forecast.
- * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from now.
- */
-type WeatherForecast = [...Tuple<WeatherData, 12>, ...Tuple<WeatherData, 12>];
+const weatherApiDataSchema = object({
+	location: object({
+		id: string(),
+		city: string(),
+		country: string(),
+	}),
+	weather: weatherDataSchema,
+	/**
+	 * Our weather API returns 24 forecast.
+	 * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from now.
+	 */
+	forecast: transform(
+		tuple([
+			unknown(),
+			unknown(),
+			unknown(),
+			weatherDataSchema,
+			unknown(),
+			unknown(),
+			weatherDataSchema,
+			unknown(),
+			unknown(),
+			weatherDataSchema,
+			unknown(),
+			unknown(),
+			weatherDataSchema,
+		]),
+		(forecast) => ({
+			'3h': forecast[3],
+			'6h': forecast[6],
+			'9h': forecast[9],
+			'12h': forecast[12],
+		}),
+	),
+});
+export type WeatherApiData = Output<typeof weatherApiDataSchema>;
 
-export type WeatherApiData = {
-	location: {
-		id: string;
-		city: string;
-		country: string;
-	};
-	weather: WeatherData;
-	forecast: WeatherForecast;
+export const parseWeatherData = (
+	data: unknown,
+): Result<'Loading' | 'ParsingError', WeatherApiData> => {
+	const result = safeParse(optional(weatherApiDataSchema), data);
+	if (!result.success) return error('ParsingError');
+	return result.output ? ok(result.output) : error('Loading');
 };

--- a/dotcom-rendering/src/types/weather.ts
+++ b/dotcom-rendering/src/types/weather.ts
@@ -33,7 +33,7 @@ const weatherApiDataSchema = object({
 	}),
 	weather: weatherDataSchema,
 	/**
-	 * Our weather API returns 24 forecast.
+	 * Our weather API returns 24h forecast.
 	 * Each forecast is 1 hour offset from the previous forecast, and the first forecast is 1 hour offset from now.
 	 */
 	forecast: transform(


### PR DESCRIPTION
Closes #12070

## What does this change?

Parse the weather API response using valibot.

## Why?

This ensures that we catch errors rather than throwing them, even if the response schema changes.

Companion to the engineering blog article “[Parsing: the merit of strictly typed JSON](https://www.theguardian.com/info/article/2024/jul/26/parsing-the-merit-of-strictly-typed-json)” 

## Screenshots

No visual change.

| breakpoint | image |
| ---- | ------ |
| mobile | <img width="523" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/c53a5df7-cf16-4823-9d15-b96eab6fb564"> |
| desktop | <img width="989" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/fa10fcdd-ec9e-4efb-a2d2-b6708bef80f1"> | 
| wide | <img width="258" alt="image" src="https://github.com/guardian/dotcom-rendering/assets/76776/1f4ee6e6-d389-49b9-afe8-1f47c52764f3"> |