### PR TITLE
Move global sport types to regular `.ts` file

### DIFF
--- a/dotcom-rendering/fixtures/manual/cricket-scoreboard.ts
+++ b/dotcom-rendering/fixtures/manual/cricket-scoreboard.ts
@@ -1,3 +1,5 @@
+import type { CricketMatch } from '../../src/types/sport';
+
 export const match: CricketMatch = {
 	teams: [
 		{

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -118,34 +118,6 @@ type ContentType =
 	| 'signup'
 	| 'userid';
 
-type CricketTeam = {
-	name: string;
-	home: boolean;
-};
-
-type FallOfWicket = {
-	order: number;
-};
-
-type CricketInnings = {
-	order: number;
-	battingTeam: string;
-	runsScored: string;
-	declared: boolean;
-	forfeited: boolean;
-	fallOfWicket: FallOfWicket[];
-	overs: string;
-};
-
-type CricketMatch = {
-	matchId: string;
-	competitionName: string;
-	venueName: string;
-	teams: CricketTeam[];
-	innings: CricketInnings[];
-	gameDate: string;
-};
-
 type StageType = 'DEV' | 'CODE' | 'PROD';
 
 type CardImageType = 'picture' | 'avatar' | 'crossword' | 'slideshow' | 'video';
@@ -164,41 +136,6 @@ type LeftColSize = 'compact' | 'wide';
 
 type UserBadge = {
 	name: string;
-};
-
-/**
- * Football
- */
-type TeamType = {
-	id: string;
-	name: string;
-	codename: string;
-	players: PlayerType[];
-	possession: number;
-	shotsOn: number;
-	shotsOff: number;
-	corners: number;
-	fouls: number;
-	colours: string;
-	score: number;
-	crest: string;
-	scorers: string[];
-};
-
-type PlayerType = {
-	id: string;
-	name: string;
-	position: string;
-	lastName: string;
-	substitute: boolean;
-	timeOnPitch: string;
-	shirtNumber: string;
-	events: EventType[];
-};
-
-type EventType = {
-	eventTime: string; // minutes
-	eventType: 'substitution' | 'dismissal' | 'booking';
 };
 
 interface Topic {

--- a/dotcom-rendering/src/components/CricketScoreboard.test.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
-import { CricketInnings, cricketScore } from './CricketScoreboard';
+import type { CricketInnings, CricketMatch } from '../types/sport';
+import { CricketInningsScores, cricketScore } from './CricketScoreboard';
 
 const defaultInnings: CricketInnings = {
 	order: 0,
@@ -106,7 +107,7 @@ describe('CricketScoreboard', () => {
 				],
 			};
 			const { getByText } = render(
-				<CricketInnings match={match} home={true} />,
+				<CricketInningsScores match={match} home={true} />,
 			);
 			expect(getByText('26 all out (10.5 overs)')).toBeInTheDocument();
 		});
@@ -139,7 +140,7 @@ describe('CricketScoreboard', () => {
 				],
 			};
 			const { getByText } = render(
-				<CricketInnings match={match} home={true} />,
+				<CricketInningsScores match={match} home={true} />,
 			);
 			expect(
 				getByText('26 & 26 - 3 forfeited (10.5 overs)'),

--- a/dotcom-rendering/src/components/CricketScoreboard.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source/foundations';
 import { decidePalette } from '../lib/decidePalette';
 import type { Palette } from '../types/palette';
+import type { CricketInnings, CricketMatch } from '../types/sport';
 import { DateTime } from './DateTime';
 
 const ALL_OUT_WICKETS = 10;
@@ -99,7 +100,7 @@ export const cricketScore = ({
 	return `${innings.runsScored} - ${innings.fallOfWicket.length}`;
 };
 
-export const CricketInnings = ({
+export const CricketInningsScores = ({
 	match,
 	home,
 }: {
@@ -163,7 +164,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 							{match.teams.find((team) => !!team.home)?.name}
 						</td>
 						<td css={cellStyle}>
-							<CricketInnings match={match} home={true} />
+							<CricketInningsScores match={match} home={true} />
 						</td>
 					</tr>
 					{/* Away team */}
@@ -172,7 +173,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 							{match.teams.find((team) => !team.home)?.name}
 						</td>
 						<td css={cellStyle}>
-							<CricketInnings match={match} home={false} />
+							<CricketInningsScores match={match} home={false} />
 						</td>
 					</tr>
 				</tbody>

--- a/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
+++ b/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
@@ -1,6 +1,7 @@
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import type { SWRConfiguration } from 'swr';
 import { useApi } from '../lib/useApi';
+import type { CricketMatch } from '../types/sport';
 import { CricketScoreboard } from './CricketScoreboard';
 import { Placeholder } from './Placeholder';
 

--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -3,6 +3,7 @@ import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import { from } from '@guardian/source/foundations';
 import type { SWRConfiguration } from 'swr';
 import { useApi } from '../lib/useApi';
+import type { TeamType } from '../types/sport';
 import type { TagType } from '../types/tag';
 import { ArticleHeadline } from './ArticleHeadline';
 import { MatchNav } from './MatchNav';

--- a/dotcom-rendering/src/components/GetMatchStats.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchStats.importable.tsx
@@ -2,6 +2,7 @@ import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import type { SWRConfiguration } from 'swr';
 import { useApi } from '../lib/useApi';
 import { useHydrated } from '../lib/useHydrated';
+import type { TeamType } from '../types/sport';
 import { MatchStats } from './MatchStats';
 import { Placeholder } from './Placeholder';
 

--- a/dotcom-rendering/src/components/Lineup.stories.tsx
+++ b/dotcom-rendering/src/components/Lineup.stories.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { PlayerType } from '../types/sport';
 import { Lineup } from './Lineup';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/dotcom-rendering/src/components/Lineup.tsx
+++ b/dotcom-rendering/src/components/Lineup.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { textSans15 } from '@guardian/source/foundations';
+import type { EventType, PlayerType } from '../types/sport';
 
 type Props = {
 	players: PlayerType[];

--- a/dotcom-rendering/src/components/MatchNav.stories.tsx
+++ b/dotcom-rendering/src/components/MatchNav.stories.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import type { TeamType } from '../types/sport';
 import { ArticleContainer } from './ArticleContainer';
 import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';

--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -6,6 +6,7 @@ import {
 	textSans15,
 	until,
 } from '@guardian/source/foundations';
+import type { TeamType } from '../types/sport';
 import { Score } from './Score';
 
 type Props = {

--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -10,6 +10,7 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { palette as themePalette } from '../palette';
+import type { TeamType } from '../types/sport';
 import { Distribution } from './Distribution';
 import { Doughnut } from './Doughnut';
 import { GoalAttempts } from './GoalAttempts';

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -5065,6 +5065,7 @@
             ]
         },
         "MatchType": {
+            "description": "General",
             "enum": [
                 "CricketMatchType",
                 "FootballMatchType"

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -12,6 +12,7 @@ import type {
 } from './content';
 import type { FooterType } from './footer';
 import type { FEOnwards } from './onwards';
+import type { MatchType } from './sport';
 import type { TagType } from './tag';
 import type { FETrailType } from './trails';
 
@@ -123,8 +124,6 @@ export interface FEArticleType {
 	lang?: string;
 	isRightToLeftLang?: boolean;
 }
-
-type MatchType = 'CricketMatchType' | 'FootballMatchType';
 
 type PageTypeType = {
 	hasShowcaseMainElement: boolean;

--- a/dotcom-rendering/src/types/matchReport.ts
+++ b/dotcom-rendering/src/types/matchReport.ts
@@ -1,3 +1,5 @@
+import type { TeamType } from './sport';
+
 export type MatchReportType = {
 	id: string;
 	isResult: boolean;

--- a/dotcom-rendering/src/types/sport.ts
+++ b/dotcom-rendering/src/types/sport.ts
@@ -1,0 +1,70 @@
+/**
+ * Football
+ */
+export type TeamType = {
+	id: string;
+	name: string;
+	codename: string;
+	players: PlayerType[];
+	possession: number;
+	shotsOn: number;
+	shotsOff: number;
+	corners: number;
+	fouls: number;
+	colours: string;
+	score: number;
+	crest: string;
+	scorers: string[];
+};
+
+export type PlayerType = {
+	id: string;
+	name: string;
+	position: string;
+	lastName: string;
+	substitute: boolean;
+	timeOnPitch: string;
+	shirtNumber: string;
+	events: EventType[];
+};
+
+export type EventType = {
+	eventTime: string; // minutes
+	eventType: 'substitution' | 'dismissal' | 'booking';
+};
+
+/**
+ * Cricket
+ */
+type CricketTeam = {
+	name: string;
+	home: boolean;
+};
+
+type FallOfWicket = {
+	order: number;
+};
+
+export type CricketInnings = {
+	order: number;
+	battingTeam: string;
+	runsScored: string;
+	declared: boolean;
+	forfeited: boolean;
+	fallOfWicket: FallOfWicket[];
+	overs: string;
+};
+
+export type CricketMatch = {
+	matchId: string;
+	competitionName: string;
+	venueName: string;
+	teams: CricketTeam[];
+	innings: CricketInnings[];
+	gameDate: string;
+};
+
+/**
+ * General
+ */
+export type MatchType = 'CricketMatchType' | 'FootballMatchType';


### PR DESCRIPTION
## What does this change?

As part of an ongoing effort to address https://github.com/guardian/dotcom-rendering/issues/7638 (see also https://github.com/guardian/dotcom-rendering/pull/11841) this moves global sport-related types out of `index.d.ts` and into a regular `sport.ts` files, with imports across the repository where appropriate.

## Why?

Global types are magic, and not in a good way. Better to import explicitly.