### PR TITLE
Fix top bar and titlepiece alignment issues

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -29,7 +29,7 @@ interface Props {
 const veggieBurgerDiameter = 40;
 
 const gridFullWidth = css`
-	grid-column: content-start / content-end;
+	grid-column: content-start / main-column-end;
 `;
 
 const editionSwitcherMenuStyles = css`
@@ -124,7 +124,7 @@ const pillarsNavStyles = css`
 `;
 
 const subNavStyles = css`
-	grid-column: content-start / content-end;
+	${gridFullWidth}
 	grid-row: 3;
 	${textSans14}
 	color: inherit;

--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -8,15 +8,14 @@ import { css } from '@emotion/react';
 import { from, space } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import { useEffect, useState } from 'react';
-import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { addTrackingCodesToUrl } from '../lib/acquisitions';
-import { center } from '../lib/center';
 import type { EditionId } from '../lib/edition';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { useAuthStatus } from '../lib/useAuthStatus';
 import { usePageViewId } from '../lib/usePageViewId';
 import { palette as themePalette } from '../palette';
 import { useConfig } from './ConfigContext';
+import { Grid } from './Masthead/Titlepiece/Grid';
 import { TopBarLink } from './TopBarLink';
 import { TopBarMyAccount } from './TopBarMyAccount';
 import { TopBarSupport } from './TopBarSupport.importable';
@@ -32,22 +31,16 @@ interface Props {
 }
 
 const topBarStyles = css`
+	grid-column: content-start / main-column-end;
 	background-color: ${themePalette('--masthead-top-bar-background')};
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-end;
-	height: 52px;
 	box-sizing: border-box;
-	padding: 0 10px;
-
-	${from.mobileLandscape} {
-		padding: 0 ${space[5]}px;
-	}
-
+	height: 52px;
 	${from.tablet} {
 		height: 60px;
 	}
-
 	${from.desktop} {
 		height: 64px;
 	}
@@ -142,52 +135,57 @@ export const TopBar = ({
 	});
 
 	return (
-		<div css={[topBarStyles, hasPageSkin ? pageSkinContainer : center]}>
-			<TopBarLinkContainer showVerticalDivider={false} alignLeft={true}>
-				<TopBarSupport
-					contributionsServiceUrl={contributionsServiceUrl}
-				/>
-			</TopBarLinkContainer>
-
-			<Hide until="desktop">
-				<TopBarLinkContainer>
-					<TopBarLink
-						dataLinkName={nestedOphanComponents(
-							'header',
-							'topbar',
-							'printsubs',
-						)}
-						href={printSubscriptionsHref}
-					>
-						Print subscriptions
-					</TopBarLink>
+		<Grid type="div" hasPageSkin={hasPageSkin}>
+			<div css={topBarStyles}>
+				<TopBarLinkContainer
+					showVerticalDivider={false}
+					alignLeft={true}
+				>
+					<TopBarSupport
+						contributionsServiceUrl={contributionsServiceUrl}
+					/>
 				</TopBarLinkContainer>
-			</Hide>
 
-			<Hide until="desktop">
-				<TopBarLinkContainer>
-					<TopBarLink
-						dataLinkName={nestedOphanComponents(
-							'header',
-							'topbar',
-							'job-cta',
-						)}
-						href="https://jobs.theguardian.com"
-					>
-						Search jobs
-					</TopBarLink>
+				<Hide until="desktop">
+					<TopBarLinkContainer>
+						<TopBarLink
+							dataLinkName={nestedOphanComponents(
+								'header',
+								'topbar',
+								'printsubs',
+							)}
+							href={printSubscriptionsHref}
+						>
+							Print subscriptions
+						</TopBarLink>
+					</TopBarLinkContainer>
+				</Hide>
+
+				<Hide until="desktop">
+					<TopBarLinkContainer>
+						<TopBarLink
+							dataLinkName={nestedOphanComponents(
+								'header',
+								'topbar',
+								'job-cta',
+							)}
+							href="https://jobs.theguardian.com"
+						>
+							Search jobs
+						</TopBarLink>
+					</TopBarLinkContainer>
+				</Hide>
+
+				<TopBarLinkContainer isLastChild={true}>
+					<TopBarMyAccount
+						mmaUrl={mmaUrl ?? 'https://manage.theguardian.com'}
+						idUrl={idUrl ?? 'https://profile.theguardian.com'}
+						discussionApiUrl={discussionApiUrl}
+						idApiUrl={idApiUrl}
+						authStatus={authStatus}
+					/>
 				</TopBarLinkContainer>
-			</Hide>
-
-			<TopBarLinkContainer isLastChild={true}>
-				<TopBarMyAccount
-					mmaUrl={mmaUrl ?? 'https://manage.theguardian.com'}
-					idUrl={idUrl ?? 'https://profile.theguardian.com'}
-					discussionApiUrl={discussionApiUrl}
-					idApiUrl={idApiUrl}
-					authStatus={authStatus}
-				/>
-			</TopBarLinkContainer>
-		</div>
+			</div>
+		</Grid>
 	);
 };


### PR DESCRIPTION
## What does this change?

The TopBar and Titlepiece were aligned to the edge of the page "content" instead of the edge of the "main column" as it should have been on the right hand side.

This PR ensures the designs match the resulting UI.

## Why?

To align better with designs on Figma.

As part of Fairgound project to improve the look and feel of the homepages.

## Screenshots

_Screenshots taken by opting into the AB test_

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/d0e13895-1371-476b-a2fa-98171816c76f
[after]: https://github.com/user-attachments/assets/7cf5b46e-8aac-4ed0-af03-7f31fde7d926


> [!TIP] 
> When reviewing the code, it will make more sense if whitespace changes are ignored
