### PR TITLE
Allow y scrolling when hovering over highlights container

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -31,7 +31,8 @@ const carouselStyles = css`
 	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
-	overscroll-behavior: contain;
+	overscroll-behavior-x: contain;
+	overscroll-behavior-y: auto;
 	${until.tablet} {
 		scroll-padding-left: 10px;
 	}


### PR DESCRIPTION
## What does this change?

Tweaks the highlights container overscroll  behaviour. The x axis behaviour stays the same (i.e. `contain`) but the y axis gets explicitly set to `auto` to allow a user to scroll down when hovering over the container.  

## Why?

Closes [this ticket ](https://trello.com/c/lScQ0LhU/361-fix-scrolling-down-on-highlights-container)

## After Video


https://github.com/user-attachments/assets/1e55d409-0fdf-4d93-adf4-ce4235c294af

