### PR TITLE
DCAR: YouTubeAtom for apps

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -107,7 +107,7 @@
 		"@types/webpack-bundle-analyzer": "4.7.0",
 		"@types/webpack-env": "1.18.5",
 		"@types/webpack-node-externals": "3.0.4",
-		"@types/youtube": "0.0.47",
+		"@types/youtube": "0.0.50",
 		"ajv": "8.17.1",
 		"ajv-formats": "2.1.1",
 		"amphtml-validator": "1.0.35",

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -112,6 +112,7 @@ export const NoConsent = {
 		},
 		imagePositionOnMobile: 'none',
 		imageSize: 'large',
+		renderingTarget: 'Web',
 	},
 	decorators: [Container],
 } satisfies Story;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/react';
+import type { ConsentState } from '@guardian/libs';
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import type {
+	ImagePositionType,
+	ImageSizeType,
+} from '../Card/components/ImageWrapper';
 import { YoutubeAtom } from './YoutubeAtom';
 
 const meta = {
@@ -89,49 +94,78 @@ const ScrollDown =
 		</div>
 	);
 
-export const NoConsent = {
+const disableAds = { disableAds: true } satisfies AdTargeting;
+
+const adTargeting = {
+	adUnit: 'adUnit',
+	customParams: {
+		sens: 'f',
+		urlkw: ['keyword1', 'keyword2'],
+	},
+} satisfies AdTargeting;
+
+const consentGiven = {
+	tcfv2: {
+		vendorConsents: { abc: false },
+		addtlConsent: 'xyz',
+		gdprApplies: true,
+		tcString: 'YAAA',
+		consents: { '1': true, '2': true },
+		eventStatus: 'useractioncomplete',
+	},
+	canTarget: true,
+	framework: 'tcfv2',
+} satisfies ConsentState;
+
+const consentNotGiven = {
+	canTarget: false,
+	framework: 'tcfv2',
+} satisfies ConsentState;
+
+const adTargetingAndConsentGiven = {
+	...adTargeting,
+	...consentGiven,
+} satisfies AdTargeting & ConsentState;
+
+const imagePositionOnMobile: ImagePositionType = 'none';
+const imageSize: ImageSizeType = 'large';
+
+const baseConfiguration = {
+	index: 123,
+	videoId: '-ZCvZmYlQD8',
+	alt: '',
+	eventEmitters: [
+		// eslint-disable-next-line no-console -- check event emitters are called
+		(e: unknown) => console.log(`event emitter ${String(e)} called`),
+	],
+	duration: 252,
+	format: {
+		theme: Pillar.Culture,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
+	},
+	height: 450,
+	width: 800,
+	shouldStick: false,
+	isMainMedia: false,
+	abTestParticipations: {},
+	adTargeting: disableAds,
+	imagePositionOnMobile,
+	imageSize,
+	consentState: consentGiven,
+};
+
+const NoConsent = {
 	args: {
-		index: 123,
-		videoId: '-ZCvZmYlQD8',
-		alt: '',
-		eventEmitters: [(e) => console.log(`analytics event ${e} called`)],
-		duration: 252,
-		format: {
-			theme: Pillar.Culture,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		height: 450,
-		width: 800,
-		shouldStick: false,
-		isMainMedia: false,
-		enableIma: false,
-		abTestParticipations: {},
-		adTargeting: {
-			disableAds: true,
-		},
-		imagePositionOnMobile: 'none',
-		imageSize: 'large',
-		renderingTarget: 'Web',
+		...baseConfiguration,
+		consentState: consentNotGiven,
 	},
 	decorators: [Container],
 } satisfies Story;
 
 export const NoOverlay = {
 	args: {
-		...NoConsent.args,
-		consentState: {
-			tcfv2: {
-				vendorConsents: { abc: false },
-				addtlConsent: 'xyz',
-				gdprApplies: true,
-				tcString: 'YAAA',
-				consents: { '1': true, '2': true },
-				eventStatus: 'useractioncomplete',
-			},
-			canTarget: true,
-			framework: 'tcfv2',
-		},
+		...baseConfiguration,
 		title: "Rayshard Brooks: US justice system treats us like 'animals'",
 	},
 	decorators: [Container],
@@ -142,8 +176,7 @@ export const NoOverlay = {
 
 export const WithOverrideImage = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		videoId: '3jpXAMwRSu4',
 		alt: 'Microscopic image of COVID',
 		format: {
@@ -162,8 +195,7 @@ export const WithOverrideImage = {
 
 export const WithPosterImage = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		videoId: 'N9Cgy-ke5-s',
 		format: {
 			theme: Pillar.Sport,
@@ -180,8 +212,7 @@ export const WithPosterImage = {
 
 export const WithOverlayAndPosterImage = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		videoId: WithPosterImage.args.videoId,
 		format: {
 			theme: Pillar.Opinion,
@@ -201,7 +232,8 @@ export const WithOverlayAndPosterImage = {
 
 export const GiveConsent = {
 	args: {
-		...NoConsent.args,
+		...baseConfiguration,
+		...consentNotGiven,
 		videoId: WithOverrideImage.args.videoId,
 		alt: WithOverrideImage.args.alt,
 		format: WithOverrideImage.args.format,
@@ -213,7 +245,9 @@ export const GiveConsent = {
 
 		return (
 			<>
-				<button onClick={() => setConsented(true)}>Give consent</button>
+				<button type="button" onClick={() => setConsented(true)}>
+					Give consent
+				</button>
 				<div
 					css={css`
 						width: 800px;
@@ -222,9 +256,7 @@ export const GiveConsent = {
 				>
 					<YoutubeAtom
 						{...args}
-						consentState={
-							consented ? NoOverlay.args.consentState : undefined
-						}
+						consentState={consented ? consentGiven : undefined}
 					/>
 				</div>
 			</>
@@ -235,8 +267,7 @@ export const GiveConsent = {
 
 export const Sticky = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		shouldStick: true,
 		isMainMedia: true,
 		shouldPauseOutOfView: true,
@@ -247,8 +278,7 @@ export const Sticky = {
 
 export const StickyMainMedia = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		shouldStick: true,
 		isMainMedia: true,
 		title: NoOverlay.args.title,
@@ -263,8 +293,7 @@ export const StickyMainMedia = {
  */
 export const DuplicateVideos = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		shouldStick: true,
 		isMainMedia: undefined,
 	},
@@ -289,8 +318,7 @@ export const DuplicateVideos = {
  */
 export const MultipleStickyVideos = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		shouldStick: true,
 		isMainMedia: true,
 		title: NoOverlay.args.title,
@@ -314,8 +342,7 @@ export const MultipleStickyVideos = {
 
 export const PausesOffscreen = {
 	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
+		...baseConfiguration,
 		isMainMedia: true,
 		title: NoOverlay.args.title,
 		shouldPauseOutOfView: true,
@@ -337,53 +364,43 @@ export const PausesOffscreen = {
 	},
 } satisfies Story;
 
-export const NoConsentWithIma = {
-	...NoConsent,
+export const NoConsentWithAds = {
 	args: {
 		...NoConsent.args,
-		enableIma: true,
+		adTargeting,
 	},
 } satisfies Story;
 
-export const AdFreeWithIma = {
-	args: {
-		...NoConsent.args,
-		consentState: NoOverlay.args.consentState,
-		enableIma: true,
-	},
-	decorators: [Container],
-} satisfies Story;
-
-export const NoOverlayWithIma = {
+export const NoOverlayWithAds = {
 	args: {
 		...NoOverlay.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 	},
 	decorators: [Container],
 } satisfies Story;
 
-export const WithOverrideImageWithIma = {
+export const WithOverrideImageWithAds = {
 	args: {
 		...WithOverrideImage.args,
+		...adTargetingAndConsentGiven,
 		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
-		enableIma: true,
 	},
 	decorators: [Container],
 } satisfies Story;
 
-export const WithPosterImageWithIma = {
+export const WithPosterImageWithAds = {
 	args: {
 		...WithPosterImage.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 		videoCategory: undefined,
 	},
 	decorators: [Container],
 } satisfies Story;
 
-export const WithOverlayAndPosterImageWithIma = {
+export const WithOverlayAndPosterImageWithAds = {
 	args: {
 		...WithOverlayAndPosterImage.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 		videoCategory: undefined,
 		kicker: undefined,
 		showTextOverlay: undefined,
@@ -391,45 +408,45 @@ export const WithOverlayAndPosterImageWithIma = {
 	decorators: [Container],
 } satisfies Story;
 
-export const GiveConsentWithIma = {
+export const GiveConsentWithAds = {
 	...GiveConsent,
 	args: {
 		...GiveConsent.args,
-		enableIma: true,
+		adTargeting,
 	},
 	decorators: [],
 } satisfies Story;
 
-export const StickyWithIma = {
+export const StickyWithAds = {
 	args: {
 		...Sticky.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 		shouldPauseOutOfView: undefined,
 	},
 	decorators: [ScrollDown('arrow')],
 } satisfies Story;
 
-export const StickyMainMediaWithIma = {
+export const StickyMainMediaWithAds = {
 	args: {
 		...StickyMainMedia.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 	},
 	decorators: [ScrollDown('arrow')],
 } satisfies Story;
 
-export const DuplicateVideosWithIma = {
+export const DuplicateVideosWithAds = {
 	...DuplicateVideos,
 	args: {
 		...DuplicateVideos.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 	},
 	parameters: undefined,
 } satisfies Story;
 
-export const MultipleStickyVideosWithIma = {
+export const MultipleStickyVideosWithAds = {
 	...MultipleStickyVideos,
 	args: {
 		...MultipleStickyVideos.args,
-		enableIma: true,
+		...adTargetingAndConsentGiven,
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -364,10 +364,25 @@ export const PausesOffscreen = {
 	},
 } satisfies Story;
 
+/**
+ * Duplicate YoutubeAtom tests but with ads enabled.
+ *
+ * The YouTube ads integration (IMA) only works on allow listed https domains.
+ * The tests require running:
+ * - DCR as normal on port 3030
+ * - scripts/nginx/setup.sh to setup nginx on https://r.thegulocal.com
+ *
+ * The ad enabled tests are a convenience for manual testing.
+ *
+ */
+
 export const NoConsentWithAds = {
 	args: {
 		...NoConsent.args,
 		adTargeting,
+	},
+	parameters: {
+		chromatic: { disableSnapshot: true },
 	},
 } satisfies Story;
 
@@ -377,6 +392,9 @@ export const NoOverlayWithAds = {
 		...adTargetingAndConsentGiven,
 	},
 	decorators: [Container],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const WithOverrideImageWithAds = {
@@ -386,6 +404,9 @@ export const WithOverrideImageWithAds = {
 		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
 	},
 	decorators: [Container],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const WithPosterImageWithAds = {
@@ -395,6 +416,9 @@ export const WithPosterImageWithAds = {
 		videoCategory: undefined,
 	},
 	decorators: [Container],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const WithOverlayAndPosterImageWithAds = {
@@ -406,6 +430,9 @@ export const WithOverlayAndPosterImageWithAds = {
 		showTextOverlay: undefined,
 	},
 	decorators: [Container],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const GiveConsentWithAds = {
@@ -415,6 +442,9 @@ export const GiveConsentWithAds = {
 		adTargeting,
 	},
 	decorators: [],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const StickyWithAds = {
@@ -424,6 +454,9 @@ export const StickyWithAds = {
 		shouldPauseOutOfView: undefined,
 	},
 	decorators: [ScrollDown('arrow')],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const StickyMainMediaWithAds = {
@@ -432,6 +465,9 @@ export const StickyMainMediaWithAds = {
 		...adTargetingAndConsentGiven,
 	},
 	decorators: [ScrollDown('arrow')],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const DuplicateVideosWithAds = {
@@ -440,7 +476,9 @@ export const DuplicateVideosWithAds = {
 		...DuplicateVideos.args,
 		...adTargetingAndConsentGiven,
 	},
-	parameters: undefined,
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const MultipleStickyVideosWithAds = {
@@ -448,5 +486,8 @@ export const MultipleStickyVideosWithAds = {
 	args: {
 		...MultipleStickyVideos.args,
 		...adTargetingAndConsentGiven,
+	},
+	parameters: {
+		chromatic: { disableSnapshot: true },
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -51,6 +51,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -89,6 +90,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -134,6 +136,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -173,6 +176,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -211,6 +215,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -250,6 +255,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -287,6 +293,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -328,6 +335,7 @@ describe('YoutubeAtom', () => {
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
+						renderingTarget="Web"
 					/>
 					<YoutubeAtom
 						index={123}
@@ -348,6 +356,7 @@ describe('YoutubeAtom', () => {
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
+						renderingTarget="Web"
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -47,11 +47,9 @@ describe('YoutubeAtom', () => {
 					consentState={consentStateCanTarget}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -86,11 +84,9 @@ describe('YoutubeAtom', () => {
 					overrideImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -132,11 +128,9 @@ describe('YoutubeAtom', () => {
 					consentState={consentStateCanTarget}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -172,11 +166,9 @@ describe('YoutubeAtom', () => {
 					overrideImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -211,11 +203,9 @@ describe('YoutubeAtom', () => {
 					}}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -251,11 +241,9 @@ describe('YoutubeAtom', () => {
 					overrideImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -289,11 +277,9 @@ describe('YoutubeAtom', () => {
 					overrideImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
-					enableIma={false}
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
-					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -331,11 +317,9 @@ describe('YoutubeAtom', () => {
 						overrideImage={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
-						enableIma={false}
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
-						renderingTarget="Web"
 					/>
 					<YoutubeAtom
 						index={123}
@@ -352,11 +336,9 @@ describe('YoutubeAtom', () => {
 						overrideImage={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
-						enableIma={false}
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
-						renderingTarget="Web"
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,8 +1,7 @@
 import type { Participations } from '@guardian/ab-core';
-import { isUndefined } from '@guardian/libs';
 import type { ArticleFormat, ConsentState } from '@guardian/libs';
+import { isUndefined } from '@guardian/libs';
 import { useCallback, useState } from 'react';
-import type { RenderingTarget } from '../../types/renderingTarget';
 import type {
 	ImagePositionType,
 	ImageSizeType,
@@ -42,7 +41,6 @@ type Props = {
 	format: ArticleFormat;
 	shouldStick?: boolean;
 	isMainMedia?: boolean;
-	enableIma: boolean;
 	abTestParticipations: Participations;
 	videoCategory?: VideoCategory;
 	kicker?: string;
@@ -50,7 +48,6 @@ type Props = {
 	showTextOverlay?: boolean;
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
-	renderingTarget: RenderingTarget;
 };
 
 export const YoutubeAtom = ({
@@ -69,7 +66,6 @@ export const YoutubeAtom = ({
 	eventEmitters,
 	shouldStick,
 	isMainMedia,
-	enableIma,
 	abTestParticipations,
 	videoCategory,
 	kicker,
@@ -78,7 +74,6 @@ export const YoutubeAtom = ({
 	showTextOverlay = false,
 	imageSize,
 	imagePositionOnMobile,
-	renderingTarget,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -89,19 +84,13 @@ export const YoutubeAtom = ({
 	const uniqueId = `${videoId}-${index ?? 'server'}`;
 
 	/**
-	 * Consent and ad targeting are set by subsequent re-renders
+	 * Consent and ad targeting are initially undefined and set by subsequent re-renders
 	 */
 	const adTargetingEnabled =
 		!!adTargeting &&
 		!adTargeting.disableAds &&
 		!!consentState &&
 		consentState.canTarget;
-
-	/**
-	 * IMA integration is only enabled if the user has consented to ad targeting
-	 */
-	const imaEnabled =
-		enableIma && renderingTarget === 'Web' && adTargetingEnabled;
 
 	/**
 	 * Update the isActive state based on video events
@@ -205,15 +194,13 @@ export const YoutubeAtom = ({
 			<MaintainAspectRatio height={height} width={width}>
 				{
 					/**
-					 * Consent and ad targeting are set by subsequent re-renders
-					 * So we wait until they are set before rendering the player
+					 * Consent and ad targeting are initially undefined and set by subsequent re-renders
+					 * Wait until they are defined before rendering the player
 					 */
 					loadPlayer && consentState && adTargeting && (
 						<YoutubeAtomPlayer
 							videoId={videoId}
 							uniqueId={uniqueId}
-							adTargeting={adTargeting}
-							consentState={consentState}
 							height={height}
 							width={width}
 							title={title}
@@ -225,11 +212,13 @@ export const YoutubeAtom = ({
 							 */
 							autoPlay={hasOverlay}
 							onReady={playerReadyCallback}
-							enableIma={imaEnabled}
 							pauseVideo={pauseVideo}
 							deactivateVideo={() => {
 								setIsActive(false);
 							}}
+							enableAds={adTargetingEnabled}
+							adTargeting={adTargeting}
+							consentState={consentState}
 							abTestParticipations={abTestParticipations}
 						/>
 					)

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,7 +1,8 @@
 import type { Participations } from '@guardian/ab-core';
-import type { ArticleFormat, ConsentState } from '@guardian/libs';
 import { isUndefined } from '@guardian/libs';
+import type { ArticleFormat, ConsentState } from '@guardian/libs';
 import { useCallback, useState } from 'react';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type {
 	ImagePositionType,
 	ImageSizeType,
@@ -49,6 +50,7 @@ type Props = {
 	showTextOverlay?: boolean;
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
+	renderingTarget: RenderingTarget;
 };
 
 export const YoutubeAtom = ({
@@ -76,6 +78,7 @@ export const YoutubeAtom = ({
 	showTextOverlay = false,
 	imageSize,
 	imagePositionOnMobile,
+	renderingTarget,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -97,7 +100,8 @@ export const YoutubeAtom = ({
 	/**
 	 * IMA integration is only enabled if the user has consented to ad targeting
 	 */
-	const imaEnabled = enableIma && adTargetingEnabled;
+	const imaEnabled =
+		enableIma && renderingTarget === 'Web' && adTargetingEnabled;
 
 	/**
 	 * Update the isActive state based on video events

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import type { Participations } from '@guardian/ab-core';
-import type { AdsConfig } from '@guardian/commercial';
 import { buildImaAdTagUrl } from '@guardian/commercial';
 import type { ConsentState } from '@guardian/libs';
 import { log } from '@guardian/libs';
@@ -416,7 +415,7 @@ export const YoutubeAtomPlayer = ({
 
 				// Since IMA the YouTube player API no longer accepts ad configuration
 				// If IMA is enabled it will configure ads via its adsRequestCallback
-				const adsConfig: AdsConfig = { disableAds: true };
+				const adsConfig = { disableAds: true } as const;
 
 				const embedConfig = {
 					relatedChannels: [],

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -347,10 +347,10 @@ const createImaManagerListeners = (uniqueId: string) => {
 const isSignedIn = async (): Promise<boolean> => {
 	try {
 		const authStatus = await getAuthStatus();
-		return authStatus.kind == 'SignedInWithCookies' ||
+		return (
+			authStatus.kind === 'SignedInWithCookies' ||
 			authStatus.kind === 'SignedInWithOkta'
-			? true
-			: false;
+		);
 	} catch (error: unknown) {
 		if (error instanceof Error) {
 			window.guardian.modules.sentry.reportError(

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -446,6 +446,19 @@ export const YoutubeAtomPlayer = ({
 					eventEmitters,
 				);
 
+				const imaAdsRequestCallback = enableIma
+					? createImaAdsRequestCallback(
+							adTargeting,
+							consentState,
+							abTestParticipations,
+							isSignedIn,
+					  )
+					: undefined;
+
+				const imaAdManagerListeners = enableIma
+					? createImaManagerListeners(uniqueId)
+					: undefined;
+
 				player.current = new YouTubePlayer({
 					id,
 					youtubeOptions: {
@@ -465,13 +478,8 @@ export const YoutubeAtomPlayer = ({
 					},
 					onReadyListener,
 					enableIma,
-					imaAdsRequestCallback: createImaAdsRequestCallback(
-						adTargeting,
-						consentState,
-						abTestParticipations,
-						isSignedIn,
-					),
-					imaAdManagerListeners: createImaManagerListeners(uniqueId),
+					imaAdsRequestCallback,
+					imaAdManagerListeners,
 				});
 
 				/**

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -56,8 +56,12 @@ type YouTubePlayerArgs = {
 	youtubeOptions: PlayerOptions;
 	onReadyListener: PlayerReadyCallback;
 	enableIma: boolean;
-	imaAdsRequestCallback: AdsRequestCallback;
-	imaAdManagerListeners: (imaManager: YT.ImaManager) => void;
+	imaAdsRequestCallback?: AdsRequestCallback;
+	imaAdManagerListeners?: (imaManager: YT.ImaManager) => void;
+};
+
+const noop = () => {
+	return;
 };
 
 class YouTubePlayer {
@@ -69,8 +73,8 @@ class YouTubePlayer {
 		youtubeOptions,
 		onReadyListener,
 		enableIma,
-		imaAdsRequestCallback,
-		imaAdManagerListeners,
+		imaAdsRequestCallback = noop,
+		imaAdManagerListeners = noop,
 	}: YouTubePlayerArgs) {
 		this.playerPromise = this.setPlayer(
 			id,
@@ -97,7 +101,7 @@ class YouTubePlayer {
 					/**
 					 * If enableIma is true, YT.createPlayerForPublishers will be called
 					 * If enableIma is false, the standard new YT.Player constructor will be called
-					 * Listeners are set at expected place for each method
+					 * Listeners are set appropriatley for each method
 					 */
 					if (enableIma) {
 						YTAPI.createPlayerForPublishers(

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -31,6 +31,7 @@ type EmbedConfig = {
 		relatedChannels: string[];
 		adsConfig: { disableAds: true };
 		enableIma: boolean;
+		disableRelatedVideos: boolean;
 	};
 };
 
@@ -98,8 +99,8 @@ class YouTubePlayer {
 			(resolve, reject) => {
 				try {
 					/**
-					 * If enableIma is true, YT.createPlayerForPublishers will be called
-					 * If enableIma is false, the standard new YT.Player constructor will be called
+					 * If enableIma is true, YT.createPlayerForPublishers will be called to initiate IMA ads
+					 * If enableIma is false, the standard YT.Player constructor will be called
 					 * Listeners are set appropriatley for each method
 					 */
 					if (enableIma) {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -1,4 +1,3 @@
-import type { AdsConfig } from '@guardian/commercial';
 import { log } from '@guardian/libs';
 import type { google } from './ima';
 import { loadYouTubeAPI } from './loadYouTubeApi';
@@ -30,7 +29,7 @@ declare global {
 type EmbedConfig = {
 	embedConfig: {
 		relatedChannels: string[];
-		adsConfig: AdsConfig;
+		adsConfig: { disableAds: true };
 		enableIma: boolean;
 	};
 };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -101,7 +101,7 @@ class YouTubePlayer {
 					/**
 					 * If enableIma is true, YT.createPlayerForPublishers will be called to initiate IMA ads
 					 * If enableIma is false, the standard YT.Player constructor will be called
-					 * Listeners are set appropriatley for each method
+					 * Listeners are set appropriately for each method
 					 */
 					if (enableIma) {
 						YTAPI.createPlayerForPublishers(

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -190,4 +190,4 @@ class YouTubePlayer {
 	}
 }
 
-export { PlayerListenerName, YouTubePlayer };
+export { PlayerListenerName, YouTubePlayer, YouTubePlayerArgs };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -141,8 +141,9 @@ class YouTubePlayer {
 		return playerPromise;
 	}
 
-	private logError(e: Error) {
-		log('dotcom', `YouTubePlayer failed to load: ${e.message}`);
+	private logError(error: Error) {
+		log('dotcom', `YouTubePlayer failed to load: ${error.message}`);
+		window.guardian.modules.sentry.reportError(error, 'youtube-player');
 	}
 
 	getPlayerState(): Promise<YT.PlayerState | void> {

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -227,7 +227,7 @@ export const YoutubeBlockComponent = ({
 				posterImage={getLargestImageSize(posterImage)?.url}
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={
-					renderingTarget === 'Web'
+					enableAds && renderingTarget === 'Web'
 						? adTargeting
 						: adTargetingDisabled
 				}
@@ -241,14 +241,12 @@ export const YoutubeBlockComponent = ({
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
 				shouldStick={stickyVideos}
 				isMainMedia={isMainMedia}
-				enableIma={enableAds}
 				abTestParticipations={abTestParticipations}
 				kicker={kickerText}
 				shouldPauseOutOfView={pauseOffscreenVideo}
 				showTextOverlay={showTextOverlay}
 				imageSize={imageSize}
 				imagePositionOnMobile={imagePositionOnMobile}
-				renderingTarget={renderingTarget}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -239,7 +239,7 @@ export const YoutubeBlockComponent = ({
 				eventEmitters={renderingTarget === 'Web' ? [ophanTracking] : []}
 				format={format}
 				origin={process.env.NODE_ENV === 'development' ? '' : origin}
-				shouldStick={stickyVideos}
+				shouldStick={renderingTarget === 'Web' ? stickyVideos : false}
 				isMainMedia={isMainMedia}
 				abTestParticipations={abTestParticipations}
 				kicker={kickerText}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -157,7 +157,7 @@ export const YoutubeBlockComponent = ({
 			});
 		}
 		if (renderingTarget === 'Apps') {
-			// set the minimum consent state for apps
+			// set the minimum unconsented state for apps
 			setConsentState({
 				canTarget: false,
 				framework: 'tcfv2',
@@ -204,7 +204,7 @@ export const YoutubeBlockComponent = ({
 		);
 	}
 
-	// TODO ophan tracking for apps?
+	// TODO video event tracking for apps
 	const ophanTracking = async (
 		trackingEvent: VideoEventKey,
 	): Promise<void> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,8 +539,8 @@ importers:
         specifier: 3.0.4
         version: 3.0.4(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
       '@types/youtube':
-        specifier: 0.0.47
-        version: 0.0.47
+        specifier: 0.0.50
+        version: 0.0.50
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -4217,7 +4217,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -6136,7 +6136,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7350,8 +7350,8 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: false
 
-  /@types/youtube@0.0.47:
-    resolution: {integrity: sha512-uwqm0DUeg+2pff/8y9b22JJb+qWKOcG5aCn2yyT7hmLdK/M8+VECcK6QuNqdAR93IAqTmZeqK2nizTlQg5j+XA==}
+  /@types/youtube@0.0.50:
+    resolution: {integrity: sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==}
     dev: false
 
   /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.5.3):
@@ -7769,8 +7769,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
     dev: false
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.93.0):
@@ -7780,8 +7780,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
     dev: false
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.93.0):
@@ -7795,8 +7795,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.93.0)
     dev: false
 
@@ -8305,7 +8305,7 @@ packages:
       '@babel/core': 7.25.2
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -9373,7 +9373,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.41)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /css-loader@7.1.2(webpack@5.93.0):
@@ -10338,7 +10338,7 @@ packages:
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -11303,7 +11303,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /form-data@3.0.1:
@@ -16766,7 +16766,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -17293,7 +17293,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.7.6)(@types/node@16.18.68)(typescript@5.1.6):
@@ -18101,7 +18101,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.2.1(webpack@5.93.0):
@@ -18119,7 +18119,7 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.3.0(webpack@5.93.0):
@@ -18181,8 +18181,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.93.0)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.93.0)
       webpack-dev-middleware: 7.2.1(webpack@5.93.0)
       ws: 8.17.1
     transitivePeerDependencies:
@@ -18227,7 +18227,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.93.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.7.6)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

Enable YoutubeAtom for apps.

As a first step apps will have ads disabled by default.

Hence this PR also refactors the YoutubeAtom into two more directly configurable experiences:
- an ads disabled experience i.e. the base player via `YT.player`
- an ads enabled experienced i.e. the IMA player via `YT.createPlayerForPublishers`

When merged this change will be functionally equivalent as video support has not been activated in Apps yet.

The flow is as follows:

```mermaid
flowchart TD
    classDef yred color:#f00
    A{YoutubeBlockComponent\nenableAds} -->|yes| B{consent and ad-targeting?}
    A{YoutubeBlockComponent\nenableAds} -->|no| C(Disable ads, Unconsented)
    B --> |yes| D(<i class="fa-brands fa-youtube"></i> Player with IMA ads)
    B --> |no| C
    C --> E(<i class="fa-brands fa-youtube"></i> Player with no ads)
    D:::yred
    E:::yred
```

