### PR TITLE
test(paid.content.e2e): Update paid content page

### DIFF
--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -6,7 +6,7 @@ import { expectToBeVisible } from '../lib/locators';
 import { ADDITIONAL_REQUEST_PATH, interceptOphanRequest } from '../lib/ophan';
 
 const paidContentPage =
-	'https://www.theguardian.com/a-taste-of-piedmont-and-alpine-italy/article/2024/may/08/anchovy-sauce-to-sundried-chillies-what-the-uks-italian-chefs-eat-for-a-real-taste-of-home';
+	'https://www.theguardian.com/power-up-your-payments-with-paypal/article/2024/jul/19/how-i-spotted-a-gap-in-the-market-for-healthy-tasty-easy-cuisine';
 
 /**
  * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
@@ -29,8 +29,8 @@ test.describe('Paid content tests', () => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
-					clickComponent === 'labs-logo | article-meta-menabrea' &&
-					clickLinkNames === '["labs-logo-article-meta-menabrea"]'
+					clickComponent === 'labs-logo | article-meta-paypal' &&
+					clickLinkNames === '["labs-logo-article-meta-paypal"]'
 				);
 			},
 		});
@@ -57,9 +57,9 @@ test.describe('Paid content tests', () => {
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
 					clickComponent ===
-						'labs-logo | article-related-content-menabrea' &&
+						'labs-logo | article-related-content-paypal' &&
 					clickLinkNames ===
-						'["labs-logo-article-related-content-menabrea","related-content"]'
+						'["labs-logo-article-related-content-paypal","related-content"]'
 				);
 			},
 		});

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -15,7 +15,7 @@ const paidContentPage =
  * You need to edit the link as well as the expected requestURL to include the new brand in the code below, where it states `expect(requestURL).to.include('el=<logo goes here>');`.
  * You can grab the required info in the dev tools network tab on the page itself.
  */
-test.skip('Paid content tests', () => {
+test.describe('Paid content tests', () => {
 	test('should send Ophan component event on click of sponsor logo in article meta', async ({
 		page,
 	}) => {


### PR DESCRIPTION
## What does this change?
It looks like the current page has expired, which is causing the build to fail as the required DOM elements cannot be found.

<details><summary>Screenshot of current (expired) page</summary>
<p>

![image](https://github.com/user-attachments/assets/38d4a012-eb0e-4a06-8449-085b53a03bef)

</p>
</details> 

This change uses a new article.

## Why?
To fix the build.

## Screenshots
N/A.
