### PR TITLE
Remove data-spacefinder-role from hr element

### DIFF
--- a/dotcom-rendering/src/components/DividerBlockComponent.tsx
+++ b/dotcom-rendering/src/components/DividerBlockComponent.tsx
@@ -50,7 +50,6 @@ export const DividerBlockComponent = ({
 	spaceAbove = 'loose',
 }: Props) => (
 	<hr
-		data-spacefinder-role="inline"
 		css={[
 			baseStyles,
 			size === 'partial' ? sizePartialStyle : sizeFullStyle,


### PR DESCRIPTION
## What does this change?
Remove data-spacefinder-role from hr element

## Why?
Added in this PR #11919, but like paragraphs should not be avoided.
