### PR TITLE
[Fairground 🎡]  Add 5:4 aspect ratio for card pictures

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1456,3 +1456,31 @@ export const DynamoWithSpecialPaletteVariations = () => {
 		</>
 	);
 };
+
+export const WithAFiveFourAspectRatio = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						image={{
+							src: 'https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/2db0f6baf3eac423bfeb07cf04d95a7f810c2f6c/554_0_2946_2356/master/2946.jpg',
+							altText: '5:4 aspect ratio',
+						}}
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Comment,
+							theme: Pillar.Opinion,
+						}}
+						aspectRatio="5:4"
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -26,7 +26,7 @@ import type { OnwardsSource } from '../../types/onwards';
 import { Avatar } from '../Avatar';
 import { CardCommentCount } from '../CardCommentCount.importable';
 import { CardHeadline } from '../CardHeadline';
-import type { Loading } from '../CardPicture';
+import type { AspectRatio, Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
@@ -108,6 +108,8 @@ export type Props = {
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
 	isTagPage?: boolean;
+	//** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
+	aspectRatio?: AspectRatio;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -236,6 +238,7 @@ export const Card = ({
 	showMainVideo = true,
 	absoluteServerTimes,
 	isTagPage = false,
+	aspectRatio,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -474,6 +477,7 @@ export const Card = ({
 											alt={headlineText}
 											loading={imageLoading}
 											roundedCorners={isOnwardContent}
+											aspectRatio={aspectRatio}
 										/>
 									</div>
 								)}
@@ -487,6 +491,7 @@ export const Card = ({
 									alt={media.imageAltText}
 									loading={imageLoading}
 									roundedCorners={isOnwardContent}
+									aspectRatio={aspectRatio}
 								/>
 								{showPlayIcon && mainMedia.duration > 0 && (
 									<MediaDuration

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -89,7 +89,7 @@ const block = css`
  * This is due to replace the existing card ratio of 5:3
  * For now, we are keeping both ratios.
  */
-const decideAspectRatio = (aspectRatio: AspectRatio) => {
+const decideAspectRatioStyles = (aspectRatio: AspectRatio) => {
 	return css`
 		padding-top: ${aspectRatio === '5:4'
 			? `${(4 / 5) * 100}%`

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -136,7 +136,7 @@ export const CardPicture = ({
 			data-size={imageSize}
 			css={[
 				block,
-				decideAspectRatio(aspectRatio),
+				decideAspectRatioStyles(aspectRatio),
 				roundedCorners && borderRadius,
 				isCircular && circularStyles,
 			]}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -7,6 +7,7 @@ import type { ImageWidthType } from './Picture';
 import { generateSources, getFallbackSource } from './Picture';
 
 export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
+export type AspectRatio = '5:3' | '5:4';
 
 type Props = {
 	imageSize: ImageSizeType;
@@ -15,6 +16,7 @@ type Props = {
 	alt?: string;
 	roundedCorners?: boolean;
 	isCircular?: boolean;
+	aspectRatio?: AspectRatio;
 };
 
 /**
@@ -82,19 +84,26 @@ const block = css`
 	display: block;
 `;
 
-/** On fronts, all images are 5:3 */
-const aspectRatio = css`
-	padding-top: ${(3 / 5) * 100}%;
-	position: relative;
-
-	& > * {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-	}
-`;
+/**
+ * On fronts, Fairground cards have an image ration of 5:4.
+ * This is due to replace the existing card ratio of 5:3
+ * For now, we are keeping both ratios.
+ */
+const decideAspectRatio = (aspectRatio: AspectRatio) => {
+	return css`
+		padding-top: ${aspectRatio === '5:4'
+			? `${(4 / 5) * 100}%`
+			: `${(3 / 5) * 100}%`};
+		position: relative;
+		& > * {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+		}
+	`;
+};
 
 const borderRadius = css`
 	& > * {
@@ -116,6 +125,7 @@ export const CardPicture = ({
 	loading,
 	roundedCorners,
 	isCircular,
+	aspectRatio = '5:3', // Default aspect ratio
 }: Props) => {
 	const sources = generateSources(mainImage, decideImageWidths(imageSize));
 
@@ -126,7 +136,7 @@ export const CardPicture = ({
 			data-size={imageSize}
 			css={[
 				block,
-				aspectRatio,
+				decideAspectRatio(aspectRatio),
 				roundedCorners && borderRadius,
 				isCircular && circularStyles,
 			]}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -48,6 +48,8 @@ export const OneCardLayout = ({
 					trailText={cards[0].trailText}
 					supportingContentAlignment="horizontal"
 					imageLoading={imageLoading}
+					aspectRatio="5:4"
+					kickerText={cards[0].kickerText}
 				/>
 			</LI>
 		</UL>
@@ -95,6 +97,7 @@ const TwoCardOrFourCardLayout = ({
 								hasTwoOrFewerCards ? 'left' : 'bottom'
 							}
 							imageSize={'medium'}
+							aspectRatio="5:4"
 							kickerText={card.kickerText}
 						/>
 					</LI>


### PR DESCRIPTION
## What does this change?
Lets the consumer of CardPicture determine the aspect ratio of the image. This is limited in the types as 5:4 or 5:3 with 5:3 being the default. 

Depending on which aspect ratio is selected, the appropriate padding is added to the image. This will require editorial to select the correct crop in the grid. 

## Why?
Fronts cards are migrating to a 5:4 aspect ratio. This change allows us to introduce this aspect whilst maintaining all other card picture ratios.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![after][] | ![before][] |

[before]: https://github.com/user-attachments/assets/425e7648-3f97-4c8f-b7ee-c35d183fce2f
[after]: https://github.com/user-attachments/assets/df8aa7f5-5f3b-4bfc-9f3f-33803e4a0ffe


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
