### PR TITLE
Align palette colour naming for Titlepiece components

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Pillar.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Pillar.tsx
@@ -88,13 +88,13 @@ const firstColumnLinks = css`
 		padding-left: 0;
 	}
 	${until.tablet} {
-		background: ${themePalette('--sub-nav-section-header-background')};
+		background: ${themePalette('--masthead-nav-background')};
 	}
 `;
 
 const pillarColumnLinks = css`
 	${until.tablet} {
-		background: ${themePalette('--sub-nav-section-header-background')};
+		background: ${themePalette('--masthead-nav-background')};
 	}
 `;
 
@@ -120,7 +120,7 @@ export const lineStyle = css`
 	${from.desktop} {
 		display: none;
 	}
-	background-color: ${themePalette('--sub-nav-horizontal-section-divider')};
+	background-color: ${themePalette('--masthead-nav-border')};
 	content: '';
 	display: block;
 	height: 1px;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
@@ -16,7 +16,7 @@ import { expandedNavLinkStyles, hideFromDesktop } from '../commonStyles';
 
 const columnLinkTitle = css`
 	${expandedNavLinkStyles}
-	color: ${themePalette('--sub-nav-reader-revenue-link-text')};
+	color: ${themePalette('--nav-reader-revenue-link-text')};
 	${textSansBold20}
 
 	${from.desktop} {

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
@@ -26,17 +26,17 @@ const searchBar = css`
 
 const searchInput = css`
 	${textSans15}
-	background-color: rgba(255,255,255, .1);
+	background-color: ${themePalette('--nav-search-bar-background')};
 	border: 0;
 	border-radius: 1000px;
 	box-sizing: border-box;
-	color: ${themePalette('--sub-nav-search-bar-text')};
+	color: ${themePalette('--nav-search-bar-text')};
 	height: 36px;
 	padding-left: 38px;
 	vertical-align: middle;
 	width: 100%;
 	&::placeholder {
-		color: ${themePalette('--sub-nav-search-bar-text')};
+		color: ${themePalette('--nav-search-bar-text')};
 	}
 	&:focus {
 		padding-right: 40px;
@@ -55,7 +55,7 @@ const searchGlass = css`
 	position: absolute;
 	left: 7px;
 	top: 7px;
-	fill: ${themePalette('--sub-nav-search-bar-icon')};
+	fill: ${themePalette('--nav-search-bar-icon')};
 `;
 
 const searchSubmit = css`
@@ -70,7 +70,7 @@ const searchSubmit = css`
 	right: 0;
 	top: 0;
 	width: 50px;
-	fill: ${themePalette('--sub-nav-search-bar-icon')};
+	fill: ${themePalette('--nav-search-bar-icon')};
 	&:focus,
 	&:active {
 		opacity: 0;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
@@ -3,13 +3,10 @@
  * This file was largely copied from src/components/Nav/ExpandedMenu/VeggieBurgerMenu.tsx
  */
 import { css } from '@emotion/react';
-import {
-	from,
-	palette as sourcePalette,
-	visuallyHidden,
-} from '@guardian/source/foundations';
+import { from, visuallyHidden } from '@guardian/source/foundations';
 import { getZIndex } from '../../../lib/getZIndex';
 import { nestedOphanComponents } from '../../../lib/ophan-helpers';
+import { palette as themePalette } from '../../../palette';
 import { navInputCheckboxId, veggieBurgerId } from './constants';
 
 const screenReadable = css`
@@ -72,8 +69,8 @@ const veggieBurgerIconStyles = css`
 `;
 
 const veggieBurgerStyles = (isImmersive: boolean) => css`
-	background-color: ${sourcePalette.brandAlt[400]};
-	color: ${sourcePalette.neutral[7]};
+	background-color: ${themePalette('--masthead-veggie-burger-background')};
+	color: ${themePalette('--masthead-veggie-burger-icon')};
 	cursor: pointer;
 	height: 42px;
 	min-width: 42px;
@@ -106,6 +103,11 @@ const veggieBurgerStyles = (isImmersive: boolean) => css`
 	}
 	:focus {
 		outline: none;
+	}
+	:hover {
+		background-color: ${themePalette(
+			'--masthead-veggie-burger-background-hover',
+		)};
 	}
 `;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3364,42 +3364,22 @@ const subNavLinkHeaderLight: PaletteFunction = (format) => {
 			return sourcePalette.neutral[7];
 	}
 };
-const subNavLinkHeaderDark: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const subNavLinkFooterLight: PaletteFunction = () => {
-	return sourcePalette.neutral[7];
-};
-const subNavLinkFooterDark: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const subNavLinkHoverLight: PaletteFunction = (format) => {
-	return articleLinkHoverLight(format);
-};
-const subNavLinkHoverDark: PaletteFunction = (format) => {
-	return articleLinkHoverDark(format);
-};
-const subNavMoreLight: PaletteFunction = () => {
-	return sourcePalette.neutral[60];
-};
-const subNavMoreDark: PaletteFunction = () => {
-	return sourcePalette.neutral[38];
-};
-const subNavHorizontalSectionDivider: PaletteFunction = () => {
-	return sourcePalette.brand[600];
-};
-const subNavReaderRevenueLinkText: PaletteFunction = () => {
-	return sourcePalette.brandAlt[400];
-};
-const subNavSearchBarIcon: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const subNavSearchBarText: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const subNavSectionHeaderBackground: PaletteFunction = () => {
-	return sourcePalette.brand[300];
-};
+const subNavLinkHeaderDark: PaletteFunction = () => sourcePalette.neutral[100];
+const subNavLinkFooterLight: PaletteFunction = () => sourcePalette.neutral[7];
+const subNavLinkFooterDark: PaletteFunction = () => sourcePalette.neutral[100];
+const subNavLinkHoverLight: PaletteFunction = (format) =>
+	articleLinkHoverLight(format);
+const subNavLinkHoverDark: PaletteFunction = (format) =>
+	articleLinkHoverDark(format);
+const subNavMoreLight: PaletteFunction = () => sourcePalette.neutral[60];
+const subNavMoreDark: PaletteFunction = () => sourcePalette.neutral[38];
+
+const navReaderRevenueLinkText: PaletteFunction = () =>
+	sourcePalette.brandAlt[400];
+const navSearchBarIcon: PaletteFunction = () => sourcePalette.neutral[100];
+const navSearchBarText: PaletteFunction = () => sourcePalette.neutral[100];
+const navSearchBarBackground: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[100], 0.1);
 
 const pullQuoteTextLight: PaletteFunction = ({
 	design,
@@ -6330,6 +6310,22 @@ const paletteColours = {
 		light: mostViewedTabBorderLight,
 		dark: mostViewedTabBorderDark,
 	},
+	'--nav-reader-revenue-link-text': {
+		light: navReaderRevenueLinkText,
+		dark: navReaderRevenueLinkText,
+	},
+	'--nav-search-bar-background': {
+		light: navSearchBarBackground,
+		dark: navSearchBarBackground,
+	},
+	'--nav-search-bar-icon': {
+		light: navSearchBarIcon,
+		dark: navSearchBarIcon,
+	},
+	'--nav-search-bar-text': {
+		light: navSearchBarText,
+		dark: navSearchBarText,
+	},
 	'--numbered-list-heading': {
 		light: numberedListHeadingLight,
 		dark: numberedListHeadingDark,
@@ -6614,10 +6610,6 @@ const paletteColours = {
 		light: subNavBorder,
 		dark: subNavBorder,
 	},
-	'--sub-nav-horizontal-section-divider': {
-		light: subNavHorizontalSectionDivider,
-		dark: subNavHorizontalSectionDivider,
-	},
 	'--sub-nav-link-footer': {
 		light: subNavLinkFooterLight,
 		dark: subNavLinkFooterDark,
@@ -6633,22 +6625,6 @@ const paletteColours = {
 	'--sub-nav-more': {
 		light: subNavMoreLight,
 		dark: subNavMoreDark,
-	},
-	'--sub-nav-reader-revenue-link-text': {
-		light: subNavReaderRevenueLinkText,
-		dark: subNavReaderRevenueLinkText,
-	},
-	'--sub-nav-search-bar-icon': {
-		light: subNavSearchBarIcon,
-		dark: subNavSearchBarIcon,
-	},
-	'--sub-nav-search-bar-text': {
-		light: subNavSearchBarText,
-		dark: subNavSearchBarText,
-	},
-	'--sub-nav-section-header-background': {
-		light: subNavSectionHeaderBackground,
-		dark: subNavSectionHeaderBackground,
 	},
 	'--subheading-text': {
 		light: subheadingTextLight,


### PR DESCRIPTION
## What does this change?

Refactors the `Titlepiece` components to ensure the colour usage comes from the `palette` declarations and tidies up the naming of colours to better describe what they represent.

## Why?

Tidying up code and ensuring other pull requests don't get too big with refactoring changes

Part of Fairground project to update the homepages
