### PR TITLE
Update whitespace around sticky tagLink

### DIFF
--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -51,7 +51,16 @@ export const ArticleTitle = ({
 	shouldShowTagLink,
 	isMatch,
 }: Props) => (
-	<div css={[sectionStyles]}>
+	<div
+		css={[
+			sectionStyles,
+			shouldShowTagLink &&
+				css`
+					padding-top: 0;
+					margin-top: 1px;
+				`,
+		]}
+	>
 		<div
 			css={[
 				format.display === ArticleDisplay.Immersive &&

--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -7,7 +7,7 @@ import {
 	headlineMedium14,
 	space,
 } from '@guardian/source/foundations';
-import { Hide, SvgArrowRightStraight } from '@guardian/source/react-components';
+import { SvgArrowRightStraight } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
 interface Props {
@@ -16,6 +16,7 @@ interface Props {
 	guardianBaseURL: string;
 	format: ArticleFormat;
 }
+
 const containerStyles = css`
 	margin-bottom: ${space[2]}px;
 `;
@@ -25,6 +26,7 @@ const tagLinkStyles = css`
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
+	gap: ${space[1]}px;
 	height: 44px;
 	width: 100%;
 	padding: ${space[2]}px;
@@ -94,11 +96,14 @@ const arrowStyles = css`
 
 const fillBarStyles = css`
 	background-color: ${palette('--tag-link-fill-background')};
-	margin-top: -${space[3]}px;
 	width: 100%;
-	height: ${space[5]}px;
-	margin-bottom: -${space[2]}px;
-	margin-right: -1px;
+	margin-top: -2px;
+	margin-bottom: -1px;
+
+	height: ${space[2]}px;
+	${from.desktop} {
+		height: 10px;
+	}
 `;
 
 export const TagLink = ({
@@ -113,9 +118,7 @@ export const TagLink = ({
 
 	return (
 		<div css={[containerStyles]}>
-			<Hide from={isBlog ? 'desktop' : 'leftCol'}>
-				<div css={fillBarStyles} />
-			</Hide>
+			<div css={fillBarStyles} />
 			<a
 				href={`${guardianBaseURL}/${sectionUrl}`}
 				css={[tagLinkStyles, isBlog && desktopTabStyles]}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| <img width=300/> | Article | Liveblog |
| - | - | - |
| mobile | ![mobile-article] | ![mobile-liveblog] |
| tablet | ![tablet-article] | ![tablet-liveblog] |
| desktop | ![desktop-article] | ![desktop-liveblog] |

[mobile-article]: https://github.com/user-attachments/assets/00a862bf-88da-439f-af8a-187f0efe07cc
[tablet-article]: https://github.com/user-attachments/assets/cc8c242e-8cd8-4930-b82c-2a9595aa5cfb
[desktop-article]: https://github.com/user-attachments/assets/e5fa0b2a-4e32-492b-be2c-8e789a9bf644
[mobile-liveblog]: https://github.com/user-attachments/assets/c01f9427-c1f0-41b7-8781-8c364283178b
[tablet-liveblog]: https://github.com/user-attachments/assets/c59040a2-e98e-45c7-9b9c-e45a82b94f33
[desktop-liveblog]: https://github.com/user-attachments/assets/8db964c0-7418-4c77-9376-4d6f0fd3240b

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
