### PR TITLE
Fix footer RR links url

### DIFF
--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -220,7 +220,7 @@ export const AllEditorialNewslettersPageLayout = ({
 				<Footer
 					pageFooter={pageFooter}
 					pillars={NAV.pillars}
-					urls={NAV.readerRevenueLinks.header}
+					urls={NAV.readerRevenueLinks.footer}
 					editionId={editionId}
 				/>
 			</Section>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -990,7 +990,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -789,7 +789,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					pageFooter={front.pageFooter}
 					selectedPillar={NAV.selectedPillar}
 					pillars={NAV.pillars}
-					urls={front.nav.readerRevenueLinks.header}
+					urls={front.nav.readerRevenueLinks.footer}
 					editionId={front.editionId}
 				/>
 			</Section>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -412,7 +412,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 					pageFooter={article.pageFooter}
 					selectedPillar={NAV.selectedPillar}
 					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
+					urls={article.nav.readerRevenueLinks.footer}
 					editionId={article.editionId}
 				/>
 			</Section>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -969,7 +969,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -926,7 +926,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1520,7 +1520,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -594,7 +594,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 					pageFooter={article.pageFooter}
 					selectedPillar={NAV.selectedPillar}
 					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.header}
+					urls={article.nav.readerRevenueLinks.footer}
 					editionId={article.editionId}
 				/>
 			</Section>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -858,7 +858,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -1010,7 +1010,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							pageFooter={article.pageFooter}
 							selectedPillar={props.NAV.selectedPillar}
 							pillars={props.NAV.pillars}
-							urls={article.nav.readerRevenueLinks.header}
+							urls={article.nav.readerRevenueLinks.footer}
 							editionId={article.editionId}
 						/>
 					</Section>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -379,7 +379,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 					pageFooter={tagPage.pageFooter}
 					selectedPillar={NAV.selectedPillar}
 					pillars={NAV.pillars}
-					urls={tagPage.nav.readerRevenueLinks.header}
+					urls={tagPage.nav.readerRevenueLinks.footer}
 					editionId={tagPage.editionId}
 				/>
 			</Section>


### PR DESCRIPTION
The reader revenue link in the footer currently has tracking for the 'header'. It's always been this way. This PR fixes this