### PR TITLE
Refactor isSignedIn checks in RR components

### DIFF
--- a/dotcom-rendering/src/components/FooterReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/FooterReaderRevenueLinks.importable.tsx
@@ -12,6 +12,7 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { shouldHideSupportMessaging } from '../lib/contributions';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import ArrowRightIcon from '../static/icons/arrow-right.svg';
 
@@ -98,7 +99,11 @@ const ReaderRevenueLinksNative = ({
 	dataLinkNamePrefix,
 	urls,
 }: ReaderRevenueLinksNativeProps) => {
-	const hideSupportMessaging = shouldHideSupportMessaging();
+	const isSignedIn = useIsSignedIn();
+
+	if (isSignedIn === 'Pending') return null;
+
+	const hideSupportMessaging = shouldHideSupportMessaging(isSignedIn);
 	const url = urls.support;
 
 	if (hideSupportMessaging) {

--- a/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { shouldHideSupportMessaging } from '../lib/contributions';
 import type { EditionId } from '../lib/edition';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { Hide } from './Hide';
 
 type InteractiveSupportButtonProps = {
@@ -32,10 +33,13 @@ export const InteractiveSupportButton = ({
 	subscribeUrl,
 }: InteractiveSupportButtonProps) => {
 	const [hideSupportMessaging, setHideSupportMessaging] = useState(true);
+	const isSignedIn = useIsSignedIn();
 
 	useEffect(() => {
-		setHideSupportMessaging(shouldHideSupportMessaging());
-	}, []);
+		if (isSignedIn !== 'Pending') {
+			setHideSupportMessaging(shouldHideSupportMessaging(isSignedIn));
+		}
+	}, [isSignedIn]);
 
 	if (!hideSupportMessaging) {
 		return (

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -269,7 +269,7 @@ export const StickyBottomBanner = ({
 		const readerRevenue = buildReaderRevenueBannerConfig(
 			remoteBannerSwitch,
 		)({
-			isSignedIn: isSignedIn ?? false,
+			isSignedIn,
 			countryCode,
 			isPreview,
 			asyncArticleCounts,

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -3,7 +3,7 @@ import type {
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
 import type { CountryCode } from '@guardian/libs';
-import { cmp, isString, storage } from '@guardian/libs';
+import { cmp, isString, isUndefined, storage } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
 import type { ArticleCounts } from '../lib/articleCount';
@@ -13,11 +13,10 @@ import type {
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
-import { useAuthStatus } from '../lib/useAuthStatus';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useIsAndroid } from '../lib/useIsAndroid';
-import { useOnce } from '../lib/useOnce';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
@@ -233,15 +232,13 @@ export const StickyBottomBanner = ({
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 
 	const countryCode = useCountryCode('sticky-bottom-banner');
-	const authStatus = useAuthStatus();
-	const isSignedIn =
-		authStatus.kind === 'SignedInWithOkta' ||
-		authStatus.kind === 'SignedInWithCookies';
+	const isSignedIn = useIsSignedIn();
+
 	const [SelectedBanner, setSelectedBanner] = useState<MaybeFC | null>(null);
 	const [asyncArticleCounts, setAsyncArticleCounts] =
 		useState<Promise<ArticleCounts | undefined>>();
 	const signInGateWillShow = useSignInGateWillShow({
-		isSignedIn,
+		isSignedIn: isSignedIn === true,
 		contentType,
 		sectionId,
 		tags,
@@ -255,19 +252,27 @@ export const StickyBottomBanner = ({
 		setAsyncArticleCounts(getArticleCounts(pageId, tags, contentType));
 	}, [contentType, tags, pageId]);
 
-	useOnce(() => {
-		if (!countryCode) return;
+	useEffect(() => {
+		// Wait for the following dependencies before checking for CMP, Braze + RRCP messages
+		if (
+			isUndefined(countryCode) ||
+			isUndefined(isSignedIn) ||
+			isUndefined(brazeMessages) ||
+			isUndefined(asyncArticleCounts) ||
+			isUndefined(signInGateWillShow) ||
+			isSignedIn === 'Pending'
+		) {
+			return;
+		}
 		const CMP = buildCmpBannerConfig();
 
 		const readerRevenue = buildReaderRevenueBannerConfig(
 			remoteBannerSwitch,
 		)({
-			isSignedIn,
+			isSignedIn: isSignedIn ?? false,
 			countryCode,
 			isPreview,
-			asyncArticleCounts: asyncArticleCounts as Promise<
-				ArticleCounts | undefined
-			>,
+			asyncArticleCounts,
 			signInGateWillShow,
 			contentType,
 			sectionId,
@@ -284,7 +289,7 @@ export const StickyBottomBanner = ({
 			section: sectionId,
 		};
 		const brazeBanner = buildBrazeBanner(
-			brazeMessages as BrazeMessagesInterface,
+			brazeMessages,
 			brazeArticleContext,
 			idApiUrl,
 			tags,
@@ -304,7 +309,26 @@ export const StickyBottomBanner = ({
 					`StickyBottomBanner pickMessage - error: ${String(e)}`,
 				),
 			);
-	}, [isSignedIn, countryCode, brazeMessages, asyncArticleCounts]);
+	}, [
+		isSignedIn,
+		countryCode,
+		brazeMessages,
+		asyncArticleCounts,
+		contentType,
+		contributionsServiceUrl,
+		idApiUrl,
+		isAndroidWebview,
+		isMinuteArticle,
+		isPaidContent,
+		isPreview,
+		isSensitive,
+		remoteBannerSwitch,
+		renderingTarget,
+		sectionId,
+		shouldHideReaderRevenue,
+		signInGateWillShow,
+		tags,
+	]);
 
 	if (SelectedBanner) {
 		return <SelectedBanner />;

--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -15,7 +15,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { shouldHideSupportMessaging } from '../lib/contributions';
 import { useAB } from '../lib/useAB';
-import { useAuthStatus } from '../lib/useAuthStatus';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { usePageViewId } from '../lib/usePageViewId';
@@ -177,13 +177,13 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 	// should we show ourselves?
 	const [showSupportMessagingForUser, setShowSupportMessaging] =
 		useState<boolean>(false);
-	const authStatus = useAuthStatus();
+	const isSignedIn = useIsSignedIn();
+
 	useEffect(() => {
-		const isSignedIn =
-			authStatus.kind === 'SignedInWithOkta' ||
-			authStatus.kind === 'SignedInWithCookies';
-		setShowSupportMessaging(!shouldHideSupportMessaging(isSignedIn));
-	}, [authStatus]);
+		if (isSignedIn !== 'Pending') {
+			setShowSupportMessaging(!shouldHideSupportMessaging(isSignedIn));
+		}
+	}, [isSignedIn]);
 
 	const ABTestAPI = useAB()?.api;
 

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -138,7 +138,7 @@ export const isRecentOneOffContributor = (): boolean => {
 	return false;
 };
 
-export const shouldHideSupportMessaging = (isSignedIn = false): boolean =>
+export const shouldHideSupportMessaging = (isSignedIn: boolean): boolean =>
 	!shouldShowSupportMessaging() ||
 	isRecurringContributor(isSignedIn) ||
 	isRecentOneOffContributor();

--- a/dotcom-rendering/src/lib/useAuthStatus.ts
+++ b/dotcom-rendering/src/lib/useAuthStatus.ts
@@ -6,6 +6,11 @@ import {
 	getSignedInStatusWithOkta,
 } from './identity';
 
+/**
+ * A hook to find out if a user is signed in.
+ * Returns `'Pending'` until status is known.
+ * Always returns `'Pending'` during server-side rendering.
+ * */
 export const useIsSignedIn = (): boolean | 'Pending' => {
 	const authStatus = useAuthStatus();
 	switch (authStatus.kind) {

--- a/dotcom-rendering/src/lib/useAuthStatus.ts
+++ b/dotcom-rendering/src/lib/useAuthStatus.ts
@@ -6,6 +6,20 @@ import {
 	getSignedInStatusWithOkta,
 } from './identity';
 
+export const useIsSignedIn = (): boolean | 'Pending' => {
+	const authStatus = useAuthStatus();
+	switch (authStatus.kind) {
+		case 'Pending':
+			return 'Pending';
+		case 'SignedInWithCookies':
+		case 'SignedInWithOkta':
+			return true;
+		case 'SignedOutWithCookies':
+		case 'SignedOutWithOkta':
+			return false;
+	}
+};
+
 export const useAuthStatus = (): AuthStatus => {
 	const [authStatus, setAuthStatus] = useState<AuthStatus>({
 		kind: 'Pending',


### PR DESCRIPTION
There are various places where we can show Reader Revenue messages.
We call the `shouldHideSupportMessaging` function to find out whether or not they should be displayed.
This function takes an `isSignedIn` parameter, which was previously optional. 

This PR does the following:
- Makes the `isSignedIn` parameter mandatory, and ensures it's always passed in.
- Replaces various implementations of e.g. `getIsSignedIn` with a shared hook called `useIsSignedIn`. This hook returns `boolean | 'Pending'`, to allow components to wait for an answer.
- Replaces usages of `useOnce` with `useEffect`. The former is no longer preferred (see end of description [here](https://github.com/guardian/dotcom-rendering/pull/9176)). With `useEffect` we must specify _all_ dependencies. Where we need to wait for dependencies to become available we can check for e.g. `isUndefined(...)` or `isSignedIn === 'Pending'` at the start of the callback.
