### PR TITLE
Update `Titlepiece` logo sizing and padding

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -54,9 +54,6 @@ const logoStyles = css`
 	${from.mobileLandscape} {
 		margin-bottom: 8px;
 	}
-	${from.desktop} {
-		margin-bottom: 10px;
-	}
 
 	svg {
 		width: 152px;
@@ -64,7 +61,7 @@ const logoStyles = css`
 			width: 207px;
 		}
 		${from.tablet} {
-			width: 297px;
+			width: 252px;
 		}
 		${from.desktop} {
 			width: 291px;
@@ -75,7 +72,7 @@ const logoStyles = css`
 const logoStylesWithoutPageSkin = css`
 	svg {
 		${from.leftCol} {
-			width: 356px;
+			width: 324px;
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

- Reduces the size of the logo from tablet breakpoint upwards
- Adjusts the padding-bottom of the logo from desktop breakpoint upwards

## Why?

- UI fixes after visual QA with design

## Screenshots

_Logo is smaller and has 2px less padding bottom:_

### Wide
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

### Desktop
| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/70cc0753-b1f8-4af9-99bc-9fe99329115f
[after]: https://github.com/user-attachments/assets/6d5ab16d-68e5-4b73-b892-ab181bfc5e19
[before2]: https://github.com/user-attachments/assets/4b137b35-095f-4e27-885e-85665b6974e2
[after2]: https://github.com/user-attachments/assets/8e075e68-23a0-4c90-8ea7-52c12e73f783
