### PR TITLE
Remove discussion-frontend URL

### DIFF
--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1805,7 +1805,6 @@
 		"isContent": true,
 		"contentId": "games/2018/aug/23/nier-automata-yoko-taro-interview",
 		"edition": "UK",
-		"discussionFrontendUrl": "https://assets.guim.co.uk/discussion/discussion-frontend.preact.iife.strict-sanctions-check-parameter.js",
 		"ipsosTag": "games",
 		"ophanJsUrl": "//j.ophan.co.uk/ophan.ng",
 		"productionOffice": "Uk",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -190,9 +190,6 @@
                 "edition": {
                     "type": "string"
                 },
-                "discussionFrontendUrl": {
-                    "type": "string"
-                },
                 "ipsosTag": {
                     "type": "string"
                 },
@@ -297,7 +294,6 @@
                 "discussionApiClientHeader",
                 "discussionApiUrl",
                 "discussionD2Uid",
-                "discussionFrontendUrl",
                 "edition",
                 "externalEmbedHost",
                 "facebookIaAdUnitRoot",

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1046,9 +1046,6 @@
                 "edition": {
                     "type": "string"
                 },
-                "discussionFrontendUrl": {
-                    "type": "string"
-                },
                 "ipsosTag": {
                     "type": "string"
                 },
@@ -1153,7 +1150,6 @@
                 "discussionApiClientHeader",
                 "discussionApiUrl",
                 "discussionD2Uid",
-                "discussionFrontendUrl",
                 "edition",
                 "externalEmbedHost",
                 "facebookIaAdUnitRoot",

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -475,7 +475,6 @@ export type FEFrontConfigType = {
 	googletagJsUrl: string;
 	supportUrl: string;
 	edition: string;
-	discussionFrontendUrl: string;
 	ipsosTag: string;
 	ophanJsUrl: string;
 	isPaidContent?: boolean;


### PR DESCRIPTION
It's not used by DCAR, and we're getting rid of it from frontend.

See #11717
