### PR TITLE
Update `ArticleMeta.apps` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -25,6 +25,10 @@ export const allModes = {
 		globalColourScheme: 'vertical',
 		viewport: breakpoints.mobileMedium,
 	},
+	'vertical tablet': {
+		globalColourScheme: 'vertical',
+		viewport: breakpoints.tablet,
+	},
 	'light desktop': {
 		globalColourScheme: 'light',
 		viewport: breakpoints.desktop,

--- a/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
@@ -1,379 +1,185 @@
-import { css } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
-import { breakpoints } from '@guardian/source/foundations';
-import type { StoryObj } from '@storybook/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import type { Meta, StoryObj } from '@storybook/react';
+import { leftColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { defaultFormats } from '../../.storybook/decorators/splitThemeDecorator';
+import { allModes } from '../../.storybook/modes';
 import { getAllThemes } from '../lib/format';
-import type { Branding as BrandingType } from '../types/branding';
 import { ArticleMetaApps } from './ArticleMeta.apps';
 
-type StoryArgs = { format: ArticleFormat; isCommentable: boolean };
-
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			width: 220px;
-			padding: 20px;
-		`}
-	>
-		{children}
-	</div>
-);
-
-const tagsWithLargeBylineImage = [
-	{
-		id: 'profile/lanre-bakare',
-		type: 'Contributor',
-		title: 'Lanre Bakare',
-		twitterHandle: 'lanre_bakare',
-		bylineImageUrl:
-			'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
-		bylineLargeImageUrl:
-			'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
-	},
-];
-
-const tagsWithByTwoContributors = [
-	{
-		id: 'profile/lanre-bakare',
-		type: 'Contributor',
-		title: 'Lanre Bakare',
-		twitterHandle: 'lanre_bakare',
-		bylineImageUrl:
-			'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
-		bylineLargeImageUrl:
-			'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
-	},
-	{
-		id: 'profile/laura-banks',
-		type: 'Contributor',
-		title: 'Laura Banks',
-	},
-];
-
-const branding: BrandingType = {
-	brandingType: { name: 'sponsored' },
-	sponsorName: 'theguardian.org',
-	logo: {
-		src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/57ba1d00-b2bd-4f6d-ba35-15a82b8d9507-0094b90a-bdb8-4e97-b866-dcf49179b29d-theguardian.org.png',
-		dimensions: {
-			width: 280,
-			height: 180,
-		},
-		link: 'https://theguardian.org/',
-		label: 'Supported by',
-	},
-	logoForDarkBackground: {
-		src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/58a1e08d-cd4a-47a5-966a-4846b0461642-46629471-cb0b-4c59-9a06-1ef23778b41f-theguardian.org2.png',
-		dimensions: {
-			width: 280,
-			height: 180,
-		},
-		link: 'https://theguardian.org/',
-		label: 'Supported by',
-	},
-	aboutThisLink:
-		'https://www.theguardian.com/environment/2023/jan/06/about-animals-farmed-investigating-modern-farming-around-the-world',
-};
-
-const brandingForAdvertisingPartner: BrandingType = {
-	brandingType: { name: 'sponsored' },
-	sponsorName: 'theguardian.org',
-	logo: {
-		src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/57ba1d00-b2bd-4f6d-ba35-15a82b8d9507-0094b90a-bdb8-4e97-b866-dcf49179b29d-theguardian.org.png',
-		dimensions: {
-			width: 280,
-			height: 180,
-		},
-		link: 'https://theguardian.org/',
-		label: 'Advertising partner',
-	},
-	logoForDarkBackground: {
-		src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/58a1e08d-cd4a-47a5-966a-4846b0461642-46629471-cb0b-4c59-9a06-1ef23778b41f-theguardian.org2.png',
-		dimensions: {
-			width: 280,
-			height: 180,
-		},
-		link: 'https://theguardian.org/',
-		label: 'Advertising partner',
-	},
-	aboutThisLink:
-		'https://www.theguardian.com/environment/2023/jan/06/about-animals-farmed-investigating-modern-farming-around-the-world',
-};
-
-export default {
+const meta = {
 	component: ArticleMetaApps,
-	title: 'Components/ArticleMetaApps',
+	title: 'Components/Article Meta (apps)',
 	parameters: {
-		viewport: {
-			defaultViewport: 'wide',
-		},
 		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.tablet],
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+				'vertical tablet': allModes['vertical tablet'],
+			},
 		},
 	},
-};
+	decorators: [leftColumnDecorator],
+} satisfies Meta<typeof ArticleMetaApps>;
 
-const defaultFormat: ArticleFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
+export default meta;
 
-const avatarFormat: ArticleFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Feature,
-	theme: Pillar.News,
-};
+type Story = StoryObj<typeof meta>;
 
-const immersiveFormat: ArticleFormat = {
-	display: ArticleDisplay.Immersive,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
+export const WithFollowStory = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+		byline: 'Lanre Bakare Chief music writer',
+		tags: [
+			{
+				id: 'profile/lanre-bakare',
+				type: 'Contributor',
+				title: 'Lanre Bakare',
+				twitterHandle: 'lanre_bakare',
+				bylineImageUrl:
+					'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
+				bylineLargeImageUrl:
+					'https://uploads.guim.co.uk/2017/10/06/Lanre-Bakare,-L.png',
+			},
+		],
+		primaryDateline: 'Sun 12 Jan 2020 18.00 GMT',
+		secondaryDateline: 'Last modified on Sun 12 Jan 2020 21.00 GMT',
+		isCommentable: false,
+		discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
+		shortUrlId: '/p/zemg8',
+	},
+	parameters: {
+		config: {
+			renderingTarget: 'Apps',
+		},
+		formats: defaultFormats,
+	},
+} satisfies Story;
 
-export const ArticleAppsWithFollowStory: StoryObj = ({
-	format,
-	isCommentable,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare Chief music writer"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithFollowStory.args = { format: defaultFormat };
-ArticleAppsWithFollowStory.parameters = { config: { renderingTarget: 'Apps' } };
-ArticleAppsWithFollowStory.decorators = [splitTheme()];
+export const WithFollowStoryNoTitle = {
+	...WithFollowStory,
+	args: {
+		...WithFollowStory.args,
+		byline: 'Lanre Bakare',
+	},
+} satisfies Story;
 
-export const ArticleAppsWithFollowStoryNoTitle: StoryObj = ({
-	format,
-	isCommentable,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithFollowStoryNoTitle.args = { format: defaultFormat };
-ArticleAppsWithFollowStoryNoTitle.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsWithFollowStoryNoTitle.decorators = [splitTheme()];
+export const WithAvatarAndFollowStory = {
+	args: {
+		...WithFollowStory.args,
+		isCommentable: true,
+	},
+	parameters: {
+		...WithFollowStory.parameters,
+		formats: getAllThemes({
+			...WithFollowStory.args.format,
+			design: ArticleDesign.Feature,
+		}),
+	},
+} satisfies Story;
 
-export const ArticleAppsWithAvatarAndFollowStory: StoryObj = ({
-	format,
-	isCommentable = true,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare Chief music writer"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithAvatarAndFollowStory.args = { format: defaultFormat };
-ArticleAppsWithAvatarAndFollowStory.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsWithAvatarAndFollowStory.decorators = [
-	splitTheme(getAllThemes(avatarFormat)),
-];
+export const WithAvatarNoTitleAndFollowStory = {
+	...WithAvatarAndFollowStory,
+	args: {
+		...WithAvatarAndFollowStory.args,
+		byline: 'Lanre Bakare',
+	},
+} satisfies Story;
 
-export const ArticleAppsWithAvatarNoTitleAndFollowStory: StoryObj = ({
-	format,
-	isCommentable = true,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithAvatarNoTitleAndFollowStory.args = { format: defaultFormat };
-ArticleAppsWithAvatarNoTitleAndFollowStory.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsWithAvatarNoTitleAndFollowStory.decorators = [
-	splitTheme(getAllThemes(avatarFormat)),
-];
+export const ImmersiveAndFollowStory = {
+	args: {
+		...WithFollowStoryNoTitle.args,
+		format: {
+			...WithFollowStoryNoTitle.args.format,
+			display: ArticleDisplay.Immersive,
+		},
+	},
+	parameters: {
+		...WithFollowStoryNoTitle.parameters,
+		formats: undefined,
+	},
+} satisfies Story;
 
-export const ArticleAppsImmersiveAndFollowStory: StoryObj = ({
-	format,
-	isCommentable,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsImmersiveAndFollowStory.args = { format: defaultFormat };
-ArticleAppsImmersiveAndFollowStory.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsImmersiveAndFollowStory.decorators = [splitTheme([immersiveFormat])];
+export const ImmersiveWithMultipleContributorsStory = {
+	...ImmersiveAndFollowStory,
+	args: {
+		...ImmersiveAndFollowStory.args,
+		byline: 'Lanre Bakare in New York and Laura Banks in London',
+		tags: [
+			...ImmersiveAndFollowStory.args.tags,
+			{
+				id: 'profile/laura-banks',
+				type: 'Contributor',
+				title: 'Laura Banks',
+			},
+		],
+	},
+} satisfies Story;
 
-export const ArticleAppsImmersiveWithMultipleContributorsStory: StoryObj = ({
-	format,
-	isCommentable,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare in New York and Laura Banks in London"
-				tags={tagsWithByTwoContributors}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsImmersiveWithMultipleContributorsStory.args = {
-	format: defaultFormat,
-};
-ArticleAppsImmersiveWithMultipleContributorsStory.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsImmersiveWithMultipleContributorsStory.decorators = [
-	splitTheme([immersiveFormat]),
-];
+export const WithMultipleContributors = {
+	...WithFollowStory,
+	args: {
+		...ImmersiveWithMultipleContributorsStory.args,
+	},
+} satisfies Story;
 
-export const ArticleAppsWithMultipleContributors: StoryObj = ({
-	format,
-	isCommentable,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare in New York and Laura Banks in London"
-				tags={tagsWithByTwoContributors}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithMultipleContributors.args = { format: defaultFormat };
-ArticleAppsWithMultipleContributors.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsWithMultipleContributors.decorators = [splitTheme()];
+export const WithBrandingStory = {
+	args: {
+		...WithFollowStory.args,
+		isCommentable: true,
+		branding: {
+			brandingType: { name: 'sponsored' },
+			sponsorName: 'theguardian.org',
+			logo: {
+				src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/57ba1d00-b2bd-4f6d-ba35-15a82b8d9507-0094b90a-bdb8-4e97-b866-dcf49179b29d-theguardian.org.png',
+				dimensions: {
+					width: 280,
+					height: 180,
+				},
+				link: 'https://theguardian.org/',
+				label: 'Supported by',
+			},
+			logoForDarkBackground: {
+				src: 'https://static.theguardian.com/commercial/sponsor/19/Dec/2022/58a1e08d-cd4a-47a5-966a-4846b0461642-46629471-cb0b-4c59-9a06-1ef23778b41f-theguardian.org2.png',
+				dimensions: {
+					width: 280,
+					height: 180,
+				},
+				link: 'https://theguardian.org/',
+				label: 'Supported by',
+			},
+			aboutThisLink:
+				'https://www.theguardian.com/environment/2023/jan/06/about-animals-farmed-investigating-modern-farming-around-the-world',
+		},
+	},
+	parameters: {
+		...WithFollowStory.parameters,
+		formats: undefined,
+	},
+} satisfies Story;
 
-export const ArticleAppsWithBrandingStory: StoryObj = ({
-	format,
-	isCommentable = true,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare Chief music writer"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-				branding={branding}
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithBrandingStory.args = { format: defaultFormat };
-ArticleAppsWithBrandingStory.parameters = {
-	config: { renderingTarget: 'Apps' },
-};
-ArticleAppsWithBrandingStory.decorators = [splitTheme([defaultFormat])];
-
-export const ArticleAppsWithBrandingStoryForAdvertisingPartner: StoryObj = ({
-	format,
-	isCommentable = true,
-}: StoryArgs) => {
-	return (
-		<Wrapper>
-			<ArticleMetaApps
-				format={format}
-				byline="Lanre Bakare Chief music writer"
-				tags={tagsWithLargeBylineImage}
-				primaryDateline="Sun 12 Jan 2020 18.00 GMT"
-				secondaryDateline="Last modified on Sun 12 Jan 2020 21.00 GMT"
-				isCommentable={isCommentable}
-				discussionApiUrl="https://discussion.theguardian.com/discussion-api"
-				shortUrlId="/p/zemg8"
-				branding={brandingForAdvertisingPartner}
-			/>
-		</Wrapper>
-	);
-};
-/** @see /dotcom-rendering/docs/development/storybook.md */
-ArticleAppsWithBrandingStoryForAdvertisingPartner.args = {
-	format: defaultFormat,
-};
-ArticleAppsWithBrandingStoryForAdvertisingPartner.parameters = {
-	config: { renderingTarget: 'Apps', updateLogoAdPartnerSwitch: true },
-};
-ArticleAppsWithBrandingStoryForAdvertisingPartner.decorators = [
-	splitTheme([defaultFormat]),
-];
+export const WithBrandingStoryForAdvertisingPartner = {
+	args: {
+		...WithBrandingStory.args,
+		branding: {
+			...WithBrandingStory.args.branding,
+			logo: {
+				...WithBrandingStory.args.branding.logo,
+				label: 'Advertising partner',
+			},
+			logoForDarkBackground: {
+				...WithBrandingStory.args.branding.logoForDarkBackground,
+				label: 'Advertising partner',
+			},
+		},
+	},
+	parameters: {
+		...WithBrandingStory.parameters,
+		config: {
+			...WithBrandingStory.parameters.config,
+			updateLogoAdPartnerSwitch: true,
+		},
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+[^1], and integrates better with some of its features.

Replaced the mock formats with existing `defaultFormats` and the `getAllThemes` function. Replaced the `Wrapper` with the `leftColumnDecorator`. Added a new Chromatic mode.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
