### PR TITLE
[Fairground 🎡] Card layout tweaks

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -76,9 +76,10 @@ const itemStyles = css`
 		*/
 
 		${from.leftCol} {
-			margin-left: 160px; /** 160 === 2 columns and 2 column gaps  */
+			padding-left: 160px; /** 160 === 2 columns and 2 column gaps  */
 		}
 		${from.wide} {
+			padding-left: 0;
 			margin-left: 240px; /** 240 === 3 columns and 3 column gaps  */
 		}
 	}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
-import { from, until } from '@guardian/source/foundations';
+import { between, from } from '@guardian/source/foundations';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
 import type { DCRFrontImage } from '../../types/front';
@@ -39,7 +39,9 @@ const gridContainer = css`
 		'headline 	headline'
 		'media-icon image';
 
-	${until.desktop} {
+	min-height: 174px;
+
+	${between.mobileMedium.and.desktop} {
 		min-height: 194px;
 		height: 100%;
 	}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -46,7 +46,7 @@ const gridContainer = css`
 	}
 
 	${from.tablet} {
-		min-height: none;
+		min-height: auto;
 		height: 100%;
 		width: 160px;
 	}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -47,6 +47,8 @@ const gridContainer = css`
 	}
 
 	${from.tablet} {
+		min-height: none;
+		height: 100%;
 		width: 160px;
 	}
 

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -38,7 +38,6 @@ const gridContainer = css`
 	grid-template-areas:
 		'headline 	headline'
 		'media-icon image';
-
 	min-height: 174px;
 
 	${between.mobileMedium.and.desktop} {
@@ -94,7 +93,6 @@ const imageArea = css`
 	${from.desktop} {
 		height: 112px;
 		width: 112px;
-		align-self: start;
 	}
 `;
 

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
-import { between, from } from '@guardian/source/foundations';
+import { between, from, until } from '@guardian/source/foundations';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
 import type { DCRFrontImage } from '../../types/front';
@@ -38,7 +38,9 @@ const gridContainer = css`
 	grid-template-areas:
 		'headline 	headline'
 		'media-icon image';
-	min-height: 174px;
+	${until.mobileMedium} {
+		min-height: 174px;
+	}
 
 	${between.mobileMedium.and.desktop} {
 		min-height: 194px;
@@ -46,7 +48,6 @@ const gridContainer = css`
 	}
 
 	${from.tablet} {
-		min-height: auto;
 		height: 100%;
 		width: 160px;
 	}


### PR DESCRIPTION
## What does this change?
Adds a smaller minimum height for small mobiles.

It also removes align-self: start for the image on tablet and above 

Uses padding-left form left col to ensure alignment with scroll-padding

## Why?
The existing minimum height was causing unwanted whitespace between the headline and the image.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6d2c7d98-12dc-44d1-972e-70c66c950d30
[after]: https://github.com/user-attachments/assets/86ebdb1f-1a5b-407e-9833-332e53b707c8

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
