### PR TITLE
Fix Headline Byline On Interview Articles In Dark Mode

### DIFF
--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -39,6 +39,7 @@ const interviewBylineBoxStyles = (format: ArticleFormat) => css`
 		-6px 0 0 ${schemedPalette('--byline-background')};
 	display: inline-block;
 	box-decoration-break: clone;
+	color: ${schemedPalette('--headline-byline')};
 
 	a {
 		color: ${schemedPalette('--byline-anchor')};

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -259,7 +259,7 @@ const headlineBlogBackgroundDark: PaletteFunction = ({
 	return headlineBackgroundDark({ design, display, theme });
 };
 
-const headlineBylineLight: PaletteFunction = ({ display, theme }) => {
+const headlineBylineLight: PaletteFunction = ({ design, display, theme }) => {
 	switch (display) {
 		case ArticleDisplay.Immersive: {
 			switch (theme) {
@@ -274,11 +274,16 @@ const headlineBylineLight: PaletteFunction = ({ display, theme }) => {
 			}
 		}
 		default:
-			return 'inherit';
+			switch (design) {
+				case ArticleDesign.Interview:
+					return sourcePalette.neutral[7];
+				default:
+					return 'inherit';
+			}
 	}
 };
 
-const headlineBylineDark: PaletteFunction = ({ display, theme }) => {
+const headlineBylineDark: PaletteFunction = ({ design, display, theme }) => {
 	switch (display) {
 		case ArticleDisplay.Immersive: {
 			switch (theme) {
@@ -293,7 +298,12 @@ const headlineBylineDark: PaletteFunction = ({ display, theme }) => {
 			}
 		}
 		default:
-			return 'inherit';
+			switch (design) {
+				case ArticleDesign.Interview:
+					return sourcePalette.neutral[7];
+				default:
+					return 'inherit';
+			}
 	}
 };
 


### PR DESCRIPTION
Previously it was inheriting a light colour, which didn't work on the yellow background.

| Before | After |
|--------|--------|
| ![byline-before] | ![byline-after] | 

[byline-after]: https://github.com/user-attachments/assets/dd84bafe-5046-493c-941d-0985a90bc978
[byline-before]: https://github.com/user-attachments/assets/d07e735e-58e8-4775-b61f-07d8f3216327
