### PR TITLE
Improve CSS of Pillars component in Titlepiece

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
@@ -74,8 +74,9 @@ const pillarUnderlineHeight = space[1] + 1;
 
 const pillarUnderline = css`
 	:after {
+		height: ${pillarUnderlineHeight}px;
 		/* This CSS var is dynamically set via the style attribute*/
-		border-bottom: ${pillarUnderlineHeight}px solid var(--pillar-underline);
+		background-color: var(--pillar-underline);
 		content: '';
 		display: block;
 		position: absolute;


### PR DESCRIPTION
## What does this change?

- Adjusts the height of the pillar underline pseudo element to account for the height of the horizontal divider underneath in the Titlepiece component
- Allows the anchor tags to occupy all available space within each pillar block, and swap margin for padding to give extra space to the hoverable link areas

## Why?

Fixes visual bugs found in the Pillars component when demoing the Masthead component to team

## Screenshots

## Before
https://github.com/user-attachments/assets/882924b1-6ebc-4391-8a26-3fe11af2b110

## After 
https://github.com/user-attachments/assets/edda52a1-6eda-40ce-a53d-c784ce82f54b


