### PR TITLE
Enable opting out of dark mode and force light colour scheme

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -29,10 +29,12 @@ export const rootStyles = (
 		${darkModeAvailable
 			? css`
 					@media (prefers-color-scheme: dark) {
-						${paletteDeclarations(format, 'dark')}
-						body {
-							color: ${sourcePalette.neutral[86]};
-							background: ${sourcePalette.neutral[7]};
+						:root:not([data-color-scheme='light']) {
+							${paletteDeclarations(format, 'dark')}
+							body {
+								color: ${sourcePalette.neutral[86]};
+								background: ${sourcePalette.neutral[7]};
+							}
 						}
 					}
 			  `

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -23,6 +23,7 @@ type BaseProps = {
 	hasPageSkin?: boolean;
 	hasLiveBlogTopAd?: boolean;
 	weAreHiring: boolean;
+	onlyLightColourScheme?: boolean;
 };
 
 interface WebProps extends BaseProps {
@@ -68,6 +69,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		canonicalUrl,
 		renderingTarget,
 		hasPageSkin = false,
+		onlyLightColourScheme = false,
 		weAreHiring,
 		config,
 	} = props;
@@ -190,7 +192,9 @@ https://workforus.theguardian.com/careers/product-engineering/
 --->`;
 
 	return `<!doctype html>
-        <html lang="en">
+        <html lang="en" ${
+			onlyLightColourScheme ? 'data-color-scheme="light"' : ''
+		}>
             <head>
 			    ${
 					weAreHiring

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -122,6 +122,9 @@ window.twttr = (function(d, s, id) {
 				? initTwitter
 				: undefined,
 		config,
+		onlyLightColourScheme:
+			format.design === ArticleDesign.FullPageInteractive ||
+			format.design === ArticleDesign.Interactive,
 	});
 
 	return {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -231,6 +231,9 @@ window.twttr = (function(d, s, id) {
 		weAreHiring: !!article.config.switches.weAreHiring,
 		config,
 		hasLiveBlogTopAd: !!article.config.hasLiveBlogTopAd,
+		onlyLightColourScheme:
+			format.design === ArticleDesign.FullPageInteractive ||
+			format.design === ArticleDesign.Interactive,
 	});
 
 	return { html: pageHtml, prefetchScripts };


### PR DESCRIPTION
## What does this change?

Adding `data-color-scheme=light` to the `html` document element enables opting out of the dark colour scheme on a page-by-page basis. All Interactive and FullPageInteractive designs are opted out by default.

```html
<html data-color-scheme="light">
  <!-- … rest of the page … -->
</html>
```

```js
// opt out …
document.documentElement.dataset.colorScheme = "light";
// … or in!
document.documentElement.dataset.colorScheme = undefined;
```

## Why?

Some pages, such as interactives, may not be readable with dark mode styles.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6493da1a-77d5-4fc1-adfd-942e096689c6
[after]: https://github.com/user-attachments/assets/7b3be5b3-d347-4692-9dc2-5e21e8bea0d4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
