### PR TITLE
Support quoted headlines in HighlightsCard

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -14,7 +14,7 @@ export type HighlightsCardProps = {
 	linkTo: string;
 	format: ArticleFormat;
 	headlineText: string;
-	// showQuotedHeadline?: boolean;
+	showQuotedHeadline: boolean;
 	image?: DCRFrontImage;
 	imageLoading?: Loading;
 	avatarUrl?: string;
@@ -105,7 +105,7 @@ export const HighlightsCard = ({
 	linkTo,
 	format,
 	headlineText,
-	// showQuotedHeadline,
+	showQuotedHeadline,
 	image,
 	imageLoading = 'lazy',
 	avatarUrl,
@@ -133,6 +133,7 @@ export const HighlightsCard = ({
 					showPulsingDot={showPulsingDot}
 					kickerText={kickerText}
 					isExternalLink={isExternalLink}
+					showQuotes={showQuotedHeadline}
 				/>
 			</div>
 			{mainMedia && showMediaIcon ? (

--- a/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsContainer.tsx
@@ -103,6 +103,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 							linkTo={trail.url}
 							dataLinkName={trail.dataLinkName}
 							isExternalLink={trail.isExternalLink}
+							showQuotedHeadline={trail.showQuotedHeadline}
 						/>
 					</li>
 				);


### PR DESCRIPTION
## What does this change?

Supports quoted headlines in highlights cards. 

## Why?

Part of the homepage redesign project, closes this [ticket](https://trello.com/c/zS4koBe9/309-highlightscard-support-showquotedheadline-prop)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: 
https://github.com/user-attachments/assets/400af356-118a-4f22-9126-4d6ee3dd750d

[after]: https://github.com/user-attachments/assets/66d74e3d-85e0-4522-ad19-26cc838a6028

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
