### PR TITLE
Do not show support messages after sign in

### DIFF
--- a/dotcom-rendering/src/components/FooterReaderRevenueLinks.importable.tsx
+++ b/dotcom-rendering/src/components/FooterReaderRevenueLinks.importable.tsx
@@ -106,6 +106,10 @@ const ReaderRevenueLinksNative = ({
 	const hideSupportMessaging = shouldHideSupportMessaging(isSignedIn);
 	const url = urls.support;
 
+	if (hideSupportMessaging === 'Pending') {
+		return null;
+	}
+
 	if (hideSupportMessaging) {
 		return (
 			<div>

--- a/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveSupportButton.importable.tsx
@@ -32,7 +32,9 @@ export const InteractiveSupportButton = ({
 	editionId,
 	subscribeUrl,
 }: InteractiveSupportButtonProps) => {
-	const [hideSupportMessaging, setHideSupportMessaging] = useState(true);
+	const [hideSupportMessaging, setHideSupportMessaging] = useState<
+		boolean | 'Pending'
+	>('Pending');
 	const isSignedIn = useIsSignedIn();
 
 	useEffect(() => {
@@ -41,7 +43,7 @@ export const InteractiveSupportButton = ({
 		}
 	}, [isSignedIn]);
 
-	if (!hideSupportMessaging) {
+	if (hideSupportMessaging === false) {
 		return (
 			<Hide when="above" breakpoint="tablet">
 				<ThemeProvider theme={buttonThemeReaderRevenue}>

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -102,6 +102,8 @@ const usePayload = ({
 	const isSignedIn = useIsSignedIn();
 
 	if (isSignedIn === 'Pending') return;
+	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
+	if (hideSupportMessagingForUser === 'Pending') return;
 	if (articleCounts === 'Pending') return;
 	if (hasOptedOutOfArticleCount === 'Pending') return;
 	log('dotcom', 'LiveBlogEpic has consent state');
@@ -122,7 +124,7 @@ const usePayload = ({
 			isMinuteArticle: true,
 			isPaidContent,
 			tags,
-			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
+			showSupportMessaging: !hideSupportMessagingForUser,
 			isRecurringContributor: isRecurringContributor(isSignedIn),
 			lastOneOffContributionDate:
 				getLastOneOffContributionTimestamp() ?? undefined,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -54,6 +54,7 @@ type BuildPayloadProps = BaseProps & {
 	optedOutOfArticleCount: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
 	userConsent: boolean;
+	hideSupportMessagingForUser: boolean;
 };
 
 type CanShowProps = BaseProps & {
@@ -127,6 +128,7 @@ const buildPayload = async ({
 	tags,
 	contentType,
 	userConsent,
+	hideSupportMessagingForUser,
 }: BuildPayloadProps): Promise<BannerPayload> => {
 	const articleCounts = await asyncArticleCounts;
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
@@ -144,7 +146,7 @@ const buildPayload = async ({
 		targeting: {
 			shouldHideReaderRevenue,
 			isPaidContent,
-			showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
+			showSupportMessaging: !hideSupportMessagingForUser,
 			engagementBannerLastClosedAt,
 			subscriptionBannerLastClosedAt,
 			signInBannerLastClosedAt,
@@ -213,6 +215,12 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		return { show: false };
 	}
 
+	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
+	if (hideSupportMessagingForUser === 'Pending') {
+		// We don't yet know the user's supporter status
+		return { show: false };
+	}
+
 	const purchaseInfo = getPurchaseInfo();
 	const showSignInPrompt =
 		purchaseInfo && !isSignedIn && !signInBannerLastClosedAt;
@@ -259,6 +267,7 @@ export const canShowRRBanner: CanShowFunctionType<BannerProps> = async ({
 		optedOutOfArticleCount,
 		asyncArticleCounts,
 		userConsent,
+		hideSupportMessagingForUser,
 	});
 
 	const response: ModuleDataResponse = await getBanner(

--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -181,7 +181,9 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 
 	useEffect(() => {
 		if (isSignedIn !== 'Pending') {
-			setShowSupportMessaging(!shouldHideSupportMessaging(isSignedIn));
+			setShowSupportMessaging(
+				shouldHideSupportMessaging(isSignedIn) === false,
+			);
 		}
 	}, [isSignedIn]);
 

--- a/dotcom-rendering/src/components/SupportTheG.importable.tsx
+++ b/dotcom-rendering/src/components/SupportTheG.importable.tsx
@@ -165,6 +165,7 @@ type ReaderRevenueLinksRemoteProps = {
 	pageViewId: string;
 	contributionsServiceUrl: string;
 	isSignedIn: boolean;
+	hideSupportMessagingForUser: boolean;
 };
 
 const ReaderRevenueLinksRemote = ({
@@ -172,6 +173,7 @@ const ReaderRevenueLinksRemote = ({
 	pageViewId,
 	contributionsServiceUrl,
 	isSignedIn,
+	hideSupportMessagingForUser,
 }: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData | null>(null);
@@ -191,7 +193,7 @@ const ReaderRevenueLinksRemote = ({
 				clientName: 'dcr',
 			},
 			targeting: {
-				showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
+				showSupportMessaging: !hideSupportMessagingForUser,
 				countryCode,
 				modulesVersion: MODULES_VERSION,
 				mvtId: Number(
@@ -264,7 +266,7 @@ type ReaderRevenueLinksNativeProps = {
 	};
 	pageViewId: string;
 	hasPageSkin: boolean;
-	isSignedIn: boolean;
+	hideSupportMessagingForUser: boolean;
 };
 
 const ReaderRevenueLinksNative = ({
@@ -274,10 +276,8 @@ const ReaderRevenueLinksNative = ({
 	urls,
 	pageViewId,
 	hasPageSkin,
-	isSignedIn,
+	hideSupportMessagingForUser,
 }: ReaderRevenueLinksNativeProps) => {
-	const hideSupportMessaging = shouldHideSupportMessaging(isSignedIn);
-
 	// Only the header component is in the AB test
 	const testName = inHeader ? 'RRHeaderLinks' : 'RRFooterLinks';
 	const campaignCode = `${testName}_control`;
@@ -298,7 +298,7 @@ const ReaderRevenueLinksNative = ({
 	});
 
 	useEffect(() => {
-		if (!hideSupportMessaging && inHeader) {
+		if (!hideSupportMessagingForUser && inHeader) {
 			void sendOphanComponentEvent('INSERT', tracking, renderingTarget);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -329,7 +329,7 @@ const ReaderRevenueLinksNative = ({
 		return urls[rrType];
 	};
 
-	if (hideSupportMessaging) {
+	if (hideSupportMessagingForUser) {
 		return (
 			<div css={inHeader && headerStyles}>
 				<div css={inHeader && hiddenUntilTablet}>
@@ -438,12 +438,20 @@ export const SupportTheG = ({
 		return null;
 	}
 
+	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
+
+	if (hideSupportMessagingForUser === 'Pending') {
+		// We don't yet know the user's supporter status
+		return null;
+	}
+
 	return inHeader && remoteHeader ? (
 		<ReaderRevenueLinksRemote
 			countryCode={countryCode}
 			pageViewId={pageViewId}
 			contributionsServiceUrl={contributionsServiceUrl}
 			isSignedIn={isSignedIn}
+			hideSupportMessagingForUser={hideSupportMessagingForUser}
 		/>
 	) : (
 		<ReaderRevenueLinksNative
@@ -453,7 +461,7 @@ export const SupportTheG = ({
 			urls={urls}
 			pageViewId={pageViewId}
 			hasPageSkin={hasPageSkin}
-			isSignedIn={isSignedIn}
+			hideSupportMessagingForUser={hideSupportMessagingForUser}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -60,6 +60,13 @@ const ReaderRevenueLinksRemote = ({
 			return;
 		}
 
+		const hideSupportMessagingForUser =
+			shouldHideSupportMessaging(isSignedIn);
+		if (hideSupportMessagingForUser === 'Pending') {
+			// We don't yet know the user's supporter status
+			return;
+		}
+
 		setAutomat();
 
 		const requestData: HeaderPayload = {
@@ -70,7 +77,7 @@ const ReaderRevenueLinksRemote = ({
 				clientName: 'dcr',
 			},
 			targeting: {
-				showSupportMessaging: !shouldHideSupportMessaging(isSignedIn),
+				showSupportMessaging: !hideSupportMessagingForUser,
 				countryCode,
 				modulesVersion: MODULES_VERSION,
 				mvtId: Number(

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -233,7 +233,7 @@ describe('hasSupporterCookie', () => {
 		expect(hasSupporterCookie(false)).toEqual(false);
 	});
 
-	it('returns true if cookie does not exist and user is signed in', () => {
-		expect(hasSupporterCookie(true)).toEqual(true);
+	it('returns Pending if cookie does not exist and user is signed in', () => {
+		expect(hasSupporterCookie(true)).toEqual('Pending');
 	});
 });

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -33,7 +33,9 @@ export const MODULES_VERSION = 'v3';
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
 // https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-export const hasSupporterCookie = (isSignedIn: boolean): boolean => {
+export const hasSupporterCookie = (
+	isSignedIn: boolean,
+): boolean | 'Pending' => {
 	const cookie = getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 	switch (cookie) {
 		case 'true':
@@ -42,11 +44,15 @@ export const hasSupporterCookie = (isSignedIn: boolean): boolean => {
 			return false;
 		default:
 			/**
-			 * If cookie is not present but user is signed in, do not show support messaging.
+			 * If cookie is not present but user is signed in, we do not want to show any messaging.
 			 * This is because of a race condition on the first page view after signing in, where
 			 * we may be awaiting the response from the API to find out if they're a supporter.
 			 */
-			return isSignedIn;
+			if (isSignedIn) {
+				return 'Pending';
+			} else {
+				return false;
+			}
 	}
 };
 
@@ -150,10 +156,20 @@ export const isRecentOneOffContributor = (): boolean => {
 	return false;
 };
 
-export const shouldHideSupportMessaging = (isSignedIn: boolean): boolean =>
-	hasSupporterCookie(isSignedIn) ||
-	isRecurringContributor(isSignedIn) ||
-	isRecentOneOffContributor();
+export const shouldHideSupportMessaging = (
+	isSignedIn: boolean,
+): boolean | 'Pending' => {
+	const hasCookie = hasSupporterCookie(isSignedIn);
+	if (hasCookie === 'Pending') {
+		return 'Pending';
+	} else {
+		return (
+			hasCookie ||
+			isRecurringContributor(isSignedIn) ||
+			isRecentOneOffContributor()
+		);
+	}
+};
 
 export const REQUIRED_CONSENTS_FOR_ARTICLE_COUNT = [1, 3, 7];
 const REQUIRED_CONSENTS_FOR_BROWSER_ID = [1, 3, 5, 7];


### PR DESCRIPTION
A slightly different approach to https://github.com/guardian/dotcom-rendering/pull/11811
In that PR we return `true` from `shouldHideSupportMessaging` if the user is signed in but the supporter cookie isn't yet available. This has the downside that they may be shown messages for supporters.
In this PR we instead return `'Pending'`.
This is then used to hide all messaging on the current page view.