### PR TITLE
Add mini profiles element

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaway.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaway.tsx
@@ -19,7 +19,7 @@ const headingIndexStyles = css`
 	font-weight: bold;
 `;
 
-const headingLineStyles = css`
+export const headingLineStyles = css`
 	width: 140px;
 	margin: 0 0 2px 0;
 	border: none;

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -10,7 +10,7 @@ import type {
 	MiniProfile as MiniProfileModel,
 	StarRating,
 } from '../types/content';
-import { Subheading } from './Subheading';
+import { subheadingStyles } from './Subheading';
 
 const miniProfileStyles = css`
 	padding-top: 8px;
@@ -25,14 +25,18 @@ const headingLineStyles = css`
 
 const bioStyles = css`
 	${textSans14};
-	line-height: 135%;
 	padding-top: 6px;
-	overflow-wrap: break-word;
-	border-bottom: 1px solid ${palette('--article-border')};
-	color: ${neutral[46]};
+	color: ${palette('--mini-profiles-text-subdued')};
+	line-height: 1.3rem;
+	p {
+		margin-bottom: 0.5rem;
+	}
 	a {
 		color: ${palette('--caption-link')};
-		text-decoration: none;
+		text-underline-offset: 3px;
+	}
+	a:not(:hover) {
+		text-decoration-color: ${neutral[86]};
 	}
 	a:hover {
 		text-decoration: underline;
@@ -40,43 +44,44 @@ const bioStyles = css`
 	strong {
 		font-weight: bold;
 	}
-	p {
-		margin-bottom: 0.5rem;
-	}
-
-	ol {
-		list-style: decimal;
-		list-style-position: inside;
-		margin-bottom: 1rem;
-	}
-
 	ul {
 		list-style: none;
 		margin: 0 0 0.75rem;
 		padding: 0;
-		margin-bottom: 1rem;
-		line-height: 1.3rem;
+		margin-bottom: 0.5rem;
 	}
-
 	ul li {
 		padding-left: 1.25rem;
 	}
-
 	ul li p {
 		display: inline-block;
 		margin-bottom: 0;
 	}
-
 	ul li:before {
 		display: inline-block;
 		content: '';
 		border-radius: 0.375rem;
 		height: 10px;
 		width: 10px;
-		margin-right: 0.5rem;
-		background-color: ${neutral[86]};
-		margin-left: -1.25rem;
+		margin: 0 0.5rem 0 -1.25rem;
+		background-color: ${palette('--bullet-fill')};
 	}
+`;
+
+const endNoteStyles = css`
+	${textSans14};
+	line-height: 135%;
+	color: ${palette('--mini-profiles-text-subdued')};
+	margin-bottom: 1rem;
+`;
+
+const bottomBorderStyles = css`
+	border-top: 1px solid ${palette('--article-border')};
+	margin-bottom: 0.5rem;
+`;
+
+const headingMarginStyle = css`
+	margin-bottom: 4px;
 `;
 
 interface MiniProfileProps {
@@ -114,13 +119,12 @@ export const MiniProfile = ({
 		<>
 			<li css={miniProfileStyles} data-spacefinder-role="nested">
 				<hr css={headingLineStyles} />
-				<Subheading
+				<h3
 					id={slugify(miniProfile.title)}
-					format={format}
-					topPadding={false}
+					css={[subheadingStyles(format), headingMarginStyle]}
 				>
 					{miniProfile.title}
-				</Subheading>
+				</h3>
 				<Bio html={miniProfile.bio} />
 				{miniProfile.body.map((element, index) => (
 					<RenderArticleElement
@@ -145,6 +149,9 @@ export const MiniProfile = ({
 						isListElement={true}
 					/>
 				))}
+				{miniProfile.endNote ? (
+					<EndNote text={miniProfile.endNote} />
+				) : null}
 			</li>
 		</>
 	);
@@ -152,6 +159,19 @@ export const MiniProfile = ({
 
 const Bio = ({ html }: { html?: string }) => {
 	if (!html) return null;
+	return (
+		<>
+			<div css={bioStyles} dangerouslySetInnerHTML={{ __html: html }} />
+			<div css={bottomBorderStyles} />
+		</>
+	);
+};
 
-	return <div css={bioStyles} dangerouslySetInnerHTML={{ __html: html }} />;
+const EndNote = ({ text }: { text?: string }) => {
+	if (!text) return null;
+	return (
+		<p css={endNoteStyles}>
+			<em>{text}</em>
+		</p>
+	);
 };

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -4,6 +4,7 @@ import { neutral, textSans14 } from '@guardian/source/foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { slugify } from '../model/enhance-H2s';
+import { sanitiseHTML } from '../model/sanitise';
 import { palette } from '../palette';
 import type { ServerSideTests, Switches } from '../types/config';
 import type {
@@ -11,7 +12,6 @@ import type {
 	StarRating,
 } from '../types/content';
 import { subheadingStyles } from './Subheading';
-import { sanitiseHTML } from 'src/model/sanitise';
 
 const miniProfileStyles = css`
 	padding-top: 8px;

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -1,16 +1,10 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat } from '@guardian/libs';
 import { neutral, textSans14 } from '@guardian/source/foundations';
-import type { EditionId } from '../lib/edition';
-import type { ArticleElementRenderer } from '../lib/renderElement';
 import { slugify } from '../model/enhance-H2s';
 import { sanitiseHTML } from '../model/sanitise';
 import { palette } from '../palette';
