### PR TITLE
Remove the show/hide button for users without hidden containers

### DIFF
--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -45,9 +45,24 @@ export const ShowHideContainers = () => {
 			storage.local.set(`gu.prefs.container-states`, containerStates);
 		};
 
-		for (const e of window.document.querySelectorAll<HTMLElement>(
-			'[data-show-hide-button]',
-		)) {
+		const allShowHideButtons = Array.from(
+			window.document.querySelectorAll<HTMLElement>(
+				'[data-show-hide-button]',
+			),
+		);
+
+		const allContainersExpanded = allShowHideButtons.every(
+			(e) => e.getAttribute('data-link-name') === 'Hide',
+		);
+
+		for (const e of allShowHideButtons) {
+			// We want to remove the ability to toggle front containers between expanded and collapsed states.
+			// The first part of doing this is removing the feature for those who do not currently use it.
+			// This logic removes the show/hide button entirely if users have all containers expanded on a front.
+			if (allContainersExpanded) {
+				e.remove();
+			}
+
 			const sectionId = e.getAttribute('data-show-hide-button');
 			if (!sectionId) continue;
 

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -58,9 +58,13 @@ export const ShowHideContainers = () => {
 		for (const e of allShowHideButtons) {
 			// We want to remove the ability to toggle front containers between expanded and collapsed states.
 			// The first part of doing this is removing the feature for those who do not currently use it.
-			// This logic removes the show/hide button entirely if users have all containers expanded on a front.
+			// This logic sets the button as disabled and hides it from view and from screenreaders.
+			// It does not remove it entirely from the DOM.
 			if (allContainersExpanded) {
-				e.remove();
+				e.setAttribute('disabled', 'true');
+				e.setAttribute('aria-disabled', 'true');
+				e.hidden = true;
+				e.style.display = 'none';
 			}
 
 			const sectionId = e.getAttribute('data-show-hide-button');


### PR DESCRIPTION
## What does this change?

There are two approaches detailed in this PR (one per commit) of how to remove show/hide buttons if users do not currently hide any front containers.

If no containers are configured to be hidden on the page:

- 880d27ed6a3ea5d643ad6cba7ee7339770f81942 Removes the show/hide button from the DOM entirely
- 9b08e8161917fdfdb3e35a6730b0926652ee5400 Sets the state of the show/hide button to disabled and sets `display: none` on the styles to hide it from view

Both manipulate the DOM in some way, but this is also how the component works in general.

Not sure yet which approach is better. Both cause a level of CLS since the `ShowHideContainers` component is an island on the `FrontPage` component, with a priority of "enhancement" (ie. lowest priority). 

Is the latter (hiding from view) better for accessibility reasons?

## Why?

We want to remove support for showing/hiding front containers in the future so a sensible first step is to prevent new users or those who do not currently use this feature from opting in.

## Screenshots

_For a user without any containers configured to be hidden/collapsed:_
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/85880f79-6bd5-460a-952e-9a2fac7c14a5
[after]: https://github.com/user-attachments/assets/df472bf7-4edc-4a38-b455-cb36f9c182f8
