### PR TITLE
Tag link component for Olympics on liveblogs

### DIFF
--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -96,7 +96,7 @@ const fillBarStyles = css`
 	background-color: ${palette('--tag-link-fill-background')};
 	margin-top: -${space[3]}px;
 	width: 100%;
-	height: 20px;
+	height: ${space[5]}px;
 	margin-bottom: -${space[2]}px;
 	margin-right: -1px;
 `;
@@ -112,20 +112,10 @@ export const TagLink = ({
 		format.design === ArticleDesign.DeadBlog;
 
 	return (
-		<div
-			css={[
-				containerStyles,
-				!isBlog &&
-					css`
-						padding-top: ${space[0]}px;
-					`,
-			]}
-		>
-			{!isBlog && (
-				<Hide from="leftCol">
-					<div css={fillBarStyles} />
-				</Hide>
-			)}
+		<div css={[containerStyles]}>
+			<Hide from={isBlog ? 'desktop' : 'leftCol'}>
+				<div css={fillBarStyles} />
+			</Hide>
 			<a
 				href={`${guardianBaseURL}/${sectionUrl}`}
 				css={[tagLinkStyles, isBlog && desktopTabStyles]}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -222,6 +222,7 @@ const sidePaddingDesktop = css`
 `;
 
 const bodyWrapper = css`
+	position: relative;
 	margin-bottom: ${space[3]}px;
 	${from.desktop} {
 		margin-bottom: 0;
@@ -256,44 +257,12 @@ const paddingBody = css`
 	}
 `;
 
-const tagOverlayGridStyles = css`
-	position: absolute;
-	${until.desktop} {
-		margin-left: 0px;
-	}
-	display: grid;
-	height: inherit;
-	width: 100%;
-	margin-left: 0;
-	grid-column-gap: 0px;
-	${getZIndex('tagLinkOverlay')}
-	${until.desktop} {
-		grid-template-columns: 100%; /* Main content */
-		grid-template-areas: 'sticky-tag';
-	}
-	${from.tablet} {
-		grid-template-columns: 1fr 700px 1fr;
-		grid-template-areas: '. sticky-tag .';
-	}
-	${from.desktop} {
-		grid-template-columns: 1fr 200px 740px 1fr;
-		grid-template-areas: '. sticky-tag . .';
-	}
-
-	${from.leftCol} {
-		grid-template-columns: 1fr 200px 900px 1fr;
-		grid-template-areas: '. sticky-tag . .';
-	}
-	${from.wide} {
-		grid-template-columns: 1fr 200px 1060px 1fr;
-		grid-template-areas: '. sticky-tag . .';
-	}
-`;
-
 const stickyTagStyles = css`
 	position: sticky;
 	top: 0;
+	${getZIndex('tagLinkOverlay')};
 `;
+
 interface BaseProps {
 	article: DCRArticle;
 	format: ArticleFormat;
@@ -354,11 +323,11 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
 
-	// The test is being paused on liveblogs whilst we investigate an issue
-	const shouldShowTagLink = false;
-	// isWeb &&
-	// article.config.abTests.tagLinkDesignVariant === 'variant' &&
-	// article.tags.some((tag) => tag.id === 'football/euro-2024');
+	const shouldShowTagLink =
+		isWeb &&
+		!!article.config.switches.tagLinkDesign &&
+		article.config.abTests.tagLinkDesignControl !== 'control' &&
+		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -504,17 +473,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					)}
 				</div>
 			)}
-			<main
-				css={
-					shouldShowTagLink &&
-					css`
-						position: relative;
-						height: 100%;
-					`
-				}
-				data-layout="LiveLayout"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
-			>
+			<main data-layout="LiveLayout">
 				{renderAds && hasLiveBlogTopAd && (
 					<Hide from="tablet">
 						<Section
@@ -533,23 +492,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						</Section>
 					</Hide>
 				)}
-				{shouldShowTagLink && (
-					<div css={tagOverlayGridStyles}>
-						<GridItem area="sticky-tag">
-							<div css={stickyTagStyles}>
-								<ArticleTitle
-									format={format}
-									tags={article.tags}
-									sectionLabel={article.sectionLabel}
-									sectionUrl={article.sectionUrl}
-									guardianBaseURL={article.guardianBaseURL}
-									shouldShowTagLink={true}
-								/>
-							</div>
-						</GridItem>
-					</div>
-				)}
-
 				{isApps && (
 					<>
 						<Island priority="critical">
@@ -619,27 +561,14 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					>
 						<HeadlineGrid>
 							<GridItem area="title">
-								{shouldShowTagLink ? (
-									<div
-										css={css`
-											height: 64px;
-											${from.desktop} {
-												height: 44px;
-											}
-										`}
-									/>
-								) : (
-									<ArticleTitle
-										format={format}
-										tags={article.tags}
-										sectionLabel={article.sectionLabel}
-										sectionUrl={article.sectionUrl}
-										guardianBaseURL={
-											article.guardianBaseURL
-										}
-										shouldShowTagLink={shouldShowTagLink}
-									/>
-								)}
+								<ArticleTitle
+									format={format}
+									tags={article.tags}
+									sectionLabel={article.sectionLabel}
+									sectionUrl={article.sectionUrl}
+									guardianBaseURL={article.guardianBaseURL}
+									shouldShowTagLink={false}
+								/>
 							</GridItem>
 							<GridItem area="headline">
 								<div css={maxWidth}>
@@ -966,6 +895,34 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									</Hide>
 								)}
 
+								{isWeb && shouldShowTagLink && (
+									<Hide until="desktop">
+										<div
+											css={[
+												stickyTagStyles,
+												css`
+													margin: 20px 0 20px 20px;
+												`,
+											]}
+										>
+											<ArticleTitle
+												format={format}
+												tags={article.tags}
+												sectionLabel={
+													article.sectionLabel
+												}
+												sectionUrl={article.sectionUrl}
+												guardianBaseURL={
+													article.guardianBaseURL
+												}
+												shouldShowTagLink={
+													shouldShowTagLink
+												}
+											/>
+										</div>
+									</Hide>
+								)}
+
 								{/* Match stats */}
 								{!!footballMatchUrl && (
 									<Island
@@ -981,6 +938,28 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							</GridItem>
 							<GridItem area="body">
 								<div id="maincontent" css={bodyWrapper}>
+									{isWeb && shouldShowTagLink && (
+										<Hide from="desktop">
+											<div css={[stickyTagStyles]}>
+												<ArticleTitle
+													format={format}
+													tags={article.tags}
+													sectionLabel={
+														article.sectionLabel
+													}
+													sectionUrl={
+														article.sectionUrl
+													}
+													guardianBaseURL={
+														article.guardianBaseURL
+													}
+													shouldShowTagLink={
+														shouldShowTagLink
+													}
+												/>
+											</div>
+										</Hide>
+									)}
 									{showKeyEventsToggle ? (
 										<Hide below="desktop">
 											<Island

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5666,7 +5666,7 @@ const tagLinkFillBackground: PaletteFunction = ({ design, display, theme }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
-			return 'transparent';
+			return sourcePalette.neutral[97];
 		// Order matters. We want comment special report pieces to have the opinion background
 		case ArticleDesign.Letter:
 			return sourcePalette.opinion[800];


### PR DESCRIPTION
Closes #11957

## What does this change?

Reintroduce a sticky tag link component on liveblogs that have the Olympics 2024 tag, similar to the test we ran [for the Euros](https://github.com/guardian/dotcom-rendering/pull/11638). The main difference is that the sticky component is now in the left column rather than the header.

## Why?

We tested this new component for the Euros and we would like to use it for the Olympics.

## Screenshots

| <img width=400/> |   |   |
| - | - | - |
| mobile | ![mobile-1] | ![mobile-2] |
| desktop | ![desktop-1] | ![desktop-2] |

[mobile-1]: https://github.com/user-attachments/assets/822eb121-dd56-4deb-bc00-aa0e07413172
[mobile-2]: https://github.com/user-attachments/assets/8199dea7-8d7a-46f9-b358-35fde1d82cc8
[desktop-1]: https://github.com/user-attachments/assets/f8e9e2bd-4cf2-4207-9a77-2661e7ae90fe
[desktop-2]: https://github.com/user-attachments/assets/1186ef9f-c56f-425e-9fdd-7de25b61ab8b

https://github.com/user-attachments/assets/dae3aff7-9559-4bc4-b23c-17f9aa41073e

https://github.com/user-attachments/assets/586cbb5c-8b68-4fa1-9048-1e870fe0f4dd

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
