### PR TITLE
Revert "Revert "Add p90 CPU Utilization step scaling policy""

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -11,6 +11,17 @@ const sharedProps = {
 	region: 'eu-west-1',
 };
 
+const cpuScalingSteps = {
+	scalingStepsOut: [
+		// When p90 CPU is lower than 70% no scaling up
+		{ lower: 0, upper: 70, change: 0 },
+		// When p90 CPU is higher than 70% we scale up by 50%
+		{ lower: 70, change: 50 },
+		// When p90 CPU is higher than 90% we scale up by 80%
+		{ lower: 90, change: 80 },
+	],
+};
+
 /** Legacy, only serves the all newsletters page */
 new DotcomRendering(cdkApp, 'DotcomRendering-PROD', {
 	...sharedProps,
@@ -35,7 +46,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 3 },
-	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',
@@ -44,21 +55,26 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	scaling: {
 		minimumInstances: 18,
 		maximumInstances: 180,
-		policy: {
-			scalingStepsOut: [
-				// No scaling up effect when latency is lower than 0.2s
-				{ lower: 0, upper: 0.2, change: 0 },
-				// When latency is higher than 0.2s we scale up by 50%
-				{ lower: 0.2, change: 50 },
-				// When latency is higher than 0.3s we scale up by 80%
-				{ lower: 0.3, change: 80 },
-			],
-			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.12s
-				{ lower: 0.12, change: 0 },
-				// When latency is lower than 0.12s we scale down by 1
-				{ upper: 0.12, lower: 0, change: -1 },
-			],
+		policies: {
+			step: {
+				cpu: cpuScalingSteps,
+				latency: {
+					scalingStepsOut: [
+						// When latency is lower than 0.2s no scaling up
+						{ lower: 0, upper: 0.2, change: 0 },
+						// When latency is higher than 0.2s we scale up by 50%
+						{ lower: 0.2, change: 50 },
+						// When latency is higher than 0.3s we scale up by 80%
+						{ lower: 0.3, change: 80 },
+					],
+					scalingStepsIn: [
+						// When latency is higher than 0.12s no scaling down
+						{ lower: 0.12, change: 0 },
+						// When latency is lower than 0.12s we scale down by 1
+						{ upper: 0.12, lower: 0, change: -1 },
+					],
+				},
+			},
 		},
 	},
 	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
@@ -79,21 +95,26 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	scaling: {
 		minimumInstances: 15,
 		maximumInstances: 150,
-		policy: {
-			scalingStepsOut: [
-				// No scaling up effect when latency is lower than 0.4s
-				{ lower: 0, upper: 0.4, change: 0 },
-				// When latency is higher than 0.4s we scale up by 50%
-				{ lower: 0.4, change: 50 },
-				// When latency is higher than 0.5s we scale up by 80%
-				{ lower: 0.5, change: 80 },
-			],
-			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.35s
-				{ lower: 0.35, change: 0 },
-				// When latency is lower than 0.35s we scale down by 1
-				{ upper: 0.35, lower: 0, change: -1 },
-			],
+		policies: {
+			step: {
+				cpu: cpuScalingSteps,
+				latency: {
+					scalingStepsOut: [
+						// When latency is lower than 0.4s no scaling up
+						{ lower: 0, upper: 0.4, change: 0 },
+						// When latency is higher than 0.4s we scale up by 50%
+						{ lower: 0.4, change: 50 },
+						// When latency is higher than 0.5s we scale up by 80%
+						{ lower: 0.5, change: 80 },
+					],
+					scalingStepsIn: [
+						// When latency is higher than 0.35s no scaling down
+						{ lower: 0.35, change: 0 },
+						// When latency is lower than 0.35s we scale down by 1
+						{ upper: 0.35, lower: 0, change: -1 },
+					],
+				},
+			},
 		},
 	},
 	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
@@ -114,21 +135,26 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	scaling: {
 		minimumInstances: 15,
 		maximumInstances: 150,
-		policy: {
-			scalingStepsOut: [
-				// No scaling up effect when latency is lower than 0.4s
-				{ lower: 0, upper: 0.4, change: 0 },
-				// When latency is higher than 0.4s we scale up by 50%
-				{ lower: 0.4, change: 50 },
-				// When latency is higher than 0.5s we scale up by 80%
-				{ lower: 0.5, change: 80 },
-			],
-			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.35s
-				{ lower: 0.35, change: 0 },
-				// When latency is lower than 0.35s we scale down by 1
-				{ upper: 0.35, lower: 0, change: -1 },
-			],
+		policies: {
+			step: {
+				cpu: cpuScalingSteps,
+				latency: {
+					scalingStepsOut: [
+						// When latency is lower than 0.4s no scaling up
+						{ lower: 0, upper: 0.4, change: 0 },
+						// When latency is higher than 0.4s we scale up by 50%
+						{ lower: 0.4, change: 50 },
+						// When latency is higher than 0.5s we scale up by 80%
+						{ lower: 0.5, change: 80 },
+					],
+					scalingStepsIn: [
+						// When latency is higher than 0.35s no scaling down
+						{ lower: 0.35, change: 0 },
+						// When latency is lower than 0.35s we scale down by 1
+						{ upper: 0.35, lower: 0, change: -1 },
+					],
+				},
+			},
 		},
 	},
 	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
@@ -149,21 +175,26 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	scaling: {
 		minimumInstances: 3,
 		maximumInstances: 30,
-		policy: {
-			scalingStepsOut: [
-				// No scaling up effect when latency is lower than 0.2s
-				{ lower: 0, upper: 0.2, change: 0 },
-				// When latency is higher than 0.3s we scale up by 50%
-				{ lower: 0.2, change: 50 },
-				// When latency is higher than 0.3s we scale up by 80%
-				{ lower: 0.3, change: 80 },
-			],
-			scalingStepsIn: [
-				// No scaling down effect when latency is higher than 0.15s
-				{ lower: 0.15, change: 0 },
-				// When latency is lower than 0.15s we scale down by 1
-				{ upper: 0.15, lower: 0, change: -1 },
-			],
+		policies: {
+			step: {
+				cpu: cpuScalingSteps,
+				latency: {
+					scalingStepsOut: [
+						// When latency is lower than 0.2s no scaling up
+						{ lower: 0, upper: 0.2, change: 0 },
+						// When latency is higher than 0.2s we scale up by 50%
+						{ lower: 0.2, change: 50 },
+						// When latency is higher than 0.3s we scale up by 80%
+						{ lower: 0.3, change: 80 },
+					],
+					scalingStepsIn: [
+						// When latency is higher than 0.15s no scaling down
+						{ lower: 0.15, change: 0 },
+						// When latency is lower than 0.15s we scale down by 1
+						{ upper: 0.15, lower: 0, change: -1 },
+					],
+				},
+			},
 		},
 	},
 	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),

--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -50,7 +50,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "ELBLogsParameter": {
-      "Default": "/TEST/frontend/rendering/elb.logs.bucketName",
+      "Default": "/PROD/frontend/rendering/elb.logs.bucketName",
       "Description": "S3 Bucket Name for ELB logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
@@ -186,7 +186,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/TEST/frontend/rendering/*",
+                      ":parameter/PROD/frontend/rendering/*",
                     ],
                   ],
                 },
@@ -234,11 +234,11 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
           "LaunchTemplateId": {
-            "Ref": "frontendTESTrenderingF3FD9600",
+            "Ref": "frontendPRODrendering10B74E2A",
           },
           "Version": {
             "Fn::GetAtt": [
-              "frontendTESTrenderingF3FD9600",
+              "frontendPRODrendering10B74E2A",
               "LatestVersionNumber",
             ],
           },
@@ -281,7 +281,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           {
             "Key": "Stage",
             "PropagateAtLaunch": true,
-            "Value": "TEST",
+            "Value": "PROD",
           },
           {
             "Key": "SystemdUnit",
@@ -297,7 +297,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
     },
     "Backend5xxAlarm": {
       "Properties": {
-        "ActionsEnabled": false,
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
             "Fn::Join": [
@@ -307,7 +307,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":Frontend-TEST-CriticalAlerts",
+                ":Frontend-PROD-CriticalAlerts",
               ],
             ],
           },
@@ -334,7 +334,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":Frontend-TEST-CriticalAlerts",
+                ":Frontend-PROD-CriticalAlerts",
               ],
             ],
           },
@@ -386,7 +386,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                     {
                       "Ref": "DistributionBucketName",
                     },
-                    "/frontend/TEST/rendering/*",
+                    "/frontend/PROD/rendering/*",
                   ],
                 ],
               },
@@ -434,7 +434,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -533,7 +533,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },
@@ -577,7 +577,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -594,7 +594,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           "S3BucketName": {
             "Ref": "ELBLogsParameter",
           },
-          "S3BucketPrefix": "ELBLogs/frontend/rendering/TEST",
+          "S3BucketPrefix": "ELBLogs/frontend/rendering/PROD",
         },
         "CrossZone": true,
         "HealthCheck": {
@@ -612,7 +612,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             "Protocol": "http",
           },
         ],
-        "LoadBalancerName": "frontend-TEST-rendering-ELB",
+        "LoadBalancerName": "frontend-PROD-rendering-ELB",
         "Scheme": "internal",
         "SecurityGroups": [
           {
@@ -644,7 +644,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },
@@ -690,7 +690,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -744,7 +744,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -755,7 +755,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
     },
     "LatencyScalingAlarm": {
       "Properties": {
-        "ActionsEnabled": false,
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
             "Fn::GetAtt": [
@@ -810,7 +810,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/frontend/rendering",
+                    ":parameter/PROD/frontend/rendering",
                   ],
                 ],
               },
@@ -833,7 +833,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/frontend/rendering/*",
+                    ":parameter/PROD/frontend/rendering/*",
                   ],
                 ],
               },
@@ -906,7 +906,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -915,7 +915,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "frontendTESTrenderingF3FD9600": {
+    "frontendPRODrendering10B74E2A": {
       "DependsOn": [
         "InstanceRole",
       ],
@@ -924,7 +924,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
           "IamInstanceProfile": {
             "Arn": {
               "Fn::GetAtt": [
-                "frontendTESTrenderingProfileA2D2425E",
+                "frontendPRODrenderingProfileD69551A3",
                 "Arn",
               ],
             },
@@ -967,7 +967,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "DotcomRendering/frontend-TEST-rendering",
+                  "Value": "DotcomRendering/frontend-PROD-rendering",
                 },
                 {
                   "Key": "Stack",
@@ -975,7 +975,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -992,7 +992,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "DotcomRendering/frontend-TEST-rendering",
+                  "Value": "DotcomRendering/frontend-PROD-rendering",
                 },
                 {
                   "Key": "Stack",
@@ -1000,7 +1000,7 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -1018,7 +1018,7 @@ aws --region eu-west-1 s3 cp s3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/frontend/TEST/rendering/rendering.tar.gz ./
+                  "/frontend/PROD/rendering/rendering.tar.gz ./
 tar -zxf rendering.tar.gz rendering
 chown -R dotcom-rendering:frontend rendering
 cd rendering
@@ -1037,7 +1037,7 @@ StandardError=journal
 StandardOutput=journal
 Environment=TERM=xterm-256color
 Environment=NODE_ENV=production
-Environment=GU_STAGE=TEST
+Environment=GU_STAGE=PROD
 Environment=GU_APP=rendering
 Environment=GU_STACK=frontend
 ExecStart=make prod
@@ -1066,7 +1066,7 @@ systemctl start rendering",
               },
               {
                 "Key": "Name",
-                "Value": "DotcomRendering/frontend-TEST-rendering",
+                "Value": "DotcomRendering/frontend-PROD-rendering",
               },
               {
                 "Key": "Stack",
@@ -1074,7 +1074,7 @@ systemctl start rendering",
               },
               {
                 "Key": "Stage",
-                "Value": "TEST",
+                "Value": "PROD",
               },
             ],
           },
@@ -1082,7 +1082,7 @@ systemctl start rendering",
       },
       "Type": "AWS::EC2::LaunchTemplate",
     },
-    "frontendTESTrenderingProfileA2D2425E": {
+    "frontendPRODrenderingProfileD69551A3": {
       "Properties": {
         "Roles": [
           {
@@ -1094,10 +1094,10 @@ systemctl start rendering",
     },
     "loadBalancerDnsName0B1DEBAD": {
       "Properties": {
-        "Name": "/frontend/TEST/rendering.loadBalancerDnsName",
+        "Name": "/frontend/PROD/rendering.loadBalancerDnsName",
         "Tags": {
           "Stack": "frontend",
-          "Stage": "TEST",
+          "Stage": "PROD",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/dotcom-rendering",
         },

--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -28,6 +28,8 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuSecurityGroup",
+      "GuAlb5xxPercentageAlarm",
+      "GuUnhealthyInstancesAlarm",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -194,11 +196,11 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
           "LaunchTemplateId": {
-            "Ref": "frontendTESTarticlerendering6160AD1F",
+            "Ref": "frontendPRODarticlerenderingC9709529",
           },
           "Version": {
             "Fn::GetAtt": [
-              "frontendTESTarticlerendering6160AD1F",
+              "frontendPRODarticlerenderingC9709529",
               "LatestVersionNumber",
             ],
           },
@@ -236,7 +238,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           {
             "Key": "Stage",
             "PropagateAtLaunch": true,
-            "Value": "TEST",
+            "Value": "PROD",
           },
           {
             "Key": "SystemdUnit",
@@ -254,6 +256,91 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "CPUScaleUpPolicyUpperAlarm7E15DD91": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "CPUScaleUpPolicyUpperPolicyDEE5DA77",
+          },
+          {
+            "Ref": "CPUScalingAlertsTopic9D0083F7",
+          },
+        ],
+        "AlarmDescription": "Upper threshold scaling alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "AutoScalingGroupName",
+            "Value": {
+              "Ref": "AutoScalingGroupArticlerenderingASG8488C3F1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "ExtendedStatistic": "p90",
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Period": 30,
+        "Threshold": 70,
+        "Unit": "Percent",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "CPUScaleUpPolicyUpperPolicyDEE5DA77": {
+      "Properties": {
+        "AdjustmentType": "PercentChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupArticlerenderingASG8488C3F1",
+        },
+        "MetricAggregationType": "Average",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": 0,
+            "MetricIntervalUpperBound": 20,
+            "ScalingAdjustment": 50,
+          },
+          {
+            "MetricIntervalLowerBound": 20,
+            "ScalingAdjustment": 80,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "CPUScalingAlertsSubscriptionEmail170D6D82": {
+      "Properties": {
+        "Endpoint": "dotcom.platform@theguardian.com",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "CPUScalingAlertsTopic9D0083F7",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "CPUScalingAlertsTopic9D0083F7": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/dotcom-rendering",
+          },
+          {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
     "CertificateArticlerendering3297EFD3": {
       "DeletionPolicy": "Retain",
@@ -282,7 +369,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "ValidationMethod": "DNS",
@@ -331,7 +418,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                     {
                       "Ref": "DistributionBucketName",
                     },
-                    "/frontend/TEST/article-rendering/*",
+                    "/frontend/PROD/article-rendering/*",
                   ],
                 ],
               },
@@ -379,7 +466,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -468,6 +555,108 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "High5xxPercentageAlarmArticlerenderingB88D9FE6": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Frontend-PROD-CriticalAlerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "article-rendering exceeded 0.5% error rate",
+        "AlarmName": "High 5XX error percentage from article-rendering in PROD",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*(m1+m2)/m3",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for article-rendering (load balancer and instances combined)",
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerArticlerendering49883BBC",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_ELB_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerArticlerendering49883BBC",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_Target_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m3",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "LoadBalancer",
+                    "Value": {
+                      "Fn::GetAtt": [
+                        "LoadBalancerArticlerendering49883BBC",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "RequestCount",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "InstanceRoleArticlerendering0D4717E8": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -516,7 +705,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
       },
@@ -553,7 +742,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -604,6 +793,157 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LatencyScaleDownPolicyLowerAlarm3AAA79CF": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "LatencyScaleDownPolicyLowerPolicy5B8C5A01",
+          },
+        ],
+        "AlarmDescription": "Lower threshold scaling alarm",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "LoadBalancer",
+            "Value": {
+              "Fn::GetAtt": [
+                "LoadBalancerArticlerendering49883BBC",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+          {
+            "Name": "TargetGroup",
+            "Value": {
+              "Fn::GetAtt": [
+                "TargetGroupArticlerendering3605E498",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "TargetResponseTime",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 30,
+        "Statistic": "Average",
+        "Threshold": 0.15,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LatencyScaleDownPolicyLowerPolicy5B8C5A01": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupArticlerenderingASG8488C3F1",
+        },
+        "MetricAggregationType": "Average",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalUpperBound": 0,
+            "ScalingAdjustment": -1,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "LatencyScaleUpPolicyUpperAlarmB2CCE62D": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "LatencyScaleUpPolicyUpperPolicy4A22B34C",
+          },
+          {
+            "Ref": "LatencyScalingAlertsTopic1A322157",
+          },
+        ],
+        "AlarmDescription": "Upper threshold scaling alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "LoadBalancer",
+            "Value": {
+              "Fn::GetAtt": [
+                "LoadBalancerArticlerendering49883BBC",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+          {
+            "Name": "TargetGroup",
+            "Value": {
+              "Fn::GetAtt": [
+                "TargetGroupArticlerendering3605E498",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "TargetResponseTime",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 30,
+        "Statistic": "Average",
+        "Threshold": 0.2,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "LatencyScaleUpPolicyUpperPolicy4A22B34C": {
+      "Properties": {
+        "AdjustmentType": "PercentChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupArticlerenderingASG8488C3F1",
+        },
+        "MetricAggregationType": "Average",
+        "PolicyType": "StepScaling",
+        "StepAdjustments": [
+          {
+            "MetricIntervalLowerBound": 0,
+            "MetricIntervalUpperBound": 0.09999999999999998,
+            "ScalingAdjustment": 50,
+          },
+          {
+            "MetricIntervalLowerBound": 0.09999999999999998,
+            "ScalingAdjustment": 80,
+          },
+        ],
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "LatencyScalingAlertsSubscriptionEmailF1826DAB": {
+      "Properties": {
+        "Endpoint": "dotcom.platform@theguardian.com",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "LatencyScalingAlertsTopic1A322157",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "LatencyScalingAlertsTopic1A322157": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/dotcom-rendering",
+          },
+          {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
     "ListenerArticlerendering9419D5F6": {
       "Properties": {
         "Certificates": [
@@ -648,7 +988,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/frontend/article-rendering/TEST",
+            "Value": "ELBLogs/frontend/article-rendering/PROD",
           },
           {
             "Key": "idle_timeout.timeout_seconds",
@@ -692,7 +1032,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "Type": "application",
@@ -721,7 +1061,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -784,7 +1124,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
             ],
           },
         ],
-        "Stage": "TEST",
+        "Stage": "PROD",
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
@@ -804,7 +1144,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/frontend/article-rendering",
+                    ":parameter/PROD/frontend/article-rendering",
                   ],
                 ],
               },
@@ -823,7 +1163,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/frontend/article-rendering/*",
+                    ":parameter/PROD/frontend/article-rendering/*",
                   ],
                 ],
               },
@@ -842,11 +1182,11 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
     },
     "RenderingBaseURLParamAE11E777": {
       "Properties": {
-        "Description": "The rendering base URL for frontend to call the article-rendering app in the TEST environment",
-        "Name": "/frontend/test/article-rendering.baseURL",
+        "Description": "The rendering base URL for frontend to call the article-rendering app in the PROD environment",
+        "Name": "/frontend/prod/article-rendering.baseURL",
         "Tags": {
           "Stack": "frontend",
-          "Stage": "TEST",
+          "Stage": "PROD",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/dotcom-rendering",
         },
@@ -883,7 +1223,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "TargetGroupAttributes": [
@@ -903,6 +1243,103 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UnhealthyInstancesAlarmArticlerendering51F6462F": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Frontend-PROD-CriticalAlerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "article-rendering's instances have failed healthchecks several times over the last 1 hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check article-rendering's application logs or ssh onto an unhealthy instance in order to debug these problems.",
+        "AlarmName": "Unhealthy instances for article-rendering in PROD",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 30,
+        "Dimensions": [
+          {
+            "Name": "LoadBalancer",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerArticlerendering9419D5F6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerArticlerendering9419D5F6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      3,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerArticlerendering9419D5F6",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Name": "TargetGroup",
+            "Value": {
+              "Fn::GetAtt": [
+                "TargetGroupArticlerendering3605E498",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 60,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "WazuhSecurityGroup": {
       "Properties": {
@@ -938,7 +1375,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "Stage",
-            "Value": "TEST",
+            "Value": "PROD",
           },
         ],
         "VpcId": {
@@ -989,7 +1426,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "frontendTESTarticlerendering6160AD1F": {
+    "frontendPRODarticlerenderingC9709529": {
       "DependsOn": [
         "InstanceRoleArticlerendering0D4717E8",
       ],
@@ -998,7 +1435,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           "IamInstanceProfile": {
             "Arn": {
               "Fn::GetAtt": [
-                "frontendTESTarticlerenderingProfile8DDE1B22",
+                "frontendPRODarticlerenderingProfile7F39AF3F",
                 "Arn",
               ],
             },
@@ -1038,7 +1475,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "ArticleRendering/frontend-TEST-article-rendering",
+                  "Value": "ArticleRendering/frontend-PROD-article-rendering",
                 },
                 {
                   "Key": "Stack",
@@ -1046,7 +1483,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -1063,7 +1500,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "ArticleRendering/frontend-TEST-article-rendering",
+                  "Value": "ArticleRendering/frontend-PROD-article-rendering",
                 },
                 {
                   "Key": "Stack",
@@ -1071,7 +1508,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
                 },
                 {
                   "Key": "Stage",
-                  "Value": "TEST",
+                  "Value": "PROD",
                 },
               ],
             },
@@ -1089,7 +1526,7 @@ aws --region eu-west-1 s3 cp s3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/frontend/TEST/article-rendering/article-rendering.tar.gz ./
+                  "/frontend/PROD/article-rendering/article-rendering.tar.gz ./
 tar -zxf article-rendering.tar.gz article-rendering
 chown -R dotcom-rendering:frontend article-rendering
 cd article-rendering
@@ -1108,7 +1545,7 @@ StandardError=journal
 StandardOutput=journal
 Environment=TERM=xterm-256color
 Environment=NODE_ENV=production
-Environment=GU_STAGE=TEST
+Environment=GU_STAGE=PROD
 Environment=GU_APP=article-rendering
 Environment=GU_STACK=frontend
 ExecStart=make prod
@@ -1137,7 +1574,7 @@ systemctl start article-rendering",
               },
               {
                 "Key": "Name",
-                "Value": "ArticleRendering/frontend-TEST-article-rendering",
+                "Value": "ArticleRendering/frontend-PROD-article-rendering",
               },
               {
                 "Key": "Stack",
@@ -1145,7 +1582,7 @@ systemctl start article-rendering",
               },
               {
                 "Key": "Stage",
-                "Value": "TEST",
+                "Value": "PROD",
               },
             ],
           },
@@ -1153,7 +1590,7 @@ systemctl start article-rendering",
       },
       "Type": "AWS::EC2::LaunchTemplate",
     },
-    "frontendTESTarticlerenderingProfile8DDE1B22": {
+    "frontendPRODarticlerenderingProfile7F39AF3F": {
       "Properties": {
         "Roles": [
           {

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.test.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.test.ts
@@ -11,7 +11,7 @@ describe('The DotcomRendering stack', () => {
 		const app = new App();
 		const stack = new DotcomRendering(app, 'DotcomRendering', {
 			stack: 'frontend',
-			stage: 'TEST',
+			stage: 'PROD',
 			app: 'rendering',
 			minCapacity: 1,
 			maxCapacity: 4,

--- a/dotcom-rendering/cdk/lib/renderingStack.test.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.test.ts
@@ -11,22 +11,36 @@ describe('The RenderingCDKStack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
 		const stack = new RenderingCDKStack(app, 'ArticleRendering', {
-			stage: 'TEST',
+			stage: 'PROD',
 			guApp: 'article-rendering',
 			domainName: 'article-rendering.test.dev-guardianapis.com',
 			scaling: {
 				minimumInstances: 1,
 				maximumInstances: 4,
-				policy: {
-					scalingStepsOut: [
-						{ lower: 0, upper: 0.2, change: 0 },
-						{ lower: 0.2, change: 50 },
-						{ lower: 0.3, change: 80 },
-					],
-					scalingStepsIn: [
-						{ lower: 0.15, change: 0 },
-						{ upper: 0.15, lower: 0, change: -1 },
-					],
+				policies: {
+					step: {
+						cpu: {
+							scalingStepsOut: [
+								// No scaling up effect when p90 CPU is lower than 70%
+								{ lower: 0, upper: 70, change: 0 },
+								// When p90 CPU is higher than 70% we scale up by 50%
+								{ lower: 70, change: 50 },
+								// When p90 CPU is higher than 90% we scale up by 80%
+								{ lower: 90, change: 80 },
+							],
+						},
+						latency: {
+							scalingStepsOut: [
+								{ lower: 0, upper: 0.2, change: 0 },
+								{ lower: 0.2, change: 50 },
+								{ lower: 0.3, change: 80 },
+							],
+							scalingStepsIn: [
+								{ lower: 0.15, change: 0 },
+								{ upper: 0.15, lower: 0, change: -1 },
+							],
+						},
+					},
 				},
 			},
 			instanceType: InstanceType.of(

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -9,10 +9,10 @@ import {
 import { GuCname } from '@guardian/cdk/lib/constructs/dns/dns-records';
 import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import type { GuAsgCapacity } from '@guardian/cdk/lib/types';
-import { type App as CDKApp, Duration } from 'aws-cdk-lib';
+import { aws_cloudwatch, type App as CDKApp, Duration } from 'aws-cdk-lib';
 import type { ScalingInterval } from 'aws-cdk-lib/aws-applicationautoscaling';
 import { AdjustmentType, StepScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
-import { Metric } from 'aws-cdk-lib/aws-cloudwatch';
+import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
@@ -25,12 +25,151 @@ export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
 	domainName: string;
 	instanceType: InstanceType;
 	scaling: GuAsgCapacity & {
-		policy?: {
-			scalingStepsOut: ScalingInterval[];
-			scalingStepsIn: ScalingInterval[];
+		policies?: {
+			step?: {
+				cpu?: {
+					scalingStepsOut: ScalingInterval[];
+				};
+				latency?: {
+					scalingStepsOut: ScalingInterval[];
+					scalingStepsIn: ScalingInterval[];
+				};
+			};
 		};
 	};
 }
+
+const addCPUStepScalingPolicy = (
+	context: RenderingCDKStack,
+	ec2App: GuEc2App,
+	props: RenderingCDKStackProps,
+	stage: string,
+) => {
+	if (stage === 'PROD' && props.scaling.policies?.step?.cpu) {
+		const cpuMetric = new Metric({
+			namespace: 'AWS/EC2',
+			metricName: 'CPUUtilization',
+			unit: Unit.PERCENT,
+			dimensionsMap: {
+				AutoScalingGroupName:
+					ec2App.autoScalingGroup.autoScalingGroupName,
+			},
+			statistic: aws_cloudwatch.Stats.percentile(90),
+			period: Duration.seconds(30),
+		});
+
+		/** Scaling policies ASCII diagram
+		 *
+		 * Metric value (latency in seconds)
+		 *  0        lower       middle       upper         infinity
+		 * --------------------------------------------------------
+		 *  |   - z    |     0      |   + x%   |     + y%      |
+		 * --------------------------------------------------------
+		 * Instance change
+		 *
+		 * -
+		 * When scaling up, we use percentage change (+x% initially then +y% if particularly high)
+		 * When scaling down, we use absolute change (-z each interval)
+		 * We take no scaling actions when latency is between lower and middle values to avoid flapping
+		 * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html#step-scaling-considerations
+		 */
+
+		const scaleOutPolicy = new StepScalingPolicy(
+			context,
+			'CPUScaleUpPolicy',
+			{
+				autoScalingGroup: ec2App.autoScalingGroup,
+				metric: cpuMetric,
+				scalingSteps: props.scaling.policies.step.cpu.scalingStepsOut,
+				adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
+				evaluationPeriods: 2, // 1 minute = 2 × 30 seconds
+			},
+		);
+
+		const scalingAlertsTopic = new Topic(context, 'CPUScalingAlertsTopic');
+		new Subscription(context, 'CPUScalingAlertsSubscriptionEmail', {
+			endpoint: 'dotcom.platform@theguardian.com',
+			protocol: SubscriptionProtocol.EMAIL,
+			topic: scalingAlertsTopic,
+		});
+
+		scaleOutPolicy.upperAlarm?.addAlarmAction(
+			new SnsAction(scalingAlertsTopic),
+		);
+	}
+};
+
+const addLatencyStepScalingPolicy = (
+	context: RenderingCDKStack,
+	ec2App: GuEc2App,
+	props: RenderingCDKStackProps,
+	stage: string,
+) => {
+	if (stage === 'PROD' && props.scaling.policies?.step?.latency) {
+		const latencyMetric = new Metric({
+			dimensionsMap: {
+				LoadBalancer: ec2App.loadBalancer.loadBalancerFullName,
+				TargetGroup: ec2App.targetGroup.targetGroupFullName,
+			},
+			metricName: 'TargetResponseTime',
+			namespace: 'AWS/ApplicationELB',
+			period: Duration.seconds(30),
+			statistic: 'Average', // TODO - should we use p90?
+		});
+
+		/** Scaling policies ASCII diagram
+		 *
+		 * Metric value (latency in seconds)
+		 *  0        lower       middle       upper         infinity
+		 * --------------------------------------------------------
+		 *  |   - z    |     0      |   + x%   |     + y%      |
+		 * --------------------------------------------------------
+		 * Instance change
+		 *
+		 * -
+		 * When scaling up, we use percentage change (+x% initially then +y% if particularly high)
+		 * When scaling down, we use absolute change (-z each interval)
+		 * We take no scaling actions when latency is between lower and middle values to avoid flapping
+		 * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html#step-scaling-considerations
+		 */
+
+		const scaleOutPolicy = new StepScalingPolicy(
+			context,
+			'LatencyScaleUpPolicy',
+			{
+				autoScalingGroup: ec2App.autoScalingGroup,
+				metric: latencyMetric,
+				scalingSteps:
+					props.scaling.policies.step.latency.scalingStepsOut,
+				adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
+				evaluationPeriods: 2, // 1 minute = 2 × 30 seconds
+			},
+		);
+
+		const scalingAlertsTopic = new Topic(
+			context,
+			'LatencyScalingAlertsTopic',
+		);
+		new Subscription(context, 'LatencyScalingAlertsSubscriptionEmail', {
+			endpoint: 'dotcom.platform@theguardian.com',
+			protocol: SubscriptionProtocol.EMAIL,
+			topic: scalingAlertsTopic,
+		});
+
+		scaleOutPolicy.upperAlarm?.addAlarmAction(
+			new SnsAction(scalingAlertsTopic),
+		);
+
+		/** Scale in policy */
+		new StepScalingPolicy(context, 'LatencyScaleDownPolicy', {
+			autoScalingGroup: ec2App.autoScalingGroup,
+			metric: latencyMetric,
+			scalingSteps: props.scaling.policies.step.latency.scalingStepsIn,
+			adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
+			evaluationPeriods: 10,
+		});
+	}
+};
 
 /** DCR infrastructure provisioning via CDK */
 export class RenderingCDKStack extends CDKStack {
@@ -138,67 +277,11 @@ export class RenderingCDKStack extends CDKStack {
 			ttl: Duration.hours(1),
 		});
 
