### PR TITLE
[Fairground 🎡] Align first carousel card of carousel 

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -51,6 +51,21 @@ const itemStyles = css`
 		${from.tablet} {
 			margin-left: 0px;
 		}
+
+		${from.leftCol} {
+			padding-left: 160px;
+		}
+		${from.wide} {
+			padding-left: 240px;
+		}
+	}
+	:last-child {
+		${from.leftCol} {
+			padding-right: 160px;
+		}
+		${from.wide} {
+			padding-right: 240px;
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -15,7 +15,10 @@ type Props = { trails: DCRFrontCard[] };
 
 const containerStyles = css`
 	${from.tablet} {
-		padding: 0 20px;
+		padding: 0 ${space[5]}px;
+	}
+	${from.wide} {
+		padding-right: 100px;
 	}
 `;
 
@@ -52,14 +55,26 @@ const itemStyles = css`
 			margin-left: 0px;
 		}
 
+		/**
+		* From left col we add padding left to the first
+		* child so that the first card in the carousel aligns
+		* with the start of the pages content in the grid.
+		*/
+
 		${from.leftCol} {
-			padding-left: 160px;
+			padding-left: 160px; /** 160 === 2 columns and 2 column gaps  */
 		}
 		${from.wide} {
-			padding-left: 240px;
+			padding-left: 240px; /** 240 === 3 columns and 3 column gaps  */
 		}
 	}
 	:last-child {
+		/**
+		*From left col we add right padding to the
+		*last child to offset the first child's left padding.
+		*This ensures the carousel swipes fully across the container.
+		*/
+
 		${from.leftCol} {
 			padding-right: 160px;
 		}

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -122,10 +122,11 @@ const previousButtonFadeStyles = css`
 `;
 
 const nextButtonFadeStyles = css`
-	right: 0;
+	right: ${space[5]}px;
+	justify-content: flex-end;
 	background: linear-gradient(
 		to left,
-		${palette('--highlight-container-start-fade')} 0%,
+		${palette('--highlight-container-start-fade')} 0px,
 		${palette('--highlight-container-mid-fade')} 60%,
 		${palette('--highlight-container-end-fade')} 100%
 	);


### PR DESCRIPTION
## What does this change?
Adds left padding to align the first card of the carousel with the start of the content column of the grid from left col breakpoint and above. Right padding is added to the last child to make sure that the carousel can still scroll the full width of the container. 

## Why?
This is as per the designs.

## Screenshots

| Left Col   | Wide      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[after]: https://github.com/user-attachments/assets/89fd32c1-3096-458e-b74e-bf9915c264b8
[before]: https://github.com/user-attachments/assets/d0781ad1-6dad-4245-94f1-2230ebd25388


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
