### PR TITLE
Notifications on DCAR-rendered Apps Liveblogs

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.apps.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.tsx
@@ -17,6 +17,7 @@ import { Contributor } from './Contributor';
 import { Dateline } from './Dateline';
 import { FollowWrapper } from './FollowWrapper.importable';
 import { Island } from './Island';
+import { LiveblogNotifications } from './LiveblogNotifications.importable';
 
 type Props = {
 	format: ArticleFormat;
@@ -28,6 +29,8 @@ type Props = {
 	discussionApiUrl: string;
 	shortUrlId: string;
 	isCommentable: boolean;
+	pageId?: string;
+	headline?: string;
 };
 
 const metaGridContainer = css`
@@ -202,21 +205,28 @@ export const ArticleMetaApps = ({
 	discussionApiUrl,
 	shortUrlId,
 	isCommentable,
+	pageId,
+	headline,
 }: Props) => {
 	const soleContributor = getSoleContributor(tags, byline);
 	const authorName = soleContributor?.title ?? 'Author Image';
-
 	const avatarUrl = shouldShowAvatar(format)
 		? soleContributor?.bylineLargeImageUrl
 		: undefined;
+
 	const isInteractive = format.design === ArticleDesign.Interactive;
 	const isPicture = format.design === ArticleDesign.Picture;
 	const isComment = format.design === ArticleDesign.Comment;
 	const isImmersive = format.display === ArticleDisplay.Immersive;
 	const isAnalysis = format.design === ArticleDesign.Analysis;
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
+
 	const shouldShowFollowButtons = (layoutOrDesignType: boolean) =>
 		layoutOrDesignType && !!byline && !isUndefined(soleContributor);
+
+	const shouldShowLiveblogNotifications =
+		isLiveBlog && !!pageId && !!headline;
+
 	const isImmersiveOrAnalysisWithMultipleAuthors =
 		(isAnalysis || isImmersive) && !!byline && isUndefined(soleContributor);
 
@@ -270,6 +280,14 @@ export const ArticleMetaApps = ({
 								/>
 							</Island>
 						)}
+					{shouldShowLiveblogNotifications && (
+						<Island priority="critical">
+							<LiveblogNotifications
+								displayName={headline}
+								id={pageId}
+							/>
+						</Island>
+					)}
 				</MetaGridByline>
 				{isCommentable && (
 					<MetaGridCommentCount

--- a/dotcom-rendering/src/components/ArticleMeta.web.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.web.test.tsx
@@ -1,7 +1,7 @@
 import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { render } from '@testing-library/react';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
-import { ArticleMeta } from './ArticleMeta.web';
+import { ArticleMeta, shouldShowContributor } from './ArticleMeta.web';
 import { ConfigProvider } from './ConfigContext';
 
 jest.mock('../lib/bridgetApi', () => jest.fn());
@@ -99,5 +99,57 @@ describe('ArticleMeta', () => {
 		expect(
 			container.querySelector(`.${interactiveLegacyClasses.shareIcons}`),
 		).toBeNull();
+	});
+});
+
+describe('shouldShowContributor', () => {
+	const standardFormat = {
+		theme: Pillar.News,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
+	};
+	const standardComment = {
+		...standardFormat,
+		design: ArticleDesign.Comment,
+	};
+	const showcaseStandard = {
+		...standardFormat,
+		display: ArticleDisplay.Showcase,
+	};
+	const showcaseComment = {
+		...showcaseStandard,
+		design: ArticleDesign.Comment,
+	};
+	const numberedList = {
+		...standardFormat,
+		display: ArticleDisplay.NumberedList,
+	};
+	const immersive = {
+		...standardFormat,
+		display: ArticleDisplay.Immersive,
+	};
+
+	it('should return true if Standard display and Standard design', () => {
+		expect(shouldShowContributor(standardFormat)).toBe(true);
+	});
+
+	it('should return false if Standard display and Comment design', () => {
+		expect(shouldShowContributor(standardComment)).toBe(false);
+	});
+
+	it('should return true if Showcase display and Standard design', () => {
+		expect(shouldShowContributor(showcaseStandard)).toBe(true);
+	});
+
+	it('should return false if Showcase display and Comment design', () => {
+		expect(shouldShowContributor(showcaseComment)).toBe(false);
+	});
+
+	it('should return true if Numbered list display', () => {
+		expect(shouldShowContributor(numberedList)).toBe(true);
+	});
+
+	it('should return false if Immersive display', () => {
+		expect(shouldShowContributor(immersive)).toBe(false);
 	});
 });

--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -183,11 +183,12 @@ export const BylineLink = ({
 
 	const { renderingTarget } = useConfig();
 	const isApps = renderingTarget === 'Apps';
+	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
 
 	return (
 		<>
 			{renderedTokens}
-			{isApps && !isHeadline && hasSoleContributor ? (
+			{isApps && !isLiveBlog && !isHeadline && hasSoleContributor ? (
 				<Hide from="leftCol">
 					<DottedLines
 						count={1}

--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -173,7 +173,6 @@ export const BylineLink = ({
 	const soleContributor = getSoleContributor(tags, byline);
 	const hasSoleContributor = !!soleContributor;
 	const bylineComponents = getBylineComponentsFromTokens(tokens, tags);
-	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
 
 	const renderedTokens = getRenderedTokens(
 		bylineComponents,
@@ -182,24 +181,17 @@ export const BylineLink = ({
 		source,
 	);
 
-	/**
-	 * Where is this coming from?
-	 * Config value is set at high in the component tree within a React context in a `<ConfigProvider />`
-	 */
 	const { renderingTarget } = useConfig();
+	const isApps = renderingTarget === 'Apps';
 
 	return (
 		<>
 			{renderedTokens}
-			{renderingTarget === 'Apps' && !isHeadline && hasSoleContributor ? (
+			{isApps && !isHeadline && hasSoleContributor ? (
 				<Hide from="leftCol">
 					<DottedLines
 						count={1}
-						color={
-							isLiveBlog
-								? 'rgba(255, 255, 255, 0.4)'
-								: themePalette('--article-meta-lines')
-						}
+						color={themePalette('--article-meta-lines')}
 					/>
 					<Island priority="critical">
 						<FollowWrapper

--- a/dotcom-rendering/src/components/LiveblogNotifications.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogNotifications.importable.tsx
@@ -3,36 +3,24 @@ import { Topic } from '@guardian/bridget/Topic';
 import { isUndefined, log } from '@guardian/libs';
 import { from, space } from '@guardian/source/foundations';
 import { useEffect, useState } from 'react';
-import { getNotificationsClient, getTagClient } from '../lib/bridgetApi';
-import { useIsBridgetCompatible } from '../lib/useIsBridgetCompatible';
-import { useIsMyGuardianEnabled } from '../lib/useIsMyGuardianEnabled';
-import { FollowNotificationsButton, FollowTagButton } from './FollowButtons';
+import { getNotificationsClient } from '../lib/bridgetApi';
+import { FollowNotificationsButton } from './FollowButtons';
 
 type Props = {
 	id: string;
 	displayName: string;
 };
 
-export const FollowWrapper = ({ id, displayName }: Props) => {
+export const LiveblogNotifications = ({ id, displayName }: Props) => {
 	const [isFollowingNotifications, setIsFollowingNotifications] = useState<
 		boolean | undefined
 	>(undefined);
-	const [isFollowingTag, setIsFollowingTag] = useState<boolean | undefined>(
-		undefined,
-	);
-	const [showFollowTagButton, setShowFollowTagButton] =
-		useState<boolean>(false);
-
-	const isMyGuardianEnabled = useIsMyGuardianEnabled();
-	const isBridgetCompatible = useIsBridgetCompatible('2.5.0');
-
-	isBridgetCompatible && isMyGuardianEnabled && setShowFollowTagButton(true);
 
 	useEffect(() => {
 		const topic = new Topic({
 			id,
 			displayName,
-			type: 'tag-contributor',
+			type: 'content',
 		});
 
 		void getNotificationsClient()
@@ -49,70 +37,13 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 						error,
 					);
 			});
-
-		void getTagClient()
-			.isFollowing(topic)
-			.then(setIsFollowingTag)
-			.catch((error) => {
-				window.guardian.modules.sentry.reportError(
-					error,
-					'bridget-getTagClient-isFollowing-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getTagClient.isFollowing Error:',
-						error,
-					);
-			});
 	}, [id, displayName]);
-
-	const tagHandler = () => {
-		const topic = new Topic({
-			id,
-			displayName,
-			type: 'tag-contributor',
-		});
-
-		isFollowingTag
-			? void getTagClient()
-					.unfollow(topic)
-					.then((success) => {
-						success && setIsFollowingTag(false);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getTagClient-unfollow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getTagClient.unfollow Error:',
-								error,
-							);
-					})
-			: void getTagClient()
-					.follow(topic)
-					.then((success) => {
-						success && setIsFollowingTag(true);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getTagClient-follow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getTagClient.follow Error:',
-								error,
-							);
-					});
-	};
 
 	const notificationsHandler = () => {
 		const topic = new Topic({
 			id,
 			displayName,
-			type: 'tag-contributor',
+			type: 'content',
 		});
 
 		isFollowingNotifications
@@ -153,6 +84,7 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 	return (
 		<div
 			css={css`
+				margin-top: ${space[3]}px;
 				min-height: ${space[6]}px;
 
 				${from.phablet} {
@@ -165,18 +97,6 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 				}
 			`}
 		>
-			{showFollowTagButton && (
-				<FollowTagButton
-					isFollowing={isFollowingTag ?? false}
-					displayName={displayName}
-					onClickHandler={
-						!isUndefined(isFollowingTag)
-							? tagHandler
-							: () => undefined
-					}
-					withExtraBottomMargin={true}
-				/>
-			)}
 			<FollowNotificationsButton
 				isFollowing={isFollowingNotifications ?? false}
 				onClickHandler={

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -36,7 +36,6 @@ import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { KeyEventsCarousel } from '../components/KeyEventsCarousel.importable';
-import { LiveblogNotifications } from '../components/LiveblogNotifications.importable';
 import { Liveness } from '../components/Liveness.importable';
 import { MainMedia } from '../components/MainMedia';
 import { Masthead } from '../components/Masthead/Masthead';
@@ -834,19 +833,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 												article.config.shortUrlId
 											}
 										/>
-										{isApps && (
-											<Island
-												priority="feature"
-												defer={{ until: 'visible' }}
-											>
-												<LiveblogNotifications
-													displayName={
-														article.headline
-													}
-													id={article.pageId}
-												/>
-											</Island>
-										)}
 									</div>
 								</Hide>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -36,6 +36,7 @@ import { Header } from '../components/Header';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { KeyEventsCarousel } from '../components/KeyEventsCarousel.importable';
+import { LiveblogNotifications } from '../components/LiveblogNotifications.importable';
 import { Liveness } from '../components/Liveness.importable';
 import { MainMedia } from '../components/MainMedia';
 import { Masthead } from '../components/Masthead/Masthead';
@@ -642,6 +643,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											article.config.discussionApiUrl
 										}
 										shortUrlId={article.config.shortUrlId}
+										pageId={article.pageId}
+										headline={article.headline}
 									></ArticleMetaApps>
 								)}
 								{isWeb && (
@@ -831,6 +834,19 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 												article.config.shortUrlId
 											}
 										/>
+										{isApps && (
+											<Island
+												priority="feature"
+												defer={{ until: 'visible' }}
+											>
+												<LiveblogNotifications
+													displayName={
+														article.headline
+													}
+													id={article.pageId}
+												/>
+											</Island>
+										)}
 									</div>
 								</Hide>
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 /* eslint sort-keys: ["error", "asc", { minKeys: 12, natural: true }]
   --
-  the palette object is large and ordering helps knowing where  to insert new elements
+  the palette object is large and ordering helps knowing where to insert new elements
 */
 import type { ArticleFormat, ArticleTheme } from '@guardian/libs';
 import {


### PR DESCRIPTION
Closes #9103

## What does this change?

Enables a user to subscribe to notifications on a liveblog in the apps.

## Why?

We want to render liveblogs with DCAR instead of native templates. Notifications are a key part of functionality on apps.

## Screenshots

| <img width=200/> | Native Templates | DCAR |
| - | - | - |
| Single contributor | ![sc-nt] | ![sc-dc] |
| multiple contributor | ![mc-nt] | ![mc-dc] |

[sc-nt]: https://github.com/user-attachments/assets/8605ae6b-1404-4606-9fa6-bcbda5d73f96
[sc-dc]: https://github.com/user-attachments/assets/91391eb7-d70c-4c6d-abbd-d797f8a3ff3c
[mc-nt]: https://github.com/user-attachments/assets/ef6ee876-6fb4-43f3-b107-06cca6be453d
[mc-dc]: https://github.com/user-attachments/assets/4c6386d9-8442-4ca3-b7ff-6c1aaeeffe4e


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
