### PR TITLE
Add new Mehdi Hasan newsletter on US only

### DIFF
--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -127,8 +127,8 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 				'green-light', // Down to Earth
 				'soccer-with-jonathan-wilson',
 				'follow-mehdi-hasan',
-				'follow-robert-reich',
 				'follow-margaret-sullivan',
+				'follow-robert-reich',
 				'patriarchy',
 				'this-is-europe',
 				'tech-scape',

--- a/dotcom-rendering/src/model/newsletter-grouping.ts
+++ b/dotcom-rendering/src/model/newsletter-grouping.ts
@@ -126,6 +126,7 @@ export const groups: Partial<Record<EditionId, StaticGroups>> = {
 			newsletters: [
 				'green-light', // Down to Earth
 				'soccer-with-jonathan-wilson',
+				'follow-mehdi-hasan',
 				'follow-robert-reich',
 				'follow-margaret-sullivan',
 				'patriarchy',


### PR DESCRIPTION
Closes #12076

## What does this change?

Adds the "Follow Mehdi Hasan" newsletter to the third position of the "In Depth" row on the [newsletters page](https://www.theguardian.com/email-newsletters).

Swaps the positions of Margaret and Robert in this row.

## Why?

Request for editorial