### PR TITLE
Titlepiece design updates

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Logo.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Logo.tsx
@@ -5,50 +5,18 @@
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source/foundations';
 import { SvgGuardianLogo } from '@guardian/source/react-components';
-import type { EditionId } from '../../../lib/edition';
 import { nestedOphanComponents } from '../../../lib/ophan-helpers';
 import { palette } from '../../../palette';
-import { SvgGuardianNewsProviderLogo } from '../../SvgGuardianNewsProviderLogo';
 
-type Props = {
-	editionId: EditionId;
-};
-
-export const Logo = ({ editionId }: Props) => {
-	switch (editionId) {
-		case 'UK':
-			return (
-				<a
-					href="/"
-					data-link-name={nestedOphanComponents('header', 'logo')}
-				>
-					<span
-						css={css`
-							${visuallyHidden};
-						`}
-					>
-						The Guardian - Back to home
-					</span>
-					<SvgGuardianNewsProviderLogo />
-				</a>
-			);
-		default:
-			return (
-				<a
-					href="/"
-					data-link-name={nestedOphanComponents('header', 'logo')}
-				>
-					<span
-						css={css`
-							${visuallyHidden};
-						`}
-					>
-						The Guardian - Back to home
-					</span>
-					<SvgGuardianLogo
-						textColor={palette('--masthead-nav-link-text')}
-					/>
-				</a>
-			);
-	}
-};
+export const Logo = () => (
+	<a href="/" data-link-name={nestedOphanComponents('header', 'logo')}>
+		<span
+			css={css`
+				${visuallyHidden};
+			`}
+		>
+			The Guardian - Back to home
+		</span>
+		<SvgGuardianLogo textColor={palette('--masthead-nav-link-text')} />
+	</a>
+);

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
@@ -130,8 +130,14 @@ const pillarLink = css`
 	padding-right: ${space[1]}px;
 
 	${from.mobileMedium} {
-		${headlineBold17}
+		${headlineBold14}
+		/** This overrides the font size to 15
+		 TODO: export headlineBold15 from source */
+		font-size: 0.9375rem;
 		padding-right: ${space[2]}px;
+	}
+	${from.mobileLandscape} {
+		${headlineBold17}
 	}
 
 	${from.desktop} {

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -28,12 +28,16 @@ interface Props {
 
 const veggieBurgerDiameter = 40;
 
-const gridFullWidth = css`
-	grid-column: content-start / main-column-end;
+const gridContent = css`
+	grid-column: content-start / content-end;
+`;
+
+const gridMainColumn = css`
+	grid-column: main-column-start / main-column-end;
 `;
 
 const editionSwitcherMenuStyles = css`
-	${gridFullWidth}
+	${gridMainColumn}
 	grid-row: 1;
 	${from.mobileMedium} {
 		justify-self: end;
@@ -42,7 +46,7 @@ const editionSwitcherMenuStyles = css`
 
 const logoStyles = css`
 	${getZIndex('TheGuardian')}
-	${gridFullWidth}
+	${gridMainColumn}
 	grid-row: 1;
 	justify-self: end;
 	align-self: end;
@@ -60,15 +64,15 @@ const logoStyles = css`
 	}
 
 	svg {
-		width: 144px;
+		width: 152px;
 		${from.mobileMedium} {
-			width: 198px;
+			width: 207px;
 		}
 		${from.tablet} {
-			width: 280px;
+			width: 297px;
 		}
 		${from.desktop} {
-			width: 276px;
+			width: 291px;
 		}
 	}
 `;
@@ -76,14 +80,14 @@ const logoStyles = css`
 const logoStylesWithoutPageSkin = css`
 	svg {
 		${from.leftCol} {
-			width: 398px;
+			width: 356px;
 		}
 	}
 `;
 
 const burgerStyles = css`
 	z-index: 2;
-	${gridFullWidth}
+	${gridMainColumn}
 	grid-row: 1;
 	justify-content: center;
 	display: flex;
@@ -111,7 +115,7 @@ const burgerStyles = css`
 `;
 
 const pillarsNavStyles = css`
-	${gridFullWidth}
+	${gridContent}
 	grid-row: 2;
 	align-self: end;
 
@@ -124,7 +128,7 @@ const pillarsNavStyles = css`
 `;
 
 const subNavStyles = css`
-	${gridFullWidth}
+	${gridContent}
 	grid-row: 3;
 	${textSans14}
 	color: inherit;
@@ -225,7 +229,7 @@ export const Titlepiece = ({
 
 			{/* Guardian logo */}
 			<div css={[logoStyles, !hasPageSkin && logoStylesWithoutPageSkin]}>
-				<Logo editionId={editionId} />
+				<Logo />
 			</div>
 
 			{/* Pillars nav */}

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -58,7 +58,7 @@ const myAccountLinkStyles = css`
 	transition: color 80ms ease-out;
 	text-decoration: none;
 
-	padding: ${space[1]}px;
+	padding: ${space[1]}px 0 ${space[1]}px ${space[1]}px;
 
 	:hover,
 	:focus {


### PR DESCRIPTION
## What does this change?

- Removes "News provider of the year" from the UK Guardian logo temporarily until a solution is designed for this additional text
- Aligns the `Titlepiece` components to the grid better: most things should be across the main _content_ of the page rather than across the whole grid. The `Pillars` and `SubNav` are the exceptions that should span the whole width of the grid
- Specifies an override font size for pillars at `mobileMedium` breakpoint where the equivalent font size does not exist in source at the moment (`headlineBold15`). This font preset _does_ exist in the design system so should be updated in source at some point.
- Removes the padding from the RHS of the `TopBarMyAccount` button to align it with the edge of the grid, matching the alignment of the edition switcher menu

## Why?

There were some issues noticed when viewing the Titlepiece in a live environment. This fixes some of the issues raised when QAing.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/420a8aa9-8680-4c7a-b20e-8c8ff70b0ee3
[after]: https://github.com/user-attachments/assets/894aadf2-bf42-419e-a94d-2be8152f29d6
[before2]: https://github.com/user-attachments/assets/21c9d9d9-50e9-4ec7-9c91-024b08b50524
[after2]: https://github.com/user-attachments/assets/bb27822d-a591-47a6-b516-50a821e801fc
