### PR TITLE
Ab gl/flexible special standard card

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -348,7 +348,9 @@ export const Card = ({
 	return (
 		<CardWrapper
 			format={format}
-			showTopBar={!isOnwardContent}
+			showTopBar={
+				!isOnwardContent && !(containerType === 'flexible/special')
+			}
 			containerPalette={containerPalette}
 			isOnwardContent={isOnwardContent}
 		>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -26,7 +26,7 @@ import type { OnwardsSource } from '../../types/onwards';
 import { Avatar } from '../Avatar';
 import { CardCommentCount } from '../CardCommentCount.importable';
 import { CardHeadline } from '../CardHeadline';
-import type { Loading } from '../CardPicture';
+import type { AspectRatio, Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
@@ -108,6 +108,7 @@ export type Props = {
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
 	isTagPage?: boolean;
+	aspectRatio?: AspectRatio;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -236,7 +237,9 @@ export const Card = ({
 	showMainVideo = true,
 	absoluteServerTimes,
 	isTagPage = false,
+	aspectRatio = '5:3',
 }: Props) => {
+	console.log('card aspect ratio', aspectRatio);
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
 		supportingContent,
@@ -476,6 +479,7 @@ export const Card = ({
 											alt={headlineText}
 											loading={imageLoading}
 											roundedCorners={isOnwardContent}
+											aspectRatio={aspectRatio}
 										/>
 									</div>
 								)}
@@ -489,6 +493,7 @@ export const Card = ({
 									alt={media.imageAltText}
 									loading={imageLoading}
 									roundedCorners={isOnwardContent}
+									aspectRatio={aspectRatio}
 								/>
 								{showPlayIcon && mainMedia.duration > 0 && (
 									<MediaDuration

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -348,6 +348,24 @@ export const Card = ({
 	 */
 	const hasBackgroundColour = !containerPalette && isMediaCard(format);
 
+	const isHorizontalOnDesktop =
+		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
+
+	const getGapSize = () => {
+		if (isOnwardContent) {
+			return 'none';
+		} else if (hasBackgroundColour) {
+			return 'small';
+		} else if (
+			containerType === 'flexible/special' &&
+			isHorizontalOnDesktop
+		) {
+			return 'large';
+		} else {
+			return 'medium';
+		}
+	};
+
 	return (
 		<CardWrapper
 			format={format}
@@ -370,8 +388,7 @@ export const Card = ({
 				minWidthInPixels={minWidthInPixels}
 				imageType={media?.type}
 				containerType={containerType}
-				isOnwardContent={isOnwardContent}
-				hasBackgroundColour={hasBackgroundColour}
+				gapSize={getGapSize()}
 			>
 				{media && (
 					<ImageWrapper

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -239,7 +239,6 @@ export const Card = ({
 	isTagPage = false,
 	aspectRatio = '5:3',
 }: Props) => {
-	console.log('card aspect ratio', aspectRatio);
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
 		supportingContent,
@@ -341,7 +340,7 @@ export const Card = ({
 	const cardBackgroundColour = isOnwardContent
 		? themePalette('--onward-content-card-background')
 		: themePalette('--card-background');
-
+	const isFlexibleContainer = containerType === 'flexible/special';
 	/**
 	 * Some cards in standard containers have contrasting background colours.
 	 * We need to add additional padding to these cards to keep the text readable.
@@ -356,10 +355,7 @@ export const Card = ({
 			return 'none';
 		} else if (hasBackgroundColour) {
 			return 'small';
-		} else if (
-			containerType === 'flexible/special' &&
-			isHorizontalOnDesktop
-		) {
+		} else if (isFlexibleContainer && isHorizontalOnDesktop) {
 			return 'large';
 		} else {
 			return 'medium';
@@ -369,9 +365,7 @@ export const Card = ({
 	return (
 		<CardWrapper
 			format={format}
-			showTopBar={
-				!isOnwardContent && !(containerType === 'flexible/special')
-			}
+			showTopBar={!isOnwardContent && !isFlexibleContainer}
 			containerPalette={containerPalette}
 			isOnwardContent={isOnwardContent}
 		>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -136,7 +136,7 @@ export const CardLayout = ({
 		]}
 		style={{
 			backgroundColor: cardBackgroundColour,
-			gap: gapStyles(isOnwardContent, hasBackgroundColour),
+			gap: gapStyles(isOnwardContent, hasBackgroundColour, containerType),
 		}}
 	>
 		{children}

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -95,11 +95,14 @@ const decidePosition = (
 const gapStyles = (
 	isOnwardContent?: boolean,
 	hasBackgroundColour?: boolean,
+	containerType?: DCRContainerType,
 ) => {
 	if (isOnwardContent) {
 		return 0;
 	} else if (hasBackgroundColour) {
 		return `${space[1]}px`;
+	} else if (containerType === 'flexible/special') {
+		return `${space[5]}px`;
 	} else {
 		return `${space[2]}px`;
 	}

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -16,6 +16,7 @@ type Props = {
 	containerType?: DCRContainerType;
 	isOnwardContent?: boolean;
 	hasBackgroundColour?: boolean;
+	gapSize?: GapSize;
 };
 
 const decideDirection = (imagePosition: ImagePositionType) => {
@@ -92,19 +93,28 @@ const decidePosition = (
 	`;
 };
 
-const gapStyles = (
-	isOnwardContent?: boolean,
-	hasBackgroundColour?: boolean,
-	containerType?: DCRContainerType,
-) => {
-	if (isOnwardContent) {
-		return 0;
-	} else if (hasBackgroundColour) {
-		return `${space[1]}px`;
-	} else if (containerType === 'flexible/special') {
-		return `${space[5]}px`;
-	} else {
-		return `${space[2]}px`;
+type GapSize = 'none' | 'small' | 'medium' | 'large';
+
+/**
+ *
+ * Detemines the gap size between components in card layout
+ */
+const decideGap = (gapSize: GapSize) => {
+	switch (gapSize) {
+		case 'none':
+			return;
+		case 'small':
+			return css`
+				gap: ${space[1]}px;
+			`;
+		case 'medium':
+			return css`
+				gap: ${space[2]}px;
+			`;
+		case 'large':
+			return css`
+				gap: ${space[5]}px;
+			`;
 	}
 };
 
@@ -116,8 +126,7 @@ export const CardLayout = ({
 	minWidthInPixels,
 	imageType,
 	containerType,
-	isOnwardContent,
-	hasBackgroundColour,
+	gapSize = 'medium',
 }: Props) => (
 	<div
 		css={[
@@ -133,10 +142,10 @@ export const CardLayout = ({
 				imagePositionOnMobile,
 				imageType,
 			),
+			decideGap(gapSize),
 		]}
 		style={{
 			backgroundColor: cardBackgroundColour,
-			gap: gapStyles(isOnwardContent, hasBackgroundColour, containerType),
 		}}
 	>
 		{children}

--- a/dotcom-rendering/src/components/Card/components/LI.tsx
+++ b/dotcom-rendering/src/components/Card/components/LI.tsx
@@ -80,6 +80,23 @@ const decideDivider = (
 		: verticalDivider(borderColour);
 };
 
+//* Function to display the correct bottom border.The percentage dictates at which breakpoint the border is visible */
+const decideBorder = (percentage: CardPercentageType) => {
+	if (percentage === '100%') {
+		return css`
+			padding-bottom: 20px;
+			border-bottom: 1px solid ${palette('--section-border')};
+		`;
+	} else {
+		return css`
+			${until.desktop} {
+				padding-bottom: 20px;
+				border-bottom: 1px solid ${palette('--section-border')};
+			}
+		`;
+	}
+};
+
 type Props = {
 	children: React.ReactNode;
 	/** Used to give a particular LI more or less weight / space */
@@ -102,6 +119,8 @@ type Props = {
 	LI will have bottom padding, but won't have another card in the same container directly below it. */
 	offsetBottomPaddingOnDivider?: boolean;
 	verticalDividerColour?: string;
+	/** Toggle to show a bottom border. */
+	showBottomBorder?: boolean;
 };
 
 export const LI = ({
@@ -116,6 +135,7 @@ export const LI = ({
 	snapAlignStart = false,
 	offsetBottomPaddingOnDivider = false,
 	verticalDividerColour,
+	showBottomBorder = false,
 }: Props) => {
 	// Decide sizing
 	const sizeStyles = decideSize(percentage, stretch);
@@ -135,6 +155,7 @@ export const LI = ({
 				padSidesOnMobile &&
 					sidePaddingStylesMobile(padSidesMobileOverride),
 				snapAlignStart && snapAlignStartStyles,
+				showBottomBorder && decideBorder(percentage ?? '100%'),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -7,6 +7,7 @@ import type { ImageWidthType } from './Picture';
 import { generateSources, getFallbackSource } from './Picture';
 
 export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
+export type AspectRatio = '5:3' | '5:4';
 
 type Props = {
 	imageSize: ImageSizeType;
@@ -15,6 +16,7 @@ type Props = {
 	alt?: string;
 	roundedCorners?: boolean;
 	isCircular?: boolean;
+	aspectRatio?: AspectRatio;
 };
 
 /**
@@ -82,19 +84,23 @@ const block = css`
 	display: block;
 `;
 
-/** On fronts, all images are 5:3 */
-const aspectRatio = css`
-	padding-top: ${(3 / 5) * 100}%;
-	position: relative;
+/** On fronts, flexible-special cards are all images are 5:3 */
+const decideAspectRatio = (aspectRatio: AspectRatio) => {
+	return css`
+		padding-top: ${aspectRatio === '5:4'
+			? `${(4 / 5) * 100}%`
+			: `${(3 / 5) * 100}%`};
+		position: relative;
 
-	& > * {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-	}
-`;
+		& > * {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+		}
+	`;
+};
 
 const borderRadius = css`
 	& > * {
@@ -116,7 +122,14 @@ export const CardPicture = ({
 	loading,
 	roundedCorners,
 	isCircular,
+	aspectRatio = '5:3',
 }: Props) => {
+	console.log(
+		'card picture aspect ratio',
+		aspectRatio,
+		decideAspectRatio(aspectRatio),
+	);
+
 	const sources = generateSources(mainImage, decideImageWidths(imageSize));
 
 	const fallbackSource = getFallbackSource(sources);
@@ -126,7 +139,7 @@ export const CardPicture = ({
 			data-size={imageSize}
 			css={[
 				block,
-				aspectRatio,
+				decideAspectRatio(aspectRatio),
 				roundedCorners && borderRadius,
 				isCircular && circularStyles,
 			]}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -71,13 +71,15 @@ const TwoCardOrFourCardLayout = ({
 	showImage?: boolean;
 	padBottom?: boolean;
 }) => {
+	//TODO : Rename isTwoCards to a better name
+	const isTwoCards = cards.length <= 2;
 	return (
 		<UL direction="row" padBottom={padBottom}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI
 						stretch={false}
-						percentage={cards.length <= 2 ? '50%' : '25%'}
+						percentage={isTwoCards ? '50%' : '25%'}
 						key={card.url}
 						padSides={true}
 						showDivider={cardIndex > 0}
@@ -90,6 +92,9 @@ const TwoCardOrFourCardLayout = ({
 							absoluteServerTimes={absoluteServerTimes}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
+							imagePositionOnDesktop={
+								isTwoCards ? 'left' : 'bottom'
+							}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -112,6 +112,7 @@ const TwoCardOrFourCardLayout = ({
 								imagePositionOnDesktop={
 									isTwoCards ? 'left' : 'bottom'
 								}
+								imageSize={'medium'}
 								aspectRatio="5:4"
 							/>
 						</LI>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -61,6 +61,7 @@ export const OneCardLayout = ({
 					trailText={cards[0].trailText}
 					supportingContentAlignment="horizontal"
 					imageLoading={imageLoading}
+					aspectRatio="5:4"
 				/>
 			</LI>
 		</UL>
@@ -111,6 +112,7 @@ const TwoCardOrFourCardLayout = ({
 								imagePositionOnDesktop={
 									isTwoCards ? 'left' : 'bottom'
 								}
+								aspectRatio="5:4"
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,6 +1,3 @@
-import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
-import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
@@ -19,16 +16,6 @@ type Props = {
 	absoluteServerTimes: boolean;
 };
 
-const topBarStyles = css`
-	border-top: 1px solid ${palette('--card-border-top')};
-	content: '';
-	z-index: 2;
-	width: 100%;
-	margin: 0 10px;
-	padding-bottom: ${space[2]}px;
-	background-color: unset;
-`;
-
 export const OneCardLayout = ({
 	cards,
 	containerPalette,
@@ -46,7 +33,7 @@ export const OneCardLayout = ({
 
 	return (
 		<UL padBottom={true}>
-			<LI padSides={true}>
+			<LI padSides={true} showBottomBorder={true}>
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
@@ -88,38 +75,36 @@ const TwoCardOrFourCardLayout = ({
 	//TODO : Rename isTwoCards to a better name
 	const isTwoCards = cards.length <= 2;
 	return (
-		<>
-			<div css={topBarStyles} />
-			<UL direction="row" padBottom={padBottom}>
-				{cards.map((card, cardIndex) => {
-					return (
-						<LI
-							stretch={false}
-							percentage={isTwoCards ? '50%' : '25%'}
-							key={card.url}
-							padSides={true}
-							showDivider={cardIndex > 0}
-						>
-							<FrontCard
-								trail={card}
-								kickerText={card.kickerText}
-								containerPalette={containerPalette}
-								containerType="flexible/special"
-								showAge={showAge}
-								absoluteServerTimes={absoluteServerTimes}
-								image={showImage ? card.image : undefined}
-								imageLoading={imageLoading}
-								imagePositionOnDesktop={
-									isTwoCards ? 'left' : 'bottom'
-								}
-								imageSize={'medium'}
-								aspectRatio="5:4"
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-		</>
+		<UL direction="row" padBottom={padBottom}>
+			{cards.map((card, cardIndex) => {
+				return (
+					<LI
+						stretch={false}
+						percentage={isTwoCards ? '50%' : '25%'}
+						key={card.url}
+						padSides={true}
+						showDivider={cardIndex > 0}
+						showBottomBorder={true}
+					>
+						<FrontCard
+							trail={card}
+							kickerText={card.kickerText}
+							containerPalette={containerPalette}
+							containerType="flexible/special"
+							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
+							image={showImage ? card.image : undefined}
+							imageLoading={imageLoading}
+							imagePositionOnDesktop={
+								isTwoCards ? 'left' : 'bottom'
+							}
+							imageSize={'medium'}
+							aspectRatio="5:4"
+						/>
+					</LI>
+				);
+			})}
+		</UL>
 	);
 };
 

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,3 +1,6 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
@@ -15,6 +18,16 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 };
+
+const topBarStyles = css`
+	border-top: 1px solid ${palette('--card-border-top')};
+	content: '';
+	z-index: 2;
+	width: 100%;
+	margin: 0 10px;
+	padding-bottom: ${space[2]}px;
+	background-color: unset;
+`;
 
 export const OneCardLayout = ({
 	cards,
@@ -37,7 +50,7 @@ export const OneCardLayout = ({
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
-					containerType="dynamic/package"
+					containerType="flexible/special"
 					showAge={showAge}
 					absoluteServerTimes={absoluteServerTimes}
 					headlineSize="large"
@@ -74,32 +87,36 @@ const TwoCardOrFourCardLayout = ({
 	//TODO : Rename isTwoCards to a better name
 	const isTwoCards = cards.length <= 2;
 	return (
-		<UL direction="row" padBottom={padBottom}>
-			{cards.map((card, cardIndex) => {
-				return (
-					<LI
-						stretch={false}
-						percentage={isTwoCards ? '50%' : '25%'}
-						key={card.url}
-						padSides={true}
-						showDivider={cardIndex > 0}
-					>
-						<FrontCard
-							trail={card}
-							containerPalette={containerPalette}
-							containerType="dynamic/package"
-							showAge={showAge}
-							absoluteServerTimes={absoluteServerTimes}
-							image={showImage ? card.image : undefined}
-							imageLoading={imageLoading}
-							imagePositionOnDesktop={
-								isTwoCards ? 'left' : 'bottom'
-							}
-						/>
-					</LI>
-				);
-			})}
-		</UL>
+		<>
+			<div css={topBarStyles} />
+			<UL direction="row" padBottom={padBottom}>
+				{cards.map((card, cardIndex) => {
+					return (
+						<LI
+							stretch={false}
+							percentage={isTwoCards ? '50%' : '25%'}
+							key={card.url}
+							padSides={true}
+							showDivider={cardIndex > 0}
+						>
+							<FrontCard
+								trail={card}
+								kickerText={card.kickerText}
+								containerPalette={containerPalette}
+								containerType="flexible/special"
+								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
+								image={showImage ? card.image : undefined}
+								imageLoading={imageLoading}
+								imagePositionOnDesktop={
+									isTwoCards ? 'left' : 'bottom'
+								}
+							/>
+						</LI>
+					);
+				})}
+			</UL>
+		</>
 	);
 };
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
