### PR TITLE
Use short title only for label not drop down list

### DIFF
--- a/dotcom-rendering/src/components/Dropdown.importable.tsx
+++ b/dotcom-rendering/src/components/Dropdown.importable.tsx
@@ -26,7 +26,7 @@ export interface DropdownLinkType {
 	id: string;
 	url: string;
 	title: string;
-	shortTitle: string;
+	shortTitle?: string;
 	isActive?: boolean;
 	dataLinkName: string;
 	notifications?: Notification[];

--- a/dotcom-rendering/src/components/Dropdown.importable.tsx
+++ b/dotcom-rendering/src/components/Dropdown.importable.tsx
@@ -26,6 +26,7 @@ export interface DropdownLinkType {
 	id: string;
 	url: string;
 	title: string;
+	shortTitle: string;
 	isActive?: boolean;
 	dataLinkName: string;
 	notifications?: Notification[];

--- a/dotcom-rendering/src/components/Dropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Dropdown.stories.tsx
@@ -46,24 +46,28 @@ const links: [
 		title: 'UK edition',
 		isActive: true,
 		dataLinkName: 'linkname-UK',
+		shortTitle: 'UK',
 	},
 	{
 		id: 'us',
 		url: '/preference/edition/us',
 		title: 'US edition',
 		dataLinkName: 'linkname-US',
+		shortTitle: 'US',
 	},
 	{
 		id: 'au',
 		url: '/preference/edition/au',
 		title: 'Australia edition',
 		dataLinkName: 'linkname-AU',
+		shortTitle: 'Aus',
 	},
 	{
 		id: 'int',
 		url: '/preference/edition/int',
 		title: 'International edition',
 		dataLinkName: 'linkname-INT',
+		shortTitle: 'Int',
 	},
 ];
 

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -60,7 +60,7 @@ export const EditionDropdown = ({
 		id: edition.editionId,
 		url: edition.url,
 		title: edition.longTitle,
-		shortTitle: edition.shortTitle ?? activeEdition.title,
+		shortTitle: edition.shortTitle,
 		dataLinkName: nestedOphanComponents(
 			'header',
 			'titlepiece',
@@ -83,7 +83,9 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition ? activeEdition.shortTitle : 'Edition';
+	const label = showCurrentEdition
+		? activeEdition.shortTitle ?? activeEdition.title
+		: 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -59,7 +59,8 @@ export const EditionDropdown = ({
 	const editionToDropdownLink = (edition: EditionLinkType) => ({
 		id: edition.editionId,
 		url: edition.url,
-		title: edition.shortTitle,
+		title: edition.longTitle,
+		shortTitle: edition.shortTitle,
 		dataLinkName: nestedOphanComponents(
 			'header',
 			'titlepiece',
@@ -82,7 +83,7 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition ? activeEdition.title : 'Edition';
+	const label = showCurrentEdition ? activeEdition.shortTitle : 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -60,7 +60,7 @@ export const EditionDropdown = ({
 		id: edition.editionId,
 		url: edition.url,
 		title: edition.longTitle,
-		shortTitle: edition.shortTitle,
+		shortTitle: edition.shortTitle ?? activeEdition.title,
 		dataLinkName: nestedOphanComponents(
 			'header',
 			'titlepiece',
@@ -83,9 +83,7 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition
-		? activeEdition.shortTitle || activeEdition.title
-		: 'Edition';
+	const label = showCurrentEdition ? activeEdition.shortTitle : 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -84,7 +84,7 @@ export const EditionDropdown = ({
 	];
 
 	const label = showCurrentEdition
-		? activeEdition.shortTitle ?? activeEdition.title
+		? activeEdition.shortTitle ?? activeEdition.id
 		: 'Edition';
 
 	return (

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -83,7 +83,9 @@ export const EditionDropdown = ({
 		...dropdownItems.filter(({ isActive }) => !isActive),
 	];
 
-	const label = showCurrentEdition ? activeEdition.shortTitle : 'Edition';
+	const label = showCurrentEdition
+		? activeEdition.shortTitle || activeEdition.title
+		: 'Edition';
 
 	return (
 		<div css={editionDropdownStyles}>


### PR DESCRIPTION
## What does this change?
Adds a short title to drop down link type so that we can display a short title as the label but the long title in the dropdown list.