-		/** Add latency-based step scaling policy for PROD only if a policy is defined */
-		if (stage === 'PROD' && props.scaling.policy) {
-			const latencyMetric = new Metric({
-				dimensionsMap: {
-					LoadBalancer: ec2App.loadBalancer.loadBalancerFullName,
-					TargetGroup: ec2App.targetGroup.targetGroupFullName,
-				},
-				metricName: 'TargetResponseTime',
-				namespace: 'AWS/ApplicationELB',
-				period: Duration.seconds(30),
-				statistic: 'Average', // TODO - should we use p90?
-			});
+		/** Add CPU utilisation based STEP scaling policy for PROD only if a policy is defined */
+		addCPUStepScalingPolicy(this, ec2App, props, stage);
 
-			/** Scaling policies ASCII diagram
-			 *
-			 * Metric value (latency in seconds)
-			 *  0        lower       middle       upper         infinity
-			 * --------------------------------------------------------
-			 *  |   - z    |     0      |   + x%   |     + y%      |
-			 * --------------------------------------------------------
-			 * Instance change
-			 *
-			 * -
-			 * When scaling up, we use percentage change (+x% initially then +y% if particularly high)
-			 * When scaling down, we use absolute change (-z each interval)
-			 * We take no scaling actions when latency is between lower and middle values to avoid flapping
-			 * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html#step-scaling-considerations
-			 */
-
-			const scaleOutPolicy = new StepScalingPolicy(
-				this,
-				'LatencyScaleUpPolicy',
-				{
-					autoScalingGroup: ec2App.autoScalingGroup,
-					metric: latencyMetric,
-					scalingSteps: props.scaling.policy.scalingStepsOut,
-					adjustmentType: AdjustmentType.PERCENT_CHANGE_IN_CAPACITY,
-					evaluationPeriods: 2, // 1 minute = 2 × 30 seconds
-				},
-			);
-
-			const scalingAlertsTopic = new Topic(this, 'ScalingAlertsTopic');
-			new Subscription(this, 'ScalingAlertsSubscriptionEmail', {
-				endpoint: 'dotcom.platform@theguardian.com',
-				protocol: SubscriptionProtocol.EMAIL,
-				topic: scalingAlertsTopic,
-			});
-
-			scaleOutPolicy.upperAlarm?.addAlarmAction(
-				new SnsAction(scalingAlertsTopic),
-			);
-
-			/** Scale in policy */
-			new StepScalingPolicy(this, 'LatencyScaleDownPolicy', {
-				autoScalingGroup: ec2App.autoScalingGroup,
-				metric: latencyMetric,
-				scalingSteps: props.scaling.policy.scalingStepsIn,
-				adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
-				evaluationPeriods: 10,
-			});
-		}
+		/** Add latency-based STEP scaling policy for PROD only if a policy is defined */
+		addLatencyStepScalingPolicy(this, ec2App, props, stage);
 
 		// Saves the value of the rendering base URL to SSM for frontend apps to use
 		new StringParameter(this, 'RenderingBaseURLParam', {


### PR DESCRIPTION
Revert-revert guardian/dotcom-rendering#11922

Re-introduce "Add p90 CPU Utilization step scaling policy" #11837

As this is a destructive change to stateful `ScalingAlertsTopic` i.e. an SNS topic, riff-raff failed the deploy so it will need to be deployed manually.