### PR TITLE
Remove `updateLogoAdPartnerSwitch` from the logic

### DIFF
--- a/dotcom-rendering/.storybook/decorators/configContextDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/configContextDecorator.tsx
@@ -6,7 +6,6 @@ import { Config } from '../../src/types/configContext';
 const defaultConfig = {
 	renderingTarget: 'Web',
 	darkModeAvailable: false,
-	updateLogoAdPartnerSwitch: false,
 	assetOrigin: '/',
 	editionId: 'UK',
 } satisfies Config;

--- a/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.stories.tsx
@@ -179,7 +179,6 @@ export const WithBrandingStoryForAdvertisingPartner = {
 		...WithBrandingStory.parameters,
 		config: {
 			...WithBrandingStory.parameters.config,
-			updateLogoAdPartnerSwitch: true,
 		},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/ArticleMeta.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.stories.tsx
@@ -196,7 +196,7 @@ export const BrandingForAdvertisingPartner: StoryObj = ({
 };
 BrandingForAdvertisingPartner.args = { format: defaultFormat };
 BrandingForAdvertisingPartner.parameters = {
-	config: { darkModeAvailable: true, updateLogoAdPartnerSwitch: true },
+	config: { darkModeAvailable: true },
 };
 BrandingForAdvertisingPartner.decorators = [
 	browserThemeDecorator(defaultFormat),

--- a/dotcom-rendering/src/components/ArticleMeta.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.test.tsx
@@ -19,7 +19,6 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -67,7 +66,6 @@ describe('ArticleMeta', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/Badge.tsx
+++ b/dotcom-rendering/src/components/Badge.tsx
@@ -47,7 +47,6 @@ type Props = {
 	ophanComponentName?: string;
 	isInLabsSection?: boolean;
 	isAdvertisingPartner?: boolean;
-	updateLogoAdPartnerSwitch?: boolean;
 };
 
 export const Badge = ({
@@ -57,7 +56,6 @@ export const Badge = ({
 	ophanComponentName,
 	isInLabsSection = false,
 	isAdvertisingPartner = false,
-	updateLogoAdPartnerSwitch = false,
 }: Props) => {
 	return (
 		<a
@@ -72,9 +70,7 @@ export const Badge = ({
 					isInLabsSection
 						? labsSectionBadgeSizingStyles
 						: frontsSectionBadgeSizingStyles,
-					isAdvertisingPartner &&
-						updateLogoAdPartnerSwitch &&
-						imageAdvertisingPartnerStyles,
+					isAdvertisingPartner && imageAdvertisingPartnerStyles,
 				]}
 				src={imageSrc}
 				alt={isInLabsSection ? 'Labs sponsor logo' : ''}

--- a/dotcom-rendering/src/components/Branding.importable.tsx
+++ b/dotcom-rendering/src/components/Branding.importable.tsx
@@ -214,7 +214,7 @@ export const Branding = ({ branding, format }: Props) => {
 		locationPrefix: 'article-meta',
 	});
 
-	const { darkModeAvailable, updateLogoAdPartnerSwitch } = useConfig();
+	const { darkModeAvailable } = useConfig();
 
 	const isAdvertisingPartnerOrExclusive =
 		branding.logo.label.toLowerCase() === 'advertising partner' ||
@@ -228,18 +228,14 @@ export const Branding = ({ branding, format }: Props) => {
 			css={[
 				brandingStyle,
 				isAdvertisingPartnerOrExclusive &&
-					updateLogoAdPartnerSwitch &&
 					brandingAdvertisingPartnerStyle,
-				isAdvertisingPartnerAndInteractive &&
-					updateLogoAdPartnerSwitch &&
-					brandingInteractiveStyle,
+				isAdvertisingPartnerAndInteractive && brandingInteractiveStyle,
 			]}
 		>
 			<div
 				css={[
 					labelStyle,
 					isAdvertisingPartnerOrExclusive &&
-						updateLogoAdPartnerSwitch &&
 						labelAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogLabelStyle,
 				]}
@@ -250,7 +246,6 @@ export const Branding = ({ branding, format }: Props) => {
 				css={[
 					brandingLogoStyle,
 					isAdvertisingPartnerOrExclusive &&
-						updateLogoAdPartnerSwitch &&
 						!isInteractive &&
 						brandingLogoAdvertisingPartnerStyle,
 				]}
@@ -273,7 +268,6 @@ export const Branding = ({ branding, format }: Props) => {
 				css={[
 					aboutLinkStyle,
 					isAdvertisingPartnerOrExclusive &&
-						updateLogoAdPartnerSwitch &&
 						aboutLinkAdvertisingPartnerStyle,
 					isLiveBlog && liveBlogAboutLinkStyle,
 				]}

--- a/dotcom-rendering/src/components/BylineLink.test.tsx
+++ b/dotcom-rendering/src/components/BylineLink.test.tsx
@@ -108,7 +108,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -152,7 +151,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -198,7 +196,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -240,7 +237,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -273,7 +269,6 @@ describe('BylineLink', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/ConfigContext.test.tsx
+++ b/dotcom-rendering/src/components/ConfigContext.test.tsx
@@ -24,21 +24,18 @@ describe('ConfigContext', () => {
 			{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
-				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 				editionId: 'UK',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: true,
-				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 				editionId: 'UK',
 			},
 			{
 				renderingTarget: 'Apps',
 				darkModeAvailable: false,
-				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 				editionId: 'INT',
 			},

--- a/dotcom-rendering/src/components/Contributor.test.tsx
+++ b/dotcom-rendering/src/components/Contributor.test.tsx
@@ -19,7 +19,6 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -55,7 +54,6 @@ describe('Contributor', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/DateTime.stories.tsx
+++ b/dotcom-rendering/src/components/DateTime.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta<typeof DateTime> = {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 						editionId,
 					}}

--- a/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion/Discussion.test.tsx
@@ -18,7 +18,6 @@ describe('App', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/Dropdown.test.tsx
+++ b/dotcom-rendering/src/components/Dropdown.test.tsx
@@ -45,7 +45,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -68,7 +67,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -94,7 +92,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -119,7 +116,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -146,7 +142,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -174,7 +169,6 @@ describe('Dropdown', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/FooterReaderRevenueLinks.test.tsx
+++ b/dotcom-rendering/src/components/FooterReaderRevenueLinks.test.tsx
@@ -41,7 +41,6 @@ describe('FooterReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -64,7 +63,6 @@ describe('FooterReaderRevenueLinks', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -336,7 +336,6 @@ export const WithSponsoredBrandingAdvertisingPartner = () => {
 				isContainerBranding: false,
 				hasMultipleBranding: false,
 			}}
-			updateLogoAdPartnerSwitch={true}
 		>
 			<Placeholder />
 		</FrontSection>
@@ -367,7 +366,6 @@ export const WithSponsoredBrandingAdvertisingPartnerTagPages = () => {
 				isContainerBranding: false,
 				hasMultipleBranding: false,
 			}}
-			updateLogoAdPartnerSwitch={true}
 		>
 			<Placeholder />
 		</FrontSection>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -81,7 +81,6 @@ type Props = {
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
-	updateLogoAdPartnerSwitch?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -444,7 +443,6 @@ export const FrontSection = ({
 	discussionApiUrl,
 	collectionBranding,
 	isTagPage = false,
-	updateLogoAdPartnerSwitch = false,
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
 	const showMore =
@@ -516,7 +514,6 @@ export const FrontSection = ({
 							/>
 						}
 						collectionBranding={collectionBranding}
-						updateLogoAdPartnerSwitch={updateLogoAdPartnerSwitch}
 					/>
 
 					{leftContent}

--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -14,7 +14,6 @@ import { Badge } from './Badge';
 type Props = {
 	title: React.ReactNode;
 	collectionBranding: CollectionBranding | undefined;
-	updateLogoAdPartnerSwitch: boolean;
 };
 
 const titleStyle = css`
@@ -78,11 +77,7 @@ const aboutThisLinkAdvertisingPartnerStyles = css`
 	color: ${sourcePalette.news[400]};
 `;
 
-export const FrontSectionTitle = ({
-	title,
-	collectionBranding,
-	updateLogoAdPartnerSwitch,
-}: Props) => {
+export const FrontSectionTitle = ({ title, collectionBranding }: Props) => {
 	switch (collectionBranding?.kind) {
 		case 'foundation': {
 			const {
@@ -172,14 +167,12 @@ export const FrontSectionTitle = ({
 				return (
 					<div css={titleStyle}>
 						{title}
-						{isAdvertisingPartnerOrExclusive &&
-						updateLogoAdPartnerSwitch ? (
+						{isAdvertisingPartnerOrExclusive ? (
 							<hr css={advertisingPartnerDottedBorder} />
 						) : null}
 						<div
 							css={
 								isAdvertisingPartnerOrExclusive &&
-								updateLogoAdPartnerSwitch &&
 								brandingAdvertisingPartnerStyle
 							}
 						>
@@ -187,7 +180,6 @@ export const FrontSectionTitle = ({
 								css={[
 									labelStyles,
 									isAdvertisingPartnerOrExclusive &&
-										updateLogoAdPartnerSwitch &&
 										labelAdvertisingPartnerStyles,
 								]}
 							>
@@ -199,16 +191,12 @@ export const FrontSectionTitle = ({
 								isAdvertisingPartner={
 									isAdvertisingPartnerOrExclusive
 								}
-								updateLogoAdPartnerSwitch={
-									updateLogoAdPartnerSwitch
-								}
 							/>
 							<a
 								href={aboutThisLink}
 								css={[
 									aboutThisLinkStyles,
 									isAdvertisingPartnerOrExclusive &&
-										updateLogoAdPartnerSwitch &&
 										aboutThisLinkAdvertisingPartnerStyles,
 								]}
 							>

--- a/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
+++ b/dotcom-rendering/src/components/GuideAtom/GuideAtom.test.tsx
@@ -11,7 +11,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -38,7 +37,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -66,7 +64,6 @@ describe('GuideAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -84,7 +84,6 @@ describe('Island: server-side rendering', () => {
 			value={{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
-				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 				editionId: 'UK',
 			}}

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -26,7 +26,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -70,7 +69,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -133,7 +131,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -181,7 +178,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -205,7 +201,6 @@ describe('MostViewedFooterData', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.test.tsx
@@ -23,7 +23,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -74,7 +73,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -104,7 +102,6 @@ describe('MostViewedList', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/Nav/Nav.test.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.test.tsx
@@ -10,7 +10,6 @@ describe('Nav', () => {
 			value={{
 				renderingTarget: 'Web',
 				darkModeAvailable: false,
-				updateLogoAdPartnerSwitch: false,
 				assetOrigin: '/',
 				editionId: 'UK',
 			}}

--- a/dotcom-rendering/src/components/ProfileAtom.test.tsx
+++ b/dotcom-rendering/src/components/ProfileAtom.test.tsx
@@ -9,7 +9,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -50,7 +49,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -92,7 +90,6 @@ describe('ProfileAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/QandaAtom.test.tsx
+++ b/dotcom-rendering/src/components/QandaAtom.test.tsx
@@ -11,7 +11,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -38,7 +37,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -66,7 +64,6 @@ describe('QandaAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.importable.test.tsx
@@ -16,7 +16,6 @@ describe('RichLinkComponent', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 						editionId: 'UK',
 					}}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMainCheckoutComplete.test.tsx
@@ -32,7 +32,6 @@ describe('SignInGateMainCheckoutComplete', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/TimelineAtom.test.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.test.tsx
@@ -11,7 +11,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -38,7 +37,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -66,7 +64,6 @@ describe('TimelineAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -28,7 +28,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -66,7 +65,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -113,7 +111,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -152,7 +149,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -193,7 +189,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -232,7 +227,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -270,7 +264,6 @@ describe('YoutubeAtom', () => {
 				value={{
 					renderingTarget: 'Web',
 					darkModeAvailable: false,
-					updateLogoAdPartnerSwitch: false,
 					assetOrigin: '/',
 					editionId: 'UK',
 				}}
@@ -312,7 +305,6 @@ describe('YoutubeAtom', () => {
 					value={{
 						renderingTarget: 'Web',
 						darkModeAvailable: false,
-						updateLogoAdPartnerSwitch: false,
 						assetOrigin: '/',
 						editionId: 'UK',
 					}}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -168,8 +168,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const inHighlightsContainerABTest =
 		abTests.mastheadWithHighlightsVariant === 'variant';
 
-	const { updateLogoAdPartner, absoluteServerTimes = false } =
-		front.config.switches;
+	const { absoluteServerTimes = false } = front.config.switches;
 
 	const Highlights = () => {
 		const showHighlights =
@@ -494,9 +493,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
-									updateLogoAdPartnerSwitch={
-										updateLogoAdPartner
-									}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -716,7 +712,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								collectionBranding={
 									collection.collectionBranding
 								}
-								updateLogoAdPartnerSwitch={updateLogoAdPartner}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -278,9 +278,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 								discussionApiUrl={
 									tagPage.config.discussionApiUrl
 								}
-								updateLogoAdPartnerSwitch={
-									!!switches.updateLogoAdPartner
-								}
 							>
 								<DecideContainerByTrails
 									trails={groupedTrails.trails}

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -28,7 +28,6 @@ export const renderEditorialNewslettersPage = ({
 	const config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
-		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: newslettersPage.editionId,
 	} satisfies Config;

--- a/dotcom-rendering/src/server/render.article.amp.tsx
+++ b/dotcom-rendering/src/server/render.article.amp.tsx
@@ -44,7 +44,6 @@ export const renderArticle = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: false,
-		updateLogoAdPartnerSwitch: false,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: 'INT', // AMP pages have all editions in the HTML
 	};

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -26,8 +26,6 @@ export const renderArticle = (
 	const config: Config = {
 		renderingTarget,
 		darkModeAvailable: true,
-		updateLogoAdPartnerSwitch:
-			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: article.editionId,
 	};

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -57,8 +57,6 @@ export const renderHtml = ({
 		renderingTarget,
 		darkModeAvailable:
 			article.config.abTests.darkModeWebVariant === 'variant',
-		updateLogoAdPartnerSwitch:
-			!!article.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: article.editionId,
 	};
@@ -268,7 +266,6 @@ export const renderBlocks = ({
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable: abTests.darkModeWebVariant === 'variant',
-		updateLogoAdPartnerSwitch: !!switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 		editionId,
 	};

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -87,7 +87,6 @@ export const renderFront = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			front.config.abTests.darkModeWebVariant === 'variant',
-		updateLogoAdPartnerSwitch: !!front.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: front.editionId,
 	} satisfies Config;
@@ -190,8 +189,6 @@ export const renderTagPage = ({
 		renderingTarget: 'Web',
 		darkModeAvailable:
 			tagPage.config.abTests.darkModeWebVariant === 'variant',
-		updateLogoAdPartnerSwitch:
-			!!tagPage.config.switches.updateLogoAdPartner,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: tagPage.editionId,
 	};

--- a/dotcom-rendering/src/types/configContext.ts
+++ b/dotcom-rendering/src/types/configContext.ts
@@ -12,14 +12,12 @@ export type Config =
 	| Readonly<{
 			renderingTarget: Extract<RenderingTarget, 'Web'>;
 			darkModeAvailable: boolean;
-			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
 			editionId: EditionId;
 	  }>
 	| Readonly<{
 			renderingTarget: Extract<RenderingTarget, 'Apps'>;
 			darkModeAvailable: boolean;
-			updateLogoAdPartnerSwitch: boolean;
 			assetOrigin: AssetOrigin;
 			editionId: EditionId;
 	  }>;


### PR DESCRIPTION
## What does this change?

This removes the `updateLogoAdPartnerSwitch` from the logic of this work and now the condition just relies on the label value which should be "Advertising partner" or "Exclusive advertising partner" in order to display the styling that the US team requested.

For more details regarding the work done previously check https://github.com/guardian/dotcom-rendering/pull/11485

## Why?

We are removing the switch as the first campaign is live and we had no issues so no need for the switch.

## Screenshots

Tested locally and in CODE in US for this series https://www.theguardian.com/business/series/the-new-face-of-small-business

![image](https://github.com/user-attachments/assets/f62087fa-a970-4513-ad43-37729e838ee3)


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
