### PR TITLE
Revert "Adjust `facia-rendering` and `tag-page-rendering` instance count"

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -77,8 +77,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 9,
-		maximumInstances: 90,
+		minimumInstances: 18,
+		maximumInstances: 180,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s
@@ -112,8 +112,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 9,
-		maximumInstances: 90,
+		minimumInstances: 18,
+		maximumInstances: 180,
 		policy: {
 			scalingStepsOut: [
 				// No scaling up effect when latency is lower than 0.4s


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#11865

Causing instability `facia-rendering
<img width="803" alt="image" src="https://github.com/user-attachments/assets/8be6e6b4-3304-4b4c-9fdb-0dcbfd93ee6f">
