### PR TITLE
Adjust `facia-rendering` and `tag-page-rendering` instance count

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -77,8 +77,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 9,
+		maximumInstances: 90,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
@@ -112,8 +112,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 9,
+		maximumInstances: 90,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s


### PR DESCRIPTION
## What does this change?
Reduce the minimum number of instances from 18 to 9 and the max from 180 to 90 for both `facia-rendering` and `tag-page-rendering`
## Why?
Average CPU utilisation is 4 - 10% for `tag-page-rendering` 
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/0124eb39-0bbc-4f51-93fa-4362a02079ac">
and 10 - 18% for `facia-rendering`
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/c40037c0-2179-4589-8a90-de7fd4680a32">

Resolves https://github.com/guardian/dotcom-rendering/issues/11441

<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
