### PR TITLE
Apply hover state to highlights cards

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -78,16 +78,21 @@ const imageArea = css`
 		width: 112px;
 	}
 	align-self: end;
+	position: relative;
 `;
 
 const hoverStyles = css`
 	:hover .image-overlay {
 		position: absolute;
-		z-index: 1000;
-		/* top: 0; */
-		width: inherit;
-		height: inherit;
-		/* left: 0; */
+		bottom: 0;
+		right: 0;
+		height: 106px;
+		width: 106px;
+		${from.desktop} {
+			height: 112px;
+			width: 112px;
+		}
+		border-radius: 100%;
 		background-color: ${palette.neutral[7]};
 		opacity: 0.1;
 	}
@@ -134,13 +139,17 @@ export const HighlightsCard = ({
 					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
 				)) ??
 					(image && (
-						<CardPicture
-							imageSize="medium"
-							mainImage={image.src}
-							alt={image.altText}
-							loading={imageLoading}
-							isCircular={true}
-						/>
+						<>
+							<CardPicture
+								imageSize="medium"
+								mainImage={image.src}
+								alt={image.altText}
+								loading={imageLoading}
+								isCircular={true}
+							/>
+							{/* This image overlay is styled when the CardLink is hovered */}
+							<div className="image-overlay"> </div>
+						</>
 					))}
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -80,6 +80,24 @@ const imageArea = css`
 	align-self: end;
 `;
 
+const hoverStyles = css`
+	:hover .image-overlay {
+		position: absolute;
+		z-index: 1000;
+		/* top: 0; */
+		width: inherit;
+		height: inherit;
+		/* left: 0; */
+		background-color: ${palette.neutral[7]};
+		opacity: 0.1;
+	}
+
+	/* Only underline the headline element we want to target (not kickers/sublink headlines) */
+	:hover .card-headline .show-underline {
+		text-decoration: underline;
+	}
+`;
+
 export const HighlightsCard = ({
 	// linkTo,
 	format,
@@ -96,7 +114,7 @@ export const HighlightsCard = ({
 	showMediaIcon,
 }: HighlightsCardProps) => {
 	return (
-		<div css={gridContainer}>
+		<div css={[gridContainer, hoverStyles]}>
 			<div css={headline}>
 				<CardHeadline
 					headlineText={headlineText}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -86,12 +86,8 @@ const hoverStyles = css`
 		position: absolute;
 		bottom: 0;
 		right: 0;
-		height: 106px;
-		width: 106px;
-		${from.desktop} {
-			height: 112px;
-			width: 112px;
-		}
+		height: 100%;
+		width: 100%;
 		border-radius: 100%;
 		background-color: ${palette.neutral[7]};
 		opacity: 0.1;


### PR DESCRIPTION
## What does this change?

Brings the highlights card in line with regular cards which, when hovered over, add an underline to the headline and slightly fade out the image. 

## Why?

Part of the homepage redesign project.

## Screenshots

| Before      | Hovered over      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/51369751-fdc7-43be-94ab-d9d17846d536
[after]: https://github.com/user-attachments/assets/5d0c7022-810b-4a4f-b7df-62ac3c9a548b
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
