### PR TITLE
Remove colour scheme logging

### DIFF
--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -15,7 +15,6 @@ import { integrateIma } from '../experiments/tests/integrate-ima';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useDetectAdBlock } from '../lib/useDetectAdBlock';
-import { useOnce } from '../lib/useOnce';
 import { usePageViewId } from '../lib/usePageViewId';
 import type { ServerSideTests } from '../types/config';
 import { useConfig } from './ConfigContext';
@@ -23,14 +22,6 @@ import { useConfig } from './ConfigContext';
 type Props = {
 	commercialMetricsEnabled: boolean;
 	tests: ServerSideTests;
-};
-
-type AmIUsedLoggingEvent = {
-	label: string;
-	properties?: {
-		name: string;
-		value: string;
-	}[];
 };
 
 const sampling = 1 / 100;
@@ -187,45 +178,6 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 			pageViewId,
 			shouldBypassSampling,
 		],
-	);
-
-	useOnce(
-		function measurePrefersColorScheme() {
-			if (isDev) return;
-
-			if (!window.guardian.config.switches.sentinelLogger) return;
-
-			const endpoint = window.guardian.config.page.isDev
-				? '//logs.code.dev-guardianapis.com/log'
-				: '//logs.guardianapis.com/log';
-
-			const prefersDark = window.matchMedia(
-				'(prefers-color-scheme: dark)',
-			).matches;
-
-			const prefersLight = window.matchMedia(
-				'(prefers-color-scheme: light)',
-			).matches;
-
-			const prefersColorScheme: 'dark' | 'light' | 'unknown' = prefersDark
-				? 'dark'
-				: prefersLight
-				? 'light'
-				: 'unknown';
-
-			const event: AmIUsedLoggingEvent = {
-				label: 'dotcom.colour-scheme',
-				properties: [
-					{
-						name: 'prefersColorScheme',
-						value: prefersColorScheme,
-					},
-				],
-			};
-
-			window.navigator.sendBeacon(endpoint, JSON.stringify(event));
-		},
-		[isDev],
 	);
 
 	// We don’t render anything


### PR DESCRIPTION
## What does this change?
Remove colour scheme logging

## Why?
This was added to determine the business case for dark mode, which is now live behind an accessiblility switch in https://github.com/guardian/dotcom-rendering/pull/11976

It's no longer needed