### PR TITLE
Fix `Carousel` arrows background in dark mode

### DIFF
--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -3,7 +3,6 @@ import { ArticleDesign } from '@guardian/libs';
 import {
 	from,
 	headlineBold24,
-	palette as sourcePalette,
 	space,
 	until,
 } from '@guardian/source/foundations';
@@ -308,7 +307,7 @@ const buttonStyle = css`
 		outline: none;
 		background-color: ${themePalette('--carousel-arrow-background-hover')};
 		svg {
-			fill: ${sourcePalette.neutral[7]};
+			fill: ${themePalette('--carousel-arrow-background')};
 		}
 	}
 
@@ -335,14 +334,14 @@ const headerStylesWithUrl = css`
 const prevButtonStyle = (index: number) => css`
 	background-color: ${index !== 0
 		? themePalette('--carousel-arrow-background')
-		: sourcePalette.neutral[46]};
+		: themePalette('--carousel-arrow-background-disabled')};
 	cursor: ${index !== 0 ? 'pointer' : 'default'};
 
 	&:hover,
 	&:focus {
 		background-color: ${index !== 0
 			? themePalette('--carousel-arrow-background-hover')
-			: sourcePalette.neutral[46]};
+			: themePalette('--carousel-arrow-background-disabled')};
 
 		svg {
 			fill: ${themePalette('--carousel-arrow')};
@@ -363,7 +362,7 @@ const nextButtonStyle = (
 		totalCardsShowing,
 	)
 		? themePalette('--carousel-arrow-background')
-		: sourcePalette.neutral[46]};
+		: themePalette('--carousel-arrow-background-disabled')};
 	cursor: ${!isLastCardShowing(index, totalStories, totalCardsShowing)
 		? 'pointer'
 		: 'default'};
@@ -376,7 +375,7 @@ const nextButtonStyle = (
 			totalCardsShowing,
 		)
 			? themePalette('--carousel-arrow-background-hover')
-			: sourcePalette.neutral[46]};
+			: themePalette('--carousel-arrow-background-disabled')};
 
 		svg {
 			fill: ${themePalette('--carousel-arrow')};
@@ -396,7 +395,6 @@ const headerRowStyles = css`
 
 const headerStyles = css`
 	${headlineBold24};
-	color: ${sourcePalette.neutral[7]};
 	color: ${themePalette('--carousel-text')};
 	${headlineBold24};
 	padding-bottom: ${space[2]}px;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5908,6 +5908,10 @@ const paletteColours = {
 		light: carouselArrowBackgroundLight,
 		dark: carouselArrowBackgroundDark,
 	},
+	'--carousel-arrow-background-disabled': {
+		light: () => sourcePalette.neutral[46],
+		dark: () => sourcePalette.neutral[60],
+	},
 	'--carousel-arrow-background-hover': {
 		light: carouselArrowBackgroundHoverLight,
 		dark: carouselArrowBackgroundHoverDark,


### PR DESCRIPTION
## What does this change?

Ensure that the carousel arrows support dark mode properly

## Why?

Scrolling does not work reliably on Android so these buttons are the only way to navigate.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/edce2609-8669-4fb2-9bed-10a3fc9fe78d
[after]: https://github.com/user-attachments/assets/eec2baa7-cc4d-4164-ba1c-2d88de53500e

