### PR TITLE
Make titlepiece an island hydrating on interaction

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Masthead.tsx
+++ b/dotcom-rendering/src/components/Masthead/Masthead.tsx
@@ -4,8 +4,8 @@ import type { NavType } from '../../model/extract-nav';
 import { palette as themePalette } from '../../palette';
 import { Island } from '../Island';
 import { Section } from '../Section';
+import { Titlepiece } from '../Titlepiece.importable';
 import { TopBar } from '../TopBar.importable';
-import { Titlepiece } from './Titlepiece/Titlepiece';
 
 type Props = {
 	nav: NavType;
@@ -101,12 +101,14 @@ export const Masthead = ({
 			</Section>
 		)}
 
-		<Titlepiece
-			nav={nav}
-			editionId={editionId}
-			showSubNav={showSubNav}
-			isImmersive={isImmersive}
-			hasPageSkin={hasPageSkin}
-		/>
+		<Island priority="critical" defer={{ until: 'interaction' }}>
+			<Titlepiece
+				nav={nav}
+				editionId={editionId}
+				showSubNav={showSubNav}
+				isImmersive={isImmersive}
+				hasPageSkin={hasPageSkin}
+			/>
+		</Island>
 	</header>
 );

--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -8,25 +8,25 @@ import {
 	until,
 	visuallyHidden,
 } from '@guardian/source/foundations';
-import type { EditionId } from '../../../lib/edition';
-import { getZIndex } from '../../../lib/getZIndex';
-import { nestedOphanComponents } from '../../../lib/ophan-helpers';
-import type { NavType } from '../../../model/extract-nav';
-import { palette as themePalette } from '../../../palette';
+import type { EditionId } from '../lib/edition';
+import { getZIndex } from '../lib/getZIndex';
+import { nestedOphanComponents } from '../lib/ophan-helpers';
+import type { NavType } from '../model/extract-nav';
+import { palette as themePalette } from '../palette';
 import {
 	expandedMenuRootId,
 	navInputCheckboxId,
 	pageMargin,
 	smallMobilePageMargin,
 	veggieBurgerId,
-} from './constants';
-import { EditionDropdown } from './EditionDropdown';
-import { ExpandedNav } from './ExpandedNav/ExpandedNav';
-import { Grid } from './Grid';
-import { Logo } from './Logo';
-import { Pillars, verticalDivider } from './Pillars';
-import { SubNav } from './SubNav';
-import { VeggieBurger } from './VeggieBurger';
+} from './Masthead/Titlepiece/constants';
+import { EditionDropdown } from './Masthead/Titlepiece/EditionDropdown';
+import { ExpandedNav } from './Masthead/Titlepiece/ExpandedNav/ExpandedNav';
+import { Grid } from './Masthead/Titlepiece/Grid';
+import { Logo } from './Masthead/Titlepiece/Logo';
+import { Pillars, verticalDivider } from './Masthead/Titlepiece/Pillars';
+import { SubNav } from './Masthead/Titlepiece/SubNav';
+import { VeggieBurger } from './Masthead/Titlepiece/VeggieBurger';
 
 interface Props {
 	nav: NavType;

--- a/dotcom-rendering/src/components/Titlepiece.stories.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from '@storybook/react';
-import { nav } from '../../Nav/Nav.mock';
-import { Titlepiece } from './Titlepiece';
+import { nav } from './Nav/Nav.mock';
+import { Titlepiece } from './Titlepiece.importable';
 
 const meta = {
 	title: 'Components/Masthead/Titlepiece',


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
