### PR TITLE
Fix labs section border and background colours

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -367,7 +367,7 @@ const cardBorderTopLight: ContainerFunction = (containerPalette) => {
 		case 'SpecialReportAltPalette':
 			return transparentColour(sourcePalette.neutral[46], 0.3);
 		case 'Branded':
-			return sourcePalette.neutral[60];
+			return sourcePalette.neutral[73];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
 		case 'PodcastPalette':
@@ -423,7 +423,7 @@ const articleBorderLight: ContainerFunction = (containerPalette) => {
 		case 'SpecialReportAltPalette':
 			return transparentColour(sourcePalette.neutral[46], 0.3);
 		case 'Branded':
-			return sourcePalette.neutral[60];
+			return sourcePalette.neutral[73];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
 		case 'PodcastPalette':

--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -389,6 +389,8 @@ export const LabsSection = ({
 				ophanComponentLink={ophanComponentLink}
 				ophanComponentName={ophanComponentName}
 				hasPageSkin={hasPageSkin}
+				borderColour={palette('--section-border')}
+				backgroundColour="transparent"
 				/**
 				 * dumathoin?
 				 * https://github.com/guardian/frontend/pull/17625


### PR DESCRIPTION
## What does this change?

Specifies border colour and background colour for `Section` component in `LabsSection`

## Why?

Some minor design details were lost after https://github.com/guardian/dotcom-rendering/pull/11965
This PR addresses the `LabsSection` discrepancy noticed by @Amouzle 

## Screenshots

|       |       |
| ----------- | ---------- |
| Before #11965 | ![b1][] |
| Before this change | ![b][] |
| After this change | ![a][] |


[b1]: https://github.com/user-attachments/assets/838d8463-b477-4d96-a625-6bf3242c3448
[b]: https://github.com/user-attachments/assets/19e1e9b3-0016-4693-8b67-e8595f56d517
[a]: https://github.com/user-attachments/assets/2246282a-fbb6-466f-91c9-79403c2c3cdd


