### PR TITLE
[Fairground] Add basic picture to HighlightsCard

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -14,6 +14,7 @@ type Props = {
 	loading: Loading;
 	alt?: string;
 	roundedCorners?: boolean;
+	isHighlightsCardImage?: boolean;
 };
 
 /**
@@ -101,12 +102,20 @@ const borderRadius = css`
 	}
 `;
 
+const highlightsCardImage = css`
+	border-radius: 100%;
+	object-fit: cover;
+	height: 100%;
+	width: 100%;
+`;
+
 export const CardPicture = ({
 	mainImage,
 	alt,
 	imageSize,
 	loading,
 	roundedCorners,
+	isHighlightsCardImage,
 }: Props) => {
 	const sources = generateSources(mainImage, decideImageWidths(imageSize));
 
@@ -115,7 +124,12 @@ export const CardPicture = ({
 	return (
 		<picture
 			data-size={imageSize}
-			css={[block, aspectRatio, roundedCorners && borderRadius]}
+			css={[
+				block,
+				aspectRatio,
+				roundedCorners && borderRadius,
+				isHighlightsCardImage && highlightsCardImage,
+			]}
 		>
 			{sources.map((source) => {
 				return (
@@ -137,7 +151,7 @@ export const CardPicture = ({
 			<img
 				alt={alt ?? ''}
 				src={fallbackSource.lowResUrl}
-				css={block}
+				css={[block, isHighlightsCardImage && highlightsCardImage]}
 				loading={loading}
 				data-chromatic="ignore"
 			/>

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -103,9 +103,7 @@ const borderRadius = css`
 `;
 
 const circularStyles = css`
-	& > * {
-		border-radius: 100%;
-	}
+	border-radius: 100%;
 	object-fit: cover;
 	height: 100%;
 	width: 100%;

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -14,7 +14,7 @@ type Props = {
 	loading: Loading;
 	alt?: string;
 	roundedCorners?: boolean;
-	isHighlightsCardImage?: boolean;
+	isCircular?: boolean;
 };
 
 /**
@@ -102,8 +102,10 @@ const borderRadius = css`
 	}
 `;
 
-const highlightsCardImage = css`
-	border-radius: 100%;
+const circularStyles = css`
+	& > * {
+		border-radius: 100%;
+	}
 	object-fit: cover;
 	height: 100%;
 	width: 100%;
@@ -115,7 +117,7 @@ export const CardPicture = ({
 	imageSize,
 	loading,
 	roundedCorners,
-	isHighlightsCardImage,
+	isCircular,
 }: Props) => {
 	const sources = generateSources(mainImage, decideImageWidths(imageSize));
 
@@ -128,7 +130,7 @@ export const CardPicture = ({
 				block,
 				aspectRatio,
 				roundedCorners && borderRadius,
-				isHighlightsCardImage && highlightsCardImage,
+				isCircular && circularStyles,
 			]}
 		>
 			{sources.map((source) => {
@@ -151,7 +153,7 @@ export const CardPicture = ({
 			<img
 				alt={alt ?? ''}
 				src={fallbackSource.lowResUrl}
-				css={[block, isHighlightsCardImage && highlightsCardImage]}
+				css={[block, isCircular && circularStyles]}
 				loading={loading}
 				data-chromatic="ignore"
 			/>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -27,10 +27,13 @@ const meta = {
 		},
 		showPulsingDot: true,
 		kickerText: 'News',
-		avatarUrl:
-			'https://uploads.guim.co.uk/2017/10/06/George-Monbiot,-L.png',
 		byline: 'Georges Monbiot',
 		mainMedia: mainGallery,
+		image: {
+			src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+			altText: 'alt text',
+		},
+		imageLoading: 'eager',
 	},
 } satisfies Meta<typeof HighlightsCard>;
 
@@ -57,6 +60,14 @@ const CardWrapper = ({ children }: { children: React.ReactNode }) => {
 };
 
 export const Default = {};
+
+export const WithAvatar: Story = {
+	args: {
+		avatarUrl:
+			'https://uploads.guim.co.uk/2017/10/06/George-Monbiot,-L.png',
+	},
+	name: 'With Avatar',
+};
 
 export const WithMediaIcon: Story = {
 	args: {

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -18,8 +18,7 @@ const meta = {
 		</CardWrapper>
 	),
 	args: {
-		headlineText:
-			'Underground cave found on moon could be ideal base for explorers',
+		headlineText: 'Underground cave found on moon could be ideal base',
 		format: {
 			display: ArticleDisplay.Standard,
 			design: ArticleDesign.Standard,

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
 import { from, palette, until } from '@guardian/source/foundations';
-// import type { DCRFrontImage } from '../../types/front';
+import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
 import { Avatar } from '../Avatar';
 import { CardHeadline } from '../CardHeadline';
-// import type { Loading } from '../CardPicture';
+import type { Loading } from '../CardPicture';
+import { CardPicture } from '../CardPicture';
 import { Icon } from '../MediaMeta';
 
 export type HighlightsCardProps = {
@@ -13,14 +14,14 @@ export type HighlightsCardProps = {
 	format: ArticleFormat;
 	headlineText: string;
 	// showQuotedHeadline?: boolean;
-	// image?: DCRFrontImage;
-	// imageLoading: Loading;
+	image: DCRFrontImage;
+	imageLoading: Loading;
 	avatarUrl?: string;
 	mainMedia?: MainMedia;
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	// dataLinkName?: string;
-	byline?: string;
+	byline: string;
 	showMediaIcon?: boolean;
 };
 
@@ -84,8 +85,8 @@ export const HighlightsCard = ({
 	format,
 	headlineText,
 	// showQuotedHeadline,
-	// image,
-	// imageLoading,
+	image,
+	imageLoading,
 	avatarUrl,
 	mainMedia,
 	kickerText,
@@ -114,7 +115,12 @@ export const HighlightsCard = ({
 				{avatarUrl ? (
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
 				) : (
-					<></>
+					<CardPicture
+						mainImage={image.src}
+						imageSize={'carousel'}
+						alt={image?.altText}
+						loading={imageLoading}
+					/>
 				)}
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -120,7 +120,7 @@ export const HighlightsCard = ({
 						mainImage={image.src}
 						alt={image.altText}
 						loading={imageLoading}
-						isHighlightsCardImage={true}
+						isCircular={true}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -116,7 +116,7 @@ export const HighlightsCard = ({
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
 				) : (
 					<CardPicture
-						imageSize={'medium'}
+						imageSize="medium"
 						mainImage={image.src}
 						alt={image.altText}
 						loading={imageLoading}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -21,7 +21,7 @@ export type HighlightsCardProps = {
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	// dataLinkName?: string;
-	byline: string;
+	byline?: string;
 	showMediaIcon?: boolean;
 };
 
@@ -116,10 +116,11 @@ export const HighlightsCard = ({
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
 				) : (
 					<CardPicture
+						imageSize={'medium'}
 						mainImage={image.src}
-						imageSize={'carousel'}
-						alt={image?.altText}
+						alt={image.altText}
 						loading={imageLoading}
+						isHighlightsCardImage={true}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -112,17 +112,18 @@ export const HighlightsCard = ({
 				</div>
 			) : null}
 			<div css={imageArea}>
-				{avatarUrl ? (
+				{(avatarUrl && (
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
-				) : image ? (
-					<CardPicture
-						imageSize="medium"
-						mainImage={image.src}
-						alt={image.altText}
-						loading={imageLoading}
-						isCircular={true}
-					/>
-				) : null}
+				)) ??
+					(image && (
+						<CardPicture
+							imageSize="medium"
+							mainImage={image.src}
+							alt={image.altText}
+							loading={imageLoading}
+							isCircular={true}
+						/>
+					))}
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -14,8 +14,8 @@ export type HighlightsCardProps = {
 	format: ArticleFormat;
 	headlineText: string;
 	// showQuotedHeadline?: boolean;
-	image: DCRFrontImage;
-	imageLoading: Loading;
+	image?: DCRFrontImage;
+	imageLoading?: Loading;
 	avatarUrl?: string;
 	mainMedia?: MainMedia;
 	kickerText?: string;
@@ -86,7 +86,7 @@ export const HighlightsCard = ({
 	headlineText,
 	// showQuotedHeadline,
 	image,
-	imageLoading,
+	imageLoading = 'lazy',
 	avatarUrl,
 	mainMedia,
 	kickerText,
@@ -114,7 +114,7 @@ export const HighlightsCard = ({
 			<div css={imageArea}>
 				{avatarUrl ? (
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
-				) : (
+				) : image ? (
 					<CardPicture
 						imageSize="medium"
 						mainImage={image.src}
@@ -122,7 +122,7 @@ export const HighlightsCard = ({
 						loading={imageLoading}
 						isCircular={true}
 					/>
-				)}
+				) : null}
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -84,6 +84,8 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 
 export const HighlightsContainer = ({ trails }: Props) => {
 	const carouselLength = trails.length;
+	const imageLoading = 'eager';
+
 	return (
 		<ol
 			css={[carouselStyles, generateCarouselColumnStyles(carouselLength)]}
@@ -97,6 +99,8 @@ export const HighlightsContainer = ({ trails }: Props) => {
 							kickerText={trail.kickerText}
 							avatarUrl={trail.avatarUrl}
 							byline={trail.byline}
+							image={trail.image}
+							imageLoading={imageLoading}
 						/>
 					</li>
 				);


### PR DESCRIPTION
## What does this change?

The card can either have an avatar cutout or an image - this adds the latter and adjusts the relevant highlights card story. 

Doesn't include hover styles functionality, that'll be a follow up PR. 

## Why?

Part of the homepage redesign project.

## Screenshots

<img width="398" alt="image" src="https://github.com/user-attachments/assets/b27d98e2-c9e8-4ac3-a48a-c80b5ca52a55">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
