### PR TITLE
Add CardLink component to highlights card

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
 		</CardWrapper>
 	),
 	args: {
+		linkTo: '',
 		headlineText: 'Underground cave found on moon could be ideal base',
 		format: {
 			display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -52,6 +52,7 @@ const CardWrapper = ({ children }: { children: React.ReactNode }) => {
 					flex-basis: 1;
 				}
 				margin: 10px;
+				position: relative;
 			`}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -4,13 +4,14 @@ import { from, palette, until } from '@guardian/source/foundations';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
 import { Avatar } from '../Avatar';
+import { CardLink } from '../Card/components/CardLink';
 import { CardHeadline } from '../CardHeadline';
 import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { Icon } from '../MediaMeta';
 
 export type HighlightsCardProps = {
-	// linkTo: string;
+	linkTo: string;
 	format: ArticleFormat;
 	headlineText: string;
 	// showQuotedHeadline?: boolean;
@@ -20,7 +21,7 @@ export type HighlightsCardProps = {
 	mainMedia?: MainMedia;
 	kickerText?: string;
 	showPulsingDot?: boolean;
-	// dataLinkName?: string;
+	dataLinkName?: string;
 	byline?: string;
 	showMediaIcon?: boolean;
 };
@@ -100,7 +101,7 @@ const hoverStyles = css`
 `;
 
 export const HighlightsCard = ({
-	// linkTo,
+	linkTo,
 	format,
 	headlineText,
 	// showQuotedHeadline,
@@ -110,12 +111,18 @@ export const HighlightsCard = ({
 	mainMedia,
 	kickerText,
 	showPulsingDot,
-	// dataLinkName,
+	dataLinkName,
 	byline,
 	showMediaIcon,
 }: HighlightsCardProps) => {
 	return (
 		<div css={[gridContainer, hoverStyles]}>
+			<CardLink
+				linkTo={linkTo}
+				headlineText={headlineText}
+				dataLinkName={dataLinkName}
+				isExternalLink={false}
+			/>
 			<div css={headline}>
 				<CardHeadline
 					headlineText={headlineText}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -24,6 +24,7 @@ export type HighlightsCardProps = {
 	dataLinkName?: string;
 	byline?: string;
 	showMediaIcon?: boolean;
+	isExternalLink: boolean;
 };
 
 const gridContainer = css`
@@ -114,6 +115,7 @@ export const HighlightsCard = ({
 	dataLinkName,
 	byline,
 	showMediaIcon,
+	isExternalLink,
 }: HighlightsCardProps) => {
 	return (
 		<div css={[gridContainer, hoverStyles]}>
@@ -121,7 +123,7 @@ export const HighlightsCard = ({
 				linkTo={linkTo}
 				headlineText={headlineText}
 				dataLinkName={dataLinkName}
-				isExternalLink={false}
+				isExternalLink={isExternalLink}
 			/>
 			<div css={headline}>
 				<CardHeadline
@@ -130,6 +132,7 @@ export const HighlightsCard = ({
 					size="medium"
 					showPulsingDot={showPulsingDot}
 					kickerText={kickerText}
+					isExternalLink={isExternalLink}
 				/>
 			</div>
 			{mainMedia && showMediaIcon ? (

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -21,7 +21,7 @@ export type HighlightsCardProps = {
 	mainMedia?: MainMedia;
 	kickerText?: string;
 	showPulsingDot?: boolean;
-	dataLinkName?: string;
+	dataLinkName: string;
 	byline?: string;
 	showMediaIcon?: boolean;
 	isExternalLink: boolean;

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -101,6 +101,8 @@ export const HighlightsContainer = ({ trails }: Props) => {
 							byline={trail.byline}
 							image={trail.image}
 							imageLoading={imageLoading}
+							linkTo={trail.url}
+							dataLinkName={trail.dataLinkName}
 						/>
 					</li>
 				);

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -30,8 +30,7 @@ const itemStyles = css`
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
-	padding: ${space[3]}px 0;
-	margin: 0 10px;
+	margin: ${space[3]}px 10px;
 	:first-child {
 		padding-left: 10px;
 	}
@@ -41,8 +40,8 @@ const verticalLineStyles = css`
 	::after {
 		content: '';
 		position: absolute;
-		top: ${space[3]}px;
-		bottom: ${space[3]}px;
+		top: 0;
+		bottom: 0;
 		right: -10px;
 		width: 1px;
 		background-color: ${palette('--card-border-top')};

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -102,6 +102,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 							imageLoading={imageLoading}
 							linkTo={trail.url}
 							dataLinkName={trail.dataLinkName}
+							isExternalLink={trail.isExternalLink}
 						/>
 					</li>
 				);


### PR DESCRIPTION
## What does this change? 

Enables someone to click on a card in the highlights container and be taken to the related article, and allows us to track the action in Ophan. 

## Why?

Part of the homepage redesign; closes this [ticket](https://trello.com/c/XUEUwGU6/308-highlightscard-support-linkto-and-datalinkname-props)

## Screenshots

![image](https://github.com/user-attachments/assets/1f67fddc-a95f-4e3d-b3e4-3b5876dc6461)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
