### PR TITLE
amend test alignto centre

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -75,10 +75,9 @@ const individualLabelCSS = css`
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
 	background-color: ${schemedPalette('--ad-background')};
-	padding: 0 8px;
 	border-top: 1px solid ${schemedPalette('--ad-border')};
 	color: ${schemedPalette('--ad-labels-text')};
-	text-align: left;
+	text-align: center;
 	box-sizing: border-box;
 `;
 


### PR DESCRIPTION
## What does this change?
This is a simple PR to amend the `individualLabelCSS` to centre align the ad label
## Why?
This is part of a larger body of work to refactor the positioning of the Ad label on all slots (including Fabric Fluid ads). 

Commercial PR: [here](https://github.com/guardian/commercial/pull/1484)
Commercial-template PR: [here](https://github.com/guardian/commercial-templates/pull/394)
Frontend PR: [here](https://github.com/guardian/frontend/pull/27360)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1062" alt="Screenshot 2024-07-31 at 10 29 33" src="https://github.com/user-attachments/assets/ec0a8598-edbd-41bc-89cf-68b610f1ff2c"> | <img width="1188" alt="Screenshot 2024-07-31 at 10 30 14" src="https://github.com/user-attachments/assets/a8c30acd-7cae-41e5-a3ad-687f517646b0"> |
| <img width="1376" alt="Screenshot 2024-07-31 at 10 36 43" src="https://github.com/user-attachments/assets/8d2f804d-1325-4cba-adc2-3a7a4d2b6ff9"> | <img width="833" alt="Screenshot 2024-07-31 at 10 39 17" src="https://github.com/user-attachments/assets/42ad168c-d5cf-4ca3-8e75-f82867bd8b79"> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.


[before]: https://example.com/before.png
[after]: https://example.com/after.png



| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
