### PR TITLE
Rework the alignment of the burger menu in the Titlepiece

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -145,23 +145,24 @@ const burgerStyles = css`
 	justify-content: center;
 	display: flex;
 	justify-self: end;
-	padding-bottom: 2px;
+	position: relative;
+	bottom: 2px;
 	${from.mobileMedium} {
-		padding-bottom: ${space[1]}px;
+		bottom: ${space[1]}px;
 	}
 	${from.desktop} {
-		margin-right: 356px;
-		padding-bottom: 6px;
+		right: 354px;
+		bottom: 6px;
 	}
 `;
 
 const burgerStylesFromLeftCol = css`
 	${from.leftCol} {
-		margin-right: 428px;
-		padding-bottom: ${space[2]}px;
+		right: 430px;
+		bottom: 14px;
 	}
 	${from.wide} {
-		margin-right: 536px;
+		right: 534px;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Adjusts the alignment of the veggie burger menu after QA review from team

## Why?

The alignment felt slightly off before.

Part of the Fairground project to update the homepages.
[Relevant trello ticket link](https://trello.com/c/mDCxb2mX/340-topbar-titlepiece-qa-fixes)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/dc7cfd9e-dd9c-4250-840d-fdd17f43bd27
[after]: https://github.com/user-attachments/assets/0bc644b8-c6dd-4a05-bae1-1ca65d474b80
[before2]: https://github.com/user-attachments/assets/2ce76d7b-7dba-4e0d-9a2c-c3ef37a27ef5
[after2]: https://github.com/user-attachments/assets/ec74acef-dabf-4914-a722-cff9ae3bdc7e
