### PR TITLE
[Fairground 🎡] Subnav fade

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Titlepiece.tsx
@@ -232,26 +232,24 @@ const subNavWrapper = css`
 	ul {
 		padding-right: ${space[8]}px;
 		position: relative;
-
-		/** Adds a fade overlay to the RHS of the subnav area,
-	 	to visually hint that it is scrollable horizontally */
-		::after {
-			content: '';
-			position: absolute;
-			width: ${space[10]}px;
-			height: 100%;
-			right: 0;
-			top: 0;
-			bottom: 0;
-			background: linear-gradient(
-				to right,
-				transparent,
-				${themePalette('--masthead-nav-background')}
-			);
-		}
 	}
 `;
 
+/** Adds a fade overlay to the RHS of the subnav area,
+			 to visually hint that it is scrollable horizontally */
+const fadeStyles = css`
+	position: absolute;
+	width: ${space[10]}px;
+	height: 100%;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	background: linear-gradient(
+		to right,
+		transparent 0%,
+		${themePalette('--masthead-nav-background')} 100%
+	);
+`;
 export const Titlepiece = ({
 	nav,
 	editionId,
@@ -503,6 +501,7 @@ export const Titlepiece = ({
 						subNavSections={nav.subNavSections}
 						currentNavLink={nav.currentNavLink}
 					/>
+					<div css={fadeStyles} />
 				</div>
 			)}
 		</Grid>


### PR DESCRIPTION
## What does this change?
Moves the subnav fade to its own component. 

## Why?
It was previously static to the component rather than being fixed to the right hand side of the container. Moving it to its own component allows us to fix it to the RHS with affecting the outline of the subnav. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/bdc14e65-f64a-466c-b20d-36749eec1978
[after]: https://github.com/user-attachments/assets/7b8bedaf-47c4-45e3-ae23-a44ab7030fc5

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
