### PR TITLE
Fix the syndication button colours

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -120,8 +120,6 @@ type Props = {
 
 const syndicationButtonOverrides = css`
 	> a {
-		color: ${palette('--syndication-button-text')};
-		border-color: ${palette('--syndication-button-border')};
 		font-weight: normal;
 	}
 `;
@@ -197,6 +195,17 @@ export const SubMeta = ({
 								target="_blank"
 								rel="noreferrer"
 								title="Reuse this content"
+								theme={{
+									textTertiary: palette(
+										'--syndication-button-text',
+									),
+									borderTertiary: palette(
+										'--syndication-button-border',
+									),
+									backgroundTertiaryHover: palette(
+										'--syndication-button-hover',
+									),
+								}}
 							>
 								Reuse this content
 							</LinkButton>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4111,10 +4111,65 @@ const subMetaTextHoverLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
-const syndicationButtonText: PaletteFunction = ({ design, theme }) => {
+const syndicationButtonTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 			return sourcePalette.neutral[7];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[100];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return sourcePalette.neutral[46];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			return sourcePalette.neutral[46];
+	}
+};
+
+const syndicationButtonTextDark: PaletteFunction = ({ design, theme }) => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[86];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[800];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.LiveBlog:
+				case ArticleDesign.DeadBlog:
+					return sourcePalette.neutral[46];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			return sourcePalette.neutral[46];
+	}
+};
+
+const syndicationButtonHoverLight: PaletteFunction = ({ design, theme }) => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[60];
+		case ArticleSpecial.SpecialReportAlt:
+			switch (design) {
+				case ArticleDesign.DeadBlog:
+				case ArticleDesign.LiveBlog:
+					return sourcePalette.neutral[86];
+				default:
+					return sourcePalette.specialReportAlt[100];
+			}
+		default:
+			return sourcePalette.neutral[86];
+	}
+};
+
+const syndicationButtonHoverDark: PaletteFunction = ({ design, theme }) => {
+	switch (theme) {
+		case ArticleSpecial.Labs:
+			return sourcePalette.neutral[38];
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.specialReport[100];
 		case ArticleSpecial.SpecialReportAlt:
@@ -6817,9 +6872,13 @@ const paletteColours = {
 		light: syndicationButtonBorder,
 		dark: syndicationButtonBorder,
 	},
+	'--syndication-button-hover': {
+		light: syndicationButtonHoverLight,
+		dark: syndicationButtonHoverDark,
+	},
 	'--syndication-button-text': {
-		light: syndicationButtonText,
-		dark: syndicationButtonText,
+		light: syndicationButtonTextLight,
+		dark: syndicationButtonTextDark,
 	},
 	'--table-of-contents': {
 		light: tableOfContentsLight,


### PR DESCRIPTION
## What does this change?

- Use the `LinkButton`’s `theme` prop rather than overrides.
- Ensure that the text and hover states are readable in dark mode

## Why?

For accessibility!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/13eda7a8-57e0-4cab-acd1-30aa0bbe7f5d
[after]: https://github.com/user-attachments/assets/5f7ee359-49d5-4c7d-ac03-e435b21a58ed