### PR TITLE
Fix Container Button Wrapping

### DIFF
--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -214,7 +214,7 @@ export const ShowMore = ({
 						}
 						/* On smaller screens, button text overflows the container so we wrap to prevent it */
 						${until.phablet} {
-							text-wrap: wrap;
+							white-space: normal;
 							height: unset;
 						}
 					`}


### PR DESCRIPTION
The `text-wrap` property is only available on recent browsers[^1], which means this button doesn't wrap on browsers that don't support it. This causes it to run off the edge of the screen when it contains a lot of copy.

`white-space`[^2] can be used as a shorthand for both `text-wrap` and `white-space-collapse`, but is supported by much older browsers. `normal` here applies `text-wrap: wrap` and `white-space-collapse: collapse` (this is the collapse behaviour already being used here, so no change).

## Screenshots

From: https://www.theguardian.com/uk

| Before | After |
|--------|--------|
| ![button-before] | ![button-after] | 

[button-after]: https://github.com/user-attachments/assets/d8f33ace-3fd2-4466-951c-1d2f0efd3ff7
[button-before]: https://github.com/user-attachments/assets/2b6b7648-21c7-42b8-867d-f1537e159234

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#browser_compatibility
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
