### PR TITLE
Make pull quotes full width at mobile breakpoints

### DIFF
--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -164,13 +164,16 @@ const inlineQuoteCss = css`
 
 const supportingQuoteCss = css`
 	position: relative;
-	width: 40%;
 	background-color: ${palette('--pullquote-background')};
 	margin-top: 2px;
 	margin-right: 10px;
 	margin-bottom: 14px;
 	clear: left;
 	float: left;
+
+	${from.phablet} {
+		width: 40%;
+	}
 
 	${from.leftCol} {
 		position: relative;


### PR DESCRIPTION
Closes #12098

## What does this change?

Use default width for pull quotes at mobile breakpoints. Use 40% width between `phablet` and `left-col` breakpoints.

## Why?

To stop long words in pull quotes from breaking out of its container

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/858a227c-f87c-4017-b83c-5b119d41cda9
[after]: https://github.com/user-attachments/assets/d3027b5e-ea70-4282-9304-ee99ac3bb31a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
