### PR TITLE
[Fairground] Remove edition switcher from mobile expanded nav

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ExpandedNav.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ExpandedNav.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source/foundations';
 import { nav } from '../../../Nav/Nav.mock';
 import { ExpandedNav } from './ExpandedNav';
 
@@ -6,6 +7,7 @@ export default {
 	title: 'Components/Masthead/Titlepiece/ExpandedNav',
 	parameters: {
 		backgrounds: { default: 'dark' },
+		chromatic: { viewports: [breakpoints.mobileMedium, breakpoints.wide] },
 	},
 };
 

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
@@ -12,18 +12,10 @@ import {
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import type { EditionId } from '../../../../lib/edition';
-import {
-	getEditionFromId,
-	getRemainingEditions,
-} from '../../../../lib/edition';
 import { nestedOphanComponents } from '../../../../lib/ophan-helpers';
 import type { LinkType, NavType } from '../../../../model/extract-nav';
 import { palette as themePalette } from '../../../../palette';
-import {
-	expandedNavLinkStyles,
-	hideFromDesktop,
-	listAccessibility,
-} from '../commonStyles';
+import { expandedNavLinkStyles, listAccessibility } from '../commonStyles';
 import { MoreSection } from './MoreSection';
 import { lineStyle, Pillar } from './Pillar';
 import { ReaderRevenueLinks } from './ReaderRevenueLinks';
@@ -124,8 +116,6 @@ export const Sections = ({
 	editionId,
 	hasPageSkin,
 }: Props) => {
-	const activeEdition = getEditionFromId(editionId);
-	const remainingEditions = getRemainingEditions(activeEdition.editionId);
 	return (
 		<ul
 			css={[
@@ -177,19 +167,6 @@ export const Sections = ({
 			/>
 
 			{/* Mobile only Brand Extensions list */}
-			<section css={hideFromDesktop}>
-				<Pillar
-					column={{
-						...activeEdition,
-						children: remainingEditions,
-					}}
-					index={10}
-					showLineBelow={false}
-					hasPageSkin={hasPageSkin}
-				/>
-				<div css={lineStyle}></div>
-			</section>
-
 			<MoreSection
 				otherLinks={nav.otherLinks}
 				brandExtensions={nav.brandExtensions}


### PR DESCRIPTION
## What does this change?

- Removes the edition switcher from the expanded nav on mobile 

## Why?

Part of the Fairground project to modernise and update front pages

Resolves [this trello ticket](https://trello.com/c/CK2C4HVc/38-masthead-navigation-changes-web)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1bb8c4d7-8779-461f-a766-19ad15c3c544
[after]: https://github.com/user-attachments/assets/15dcf7ba-1ccc-4b6f-a965-44525a865b5a

