### PR TITLE
Remove border-radius from top corners of tag link component

### DIFF
--- a/dotcom-rendering/src/components/TagLink.tsx
+++ b/dotcom-rendering/src/components/TagLink.tsx
@@ -31,7 +31,7 @@ const tagLinkStyles = css`
 	height: 44px;
 	width: 100%;
 	padding: ${space[2]}px;
-	border-radius: ${space[2]}px;
+	border-radius: 0 0 ${space[2]}px ${space[2]}px;
 	text-decoration: none;
 	background-color: ${palette('--tag-link-background')};
 	color: ${palette('--tag-link-accent')};


### PR DESCRIPTION
Closes #12047

## What does this change?

Removes the border-radius from the top corners of the tag link component

## Why?

This was causing an unintended visual effect with images below this component

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3ffa8803-0fd4-4205-a1de-17169b048254
[after]: https://github.com/user-attachments/assets/e05f2c1a-54ab-4785-9ec0-ee713c8e1c57

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
