### PR TITLE
DCAR: Fix CCPA open privacy settings manager

### DIFF
--- a/dotcom-rendering/src/components/AppsFooter.importable.tsx
+++ b/dotcom-rendering/src/components/AppsFooter.importable.tsx
@@ -25,14 +25,12 @@ const linkStyles = css`
 
 type PrivacySettingsProps = {
 	isCcpa: boolean;
-	privacyPolicyClickHandler: (e: React.MouseEvent<HTMLButtonElement>) => void;
 	privacySettingsClickHandler: (
 		e: React.MouseEvent<HTMLButtonElement>,
 	) => void;
 };
 const PrivacySettings = ({
 	isCcpa,
-	privacyPolicyClickHandler,
 	privacySettingsClickHandler,
 }: PrivacySettingsProps) => {
 	if (isCcpa) {
@@ -40,7 +38,7 @@ const PrivacySettings = ({
 			<>
 				<ButtonLink
 					priority="secondary"
-					onClick={privacyPolicyClickHandler}
+					onClick={privacySettingsClickHandler}
 					css={linkStyles}
 				>
 					California Residents - Do Not Sell
@@ -98,7 +96,6 @@ export const AppsFooter = () => {
 			<br />
 			<PrivacySettings
 				isCcpa={isCcpa}
-				privacyPolicyClickHandler={privacyPolicyClickHandler}
 				privacySettingsClickHandler={privacySettingsClickHandler}
 			/>
 			<ButtonLink


### PR DESCRIPTION
## What does this change?
Ensures the onClick handler points to the privacySettings
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/11970
## Screenshots


https://github.com/user-attachments/assets/0c6cce60-dbee-437d-b40c-cab18d8d2512






<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
