### PR TITLE
Remove conditions when sticky liveblog ask is hidden owing to AB test.

### DIFF
--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -194,8 +194,8 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 			clientName: 'dcr',
 			referrerUrl,
 			// message tests
-			abTestName: '', // quick and dirty but doesn't feel right.
-			abTestVariant: '', // is this the right way to go about this?
+			abTestName: '', // stop tracking AB test.
+			abTestVariant: '', // stop tracking AB test.
 			campaignCode: whatAmI,
 			componentType: 'ACQUISITIONS_OTHER',
 		};


### PR DESCRIPTION
## What does this change?

Ensures that the sticky liveblog ask remains in place following the AB Test.
Once this is merged, I will remove the AB Test elements in DCR and Frontend -> PRs:

- [DCR PR12040](https://github.com/guardian/dotcom-rendering/pull/12040)
- [Frontend PR27370](https://github.com/guardian/frontend/pull/27370)

## Why?

There has been agreement that this component has been successful and we would like to retain it and in future add tooling to be able to conduct future ab tests with messaging etc.

## Screenshots
No visible difference.

Captured the difference in Component Event here: 

Current - sending AB test data in Component Event:
![prod passing ab data](https://github.com/user-attachments/assets/3742ee0b-3a85-4a13-bd00-5135576a2f79)

Proposed - component shows even when ab test is control and no longer sending AB test data in Component Event:
![code no longer passing ab data](https://github.com/user-attachments/assets/1828ea76-0911-4895-889b-68b75da732fa)

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