-import type { ServerSideTests, Switches } from '../types/config';
-import type {
-	MiniProfile as MiniProfileModel,
-	StarRating,
-} from '../types/content';
+import type { MiniProfile as MiniProfileModel } from '../types/content';
 import { subheadingStyles } from './Subheading';
 
 const miniProfileStyles = css`
@@ -90,35 +84,15 @@ const headingMarginStyle = css`
 `;
 
 interface MiniProfileProps {
-	format: ArticleFormat;
-	ajaxUrl: string;
-	host?: string;
-	pageId: string;
-	isAdFreeUser: boolean;
-	isSensitive: boolean;
-	abTests: ServerSideTests;
-	switches: Switches;
-	editionId: EditionId;
-	hideCaption?: boolean;
-	starRating?: StarRating;
 	miniProfile: MiniProfileModel;
-	RenderArticleElement: ArticleElementRenderer;
+	format: ArticleFormat;
+	children: React.ReactNode;
 }
 
 export const MiniProfile = ({
 	miniProfile,
 	format,
-	ajaxUrl,
-	host,
-	pageId,
-	isAdFreeUser,
-	isSensitive,
-	switches,
-	abTests,
-	editionId,
-	hideCaption,
-	starRating,
-	RenderArticleElement,
+	children,
 }: MiniProfileProps) => {
 	return (
 		<>
@@ -131,29 +105,7 @@ export const MiniProfile = ({
 					{miniProfile.title}
 				</h3>
 				<Bio html={miniProfile.bio} />
-				{miniProfile.body.map((element, index) => (
-					<RenderArticleElement
-						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
-						key={index}
-						format={format}
-						element={element}
-						ajaxUrl={ajaxUrl}
-						host={host}
-						index={index}
-						isMainMedia={false}
-						pageId={pageId}
-						webTitle={miniProfile.title}
-						isAdFreeUser={isAdFreeUser}
-						isSensitive={isSensitive}
-						switches={switches}
-						abTests={abTests}
-						editionId={editionId}
-						hideCaption={hideCaption}
-						starRating={starRating}
-						forceDropCap="off"
-						isListElement={true}
-					/>
-				))}
+				{children}
 				{miniProfile.endNote ? (
 					<EndNote text={miniProfile.endNote} />
 				) : null}

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -1,21 +1,15 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat } from '@guardian/libs';
-import { neutral, textSans14 } from '@guardian/source/foundations';
+import { neutral, space, textSans14 } from '@guardian/source/foundations';
 import sanitise from 'sanitize-html';
 import { slugify } from '../model/enhance-H2s';
 import { palette } from '../palette';
 import type { MiniProfile as MiniProfileModel } from '../types/content';
+import { headingLineStyles } from './KeyTakeaway';
 import { subheadingStyles } from './Subheading';
 
 const miniProfileStyles = css`
 	padding-top: 8px;
