### PR TITLE
Using tags to hide sticky from olympics liveblog

### DIFF
--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -27,6 +27,7 @@ import {
 	createInsertEventFromTracking,
 	createViewEventFromTracking,
 } from './marketing/lib/tracking';
+import { TagType } from 'src/types/tag';
 
 const baseUrl = 'https://support.theguardian.com/contribute';
 
@@ -163,13 +164,14 @@ export const StickyLiveblogAsk: ReactComponent<StickyLiveblogAskProps> = ({
 interface StickyLiveblogAskWrapperProps {
 	referrerUrl: string;
 	shouldHideReaderRevenueOnArticle: boolean;
+	tags: TagType[];
 }
 
 const whatAmI = 'sticky-liveblog-ask';
 
 export const StickyLiveblogAskWrapper: ReactComponent<
 	StickyLiveblogAskWrapperProps
-> = ({ referrerUrl, shouldHideReaderRevenueOnArticle }) => {
+> = ({ referrerUrl, shouldHideReaderRevenueOnArticle, tags }) => {
 	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode(whatAmI);
 	const pageViewId = usePageViewId(renderingTarget);
@@ -269,10 +271,18 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 			renderingTarget,
 		);
 	};
+
+	// TODO: 'some' doesn't like underlying array to change
+	// I think tags are added as the blog is added to... will this cause an issue?
+	const shouldHideBasedOnTags = tags.some((a) => {
+		a.id === 'sport/olympic-games-2024';
+	});
+
 	const canShow =
 		variantName === 'variant' &&
 		showSupportMessagingForUser &&
-		!shouldHideReaderRevenueOnArticle;
+		!shouldHideReaderRevenueOnArticle &&
+		!shouldHideBasedOnTags;
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -19,6 +19,7 @@ import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useIsInView } from '../lib/useIsInView';
 import { usePageViewId } from '../lib/usePageViewId';
+import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import type { ReactComponent } from './marketing/lib/ReactComponent';
 import {
@@ -27,7 +28,6 @@ import {
 	createInsertEventFromTracking,
 	createViewEventFromTracking,
 } from './marketing/lib/tracking';
-import { TagType } from 'src/types/tag';
 
 const baseUrl = 'https://support.theguardian.com/contribute';
 
@@ -272,10 +272,11 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 		);
 	};
 
-	// TODO: 'some' doesn't like underlying array to change
-	// I think tags are added as the blog is added to... will this cause an issue?
+	/* This is based on the assumption that the tag is added at the point of blog creation
+	 *  and not added later.  It's a balancing act between adding a useEffect that will run
+	 *  each time a tag is added to check (less performant) and doing it on load. */
 	const shouldHideBasedOnTags = tags.some((a) => {
-		a.id === 'sport/olympic-games-2024';
+		return a.id === 'sport/olympic-games-2024';
 	});
 
 	const canShow =

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -958,6 +958,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 												shouldHideReaderRevenueOnArticle={
 													article.shouldHideReaderRevenue
 												}
+												tags={article.tags}
 											/>
 										</Island>
 									</Hide>


### PR DESCRIPTION
## What does this change?

This hides the sticky liveblog ask from liveblogs using the 'sport/olympic-games-2024' tag.

## Why?

The space will be used by another component on the olympics liveblogs.
This is hard-coded at least until we are able to instrument it in the RRCP - currently it is an AB Test.
This assumes that the relevant tag is already on the liveblog before the component is loaded to avoid adding an useEffect to scan each of the tags to reduce the performance hit.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before](https://github.com/user-attachments/assets/2fbff54c-92d5-46f5-a0f1-196d581e6887) | ![after](https://github.com/user-attachments/assets/c6a51ee4-039e-4648-b73e-50acf3c6c0c8) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
