### PR TITLE
[Fairground 🎡][Highlights] Hide nav buttons depending on visible cards

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -6,7 +6,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
 import { HighlightsCard } from './Masthead/HighlightsCard';
@@ -67,22 +67,8 @@ const verticalLineStyles = css`
 	}
 `;
 
-const buttonContainerStyles = css`
-	position: absolute;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	height: 100%;
-	width: calc(
-		100% - 40px
-	); /* This accounts for the 20px padding on each side of the carousel */
-	top: 0;
-	pointer-events: none;
-`;
-
 const buttonStyles = css`
 	z-index: 1;
-	pointer-events: all;
 `;
 
 const buttonOverlayStyles = css`
@@ -90,9 +76,13 @@ const buttonOverlayStyles = css`
 	height: 100%;
 	display: flex;
 	align-items: center;
+	position: absolute;
+	top: 0;
+	pointer-events: all;
 `;
 
 const previousButtonFadeStyles = css`
+	left: 20px;
 	background: linear-gradient(
 		to right,
 		${palette('--highlight-container-start-fade')} 0%,
@@ -102,6 +92,7 @@ const previousButtonFadeStyles = css`
 `;
 
 const nextButtonFadeStyles = css`
+	right: 0;
 	background: linear-gradient(
 		to left,
 		${palette('--highlight-container-start-fade')} 0%,
@@ -147,6 +138,8 @@ export const HighlightsContainer = ({ trails }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
 	const imageLoading = 'eager';
+	const [showLeftChevron, setShowLeftChevron] = useState(false);
+	const [showRightChevron, setShowRightChevron] = useState(true);
 
 	const scrollTo = (direction: 'left' | 'right') => {
 		if (!carouselRef.current) return;
@@ -160,6 +153,29 @@ export const HighlightsContainer = ({ trails }: Props) => {
 			behavior: 'smooth',
 		});
 	};
+
+	const handleScroll = () => {
+		if (!carouselRef.current) return;
+
+		const scrollLeft = carouselRef.current.scrollLeft;
+		const maxScrollLeft =
+			carouselRef.current.scrollWidth - carouselRef.current.clientWidth;
+
+		setShowLeftChevron(scrollLeft > 0);
+		setShowRightChevron(scrollLeft < maxScrollLeft);
+	};
+
+	useEffect(() => {
+		const carouselElement = carouselRef.current;
+		if (!carouselElement) return;
+
+		carouselElement.addEventListener('scroll', handleScroll);
+
+		return () => {
+			carouselElement.removeEventListener('scroll', handleScroll);
+		};
+	}, []);
+
 	return (
 		<div css={containerStyles}>
 			<ol
@@ -194,32 +210,41 @@ export const HighlightsContainer = ({ trails }: Props) => {
 			</ol>
 
 			<Hide until={'tablet'}>
-				<div css={buttonContainerStyles}>
-					<div css={[buttonOverlayStyles, previousButtonFadeStyles]}>
-						<Button
-							css={buttonStyles}
-							hideLabel={true}
-							iconSide="left"
-							icon={<SvgChevronLeftSingle />}
-							onClick={() => scrollTo('left')}
-							aria-label="Move highlights carousel backwards"
-							data-link-name="highlights carousel left chevron"
-							size="small"
-						/>
-					</div>
-					<div css={[buttonOverlayStyles, nextButtonFadeStyles]}>
-						<Button
-							css={buttonStyles}
-							hideLabel={true}
-							iconSide="left"
-							icon={<SvgChevronRightSingle />}
-							onClick={() => scrollTo('right')}
-							aria-label="Move highlights carousel forwards"
-							data-link-name="highlights carousel right chevron"
-							size="small"
-						/>
-					</div>
-				</div>
+				<>
+					{showLeftChevron && (
+						<div
+							css={[
+								buttonOverlayStyles,
+								previousButtonFadeStyles,
+							]}
+						>
+							<Button
+								css={buttonStyles}
+								hideLabel={true}
+								iconSide="left"
+								icon={<SvgChevronLeftSingle />}
+								onClick={() => scrollTo('left')}
+								aria-label="Move highlights carousel backwards"
+								data-link-name="highlights carousel left chevron"
+								size="small"
+							/>
+						</div>
+					)}
+					{showRightChevron && (
+						<div css={[buttonOverlayStyles, nextButtonFadeStyles]}>
+							<Button
+								css={buttonStyles}
+								hideLabel={true}
+								iconSide="left"
+								icon={<SvgChevronRightSingle />}
+								onClick={() => scrollTo('right')}
+								aria-label="Move highlights carousel forwards"
+								data-link-name="highlights carousel right chevron"
+								size="small"
+							/>
+						</div>
+					)}
+				</>
 			</Hide>
 		</div>
 	);

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -82,7 +82,7 @@ const buttonOverlayStyles = css`
 `;
 
 const previousButtonFadeStyles = css`
-	left: 20px;
+	left: ${space[5]}px;
 	background: linear-gradient(
 		to right,
 		${palette('--highlight-container-start-fade')} 0%,
@@ -225,41 +225,34 @@ export const HighlightsContainer = ({ trails }: Props) => {
 			</ol>
 
 			<Hide until={'tablet'}>
-				<>
-					{showPreviousButton && (
-						<div
-							css={[
-								buttonOverlayStyles,
-								previousButtonFadeStyles,
-							]}
-						>
-							<Button
-								css={buttonStyles}
-								hideLabel={true}
-								iconSide="left"
-								icon={<SvgChevronLeftSingle />}
-								onClick={() => scrollTo('left')}
-								aria-label="Move highlight stories backwards"
-								data-link-name="highlights carousel left chevron"
-								size="small"
-							/>
-						</div>
-					)}
-					{showNextButton && (
-						<div css={[buttonOverlayStyles, nextButtonFadeStyles]}>
-							<Button
-								css={buttonStyles}
-								hideLabel={true}
-								iconSide="left"
-								icon={<SvgChevronRightSingle />}
-								onClick={() => scrollTo('right')}
-								aria-label="Move highlight stories forwards"
-								data-link-name="highlights carousel right chevron"
-								size="small"
-							/>
-						</div>
-					)}
-				</>
+				{showPreviousButton && (
+					<div css={[buttonOverlayStyles, previousButtonFadeStyles]}>
+						<Button
+							css={buttonStyles}
+							hideLabel={true}
+							iconSide="left"
+							icon={<SvgChevronLeftSingle />}
+							onClick={() => scrollTo('left')}
+							aria-label="Move highlight stories backwards"
+							data-link-name="highlights carousel left chevron"
+							size="small"
+						/>
+					</div>
+				)}
+				{showNextButton && (
+					<div css={[buttonOverlayStyles, nextButtonFadeStyles]}>
+						<Button
+							css={buttonStyles}
+							hideLabel={true}
+							iconSide="left"
+							icon={<SvgChevronRightSingle />}
+							onClick={() => scrollTo('right')}
+							aria-label="Move highlight stories forwards"
+							data-link-name="highlights carousel right chevron"
+							size="small"
+						/>
+					</div>
+				)}
 			</Hide>
 		</div>
 	);

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -18,6 +18,7 @@ const containerStyles = css`
 		padding: 0 20px;
 	}
 `;
+
 const carouselStyles = css`
 	display: grid;
 	grid-auto-columns: 1fr;

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -15,7 +15,7 @@ type Props = { trails: DCRFrontCard[] };
 
 const containerStyles = css`
 	${from.tablet} {
-		padding: 0 10px 0 20px;
+		padding: 0 20px;
 	}
 `;
 const carouselStyles = css`

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -6,7 +6,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
 import { HighlightsCard } from './Masthead/HighlightsCard';

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -6,7 +6,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
 import { HighlightsCard } from './Masthead/HighlightsCard';

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -15,7 +15,7 @@ type Props = { trails: DCRFrontCard[] };
 
 const containerStyles = css`
 	${from.tablet} {
-		padding: 0 20px;
+		padding: 0 10px 0 20px;
 	}
 `;
 const carouselStyles = css`

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -18,7 +18,6 @@ const containerStyles = css`
 		padding: 0 20px;
 	}
 `;
-
 const carouselStyles = css`
 	display: grid;
 	grid-auto-columns: 1fr;

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -138,8 +138,8 @@ export const HighlightsContainer = ({ trails }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
 	const imageLoading = 'eager';
-	const [showLeftChevron, setShowLeftChevron] = useState(false);
-	const [showRightChevron, setShowRightChevron] = useState(true);
+	const [showPreviousButton, setShowPreviousButton] = useState(false);
+	const [showNextButton, setShowNextButton] = useState(true);
 
 	const scrollTo = (direction: 'left' | 'right') => {
 		if (!carouselRef.current) return;
@@ -154,25 +154,40 @@ export const HighlightsContainer = ({ trails }: Props) => {
 		});
 	};
 
-	const handleScroll = () => {
-		if (!carouselRef.current) return;
+	/**
+	 * Updates the visibility of the navigation buttons based on the carousel's scroll position.
+	 *
+	 * This function checks the current scroll position of the carousel and sets the visibility
+	 * of the previous and next buttons accordingly. The previous button is shown if the carousel
+	 * is scrolled to the right of the start, and the next button is shown if the carousel is not
+	 * fully scrolled to the end.
+	 */
+	const updateButtonVisibilityOnScroll = () => {
+		const carouselElement = carouselRef.current;
+		if (!carouselElement) return;
 
-		const scrollLeft = carouselRef.current.scrollLeft;
+		const scrollLeft = carouselElement.scrollLeft;
 		const maxScrollLeft =
-			carouselRef.current.scrollWidth - carouselRef.current.clientWidth;
+			carouselElement.scrollWidth - carouselElement.clientWidth;
 
-		setShowLeftChevron(scrollLeft > 0);
-		setShowRightChevron(scrollLeft < maxScrollLeft);
+		setShowPreviousButton(scrollLeft > 0);
+		setShowNextButton(scrollLeft < maxScrollLeft);
 	};
 
 	useEffect(() => {
 		const carouselElement = carouselRef.current;
 		if (!carouselElement) return;
 
-		carouselElement.addEventListener('scroll', handleScroll);
+		carouselElement.addEventListener(
+			'scroll',
+			updateButtonVisibilityOnScroll,
+		);
 
 		return () => {
-			carouselElement.removeEventListener('scroll', handleScroll);
+			carouselElement.removeEventListener(
+				'scroll',
+				updateButtonVisibilityOnScroll,
+			);
 		};
 	}, []);
 
@@ -211,7 +226,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 
 			<Hide until={'tablet'}>
 				<>
-					{showLeftChevron && (
+					{showPreviousButton && (
 						<div
 							css={[
 								buttonOverlayStyles,
@@ -224,13 +239,13 @@ export const HighlightsContainer = ({ trails }: Props) => {
 								iconSide="left"
 								icon={<SvgChevronLeftSingle />}
 								onClick={() => scrollTo('left')}
-								aria-label="Move highlights carousel backwards"
+								aria-label="Move highlight stories backwards"
 								data-link-name="highlights carousel left chevron"
 								size="small"
 							/>
 						</div>
 					)}
-					{showRightChevron && (
+					{showNextButton && (
 						<div css={[buttonOverlayStyles, nextButtonFadeStyles]}>
 							<Button
 								css={buttonStyles}
@@ -238,7 +253,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 								iconSide="left"
 								icon={<SvgChevronRightSingle />}
 								onClick={() => scrollTo('right')}
-								aria-label="Move highlights carousel forwards"
+								aria-label="Move highlight stories forwards"
 								data-link-name="highlights carousel right chevron"
 								size="small"
 							/>


### PR DESCRIPTION
## What does this change?
Adds the ability to navigate the highlights container with buttons previous/next chevron buttons. 

There was a design requirement for this feature that the previous/next buttons visibility should change depending on if the first and last cards were visible. To do this, we keep track of scrolling via an event listener and check if the scroll was to the to the beginning or the end of the carousel and then set the visibility status of each button accordingly in state..

## Why?
We want users on larger devices (tablet breakpoint and higher) to be able to navigate with buttons as well as sliding. 

## Screenshots

https://github.com/user-attachments/assets/95cdc709-48e4-41e5-a631-c8ed489e8e6a


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
