### PR TITLE
Ensure data-spacefinder-role is on all block types

### DIFF
--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -82,6 +82,7 @@ const textElement =
 				return jsx('blockquote', {
 					key,
 					children,
+					'data-spacefinder-role': 'inline',
 					css: isQuoted
 						? quotedBlockquoteStyles
 						: simpleBlockquoteStyles,

--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -245,6 +245,7 @@ export const Caption = ({
 					tabletCaptionPadding,
 				padCaption && captionPadding,
 			]}
+			data-spacefinder-role="inline"
 		>
 			{mediaType === 'Video' ? (
 				<VideoIcon format={format} />
@@ -305,6 +306,7 @@ export const Caption = ({
 						shouldLimitWidth && veryLimitedWidth,
 						shouldLimitWidth && bigLeftMargin,
 					]}
+					data-spacefinder-role="inline"
 				>
 					{!!captionText && (
 						<span

--- a/dotcom-rendering/src/components/CodeBlockComponent.tsx
+++ b/dotcom-rendering/src/components/CodeBlockComponent.tsx
@@ -52,7 +52,7 @@ export const CodeBlockComponent = ({
 	language = 'text',
 }: Props) => {
 	return (
-		<pre css={codeStyles}>
+		<pre css={codeStyles} data-spacefinder-role="inline">
 			<code>
 				<div dangerouslySetInnerHTML={{ __html: code }} />
 			</code>

--- a/dotcom-rendering/src/components/DividerBlockComponent.tsx
+++ b/dotcom-rendering/src/components/DividerBlockComponent.tsx
@@ -50,6 +50,7 @@ export const DividerBlockComponent = ({
 	spaceAbove = 'loose',
 }: Props) => (
 	<hr
+		data-spacefinder-role="inline"
 		css={[
 			baseStyles,
 			size === 'partial' ? sizePartialStyle : sizeFullStyle,

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -36,6 +36,7 @@ type PriorityProps = {
 
 type IslandProps = {
 	children: JSX.Element;
+	role?: string;
 } & PriorityProps[keyof PriorityProps];
 
 /**
@@ -47,7 +48,7 @@ type IslandProps = {
  * @param {IslandProps} props - JSX Props
  * @param {JSX.Element} props.children - The component being inserted. Must be a single JSX Element
  */
-export const Island = ({ priority, defer, children }: IslandProps) => {
+export const Island = ({ priority, defer, children, role }: IslandProps) => {
 	const rootMargin =
 		defer?.until === 'visible' ? defer.rootMargin : undefined;
 
@@ -61,6 +62,7 @@ export const Island = ({ priority, defer, children }: IslandProps) => {
 			deferUntil={defer?.until}
 			props={JSON.stringify(children.props)}
 			rootMargin={rootMargin}
+			data-spacefinder-role={role}
 		>
 			{children}
 		</gu-island>

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -262,6 +262,7 @@ export const PullQuoteBlockComponent = ({
 				fontCss(role, format),
 				alignmentCss(role, format),
 			]}
+			data-spacefinder-role={role}
 		>
 			<QuoteIcon colour={palette('--pullquote-icon')} />
 			<blockquote

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
@@ -15,7 +15,7 @@ const starsWrapper = css`
 `;
 
 export const StarRatingBlockComponent = ({ rating, size }: Props) => (
-	<div css={starsWrapper}>
+	<div css={starsWrapper} data-spacefinder-role="inline">
 		<StarRating rating={rating} size={size} />
 	</div>
 );

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -20,7 +20,11 @@ export const VideoAtom = ({
 }: Props) => {
 	if (assets.length === 0) return null; // Handle empty assets array
 	return (
-		<MaintainAspectRatio height={height} width={width}>
+		<MaintainAspectRatio
+			height={height}
+			width={width}
+			data-spacefinder-role="inline"
+		>
 			{/* eslint-disable-next-line jsx-a11y/media-has-caption */}
 			<video
 				controls={true}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -403,7 +403,11 @@ export const renderElement = ({
 			return (
 				// Deferring interactives until CPU idle achieves the lowest Cumulative Layout Shift (CLS)
 				// For more information on the experiment we ran see: https://github.com/guardian/dotcom-rendering/pull/4942
-				<Island priority="critical" defer={{ until: 'idle' }}>
+				<Island
+					priority="critical"
+					defer={{ until: 'idle' }}
+					role={element.role}
+				>
 					<InteractiveBlockComponent
 						url={element.url}
 						scriptUrl={element.scriptUrl}
@@ -421,7 +425,7 @@ export const renderElement = ({
 			return <ItemLinkBlockElement html={element.html} />;
 		case 'model.dotcomrendering.pageElements.InteractiveContentsBlockElement':
 			return (
-				<div id={element.elementId}>
+				<div id={element.elementId} data-spacefinder-role="inline">
 					<Island priority="critical" defer={{ until: 'visible' }}>
 						<InteractiveContentsBlockComponent
 							subheadingLinks={element.subheadingLinks}


### PR DESCRIPTION
## What does this change?
Add `data-spacefinder-role` to blocks that are not wrapped in a `figure` and are not paragraphs or headings. [So just the ones listed here](https://github.com/guardian/dotcom-rendering/blob/3b2cb842002d74eb4f2d6c35798f5c443cabd516/dotcom-rendering/src/lib/renderElement.tsx#L839).

## Why?
At the moment spacefinder in commercial has a "catch-all" rule to avoid elements without any rules but it involves are rather confusing string of css `:not()` selectors.

The `data-spacefinder-role` attribute tells spacefinder the alignment of the block, whether it extends into the left or right column.

We know all the blocks, so if `data-spacefinder-role` is available on all blocks, we can rely on it to decide how ads should appear around them.

Although we may not mind placing ads next to some of these block types, initially we will replicate the current behaviour and avoid them. And take a look at the rules later.


