### PR TITLE
Sort tag pages by `webPublicationDate`

### DIFF
--- a/dotcom-rendering/src/model/groupTrailsByDates.ts
+++ b/dotcom-rendering/src/model/groupTrailsByDates.ts
@@ -239,5 +239,19 @@ export const groupTrailsByDates = (
 		.sort((a, b) => b.epoch - a.epoch)
 		.map(({ groupedTrail }) => groupedTrail);
 
-	return sortedGroupedTrails;
+	const sortedGroupedTrailsByTime = sortedGroupedTrails.map(
+		(groupedTrail) => {
+			groupedTrail.trails.sort((a, b) => {
+				if (b.webPublicationDate && a.webPublicationDate) {
+					return (
+						new Date(b.webPublicationDate).getTime() -
+						new Date(a.webPublicationDate).getTime()
+					);
+				}
+				return 0;
+			});
+			return groupedTrail;
+		},
+	);
+	return sortedGroupedTrailsByTime;
 };


### PR DESCRIPTION
## What does this change?
Sorts tag page trails by `webPublicationDate`. This was not being done explicitly as trails come through mostly sorted correctly, the issue is mostly visible when a liveblog is present.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/12028
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1601ca93-69cd-4e9e-9764-6ab847b4f55a
[after]: https://github.com/user-attachments/assets/0bded374-fc05-4010-b314-d6c3978a88f0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
