### PR TITLE
[Fairground 🎡] Fix nav not closing

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -342,7 +342,7 @@ export const Titlepiece = ({
                         })
                         // onBlur close dialog
                         document.addEventListener('mousedown', function(e){
-                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target)){
+                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target) && !veggieBurger.contains(e.target)){
                             toggleMainMenu()
                           }
                         });


### PR DESCRIPTION
## What does this change?
Checks that the veggie burger is not the target of the mouse down before triggering the toggle.

## Why?
Due to the titlepiece redesign the veggie menu now sits in a different position and so clicking on the veggie menu was triggering the mousedown as well as the click event causing the menu to close then immediately reopen. By checking if the veggie burger is the target, we can prevent the effect of the mouse down triggering.

## Screenshots

https://github.com/user-attachments/assets/5d104701-59da-4c16-90b1-3112b69aac60


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
