### PR TITLE
[Fairground 🎡] Refactor the titlepiece script to make it easier to reason about

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -282,70 +282,114 @@ export const Titlepiece = ({
             */}
 			<script
 				dangerouslySetInnerHTML={{
-					__html: `document.addEventListener('DOMContentLoaded', function(){
-                        // Used to toggle data-link-name on label buttons
-                        var navInputCheckbox = document.getElementById('${navInputCheckboxId}')
-                        var veggieBurger = document.getElementById('${veggieBurgerId}')
-                        var expandedMenuClickableTags = document.querySelectorAll('.selectableMenuItem')
-                        var expandedMenu = document.getElementById('${expandedMenuRootId}')
-                        // We assume News is the 1st column
-                        var firstColLabel = document.getElementById('News-button')
-                        var firstColLink = document.querySelectorAll('#newsLinks > li:nth-of-type(2) > a')[0]
-                        var focusOnFirstNavElement = function(){
-                          // need to focus on first element in list, firstColLabel is not viewable on desktop
-                          if(window.getComputedStyle(firstColLabel).display === 'none'){
-                            firstColLink.focus()
-                          } else {
-                            firstColLabel.focus()
-                          }
-                        }
-						if (!navInputCheckbox) return;
-                        navInputCheckbox.addEventListener('click',function(){
-                          document.body.classList.toggle('nav-is-open')
-                          if(!navInputCheckbox.checked) {
-							firstColLabel.setAttribute('aria-expanded', 'false')
-                            veggieBurger.setAttribute('data-link-name','header : veggie-burger : show')
-                            expandedMenuClickableTags.forEach(function($selectableElement){
-                                $selectableElement.setAttribute('tabindex','-1')
-                            })
-                          } else {
-							firstColLabel.setAttribute('aria-expanded', 'true')
-                            veggieBurger.setAttribute('data-link-name','header : veggie-burger : hide')
-                            expandedMenuClickableTags.forEach(function($selectableElement){
-                                $selectableElement.setAttribute('tabindex','0')
-                            })
-                            focusOnFirstNavElement()
-                          }
-                        })
-                        var toggleMainMenu = function(e){
-                          navInputCheckbox.click()
-                        }
-                        // Close hide menu on press enter
-                        var keydownToggleMainMenu = function(e){
-                          // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                          if (e.keyCode === 13 || e.keyCode === 32) {
-                            e.preventDefault()
-                            toggleMainMenu()
-                          }
-                        }
-                        veggieBurger.addEventListener('keydown', keydownToggleMainMenu)
-                        // Accessibility to hide Nav when pressing escape key
-                        document.addEventListener('keydown', function(e){
-                          // keyCode: 27 => esc
-                          if (e.keyCode === 27) {
-                            if(navInputCheckbox.checked) {
-                              toggleMainMenu()
-                              veggieBurger.focus()
-                            }
-                          }
-                        })
-                        // onBlur close dialog
-                        document.addEventListener('mousedown', function(e){
-                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target) && !veggieBurger.contains(e.target)){
-                            toggleMainMenu()
-                          }
-                        });
-                      })`,
+					__html: `document.addEventListener('DOMContentLoaded', function () {
+
+					/** The checkbox input element used to toggle the navigation menu. */
+					const navInputCheckbox = document.getElementById('${navInputCheckboxId}');
+
+					/** The veggie burger button element used to open/close the menu. */
+					const veggieBurger = document.getElementById('${veggieBurgerId}');
+
+					/** List of menu items that should be selectable when the menu is open. */
+					const expandedMenuClickableTags = document.querySelectorAll(
+						'.selectableMenuItem',
+					);
+
+					/** The root element of the expanded menu. */
+					const expandedMenu = document.getElementById('${expandedMenuRootId}');
+
+					/** The label for the first column in the menu, assumed to be "News".*/
+					const firstColLabel = document.getElementById('News-button');
+
+					/** The link element in the second list item under news links. */
+					const firstColLink = document.querySelector(
+						'#newsLinks > li:nth-of-type(2) > a',
+					);
+
+					/**
+					 * Focuses on the first navigation element depending on whether the first column label is visible.
+					 *
+					 * If the first column label is not visible, the function focuses on the first link element.
+					 * Otherwise, it focuses on the first column label.
+					 */
+					const focusOnFirstNavElement = () => {
+						if (window.getComputedStyle(firstColLabel).display === 'none') {
+							firstColLink.focus();
+						} else {
+							firstColLabel.focus();
+						}
+					};
+
+					/**
+					 * Updates ARIA attributes and tabindex values based on whether the menu is open or closed.
+					 */
+					const updateAttributesForMenu = (isOpen) => {
+						firstColLabel.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+						veggieBurger.setAttribute(
+							'data-link-name',
+							isOpen
+								? 'header : veggie-burger : hide'
+								: 'header : veggie-burger : show',
+						);
+						expandedMenuClickableTags.forEach((tag) => {
+							tag.setAttribute('tabindex', isOpen ? '0' : '-1');
+						});
+					};
+
+					/** Toggles the navigation menu by simulating a click on the checkbox. */
+					const toggleMainMenu = () => {
+						if (navInputCheckbox) {
+							navInputCheckbox.click();
+						}
+					};
+
+					/**
+					 * Handles keydown events to toggle the menu when the Enter or Space key is pressed.
+					 */
+					const keydownToggleMainMenu = (e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							toggleMainMenu();
+						}
+					};
+
+					/**
+					 * Handles click events to manage the state of the navigation menu.
+					 *
+					 * - Toggles the menu open/close state when the menu button (veggieBurger) is clicked.
+					 * - Closes the menu if the click occurs outside both the menu button and the expanded menu.
+					 */
+						const handleMenuClick = (e) => {
+							const menuButtonClicked = veggieBurger.contains(e.target);
+							const clickInsideMenu = expandedMenu.contains(e.target);
+							const menuIsOpen = navInputCheckbox.checked
+							if (menuButtonClicked) {
+									document.body.classList.toggle('nav-is-open');
+									updateAttributesForMenu(menuIsOpen);
+									if (menuIsOpen) {
+										focusOnFirstNavElement();
+									}
+							}
+
+							if (!menuButtonClicked && !clickInsideMenu && menuIsOpen) {
+									toggleMainMenu()
+							}
+						};
+
+					/** Adds event listeners to manage the navigation menu. */
+					if (navInputCheckbox) {
+						document.addEventListener('click', handleMenuClick);
+
+						veggieBurger.addEventListener('keydown', keydownToggleMainMenu);
+
+						document.addEventListener('keydown', (e) => {
+							if (e.key === 'Escape' && navInputCheckbox.checked) {
+								toggleMainMenu();
+								veggieBurger.focus();
+							}
+						});
+					}
+				});`,
 				}}
 			/>
 

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -341,7 +341,7 @@ export const Titlepiece = ({
                         })
                         // onBlur close dialog
                         document.addEventListener('mousedown', function(e){
-                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target)){
+                          if(navInputCheckbox.checked && !expandedMenu.contains(e.target) && !veggieBurger.contains(e.target)){
                             toggleMainMenu()
                           }
                         });


### PR DESCRIPTION
## What does this change?
Restructures the code and adds comments to make the code easier to reason about. It also removes the need for a click and mousedown handler by combining the two into one document click handler.

## Why?
It was a headache before.
