### PR TITLE
Remove use of small mobile headline prop

### DIFF
--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -803,7 +803,6 @@ export const CardDefault = ({
 			imageLoading={'lazy'}
 			avatarUrl={undefined}
 			headlineSize="small"
-			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
 			isTagPage={isTagPage}
 		/>
@@ -842,7 +841,6 @@ export const CardDefaultMedia = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSize="small"
-			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
 		/>
 	);
@@ -880,7 +878,6 @@ export const CardDefaultMediaMobile = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSize="small"
-			headlineSizeOnMobile="small"
 			isPlayableMediaCard={false}
 		/>
 	);


### PR DESCRIPTION
## What does this change?
We are setting the headline size on mobile to small but [there is not a correlating mobile headline font size style ](https://github.com/guardian/dotcom-rendering/blob/df0fbdc34ffa361c8b41885dffc54b74d7bc1afe/dotcom-rendering/src/components/CardHeadline.tsx#L76)and so this in fact just defaults to null and fallbacks to the standard headline font styles. This PR removes the use of this prop on front cards as it is not needed in this context.

## Screenshots
There are no visual changes as a consequence of this PR.


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
