### PR TITLE
Add heatphan indicator to the carousel

### DIFF
--- a/dotcom-rendering/docs/contracts/004-heatphan-selectors.md
+++ b/dotcom-rendering/docs/contracts/004-heatphan-selectors.md
@@ -1,0 +1,17 @@
+## Heatphan selectors
+
+## What is the contract?
+
+Within the article body, we add the following attributes to certain elements:
+
+-   `data-heatphan-type`: This denotes the component or element type, eg "carousel"
+
+These are elements that heatphan needs to be able to find and modify for heatphan to function correctly.
+
+## Where is it relied upon?
+
+It is relied upon by Ophan.
+
+## Why is it required?
+
+This allows Heatphan to find elements and then adjusts the CSS/HTML of the page (typically a Front) in order to dynamically modify the appearance and structure of the element.

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -908,6 +908,7 @@ export const Carousel = ({
 				css={wrapperStyle(trails.length)}
 				data-link-name={formatAttrString(heading)}
 				data-component={isVideoContainer ? 'video-playlist' : undefined}
+				data-heatphan-type="carousel"
 			>
 				<LeftColumn
 					size={leftColSize}

--- a/dotcom-rendering/src/components/CarouselForNewsletters.importable.tsx
+++ b/dotcom-rendering/src/components/CarouselForNewsletters.importable.tsx
@@ -501,6 +501,7 @@ export const CarouselForNewsletters = ({
 		<div
 			css={wrapperStyle(newsletters.length)}
 			data-link-name={formatAttrString(heading)}
+			data-heatphan-type="carousel"
 		>
 			<LeftColumn borderType="partial" size={leftColSize}>
 				<HeaderAndNav

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -161,7 +161,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 		});
 	};
 	return (
-		<div data-heatphan="carousel" css={containerStyles}>
+		<div data-heatphan-type="carousel" css={containerStyles}>
 			<ol
 				ref={carouselRef}
 				css={[

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -161,7 +161,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 		});
 	};
 	return (
-		<div css={containerStyles}>
+		<div data-heatphan="carousel" css={containerStyles}>
 			<ol
 				ref={carouselRef}
 				css={[


### PR DESCRIPTION
## What does this change?
Adds a data attribute for heatphan-type. This can be used to indicate to heatphan a component or element of a certain type, eg `carousel`.

## Why?
Heatphan sometimes needs to make manipulate the DOM to ensure the heatphan overlay appears and functions correctly. This data attribute heatphan-type provides a mechanism for heatphan to find and adjust components. 

## Screenshots
![Screenshot 2024-07-31 at 10 57 15](https://github.com/user-attachments/assets/c9f16521-75b1-49b0-b590-de1d5db37c0a)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
