### PR TITLE
[Fairground 🎡] [Highlights] Tablet alignment

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -168,10 +168,6 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		${from.tablet} {
 			grid-template-columns: repeat(${totalCards}, 1fr);
 		}
-
-		${from.desktop} {
-			grid-template-columns: repeat(${totalCards}, 1fr);
-		}
 	`;
 };
 

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -31,8 +31,11 @@ const carouselStyles = css`
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 	overscroll-behavior: contain;
-	${until.desktop} {
+	${until.tablet} {
 		scroll-padding-left: 10px;
+	}
+	${from.tablet} {
+		scroll-padding-left: 120px;
 	}
 	${from.desktop} {
 		scroll-padding-left: 240px;
@@ -163,10 +166,7 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		}
 
 		${from.tablet} {
-			grid-template-columns: repeat(
-				${totalCards},
-				calc((100% - ${peepingCardWidth}px) / 4)
-			);
+			grid-template-columns: repeat(${totalCards}, 1fr);
 		}
 
 		${from.desktop} {

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -38,6 +38,11 @@ const gridContainer = css`
 	${until.desktop} {
 		height: 194px;
 	}
+
+	${from.tablet} {
+		width: 160px;
+	}
+
 	${from.desktop} {
 		width: 300px;
 		grid-template-areas:


### PR DESCRIPTION
## What does this change?
Removes the peeping card and fixes the card width to 3 columns. It also adjusts the scroll padding so that only 2 columns of the far left card and one column of a fourth card is visible after the initial scroll / click.

## Why?
Previously, tablet cards had a fluid width and a peep card like mobile. This makes sense for mobile as mobile devices have a fluid grid. Tablet has a fixed grid like desktop and above. This change aligns tablet with the design patterns on desktop and higher which have fixed grids.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/caf1d5fc-ae75-464c-914e-cba20ec45f9f
[after]: https://github.com/user-attachments/assets/8fbf803b-3812-4109-aa7f-283dca77f968


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
