### PR TITLE
Simplify Byline props

### DIFF
--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { type ArticleFormat, ArticleSpecial } from '@guardian/libs';
 import {
 	headlineMediumItalic17,
 	headlineMediumItalic20,
@@ -14,7 +13,7 @@ import { palette } from '../palette';
 
 type Props = {
 	text: string;
-	format: ArticleFormat;
+	isLabs: boolean;
 	size: SmallHeadlineSize;
 };
 
@@ -23,11 +22,11 @@ const baseStyles = css`
 	color: ${palette('--byline')};
 `;
 
-const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
+const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 	switch (size) {
 		case 'ginormous':
 		case 'huge':
-			if (format.theme === ArticleSpecial.Labs) {
+			if (isLabs) {
 				return css`
 					${textSansItalic24};
 					font-size: 24px;
@@ -45,7 +44,7 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 				}
 			`;
 		case 'large': {
-			if (format.theme === ArticleSpecial.Labs) {
+			if (isLabs) {
 				return css`
 					${textSansItalic20};
 					font-size: 24px;
@@ -64,7 +63,7 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 			`;
 		}
 		case 'medium': {
-			if (format.theme === ArticleSpecial.Labs) {
+			if (isLabs) {
 				return css`
 					${textSansItalic20};
 					line-height: 20px;
@@ -82,7 +81,7 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 			`;
 		}
 		case 'small': {
-			if (format.theme === ArticleSpecial.Labs) {
+			if (isLabs) {
 				return css`
 					${textSansItalic17};
 					line-height: 18px;
@@ -97,6 +96,6 @@ const bylineStyles = (size: SmallHeadlineSize, format: ArticleFormat) => {
 	}
 };
 
-export const Byline = ({ text, format, size }: Props) => {
-	return <span css={[baseStyles, bylineStyles(size, format)]}>{text}</span>;
+export const Byline = ({ text, isLabs, size }: Props) => {
+	return <span css={[baseStyles, bylineStyles(size, isLabs)]}>{text}</span>;
 };

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -262,7 +262,11 @@ export const CardHeadline = ({
 				</span>
 			</h3>
 			{!!byline && showByline && (
-				<Byline text={byline} format={format} size={size} />
+				<Byline
+					text={byline}
+					isLabs={format.theme === ArticleSpecial.Labs}
+					size={size}
+				/>
 			)}
 		</WithLink>
 	);

--- a/dotcom-rendering/src/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.stories.tsx
@@ -2,6 +2,7 @@ import {
 	ArticleDesign,
 	ArticleDisplay,
 	type ArticleFormat,
+	ArticleSpecial,
 	Pillar,
 } from '@guardian/libs';
 import type { StoryObj } from '@storybook/react';
@@ -26,7 +27,7 @@ export const defaultStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with each pillar looks"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			kickerText="The kicker text"
 		/>
 	</Section>
@@ -38,7 +39,7 @@ export const xsmallStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a large headline link looks"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			size="large"
 		/>
 	</Section>
@@ -52,7 +53,7 @@ export const liveStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a live kicker looks"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			kickerText="Live"
 		/>
 	</Section>
@@ -64,7 +65,7 @@ export const noLinebreak: StoryObj = ({ format }: StoryArgs) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with no kicker line break looks"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			kickerText="Live"
 			hideLineBreak={true}
 		/>
@@ -77,7 +78,7 @@ export const pulsingDot: StoryObj = ({ format }: StoryArgs) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline with a pulsing dot looks"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			kickerText="Live"
 			showPulsingDot={true}
 		/>
@@ -90,7 +91,7 @@ export const opinionxxxsmall: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how small links to opinion articles look"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			size="small"
 			byline="Comment byline"
@@ -112,7 +113,7 @@ export const InUnderlinedState: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is the underlined state when showUnderline is true"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showUnderline={true}
 			size="small"
 			kickerText="I am never underlined"
@@ -129,7 +130,7 @@ export const linkStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="This is how a headline looks as a link"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			kickerText="I am not a link"
 			link={{
 				to: 'https://www.theguardian.com/us-news/2019/nov/14/nancy-pelosi-trump-ukraine-bribery',
@@ -152,7 +153,7 @@ export const LiveBlogSizes: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Large live"
 			showPulsingDot={true}
@@ -161,7 +162,7 @@ export const LiveBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Medium live"
 			showPulsingDot={true}
@@ -170,7 +171,7 @@ export const LiveBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Small live"
 			showPulsingDot={true}
@@ -179,7 +180,7 @@ export const LiveBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Tiny live"
 			showPulsingDot={true}
@@ -202,7 +203,7 @@ export const DeadBlogSizes: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Large dead"
 			showPulsingDot={false}
@@ -211,7 +212,7 @@ export const DeadBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Medium dead"
 			showPulsingDot={false}
@@ -220,7 +221,7 @@ export const DeadBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Small dead"
 			showPulsingDot={false}
@@ -229,7 +230,7 @@ export const DeadBlogSizes: StoryObj = ({ format }: StoryProps) => (
 		<br />
 		<LinkHeadline
 			headlineText="Revealed: how US and UK spy agencies defeat internet privacy and security"
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showQuotes={true}
 			kickerText="Tiny dead"
 			showPulsingDot={false}
@@ -252,7 +253,7 @@ export const Updated: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
 		<LinkHeadline
 			headlineText=""
-			format={format}
+			isLabs={format.theme === ArticleSpecial.Labs}
 			showPulsingDot={true}
 			hideLineBreak={true}
 			kickerText="Updated 7m ago"

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	headlineMedium17,
 	headlineMedium20,
@@ -19,7 +18,7 @@ type HeadlineLink = {
 
 type Props = {
 	headlineText: string; // The text shown
-	format: ArticleFormat;
+	isLabs: boolean;
 	showUnderline?: boolean; // Some headlines have text-decoration underlined when hovered
 	kickerText?: string;
 	showPulsingDot?: boolean;
@@ -78,11 +77,11 @@ const visitedStyles = (visitedColour: string) => css`
 
 export const LinkHeadline = ({
 	headlineText,
-	format,
 	showUnderline = false,
 	kickerText,
 	showPulsingDot,
 	hideLineBreak,
+	isLabs,
 	showQuotes = false,
 	size = 'medium',
 	link,
@@ -119,7 +118,7 @@ export const LinkHeadline = ({
 						{headlineText}
 					</a>
 					{!!byline && (
-						<Byline text={byline} format={format} size={size} />
+						<Byline text={byline} size={size} isLabs={isLabs} />
 					)}
 				</>
 			) : (
@@ -127,7 +126,7 @@ export const LinkHeadline = ({
 				<>
 					<span>{headlineText}</span>
 					{!!byline && (
-						<Byline text={byline} size={size} format={format} />
+						<Byline text={byline} size={size} isLabs={isLabs} />
 					)}
 				</>
 			)}

--- a/dotcom-rendering/src/components/MostViewedFooterItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterItem.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { ArticleDesign } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import { headlineMedium17 } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import { AgeWarning } from './AgeWarning';
@@ -86,7 +86,7 @@ export const MostViewedFooterItem = ({
 					{format.design === ArticleDesign.LiveBlog ? (
 						<LinkHeadline
 							headlineText={headlineText}
-							format={format}
+							isLabs={format.theme === ArticleSpecial.Labs}
 							size="small"
 							kickerText="Live"
 							hideLineBreak={false}
@@ -96,7 +96,7 @@ export const MostViewedFooterItem = ({
 					) : (
 						<LinkHeadline
 							headlineText={headlineText}
-							format={format}
+							isLabs={format.theme === ArticleSpecial.Labs}
 							size="small"
 							showQuotes={
 								format.design === ArticleDesign.Comment ||

--- a/dotcom-rendering/src/components/MostViewedRightItem.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightItem.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ArticleDesign } from '@guardian/libs';
+import { ArticleDesign, ArticleSpecial } from '@guardian/libs';
 import {
 	headlineMedium17,
 	palette as sourcePalette,
@@ -100,7 +100,10 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 							{trail.format.design === ArticleDesign.LiveBlog ? (
 								<LinkHeadline
 									headlineText={trail.headline}
-									format={trail.format}
+									isLabs={
+										trail.format.theme ===
+										ArticleSpecial.Labs
+									}
 									size="small"
 									showUnderline={isHovered}
 									kickerText="Live"
@@ -115,7 +118,10 @@ export const MostViewedRightItem = ({ trail, mostViewedItemIndex }: Props) => {
 							) : (
 								<LinkHeadline
 									headlineText={trail.headline}
-									format={trail.format}
+									isLabs={
+										trail.format.theme ===
+										ArticleSpecial.Labs
+									}
 									size="small"
 									showUnderline={isHovered}
 									byline={


### PR DESCRIPTION
## What does this change?

Only check if a Byline is `ArticleSpecial.Labs` rather than passing the entire format.

## Why?

Simplify the prop by only taking what is stricly necessary. This has the benefit of makings tests and stories easier to reason about, and passing less data through prop drilling.

## Drawbacks

The `format` object is commonly used for making decisions about how a component should look, so it’s possible that passing it in its entirety is “simpler”. Both approaches exist in this codebase, so there’s not clear winner.