### PR TITLE
[Fairground 🎡] Fix width of  highlight card in the card component for desktop and above

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -36,6 +36,7 @@ const gridContainer = css`
 		height: 194px;
 	}
 	${from.desktop} {
+		width: 300px;
 		grid-template-areas:
 			'headline 	image'
 			'media-icon image';

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -77,7 +77,7 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		}
 
 		${from.desktop} {
-			grid-template-columns: repeat(${totalCards}, calc((100%) / 3));
+			grid-template-columns: repeat(${totalCards}, 1fr);
 		}
 	`;
 };


### PR DESCRIPTION
## What does this change?
Highlight cards on breakpoints desktop and greater have a fixed width of 300px. This PR moves the width styles in to the card component rather than letting the container grid determine it. 

## Why?
This keeps the card at a fixed width and prevents it stretching at wide breakpoints.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c2b38098-9a82-4131-892c-26b3c184cf02
[after]: https://github.com/user-attachments/assets/d42c1338-99d1-4916-bffd-f58e59520df5


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.
![Screenshot 2024-07-25 at 11 37 02](https://github.com/user-attachments/assets/d42c1338-99d1-4916-bffd-f58e59520df5)

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
