### PR TITLE
Reduce right-column to `300px` and increase gap for wide breakpoint

### DIFF
--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -35,7 +35,7 @@ const articleWidth = (format: ArticleFormat) => {
 				}
 				/* Make the video player as wide as possible on larger screens */
 				${from.wide} {
-					width: 688px;
+					width: 100%;
 				}
 			`;
 		default: {

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -152,7 +152,7 @@ const adStyles = css`
 		}
 
 		${from.wide} {
-			margin-right: -380px;
+			margin-right: -400px;
 		}
 	}
 

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -95,8 +95,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
-					margin-left: 20px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 
 					${display === ArticleDisplay.Showcase
 						? css`

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -95,7 +95,8 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 320px;
+					grid-template-columns: 219px 1px 620px 60px 300px;
+					margin-left: 20px;
 
 					${display === ArticleDisplay.Showcase
 						? css`

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -92,7 +92,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 					grid-template-areas:
 						'caption    border      title      . right-column'
 						'.          border      headline   . right-column'
@@ -103,7 +103,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta       border      body       . right-column'
 						'.          border      body       . right-column'
 						'.          border      .          . right-column';
-					margin-left: 20px;
 				}
 
 				/*

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -92,7 +92,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
-					grid-template-columns: 219px 1px 620px 60px 320px;
+					grid-template-columns: 219px 1px 620px 60px 300px;
 					grid-template-areas:
 						'caption    border      title      . right-column'
 						'.          border      headline   . right-column'
@@ -103,6 +103,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta       border      body       . right-column'
 						'.          border      body       . right-column'
 						'.          border      .          . right-column';
+					margin-left: 20px;
 				}
 
 				/*

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -92,7 +92,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 320px;
+					grid-template-columns: 219px 1px 620px 60px 300px;
 					grid-template-areas:
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'
@@ -100,6 +100,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta   border  standfirst .        right-column'
 						'.      border  body       .        right-column'
 						'.      border  .          .        right-column';
+					margin-left: 20px;
 				}
 
 				${until.wide} {

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -92,7 +92,7 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 					grid-template-areas:
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'
@@ -100,7 +100,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta   border  standfirst .        right-column'
 						'.      border  body       .        right-column'
 						'.      border  .          .        right-column';
-					margin-left: 20px;
 				}
 
 				${until.wide} {

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -104,8 +104,7 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 300px;
-					margin-left: 20px;
+					grid-template-columns: 219px 1px 620px 80px 300px;
 
 					${isMatchReport
 						? css`

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -104,7 +104,8 @@ const StandardGrid = ({
 					Right Column
 				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 60px 320px;
+					grid-template-columns: 219px 1px 620px 60px 300px;
+					margin-left: 20px;
 
 					${isMatchReport
 						? css`


### PR DESCRIPTION
## What does this change?

This PR follows the Guardian grid for the `right-column` to be `300px` instead of `320px` for wide breakpoint which was made by this change https://github.com/guardian/dotcom-rendering/pull/11800. 

The above PR had a request to fix the gap between the `right-column` and the right border which should be `20px` and that's why a quick fix to just expand the `right-column` to be `320px`. 

A bigger gap between main content (centre column) and the right-column is added so instead of `60px` it's now `80px`. 

I also needed to align the subsequent inline ads with the right column so I had to change the `margin-right` to be `-400px` instead of `-380px`.

Media articles doesn't respect the gap so the main content takes the width of the centre column plus the gap so by increasing the gap that means media articles will fill in that extra space. A great suggestion by @Jakeii to increase the lines at the end of the article to 100% width so they will aligned with the media width. 

The below screenshots are for `StandardLayout`, `ShowcaseLayout`, `ImmersiveLayout` and `CommentLayout` respectively.

Tested locally and in CODE.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1301" alt="image" src="https://github.com/user-attachments/assets/f92b743e-bbe1-448b-99d1-0a75134b9c61"> | <img width="1297" alt="image" src="https://github.com/user-attachments/assets/fe1df51c-db99-4679-afd2-a43d53313de4"> |
| <img width="1301" alt="image" src="https://github.com/user-attachments/assets/92fa3efb-ab20-4955-9806-d1ecfd6febc3"> | <img width="1297" alt="image" src="https://github.com/user-attachments/assets/fcb944f2-6ddd-49b7-b4f8-7c3728ad22c7"> |
| <img width="1301" alt="image" src="https://github.com/user-attachments/assets/7b4622a7-8401-4bb1-aa71-66f21e86b463"> | <img width="1297" alt="image" src="https://github.com/user-attachments/assets/2dd4377b-1723-487c-974c-894556c64031"> |
| <img width="1301" alt="image" src="https://github.com/user-attachments/assets/5f2f302f-399e-4383-9fd6-13f0d6f6ff5f"> | <img width="1297" alt="image" src="https://github.com/user-attachments/assets/f0111979-afaf-453a-9035-ca2e26340caa"> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
