### PR TITLE
Demo of a potential noJS nav page solution

### DIFF
--- a/dotcom-rendering/scripts/json-schema/gen-schema.js
+++ b/dotcom-rendering/scripts/json-schema/gen-schema.js
@@ -7,6 +7,7 @@ const {
 	getNewsletterPageSchema,
 	getTagPageSchema,
 	getBlockSchema,
+	getNavPageSchema,
 } = require('./get-schema');
 
 const root = path.resolve(__dirname, '..', '..');
@@ -15,6 +16,7 @@ const articleSchema = getArticleSchema();
 const frontSchema = getFrontSchema();
 const tagPageSchema = getTagPageSchema();
 const newsletterPageSchema = getNewsletterPageSchema();
+const navPageSchema = getNavPageSchema();
 const blockSchema = getBlockSchema();
 
 fs.writeFile(
@@ -53,6 +55,17 @@ fs.writeFile(
 fs.writeFile(
 	`${root}/src/model/newsletter-page-schema.json`,
 	newsletterPageSchema,
+	'utf8',
+	(err) => {
+		if (err) {
+			console.log(err);
+		}
+	},
+);
+
+fs.writeFile(
+	`${root}/src/model/nav-page-schema.json`,
+	navPageSchema,
 	'utf8',
 	(err) => {
 		if (err) {

--- a/dotcom-rendering/scripts/json-schema/get-schema.js
+++ b/dotcom-rendering/scripts/json-schema/get-schema.js
@@ -9,6 +9,7 @@ const program = TJS.getProgramFromFiles(
 		path.resolve(`${root}/src/types/frontend.ts`),
 		path.resolve(`${root}/src/types/tagPage.ts`),
 		path.resolve(`${root}/src/types/newslettersPage.ts`),
+		path.resolve(`${root}/src/types/navPage.ts`),
 	],
 	{
 		skipLibCheck: true,
@@ -49,6 +50,14 @@ const getNewsletterPageSchema = () => {
 	);
 };
 
+const getNavPageSchema = () => {
+	return JSON.stringify(
+		TJS.generateSchema(program, 'FENavPage', settings),
+		null,
+		4,
+	);
+};
+
 const getBlockSchema = () => {
 	return JSON.stringify(
 		TJS.generateSchema(program, 'Block', settings),
@@ -62,5 +71,6 @@ module.exports = {
 	getFrontSchema,
 	getTagPageSchema,
 	getNewsletterPageSchema,
+	getNavPageSchema,
 	getBlockSchema,
 };

--- a/dotcom-rendering/src/components/NavPage.tsx
+++ b/dotcom-rendering/src/components/NavPage.tsx
@@ -1,7 +1,7 @@
 import { Global } from '@emotion/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { StrictMode } from 'react';
-import { NavLayout } from '../layouts/NavLayout';
+import { NavPageLayout } from '../layouts/NavPageLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { rootStyles } from '../lib/rootStyles';
 import { filterABTestSwitches } from '../model/enhance-switches';
@@ -98,7 +98,7 @@ export const NavPage = ({ navPage, NAV }: Props) => {
 					if anything is unreadable or odd.
 				</DarkModeMessage>
 			)}
-			<NavLayout navPage={navPage} NAV={NAV} />
+			<NavPageLayout navPage={navPage} NAV={NAV} />
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/components/NavPage.tsx
+++ b/dotcom-rendering/src/components/NavPage.tsx
@@ -1,0 +1,104 @@
+import { Global } from '@emotion/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
+import { StrictMode } from 'react';
+import { NavLayout } from '../layouts/NavLayout';
+import { buildAdTargeting } from '../lib/ad-targeting';
+import { rootStyles } from '../lib/rootStyles';
+import { filterABTestSwitches } from '../model/enhance-switches';
+import type { NavType } from '../model/extract-nav';
+import type { DCRNavPage } from '../types/navPage';
+import { AlreadyVisited } from './AlreadyVisited.importable';
+import { DarkModeMessage } from './DarkModeMessage';
+import { FocusStyles } from './FocusStyles.importable';
+import { Island } from './Island';
+import { Metrics } from './Metrics.importable';
+import { SetABTests } from './SetABTests.importable';
+import { SetAdTargeting } from './SetAdTargeting.importable';
+import { SkipTo } from './SkipTo';
+
+type Props = {
+	navPage: DCRNavPage;
+	NAV: NavType;
+};
+
+/**
+ * @description
+ * NavPage is a high level wrapper for the static navigation page on Dotcom.
+ * Sets strict mode and some globals
+ *
+ * This is only used if a user has disbaled Javascript.
+ *
+ * @param {Props} props
+ * @param {DCRFrontType} props.front - The article JSON data
+ * @param {NAVType} props.NAV - The article JSON data
+ * */
+export const NavPage = ({ navPage, NAV }: Props) => {
+	const adTargeting = buildAdTargeting({
+		isAdFreeUser: navPage.isAdFreeUser,
+		isSensitive: navPage.config.isSensitive,
+		edition: navPage.config.edition,
+		section: navPage.config.section,
+		sharedAdTargeting: navPage.config.sharedAdTargeting,
+		adUnit: navPage.config.adUnit,
+	});
+
+	/* We use this as our "base" or default format */
+	const format = {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	};
+
+	const darkModeAvailable =
+		navPage.config.abTests.darkModeWebVariant === 'variant';
+
+	return (
+		<StrictMode>
+			<Global styles={rootStyles(format, darkModeAvailable)} />
+			<SkipTo id="maincontent" label="Skip to main content" />
+			<SkipTo id="navigation" label="Skip to navigation" />
+			<Island priority="feature" defer={{ until: 'idle' }}>
+				<AlreadyVisited />
+			</Island>
+			<Island priority="feature" defer={{ until: 'idle' }}>
+				<FocusStyles />
+			</Island>
+			<Island priority="critical">
+				<Metrics
+					commercialMetricsEnabled={
+						!!navPage.config.switches.commercialMetrics
+					}
+					tests={navPage.config.abTests}
+				/>
+			</Island>
+			<Island priority="critical">
+				<SetABTests
+					abTestSwitches={filterABTestSwitches(
+						navPage.config.switches,
+					)}
+					pageIsSensitive={navPage.config.isSensitive}
+					isDev={!!navPage.config.isDev}
+					serverSideTests={navPage.config.abTests}
+				/>
+			</Island>
+			<Island priority="critical">
+				<SetAdTargeting adTargeting={adTargeting} />
+			</Island>
+			{darkModeAvailable && (
+				<DarkModeMessage>
+					Dark mode is a work-in-progress.
+					<br />
+					You can{' '}
+					<a
+						style={{ color: 'inherit' }}
+						href="/opt/out/dark-mode-web"
+					>
+						opt out anytime
+					</a>{' '}
+					if anything is unreadable or odd.
+				</DarkModeMessage>
+			)}
+			<NavLayout navPage={navPage} NAV={NAV} />
+		</StrictMode>
+	);
+};

--- a/dotcom-rendering/src/layouts/NavLayout.tsx
+++ b/dotcom-rendering/src/layouts/NavLayout.tsx
@@ -1,0 +1,136 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineMedium20,
+	palette as sourcePalette,
+	space,
+} from '@guardian/source/foundations';
+import { Footer } from '../components/Footer';
+import { Masthead } from '../components/Masthead/Masthead';
+import { Section } from '../components/Section';
+import { getContributionsServiceUrl } from '../lib/contributions';
+import type { NavType } from '../model/extract-nav';
+import { palette } from '../palette';
+import type { DCRNavPage } from '../types/navPage';
+
+interface Props {
+	navPage: DCRNavPage;
+	NAV: NavType;
+}
+
+/** This page displays the full expanded nav for no JS users */
+export const NavLayout = ({ navPage, NAV }: Props) => {
+	return (
+		<>
+			<div data-print-layout="hide" id="bannerandheader">
+				<Masthead
+					nav={NAV}
+					editionId={navPage.editionId}
+					idUrl={navPage.config.idUrl}
+					mmaUrl={navPage.config.mmaUrl}
+					discussionApiUrl={navPage.config.discussionApiUrl}
+					contributionsServiceUrl={getContributionsServiceUrl(
+						navPage,
+					)}
+					showSubNav={false}
+					idApiUrl={navPage.config.idApiUrl}
+				/>
+			</div>
+			<main
+				data-layout="NavLayout"
+				data-link-name="Nav (noJS)"
+				id="maincontent"
+			>
+				{NAV.pillars.map((pillar) => {
+					return (
+						<Section
+							key={pillar.title}
+							title={pillar.title}
+							showTopBorder={true}
+							url={pillar.url}
+							containerName={pillar.title}
+							description={pillar.longTitle}
+						>
+							<ul
+								css={css`
+									display: flex;
+
+									flex-direction: row;
+									flex-wrap: wrap;
+									justify-content: space-between;
+								`}
+							>
+								{pillar.children?.map((navLink) => {
+									return (
+										<li
+											key={navLink.title}
+											css={css`
+												display: flex;
+												flex-direction: column;
+												flex-basis: 50%;
+												${from.mobileLandscape} {
+													flex-basis: 33.33%;
+												}
+												${from.desktop} {
+													flex-basis: 25%;
+												}
+												padding: ${space[1]}px 0
+													${space[2]}px 0;
+												margin-right: ${space[4]}px;
+
+												:before {
+													border-top: 1px solid
+														${palette(
+															'--card-border-top',
+														)};
+													content: '';
+													width: 100%;
+													padding-bottom: ${space[2]}px;
+													background-color: unset;
+												}
+											`}
+										>
+											<a
+												css={css`
+													flex-grow: 1;
+													${headlineMedium20}
+													color: ${sourcePalette
+														.neutral[7]};
+													text-decoration: none;
+													:hover {
+														text-decoration: underline;
+													}
+												`}
+												href={navLink.url}
+											>
+												{navLink.title}
+											</a>
+										</li>
+									);
+								})}
+							</ul>
+						</Section>
+					);
+				})}
+			</main>
+
+			<Section
+				fullWidth={true}
+				data-print-layout="hide"
+				padSides={false}
+				backgroundColour={sourcePalette.brand[400]}
+				borderColour={sourcePalette.brand[600]}
+				showSideBorders={false}
+				showTopBorder={false}
+				element="footer"
+			>
+				<Footer
+					pageFooter={navPage.pageFooter}
+					pillars={NAV.pillars}
+					urls={navPage.nav.readerRevenueLinks.footer}
+					editionId={navPage.editionId}
+				/>
+			</Section>
+		</>
+	);
+};

--- a/dotcom-rendering/src/layouts/NavPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/NavPageLayout.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	from,
+	headlineMedium17,
 	headlineMedium20,
 	palette as sourcePalette,
 	space,
@@ -18,8 +19,52 @@ interface Props {
 	NAV: NavType;
 }
 
+const listStyles = css`
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	gap: ${space[4]}px;
+`;
+
+const listItemStyles = css`
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
+	flex-basis: 100%;
+	${from.mobileMedium} {
+		flex-basis: 40%;
+	}
+	${from.tablet} {
+		flex-basis: 30%;
+	}
+
+	:before {
+		border-top: 1px solid ${palette('--card-border-top')};
+		content: '';
+		width: 100%;
+		padding-bottom: ${space[2]}px;
+		background-color: unset;
+	}
+`;
+
+const linkStyles = css`
+	flex-grow: 1;
+	${headlineMedium17}
+	${from.tablet} {
+		${headlineMedium20}
+	}
+	color: ${sourcePalette.neutral[7]};
+	text-decoration: none;
+	:hover {
+		text-decoration: underline;
+	}
+	padding-bottom: ${space[1]}px;
+	margin-right: ${space[4]}px;
+`;
+
 /** This page displays the full expanded nav for no JS users */
-export const NavLayout = ({ navPage, NAV }: Props) => {
+export const NavPageLayout = ({ navPage, NAV }: Props) => {
 	return (
 		<>
 			<div data-print-layout="hide" id="bannerandheader">
@@ -51,56 +96,15 @@ export const NavLayout = ({ navPage, NAV }: Props) => {
 							containerName={pillar.title}
 							description={pillar.longTitle}
 						>
-							<ul
-								css={css`
-									display: flex;
-
-									flex-direction: row;
-									flex-wrap: wrap;
-									justify-content: space-between;
-								`}
-							>
+							<ul css={listStyles}>
 								{pillar.children?.map((navLink) => {
 									return (
 										<li
 											key={navLink.title}
-											css={css`
-												display: flex;
-												flex-direction: column;
-												flex-basis: 50%;
-												${from.mobileLandscape} {
-													flex-basis: 33.33%;
-												}
-												${from.desktop} {
-													flex-basis: 25%;
-												}
-												padding: ${space[1]}px 0
-													${space[2]}px 0;
-												margin-right: ${space[4]}px;
-
-												:before {
-													border-top: 1px solid
-														${palette(
-															'--card-border-top',
-														)};
-													content: '';
-													width: 100%;
-													padding-bottom: ${space[2]}px;
-													background-color: unset;
-												}
-											`}
+											css={listItemStyles}
 										>
 											<a
-												css={css`
-													flex-grow: 1;
-													${headlineMedium20}
-													color: ${sourcePalette
-														.neutral[7]};
-													text-decoration: none;
-													:hover {
-														text-decoration: underline;
-													}
-												`}
+												css={linkStyles}
 												href={navLink.url}
 											>
 												{navLink.title}

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -1,10 +1,8 @@
 import { getCookie, onConsentChange, storage } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { useEffect, useState } from 'react';
-import type { DCRFrontType } from '../types/front';
-import type { DCRArticle } from '../types/frontend';
-import type { DCRNewslettersPageType } from '../types/newslettersPage';
-import type { DCRTagPageType } from '../types/tagPage';
+import type { DCRPageType } from '../types/page';
+
 // User Atributes API cookies (dropped on sign-in)
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
@@ -235,9 +233,8 @@ export const recentlyClosedBanner = (
 	return false;
 };
 
-export const getContributionsServiceUrl = (
-	config: DCRArticle | DCRFrontType | DCRTagPageType | DCRNewslettersPageType,
-): string => process.env.SDC_URL ?? config.contributionsServiceUrl;
+export const getContributionsServiceUrl = (config: DCRPageType): string =>
+	process.env.SDC_URL ?? config.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
 export const getPurchaseInfo = (): PurchaseInfo => {

--- a/dotcom-rendering/src/model/nav-page-schema.json
+++ b/dotcom-rendering/src/model/nav-page-schema.json
@@ -1,0 +1,816 @@
+{
+    "type": "object",
+    "properties": {
+        "nav": {
+            "$ref": "#/definitions/FENavType"
+        },
+        "editionId": {
+            "$ref": "#/definitions/EditionId"
+        },
+        "editionLongForm": {
+            "type": "string"
+        },
+        "guardianBaseURL": {
+            "type": "string"
+        },
+        "pageId": {
+            "type": "string"
+        },
+        "webTitle": {
+            "type": "string"
+        },
+        "webURL": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "keywordIds": {
+                    "type": "string"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "$ref": "#/definitions/SharedAdTargeting"
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "userAttributesApiUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "isFront": {
+                    "type": "boolean",
+                    "const": true
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "discussionFrontendUrl": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "weatherapiurl": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "buildNumber",
+                "calloutsUrl",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "discussionFrontendUrl",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isFront",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "keywordIds",
+                "keywords",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "userAttributesApiUrl",
+                "weatherapiurl",
+                "webTitle"
+            ]
+        },
+        "commercialProperties": {
+            "$ref": "#/definitions/CommercialProperties"
+        },
+        "pageFooter": {
+            "$ref": "#/definitions/FooterType"
+        },
+        "isAdFreeUser": {
+            "type": "boolean"
+        },
+        "canonicalUrl": {
+            "type": "string"
+        },
+        "contributionsServiceUrl": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "commercialProperties",
+        "config",
+        "contributionsServiceUrl",
+        "editionId",
+        "editionLongForm",
+        "guardianBaseURL",
+        "isAdFreeUser",
+        "nav",
+        "pageFooter",
+        "pageId",
+        "webTitle",
+        "webURL"
+    ],
+    "definitions": {
+        "FENavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/FELinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/FELinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FELinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "FELinkType": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "SharedAdTargeting": {
+            "type": "object"
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
+        },
+        "CommercialProperties": {
+            "type": "object",
+            "properties": {
+                "UK": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "US": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "AU": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "INT": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                },
+                "EUR": {
+                    "$ref": "#/definitions/EditionCommercialProperties"
+                }
+            },
+            "required": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ]
+        },
+        "EditionCommercialProperties": {
+            "type": "object",
+            "properties": {
+                "adTargeting": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdTargetParam"
+                    }
+                },
+                "branding": {
+                    "$ref": "#/definitions/Branding"
+                }
+            },
+            "required": [
+                "adTargeting"
+            ]
+        },
+        "AdTargetParam": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ]
+        },
+        "Branding": {
+            "type": "object",
+            "properties": {
+                "brandingType": {
+                    "$ref": "#/definitions/BrandingType"
+                },
+                "sponsorName": {
+                    "type": "string"
+                },
+                "logo": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                },
+                "aboutThisLink": {
+                    "type": "string"
+                },
+                "logoForDarkBackground": {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "type": "string"
+                        },
+                        "link": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "object",
+                            "properties": {
+                                "width": {
+                                    "type": "number"
+                                },
+                                "height": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "height",
+                                "width"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "dimensions",
+                        "label",
+                        "link",
+                        "src"
+                    ]
+                }
+            },
+            "required": [
+                "aboutThisLink",
+                "logo",
+                "sponsorName"
+            ]
+        },
+        "BrandingType": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "paid-content"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "foundation"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "const": "sponsored"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                }
+            ]
+        },
+        "FooterType": {
+            "type": "object",
+            "properties": {
+                "footerLinks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/FooterLink"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "footerLinks"
+            ]
+        },
+        "FooterLink": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "dataLinkName": {
+                    "type": "string"
+                },
+                "extraClasses": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -4,11 +4,13 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import type { FEFrontType } from '../../src/types/front';
 import type { FEArticleType } from '../types/frontend';
+import type { FENavPage } from '../types/navPage';
 import type { FENewslettersPageType } from '../types/newslettersPage';
 import type { FETagPageType } from '../types/tagPage';
 import articleSchema from './article-schema.json';
 import blockSchema from './block-schema.json';
 import frontSchema from './front-schema.json';
+import navPageSchema from './nav-page-schema.json';
 import newslettersPageSchema from './newsletter-page-schema.json';
 import tagPageSchema from './tag-page-schema.json';
 
@@ -28,6 +30,7 @@ const validateTagPage = ajv.compile<FETagPageType>(tagPageSchema);
 const validateAllEditorialNewslettersPage = ajv.compile<FENewslettersPageType>(
 	newslettersPageSchema,
 );
+const validateNavPage = ajv.compile<FENavPage>(navPageSchema);
 const validateBlock = ajv.compile<Block[]>(blockSchema);
 
 export const validateAsArticleType = (data: unknown): FEArticleType => {
@@ -81,5 +84,17 @@ export const validateAsBlock = (data: unknown): Block[] => {
 	throw new TypeError(
 		`Unable to validate request body for block.\n
             ${JSON.stringify(validateBlock.errors, null, 2)}`,
+	);
+};
+
+export const validateAsNavPageType = (data: unknown): FENavPage => {
+	if (validateNavPage(data)) return data;
+
+	const url =
+		isObject(data) && isString(data.webURL) ? data.webURL : 'unknown url';
+
+	throw new TypeError(
+		`Unable to validate request body for url ${url}.\n
+            ${JSON.stringify(validateNavPage.errors, null, 2)}`,
 	);
 };

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -14,6 +14,8 @@ import {
 import {
 	handleFront,
 	handleFrontJson,
+	handleNavPage,
+	handleNavPageJson,
 	handleTagPage,
 	handleTagPageJson,
 } from './handler.front.web';
@@ -85,6 +87,10 @@ export const devServer = (): Handler => {
 				return handleAppsArticle(req, res, next);
 			case 'AppsInteractive':
 				return handleAppsInteractive(req, res, next);
+			case 'NavPage':
+				return handleNavPage(req, res, next);
+			case 'NavPageJSON':
+				return handleNavPageJson(req, res, next);
 			default: {
 				// Do not redirect assets urls
 				if (req.url.match(ASSETS_URL)) return next();

--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -22,6 +22,8 @@ import {
 import {
 	handleFront,
 	handleFrontJson,
+	handleNavPage,
+	handleNavPageJson,
 	handleTagPage,
 	handleTagPageJson,
 } from './handler.front.web';
@@ -78,6 +80,9 @@ export const prodServer = (): void => {
 	);
 	app.post('/AppsArticle', logRenderTime, handleAppsArticle);
 	app.post('/AppsInteractive', logRenderTime, handleAppsInteractive);
+
+	app.post('/NavPage', logRenderTime, handleNavPage);
+	app.post('/NavPageJson', logRenderTime, handleNavPageJson);
 
 	// These GET's are for checking any given URL directly from PROD
 	app.get(
@@ -140,6 +145,19 @@ export const prodServer = (): void => {
 		logRenderTime,
 		getContentFromURLMiddleware,
 		handleAppsInteractive,
+	);
+
+	app.get(
+		'/NavPage/*',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleNavPage,
+	);
+	app.get(
+		'/NavPageJSON/*',
+		logRenderTime,
+		getContentFromURLMiddleware,
+		handleNavPageJson,
 	);
 
 	app.use('/ArticlePerfTest/*', handleArticlePerfTest);

--- a/dotcom-rendering/src/types/navPage.ts
+++ b/dotcom-rendering/src/types/navPage.ts
@@ -1,0 +1,36 @@
+import type { EditionId } from '../lib/edition';
+import type { CommercialProperties } from './commercial';
+import type { FooterType } from './footer';
+import type { FEFrontConfigType } from './front';
+import type { FENavType } from './frontend';
+
+export interface FENavPage {
+	nav: FENavType;
+	editionId: EditionId;
+	editionLongForm: string;
+	guardianBaseURL: string;
+	pageId: string;
+	webTitle: string;
+	webURL: string;
+	config: FEFrontConfigType;
+	commercialProperties: CommercialProperties;
+	pageFooter: FooterType;
+	isAdFreeUser: boolean;
+	canonicalUrl?: string;
+	contributionsServiceUrl: string;
+}
+
+export interface DCRNavPage {
+	nav: FENavType;
+	editionId: EditionId;
+	guardianBaseURL: string;
+	pageId: string;
+	webTitle: string;
+	webURL: string;
+	config: FEFrontConfigType;
+	commercialProperties: CommercialProperties;
+	pageFooter: FooterType;
+	isAdFreeUser: boolean;
+	canonicalUrl?: string;
+	contributionsServiceUrl: string;
+}

--- a/dotcom-rendering/src/types/page.ts
+++ b/dotcom-rendering/src/types/page.ts
@@ -1,0 +1,12 @@
+import type { DCRFrontType } from './front';
+import type { DCRArticle } from './frontend';
+import type { DCRNavPage } from './navPage';
+import type { DCRNewslettersPageType } from './newslettersPage';
+import type { DCRTagPageType } from './tagPage';
+
+export type DCRPageType =
+	| DCRArticle
+	| DCRFrontType
+	| DCRTagPageType
+	| DCRNewslettersPageType
+	| DCRNavPage;


### PR DESCRIPTION
## What does this change?

Adds a `NavPage` component which renders the nav JSON as a page so that no JS users can view the nav as a static page and users who use JS can toggle a menu in a more standard way

This is one step towards the goal. We would also need to implement a change in frontend to be able to support this type of page.

## Why?

The developer experience is quite poor when it comes to understanding how the nav works in the header, which leads to lots of wasted time of multiple developers who want to update it.

This solution supports both JS and no JS by supplying two different solutions to these problems rather than trying to tackle it in one.

- JS: use the expandable nav within the header
- No JS: use the static page nav accessable by clicking the menu button in the header


## Screenshots
<img width="1401" alt="Screenshot 2024-07-19 at 17 39 24" src="https://github.com/user-attachments/assets/2040151e-27d0-416c-8ab9-4bfbf1695747">
