### PR TITLE
[Fairground 🎡] Add support and layout for flexible special container

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -229,7 +229,15 @@ export const DecideContainer = ({
 				</Island>
 			);
 		case 'flexible/special':
-			return <FlexibleSpecial groupedTrails={groupedTrails} />;
+			return (
+				<FlexibleSpecial
+					groupedTrails={groupedTrails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+				/>
+			);
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -22,10 +22,10 @@ import { FixedSmallSlowIV } from './FixedSmallSlowIV';
 import { FixedSmallSlowVHalf } from './FixedSmallSlowVHalf';
 import { FixedSmallSlowVMPU } from './FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from './FixedSmallSlowVThird';
+import { FlexibleSpecial } from './FlexibleSpecial';
 import { HighlightsContainer } from './HighlightsContainer.importable';
 import { Island } from './Island';
 import { NavList } from './NavList';
-import { FlexibleSpecial } from './FlexibleSpecial';
 
 type Props = {
 	trails: DCRFrontCard[];

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -229,7 +229,7 @@ export const DecideContainer = ({
 				</Island>
 			);
 		case 'flexible/special':
-			return <FlexibleSpecial trails={trails} />;
+			return <FlexibleSpecial groupedTrails={groupedTrails} />;
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -25,6 +25,7 @@ import { FixedSmallSlowVThird } from './FixedSmallSlowVThird';
 import { HighlightsContainer } from './HighlightsContainer.importable';
 import { Island } from './Island';
 import { NavList } from './NavList';
+import { FlexibleSpecial } from './FlexibleSpecial';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -227,6 +228,8 @@ export const DecideContainer = ({
 					<HighlightsContainer trails={trails} />
 				</Island>
 			);
+		case 'flexible/special':
+			return <FlexibleSpecial trails={trails} />;
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -28,7 +28,7 @@ type Props = {
 const limitSupportingContent = (card: DCRFrontCard, items = 4) =>
 	card.supportingContent?.slice(0, items) ?? [];
 
-export const Snap100 = ({
+const Snap100 = ({
 	snaps,
 	containerPalette,
 	showAge,

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -28,7 +28,7 @@ type Props = {
 const limitSupportingContent = (card: DCRFrontCard, items = 4) =>
 	card.supportingContent?.slice(0, items) ?? [];
 
-const Snap100 = ({
+export const Snap100 = ({
 	snaps,
 	containerPalette,
 	showAge,

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -1,0 +1,36 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { FlexibleSpecial } from './FlexibleSpecial';
+import { FrontSection } from './FrontSection';
+
+const meta = {
+	component: FlexibleSpecial,
+	title: 'Components/FlexibleSpecial',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+	render: () => (
+		<FrontSection
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+			showTopBorder={true}
+		>
+			<FlexibleSpecial />
+		</FrontSection>
+	),
+} satisfies Meta<typeof FlexibleSpecial>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const One: Story = {
+	name: 'With one standard card',
+};

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -35,7 +35,12 @@ const meta = {
 			editionId={'UK'}
 			showTopBorder={true}
 		>
-			<FlexibleSpecial groupedTrails={args.groupedTrails} />
+			<FlexibleSpecial
+				showAge={true}
+				absoluteServerTimes={true}
+				imageLoading="eager"
+				groupedTrails={args.groupedTrails}
+			/>
 		</FrontSection>
 	),
 } satisfies Meta<typeof FlexibleSpecial>;

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -2,8 +2,17 @@ import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
+import type { DCRGroupedTrails } from '../types/front';
 import { FlexibleSpecial } from './FlexibleSpecial';
 import { FrontSection } from './FrontSection';
+
+const defaultGroupedTrails: DCRGroupedTrails = {
+	huge: [],
+	veryBig: [],
+	big: [],
+	standard: [],
+	snap: [],
+};
 
 const meta = {
 	component: FlexibleSpecial,
@@ -17,13 +26,16 @@ const meta = {
 			],
 		},
 	},
-	render: () => (
+	args: {
+		groupedTrails: defaultGroupedTrails,
+	},
+	render: (args) => (
 		<FrontSection
 			discussionApiUrl={discussionApiUrl}
 			editionId={'UK'}
 			showTopBorder={true}
 		>
-			<FlexibleSpecial trails={[]} />
+			<FlexibleSpecial groupedTrails={args.groupedTrails} />
 		</FrontSection>
 	),
 } satisfies Meta<typeof FlexibleSpecial>;
@@ -35,6 +47,10 @@ type Story = StoryObj<typeof meta>;
 export const One: Story = {
 	name: 'With one standard card',
 	args: {
-		trails: trails.slice(0, 5),
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: trails.slice(0, 1),
+		},
 	},
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -28,6 +28,9 @@ const meta = {
 	},
 	args: {
 		groupedTrails: defaultGroupedTrails,
+		showAge: true,
+		absoluteServerTimes: true,
+		imageLoading: 'eager',
 	},
 	render: (args) => (
 		<FrontSection
@@ -35,12 +38,7 @@ const meta = {
 			editionId={'UK'}
 			showTopBorder={true}
 		>
-			<FlexibleSpecial
-				showAge={true}
-				absoluteServerTimes={true}
-				imageLoading="eager"
-				groupedTrails={args.groupedTrails}
-			/>
+			<FlexibleSpecial {...args} />
 		</FrontSection>
 	),
 } satisfies Meta<typeof FlexibleSpecial>;

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -45,12 +45,52 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const One: Story = {
-	name: 'With one standard card',
+	name: 'With one splash card',
 	args: {
 		groupedTrails: {
 			...defaultGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 1),
+		},
+	},
+};
+export const Two: Story = {
+	name: 'With one splash card and one standard card',
+	args: {
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: trails.slice(0, 2),
+		},
+	},
+};
+export const Three: Story = {
+	name: 'With one splash card and two standard cards',
+	args: {
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: trails.slice(0, 3),
+		},
+	},
+};
+export const Four: Story = {
+	name: 'With one splash card and three standard cards',
+	args: {
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: trails.slice(0, 4),
+		},
+	},
+};
+export const Five: Story = {
+	name: 'With one splash card and four standard cards',
+	args: {
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: trails.slice(0, 5),
 		},
 	},
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -1,6 +1,7 @@
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { trails } from '../../fixtures/manual/trails';
 import { FlexibleSpecial } from './FlexibleSpecial';
 import { FrontSection } from './FrontSection';
 
@@ -22,7 +23,7 @@ const meta = {
 			editionId={'UK'}
 			showTopBorder={true}
 		>
-			<FlexibleSpecial />
+			<FlexibleSpecial trails={[]} />
 		</FrontSection>
 	),
 } satisfies Meta<typeof FlexibleSpecial>;
@@ -33,4 +34,7 @@ type Story = StoryObj<typeof meta>;
 
 export const One: Story = {
 	name: 'With one standard card',
+	args: {
+		trails: trails.slice(0, 5),
+	},
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -2,9 +2,9 @@
 
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
-import type { DCRFrontCard } from '../types/front';
+import type { DCRGroupedTrails } from '../types/front';
 
-type Props = { trails: DCRFrontCard[] };
+type Props = { groupedTrails: DCRGroupedTrails };
 
 const grid = css`
 	display: grid;
@@ -29,7 +29,13 @@ const grid = css`
 
 //desktop
 
-export const FlexibleSpecial = ({ trails }: Props) => {
+export const FlexibleSpecial = ({ groupedTrails }: Props) => {
+	const snaps = [...groupedTrails.snap].slice(0, 1);
+	const cards = [
+		...groupedTrails.snap.slice(1),
+		...groupedTrails.standard,
+	].slice(0, 5);
+
 	return (
 		<div css={grid}>
 			<div
@@ -53,15 +59,10 @@ export const FlexibleSpecial = ({ trails }: Props) => {
 			>
 				<ul>
 					<li>
-						<div>story 1</div>
-						<div>story 2</div>
+						<div>{snaps[0]?.headline}</div>
+						<div>{cards[0]?.headline}</div>
 					</li>
 				</ul>
-			</div>
-			<div>
-				{trails.map((trail) => {
-					return <li key={trail.url}>{trail.headline}</li>;
-				})}
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -3,7 +3,6 @@ import type {
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
-import { Snap100 } from './DynamicPackage';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import { Loading } from './CardPicture';
@@ -11,7 +10,45 @@ import { FrontCard } from './FrontCard';
 
 type Props = { groupedTrails: DCRGroupedTrails };
 
-const SupportingStoryLayout = ({
+export const OneCardLayout = ({
+	cards,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	imageLoading,
+}: {
+	cards: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+}) => {
+	if (!cards[0]) return null;
+
+	return (
+		<UL padBottom={true}>
+			<LI padSides={true}>
+				<FrontCard
+					trail={cards[0]}
+					containerPalette={containerPalette}
+					containerType="dynamic/package"
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					headlineSize="large"
+					headlineSizeOnMobile="medium"
+					imagePositionOnDesktop="right"
+					imagePositionOnMobile="left"
+					imageSize="medium"
+					trailText={cards[0].trailText}
+					supportingContentAlignment="horizontal"
+					imageLoading={imageLoading}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
+const TwoCardorFourCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -57,17 +94,28 @@ const SupportingStoryLayout = ({
 
 export const FlexibleSpecial = ({ groupedTrails }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
-	const cards = [...groupedTrails.standard].slice(0, 4);
-	cards.map((card) => console.log(card.headline));
+	const splash = [...groupedTrails.standard].slice(0, 1);
+	const cards = [...groupedTrails.standard].slice(1, 5);
+	console.log('snaps::', snaps[0]?.headline);
+	console.log('splash::', splash[0]?.headline);
+	cards.map((card, i) => console.log(`card headline ${i}:: `, card.headline));
 
 	return (
 		<>
-			<Snap100
-				snaps={snaps}
+			{snaps && snaps.length > 0 && (
+				<OneCardLayout
+					cards={snaps}
+					absoluteServerTimes={false}
+					imageLoading={'eager'}
+				/>
+			)}
+			<OneCardLayout
+				cards={splash}
 				absoluteServerTimes={false}
 				imageLoading={'eager'}
 			/>
-			<SupportingStoryLayout
+
+			<TwoCardorFourCardLayout
 				cards={cards}
 				absoluteServerTimes={false}
 				imageLoading={'eager'}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,0 +1,7 @@
+import type { DCRFrontCard } from '../types/front';
+
+type Props = { trails: DCRFrontCard[] };
+
+export const FlexibleSpecial = ({ trails }: Props) => {
+	return null;
+};

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -8,7 +8,13 @@ import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
 
-type Props = { groupedTrails: DCRGroupedTrails };
+type Props = {
+	groupedTrails: DCRGroupedTrails;
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+};
 
 export const OneCardLayout = ({
 	cards,
@@ -92,7 +98,13 @@ const TwoCardOrFourCardLayout = ({
 	);
 };
 
-export const FlexibleSpecial = ({ groupedTrails }: Props) => {
+export const FlexibleSpecial = ({
+	groupedTrails,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	imageLoading,
+}: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
 	const splash = [...groupedTrails.standard].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(1, 5);
@@ -101,20 +113,26 @@ export const FlexibleSpecial = ({ groupedTrails }: Props) => {
 		<>
 			<OneCardLayout
 				cards={snaps}
-				absoluteServerTimes={false}
-				imageLoading={'eager'}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				absoluteServerTimes={absoluteServerTimes}
+				imageLoading={imageLoading}
 			/>
 
 			<OneCardLayout
 				cards={splash}
-				absoluteServerTimes={false}
-				imageLoading={'eager'}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				absoluteServerTimes={absoluteServerTimes}
+				imageLoading={imageLoading}
 			/>
 
 			<TwoCardOrFourCardLayout
 				cards={cards}
-				absoluteServerTimes={false}
-				imageLoading={'eager'}
+				containerPalette={containerPalette}
+				showAge={showAge}
+				absoluteServerTimes={absoluteServerTimes}
+				imageLoading={imageLoading}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,69 +1,77 @@
-//mobile
-
-import { css } from '@emotion/react';
-import { from } from '@guardian/source/foundations';
-import type { DCRGroupedTrails } from '../types/front';
+import type {
+	DCRContainerPalette,
+	DCRFrontCard,
+	DCRGroupedTrails,
+} from '../types/front';
+import { Snap100 } from './DynamicPackage';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
+import { FrontCard } from './FrontCard';
 
 type Props = { groupedTrails: DCRGroupedTrails };
 
-const grid = css`
-	display: grid;
-
-	${from.mobile} {
-		grid-template-columns: 1fr;
-		grid-template-areas:
-			'splash'
-			'standard-stories';
-	}
-
-	${from.tablet} {
-		column-gap: 20px;
-		grid-template-columns: repeat(11, 40px);
-		grid-template-areas:
-			'splash'
-			'standard-stories';
-	}
-`;
-
-//tablet and above
-
-//desktop
+const SupportingStoryLayout = ({
+	cards,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	showImage = true,
+	padBottom,
+	imageLoading,
+}: {
+	cards: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+	showImage?: boolean;
+	padBottom?: boolean;
+}) => {
+	return (
+		<UL direction="row" padBottom={padBottom}>
+			{cards.map((card, cardIndex) => {
+				return (
+					<LI
+						stretch={false}
+						percentage={cards.length <= 2 ? '50%' : '25%'}
+						key={card.url}
+						padSides={true}
+						showDivider={cardIndex > 0}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="dynamic/package"
+							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
+							image={showImage ? card.image : undefined}
+							imageLoading={imageLoading}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
 
 export const FlexibleSpecial = ({ groupedTrails }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
-	const cards = [
-		...groupedTrails.snap.slice(1),
-		...groupedTrails.standard,
-	].slice(0, 5);
+	const cards = [...groupedTrails.standard].slice(0, 4);
+	cards.map((card) => console.log(card.headline));
 
 	return (
-		<div css={grid}>
-			<div
-				css={css`
-					grid-area: splash;
-					grid-column: span 12;
-					background-color: pink;
-					height: 120px;
-					border: 1px solid red;
-				`}
-			>
-				This is the splash
-			</div>
-			<div
-				css={css`
-					grid-area: standard-stories;
-					background-color: lightblue;
-					height: 60px;
-					border: 1px solid blue;
-				`}
-			>
-				<ul>
-					<li>
-						<div>{snaps[0]?.headline}</div>
-						<div>{cards[0]?.headline}</div>
-					</li>
-				</ul>
-			</div>
-		</div>
+		<>
+			<Snap100
+				snaps={snaps}
+				absoluteServerTimes={false}
+				imageLoading={'eager'}
+			/>
+			<SupportingStoryLayout
+				cards={cards}
+				absoluteServerTimes={false}
+				imageLoading={'eager'}
+			/>
+		</>
 	);
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,7 +1,60 @@
-import type { DCRFrontCard } from '../types/front';
+//mobile
 
-type Props = { trails: DCRFrontCard[] };
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
 
-export const FlexibleSpecial = ({ trails }: Props) => {
-	return null;
+const grid = css`
+	display: grid;
+
+	${from.mobile} {
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'splash'
+			'standard-stories';
+	}
+
+	${from.tablet} {
+		column-gap: 20px;
+		grid-template-columns: repeat(11, 40px);
+		grid-template-areas:
+			'splash'
+			'standard-stories';
+	}
+`;
+
+//tablet and above
+
+//desktop
+
+export const FlexibleSpecial = () => {
+	return (
+		<div css={grid}>
+			<div
+				css={css`
+					grid-area: splash;
+					grid-column: span 12;
+					background-color: pink;
+					height: 120px;
+					border: 1px solid red;
+				`}
+			>
+				This is the splash
+			</div>
+			<div
+				css={css`
+					grid-area: standard-stories;
+					background-color: lightblue;
+					height: 60px;
+					border: 1px solid blue;
+				`}
+			>
+				<ul>
+					<li>
+						<div>story 1</div>
+						<div>story 2</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+	);
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -5,7 +5,7 @@ import type {
 } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { Loading } from './CardPicture';
+import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
 
 type Props = { groupedTrails: DCRGroupedTrails };
@@ -48,7 +48,7 @@ export const OneCardLayout = ({
 	);
 };
 
-const TwoCardorFourCardLayout = ({
+const TwoCardOrFourCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -102,20 +102,19 @@ export const FlexibleSpecial = ({ groupedTrails }: Props) => {
 
 	return (
 		<>
-			{snaps && snaps.length > 0 && (
-				<OneCardLayout
-					cards={snaps}
-					absoluteServerTimes={false}
-					imageLoading={'eager'}
-				/>
-			)}
+			<OneCardLayout
+				cards={snaps}
+				absoluteServerTimes={false}
+				imageLoading={'eager'}
+			/>
+
 			<OneCardLayout
 				cards={splash}
 				absoluteServerTimes={false}
 				imageLoading={'eager'}
 			/>
 
-			<TwoCardorFourCardLayout
+			<TwoCardOrFourCardLayout
 				cards={cards}
 				absoluteServerTimes={false}
 				imageLoading={'eager'}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -96,9 +96,6 @@ export const FlexibleSpecial = ({ groupedTrails }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
 	const splash = [...groupedTrails.standard].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(1, 5);
-	console.log('snaps::', snaps[0]?.headline);
-	console.log('splash::', splash[0]?.headline);
-	cards.map((card, i) => console.log(`card headline ${i}:: `, card.headline));
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -2,6 +2,9 @@
 
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
+import type { DCRFrontCard } from '../types/front';
+
+type Props = { trails: DCRFrontCard[] };
 
 const grid = css`
 	display: grid;
@@ -26,7 +29,7 @@ const grid = css`
 
 //desktop
 
-export const FlexibleSpecial = () => {
+export const FlexibleSpecial = ({ trails }: Props) => {
 	return (
 		<div css={grid}>
 			<div
@@ -54,6 +57,11 @@ export const FlexibleSpecial = () => {
 						<div>story 2</div>
 					</li>
 				</ul>
+			</div>
+			<div>
+				{trails.map((trail) => {
+					return <li key={trail.url}>{trail.headline}</li>;
+				})}
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3205,7 +3205,7 @@
                 "fixed/thrasher",
                 "fixed/video",
                 "fixed/video/vertical",
-				"flexible/special",
+                "flexible/special",
                 "nav/list",
                 "nav/media-list",
                 "news/most-popular"

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3205,6 +3205,7 @@
                 "fixed/thrasher",
                 "fixed/video",
                 "fixed/video/vertical",
+				"flexible/special",
                 "nav/list",
                 "nav/media-list",
                 "news/most-popular"

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -96,6 +96,7 @@ export const groupCards = (
 				),
 			};
 		}
+		case 'flexible/special':
 		case 'dynamic/package': {
 			const snap = curated.filter(({ card }) => card.group === '1');
 			return {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -90,7 +90,8 @@ type FEContainerType =
 	| 'nav/list'
 	| 'nav/media-list'
 	| 'news/most-popular'
-	| 'fixed/highlights';
+	| 'fixed/highlights'
+	| 'flexible/special';
 
 export type FEContainerPalette =
 	| 'EventPalette'


### PR DESCRIPTION
## What does this change?
Adds a container layout for flexible/special. This follows the existing layout pattern of all other containers. 
The layout of flexible/special is as follows:

1. **Snap link** - this is optional
2. **Splash card** - This will always be the first card. It will always take the full width of the container.
3. **Supporting story cards** - These are optional and can be a maximum of 4. They are always positioned in a row below the splash card. If there are 1 or 2 supporting stories, they each take up 50% of the row. If there are 3 or 4 supporting stories, they each take up 25% of the row. Unlike in previous containers, these cards do not stretch to fill empty space if there is an odd number of cards.

## Why?
`Flexible/special` is a new container that is being  introduced to replace `dynamic/package`.

## Screenshots

| Splash only      | with 1 supporting      |
| ----------- | ---------- |
| ![splash][] | ![one][] |

| with 2 supporting   | with 3 supporting      |
| ----------- | ---------- |
| ![two][] | ![three][] |

| with 4 supporting      |
| ----------- | 
| ![four][] | 

[splash]: https://github.com/user-attachments/assets/d9ea7446-dbb0-4ee2-bcc2-f4441ebc4857
[one]: https://github.com/user-attachments/assets/f74df086-e2e6-4c5a-a89e-2023f2dbc8f1
[two]: https://github.com/user-attachments/assets/ee6c6765-e694-4704-b7b4-0320bc1823bd
[three]: https://github.com/user-attachments/assets/03be64ca-aa59-40ea-ab4a-e74b00ecf9e1
[four]: https://github.com/user-attachments/assets/3fd67f35-1063-4044-a80e-b6d4fde4a1d9
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
