### PR TITLE
Make `VideoAssets.mimeType` optional

### DIFF
--- a/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
@@ -21,7 +21,7 @@ export const GuVideoBlockComponent = ({ element, pillar }: Props) => {
 					<source
 						key={asset.url}
 						src={asset.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
-						type={asset.mimeType ?? 'video/mp4'}
+						type={asset.mimeType}
 					/>
 				))}
 			</amp-video>

--- a/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/GuVideoBlockComponent.amp.tsx
@@ -17,16 +17,13 @@ export const GuVideoBlockComponent = ({ element, pillar }: Props) => {
 					Please <a href="http://whatbrowser.org/">upgrade</a> to a
 					modern browser and try again.
 				</div>
-				{element.assets.map(
-					(encoding) =>
-						encoding.mimeType.includes('video') && (
-							<source
-								key={encoding.url}
-								src={encoding.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
-								type={encoding.mimeType}
-							/>
-						),
-				)}
+				{element.assets.map((asset) => (
+					<source
+						key={asset.url}
+						src={asset.url.replace('http:', 'https:')} // Force https as CAPI doesn't always send them
+						type={asset.mimeType ?? 'video/mp4'}
+					/>
+				))}
 			</amp-video>
 		</Caption>
 	);

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -2,7 +2,7 @@ import { MaintainAspectRatio } from './MaintainAspectRatio';
 
 type AssetType = {
 	url: string;
-	mimeType: string;
+	mimeType?: string;
 };
 
 interface Props {
@@ -25,7 +25,7 @@ export const VideoAtom = ({
 			width={width}
 			data-spacefinder-role="inline"
 		>
-			{/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
 			<video
 				controls={true}
 				preload="metadata"
@@ -34,7 +34,11 @@ export const VideoAtom = ({
 				poster={poster}
 			>
 				{assets.map((asset, index) => (
-					<source key={index} src={asset.url} type={asset.mimeType} />
+					<source
+						key={index}
+						src={asset.url}
+						type={asset.mimeType ?? 'video/mp4'}
+					/>
 				))}
 				<p>
 					{`Your browser doesn't support HTML5 video. Here is a `}

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -34,11 +34,7 @@ export const VideoAtom = ({
 				poster={poster}
 			>
 				{assets.map((asset, index) => (
-					<source
-						key={index}
-						src={asset.url}
-						type={asset.mimeType ?? 'video/mp4'}
-					/>
+					<source key={index} src={asset.url} type={asset.mimeType} />
 				))}
 				<p>
 					{`Your browser doesn't support HTML5 video. Here is a `}

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2081,7 +2081,6 @@
                 }
             },
             "required": [
-                "mimeType",
                 "url"
             ]
         },

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -1685,7 +1685,6 @@
                 }
             },
             "required": [
-                "mimeType",
                 "url"
             ]
         },

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -824,7 +824,7 @@ export interface Image {
 
 interface VideoAssets {
 	url: string;
-	mimeType: string;
+	mimeType?: string;
 	fields?: {
 		source?: string;
 		embeddable?: string;


### PR DESCRIPTION
## What does this change?

Make `VideoAssets.mimeType` optional and default to `video/mp4` if mime type is undefined.

## Why?

This video article is failing article schema validation and throwing 500s:

https://www.theguardian.com/uk-news/video/2024/jul/28/greater-manchester-mayor-urges-restraint-after-new-airport-footage-emerges-video-report

Although the main video for the `mainMediaElements.assets` property on this article has a `video/mp4` mimeType the other 3 assets do not:

https://www.theguardian.com/uk-news/video/2024/jul/28/greater-manchester-mayor-urges-restraint-after-new-airport-footage-emerges-video-report.json?dcr


```json
"assets": [
    {
        "url": "https://uploads.guim.co.uk/2024%2F54%2F29%2FGreater+Manchester+mayor+urges+restraint+after+new+airport+footage+emerges+%E2%80%93+video+report--68a7c506-64de-4a24-bf26-b0e75cc1ab70-11.mp4",
        "mimeType": "video/mp4"
    },
    {
        "url": "hlo-AHEb4gk"
    },
    {
        "url": "wxecwWfwT_4"
    },
    {
        "url": "lQDjwQ04xO8"
    }
],
```


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/de1f1c84-4c4b-4a5e-8f97-2650acf39594
[after]: https://github.com/user-attachments/assets/39ca75db-42b0-4900-af97-62866f8aa768