### PR TITLE
Remove padding-bottom from inline kickers

### DIFF
--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -24,7 +24,7 @@ const standardTextStyles = css`
 	and add additional padding below the text, to align the text to
 	the top and match the overall height of the live kicker */
 	line-height: 1;
-	padding: 0 0 0.2em 0;
+	padding-bottom: 0.2em;
 `;
 
 const boldTextOverrideStyles = css`
@@ -43,6 +43,8 @@ const liveTextStyles = css`
 const hideLineBreakStyles = css`
 	display: inline-block;
 	margin-right: ${space[1]}px;
+	/** Unset the padding-bottom from standard kicker */
+	padding-bottom: 0;
 `;
 
 /**


### PR DESCRIPTION
## What does this change?

Unsets the padding-bottom on kickers when inline

## Why?

Inline kickers take the line height of the headline. When the headline text is smaller than the kicker text, such as in sublinks, the kicker text causes the line height to increase. This results in a large distance between the first and second line of text, and the second and third line of text.

This bug already existed but became more pronounced after adding explicit padding to the bottom of the `Kicker` component

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fd39c0e0-ded7-4ede-8814-9391cf37ea4e
[after]: https://github.com/user-attachments/assets/04e765b7-38b1-4c2c-a1aa-8314c1bd5d14

