### PR TITLE
Use palette for `ElementContainer`’s fallback border colour

### DIFF
--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -1,9 +1,8 @@
 import { css, jsx } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
-import { from, palette, space } from '@guardian/source/foundations';
+import { from, space } from '@guardian/source/foundations';
 import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { center } from '../lib/center';
-import { transparentColour } from '../lib/transparentColour';
+import { palette } from '../palette';
 
 const sidePadding = css`
 	padding-left: 10px;
@@ -19,27 +18,22 @@ const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-const sideBorderStyles = (colour: string) => css`
+const sideBorderStyles = css`
 	${from.tablet} {
-		border-left: 1px solid ${colour};
-		border-right: 1px solid ${colour};
+		border-left: 1px solid;
+		border-right: 1px solid;
+		border-color: ${palette('--article-border')};
 	}
 `;
 
-const topBorderStyles = (colour: string) => css`
-	border-top: 1px solid ${colour};
+const topBorderStyles = css`
+	border-top: 1px solid;
+	border-color: ${palette('--article-border')};
 `;
 
 const setBackgroundColour = (colour: string) => css`
 	background-color: ${colour};
 `;
-
-//Previously, borderColour would be set to palette.neutral[86] if the parameter being passed was undefined. We still want this as a fallback, but not for ArticleDesign.Picture pages (and probably not for any future pages with a similar design).
-const decideFallbackBorderColour = (format: ArticleFormat | undefined) => {
-	return format?.design === ArticleDesign.Picture
-		? transparentColour(palette.neutral[60], 0.5)
-		: palette.neutral[86];
-};
 
 type Props = {
 	sectionId?: string;
@@ -67,7 +61,6 @@ type Props = {
 	containerName?: string;
 	hasPageSkin?: boolean;
 	hasPageSkinContentSelfConstrain?: boolean;
-	format?: ArticleFormat;
 };
 
 /**
@@ -82,8 +75,7 @@ export const ElementContainer = ({
 	showTopBorder = true,
 	padSides = true,
 	padBottom = false,
-	format,
-	borderColour = decideFallbackBorderColour(format),
+	borderColour,
 	backgroundColour,
 	innerBackgroundColour,
 	shouldCenter = true,
@@ -101,8 +93,10 @@ export const ElementContainer = ({
 		'data-link-name': ophanComponentLink,
 		'data-component': ophanComponentName,
 		'data-container-name': containerName,
+		style: {
+			backgroundColor: backgroundColour,
+		},
 		css: [
-			backgroundColour && setBackgroundColour(backgroundColour),
 			hasPageSkin &&
 				!hasPageSkinContentSelfConstrain &&
 				pageSkinContainer,
@@ -115,10 +109,13 @@ export const ElementContainer = ({
 				 * this id pre-existed showMore so is probably also being used for something else.
 				 */
 				id={sectionId}
+				style={{
+					borderColor: borderColour,
+				}}
 				css={[
 					shouldCenter && center,
-					showSideBorders && sideBorderStyles(borderColour),
-					showTopBorder && topBorderStyles(borderColour),
+					showSideBorders && sideBorderStyles,
+					showTopBorder && topBorderStyles,
 					innerBackgroundColour &&
 						setBackgroundColour(innerBackgroundColour),
 					padSides && sidePadding,

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -315,7 +315,6 @@ export const Section = ({
 				showTopBorder={showTopBorder}
 				padSides={padSides}
 				padBottom={padBottom}
-				format={format}
 				borderColour={borderColour ?? overrides?.border.container}
 				backgroundColour={decideBackgroundColour(
 					backgroundColour,
@@ -345,7 +344,6 @@ export const Section = ({
 			showSideBorders={showSideBorders}
 			showTopBorder={showTopBorder}
 			padSides={padSides}
-			format={format}
 			borderColour={borderColour ?? overrides?.border.container}
 			backgroundColour={decideBackgroundColour(
 				backgroundColour,


### PR DESCRIPTION
## What does this change?

Use the `palette` for the `ElementContainer`’s fallback border colour. Use the `style` prop for dynamic style [as per the Emotion Best practices](https://emotion.sh/docs/best-practices#use-the-style-prop-for-dynamic-styles).

## Why?

Simpler, more consistent colour decision.