### PR TITLE
[Fairground 🎡]  Z-index titlepiece 

### DIFF
--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -6,18 +6,18 @@ describe('getZIndex', () => {
 		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
 		expect(getZIndex('banner')).toBe('z-index: 29;');
 		expect(getZIndex('dropdown')).toBe('z-index: 28;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 27;');
-		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 26;');
-		expect(getZIndex('burger')).toBe('z-index: 25;');
+		expect(getZIndex('burger')).toBe('z-index: 27;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 24;',
+			'z-index: 26;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 23;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 22;');
-		expect(getZIndex('mobileSticky')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 19;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 18;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 22;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 19;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 18;');
 		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
 		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
 		expect(getZIndex('toast')).toBe('z-index: 15;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -30,8 +30,6 @@ const indices = [
 	'sticky-video',
 	'banner',
 	'dropdown',
-	'mastheadMyAccountDropdown',
-	'mastheadEditionDropdown',
 	'burger',
 	'mastheadVeggieBurgerExpandedMobile',
 	'expanded-veggie-menu-wrapper',
@@ -44,6 +42,12 @@ const indices = [
 	'stickyAdWrapperLabsHeader',
 	'stickyAdWrapper',
 	'stickyAdWrapperNav',
+
+	// My Account dropdown in masthead - needs to be below stickyAdWrapper
+	'mastheadMyAccountDropdown',
+
+	// Edition selector in masthead - needs to be below stickyAdWrapper
+	'mastheadEditionDropdown',
 
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',


### PR DESCRIPTION
## What does this change?
Prevents the account button and edition switcher overlapping with the sticky ad slot by reducing the zindex on these two components. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[after]: https://github.com/user-attachments/assets/5ff3b890-25bb-4c97-a305-a6fdf6e09d26
[before]: https://github.com/user-attachments/assets/9d79c3e2-9851-465e-87af-0ff8de99f651

[after2]: https://github.com/user-attachments/assets/dfce9982-c08c-4061-9789-36c8a231b48c
[before2]: https://github.com/user-attachments/assets/951c80bb-5050-4393-8327-262d69b72a7c

<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.


You can then reference the labels and map them to corresponding links.

-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
