### PR TITLE
Revert "Align contributions service URL logic in page layouts"

### DIFF
--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -12,7 +12,6 @@ import { Nav } from '../components/Nav/Nav';
 import { NewslettersPageHeading } from '../components/NewsletterPageHeading';
 import { Section } from '../components/Section';
 import { SubNav } from '../components/SubNav.importable';
-import { getContributionsServiceUrl } from '../lib/contributions';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -27,12 +26,19 @@ export const AllEditorialNewslettersPageLayout = ({
 	newslettersPage,
 	NAV,
 }: Props) => {
-	const { subscribeUrl, editionId, pageFooter, config, isAdFreeUser } =
-		newslettersPage;
+	const {
+		subscribeUrl,
+		editionId,
+		pageFooter,
+		contributionsServiceUrl: pageContributionsServiceUrl,
+		config,
+		isAdFreeUser,
+	} = newslettersPage;
 
 	const renderAds = !isAdFreeUser;
 
-	const contributionsServiceUrl = getContributionsServiceUrl(newslettersPage);
+	const contributionsServiceUrl =
+		process.env.SDC_URL ?? pageContributionsServiceUrl;
 
 	const displayedNewslettersCount =
 		newslettersPage.groupedNewsletters.groups.reduce<number>(

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -23,7 +23,6 @@ import { SubNav } from '../components/SubNav.importable';
 import { TagPageHeader } from '../components/TagPageHeader';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { canRenderAds } from '../lib/canRenderAds';
-import { getContributionsServiceUrl } from '../lib/contributions';
 import {
 	getTagPageBannerAdPositions,
 	getTagPageMobileAdPositions,
@@ -70,7 +69,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 	const inUpdatedHeaderABTest =
 		abTests.updatedHeaderDesignVariant === 'variant';
 
-	const contributionsServiceUrl = getContributionsServiceUrl(tagPage);
+	const contributionsServiceUrl = 'https://contributions.guardianapis.com'; // TODO: Read this from config (use getContributionsServiceUrl)
 
 	const isAccessibilityPage =
 		tagPage.config.pageId === 'help/accessibility-help';

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -1,10 +1,9 @@
-import { getCookie, onConsentChange, storage } from '@guardian/libs';
+import { onConsentChange } from '@guardian/libs';
+import { getCookie, storage } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
 import type { DCRFrontType } from '../types/front';
 import type { DCRArticle } from '../types/frontend';
-import type { DCRNewslettersPageType } from '../types/newslettersPage';
-import type { DCRTagPageType } from '../types/tagPage';
 // User Atributes API cookies (dropped on sign-in)
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
@@ -236,7 +235,7 @@ export const recentlyClosedBanner = (
 };
 
 export const getContributionsServiceUrl = (
-	config: DCRArticle | DCRFrontType | DCRTagPageType | DCRNewslettersPageType,
+	config: DCRArticle | DCRFrontType,
 ): string => process.env.SDC_URL ?? config.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1224,16 +1224,12 @@
         },
         "canonicalUrl": {
             "type": "string"
-        },
-        "contributionsServiceUrl": {
-            "type": "string"
         }
     },
     "required": [
         "commercialProperties",
         "config",
         "contents",
-        "contributionsServiceUrl",
         "editionId",
         "editionLongForm",
         "forceDay",

--- a/dotcom-rendering/src/types/tagPage.ts
+++ b/dotcom-rendering/src/types/tagPage.ts
@@ -26,7 +26,6 @@ export interface FETagPageType {
 	isAdFreeUser: boolean;
 	forceDay: boolean;
 	canonicalUrl?: string;
-	contributionsServiceUrl: string;
 }
 
 /**
@@ -81,7 +80,6 @@ export interface DCRTagPageType {
 	};
 	branding: CollectionBranding | undefined;
 	canonicalUrl?: string;
-	contributionsServiceUrl: string;
 }
 
 export interface DCRFrontPagination {


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#11929 while investigating an issue