### PR TITLE
Unsticky the edition switcher banner

### DIFF
--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -16,7 +16,7 @@ import {
 import XIcon from '../static/icons/x.svg';
 
 const container = css`
-	position: sticky;
+	position: relative;
 	top: 0;
 	background-color: ${palette.brand[800]};
 	${getZIndex('editionSwitcherBanner')};


### PR DESCRIPTION
## What does this change?
Per the design the edition switcher banner was implemented to be sticky - follows the user as they scroll down the page.

## Why?
Editorial would like to make other things sticky, and having this sticky confuses things. So this is being unstickied.
