### PR TITLE
Simplify grid styles for page skins

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Grid.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Grid.tsx
@@ -43,6 +43,9 @@ const grid = css`
 			minmax(0, 1fr)
 			[viewport-end];
 	}
+`;
+
+const gridBeyondDesktop = css`
 	${from.leftCol} {
 		grid-template-columns:
 			[viewport-start]
@@ -72,19 +75,6 @@ const grid = css`
 	}
 `;
 
-const pageSkinGrid = css`
-	${from.desktop} {
-		grid-template-columns:
-			[viewport-start]
-			minmax(0, 1fr)
-			[content-start main-column-start]
-			repeat(12, 60px)
-			[content-end main-column-end]
-			minmax(0, 1fr)
-			[viewport-end];
-	}
-`;
-
 /**
  * Create a CSS grid container.
  * Use jointly with Content, LeftCol & RightCol.
@@ -100,7 +90,12 @@ export const Grid = ({
 	type: keyof JSX.IntrinsicElements;
 	hasPageSkin?: boolean;
 	style?: CSSProperties;
-}>) => jsx(type, { css: [grid, hasPageSkin && pageSkinGrid], style }, children);
+}>) =>
+	jsx(
+		type,
+		{ css: [grid, !hasPageSkin && gridBeyondDesktop], style },
+		children,
+	);
 
 /** Spans the entire width of the grid */
 export const Content = ({


### PR DESCRIPTION
## What does this change?

Refactor the page skin styles: rather than having override styles when there is a page skin, we can avoid duplication by only applying styles beyond the desktop breakpoint when there is no page skin.

## Why?

Possibly simpler than #11906 and more consistent with other such patterns.