-`;
-
-const headingLineStyles = css`
-	width: 140px;
-	margin: 0 0 2px 0;
-	border: none;
-	border-top: 4px solid ${palette('--heading-line')};
 `;
 
 /** Nesting is necessary in the bio styles because we receive a string of html from the
@@ -25,11 +19,10 @@ const headingLineStyles = css`
  */
 const bioStyles = css`
 	${textSans14};
-	padding-top: 6px;
+	padding: ${space[1]}px 0;
 	color: ${palette('--mini-profiles-text-subdued')};
-	line-height: 1.3rem;
 	p {
-		margin-bottom: 0.5rem;
+		margin-bottom: ${space[2]}px;
 	}
 	a {
 		color: ${palette('--caption-link')};
@@ -43,12 +36,11 @@ const bioStyles = css`
 	}
 	ul {
 		list-style: none;
-		margin: 0 0 0.75rem;
+		margin: 0 0 ${space[2]}px;
 		padding: 0;
-		margin-bottom: 0.5rem;
 	}
 	ul li {
-		padding-left: 1.25rem;
+		padding-left: ${space[5]}px;
 	}
 	ul li p {
 		display: inline-block;
@@ -60,7 +52,7 @@ const bioStyles = css`
 		border-radius: 0.375rem;
 		height: 10px;
 		width: 10px;
-		margin: 0 0.5rem 0 -1.25rem;
+		margin: 0 ${space[2]}px 0 -${space[5]}px;
 		background-color: ${palette('--bullet-fill')};
 	}
 	strong {
@@ -70,18 +62,17 @@ const bioStyles = css`
 
 const endNoteStyles = css`
 	${textSans14};
-	line-height: 135%;
 	color: ${palette('--mini-profiles-text-subdued')};
-	margin-bottom: 1rem;
+	margin-bottom: ${space[3]}px;
 `;
 
 const bottomBorderStyles = css`
 	border-top: 1px solid ${palette('--article-border')};
-	margin-bottom: 0.5rem;
+	margin-bottom: ${space[2]}px;
 `;
 
 const headingMarginStyle = css`
-	margin-bottom: 4px;
+	margin-bottom: ${space[2]}px;
 `;
 
 interface MiniProfileProps {

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat } from '@guardian/libs';
+import { neutral, textSans14 } from '@guardian/source/foundations';
 import type { EditionId } from '../lib/edition';
 import type { ArticleElementRenderer } from '../lib/renderElement';
 import { slugify } from '../model/enhance-H2s';
@@ -15,15 +16,67 @@ const miniProfileStyles = css`
 	padding-top: 8px;
 `;
 
-const headingIndexStyles = css`
-	font-weight: bold;
-`;
-
 const headingLineStyles = css`
 	width: 140px;
 	margin: 0 0 2px 0;
 	border: none;
 	border-top: 4px solid ${palette('--heading-line')};
+`;
+
+const bioStyles = css`
+	${textSans14};
+	line-height: 135%;
+	padding-top: 6px;
+	overflow-wrap: break-word;
+	border-bottom: 1px solid ${palette('--article-border')};
+	color: ${neutral[46]};
+	a {
+		color: ${palette('--caption-link')};
+		text-decoration: none;
+	}
+	a:hover {
+		text-decoration: underline;
+	}
+	strong {
+		font-weight: bold;
+	}
+	p {
+		margin-bottom: 0.5rem;
+	}
+
+	ol {
+		list-style: decimal;
+		list-style-position: inside;
+		margin-bottom: 1rem;
+	}
+
+	ul {
+		list-style: none;
+		margin: 0 0 0.75rem;
+		padding: 0;
+		margin-bottom: 1rem;
+		line-height: 1.3rem;
+	}
+
+	ul li {
+		padding-left: 1.25rem;
+	}
+
+	ul li p {
+		display: inline-block;
+		margin-bottom: 0;
+	}
+
+	ul li:before {
+		display: inline-block;
+		content: '';
+		border-radius: 0.375rem;
+		height: 10px;
+		width: 10px;
+		margin-right: 0.5rem;
+		background-color: ${neutral[86]};
+		margin-left: -1.25rem;
+	}
 `;
 
 interface MiniProfileProps {
@@ -39,7 +92,6 @@ interface MiniProfileProps {
 	hideCaption?: boolean;
 	starRating?: StarRating;
 	miniProfile: MiniProfileModel;
-	titleIndex: number;
 	RenderArticleElement: ArticleElementRenderer;
 }
 
@@ -54,7 +106,6 @@ export const MiniProfile = ({
 	switches,
 	abTests,
 	editionId,
-	titleIndex,
 	hideCaption,
 	starRating,
 	RenderArticleElement,
@@ -68,9 +119,9 @@ export const MiniProfile = ({
 					format={format}
 					topPadding={false}
 				>
-					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
 					{miniProfile.title}
 				</Subheading>
+				<Bio html={miniProfile.bio} />
 				{miniProfile.body.map((element, index) => (
 					<RenderArticleElement
 						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
@@ -97,4 +148,10 @@ export const MiniProfile = ({
 			</li>
 		</>
 	);
+};
+
+const Bio = ({ html }: { html?: string }) => {
+	if (!html) return null;
+
+	return <div css={bioStyles} dangerouslySetInnerHTML={{ __html: html }} />;
 };

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -25,7 +25,7 @@ const bioStyles = css`
 		margin-bottom: ${space[2]}px;
 	}
 	a {
-		color: ${palette('--caption-link')};
+		color: ${palette('--link-kicker-text')};
 		text-underline-offset: 3px;
 	}
 	a:not(:hover) {

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -18,10 +18,11 @@ const headingLineStyles = css`
 	border-top: 4px solid ${palette('--heading-line')};
 `;
 
-// Nesting is necessary in the bio styles because we receive a string of html from the
-// field. This can contain the following tags:
-// Blocks: p, ul, li
-// Inline: strong, em, a
+/** Nesting is necessary in the bio styles because we receive a string of html from the
+ * field. This can contain the following tags:
+ * Blocks: p, ul, li
+ * Inline: strong, em, a
+ */
 const bioStyles = css`
 	${textSans14};
 	padding-top: 6px;

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat } from '@guardian/libs';
 import { neutral, textSans14 } from '@guardian/source/foundations';
+import sanitise from 'sanitize-html';
 import { slugify } from '../model/enhance-H2s';
-import { sanitiseHTML } from '../model/sanitise';
 import { palette } from '../palette';
 import type { MiniProfile as MiniProfileModel } from '../types/content';
 import { subheadingStyles } from './Subheading';
@@ -117,7 +117,7 @@ export const MiniProfile = ({
 
 const Bio = ({ html }: { html?: string }) => {
 	if (!html) return null;
-	const sanitizedHtml = sanitiseHTML(html, {});
+	const sanitizedHtml = sanitise(html, {});
 	return (
 		<>
 			<div

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -1,0 +1,100 @@
+import { css } from '@emotion/react';
+import { type ArticleFormat } from '@guardian/libs';
+import type { EditionId } from '../lib/edition';
+import type { ArticleElementRenderer } from '../lib/renderElement';
+import { slugify } from '../model/enhance-H2s';
+import { palette } from '../palette';
+import type { ServerSideTests, Switches } from '../types/config';
+import type {
+	MiniProfile as MiniProfileModel,
+	StarRating,
+} from '../types/content';
+import { Subheading } from './Subheading';
+
+const miniProfileStyles = css`
+	padding-top: 8px;
+`;
+
+const headingIndexStyles = css`
+	font-weight: bold;
+`;
+
+const headingLineStyles = css`
+	width: 140px;
+	margin: 0 0 2px 0;
+	border: none;
+	border-top: 4px solid ${palette('--heading-line')};
+`;
+
+interface MiniProfileProps {
+	format: ArticleFormat;
+	ajaxUrl: string;
+	host?: string;
+	pageId: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	abTests: ServerSideTests;
+	switches: Switches;
+	editionId: EditionId;
+	hideCaption?: boolean;
+	starRating?: StarRating;
+	miniProfile: MiniProfileModel;
+	titleIndex: number;
+	RenderArticleElement: ArticleElementRenderer;
+}
+
+export const MiniProfile = ({
+	miniProfile,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	titleIndex,
+	hideCaption,
+	starRating,
+	RenderArticleElement,
+}: MiniProfileProps) => {
+	return (
+		<>
+			<li css={miniProfileStyles} data-spacefinder-role="nested">
+				<hr css={headingLineStyles} />
+				<Subheading
+					id={slugify(miniProfile.title)}
+					format={format}
+					topPadding={false}
+				>
+					<span css={headingIndexStyles}>{`${titleIndex}. `}</span>
+					{miniProfile.title}
+				</Subheading>
+				{miniProfile.body.map((element, index) => (
+					<RenderArticleElement
+						// eslint-disable-next-line react/no-array-index-key -- This is only rendered once so we can safely use index to suppress the warning
+						key={index}
+						format={format}
+						element={element}
+						ajaxUrl={ajaxUrl}
+						host={host}
+						index={index}
+						isMainMedia={false}
+						pageId={pageId}
+						webTitle={miniProfile.title}
+						isAdFreeUser={isAdFreeUser}
+						isSensitive={isSensitive}
+						switches={switches}
+						abTests={abTests}
+						editionId={editionId}
+						hideCaption={hideCaption}
+						starRating={starRating}
+						forceDropCap="off"
+						isListElement={true}
+					/>
+				))}
+			</li>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -11,6 +11,7 @@ import type {
 	StarRating,
 } from '../types/content';
 import { subheadingStyles } from './Subheading';
+import { sanitiseHTML } from 'src/model/sanitise';
 
 const miniProfileStyles = css`
 	padding-top: 8px;
@@ -163,9 +164,13 @@ export const MiniProfile = ({
 
 const Bio = ({ html }: { html?: string }) => {
 	if (!html) return null;
+	const sanitizedHtml = sanitiseHTML(html, {});
 	return (
 		<>
-			<div css={bioStyles} dangerouslySetInnerHTML={{ __html: html }} />
+			<div
+				css={bioStyles}
+				dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+			/>
 			<div css={bottomBorderStyles} />
 		</>
 	);

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -23,6 +23,10 @@ const headingLineStyles = css`
 	border-top: 4px solid ${palette('--heading-line')};
 `;
 
+// Nesting is necessary in the bio styles because we receive a string of html from the
+// field. This can contain the following tags:
+// Blocks: p, ul, li
+// Inline: strong, em, a
 const bioStyles = css`
 	${textSans14};
 	padding-top: 6px;
@@ -40,9 +44,6 @@ const bioStyles = css`
 	}
 	a:hover {
 		text-decoration: underline;
-	}
-	strong {
-		font-weight: bold;
 	}
 	ul {
 		list-style: none;
@@ -65,6 +66,9 @@ const bioStyles = css`
 		width: 10px;
 		margin: 0 0.5rem 0 -1.25rem;
 		background-color: ${palette('--bullet-fill')};
+	}
+	strong {
+		font-weight: bold;
 	}
 `;
 

--- a/dotcom-rendering/src/components/MiniProfiles.stories.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.stories.tsx
@@ -34,6 +34,8 @@ const testParagraph =
 const testListHtml =
 	'<ul><li><p>This is the <em>first</em> item in the list</p></li><li><p>The second item has a <a href="#">hyperlink</a>.</p></li></ul>';
 const testBioText = testParagraph + testListHtml;
+const endNoteText =
+	'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu auctor ex.';
 
 export const ThemeVariations = {
 	args: {
@@ -42,7 +44,7 @@ export const ThemeVariations = {
 				title: 'The first mini profile',
 				bio: testBioText,
 				body: [testTextElement],
-				endNote: 'End note',
+				endNote: endNoteText,
 			},
 			{
 				title: 'The second mini profile',
@@ -159,7 +161,7 @@ export const Images = {
 					{ ...images[1], displayCredit: true, role: 'thumbnail' },
 					testTextElement,
 				],
-				endNote: 'End note.',
+				endNote: endNoteText,
 			},
 			{
 				title: 'The second mini profile',

--- a/dotcom-rendering/src/components/MiniProfiles.stories.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.stories.tsx
@@ -29,12 +29,20 @@ const testTextElement: TextBlockElement = {
 	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
 };
 
+const testParagraph =
+	'<p>Proin <strong>imperdiet</strong> pellentesque <a href="#">adipiscing</a> turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus.</p>';
+const testListHtml =
+	'<ul><li><p>This is the <em>first</em> item in the list</p></li><li><p>The second item has a <a href="#">hyperlink</a>.</p></li></ul>';
+const testBioText = testParagraph + testListHtml;
+
 export const ThemeVariations = {
 	args: {
 		miniProfiles: [
 			{
 				title: 'The first mini profile',
+				bio: testBioText,
 				body: [testTextElement],
+				endNote: 'End note',
 			},
 			{
 				title: 'The second mini profile',
@@ -144,12 +152,14 @@ export const Images = {
 		miniProfiles: [
 			{
 				title: 'The first mini profile',
+				bio: testBioText,
 				body: [
 					testTextElement,
 					{ ...images[0], displayCredit: true, role: 'inline' },
 					{ ...images[1], displayCredit: true, role: 'thumbnail' },
 					testTextElement,
 				],
+				endNote: 'End note.',
 			},
 			{
 				title: 'The second mini profile',

--- a/dotcom-rendering/src/components/MiniProfiles.stories.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.stories.tsx
@@ -1,0 +1,188 @@
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
+import { images } from '../../fixtures/generated/images';
+import { getAllDesigns, getAllThemes } from '../lib/format';
+import { RenderArticleElement } from '../lib/renderElement';
+import type { TextBlockElement } from '../types/content';
+import { MiniProfiles } from './MiniProfiles';
+
+const meta = {
+	component: MiniProfiles,
+	title: 'Components/MiniProfiles',
+} satisfies Meta<typeof MiniProfiles>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const testTextElement: TextBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+	elementId: 'test-text-element-id-1',
+	dropCap: 'on', // this should be overruled by mini profile which always sets forceDropCap="off"
+	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
+};
+
+export const ThemeVariations = {
+	args: {
+		miniProfiles: [
+			{
+				title: 'The first mini profile',
+				body: [testTextElement],
+			},
+			{
+				title: 'The second mini profile',
+				body: [testTextElement],
+			},
+		],
+		isLastElement: true,
+		/**
+		 * This will be replaced by the `formats` parameter, but it's
+		 * required by the type.
+		 */
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+		abTests: {},
+		/**
+		 * This is used for rich links. An empty string isn't technically valid,
+		 * but there are no rich links in this example.
+		 */
+		ajaxUrl: '',
+		editionId: 'UK',
+		isAdFreeUser: false,
+		isSensitive: false,
+		pageId: 'testID',
+		switches: {},
+		RenderArticleElement,
+	},
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: getAllThemes({
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+		}),
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const DesignVariations = {
+	args: ThemeVariations.args,
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: getAllDesigns({
+			theme: Pillar.News,
+			display: ArticleDisplay.Standard,
+		}),
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const OtherVariations = {
+	args: ThemeVariations.args,
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: [
+			{
+				design: ArticleDesign.Obituary,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Review,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Sport,
+			},
+			{
+				design: ArticleDesign.Recipe,
+				display: ArticleDisplay.Immersive,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReport,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReportAlt,
+			},
+		],
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const Images = {
+	args: {
+		...ThemeVariations.args,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+		miniProfiles: [
+			{
+				title: 'The first mini profile',
+				body: [
+					testTextElement,
+					{ ...images[0], displayCredit: true, role: 'inline' },
+					{ ...images[1], displayCredit: true, role: 'thumbnail' },
+					testTextElement,
+				],
+			},
+			{
+				title: 'The second mini profile',
+				body: [
+					testTextElement,
+					{
+						...images[2],
+						displayCredit: true,
+						data: { ...images[2].data, caption: 'Sunset' },
+					},
+				],
+			},
+		],
+	},
+	decorators: [centreColumnDecorator],
+	parameters: {
+		chromatic: {
+			modes: {
+				vertical: allModes.splitVertical,
+			},
+		},
+	},
+} satisfies Story;
+
+export const WithSeparatorLine = {
+	args: {
+		...ThemeVariations.args,
+		isLastElement: false,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+	},
+	decorators: [centreColumnDecorator],
+} satisfies Story;

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -52,22 +52,35 @@ export const MiniProfiles = ({
 	return (
 		<ol data-ignore="global-ol-styling">
 			{miniProfiles.map((miniProfile, index) => (
+				// eslint-disable-next-line react/no-array-index-key -- Title should usually be identical, but in case it isn't, also use array index
 				<MiniProfileComponent
 					miniProfile={miniProfile}
 					format={format}
-					ajaxUrl={ajaxUrl}
-					host={host}
-					pageId={pageId}
-					isAdFreeUser={isAdFreeUser}
-					isSensitive={isSensitive}
-					switches={switches}
-					abTests={abTests}
-					editionId={editionId}
-					hideCaption={hideCaption}
-					starRating={starRating}
-					key={index}
-					RenderArticleElement={RenderArticleElement}
-				/>
+					key={`${miniProfile.title}-${index}`}
+				>
+					{miniProfile.body.map((element) => (
+						// eslint-disable-next-line react/jsx-key -- The element array should remain consistent as it's derived from the order of elements in CAPI
+						<RenderArticleElement
+							format={format}
+							element={element}
+							ajaxUrl={ajaxUrl}
+							host={host}
+							index={index}
+							isMainMedia={false}
+							pageId={pageId}
+							webTitle={miniProfile.title}
+							isAdFreeUser={isAdFreeUser}
+							isSensitive={isSensitive}
+							switches={switches}
+							abTests={abTests}
+							editionId={editionId}
+							hideCaption={hideCaption}
+							starRating={starRating}
+							forceDropCap="off"
+							isListElement={true}
+						/>
+					))}
+				</MiniProfileComponent>
 			))}
 			{!isLastElement && <hr css={separatorStyles} />}
 		</ol>

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -63,7 +63,6 @@ export const MiniProfiles = ({
 					switches={switches}
 					abTests={abTests}
 					editionId={editionId}
-					titleIndex={index + 1}
 					hideCaption={hideCaption}
 					starRating={starRating}
 					key={index}

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -1,0 +1,76 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { palette } from '@guardian/source/foundations';
+import type { EditionId } from '../lib/edition';
+import type { ArticleElementRenderer } from '../lib/renderElement';
+import type { ServerSideTests, Switches } from '../types/config';
+import type { MiniProfile, StarRating } from '../types/content';
+import { MiniProfile as MiniProfileComponent } from './MiniProfile';
+
+interface MiniProfilesProps {
+	format: ArticleFormat;
+	ajaxUrl: string;
+	host?: string;
+	pageId: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	abTests: ServerSideTests;
+	switches: Switches;
+	editionId: EditionId;
+	hideCaption?: boolean;
+	starRating?: StarRating;
+	miniProfiles: MiniProfile[];
+	RenderArticleElement: ArticleElementRenderer;
+	/**
+	 * Whether this is the last element in the article. If true, no separator will be rendered.
+	 */
+	isLastElement: boolean;
+}
+
+const separatorStyles = css`
+	width: 140px;
+	margin: 8px 0 2px 0;
+	border-top: 1px solid ${palette.neutral[86]};
+`;
+
+export const MiniProfiles = ({
+	miniProfiles,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	hideCaption,
+	starRating,
+	RenderArticleElement,
+	isLastElement,
+}: MiniProfilesProps) => {
+	return (
+		<ol data-ignore="global-ol-styling">
+			{miniProfiles.map((miniProfile, index) => (
+				<MiniProfileComponent
+					miniProfile={miniProfile}
+					format={format}
+					ajaxUrl={ajaxUrl}
+					host={host}
+					pageId={pageId}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					switches={switches}
+					abTests={abTests}
+					editionId={editionId}
+					titleIndex={index + 1}
+					hideCaption={hideCaption}
+					starRating={starRating}
+					key={index}
+					RenderArticleElement={RenderArticleElement}
+				/>
+			))}
+			{!isLastElement && <hr css={separatorStyles} />}
+		</ol>
+	);
+};

--- a/dotcom-rendering/src/components/Subheading.tsx
+++ b/dotcom-rendering/src/components/Subheading.tsx
@@ -122,7 +122,7 @@ const fontStyles = ({
 	}
 `;
 
-const paddingStyles = (topPadding: boolean) => css`
+export const paddingStyles = (topPadding: boolean) => css`
 	padding-top: ${topPadding ? space[2] : 0}px;
 	padding-bottom: ${space[0]}px;
 	${from.tablet} {
@@ -130,7 +130,7 @@ const paddingStyles = (topPadding: boolean) => css`
 	}
 `;
 
-const subheadingStyles = (format: ArticleFormat) => {
+export const subheadingStyles = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Comment:

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -32,6 +32,7 @@ import { KeyTakeaways } from '../components/KeyTakeaways';
 import { KnowledgeQuizAtom } from '../components/KnowledgeQuizAtom.importable';
 import { MainMediaEmbedBlockComponent } from '../components/MainMediaEmbedBlockComponent';
 import { MapEmbedBlockComponent } from '../components/MapEmbedBlockComponent.importable';
+import { MiniProfiles } from '../components/MiniProfiles';
 import { MultiImageBlockComponent } from '../components/MultiImageBlockComponent';
 import { NumberedTitleBlockComponent } from '../components/NumberedTitleBlockComponent';
 import { PersonalityQuizAtom } from '../components/PersonalityQuizAtom.importable';
@@ -479,7 +480,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.MiniProfilesBlockElement':
 			return (
 				<MiniProfiles
-					qAndAExplainers={element.miniProfiles}
+					miniProfiles={element.miniProfiles}
 					format={format}
 					ajaxUrl={ajaxUrl}
 					pageId={pageId}
@@ -489,6 +490,7 @@ export const renderElement = ({
 					switches={switches}
 					editionId={editionId}
 					RenderArticleElement={RenderArticleElement}
+					isLastElement={index === totalElements - 1}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MultiImageBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -476,6 +476,21 @@ export const renderElement = ({
 					poster={element.posterImage?.[0]?.url}
 				/>
 			);
+		case 'model.dotcomrendering.pageElements.MiniProfilesBlockElement':
+			return (
+				<MiniProfiles
+					qAndAExplainers={element.miniProfiles}
+					format={format}
+					ajaxUrl={ajaxUrl}
+					pageId={pageId}
+					isAdFreeUser={isAdFreeUser}
+					isSensitive={isSensitive}
+					abTests={abTests}
+					switches={switches}
+					editionId={editionId}
+					RenderArticleElement={RenderArticleElement}
+				/>
+			);
 		case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
 			return (
 				<MultiImageBlockComponent

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -583,6 +583,9 @@
                     "$ref": "#/definitions/MediaAtomBlockElement"
                 },
                 {
+                    "$ref": "#/definitions/MiniProfilesBlockElement"
+                },
+                {
                     "$ref": "#/definitions/MultiImageBlockElement"
                 },
                 {
@@ -2489,6 +2492,7 @@
                 "listElementType": {
                     "enum": [
                         "KeyTakeaways",
+                        "MiniProfiles",
                         "QAndAExplainer"
                     ],
                     "type": "string"
@@ -2521,6 +2525,12 @@
                     "items": {
                         "$ref": "#/definitions/FEElement"
                     }
+                },
+                "bio": {
+                    "type": "string"
+                },
+                "endNote": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -2628,6 +2638,49 @@
                 "assets",
                 "elementId",
                 "id"
+            ]
+        },
+        "MiniProfilesBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.MiniProfilesBlockElement"
+                },
+                "miniProfiles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MiniProfile"
+                    }
+                }
+            },
+            "required": [
+                "_type",
+                "miniProfiles"
+            ]
+        },
+        "MiniProfile": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FEElement"
+                    }
+                },
+                "bio": {
+                    "type": "string"
+                },
+                "endNote": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "body",
+                "title"
             ]
         },
         "MultiImageBlockElement": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -175,6 +175,9 @@
                     "$ref": "#/definitions/MediaAtomBlockElement"
                 },
                 {
+                    "$ref": "#/definitions/MiniProfilesBlockElement"
+                },
+                {
                     "$ref": "#/definitions/MultiImageBlockElement"
                 },
                 {
@@ -2081,6 +2084,7 @@
                 "listElementType": {
                     "enum": [
                         "KeyTakeaways",
+                        "MiniProfiles",
                         "QAndAExplainer"
                     ],
                     "type": "string"
@@ -2113,6 +2117,12 @@
                     "items": {
                         "$ref": "#/definitions/FEElement"
                     }
+                },
+                "bio": {
+                    "type": "string"
+                },
+                "endNote": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -2220,6 +2230,49 @@
                 "assets",
                 "elementId",
                 "id"
+            ]
+        },
+        "MiniProfilesBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.MiniProfilesBlockElement"
+                },
+                "miniProfiles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MiniProfile"
+                    }
+                }
+            },
+            "required": [
+                "_type",
+                "miniProfiles"
+            ]
+        },
+        "MiniProfile": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FEElement"
+                    }
+                },
+                "bio": {
+                    "type": "string"
+                },
+                "endNote": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "body",
+                "title"
             ]
         },
         "MultiImageBlockElement": {

--- a/dotcom-rendering/src/model/enhanceLists.ts
+++ b/dotcom-rendering/src/model/enhanceLists.ts
@@ -32,6 +32,33 @@ const constructQAndAExplainer =
 		return [];
 	};
 
