### PR TITLE
Nudge ad label text down a few pixels

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -75,6 +75,7 @@ const individualLabelCSS = css`
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
 	background-color: ${schemedPalette('--ad-background')};
+	padding-top: 3px;
 	border-top: 1px solid ${schemedPalette('--ad-border')};
 	color: ${schemedPalette('--ad-labels-text')};
 	text-align: center;


### PR DESCRIPTION
## What does this change?
Add some padding to the top of ad labels to vertically center the label

## Why?
The word `Advertisement` has no [descenders](https://en.wikipedia.org/wiki/Descender), so is not optically centered vertically.

It seems more noticeable now that labels are horizontally centered!


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/dcda3caa-b88d-491b-b6da-6ffe48077413

[after]: https://github.com/user-attachments/assets/cb26195e-ec00-44f8-b05d-a5bc6ec93cb9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
