### PR TITLE
Remove fit-content from top-above-nav ad

### DIFF
--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -36,7 +36,6 @@ const headerAdWrapper = css`
 // Remove this once new `ad-slot-container--centre-slot` class is in place
 const topAboveNavContainer = css`
 	&[top-above-nav-ad-rendered] {
-		width: fit-content;
 		margin: auto;
 	}
 	padding-bottom: ${padding}px;


### PR DESCRIPTION
## What does this change?
Removes the fit-content styling from the top-above-nav ad. It looks like this isn't needed for centring ads anyway.

## Why?
It was causing Fabrics to display incorrectly. The change in behaviour is likely linked to the ad label rendering change, since the container was fitting the content of the label, not the ad.

## Screenshots

Before:
<img width="1244" alt="Screenshot 2024-08-09 at 15 05 13" src="https://github.com/user-attachments/assets/48685109-24df-462e-80ea-3bd8550575ce"> 

After:
<img width="1473" alt="Screenshot 2024-08-09 at 15 13 45" src="https://github.com/user-attachments/assets/77fc8f3b-8cde-45bd-be6b-36f146e86b06">

Tested with non fabric ad, still behaves as expected:

<img width="1295" alt="Screenshot 2024-08-09 at 15 17 58" src="https://github.com/user-attachments/assets/a64bd212-b0cb-4e26-9c3c-e35d8ddd1b5b">
