### PR TITLE
Remove `URL.canParse` from the client

### DIFF
--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -6,15 +6,18 @@ import { Weather, WeatherPlaceholder } from './Weather';
 const appendPartnerCodeToUrl = (
 	url: string | undefined,
 ): string | undefined => {
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- We're on the client so we don't know if URL.canParse is available
-	if (!url || (!!window.URL.canParse && !URL.canParse(url))) {
+	try {
+		if (url && URL.canParse(url)) {
+			const link = new URL(url);
+			link.searchParams.append('partner', 'web_guardian_adc');
+
+			return link.href;
+		}
+	} catch {
 		return undefined;
 	}
 
-	const link = new URL(url);
-	link.searchParams.append('partner', 'web_guardian_adc');
-
-	return link.href;
+	return undefined;
 };
 
 type Props = {

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -6,18 +6,15 @@ import { Weather, WeatherPlaceholder } from './Weather';
 const appendPartnerCodeToUrl = (
 	url: string | undefined,
 ): string | undefined => {
-	try {
-		if (url && URL.canParse(url)) {
-			const link = new URL(url);
-			link.searchParams.append('partner', 'web_guardian_adc');
+	if (!url) return undefined;
 
-			return link.href;
-		}
+	try {
+		const link = new URL(url);
+		link.searchParams.append('partner', 'web_guardian_adc');
+		return link.href;
 	} catch {
 		return undefined;
 	}
-
-	return undefined;
 };
 
 type Props = {

--- a/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/WeatherWrapper.importable.tsx
@@ -6,7 +6,8 @@ import { Weather, WeatherPlaceholder } from './Weather';
 const appendPartnerCodeToUrl = (
 	url: string | undefined,
 ): string | undefined => {
-	if (!url || !URL.canParse(url)) {
+	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- We're on the client so we don't know if URL.canParse is available
+	if (!url || (!!window.URL.canParse && !URL.canParse(url))) {
 		return undefined;
 	}
 


### PR DESCRIPTION
Closes #11973

## What does this change?

Removes `URL.canParse` in favour of a `try...catch`.

## Why?

Users on older devices may see errors if [their browser does not have this method](https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static#browser_compatibility).