### PR TITLE
Remove old default choice in favour of the new 3 tier choice cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -13,7 +13,6 @@ import {
 } from '@guardian/source/foundations';
 import {
 	containsNonArticleCountPlaceholder,
-	getLocalCurrencySymbol,
 	replaceNonArticleCountPlaceholders,
 } from '@guardian/support-dotcom-components';
 import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/src/types';
@@ -27,7 +26,6 @@ import {
 	createViewEventFromTracking,
 } from '../lib/tracking';
 import { logEpicView } from '../lib/viewLog';
-import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
@@ -146,11 +144,6 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 		ChoiceCardSelection | undefined
 	>();
 
-	const showThreeTierChoiceCards =
-		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
-
-	const variantOfChoiceCard = 'THREE_TIER_CHOICE_CARDS';
-
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
 			const localAmounts =
@@ -165,8 +158,6 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 			});
 		}
 	}, [showChoiceCards, choiceCardAmounts]);
-
-	const currencySymbol = getLocalCurrencySymbol(countryCode);
 
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
@@ -237,16 +228,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 					/>
 				) : (
 					<>
-						{choiceCardAmounts && !showThreeTierChoiceCards && (
-							<ContributionsEpicChoiceCards
-								setSelectionsCallback={setChoiceCardSelection}
-								selection={choiceCardSelection}
-								submitComponentEvent={submitComponentEvent}
-								currencySymbol={currencySymbol}
-								amountsTest={choiceCardAmounts}
-							/>
-						)}
-						{showThreeTierChoiceCards && (
+						{showChoiceCards && (
 							<ThreeTierChoiceCards
 								countryCode={countryCode}
 								selectedAmount={
@@ -255,7 +237,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 								setSelectedAmount={
 									setThreeTierChoiceCardSelectedAmount
 								}
-								variantOfChoiceCard={variantOfChoiceCard}
+								variantOfChoiceCard="THREE_TIER_CHOICE_CARDS"
 							/>
 						)}
 						<ContributionsEpicCtas
@@ -268,7 +250,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 							submitComponentEvent={submitComponentEvent}
 							showChoiceCards={showChoiceCards}
 							choiceCardSelection={choiceCardSelection}
-							showThreeTierChoiceCards={showThreeTierChoiceCards}
+							showThreeTierChoiceCards={showChoiceCards}
 							threeTierChoiceCardSelectedAmount={
 								threeTierChoiceCardSelectedAmount
 							}


### PR DESCRIPTION
## What does this change?

This removes the older default choice cards in favour of the new 3 tier choice cards.

## Why?

The recent AB test was very successful and so it has been decided that the variant 1 of that test will become the default choice card option.
This is still hard-coded in dotcom-rendering but there is an option to include or not include choice cards defined in the RRCP.
[Trello Card](https://trello.com/c/KeW4x6OP/622-roll-out-new-choice-cards-on-liveblog-epic)

## Screenshots

### Before: 
![Before](https://github.com/user-attachments/assets/7dd39c3e-dff2-4c37-b12d-3557ee73635a)
### After
![After](https://github.com/user-attachments/assets/fa7529b1-e2bf-4eab-9e0a-f9898ba89e0a)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
