### PR TITLE
Changes for Epic choice cards v2 - single contributions test

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -524,6 +524,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					threeTierChoiceCardSelectedAmount={
 						threeTierChoiceCardSelectedAmount
 					}
+					variantOfChoiceCard={variantOfChoiceCard}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -314,6 +314,18 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	const showThreeTierChoiceCards =
 		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
 
+	const showThreeTierChoiceCardsV1 =
+		showChoiceCards && variant.name.includes('V1_THREE_TIER_CHOICE_CARDS');
+
+	const showThreeTierChoiceCardsV2 =
+		showChoiceCards && variant.name.includes('V2_THREE_TIER_CHOICE_CARDS');
+
+	const variantOfChoiceCard = showThreeTierChoiceCardsV1
+		? 'V1_THREE_TIER_CHOICE_CARDS'
+		: showThreeTierChoiceCardsV2
+		? 'V2_THREE_TIER_CHOICE_CARDS'
+		: 'THREE_TIER_CHOICE_CARDS';
+
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
 			const localAmounts =
@@ -485,6 +497,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					countryCode={countryCode}
 					selectedAmount={threeTierChoiceCardSelectedAmount}
 					setSelectedAmount={setThreeTierChoiceCardSelectedAmount}
+					variantOfChoiceCard={variantOfChoiceCard}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -145,7 +145,7 @@ interface ContributionsEpicButtonsProps {
 	showThreeTierChoiceCards?: boolean;
 	threeTierChoiceCardSelectedAmount?: number;
 	numArticles: number;
-	variantOfChoiceCard: string;
+	variantOfChoiceCard?: string;
 }
 
 export const ContributionsEpicButtons = ({
@@ -188,10 +188,7 @@ export const ContributionsEpicButtons = ({
 	const getChoiceCardCta = (cta: Cta): Cta => {
 		if (
 			showThreeTierChoiceCards &&
-			![
-				'V1_THREE_TIER_CHOICE_CARDS',
-				'V2_THREE_TIER_CHOICE_CARDS',
-			].includes(variantOfChoiceCard) &&
+			!variantOfChoiceCard &&
 			threeTierChoiceCardSelectedAmount != undefined
 		) {
 			return {
@@ -204,6 +201,7 @@ export const ContributionsEpicButtons = ({
 			};
 		}
 		if (
+			variantOfChoiceCard &&
 			[
 				'V1_THREE_TIER_CHOICE_CARDS',
 				'V2_THREE_TIER_CHOICE_CARDS',
@@ -271,7 +269,6 @@ export const ContributionsEpicButtons = ({
 							amountsVariantName={amountsVariantName}
 							countryCode={countryCode}
 							submitComponentEvent={submitComponentEvent}
-							variantOfChoiceCard={variantOfChoiceCard}
 						/>
 						{secondaryCta?.type === SecondaryCtaType.Custom &&
 							!!secondaryCta.cta.baseUrl &&

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -145,6 +145,7 @@ interface ContributionsEpicButtonsProps {
 	showThreeTierChoiceCards?: boolean;
 	threeTierChoiceCardSelectedAmount?: number;
 	numArticles: number;
+	variantOfChoiceCard: string;
 }
 
 export const ContributionsEpicButtons = ({
@@ -162,6 +163,7 @@ export const ContributionsEpicButtons = ({
 	amountsTestName,
 	amountsVariantName,
 	numArticles,
+	variantOfChoiceCard,
 }: ContributionsEpicButtonsProps): JSX.Element | null => {
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
@@ -186,6 +188,10 @@ export const ContributionsEpicButtons = ({
 	const getChoiceCardCta = (cta: Cta): Cta => {
 		if (
 			showThreeTierChoiceCards &&
+			![
+				'V1_THREE_TIER_CHOICE_CARDS',
+				'V2_THREE_TIER_CHOICE_CARDS',
+			].includes(variantOfChoiceCard) &&
 			threeTierChoiceCardSelectedAmount != undefined
 		) {
 			return {
@@ -193,6 +199,32 @@ export const ContributionsEpicButtons = ({
 				baseUrl: addChoiceCardsParams(
 					cta.baseUrl,
 					'MONTHLY', // only doing monthly in the first test
+					threeTierChoiceCardSelectedAmount,
+				),
+			};
+		}
+		if (
+			[
+				'V1_THREE_TIER_CHOICE_CARDS',
+				'V2_THREE_TIER_CHOICE_CARDS',
+			].includes(variantOfChoiceCard) &&
+			threeTierChoiceCardSelectedAmount != undefined
+		) {
+			if (threeTierChoiceCardSelectedAmount === 0) {
+				return {
+					text: cta.text,
+					baseUrl: addChoiceCardsParams(
+						'https://support.theguardian.com/contribute/checkout?selected-contribution-type=one_off',
+						'ONE_OFF',
+						threeTierChoiceCardSelectedAmount,
+					),
+				};
+			}
+			return {
+				text: cta.text,
+				baseUrl: addChoiceCardsParams(
+					'https://support.theguardian.com/uk/contribute/checkout',
+					'MONTHLY',
 					threeTierChoiceCardSelectedAmount,
 				),
 			};
@@ -239,6 +271,7 @@ export const ContributionsEpicButtons = ({
 							amountsVariantName={amountsVariantName}
 							countryCode={countryCode}
 							submitComponentEvent={submitComponentEvent}
+							variantOfChoiceCard={variantOfChoiceCard}
 						/>
 						{secondaryCta?.type === SecondaryCtaType.Custom &&
 							!!secondaryCta.cta.baseUrl &&

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -6,6 +6,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { OphanComponentEvent } from '@guardian/libs';
+import { isUndefined } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
 import { SecondaryCtaType } from '@guardian/support-dotcom-components';
 import type { EpicVariant } from '@guardian/support-dotcom-components/dist/shared/src/types/abTests/epic';
@@ -193,7 +194,7 @@ export const ContributionsEpicButtons = ({
 				'V1_THREE_TIER_CHOICE_CARDS',
 				'V2_THREE_TIER_CHOICE_CARDS',
 			].includes(variantOfChoiceCard) &&
-			threeTierChoiceCardSelectedAmount != undefined
+			!isUndefined(threeTierChoiceCardSelectedAmount)
 		) {
 			if (threeTierChoiceCardSelectedAmount === 0) {
 				return {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -188,19 +188,6 @@ export const ContributionsEpicButtons = ({
 	const getChoiceCardCta = (cta: Cta): Cta => {
 		if (
 			showThreeTierChoiceCards &&
-			!variantOfChoiceCard &&
-			threeTierChoiceCardSelectedAmount != undefined
-		) {
-			return {
-				text: cta.text,
-				baseUrl: addChoiceCardsParams(
-					cta.baseUrl,
-					'MONTHLY', // only doing monthly in the first test
-					threeTierChoiceCardSelectedAmount,
-				),
-			};
-		}
-		if (
 			variantOfChoiceCard &&
 			[
 				'V1_THREE_TIER_CHOICE_CARDS',

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicChoiceCards.tsx
@@ -5,6 +5,7 @@
  */
 import { css } from '@emotion/react';
 import type { OphanComponentEvent } from '@guardian/libs';
+import { isUndefined } from '@guardian/libs';
 import { until, visuallyHidden } from '@guardian/source/foundations';
 import { ChoiceCard, ChoiceCardGroup } from '@guardian/source/react-components';
 import { contributionTabFrequencies } from '@guardian/support-dotcom-components';
@@ -127,7 +128,7 @@ export const ContributionsEpicChoiceCards: ReactComponent<
 	};
 
 	const ChoiceCardAmount = ({ amount }: { amount?: number }) => {
-		if (amount !== undefined) {
+		if (!isUndefined(amount)) {
 			return (
 				<ChoiceCard
 					value={`${amount}`}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicCtas.tsx
@@ -21,6 +21,7 @@ type ContributionsEpicCtasProps = EpicProps & {
 	threeTierChoiceCardSelectedAmount?: number;
 	amountsTestName?: string;
 	amountsVariantName?: string;
+	variantOfChoiceCard?: string;
 };
 
 export const ContributionsEpicCtas: ReactComponent<
@@ -39,6 +40,7 @@ export const ContributionsEpicCtas: ReactComponent<
 	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
+	variantOfChoiceCard,
 }: ContributionsEpicCtasProps): JSX.Element => {
 	const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(
 		undefined,
@@ -91,6 +93,7 @@ export const ContributionsEpicCtas: ReactComponent<
 				amountsTestName={amountsTestName}
 				amountsVariantName={amountsVariantName}
 				numArticles={articleCounts.for52Weeks}
+				variantOfChoiceCard={variantOfChoiceCard}
 			/>
 			{isReminderActive && showReminderFields && (
 				<ContributionsEpicReminder

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -149,6 +149,8 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 	const showThreeTierChoiceCards =
 		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
 
+	const variantOfChoiceCard = 'THREE_TIER_CHOICE_CARDS';
+
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
 			const localAmounts =
@@ -253,6 +255,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 								setSelectedAmount={
 									setThreeTierChoiceCardSelectedAmount
 								}
+								variantOfChoiceCard={variantOfChoiceCard}
 							/>
 						)}
 						<ContributionsEpicCtas

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
@@ -1,7 +1,7 @@
 export const ChoiceCardTestData_REGULAR = [
 	{
 		supportTier: 'support',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'Support',
 		benefits: [
@@ -11,7 +11,7 @@ export const ChoiceCardTestData_REGULAR = [
 	},
 	{
 		supportTier: 'allAccess',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'All-access digital',
 		benefits: [
@@ -24,7 +24,7 @@ export const ChoiceCardTestData_REGULAR = [
 	},
 	{
 		supportTier: 'other',
-		label: () => 'Support with another amount',
+		label: (): string => 'Support with another amount',
 		benefitsLabel: undefined,
 		benefits: ['We welcome support of any size, any time'],
 		recommended: false,
@@ -34,7 +34,7 @@ export const ChoiceCardTestData_REGULAR = [
 export const ChoiceCardTestData_V1 = [
 	{
 		supportTier: 'support',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'Support',
 		benefits: [
@@ -44,7 +44,7 @@ export const ChoiceCardTestData_V1 = [
 	},
 	{
 		supportTier: 'allAccess',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'All-access digital',
 		benefits: [
@@ -57,7 +57,7 @@ export const ChoiceCardTestData_V1 = [
 	},
 	{
 		supportTier: 'other',
-		label: () => 'Support just once from £1',
+		label: (): string => 'Support just once from £1',
 		benefitsLabel: undefined,
 		benefits: [
 			'We welcome support of any size, any time - whether you choose to give £1 or more',
@@ -69,7 +69,7 @@ export const ChoiceCardTestData_V1 = [
 export const ChoiceCardTestData_V2 = [
 	{
 		supportTier: 'other',
-		label: () => 'Support just once from £1',
+		label: (): string => 'Support just once from £1',
 		benefitsLabel: undefined,
 		benefits: [
 			'We welcome support of any size, any time - whether you choose to give £1 or more',
@@ -78,7 +78,7 @@ export const ChoiceCardTestData_V2 = [
 	},
 	{
 		supportTier: 'support',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'Support',
 		benefits: [
@@ -88,7 +88,7 @@ export const ChoiceCardTestData_V2 = [
 	},
 	{
 		supportTier: 'allAccess',
-		label: (amount: number, currencySymbol: string) =>
+		label: (amount: number, currencySymbol: string): string =>
 			`Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'All-access digital',
 		benefits: [

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
@@ -1,0 +1,102 @@
+export const ChoiceCardTestData_REGULAR = [
+	{
+		supportTier: 'support',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'Support',
+		benefits: [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		],
+		recommended: false,
+	},
+	{
+		supportTier: 'allAccess',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'All-access digital',
+		benefits: [
+			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		],
+		recommended: true,
+	},
+	{
+		supportTier: 'other',
+		label: () => 'Support with another amount',
+		benefitsLabel: undefined,
+		benefits: ['We welcome support of any size, any time'],
+		recommended: false,
+	},
+];
+
+export const ChoiceCardTestData_V1 = [
+	{
+		supportTier: 'support',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'Support',
+		benefits: [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		],
+		recommended: false,
+	},
+	{
+		supportTier: 'allAccess',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'All-access digital',
+		benefits: [
+			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		],
+		recommended: true,
+	},
+	{
+		supportTier: 'other',
+		label: () => 'Support just once from £1',
+		benefitsLabel: undefined,
+		benefits: [
+			'We welcome support of any size, any time - whether you choose to give £1 or more',
+		],
+		recommended: false,
+	},
+];
+
+export const ChoiceCardTestData_V2 = [
+	{
+		supportTier: 'other',
+		label: () => 'Support just once from £1',
+		benefitsLabel: undefined,
+		benefits: [
+			'We welcome support of any size, any time - whether you choose to give £1 or more',
+		],
+		recommended: false,
+	},
+	{
+		supportTier: 'support',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'Support',
+		benefits: [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		],
+		recommended: false,
+	},
+	{
+		supportTier: 'allAccess',
+		label: (amount: number, currencySymbol: string) =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'All-access digital',
+		benefits: [
+			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		],
+		recommended: false,
+	},
+];

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
@@ -1,4 +1,6 @@
-export const ChoiceCardTestData_REGULAR = [
+import type { ChoiceInfo } from './ThreeTierChoiceCards';
+
+export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 	{
 		supportTier: 'support',
 		label: (amount: number, currencySymbol: string): string =>
@@ -31,7 +33,7 @@ export const ChoiceCardTestData_REGULAR = [
 	},
 ];
 
-export const ChoiceCardTestData_V1 = [
+export const ChoiceCardTestData_V1: ChoiceInfo[] = [
 	{
 		supportTier: 'support',
 		label: (amount: number, currencySymbol: string): string =>
@@ -66,7 +68,7 @@ export const ChoiceCardTestData_V1 = [
 	},
 ];
 
-export const ChoiceCardTestData_V2 = [
+export const ChoiceCardTestData_V2: ChoiceInfo[] = [
 	{
 		supportTier: 'other',
 		label: (): string => 'Support just once from £1',

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -18,6 +18,11 @@ import {
 	getLocalCurrencySymbol,
 } from '@guardian/support-dotcom-components';
 import type { Dispatch, SetStateAction } from 'react';
+import {
+	ChoiceCardTestData_REGULAR,
+	ChoiceCardTestData_V1,
+	ChoiceCardTestData_V2,
+} from './ThreeTierChoiceCardData';
 import type { SupportTier } from './utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';
 
@@ -104,39 +109,6 @@ function getChoiceAmount(
 	return threeTierChoiceCardAmounts[countryGroupId][supportTier];
 }
 
-const Choices = [
-	{
-		supportTier: 'support',
-		label: (amount: number, currencySymbol: string) =>
-			`Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'Support',
-		benefits: [
-			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-		],
-		recommended: false,
-	},
-	{
-		supportTier: 'allAccess',
-		label: (amount: number, currencySymbol: string) =>
-			`Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'All-access digital',
-		benefits: [
-			'Unlimited access to the Guardian app',
-			'Ad-free reading on all your devices',
-			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-			'Far fewer asks for support',
-		],
-		recommended: true,
-	},
-	{
-		supportTier: 'other',
-		label: () => 'Support with another amount',
-		benefitsLabel: undefined,
-		benefits: ['We welcome support of any size, any time'],
-		recommended: false,
-	},
-] as const satisfies ReadonlyArray<ChoiceInfo>;
-
 const SupportingBenefits = ({
 	benefitsLabel,
 	benefits,
@@ -172,15 +144,32 @@ type ThreeTierChoiceCardsProps = {
 	selectedAmount: number;
 	setSelectedAmount: Dispatch<SetStateAction<number>>;
 	countryCode?: string;
+	variantOfChoiceCard: string;
 };
 
 export const ThreeTierChoiceCards = ({
 	countryCode,
 	selectedAmount,
 	setSelectedAmount,
+	variantOfChoiceCard,
 }: ThreeTierChoiceCardsProps) => {
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
+
+	const getChoiceCardData = (variant: string) => {
+		switch (variant) {
+			case 'THREE_TIER_CHOICE_CARDS':
+				return ChoiceCardTestData_REGULAR;
+			case 'V1_THREE_TIER_CHOICE_CARDS':
+				return ChoiceCardTestData_V1;
+			case 'V2_THREE_TIER_CHOICE_CARDS':
+				return ChoiceCardTestData_V2;
+			default:
+				return ChoiceCardTestData_REGULAR;
+		}
+	};
+
+	const Choices = getChoiceCardData(variantOfChoiceCard) as ChoiceInfo[];
 
 	return (
 		<RadioGroup

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -94,13 +94,12 @@ const recommendedPillStyles = css`
 	right: ${space[5]}px;
 `;
 
-type ChoiceInfo = {
+export type ChoiceInfo = {
 	supportTier: SupportTier;
 	label: (amount: number, currencySymbol: string) => string;
 	benefitsLabel?: string;
 	benefits: string[];
 	recommended: boolean;
-	url: string;
 };
 
 function getChoiceAmount(
@@ -148,7 +147,7 @@ type ThreeTierChoiceCardsProps = {
 	variantOfChoiceCard: string;
 };
 
-export const getChoiceCardData = (variant: string) => {
+export const getChoiceCardData = (variant: string): ChoiceInfo[] => {
 	switch (variant) {
 		case 'THREE_TIER_CHOICE_CARDS':
 			return ChoiceCardTestData_REGULAR;
@@ -170,7 +169,7 @@ export const ThreeTierChoiceCards = ({
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
 
-	const Choices = getChoiceCardData(variantOfChoiceCard) as ChoiceInfo[];
+	const Choices = getChoiceCardData(variantOfChoiceCard);
 
 	return (
 		<RadioGroup

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -100,6 +100,7 @@ type ChoiceInfo = {
 	benefitsLabel?: string;
 	benefits: string[];
 	recommended: boolean;
+	url: string;
 };
 
 function getChoiceAmount(
@@ -147,6 +148,19 @@ type ThreeTierChoiceCardsProps = {
 	variantOfChoiceCard: string;
 };
 
+export const getChoiceCardData = (variant: string) => {
+	switch (variant) {
+		case 'THREE_TIER_CHOICE_CARDS':
+			return ChoiceCardTestData_REGULAR;
+		case 'V1_THREE_TIER_CHOICE_CARDS':
+			return ChoiceCardTestData_V1;
+		case 'V2_THREE_TIER_CHOICE_CARDS':
+			return ChoiceCardTestData_V2;
+		default:
+			return ChoiceCardTestData_REGULAR;
+	}
+};
+
 export const ThreeTierChoiceCards = ({
 	countryCode,
 	selectedAmount,
@@ -155,19 +169,6 @@ export const ThreeTierChoiceCards = ({
 }: ThreeTierChoiceCardsProps) => {
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
-
-	const getChoiceCardData = (variant: string) => {
-		switch (variant) {
-			case 'THREE_TIER_CHOICE_CARDS':
-				return ChoiceCardTestData_REGULAR;
-			case 'V1_THREE_TIER_CHOICE_CARDS':
-				return ChoiceCardTestData_V1;
-			case 'V2_THREE_TIER_CHOICE_CARDS':
-				return ChoiceCardTestData_V2;
-			default:
-				return ChoiceCardTestData_REGULAR;
-		}
-	};
 
 	const Choices = getChoiceCardData(variantOfChoiceCard) as ChoiceInfo[];
 


### PR DESCRIPTION
## What does this change?

Epic choice cards v2 - single contributions test

## Why?

The first choice card redesign test provided a fantastic result for non-US regions. However, we need to optimise this functionality for the US as well and will re-try the design but with an emphasis on single contributions too.
V1: By anchoring a SC at the lowest price point and directing the user to the second step of the checkout, we can capture better S+ acquisitions without a drop off in SC.
V2: By removing the recommended pill, we can empower our users to select a flexible offering that best suits their needs, thus driving extra revenue per impression.

[Trello card](https://trello.com/c/BdzdycMR/560-epic-choice-cards-v2-single-contributions-test)
[Figma file](https://www.figma.com/design/5gqxF1hxYTVRESozSZpyI2/Live-Blogs-Epic?node-id=563-1625&t=GOMcyUECGhFUAHxE-4)
## Screenshots

## V1 of New Choice cards
<img width="567" alt="image" src="https://github.com/user-attachments/assets/49cbec40-0b0f-4b0a-a0b4-df9eb888c1ea">


## V2 of New Choice cards
<img width="567" alt="image" src="https://github.com/user-attachments/assets/a745ea0f-1577-493d-9c98-3e0923bf0bd0">

## Clicking on Support just once from £1 , takes user to

<img width="1571" alt="image" src="https://github.com/user-attachments/assets/48174767-8a4a-4d59-90d1-271a338ecb53">

## Clicking on Support £4/month, takes user to

<img width="1571" alt="image" src="https://github.com/user-attachments/assets/69c24a5f-28d3-42fa-9ade-41d03b7a536b">

## Clicking on Support £12/month, takes user to
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/ceb05df7-a759-4198-bf89-ee6ac60903c5">

<!--
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
