### PR TITLE
Tag link component for Olympics on articles

### DIFF
--- a/dotcom-rendering/src/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.stories.tsx
@@ -31,7 +31,9 @@ const FEArticle = {
 	fallbackToSection: true,
 	sectionLabel: 'Section label',
 	sectionUrl: '/section_url',
+	inTagLinkTest: false,
 };
+
 const FEBrexit = {
 	...FEArticle,
 	...{

--- a/dotcom-rendering/src/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.stories.tsx
@@ -31,7 +31,7 @@ const FEArticle = {
 	fallbackToSection: true,
 	sectionLabel: 'Section label',
 	sectionUrl: '/section_url',
-	inTagLinkTest: false,
+	shouldShowTagLink: false,
 };
 
 const FEBrexit = {

--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -14,7 +14,7 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	inTagLinkTest: boolean;
+	shouldShowTagLink: boolean;
 	isMatch?: boolean;
 };
 
@@ -48,7 +48,7 @@ export const ArticleTitle = ({
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
-	inTagLinkTest,
+	shouldShowTagLink,
 	isMatch,
 }: Props) => (
 	<div css={[sectionStyles]}>
@@ -57,7 +57,7 @@ export const ArticleTitle = ({
 				format.display === ArticleDisplay.Immersive &&
 					format.design !== ArticleDesign.PrintShop &&
 					immersiveMargins,
-				inTagLinkTest &&
+				shouldShowTagLink &&
 					css`
 						width: 100%;
 					`,
@@ -70,7 +70,7 @@ export const ArticleTitle = ({
 				sectionUrl={sectionUrl}
 				guardianBaseURL={guardianBaseURL}
 				isMatch={isMatch}
-				inTagLinkTest={inTagLinkTest}
+				shouldShowTagLink={shouldShowTagLink}
 			/>
 		</div>
 	</div>

--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -14,8 +14,8 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
+	inTagLinkTest: boolean;
 	isMatch?: boolean;
-	inTagLinkTest?: boolean;
 };
 
 const sectionStyles = css`
@@ -48,8 +48,8 @@ export const ArticleTitle = ({
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
+	inTagLinkTest,
 	isMatch,
-	inTagLinkTest = false,
 }: Props) => (
 	<div css={[sectionStyles]}>
 		<div

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -31,7 +31,7 @@ const bodyStyles = css`
 
 const titleStyles = css`
 	.sticky-tag-link-test & {
-		z-index: 10;
+		${getZIndex('tagLinkOverlay')}
 		position: sticky;
 		top: 0;
 		margin-left: -10px;

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -30,8 +30,8 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
+	inTagLinkTest: boolean;
 	isMatch?: boolean;
-	inTagLinkTest?: boolean;
 };
 
 const sectionLabelLink = css`
@@ -169,8 +169,8 @@ export const SeriesSectionLink = ({
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
-	isMatch,
 	inTagLinkTest,
+	isMatch,
 }: Props) => {
 	const observerTag = tags.find(
 		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
@@ -201,13 +201,14 @@ export const SeriesSectionLink = ({
 	if (inTagLinkTest) {
 		return (
 			<TagLink
-				format={format}
-				sectionLabel={'Euro 2024'}
-				sectionUrl={'football/euro-2024'}
+				sectionUrl="sport/olympic-games-2024"
+				sectionLabel="Paris Olympic Games 2024"
 				guardianBaseURL={guardianBaseURL}
+				format={format}
 			/>
 		);
 	}
+
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -30,7 +30,7 @@ type Props = {
 	sectionLabel: string;
 	sectionUrl: string;
 	guardianBaseURL: string;
-	inTagLinkTest: boolean;
+	shouldShowTagLink: boolean;
 	isMatch?: boolean;
 };
 
@@ -169,7 +169,7 @@ export const SeriesSectionLink = ({
 	sectionLabel,
 	sectionUrl,
 	guardianBaseURL,
-	inTagLinkTest,
+	shouldShowTagLink,
 	isMatch,
 }: Props) => {
 	const observerTag = tags.find(
@@ -198,7 +198,7 @@ export const SeriesSectionLink = ({
 		? themePalette('--series-title-match-text')
 		: themePalette('--series-title-text');
 
-	if (inTagLinkTest) {
+	if (shouldShowTagLink) {
 		return (
 			<TagLink
 				sectionUrl="sport/olympic-games-2024"

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -11,8 +11,8 @@ import { Hide, SvgArrowRightStraight } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
 interface Props {
-	sectionLabel: string;
 	sectionUrl: string;
+	sectionLabel: string;
 	guardianBaseURL: string;
 	format: ArticleFormat;
 }
@@ -110,13 +110,14 @@ export const TagLink = ({
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
+
 	return (
 		<div
 			css={[
 				containerStyles,
 				!isBlog &&
 					css`
-						padding-top: ${space[1]}px;
+						padding-top: ${space[0]}px;
 					`,
 			]}
 		>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -307,10 +307,11 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
 	const { absoluteServerTimes = false } = article.config.switches;
+
 	const inTagLinkTest =
 		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
-		article.tags.some((tag) => tag.id === 'football/euro-2024');
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	return (
 		<>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -308,9 +308,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
-	const inTagLinkTest =
+	const shouldShowTagLink =
 		isWeb &&
-		article.config.abTests.tagLinkDesignVariant === 'variant' &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
 		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	return (
@@ -468,7 +468,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 			<main
 				data-layout="CommentLayout"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 			>
 				{isApps && (
 					<>
@@ -526,7 +526,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={inTagLinkTest}
+								shouldShowTagLink={shouldShowTagLink}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -313,9 +313,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
-	const inTagLinkTest =
+	const shouldShowTagLink =
 		isWeb &&
-		article.config.abTests.tagLinkDesignVariant === 'variant' &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
 		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const inUpdatedHeaderABTest =
@@ -457,7 +457,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
-									inTagLinkTest={false}
+									shouldShowTagLink={false}
 								/>
 							</Section>
 							<Box>
@@ -486,7 +486,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="ImmersiveLayout"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 			>
 				{isApps && (
 					<>
@@ -547,7 +547,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											guardianBaseURL={
 												article.guardianBaseURL
 											}
-											inTagLinkTest={inTagLinkTest}
+											shouldShowTagLink={
+												shouldShowTagLink
+											}
 										/>
 									</div>
 								)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -312,10 +312,11 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 
 	const { absoluteServerTimes = false } = article.config.switches;
+
 	const inTagLinkTest =
 		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
-		article.tags.some((tag) => tag.id === 'football/euro-2024');
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
@@ -434,10 +435,10 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 							css={css`
 								margin-top: -${HEADLINE_OFFSET}px;
 								/*
-                        This z-index is what ensures the headline title text shows above main media. For
-                        the actual headline we set the z-index deeper in ArticleHeadline itself so that
-                        the text appears above the pseudo Box element
-                    */
+									This z-index is what ensures the headline title text shows above main media. For
+									the actual headline we set the z-index deeper in ArticleHeadline itself so that
+									the text appears above the pseudo Box element
+								*/
 								position: relative;
 								${getZIndex('articleHeadline')};
 							`}
@@ -456,6 +457,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
+									inTagLinkTest={false}
 								/>
 							</Section>
 							<Box>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -491,7 +491,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										tags={article.tags}
 										sectionLabel={article.sectionLabel}
 										sectionUrl={article.sectionUrl}
-										inTagLinkTest={false}
+										shouldShowTagLink={false}
 										guardianBaseURL={
 											article.guardianBaseURL
 										}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -491,6 +491,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 										tags={article.tags}
 										sectionLabel={article.sectionLabel}
 										sectionUrl={article.sectionUrl}
+										inTagLinkTest={false}
 										guardianBaseURL={
 											article.guardianBaseURL
 										}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -575,6 +575,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={false}
 								isMatch={true}
 							/>
 						}
@@ -589,6 +590,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
+								inTagLinkTest={false}
 								isMatch={true}
 							/>
 						</Hide>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -353,9 +353,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
-	// The test is being paused on liveblogs whilst we investigate an issue
 
-	const inTagLinkTest = false;
+	// The test is being paused on liveblogs whilst we investigate an issue
+	const shouldShowTagLink = false;
 	// isWeb &&
 	// article.config.abTests.tagLinkDesignVariant === 'variant' &&
 	// article.tags.some((tag) => tag.id === 'football/euro-2024');
@@ -505,14 +505,14 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main
 				css={
-					inTagLinkTest &&
+					shouldShowTagLink &&
 					css`
 						position: relative;
 						height: 100%;
 					`
 				}
 				data-layout="LiveLayout"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 			>
 				{renderAds && hasLiveBlogTopAd && (
 					<Hide from="tablet">
@@ -532,7 +532,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						</Section>
 					</Hide>
 				)}
-				{inTagLinkTest && (
+				{shouldShowTagLink && (
 					<div css={tagOverlayGridStyles}>
 						<GridItem area="sticky-tag">
 							<div css={stickyTagStyles}>
@@ -542,7 +542,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									sectionLabel={article.sectionLabel}
 									sectionUrl={article.sectionUrl}
 									guardianBaseURL={article.guardianBaseURL}
-									inTagLinkTest={true}
+									shouldShowTagLink={true}
 								/>
 							</div>
 						</GridItem>
@@ -575,7 +575,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={false}
+								shouldShowTagLink={false}
 								isMatch={true}
 							/>
 						}
@@ -590,7 +590,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={false}
+								shouldShowTagLink={false}
 								isMatch={true}
 							/>
 						</Hide>
@@ -618,7 +618,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					>
 						<HeadlineGrid>
 							<GridItem area="title">
-								{inTagLinkTest ? (
+								{shouldShowTagLink ? (
 									<div
 										css={css`
 											height: 64px;
@@ -636,7 +636,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										guardianBaseURL={
 											article.guardianBaseURL
 										}
-										inTagLinkTest={inTagLinkTest}
+										shouldShowTagLink={shouldShowTagLink}
 									/>
 								)}
 							</GridItem>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -287,10 +287,11 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
+
 	const inTagLinkTest =
 		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
-		article.tags.some((tag) => tag.id === 'football/euro-2024');
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -288,9 +288,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
-	const inTagLinkTest =
+	const shouldShowTagLink =
 		isWeb &&
-		article.config.abTests.tagLinkDesignVariant === 'variant' &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
 		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
@@ -447,7 +447,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 			<main
 				data-layout="PictureLayout"
 				id="maincontent"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>
@@ -478,7 +478,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={inTagLinkTest}
+								shouldShowTagLink={shouldShowTagLink}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -250,9 +250,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
-	const inTagLinkTest =
+	const shouldShowTagLink =
 		isWeb &&
-		article.config.abTests.tagLinkDesignVariant === 'variant' &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
 		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
@@ -527,7 +527,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main
 				data-layout="ShowcaseLayout"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 				id="maincontent"
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
@@ -583,7 +583,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								sectionLabel={article.sectionLabel}
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
-								inTagLinkTest={inTagLinkTest}
+								shouldShowTagLink={shouldShowTagLink}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -253,7 +253,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 	const inTagLinkTest =
 		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
-		article.tags.some((tag) => tag.id === 'football/euro-2024');
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -411,9 +411,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
-	const inTagLinkTest =
+	const shouldShowTagLink =
 		isWeb &&
-		article.config.abTests.tagLinkDesignVariant === 'variant' &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
 		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	return (
@@ -594,7 +594,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="StandardLayout"
-				className={inTagLinkTest ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
 			>
 				{isApps && (
 					<>
@@ -685,7 +685,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								sectionUrl={article.sectionUrl}
 								guardianBaseURL={article.guardianBaseURL}
 								isMatch={!!footballMatchUrl}
-								inTagLinkTest={inTagLinkTest}
+								shouldShowTagLink={shouldShowTagLink}
 							/>
 						</GridItem>
 						<GridItem area="border">

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -414,7 +414,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const inTagLinkTest =
 		isWeb &&
 		article.config.abTests.tagLinkDesignVariant === 'variant' &&
-		article.tags.some((tag) => tag.id === 'football/euro-2024');
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	return (
 		<>


### PR DESCRIPTION
Closes #11955

## What does this change?

Implement a sticky tag link component on articles that have the Olympics 2024 tag

## Why?

We tested [this new component for the Euros](https://github.com/guardian/dotcom-rendering/pull/11449) and we would like to use it for the Olympics.

## Screenshots

| <img width=400/> |   |   |
| - | - | - |
| mobile | ![mobile-1] | ![mobile-2] |
| tablet | ![tablet-1] | ![tablet-2] |
| desktop | ![desktop-1] | ![desktop-2] |

[mobile-1]: https://github.com/user-attachments/assets/da97129a-5282-4b1e-8783-cd8efe7f0f1d
[mobile-2]: https://github.com/user-attachments/assets/e8cb9551-ad5c-43c8-9b9d-60009306352f
[tablet-1]: https://github.com/user-attachments/assets/8933ea62-578e-4e30-989e-71e8b2bcf2ed
[tablet-2]: https://github.com/user-attachments/assets/856e236e-62a3-4372-9b0a-57d16a2b8c78
[desktop-1]: https://github.com/user-attachments/assets/7de6816d-bba8-45fd-a181-e08e169afadc
[desktop-2]: https://github.com/user-attachments/assets/59f87d49-3eda-4c33-bdf7-df29b1a877cb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
