### PR TITLE
feat: Switch to using IMDSv2

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/dotcom-rendering.test.ts.snap
@@ -933,6 +933,9 @@ exports[`The DotcomRendering stack matches the snapshot 1`] = `
             "Ref": "AMIRendering",
           },
           "InstanceType": "t4g.micro",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [

--- a/dotcom-rendering/cdk/lib/dotcom-rendering.ts
+++ b/dotcom-rendering/cdk/lib/dotcom-rendering.ts
@@ -245,7 +245,6 @@ export class DotcomRendering extends GuStack {
 			role: instanceRole,
 			additionalSecurityGroups: [instanceSecurityGroup],
 			vpcSubnets: { subnets: privateSubnets },
-			withoutImdsv2: true,
 		});
 
 		Tags.of(asg).add('LogKinesisStreamName', loggingStreamName);


### PR DESCRIPTION
## What does this change?
Updates the `dotcom-rendering` ASG to satisfy [FSBP EC2.8](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8).

[This guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html#recommended-path-for-requiring-imdsv2) suggests looking at the `MetadataNoToken` CloudWatch Metric to understand if IMDSv1 is in use. We can see this [in Grafana](https://metrics.gutools.co.uk/goto/LE59tNXSg?orgId=1), and it looks like IMDSv1 is not used.

> [!NOTE]
> With `HttpTokens` set to `required`, the IMDSv1 endpoint will no longer be enabled.
> 
> See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-metadataoptions.html.

## Why?
- For @guardian/devx-security - satisfies the FSBP EC2.8 rule
- For @guardian/devx-operations - helps deprecate the `withoutImdsv2` property[^1] in GuCDK, which in turn simplifies support for an improved ASG deployment mechanism[^2]

[^1]: Usage here - https://github.com/search?q=org%3Aguardian%20withoutImdsv2&type=code.
[^2]: This change is being developed, and will land in a new version of GuCDK, with comms. That is, this change does not itself impact the deployment mechanism used today.