### PR TITLE
Add basic set up to flexible special card layouts

### DIFF
--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -37,14 +37,14 @@ export const OneCardLayout = ({
 				<FrontCard
 					trail={cards[0]}
 					containerPalette={containerPalette}
-					containerType="dynamic/package"
+					containerType="flexible/special"
 					showAge={showAge}
 					absoluteServerTimes={absoluteServerTimes}
 					headlineSize="large"
 					headlineSizeOnMobile="medium"
 					imagePositionOnDesktop="right"
 					imagePositionOnMobile="left"
-					imageSize="medium"
+					imageSize="jumbo"
 					trailText={cards[0].trailText}
 					supportingContentAlignment="horizontal"
 					imageLoading={imageLoading}
@@ -71,13 +71,14 @@ const TwoCardOrFourCardLayout = ({
 	showImage?: boolean;
 	padBottom?: boolean;
 }) => {
+	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
 		<UL direction="row" padBottom={padBottom}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI
 						stretch={false}
-						percentage={cards.length <= 2 ? '50%' : '25%'}
+						percentage={hasTwoOrFewerCards ? '50%' : '25%'}
 						key={card.url}
 						padSides={true}
 						showDivider={cardIndex > 0}
@@ -85,11 +86,16 @@ const TwoCardOrFourCardLayout = ({
 						<FrontCard
 							trail={card}
 							containerPalette={containerPalette}
-							containerType="dynamic/package"
+							containerType="flexible/special"
 							showAge={showAge}
 							absoluteServerTimes={absoluteServerTimes}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
+							imagePositionOnDesktop={
+								hasTwoOrFewerCards ? 'left' : 'bottom'
+							}
+							imageSize={'medium'}
+							kickerText={card.kickerText}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
## What does this change?
Adjusts the props passed from flexible special to their cards. This sets up the basic layout of cards in the flexible special container.

## Screenshots

| Two card before      | Two card after      | four card before      | four card after      |
| ----------- | ---------- | ----------- | ---------- |
| ![2before][] | ![2after][] | ![4before][] | ![4after][] |

[2before]: https://github.com/user-attachments/assets/3497bc77-82f4-419f-8b34-f0dc59471f3a
[2after]: https://github.com/user-attachments/assets/0b71256e-c74e-4106-a8da-4961e2c68333
[4before]: https://github.com/user-attachments/assets/96331b18-b4f5-43fd-8d58-c43f1ef14371
[4after]: https://github.com/user-attachments/assets/30d7c7b1-bda4-4a03-ae20-1c66a8a3f71d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