+const constructMiniProfile =
+	(enhanceElements: ElementsEnhancer) =>
+	({
+		title,
+		elements,
+		bio,
+		endNote,
+	}: {
+		title?: string;
+		elements: FEElement[];
+		bio?: string;
+		endNote?: string;
+	}) => {
+		// if the element is missing its title for any reason, we will skip it
+		if (title !== undefined) {
+			return [
+				{
+					title,
+					bio,
+					endNote,
+					body: enhanceElements(elements),
+				},
+			];
+		}
+		return [];
+	};
+
 const enhanceListBlockElement = (
 	element: ListBlockElement,
 	elementsEnhancer: ElementsEnhancer,
@@ -52,6 +79,15 @@ const enhanceListBlockElement = (
 					_type: 'model.dotcomrendering.pageElements.QAndAExplainerBlockElement',
 					qAndAExplainers: element.items.flatMap(
 						constructQAndAExplainer(elementsEnhancer),
+					),
+				},
+			];
+		case 'MiniProfiles':
+			return [
+				{
+					_type: 'model.dotcomrendering.pageElements.MiniProfilesBlockElement',
+					miniProfiles: element.items.flatMap(
+						constructMiniProfile(elementsEnhancer),
 					),
 				},
 			];

--- a/dotcom-rendering/src/model/enhanceLists.ts
+++ b/dotcom-rendering/src/model/enhanceLists.ts
@@ -46,7 +46,7 @@ const constructMiniProfile =
 		endNote?: string;
 	}) => {
 		// if the element is missing its title for any reason, we will skip it
-		if (title !== undefined) {
+		if (title !== undefined && title !== '') {
 			return [
 				{
 					title,

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -65,6 +65,16 @@ export const enhanceTableOfContents = (
 				}
 			} else if (
 				element._type ===
+				'model.dotcomrendering.pageElements.MiniProfilesBlockElement'
+			) {
+				for (const miniProfile of element.miniProfiles) {
+					tocItems.push({
+						id: slugify(miniProfile.title),
+						title: miniProfile.title,
+					});
+				}
+			} else if (
+				element._type ===
 					'model.dotcomrendering.pageElements.SubheadingBlockElement' ||
 				element._type ===
 					'model.dotcomrendering.pageElements.NumberedTitleBlockElement'

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -93,6 +93,7 @@ const checkIfAfterText = (index: number, elements: FEElement[]): boolean =>
 const listElements = [
 	'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement',
 	'model.dotcomrendering.pageElements.QAndAExplainerBlockElement',
+	'model.dotcomrendering.pageElements.MiniProfilesBlockElement',
 	'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement',
 	'model.dotcomrendering.pageElements.DCRTimelineBlockElement',
 ] as const;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1759,6 +1759,109 @@ const blockQuoteLinkDark: PaletteFunction = (format: ArticleFormat) => {
 	}
 };
 
+const bulletFillLight: PaletteFunction = (format: ArticleFormat) => {
+	if (format.theme === ArticleSpecial.Labs) {
+		return sourcePalette.labs[300];
+	}
+
+	if (format.theme === Pillar.News) {
+		return sourcePalette.neutral[46];
+	}
+
+	switch (format.design) {
+		case ArticleDesign.Obituary:
+		case ArticleDesign.Standard:
+		case ArticleDesign.Profile:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Timeline: {
+			return sourcePalette.neutral[46];
+		}
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Recipe:
+		case ArticleDesign.Review: {
+			switch (format.theme) {
+				case Pillar.Opinion:
+				case Pillar.Sport:
+				case Pillar.Culture:
+				case Pillar.Lifestyle:
+					return pillarPalette(format.theme, 200);
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[200];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+			}
+		}
+		default: {
+			switch (format.theme) {
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Sport:
+				case Pillar.Culture:
+				case Pillar.Lifestyle:
+					return pillarPalette(format.theme, 400);
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+			}
+		}
+	}
+};
+
+const bulletFillDark: PaletteFunction = ({ design, theme }: ArticleFormat) => {
+	if (theme === ArticleSpecial.Labs) {
+		return sourcePalette.labs[400];
+	}
+
+	switch (design) {
+		case ArticleDesign.Obituary:
+		case ArticleDesign.Standard:
+		case ArticleDesign.Profile:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Timeline: {
+			return sourcePalette.neutral[46];
+		}
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Recipe:
+		case ArticleDesign.Review: {
+			switch (theme) {
+				case Pillar.News:
+				case Pillar.Opinion:
+				case Pillar.Sport:
+				case Pillar.Culture:
+				case Pillar.Lifestyle:
+					return pillarPalette(theme, 500);
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[500];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[300];
+			}
+		}
+		default:
+			switch (theme) {
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.News:
+				case Pillar.Sport:
+				case Pillar.Culture:
+				case Pillar.Lifestyle:
+					return pillarPalette(theme, 400);
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[400];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+			}
+	}
+};
+
 const accordionTitleRowFillLight: PaletteFunction = () =>
 	sourcePalette.neutral[46];
 const accordionTitleRowFillDark: PaletteFunction = () =>
@@ -5416,6 +5519,11 @@ const lastUpdatedTextDark: PaletteFunction = ({ theme, design }) => {
 	}
 };
 
+const miniProfilesTextSubduedLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+const miniProfilesTextSubduedDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
 const interactiveAtomBackgroundLight: PaletteFunction = () => 'transparent';
 const interactiveAtomBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[100];
@@ -5795,6 +5903,10 @@ const paletteColours = {
 	'--branding-link-text': {
 		light: brandingLinkLight,
 		dark: brandingLinkDark,
+	},
+	'--bullet-fill': {
+		light: bulletFillLight,
+		dark: bulletFillDark,
 	},
 	'--byline': {
 		light: bylineLight,
@@ -6351,6 +6463,10 @@ const paletteColours = {
 	'--match-tab-border-active': {
 		light: matchActiveTabBorderLight,
 		dark: matchActiveTabBorderDark,
+	},
+	'--mini-profiles-text-subdued': {
+		light: miniProfilesTextSubduedLight,
+		dark: miniProfilesTextSubduedDark,
 	},
 	'--most-viewed-footer-hover': {
 		light: mostViewedFooterHoverLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6467,7 +6467,7 @@ const paletteColours = {
 	'--mini-profiles-text-subdued': {
 		light: miniProfilesTextSubduedLight,
 		dark: miniProfilesTextSubduedDark,
-  },
+	},
 	'--most-viewed-description': {
 		light: () => sourcePalette.neutral[46],
 		dark: () => sourcePalette.neutral[60],

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -323,6 +323,13 @@ export interface QAndAExplainer {
 	body: FEElement[];
 }
 
+export interface MiniProfile {
+	title: string;
+	body: FEElement[];
+	bio?: string;
+	endNote?: string;
+}
+
 export interface KeyTakeawaysBlockElement {
 	_type: 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement';
 	keyTakeaways: KeyTakeaway[];
@@ -333,14 +340,21 @@ interface QAndAExplainerBlockElement {
 	qAndAExplainers: QAndAExplainer[];
 }
 
+interface MiniProfilesBlockElement {
+	_type: 'model.dotcomrendering.pageElements.MiniProfilesBlockElement';
+	miniProfiles: MiniProfile[];
+}
+
 interface ListItem {
 	title?: string;
 	elements: FEElement[];
+	bio?: string;
+	endNote?: string;
 }
 
 export interface ListBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ListBlockElement';
-	listElementType: 'KeyTakeaways' | 'QAndAExplainer';
+	listElementType: 'KeyTakeaways' | 'QAndAExplainer' | 'MiniProfiles';
 	items: ListItem[];
 	elementId: string;
 }
@@ -730,6 +744,7 @@ export type FEElement =
 	| ListBlockElement
 	| MapBlockElement
 	| MediaAtomBlockElement
+	| MiniProfilesBlockElement
 	| MultiImageBlockElement
 	| NumberedTitleBlockElement
 	| NewsletterSignupBlockElement


### PR DESCRIPTION
## What does this change?
This PR adds rendering for the `MiniProfiles` element.

This is a variant of the [`List`](https://github.com/guardian/content-api-models/blob/ac9b9cb6826717a053667a80c5b06e543f8d669a/models/src/main/thrift/content/v1.thrift#L893) element from CAPI, in addition to [the Key Takeaways and Q&A elements](https://github.com/guardian/dotcom-rendering/pull/10795/files), which are rendered by DCR.

This PR involves:
- adding the new `MiniProfiles` variant to 'enhanceLists.ts'.
- representing the new element variant in DCR's models
- adding new components to represent the element
- adding new styles to 'palette.ts', mostly notably a bullet style for bullet lists in the `MiniProfiles` `bio` field, to be used in the `MiniProfile` component.

This work has been done according to some designs available in Figma:
https://www.figma.com/design/TK4X89VBAIZ65zmIqApOkI/Formats-%E2%80%94-Structured-elements?node-id=5-165675&t=BJK6VLoxp6kjbmuD-0

The MiniProfiles element has the following fields:

```ts
title: string;
body: Element[]
bio: string // HTML string representing rich text, including : `p`, `ul`, `li` block tags and `a`, `strong`, `em` inline tags.
endNote: string // Standard text, to be rendered as italic
```

## Why?
`MiniProfiles` are one of a number of new structure articles formats that Content Production have been developing, and which needs to be supported by our website.

## Screenshots

Non exhaustive variant screenshots, more available in stories:
### News
![image](https://github.com/user-attachments/assets/49fc0881-54db-45f2-91ae-803bcd6c75f3)

### Labs
![image](https://github.com/user-attachments/assets/95b8a4ff-65cb-4a83-9f91-5434c1710775)

### Sport
![image](https://github.com/user-attachments/assets/c2d4b0a3-4d15-49d1-90d4-d944fb2a5225)

### Lifestyle
![image](https://github.com/user-attachments/assets/6cb02b86-547b-4511-a1db-f7c378f62eff)