### PR TITLE
Add Olympics Briefing to the All Newsletters page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -72,6 +72,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'Sport',
 			newsletters: [
+				'tokyo-2020-daily-briefing',
 				'the-fiver', // Football Daily
 				'moving-the-goalposts',
 				'soccer-with-jonathan-wilson',
@@ -172,6 +173,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'Sport',
 			newsletters: [
+				'tokyo-2020-daily-briefing',
 				'the-fiver', // Football Daily
 				'moving-the-goalposts',
 				'the-spin',
@@ -272,6 +274,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 		{
 			title: 'Sport',
 			newsletters: [
+				'tokyo-2020-daily-briefing',
 				'sports-au',
 				'the-fiver', // Football Daily
 				'moving-the-goalposts',


### PR DESCRIPTION
## What does this change?
Adds Olympics Briefing newsletter to the all newsletters page

## Why?
Editorial request. See newsletters order [here](https://docs.google.com/spreadsheets/d/1Pfdow0Yj8OzkrnIWqIC-oSzVhwtwwDBdLmFx5hY-Gt4/edit?gid=2107885196#gid=2107885196).

## Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/551b8510-2bc2-4e74-b592-bf5dde36da79) | ![image](https://github.com/user-attachments/assets/20335152-fc1d-489b-9835-128a415e2431) |
