### PR TITLE
Fix various issues with ordered and unordered lists styling

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -55,11 +55,13 @@ type Props = {
 const globalOlStyles = () => css`
 	ol:not([data-ignore='global-ol-styling']) {
 		counter-reset: li;
-		li:before {
+
+		> li:before {
 			${body.medium({ lineHeight: 'tight' })};
 			content: counter(li);
 			counter-increment: li;
 			margin-right: ${remSpace[1]};
+			float: left;
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -187,7 +187,7 @@ const styles = (format: ArticleFormat) => css`
 		}
 	}
 
-	li:before {
+	ul > li:before {
 		display: inline-block;
 		content: '';
 		border-radius: 50%;

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -187,7 +187,7 @@ const styles = (format: ArticleFormat) => css`
 		}
 	}
 
-	ul > li:before {
+	&:is(ul) > li:before {
 		display: inline-block;
 		content: '';
 		border-radius: 50%;


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/11937

They were getting mixed up, so this PR tries to improve the specificity.

## What does this change?
* Improves CSS specificity when targeting `ol > li:before` and `ul > li:before` elements.
* Adds `float:left` to the `ol > li:before`

## Why?
* Fixes two bugs where styles of ordered and unordered lists were getting mixed up.
* Brings the title of the ordered list to the level of the number

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/d5ca9970-13ec-41fc-a202-7841ccd4762b) | ![image](https://github.com/user-attachments/assets/305010e5-9026-4df3-bbf1-5f1b7931e780) |
| ![image](https://github.com/user-attachments/assets/6c0a5a08-4004-4c05-9fc4-cf8ab80a31e4) | ![image](https://github.com/user-attachments/assets/f9e71c9c-ae99-46ad-b97f-bcb52c084d24) |
| ![image](https://github.com/user-attachments/assets/54e6df40-3344-479b-adfa-48839d0b9af3) | ![image](https://github.com/user-attachments/assets/f19910df-0186-4ee6-93e0-a7e029528a9b) |
