### PR TITLE
Inline `AgeWarning` clock icon

### DIFF
--- a/dotcom-rendering/src/components/AgeWarning.tsx
+++ b/dotcom-rendering/src/components/AgeWarning.tsx
@@ -6,7 +6,6 @@ import {
 	visuallyHidden,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
-import ClockIcon from '../static/icons/clock.svg';
 
 type Props = {
 	age: string;
@@ -53,7 +52,10 @@ export const AgeWarning = ({ age, isScreenReader, size = 'medium' }: Props) => {
 
 	return (
 		<div css={ageWarningStyles(isSmall)} aria-hidden="true">
-			<ClockIcon /> {warningPrefix}
+			<svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor">
+				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>
+			</svg>{' '}
+			{warningPrefix}
 			<strong>{ageOld}</strong>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Inline the `AgeWarning` clock icon

## Why?

This enables the icon to take the surrouding text colour with the `currentColor` keyword