### PR TITLE
Fix avatar obscuring headline in `PictureLayout`

### DIFF
--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -198,10 +198,6 @@ const avatarHeadlineWrapper = css`
 	justify-content: space-between;
 `;
 
-const minHeightWithAvatar = css`
-	min-height: 259px;
-`;
-
 // This styling taken from the similar approach in CommentLayout.tsx
 // If in mobile increase the margin top and margin right deficit
 const avatarPositionStyles = css`
@@ -209,8 +205,10 @@ const avatarPositionStyles = css`
 	justify-content: flex-end;
 	position: relative;
 	margin-bottom: -29px;
-	margin-top: -50px;
 	pointer-events: none;
+	${from.desktop} {
+		margin-top: -50px;
+	}
 	${until.tablet} {
 		overflow: hidden;
 	}
@@ -495,12 +493,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 						{displayAvatarUrl ? (
 							<GridItem area="headline">
-								<div
-									css={[
-										avatarHeadlineWrapper,
-										avatarUrl && minHeightWithAvatar,
-									]}
-								>
+								<div css={avatarHeadlineWrapper}>
 									<div css={maxWidth}>
 										<ArticleHeadline
 											format={format}


### PR DESCRIPTION
## What does this change?

Remove negative margin from avatar in `PictureLayout` below desktop breakpoint.

## Why?

The negative margin pulls the avatar up into the space occupied by the headline, overlaying it at smaller viewport widths. The headline has a maximum width applied above the desktop breakpoint allowing the avatar to sit alongside.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/2f585d7e-370a-4b33-ba75-6579b3dfd4e8
[after]: https://github.com/user-attachments/assets/ee05462a-3bee-4909-970f-91c53c9fb3f1
[before2]: https://github.com/user-attachments/assets/4405448e-26a3-48ea-b811-bbca16e9a34d
[after2]: https://github.com/user-attachments/assets/faa1ecbd-c76a-4246-ab31-7ff0ca2d3b19
[before3]: https://github.com/user-attachments/assets/6a66fd0e-0f82-49e2-ae28-22856611cc1e
[after3]: https://github.com/user-attachments/assets/7fb0a1d4-ff6a-49e9-9587-20335c6cb3ac
