### PR TITLE
Bump ophan-tracker-js to v2.2.2

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",
 		"@guardian/libs": "17.0.1",
-		"@guardian/ophan-tracker-js": "2.2.1",
+		"@guardian/ophan-tracker-js": "2.2.2",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "workspace:*",
 		"@guardian/source-development-kitchen": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: 17.0.1
         version: 17.0.1(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js':
-        specifier: 2.2.1
-        version: 2.2.1
+        specifier: 2.2.2
+        version: 2.2.2
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -3996,8 +3996,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@guardian/ophan-tracker-js@2.2.1:
-    resolution: {integrity: sha512-aQnmZQyfzeoImZ+wnf3QCKbMh2pMmUa2KAl2n0sEUGcV5ejsHgxP8KHyEDNxPzF8QhI7S1t9OaQlzlEA+Xs5Tw==}
+  /@guardian/ophan-tracker-js@2.2.2:
+    resolution: {integrity: sha512-g+Xouc0bU1fC+8qltuLexBxK67V534ZFDQ/bGWQtYDFSJJJtyPIq6ytPcn4KULNOQc+zRsUcRIfO0uRnjJScbw==}
     engines: {node: '>=16'}
     dependencies:
       '@guardian/tsconfig': 1.0.0


### PR DESCRIPTION
## What does this change?

Bumps `ophan-tracker-js` to v2.2.2

## Why?

Keep dependencies up to date