### PR TITLE
Filter out `MediaAtomBlockElement` assets without a `mimetype`

### DIFF
--- a/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
@@ -1,4 +1,4 @@
-import type { ArticleTheme } from '@guardian/libs';
+import { type ArticleTheme } from '@guardian/libs';
 import type { GuVideoBlockElement } from '../types/content';
 import { Caption } from './Caption.amp';
 
@@ -17,16 +17,18 @@ export const GuVideoBlockComponent = ({ element, pillar }: Props) => {
 					Please <a href="http://whatbrowser.org/">upgrade</a> to a
 					modern browser and try again.
 				</div>
-				{element.assets.map(
-					(encoding) =>
-						encoding.mimeType.includes('video') && (
+				{element.assets.map((asset) => {
+					return (
+						asset.mimeType &&
+						asset.mimeType.includes('video') && (
 							<source
-								key={encoding.url}
-								src={encoding.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
-								type={encoding.mimeType}
+								key={asset.url}
+								src={asset.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
+								type={asset.mimeType}
 							/>
-						),
-				)}
+						)
+					);
+				})}
 			</amp-video>
 		</Caption>
 	);

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -25,7 +25,7 @@ export const VideoAtom = ({
 			width={width}
 			data-spacefinder-role="inline"
 		>
-			{/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not provided */}
 			<video
 				controls={true}
 				preload="metadata"

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -2,7 +2,7 @@ import { MaintainAspectRatio } from './MaintainAspectRatio';
 
 type AssetType = {
 	url: string;
-	mimeType: string;
+	mimeType?: string;
 };
 
 interface Props {

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2081,7 +2081,6 @@
                 }
             },
             "required": [
-                "mimeType",
                 "url"
             ]
         },

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -1685,7 +1685,6 @@
                 }
             },
             "required": [
-                "mimeType",
                 "url"
             ]
         },

--- a/dotcom-rendering/src/model/enhance-videos.test.ts
+++ b/dotcom-rendering/src/model/enhance-videos.test.ts
@@ -1,9 +1,9 @@
 import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import type { FEElement } from '../types/content';
-import { enhanceGuVideos } from './enhance-videos';
+import { enhanceGuVideos, enhanceMediaAtomVideos } from './enhance-videos';
 
 describe('Enhance Videos', () => {
-	describe('for GuVideoElement', () => {
+	describe('for GuVideoBlockElement', () => {
 		it('sets the html of the GuVideoBlockElement', () => {
 			const html = '<video></video>';
 
@@ -30,6 +30,42 @@ describe('Enhance Videos', () => {
 			} as unknown as ArticleFormat;
 
 			expect(enhanceGuVideos(format, html)(inputElements)).toEqual(
+				expectedOutput,
+			);
+		});
+	});
+	describe('for MediaAtomBlockElement', () => {
+		it('filters out assets without a mimetype', () => {
+			const videoElement: FEElement = {
+				_type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement',
+				id: 'mockId',
+				elementId: 'mockElementId',
+				assets: [
+					{
+						url: 'mockUrl1',
+						mimeType: 'mockMimeType1',
+					},
+					{
+						url: 'mockUrl2',
+					},
+				],
+			};
+
+			const inputElements: FEElement[] = [videoElement];
+
+			const expectedOutput: FEElement[] = [
+				{
+					...videoElement,
+					assets: [
+						{
+							url: 'mockUrl1',
+							mimeType: 'mockMimeType1',
+						},
+					],
+				},
+			];
+
+			expect(enhanceMediaAtomVideos(inputElements)).toEqual(
 				expectedOutput,
 			);
 		});

--- a/dotcom-rendering/src/model/enhance-videos.ts
+++ b/dotcom-rendering/src/model/enhance-videos.ts
@@ -1,4 +1,4 @@
-import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
+import { ArticleDesign, type ArticleFormat, isUndefined } from '@guardian/libs';
 import type { FEElement } from '../types/content';
 
 const addHtmlToGuVideoBlocks = (elements: FEElement[], html?: string) => {
@@ -29,3 +29,21 @@ export const enhanceGuVideos =
 		}
 		return elements;
 	};
+
+export const enhanceMediaAtomVideos = (elements: FEElement[]): FEElement[] => {
+	const enhancedElements = elements.map((element) => {
+		if (
+			element._type ===
+			'model.dotcomrendering.pageElements.MediaAtomBlockElement'
+		) {
+			return {
+				...element,
+				assets: element.assets.filter(
+					(asset) => !isUndefined(asset.mimeType),
+				),
+			};
+		}
+		return element;
+	});
+	return enhancedElements;
+};

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -12,7 +12,7 @@ import { enhanceElementsImages, enhanceImages } from './enhance-images';
 import { enhanceInteractiveContentsElements } from './enhance-interactive-contents-elements';
 import { enhanceNumberedLists } from './enhance-numbered-lists';
 import { enhanceTweets } from './enhance-tweets';
-import { enhanceGuVideos } from './enhance-videos';
+import { enhanceGuVideos, enhanceMediaAtomVideos } from './enhance-videos';
 import { enhanceLists } from './enhanceLists';
 import { enhanceTimeline } from './enhanceTimeline';
 import { insertPromotedNewsletter } from './insertPromotedNewsletter';
@@ -81,6 +81,7 @@ export const enhanceMainMedia =
 		return [
 			enhanceElementsImages(format, isMainMedia, imagesForLightbox),
 			enhanceGuVideos(format, mediaHTML),
+			enhanceMediaAtomVideos,
 		].reduce(
 			(enhancedBlocks, enhancer) => enhancer(enhancedBlocks),
 			elements,

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -824,7 +824,7 @@ export interface Image {
 
 interface VideoAssets {
 	url: string;
-	mimeType: string;
+	mimeType?: string;
 	fields?: {
 		source?: string;
 		embeddable?: string;


### PR DESCRIPTION
## What does this change?

Add `enhanceMediaAtomVideos` to filter out `MediaAtomBlockElement` assets without a `mimetype`

## Why?

This video article is failing article schema validation and throwing 500s:

https://www.theguardian.com/uk-news/video/2024/jul/28/greater-manchester-mayor-urges-restraint-after-new-airport-footage-emerges-video-report

The `mainMediaElements.assets` property has assets with no `mimeType`:

https://www.theguardian.com/uk-news/video/2024/jul/28/greater-manchester-mayor-urges-restraint-after-new-airport-footage-emerges-video-report.json?dcr

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/de1f1c84-4c4b-4a5e-8f97-2650acf39594
[after]: https://github.com/user-attachments/assets/39ca75db-42b0-4900-af97-62866f8aa768
