### PR TITLE
[Fairground 🎡] Carousel scroll padding

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -34,6 +34,16 @@ const carouselStyles = css`
 	${until.desktop} {
 		scroll-padding-left: 10px;
 	}
+	${from.desktop} {
+		scroll-padding-left: 240px;
+	}
+	${from.leftCol} {
+		scroll-padding-left: 80px;
+	}
+
+	${from.wide} {
+		scroll-padding-left: 240px;
+	}
 	/**
 	* Hide scrollbars
 	* See: https://stackoverflow.com/a/38994837


### PR DESCRIPTION
## What does this change?
Updates the scroll padding across wider breakpoints to ensure the correct snap position. It also adjusts the background fade of the next button to make sure it aligns with the edge of the button and card.

## Why?
This is to make sure the correct cards are visible on screen after the initial scroll/click.

## Screenshots

| Desktop      | Left Col      | Wide      |
| ----------- | ---------- | ---------- |
| ![desktop][] | ![leftcol][] | ![wide][] |

[desktop]: https://github.com/user-attachments/assets/d3b18a1d-c2b0-42d9-b131-ec251d3224e5
[leftcol]: https://github.com/user-attachments/assets/97759d78-dcab-4e52-bc74-e07fed1377cb
[wide]: https://github.com/user-attachments/assets/dca131cd-cf17-406b-abd0-96c0031f2835

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
