### PR TITLE
[Fairground 🎡] Infer pulsing dot from format on cards

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -25,7 +25,6 @@ const meta = {
 			design: ArticleDesign.Standard,
 			theme: Pillar.Sport,
 		},
-		showPulsingDot: true,
 		kickerText: 'News',
 		byline: 'Georges Monbiot',
 		mainMedia: mainGallery,
@@ -76,6 +75,18 @@ export const WithMediaIcon: Story = {
 			design: ArticleDesign.Audio,
 			display: ArticleDisplay.Standard,
 			theme: Pillar.Culture,
+		},
+	},
+	parameters: {},
+	name: 'With Media Icon',
+};
+
+export const WithLiveKicker: Story = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.LiveBlog,
+			theme: Pillar.News,
 		},
 	},
 	parameters: {},

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -90,5 +90,5 @@ export const WithLiveKicker: Story = {
 		},
 	},
 	parameters: {},
-	name: 'With Media Icon',
+	name: 'With Live Kicker',
 };

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import { from, until } from '@guardian/source/foundations';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
@@ -23,7 +23,6 @@ export type HighlightsCardProps = {
 	avatarUrl?: string;
 	mainMedia?: MainMedia;
 	kickerText?: string;
-	showPulsingDot?: boolean;
 	dataLinkName: string;
 	byline?: string;
 	isExternalLink: boolean;
@@ -123,7 +122,6 @@ export const HighlightsCard = ({
 	avatarUrl,
 	mainMedia,
 	kickerText,
-	showPulsingDot,
 	dataLinkName,
 	byline,
 	isExternalLink,
@@ -146,7 +144,9 @@ export const HighlightsCard = ({
 						format={format}
 						size="medium"
 						sizeOnMobile="small"
-						showPulsingDot={showPulsingDot}
+						showPulsingDot={
+							format.design === ArticleDesign.LiveBlog
+						}
 						kickerText={kickerText}
 						isExternalLink={isExternalLink}
 						showQuotes={showQuotedHeadline}


### PR DESCRIPTION
## What does this change?
Determine if the card should show a pulsing dot and a live kicker by checking the format rather than passing through an additional prop.

It also adds a story to reflect this change. 

## Why?
We only want to show the pulsing dot and live kicker styles on liveblog articles so we can get that from format rather than passing through an additional prop.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![after][] | ![before][] |

[before]: https://github.com/user-attachments/assets/f0e5b645-86ae-4121-b1c6-6b65631d4d50
[after]: https://github.com/user-attachments/assets/781c2c3a-34c2-4b51-845b-ece1de7d213b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
