### PR TITLE
Fix width bug on Masthead TopBar component for leftCol and wide breakpoints

### DIFF
--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -53,12 +53,6 @@ const topBarStyles = css`
 	}
 `;
 
-const topBarStylesWithoutPageSkin = css`
-	${from.wide} {
-		padding-right: 96px;
-	}
-`;
-
 const topBarLinkContainerStyles = css`
 	height: 100%;
 	display: flex;
@@ -148,13 +142,7 @@ export const TopBar = ({
 	});
 
 	return (
-		<div
-			css={[
-				topBarStyles,
-				!hasPageSkin && topBarStylesWithoutPageSkin,
-				hasPageSkin ? pageSkinContainer : center,
-			]}
-		>
+		<div css={[topBarStyles, hasPageSkin ? pageSkinContainer : center]}>
 			<TopBarLinkContainer showVerticalDivider={false} alignLeft={true}>
 				<TopBarSupport
 					contributionsServiceUrl={contributionsServiceUrl}


### PR DESCRIPTION
## What does this change?

Removes the CSS to specify a padding-right from leftCol breakpoint onwards to align the edge of the top bar content to the edge of the page content

## Why?

This was mistakenly brought through from the old component and shouldn't have been there

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/eb311291-ebeb-45d0-a511-c1eb84e2dae8
[after]: https://github.com/user-attachments/assets/e1ed02b6-f913-4b6a-be14-f6e2d8b55121
