### PR TITLE
Changed the success message to reflect the transition from instant signup to a confirmation email

### DIFF
--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -183,7 +183,7 @@ export const ManyNewslettersForm = ({
 					</>
 				) : (
 					<p css={successMessageStyle}>
-						You are now a subscriber! Thank you for signing up
+						Please check your email and confirm your subscription
 					</p>
 				)}
 			</div>

--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -183,7 +183,7 @@ export const ManyNewslettersForm = ({
 					</>
 				) : (
 					<p css={successMessageStyle}>
-						Please check your email and confirm your subscription
+						Please check your email to confirm your subscription
 					</p>
 				)}
 			</div>


### PR DESCRIPTION
## What does this change?

Changes the confirmation message on ManyNewsletterForm from `You are now a subscriber! Thank you for signing up` to `Please check your email and confirm your subscription`.

## Why?

After moving from `/consent-email`( automatically signing up user to selected newsletter) to `/consent-email`( sending confirmation emails), the success message needs to be updated.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1920" alt="Screenshot 2024-07-17 at 15 53 58" src="https://github.com/user-attachments/assets/318546fb-81fc-44f4-89ec-a5bab06b3606"> | <img width="1920" alt="Screenshot 2024-07-17 at 15 49 25" src="https://github.com/user-attachments/assets/39ddc28d-ccdc-4ed5-966a-1891543758df"> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
