### PR TITLE
Align kickers for cards

### DIFF
--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -60,15 +60,6 @@ const flexBasisStyles = ({
 	}
 };
 
-const negativeTopMargin = css`
-	/**
-	* This reduces excess space above the card content, due to the line
-	* height of the text. It also ensures the top of the content aligns with
-	* with the top of the card image when the image is on the left or right.
-	*/
-	margin-top: -${space[1]}px;
-`;
-
 type Props = {
 	children: React.ReactNode;
 	imageType?: CardImageType;
@@ -96,7 +87,6 @@ export const ContentWrapper = ({
 				isHorizontalOnDesktop && [
 					flexBasisStyles({ imageSize, imageType }),
 				],
-				!isOnwardContent && negativeTopMargin,
 				css`
 					padding: ${!!hasBackgroundColour || !!isOnwardContent
 						? space[1]

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -21,11 +21,13 @@ type Props = {
 const standardTextStyles = css`
 	${textSans15}
 	/** We override the line height of the standard kicker
-	to match the overall height of the live kicker */
+	and add additional padding below the text, to align the text to
+	the top and match the overall height of the live kicker */
 	line-height: 1;
+	padding: 0 0 0.2em 0;
 `;
 
-const boldTextStyles = css`
+const boldTextOverrideStyles = css`
 	${textSansBold15}
 `;
 
@@ -65,7 +67,10 @@ export const Kicker = ({
 		if (isLiveKicker) {
 			return liveTextStyles;
 		} else {
-			return fontWeight === 'bold' ? boldTextStyles : standardTextStyles;
+			return [
+				standardTextStyles,
+				fontWeight === 'bold' && boldTextOverrideStyles,
+			];
 		}
 	};
 


### PR DESCRIPTION
## What does this change?

- Changes the alignment for standard kickers to ensure that they occupy the same height as for live kickers.
- Removes negative top margin on card content, which was there to align the top of the text to the edge of the image (if one existed)

Live kickers have a height of 18.2px (which is 14px from the font x 1.3 line height)

Standard kickers used to have a height of 19.5px (15px * 1.3) which has been adapted to 18px by setting the line height to 1 and then adding 0.2em of padding to the bottom of the kicker only, resulting in a total height of 18px (or 15px * 1.2)

This means there is now only 0.2px difference between the two and the alignment on the page can match in a variety of scenarios

## Why?

There is effort from the design teams to ensure accurate mark up of the new card UI. Without ensuring that the alignment and height of the kickers match, this makes their job extra difficult.

Resolving this in the code also reduces complexity and potential alignment bugs introduced in negative margin for the whole card content.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/7ccbf0f3-f469-43c6-97b3-dfc4369fac62
[after]: https://github.com/user-attachments/assets/e445b13f-024c-4b7a-b4b7-4d44fa7337df
[before2]: https://github.com/user-attachments/assets/4a78173e-532d-4e49-8723-371ff796a33d
[after2]: https://github.com/user-attachments/assets/3d3a1b24-e4e2-4d24-9050-2362ec7b4677

