### PR TITLE
Fix styling for right ad to avoid seeing the background-colour

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -241,6 +241,7 @@ const inlineAdStyles = css`
 
 const rightAdStyles = css`
 	background-color: ${schemedPalette('--ad-background-article-inner')};
+	max-width: 300px;
 `;
 
 const liveblogInlineAdStyles = css`


### PR DESCRIPTION
## What does this change?

This bug is caused by increasing the width of the `most-viewed-right-container` which the right ad inherits from it so adding a `max-width` to the right ad styles should fix it.

This is a quick fix as we discussed in Commercial and there will be another iteration for our best solution based on the different aspects including the suggested review comments.

## Why?

Fix a bug which will improve UI and adds consistency to all the ads on the right side of the main content.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/f341b366-66b9-4ff9-b179-037d51351a59) | ![image](https://github.com/user-attachments/assets/21ec74c7-17d9-4674-936f-c7960780b2bf) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
