### PR TITLE
Adjust subnav width and horizontal divider styling on new Titlepiece component

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
@@ -119,8 +119,7 @@ const pillarUnderline = css`
 		left: 0;
 		right: 0;
 
-		/** The pillar underline is offset by the height of the horizontal divider (1px) */
-		height: ${space[1] + 1}px;
+		height: ${space[1]}px;
 		/*
 		This is 100% width of pillar block minus the left margin
 		and 1px border on the right


### PR DESCRIPTION
## What does this change?

- Adjusts the width of the subnav and horizontal divider
  - Should be as 100% of the width of the page content unless below tablet breakpoint in which case it should overflow to the right edge of the screen where there is a subnav
  - For no subnav present, it should always be 100% the width of the page content
 
It had previously been set to various widths depending on the viewport size. After speaking to designers, turns out the intention is to deliberately not line up with other page borders and should remain the same width as the pillars block. 

## Why?

Aligns better with designs, and agreed with designers

Part of [trello ticket](https://trello.com/c/KMzghGe3/23-masthead-titlepiece)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![b1][] | ![a1][] |
| ![b2][] | ![a2][] |
| ![b3][] | ![a3][] |

[b1]:https://github.com/user-attachments/assets/0d14a8ec-f7e2-4bc9-a925-05a395adfe8f
[a1]:https://github.com/user-attachments/assets/4730c2d6-46f7-44f3-93b7-af785dcc885a
[b2]:https://github.com/user-attachments/assets/b5be26ef-0412-4187-a52e-29849741ebf4
[a2]:https://github.com/user-attachments/assets/10912668-a452-499a-bcf8-b8831ca2cdc0
[b3]:https://github.com/user-attachments/assets/ce663302-2687-40c1-85b4-aeff1a352c49
[a3]:https://github.com/user-attachments/assets/1160623d-f3e5-475f-8c5a-ba741abf781d

