### PR TITLE
Give masthead dropdowns higher z-indices

### DIFF
--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -6,18 +6,18 @@ describe('getZIndex', () => {
 		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
 		expect(getZIndex('banner')).toBe('z-index: 29;');
 		expect(getZIndex('dropdown')).toBe('z-index: 28;');
-		expect(getZIndex('burger')).toBe('z-index: 27;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 27;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 26;');
+		expect(getZIndex('burger')).toBe('z-index: 25;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 26;',
+			'z-index: 24;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
-		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 22;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 19;');
-		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 18;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 23;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 22;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 20;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 19;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 18;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
 		expect(getZIndex('toast')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -30,6 +30,8 @@ const indices = [
 	'sticky-video',
 	'banner',
 	'dropdown',
+	'mastheadMyAccountDropdown',
+	'mastheadEditionDropdown',
 	'burger',
 	'mastheadVeggieBurgerExpandedMobile',
 	'expanded-veggie-menu-wrapper',
@@ -42,9 +44,6 @@ const indices = [
 	'stickyAdWrapperLabsHeader',
 	'stickyAdWrapper',
 	'stickyAdWrapperNav',
-
-	'mastheadMyAccountDropdown',
-	'mastheadEditionDropdown',
 
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',


### PR DESCRIPTION
## What does this change?

Pushes the masthead dropdown components higher up on the list of z-indices - which stops it getting cut by the expanded veggie burger. 

## Why?

Closes this [ticket](https://trello.com/c/32Vsfl5Z/351-fix-titlepiece-z-index-issues)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a9ad7196-bd8f-403a-b621-25ca499e1e78
[after]: https://github.com/user-attachments/assets/16c02cde-6387-4451-9a03-54c320313018


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
