### PR TITLE
Add edition label map to edition switcher

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -67,7 +67,7 @@ export const EditionDropdown = ({
 	const editionToDropdownLink = (edition: EditionLinkType) => ({
 		id: edition.editionId,
 		url: edition.url,
-		title: edition.longTitle,
+		title: edition.shortTitle,
 		dataLinkName: nestedOphanComponents(
 			'header',
 			'titlepiece',
@@ -90,9 +90,7 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition
-		? editionIdMap[activeEdition.id as EditionId]
-		: 'Edition';
+	const label = showCurrentEdition ? activeEdition.title : 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -51,6 +51,14 @@ const dropDownOverrides = css`
 	}
 `;
 
+const editionIdMap: Record<EditionId, string> = {
+	INT: 'Int',
+	UK: 'UK',
+	US: 'US',
+	AU: 'Aus',
+	EUR: 'Eur',
+};
+
 export const EditionDropdown = ({
 	editionId,
 	dataLinkName,
@@ -82,7 +90,9 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition ? activeEdition.id : 'Edition';
+	const label = showCurrentEdition
+		? editionIdMap[activeEdition.id as EditionId]
+		: 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -51,14 +51,6 @@ const dropDownOverrides = css`
 	}
 `;
 
-const editionIdMap: Record<EditionId, string> = {
-	INT: 'Int',
-	UK: 'UK',
-	US: 'US',
-	AU: 'Aus',
-	EUR: 'Eur',
-};
-
 export const EditionDropdown = ({
 	editionId,
 	dataLinkName,

--- a/dotcom-rendering/src/lib/edition.ts
+++ b/dotcom-rendering/src/lib/edition.ts
@@ -16,6 +16,7 @@ const editionList = [
 		timeZone: 'Europe/London',
 		langLocale: 'en-GB',
 		hasEditionalisedPages: true,
+		shortTitle: 'UK',
 	},
 	{
 		url: '/preference/edition/us',
@@ -27,6 +28,7 @@ const editionList = [
 		timeZone: 'America/New_York',
 		langLocale: 'en-US',
 		hasEditionalisedPages: true,
+		shortTitle: 'US',
 	},
 	{
 		url: '/preference/edition/au',
@@ -38,6 +40,7 @@ const editionList = [
 		timeZone: 'Australia/Sydney',
 		langLocale: 'en-AU',
 		hasEditionalisedPages: true,
+		shortTitle: 'Aus',
 	},
 	{
 		url: '/preference/edition/eur',
@@ -49,6 +52,7 @@ const editionList = [
 		timeZone: 'Europe/Paris',
 		langLocale: 'en-EU',
 		hasEditionalisedPages: false,
+		shortTitle: 'Eur',
 	},
 	{
 		url: '/preference/edition/int',
@@ -60,6 +64,7 @@ const editionList = [
 		timeZone: 'Europe/London',
 		langLocale: 'en',
 		hasEditionalisedPages: false,
+		shortTitle: 'Int',
 	},
 ] as const satisfies ReadonlyArray<{
 	url: string;
@@ -71,6 +76,7 @@ const editionList = [
 	timeZone: string;
 	langLocale?: string;
 	hasEditionalisedPages: boolean;
+	shortTitle: string;
 }>;
 
 const [ukEdition] = editionList;

--- a/dotcom-rendering/src/model/extract-nav.ts
+++ b/dotcom-rendering/src/model/extract-nav.ts
@@ -18,6 +18,7 @@ export interface EditionLinkType extends LinkType {
 	editionId: EditionId;
 	dateLocale: string;
 	timeZone: string;
+	shortTitle: string;
 }
 
 export interface PillarLinkType extends LinkType {


### PR DESCRIPTION
## What does this change?
Adds a short title to each edition which is a lowercase abbreviation of the title. This maps to the following:

	INT =>'Int',
	UK => 'UK',
	US => 'US',
	AU =>'Aus',
	EUR => 'Eur',

## Why?
We want the Edition label to be as readable as possible. We cannot display the full name of the edition as there is not enough space in the new designs on mobile. This also brings consistency with apps.

## Edition Screenshots

| Europe Before      | Europe After      | 
| ----------- | ---------- | 
| ![before][] | ![after][] | 

| International Before      |  International After      | 
| ----------- | ---------- |
| ![int-b][] | ![int-a][] |

| Australia Before      | Australia After      |
| ----------- | ---------- |
| ![aus-b][] | ![aus-a][] |

[before]: https://github.com/user-attachments/assets/7cc25307-e5b3-4db1-b3f9-a138c7d0ee24
[after]: https://github.com/user-attachments/assets/69aff412-c3a0-4182-b08a-e3731a65c0da
[int-b]: https://github.com/user-attachments/assets/2b90431a-0762-4f88-8650-e76371598685
[int-a]: https://github.com/user-attachments/assets/b9800aa0-5df6-4679-8507-3703f0a01456
[aus-b]: https://github.com/user-attachments/assets/1cdb0879-7451-4b33-87f2-1c7f2a0ec918
[aus-a]: https://github.com/user-attachments/assets/6bf12e39-b6a3-45f0-814e-59bc6bdc52fc

### NB that UK and US are acronyms and so their appearance won't change, as evidenced below.

| UK Before      | UK After      | 
| ----------- | ---------- | 
| ![uk-b][] | ![uk-a][] | 

 | US Before      |  US After      | 
| ----------- | ---------- |
| ![us-b][] | ![us-a][] |

[uk-b]: https://github.com/user-attachments/assets/b2511c97-718c-4b73-b2b0-e0838eb8fd88
[uk-a]: https://github.com/user-attachments/assets/375e2066-5906-4085-9ce9-65e5d0b23c30
[us-b]: https://github.com/user-attachments/assets/b53ccb1a-1008-42d3-aa0f-fdd955918c0b
[us-a]: https://github.com/user-attachments/assets/ceaae8ac-3c8e-47ec-becf-76e7044fc214

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
