### PR TITLE
Do not index commissioningdesk

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -74,6 +74,8 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		config,
 	} = props;
 
+	const doNotIndex = canonicalUrl?.includes('tracking/commissioningdesk');
+
 	/**
 	 * We escape windowGuardian here to prevent errors when the data
 	 * is placed in a script tag on the page
@@ -261,6 +263,7 @@ https://workforus.theguardian.com/careers/product-engineering/
                 <!--  This tag enables pages to be featured in Google Discover as large previews
                     See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1 -->
                 <meta name="robots" content="max-image-preview:large">
+				${doNotIndex && '<meta name="robots" content="noindex">'}
 
                 <script>
                     window.guardian = ${windowGuardian};


### PR DESCRIPTION
## What does this change?
Adds a noindex tag for /tracking/commissioningdesk
## Why?
We do not want these pages indexed by google
## Screenshots

<img width="473" alt="image" src="https://github.com/user-attachments/assets/31084d62-e7b4-49cf-9072-44416a7eba76">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
