### PR TITLE
Update SDC to 2.6.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -52,7 +52,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "workspace:*",
 		"@guardian/source-development-kitchen": "workspace:*",
-		"@guardian/support-dotcom-components": "2.6.0",
+		"@guardian/support-dotcom-components": "2.6.1",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.40.1",
 		"@sentry/browser": "7.75.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,8 +374,8 @@ importers:
         specifier: workspace:*
         version: link:../libs/@guardian/source-development-kitchen
       '@guardian/support-dotcom-components':
-        specifier: 2.6.0
-        version: 2.6.0(@guardian/libs@17.0.1)(zod@3.22.4)
+        specifier: 2.6.1
+        version: 2.6.1(@guardian/libs@17.0.1)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4270,7 +4270,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -4547,8 +4547,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@2.6.0(@guardian/libs@17.0.1)(zod@3.22.4):
-    resolution: {integrity: sha512-RV6GFYFt9GZWacy3OwpSVejloz0/hy3+Z2sRHAfp6vFqlD4M5D4uG3cXhaRIlre1b7Jue3kwNx/+XCcQ4QZgXw==}
+  /@guardian/support-dotcom-components@2.6.1(@guardian/libs@17.0.1)(zod@3.22.4):
+    resolution: {integrity: sha512-zCxBPINdz0QL/axO8LRUnGK0vMNONp2tUnzIznRL1/PvyP+IB5dIb369pEPVFPIFL1xu4aWmNir962jW+5a41g==}
     peerDependencies:
       '@guardian/libs': ^17.0.0
       zod: ^3.22.4
@@ -6461,7 +6461,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8230,8 +8230,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
     dev: false
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.93.0):
@@ -8241,8 +8241,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
     dev: false
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.93.0):
@@ -8256,8 +8256,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.93.0)
     dev: false
 
@@ -8766,7 +8766,7 @@ packages:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -9811,7 +9811,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.39)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /css-loader@7.1.2(webpack@5.93.0):
@@ -10764,7 +10764,7 @@ packages:
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -11725,7 +11725,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /form-data@3.0.1:
@@ -17124,7 +17124,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -17662,7 +17662,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.6.13)(@types/node@16.18.68)(typescript@4.9.5):
@@ -18449,7 +18449,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.2.1(webpack@5.93.0):
@@ -18511,8 +18511,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
       webpack-dev-middleware: 7.2.1(webpack@5.93.0)
       ws: 8.17.1
     transitivePeerDependencies:
@@ -18557,7 +18557,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?
This is to change SDC version to 2.6.1 as per [Version Packages #1192](https://github.com/guardian/support-dotcom-components/pull/1192).This was done to add new tags to the tracking for WeeklyArticleHistory