### PR TITLE
Add accreditation copy to Titlepiece section

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -1,5 +1,12 @@
 import { css } from '@emotion/react';
-import { from, headlineBold14, space } from '@guardian/source/foundations';
+import {
+	from,
+	headlineBold14,
+	space,
+	textSansBold14,
+	textSansBold17,
+	until,
+} from '@guardian/source/foundations';
 import { Hide, SvgMenu } from '@guardian/source/react-components';
 import type { EditionId } from '../../../lib/edition';
 import { getZIndex } from '../../../lib/getZIndex';
@@ -36,6 +43,29 @@ const editionSwitcherMenuStyles = css`
 	grid-row: 1;
 	${from.mobileMedium} {
 		justify-self: end;
+	}
+`;
+
+const accreditationStyles = css`
+	${gridContent}
+	grid-row: 1;
+	justify-self: start;
+	align-self: start;
+	display: flex;
+	flex-wrap: wrap;
+	padding-top: 10px;
+	color: ${themePalette('--masthead-accreditation-text')};
+
+	${textSansBold14}
+	${from.leftCol} {
+		${textSansBold17}
+	}
+
+	${until.mobileMedium} {
+		display: none;
+	}
+	${until.mobileLandscape} {
+		max-width: 100px;
 	}
 `;
 
@@ -224,6 +254,10 @@ export const Titlepiece = ({
 			<div css={[logoStyles, !hasPageSkin && logoStylesWithoutPageSkin]}>
 				<Logo />
 			</div>
+
+			{editionId === 'UK' && (
+				<span css={accreditationStyles}>News provider of the year</span>
+			)}
 
 			{/* Pillars nav */}
 			<nav

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5570,6 +5570,9 @@ const mastheadHighlightsBackground: PaletteFunction = () =>
 const mastheadHighlightsBorder: PaletteFunction = () =>
 	sourcePalette.neutral[60];
 
+const mastheadAccreditationText: PaletteFunction = () =>
+	sourcePalette.brandAlt[400];
+
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
@@ -6388,6 +6391,10 @@ const paletteColours = {
 	'--live-block-container-background': {
 		light: liveBlockContainerBackgroundLight,
 		dark: liveBlockContainerBackgroundDark,
+	},
+	'--masthead-accreditation-text': {
+		light: mastheadAccreditationText,
+		dark: mastheadAccreditationText,
 	},
 	'--masthead-highlights-background': {
 		light: mastheadHighlightsBackground,


### PR DESCRIPTION
## What does this change?

Adds "News provider of the year" text to the `Titlepiece` part of the Masthead for UK edition only

## Why?

Replaces the same text which used to appear as part of the Guardian logo SVG.

As part of the Fairground project to update the homepages.

[Trello ticket](https://trello.com/c/a5bEacF9/282-titlepiece-add-news-provider-of-the-year-text)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![b1][] | ![a1][] |
| ![b2][] | ![a2][] |


[b1]: https://github.com/user-attachments/assets/306c9526-dcfd-46cb-ab4f-ddd65dff2b86
[a1]: https://github.com/user-attachments/assets/1c63bd23-8e58-4976-9d0c-5610fca616cc
[b2]: https://github.com/user-attachments/assets/21734eee-08f5-473c-8b9f-cb1aabe77e70
[a2]: https://github.com/user-attachments/assets/9187c514-48bc-4b2b-bbb3-6c4056ec1c01

