### PR TITLE
Fix e2e test which fails when in UpdatedHeaderDesign test

### DIFF
--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { devices, expect, test } from '@playwright/test';
+import { addCookie } from 'playwright/lib/cookies';
 import { disableCMP } from '../lib/cmp';
 import { waitForIsland } from '../lib/islands';
 import { loadPage } from '../lib/load-page';
@@ -118,6 +119,10 @@ test.describe('Interactivity', () => {
 			context,
 			page,
 		}) => {
+			await addCookie(context, {
+				name: 'X-GU-Experiment-50perc',
+				value: 'false',
+			});
 			await disableCMP(context);
 			await loadPage(page, `/Article/${articleUrl}`);
 			await waitForIsland(page, 'SupportTheG');


### PR DESCRIPTION
## What does this change?

Opts out of the [UpdatedHeaderDesign](https://github.com/guardian/frontend/blob/main/common/app/experiments/Experiments.scala#L31) experiment when running a playwright test that waits for an island in the header. 

## Why?

An article interactivity [test is failing](https://github.com/guardian/dotcom-rendering/actions/runs/10527416729/job/29170956781) when inside the UpdatedHeaderDesign experiment.

## Screenshots

<img width="1290" alt="Screenshot 2024-08-23 at 15 55 45" src="https://github.com/user-attachments/assets/c7660fab-5ecd-4470-8b0c-4dc5244c0b57">
