### PR TITLE
Specify `key` prop for all top level children inside `map` for `FrontLayout`

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -444,7 +444,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							: undefined;
 
 						return (
-							<>
+							<Fragment key={ophanName}>
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
@@ -507,7 +507,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									mobileAdPositions,
 									hasPageSkin,
 								)}
-							</>
+							</Fragment>
 						);
 					}
 


### PR DESCRIPTION
## What does this change?

- Adds `key` prop to `Fragment` component as done in other places in the container mapping function in `FrontLayout`

## Why?

To silence rendering warnings in the console

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | 😌  |

[before]: https://github.com/user-attachments/assets/1e3e71ca-e50d-4cd2-8b64-5b76d00cdcea
