### PR TITLE
Ensure highlights cards have their own format applied

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -39,6 +39,8 @@ type Props = {
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isExternalLink?: boolean;
+	/** Is the headline inside a Highlights card? */
+	isHighlights?: boolean;
 };
 
 const fontStyles = ({ size }: { size: SmallHeadlineSize }) => {
@@ -218,8 +220,11 @@ export const CardHeadline = ({
 	showByline,
 	linkTo,
 	isExternalLink,
+	isHighlights = false,
 }: Props) => {
-	const kickerColour = palette('--card-kicker-text');
+	const kickerColour = isHighlights
+		? palette('--highlights-card-kicker-text')
+		: palette('--card-kicker-text');
 	const cleanHeadLineText = headlineText.match(isFirstWordShort)
 		? headlineText.replace(' ', ' ') // from regular to non-breaking space
 		: headlineText;
@@ -250,7 +255,9 @@ export const CardHeadline = ({
 				{showQuotes && <QuoteIcon colour={kickerColour} />}
 				<span
 					css={css`
-						color: ${palette('--card-headline-trail-text')};
+						color: ${isHighlights
+							? palette('--highlights-card-headline')
+							: palette('--card-headline-trail-text')};
 					`}
 					className="show-underline"
 				>

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -128,9 +128,9 @@ const previousButtonFadeStyles = css`
 	left: ${space[5]}px;
 	background: linear-gradient(
 		to right,
-		${palette('--highlight-container-start-fade')} 0%,
-		${palette('--highlight-container-mid-fade')} 60%,
-		${palette('--highlight-container-end-fade')} 100%
+		${palette('--highlights-container-start-fade')} 0%,
+		${palette('--highlights-container-mid-fade')} 60%,
+		${palette('--highlights-container-end-fade')} 100%
 	);
 `;
 
@@ -139,9 +139,9 @@ const nextButtonFadeStyles = css`
 	justify-content: flex-end;
 	background: linear-gradient(
 		to left,
-		${palette('--highlight-container-start-fade')} 0px,
-		${palette('--highlight-container-mid-fade')} 60%,
-		${palette('--highlight-container-end-fade')} 100%
+		${palette('--highlights-container-start-fade')} 0px,
+		${palette('--highlights-container-mid-fade')} 60%,
+		${palette('--highlights-container-end-fade')} 100%
 	);
 `;
 /**

--- a/dotcom-rendering/src/components/HighlightsContainer.stories.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react';
-import { trails } from '../../../fixtures/manual/highlights-trails';
-import { HighlightsContainer } from '../HighlightsContainer.importable';
+import { trails } from '../../fixtures/manual/highlights-trails';
+import { HighlightsContainer } from './HighlightsContainer.importable';
 
 export default {
 	title: 'Masthead/HighlightsContainer',

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
 		format: {
 			display: ArticleDisplay.Standard,
 			design: ArticleDesign.Standard,
-			theme: Pillar.News,
+			theme: Pillar.Sport,
 		},
 		showPulsingDot: true,
 		kickerText: 'News',
@@ -72,7 +72,11 @@ export const WithAvatar: Story = {
 
 export const WithMediaIcon: Story = {
 	args: {
-		showMediaIcon: true,
+		format: {
+			design: ArticleDesign.Audio,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
 	},
 	parameters: {},
 	name: 'With Media Icon',

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { from, palette, until } from '@guardian/source/foundations';
+import { from, until } from '@guardian/source/foundations';
+import { isMediaCard } from '../../lib/cardHelpers';
+import { palette } from '../../palette';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
 import { Avatar } from '../Avatar';
@@ -8,6 +10,7 @@ import { CardLink } from '../Card/components/CardLink';
 import { CardHeadline } from '../CardHeadline';
 import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
+import { FormatBoundary } from '../FormatBoundary';
 import { Icon } from '../MediaMeta';
 
 export type HighlightsCardProps = {
@@ -23,13 +26,15 @@ export type HighlightsCardProps = {
 	showPulsingDot?: boolean;
 	dataLinkName: string;
 	byline?: string;
-	showMediaIcon?: boolean;
 	isExternalLink: boolean;
 };
 
 const gridContainer = css`
 	display: grid;
-	background-color: ${palette.neutral[97]};
+	background-color: ${palette('--highlights-container-background')};
+	/** Relative positioning is required to absolutely
+	position the card link overlay */
+	position: relative;
 	gap: 8px;
 	grid-template-areas:
 		'headline 	headline'
@@ -61,7 +66,7 @@ const mediaIcon = css`
 	width: 24px;
 	height: 24px;
 	/* We’re using the text colour for the icon badge */
-	background-color: ${palette.neutral[10]};
+	background-color: ${palette('--highlights-card-headline')};
 	border-radius: 50%;
 	display: inline-block;
 
@@ -72,7 +77,7 @@ const mediaIcon = css`
 		margin-right: auto;
 		margin-top: 2px;
 		display: block;
-		fill: ${palette.neutral[97]};
+		fill: ${palette('--highlights-container-background')};
 	}
 `;
 
@@ -96,7 +101,7 @@ const hoverStyles = css`
 		height: 100%;
 		width: 100%;
 		border-radius: 100%;
-		background-color: ${palette.neutral[7]};
+		background-color: ${palette('--highlights-card-headline')};
 		opacity: 0.1;
 	}
 
@@ -119,52 +124,63 @@ export const HighlightsCard = ({
 	showPulsingDot,
 	dataLinkName,
 	byline,
-	showMediaIcon,
 	isExternalLink,
 }: HighlightsCardProps) => {
+	const showMediaIcon = isMediaCard(format);
+
 	return (
-		<div css={[gridContainer, hoverStyles]}>
-			<CardLink
-				linkTo={linkTo}
-				headlineText={headlineText}
-				dataLinkName={dataLinkName}
-				isExternalLink={isExternalLink}
-			/>
-			<div css={headline}>
-				<CardHeadline
+		<FormatBoundary format={format}>
+			<div css={[gridContainer, hoverStyles]}>
+				<CardLink
+					linkTo={linkTo}
 					headlineText={headlineText}
-					format={format}
-					size="medium"
-					sizeOnMobile="small"
-					showPulsingDot={showPulsingDot}
-					kickerText={kickerText}
+					dataLinkName={dataLinkName}
 					isExternalLink={isExternalLink}
-					showQuotes={showQuotedHeadline}
 				/>
-			</div>
-			{mainMedia && showMediaIcon ? (
-				<div css={mediaIcon}>
-					<Icon mediaType={mainMedia.type} />
+
+				<div css={headline}>
+					<CardHeadline
+						headlineText={headlineText}
+						format={format}
+						size="medium"
+						sizeOnMobile="small"
+						showPulsingDot={showPulsingDot}
+						kickerText={kickerText}
+						isExternalLink={isExternalLink}
+						showQuotes={showQuotedHeadline}
+						isHighlights={true}
+					/>
 				</div>
-			) : null}
-			<div css={imageArea}>
-				{(avatarUrl && (
-					<Avatar src={avatarUrl} alt={byline ?? ''} shape="cutout" />
-				)) ??
-					(image && (
-						<>
-							<CardPicture
-								imageSize="medium"
-								mainImage={image.src}
-								alt={image.altText}
-								loading={imageLoading}
-								isCircular={true}
-							/>
-							{/* This image overlay is styled when the CardLink is hovered */}
-							<div className="image-overlay"> </div>
-						</>
-					))}
+
+				{!!mainMedia && showMediaIcon && (
+					<div css={mediaIcon}>
+						<Icon mediaType={mainMedia.type} />
+					</div>
+				)}
+
+				<div css={imageArea}>
+					{(avatarUrl && (
+						<Avatar
+							src={avatarUrl}
+							alt={byline ?? ''}
+							shape="cutout"
+						/>
+					)) ??
+						(image && (
+							<>
+								<CardPicture
+									imageSize="medium"
+									mainImage={image.src}
+									alt={image.altText}
+									loading={imageLoading}
+									isCircular={true}
+								/>
+								{/* This image overlay is styled when the CardLink is hovered */}
+								<div className="image-overlay"> </div>
+							</>
+						))}
+				</div>
 			</div>
-		</div>
+		</FormatBoundary>
 	);
 };

--- a/dotcom-rendering/src/components/Masthead/Masthead.tsx
+++ b/dotcom-rendering/src/components/Masthead/Masthead.tsx
@@ -86,9 +86,9 @@ export const Masthead = ({
 				showSideBorders={false}
 				fullWidth={true}
 				backgroundColour={themePalette(
-					'--masthead-highlights-background',
+					'--highlights-container-background',
 				)}
-				borderColour={themePalette('--masthead-highlights-border')}
+				borderColour={themePalette('--highlights-container-border')}
 				showTopBorder={false}
 				padSides={false}
 				element="section"

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5402,6 +5402,25 @@ const mastheadHighlightsBackground: PaletteFunction = () =>
 const mastheadHighlightsBorder: PaletteFunction = () =>
 	sourcePalette.neutral[60];
 
+const highlightsCardHeadline: PaletteFunction = () => sourcePalette.neutral[7];
+const highlightsCardKickerText: PaletteFunction = (format) => {
+	switch (format.theme) {
+		case Pillar.Opinion:
+			return pillarPalette(format.theme, 300);
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+		case Pillar.News:
+			return pillarPalette(format.theme, 400);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[200];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.news[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[200];
+	}
+};
+
 const mastheadAccreditationText: PaletteFunction = () =>
 	sourcePalette.brandAlt[400];
 
@@ -6102,15 +6121,31 @@ const paletteColours = {
 		light: headlineTextLight,
 		dark: headlineTextDark,
 	},
-	'--highlight-container-end-fade': {
+	'--highlights-card-headline': {
+		light: highlightsCardHeadline,
+		dark: highlightsCardHeadline,
+	},
+	'--highlights-card-kicker-text': {
+		light: highlightsCardKickerText,
+		dark: highlightsCardKickerText,
+	},
+	'--highlights-container-background': {
+		light: mastheadHighlightsBackground,
+		dark: mastheadHighlightsBackground,
+	},
+	'--highlights-container-border': {
+		light: mastheadHighlightsBorder,
+		dark: mastheadHighlightsBorder,
+	},
+	'--highlights-container-end-fade': {
 		light: highlightContainerEndFade,
 		dark: highlightContainerEndFade,
 	},
-	'--highlight-container-mid-fade': {
+	'--highlights-container-mid-fade': {
 		light: highlightContainerMidFade,
 		dark: highlightContainerMidFade,
 	},
-	'--highlight-container-start-fade': {
+	'--highlights-container-start-fade': {
 		light: highlightContainerStartFade,
 		dark: highlightContainerStartFade,
 	},
@@ -6201,14 +6236,6 @@ const paletteColours = {
 	'--masthead-accreditation-text': {
 		light: mastheadAccreditationText,
 		dark: mastheadAccreditationText,
-	},
-	'--masthead-highlights-background': {
-		light: mastheadHighlightsBackground,
-		dark: mastheadHighlightsBackground,
-	},
-	'--masthead-highlights-border': {
-		light: mastheadHighlightsBorder,
-		dark: mastheadHighlightsBorder,
 	},
 	'--masthead-nav-background': {
 		light: mastheadNavBackground,


### PR DESCRIPTION
## What does this change?

- Adds a `FormatBoundary` to the `HighlightsCard` so that it can use its containing article format to influence the palette decisions
- Adds `isHighlights` prop to `CardHeadline` to make sure we don't carry through media card colours for kickers or card headlines
- Replaces hardcoded colours in `HighlightsCard` with palette colours
- Tidies up naming of other highlights palette colours

## Why?

Fixes a bug where Highlights cards were not having their own format

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e0297cd8-f413-47af-b785-a9be96d66980
[after]: https://github.com/user-attachments/assets/d3e5e53a-04af-41cb-b11b-da4f5564c85b

