### PR TITLE
Add 0% test for spacefinder inline1 changes

### DIFF
--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { adBlockAsk } from './tests/ad-block-ask';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { optimiseSpacefinderInline } from './tests/optimise-spacefinder-inline';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 
@@ -17,4 +18,5 @@ export const tests: ABTest[] = [
 	integrateIma,
 	mpuWhenNoEpic,
 	adBlockAsk,
+	optimiseSpacefinderInline,
 ];

--- a/dotcom-rendering/src/experiments/tests/optimise-spacefinder-inline.ts
+++ b/dotcom-rendering/src/experiments/tests/optimise-spacefinder-inline.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const optimiseSpacefinderInline: ABTest = {
+	id: 'OptimiseSpacefinderInline',
+	author: '@commercial-dev',
+	start: '2024-08-08',
+	expiry: '2024-09-13',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description: 'Test new spacefinder rules for inline1 ads on desktop.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?
Adds a 0% test for some changes to Spacefinder's rules for inline1 ads. 0% for now, as we're waiting on sample sizes to be confirmed, but still useful to have the 0% test so that we can check the new ad rules look good on a range of articles.
