### PR TITLE
Fix Titlepiece dropdown menus alignment

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -15,7 +15,7 @@ interface EditionDropdownProps {
 }
 
 const editionDropdownStyles = css`
-	${getZIndex('mastheadEditionSwitcher')};
+	${getZIndex('mastheadEditionDropdown')};
 	display: flex;
 	/** Required to absolutely position the dropdown menu */
 	position: relative;
@@ -31,10 +31,8 @@ const editionDropdownStyles = css`
 		min-width: 200px;
 
 		${from.mobileMedium} {
-			position: absolute;
-			right: 0;
 			left: unset;
-			max-height: unset;
+			right: 0;
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -23,12 +23,18 @@ const editionDropdownStyles = css`
 	${textSans17}
 	margin-top: ${space[1]}px;
 
-	${from.mobileMedium} {
-		ul {
+	ul {
+		position: absolute;
+		left: 0;
+		right: unset;
+		max-height: unset;
+		min-width: 200px;
+
+		${from.mobileMedium} {
 			position: absolute;
 			right: 0;
 			left: unset;
-			max-height: auto;
+			max-height: unset;
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -17,20 +17,33 @@ interface EditionDropdownProps {
 const editionDropdownStyles = css`
 	${getZIndex('editionDropdown')};
 	display: flex;
+	/** Required to absolutely position the dropdown menu */
 	position: relative;
+	color: ${themePalette('--masthead-nav-link-text')};
+	${textSans17}
+	margin-top: ${space[1]}px;
 `;
 
 const dropDownOverrides = css`
 	${textSans17}
 	color: ${themePalette('--masthead-nav-link-text')};
-	padding: 0;
+	padding: 6px 0 0 0;
 	margin-top: ${space[1]}px;
+
 	&:not(ul):hover {
 		color: ${themePalette('--masthead-nav-link-text')};
 		text-decoration: underline;
 	}
-	${from.tablet} {
-		right: 0;
+
+	&:not(button) {
+		position: absolute;
+		top: 32px;
+		max-height: max-content;
+
+		${from.mobileMedium} {
+			right: 0;
+			left: unset;
+		}
 	}
 `;
 
@@ -71,10 +84,7 @@ export const EditionDropdown = ({
 				links={linksToDisplay}
 				id="edition"
 				dataLinkName={dataLinkName}
-				cssOverrides={css`
-					${dropDownOverrides};
-					padding-top: 6px;
-				`}
+				cssOverrides={dropDownOverrides}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -15,13 +15,22 @@ interface EditionDropdownProps {
 }
 
 const editionDropdownStyles = css`
-	${getZIndex('editionDropdown')};
+	${getZIndex('mastheadEditionSwitcher')};
 	display: flex;
 	/** Required to absolutely position the dropdown menu */
 	position: relative;
 	color: ${themePalette('--masthead-nav-link-text')};
 	${textSans17}
 	margin-top: ${space[1]}px;
+
+	${from.mobileMedium} {
+		ul {
+			position: absolute;
+			right: 0;
+			left: unset;
+			max-height: auto;
+		}
+	}
 `;
 
 const dropDownOverrides = css`
@@ -33,17 +42,6 @@ const dropDownOverrides = css`
 	&:not(ul):hover {
 		color: ${themePalette('--masthead-nav-link-text')};
 		text-decoration: underline;
-	}
-
-	&:not(button) {
-		position: absolute;
-		top: 32px;
-		max-height: max-content;
-
-		${from.mobileMedium} {
-			right: 0;
-			left: unset;
-		}
 	}
 `;
 
@@ -82,7 +80,7 @@ export const EditionDropdown = ({
 			<Dropdown
 				label={activeEdition.id}
 				links={linksToDisplay}
-				id="edition"
+				id="masthead-edition"
 				dataLinkName={dataLinkName}
 				cssOverrides={dropDownOverrides}
 			/>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -51,6 +51,7 @@ const editionSwitcherMenuStyles = css`
 	${from.mobileMedium} {
 		justify-self: end;
 	}
+	width: fit-content;
 `;
 
 const accreditationStyles = css`

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -9,7 +9,6 @@ import {
 	visuallyHidden,
 } from '@guardian/source/foundations';
 import type { EditionId } from '../../../lib/edition';
-import { getZIndex } from '../../../lib/getZIndex';
 import { nestedOphanComponents } from '../../../lib/ophan-helpers';
 import type { NavType } from '../../../model/extract-nav';
 import { palette as themePalette } from '../../../palette';
@@ -81,7 +80,6 @@ const accreditationStylesFromLeftCol = css`
 `;
 
 const logoStyles = css`
-	${getZIndex('TheGuardian')}
 	${gridMainColumn}
 	grid-row: 1;
 	justify-self: end;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
@@ -12,7 +12,7 @@ const labelStyles = css`
 	${`#${navInputCheckboxId}`}:checked ~ div & {
 		${until.desktop} {
 			/* Bump the z-index of the burger menu when expanded */
-			${getZIndex('expanded-veggie-burger-mobile')}
+			${getZIndex('mastheadVeggieBurgerExpandedMobile')}
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
@@ -11,7 +11,7 @@ const labelStyles = css`
 	z-index: 1;
 	${`#${navInputCheckboxId}`}:checked ~ div & {
 		/* Bump the z-index of the burger menu when expanded */
-		${getZIndex('burger')}
+		${getZIndex('expanded-veggie-burger')}
 	}
 `;
 

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/VeggieBurger.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { visuallyHidden } from '@guardian/source/foundations';
+import { until, visuallyHidden } from '@guardian/source/foundations';
 import { SvgCross, SvgMenu } from '@guardian/source/react-components';
 import { getZIndex } from '../../../lib/getZIndex';
 import { nestedOphanComponents } from '../../../lib/ophan-helpers';
@@ -10,8 +10,10 @@ const labelStyles = css`
 	position: relative;
 	z-index: 1;
 	${`#${navInputCheckboxId}`}:checked ~ div & {
-		/* Bump the z-index of the burger menu when expanded */
-		${getZIndex('expanded-veggie-burger')}
+		${until.desktop} {
+			/* Bump the z-index of the burger menu when expanded */
+			${getZIndex('expanded-veggie-burger-mobile')}
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -173,16 +173,16 @@ export const dropDownOverrides = css`
 	/** Handles case of *new* top bar being 52px high until tablet */
 	&:not(button) {
 		${until.tablet} {
-			top: 48px;
+			top: 44px;
 		}
 
 		${from.tablet} {
-			left: 0;
-			top: 56px;
+			right: 0;
+			top: 52px;
 		}
 
 		${from.desktop} {
-			top: 60px;
+			top: 56px;
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -75,7 +75,7 @@ const myAccountLinkStyles = css`
 		margin: 0 ${space[1]}px 0 0;
 	}
 
-	${getZIndex('myAccountDropdownV2')}
+	${getZIndex('mastheadMyAccountDropdown')}
 `;
 
 export const buildIdentityLinks = (

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,18 +2,20 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 29;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 28;');
-		expect(getZIndex('banner')).toBe('z-index: 27;');
-		expect(getZIndex('dropdown')).toBe('z-index: 26;');
-		expect(getZIndex('burger')).toBe('z-index: 25;');
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 24;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 23;');
-		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 19;');
-		expect(getZIndex('myAccountDropdownV2')).toBe('z-index: 18;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 31;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
+		expect(getZIndex('banner')).toBe('z-index: 29;');
+		expect(getZIndex('dropdown')).toBe('z-index: 28;');
+		expect(getZIndex('burger')).toBe('z-index: 27;');
+		expect(getZIndex('mastheadEditionSwitcher')).toBe('z-index: 26;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 22;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
+		expect(getZIndex('expanded-veggie-burger')).toBe('z-index: 19;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 18;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
 		expect(getZIndex('toast')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -7,15 +7,15 @@ describe('getZIndex', () => {
 		expect(getZIndex('banner')).toBe('z-index: 29;');
 		expect(getZIndex('dropdown')).toBe('z-index: 28;');
 		expect(getZIndex('burger')).toBe('z-index: 27;');
-		expect(getZIndex('mastheadEditionSwitcher')).toBe('z-index: 26;');
+		expect(getZIndex('expanded-veggie-burger-mobile')).toBe('z-index: 26;');
 		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
 		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
 		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
 		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 22;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
 		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
-		expect(getZIndex('expanded-veggie-burger')).toBe('z-index: 19;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 18;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 19;');
+		expect(getZIndex('mastheadEditionSwitcher')).toBe('z-index: 18;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
 		expect(getZIndex('toast')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -7,7 +7,9 @@ describe('getZIndex', () => {
 		expect(getZIndex('banner')).toBe('z-index: 29;');
 		expect(getZIndex('dropdown')).toBe('z-index: 28;');
 		expect(getZIndex('burger')).toBe('z-index: 27;');
-		expect(getZIndex('expanded-veggie-burger-mobile')).toBe('z-index: 26;');
+		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
+			'z-index: 26;',
+		);
 		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
 		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
 		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
@@ -15,7 +17,7 @@ describe('getZIndex', () => {
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
 		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
 		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 19;');
-		expect(getZIndex('mastheadEditionSwitcher')).toBe('z-index: 18;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 18;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
 		expect(getZIndex('toast')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -31,7 +31,7 @@ const indices = [
 	'banner',
 	'dropdown',
 	'burger',
-	'expanded-veggie-burger-mobile',
+	'mastheadVeggieBurgerExpandedMobile',
 	'expanded-veggie-menu-wrapper',
 	'expanded-veggie-menu',
 
@@ -44,7 +44,7 @@ const indices = [
 	'stickyAdWrapperNav',
 
 	'mastheadMyAccountDropdown',
-	'mastheadEditionSwitcher',
+	'mastheadEditionDropdown',
 
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -31,8 +31,6 @@ const indices = [
 	'banner',
 	'dropdown',
 	'burger',
-	'expanded-veggie-menu-wrapper',
-	'expanded-veggie-menu',
 
 	// Mobile sticky appears below banners
 	'mobileSticky',
@@ -42,7 +40,12 @@ const indices = [
 	'stickyAdWrapper',
 	'stickyAdWrapperNav',
 
-	'myAccountDropdownV2',
+	'mastheadEditionSwitcher',
+	'expanded-veggie-menu-wrapper',
+	'expanded-veggie-menu',
+	// Burger (expanded nav) should be below sticky ads
+	'expanded-veggie-burger',
+	'mastheadMyAccountDropdown',
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -31,6 +31,9 @@ const indices = [
 	'banner',
 	'dropdown',
 	'burger',
+	'expanded-veggie-burger-mobile',
+	'expanded-veggie-menu-wrapper',
+	'expanded-veggie-menu',
 
 	// Mobile sticky appears below banners
 	'mobileSticky',
@@ -40,12 +43,9 @@ const indices = [
 	'stickyAdWrapper',
 	'stickyAdWrapperNav',
 
-	'mastheadEditionSwitcher',
-	'expanded-veggie-menu-wrapper',
-	'expanded-veggie-menu',
-	// Burger (expanded nav) should be below sticky ads
-	'expanded-veggie-burger',
 	'mastheadMyAccountDropdown',
+	'mastheadEditionSwitcher',
+
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 


### PR DESCRIPTION
## What does this change?

- Amends the styles for the `EditionDropdown` component, targeting the inner `ul` element directly rather than using the `cssOverrides` for positioning the expanded dropdown menu
  - Overrides the `position: fixed` for mobile and tablet screens in favour of relative positioning as the menu is no longer part of the top bar so cannot be guaranteed to be at the top of the screen
- Removes the `z-index` value on the logo as this isn't required
- Fixes the burger menu `z-index` problem (overlapping banner ad) as it only needs to apply to mobile/tablet screen sizes
- Uses separate names for `z-index` IDs in `getZIndex` to avoid altering the stacking order of menu items in the current nav
- Adjusts the position of the my account dropdown menu which fixes a visual bug where the menu appeared too far to the right

## Why?

Fixing visual bugs for the new Titlepiece component after a team QA session

Resolves two items on [this checklist ticket](https://trello.com/c/mDCxb2mX/340-topbar-titlepiece-qa-fixes)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/fa13534e-dd5c-4a55-9eab-a3980648090a
[after]: https://github.com/user-attachments/assets/baaa028c-6182-4b29-8575-2f338a7e3d29
[before2]: https://github.com/user-attachments/assets/5fa9f2db-f915-47b8-ad84-31ae9ed8aba9
[after2]: https://github.com/user-attachments/assets/69f7f90f-de58-4038-896c-7683ef7a03b2
[before3]: https://github.com/user-attachments/assets/43028c8c-fcee-4abc-b4b3-aeeb1f69699d
[after3]: https://github.com/user-attachments/assets/81ff75b7-e62f-4a36-95d5-6cae8e3661e5






