### PR TITLE
[Fairground] Style multiple line kickers

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -687,8 +687,12 @@ export const WhenNewsWithMoreThanTwoSublinks = () => {
 					},
 					{
 						...aBasicLink,
-						headline: 'A longer headline to see how wrapping works',
-						kickerText: 'Kicker',
+						headline: 'Headline 3',
+						kickerText: 'Kicker Kicker Kicker Kicker Kicker',
+						format: {
+							...aBasicLink.format,
+							design: ArticleDesign.LiveBlog,
+						},
 					},
 					{
 						...aBasicLink,

--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -194,11 +194,23 @@ MobileSize.parameters = {
 
 export const liveStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with a live kicker looks"
-			format={format}
-			kickerText="Live"
-		/>
+		<div style={{ width: '360px' }}>
+			<CardHeadline
+				headlineText="This is how a card headline with a live kicker looks"
+				format={format}
+				kickerText="Live"
+				showPulsingDot={true}
+			/>
+
+			<div style={{ marginTop: '40px' }}>
+				<CardHeadline
+					headlineText="This is how a card headline with a live kicker looks"
+					format={format}
+					kickerText="This is a really long kicker that will wrap onto multiple lines"
+					showPulsingDot={true}
+				/>
+			</div>
+		</div>
 	</Section>
 );
 liveStory.storyName = 'With Live kicker';
@@ -206,7 +218,7 @@ liveStory.decorators = [
 	splitTheme([
 		{
 			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
+			design: ArticleDesign.LiveBlog,
 			theme: Pillar.News,
 		},
 	]),
@@ -214,37 +226,29 @@ liveStory.decorators = [
 
 export const noLineBreak: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with no kicker linebreak looks"
-			format={format}
-			kickerText="Live"
-			hideLineBreak={true}
-		/>
+		<div style={{ width: '360px' }}>
+			<CardHeadline
+				headlineText="This is how a card headline with a live kicker looks"
+				format={format}
+				kickerText="Live"
+				showPulsingDot={true}
+				hideLineBreak={true}
+			/>
+
+			<div style={{ marginTop: '40px' }}>
+				<CardHeadline
+					headlineText="This is how a card headline with a live kicker looks"
+					format={format}
+					kickerText="This is a really long kicker that will wrap onto multiple lines"
+					showPulsingDot={true}
+					hideLineBreak={true}
+				/>
+			</div>
+		</div>
 	</Section>
 );
 noLineBreak.storyName = 'With Live kicker but no line break';
 noLineBreak.decorators = [
-	splitTheme([
-		{
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
-
-export const pulsingDot: StoryObj = ({ format }: StoryProps) => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<CardHeadline
-			headlineText="This is how a card headline with a pulsing dot looks"
-			format={format}
-			kickerText="Live"
-			showPulsingDot={true}
-		/>
-	</Section>
-);
-pulsingDot.storyName = 'With pulsing dot';
-pulsingDot.decorators = [
 	splitTheme([
 		{
 			display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -231,12 +231,19 @@ export const CardHeadline = ({
 				]}
 			>
 				{!!kickerText && (
-					<Kicker
-						text={kickerText}
-						color={kickerColour}
-						showPulsingDot={showPulsingDot}
-						hideLineBreak={hideLineBreak}
-					/>
+					<span
+						style={
+							hideLineBreak
+								? { display: 'inline', marginRight: '4px' }
+								: { display: 'block' }
+						}
+					>
+						<Kicker
+							text={kickerText}
+							color={kickerColour}
+							showPulsingDot={showPulsingDot}
+						/>
+					</span>
 				)}
 				{showQuotes && <QuoteIcon colour={kickerColour} />}
 				<span

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -231,7 +231,7 @@ export const CardHeadline = ({
 				]}
 			>
 				{!!kickerText && (
-					<span
+					<div
 						style={
 							hideLineBreak
 								? { display: 'inline', marginRight: '4px' }
@@ -243,7 +243,7 @@ export const CardHeadline = ({
 							color={kickerColour}
 							showPulsingDot={showPulsingDot}
 						/>
-					</span>
+					</div>
 				)}
 				{showQuotes && <QuoteIcon colour={kickerColour} />}
 				<span

--- a/dotcom-rendering/src/components/Kicker.stories.tsx
+++ b/dotcom-rendering/src/components/Kicker.stories.tsx
@@ -38,7 +38,6 @@ const meta = {
 		text: 'Kicker',
 		color: palette('--card-kicker-text'),
 		showPulsingDot: false,
-		hideLineBreak: false,
 	},
 	render: (args) => (
 		<div style={kickerWrapperStyles}>
@@ -71,7 +70,12 @@ export const CardKickerWithContainerOverrides = {
 			},
 		]),
 	],
-	render: () => (
+	args: {
+		text: 'Kicker',
+		color: palette('--card-kicker-text'),
+		showPulsingDot: false,
+	},
+	render: ((args) => (
 		<>
 			{containerPalettes.map((containerPalette) => (
 				<>
@@ -91,24 +95,14 @@ export const CardKickerWithContainerOverrides = {
 									{containerPalette}
 								</span>
 
-								<Kicker
-									text="Standard kicker"
-									color={palette('--card-kicker-text')}
-									showPulsingDot={false}
-									hideLineBreak={false}
-								/>
+								<Kicker {...args} text="Standard kicker" />
 
-								<Kicker
-									text="Live kicker"
-									color={palette('--card-kicker-text')}
-									showPulsingDot={true}
-									hideLineBreak={false}
-								/>
+								<Kicker {...args} text="Live kicker" />
 							</div>
 						</ContainerOverrides>
 					</Section>
 				</>
 			))}
 		</>
-	),
+	)) satisfies (typeof meta)['render'],
 };

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -13,7 +13,6 @@ type Props = {
 	text: string;
 	color: string;
 	showPulsingDot?: boolean;
-	hideLineBreak?: boolean;
 	/** Controls the weight of the standard, non-live kicker. Defaults to regular */
 	fontWeight?: 'regular' | 'bold';
 };
@@ -28,22 +27,9 @@ const boldTextStyles = css`
 
 const liveTextStyles = css`
 	${textSansBold14}
-	display: flex;
-	flex-direction: row;
-	align-items: baseline;
-	width: fit-content;
-	padding: 0 ${space[1]}px;
-
-	/*
-	This is to keep the same height as the standard kicker
-	which has a slightly larger font
-	*/
-	margin-bottom: 1px;
-`;
-
-const hideLineBreakStyles = css`
-	display: inline-block;
-	margin-right: ${space[1]}px;
+	box-decoration-break: clone;
+	display: inline;
+	padding: 2px ${space[1]}px;
 `;
 
 /**
@@ -53,7 +39,6 @@ export const Kicker = ({
 	text,
 	color,
 	showPulsingDot,
-	hideLineBreak,
 	fontWeight = 'regular',
 }: Props) => {
 	/** @todo
@@ -72,7 +57,7 @@ export const Kicker = ({
 
 	return (
 		<div
-			css={[textStyles(), hideLineBreak && hideLineBreakStyles]}
+			css={textStyles()}
 			style={{
 				color: isLiveKicker ? palette('--kicker-text-live') : color,
 				backgroundColor: isLiveKicker

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -17,6 +17,10 @@ type Props = {
 	fontWeight?: 'regular' | 'bold';
 };
 
+const commonStyles = css`
+	display: inline;
+`;
+
 const standardTextStyles = css`
 	${textSans15}
 `;
@@ -27,9 +31,11 @@ const boldTextStyles = css`
 
 const liveTextStyles = css`
 	${textSansBold14}
+	padding: 0 ${space[1]}px;
+	box-shadow: 0 0.05em 0 0 ${palette('--kicker-background-live')};
 	box-decoration-break: clone;
-	display: inline;
-	padding: 2px ${space[1]}px;
+	/** This is a hack to ensure designs look right for multi line kickers */
+	line-height: 1.2rem;
 `;
 
 /**
@@ -57,7 +63,7 @@ export const Kicker = ({
 
 	return (
 		<div
-			css={textStyles()}
+			css={[commonStyles, textStyles()]}
 			style={{
 				color: isLiveKicker ? palette('--kicker-text-live') : color,
 				backgroundColor: isLiveKicker

--- a/dotcom-rendering/src/components/LinkHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.stories.tsx
@@ -51,11 +51,23 @@ const liveFormat = { ...defaultFormat, design: ArticleDesign.LiveBlog };
 
 export const liveStory: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a headline with a live kicker looks"
-			isLabs={format.theme === ArticleSpecial.Labs}
-			kickerText="Live"
-		/>
+		<div style={{ width: '360px' }}>
+			<LinkHeadline
+				headlineText="This is how a headline with no kicker line break looks"
+				isLabs={format.theme === ArticleSpecial.Labs}
+				kickerText="Live"
+				showPulsingDot={true}
+			/>
+
+			<div style={{ marginTop: '40px' }}>
+				<LinkHeadline
+					headlineText="This is how a headline with a live kicker looks"
+					isLabs={format.theme === ArticleSpecial.Labs}
+					kickerText="This is a really long kicker that will wrap onto multiple lines"
+					showPulsingDot={true}
+				/>
+			</div>
+		</div>
 	</Section>
 );
 liveStory.storyName = 'With Live kicker';
@@ -63,29 +75,29 @@ liveStory.decorators = [splitTheme([liveFormat])];
 
 export const noLinebreak: StoryObj = ({ format }: StoryArgs) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a headline with no kicker line break looks"
-			isLabs={format.theme === ArticleSpecial.Labs}
-			kickerText="Live"
-			hideLineBreak={true}
-		/>
+		<div style={{ width: '360px' }}>
+			<LinkHeadline
+				headlineText="This is how a headline with no kicker line break looks"
+				isLabs={format.theme === ArticleSpecial.Labs}
+				kickerText="Live"
+				hideLineBreak={true}
+				showPulsingDot={true}
+			/>
+
+			<div style={{ marginTop: '40px' }}>
+				<LinkHeadline
+					headlineText="This is how a headline with a live kicker looks"
+					isLabs={format.theme === ArticleSpecial.Labs}
+					kickerText="This is a really long kicker that will wrap onto multiple lines"
+					hideLineBreak={true}
+					showPulsingDot={true}
+				/>
+			</div>
+		</div>
 	</Section>
 );
 noLinebreak.storyName = 'With Live kicker but no line break';
 noLinebreak.decorators = [splitTheme([liveFormat])];
-
-export const pulsingDot: StoryObj = ({ format }: StoryArgs) => (
-	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>
-		<LinkHeadline
-			headlineText="This is how a headline with a pulsing dot looks"
-			isLabs={format.theme === ArticleSpecial.Labs}
-			kickerText="Live"
-			showPulsingDot={true}
-		/>
-	</Section>
-);
-pulsingDot.storyName = 'With pulsing dot';
-pulsingDot.decorators = [splitTheme([liveFormat])];
 
 export const opinionxxxsmall: StoryObj = ({ format }: StoryProps) => (
 	<Section fullWidth={true} showTopBorder={false} showSideBorders={false}>

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -90,7 +90,7 @@ export const LinkHeadline = ({
 	return (
 		<h4 css={fontStyles(size)}>
 			{!!kickerText && (
-				<span
+				<div
 					style={
 						hideLineBreak
 							? { display: 'inline', marginRight: '4px' }
@@ -102,7 +102,7 @@ export const LinkHeadline = ({
 						color={palette('--link-kicker-text')}
 						showPulsingDot={showPulsingDot}
 					/>
-				</span>
+				</div>
 			)}
 			{showQuotes && <QuoteIcon colour={palette('--link-kicker-text')} />}
 			{link ? (

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -88,14 +88,21 @@ export const LinkHeadline = ({
 	byline,
 }: Props) => {
 	return (
-		<h4 css={[fontStyles(size)]}>
+		<h4 css={fontStyles(size)}>
 			{!!kickerText && (
-				<Kicker
-					text={kickerText}
-					color={palette('--link-kicker-text')}
-					showPulsingDot={showPulsingDot}
-					hideLineBreak={hideLineBreak}
-				/>
+				<span
+					style={
+						hideLineBreak
+							? { display: 'inline', marginRight: '4px' }
+							: { display: 'block' }
+					}
+				>
+					<Kicker
+						text={kickerText}
+						color={palette('--link-kicker-text')}
+						showPulsingDot={showPulsingDot}
+					/>
+				</span>
 			)}
 			{showQuotes && <QuoteIcon colour={palette('--link-kicker-text')} />}
 			{link ? (


### PR DESCRIPTION
## What does this change?

Improves the styling of kickers which spread onto multiple lines

## Why?

A result of internal feedback of the kicker design for non-curated cards on tag pages and for kickers which wrap onto two lines on standard fronts

Part of the Fairground project to upgrade the homepage designs. [Trello ticket](https://trello.com/c/My45qrCG/296-web-update-kicker-design-for-two-line-variant)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
