### PR TITLE
Restyle and refactor card footer

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -248,6 +248,7 @@ export const Card = ({
 	);
 
 	const showQuotes = !!showQuotedHeadline;
+	const isFlexibleContainer = containerType === 'flexible/special';
 
 	const isOpinion =
 		format.design === ArticleDesign.Comment ||
@@ -265,7 +266,6 @@ export const Card = ({
 
 		return (
 			<CardAge
-				format={format}
 				webPublication={{
 					date: webPublicationDate,
 					isWithinTwelveHours: withinTwelveHours,
@@ -581,37 +581,13 @@ export const Card = ({
 									/>
 								</TrailTextWrapper>
 							)}
-						</div>
-
-						{/* This div is needed to push this content to the bottom of the card */}
-						<div
-							style={
-								isOnwardContent
-									? { marginTop: `${space[4]}px` }
-									: {}
-							}
-						>
-							{showLivePlayable && (
-								<Island
-									priority="feature"
-									defer={{ until: 'visible' }}
-								>
-									<LatestLinks
-										id={linkTo}
-										isDynamo={isDynamo}
-										direction={supportingContentAlignment}
-										containerPalette={containerPalette}
-										absoluteServerTimes={
-											absoluteServerTimes
-										}
-									></LatestLinks>
-								</Island>
-							)}
-
 							{!showCommentFooter && (
 								<CardFooter
 									format={format}
-									leftAlign={isOnwardContent}
+									topAlign={
+										isFlexibleContainer &&
+										imageSize === 'jumbo'
+									}
 									age={decideAge()}
 									commentCount={<CommentCount />}
 									cardBranding={
@@ -628,6 +604,28 @@ export const Card = ({
 									}
 									showLivePlayable={showLivePlayable}
 								/>
+							)}
+						</div>
+
+						{/* This div is needed to push this content to the bottom of the card */}
+						<div
+							style={isOnwardContent ? { marginTop: 'auto' } : {}}
+						>
+							{showLivePlayable && (
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<LatestLinks
+										id={linkTo}
+										isDynamo={isDynamo}
+										direction={supportingContentAlignment}
+										containerPalette={containerPalette}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
+									></LatestLinks>
+								</Island>
 							)}
 
 							{hasSublinks && sublinkPosition === 'inner' && (
@@ -663,7 +661,6 @@ export const Card = ({
 				{showCommentFooter && (
 					<CardFooter
 						format={format}
-						leftAlign={isOnwardContent}
 						age={decideAge()}
 						commentCount={<CommentCount />}
 						cardBranding={

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
-import { type ArticleFormat, timeAgo } from '@guardian/libs';
-import { from, textSans12, textSansBold12 } from '@guardian/source/foundations';
-import { cardHasDarkBackground } from '../../../lib/cardHelpers';
+import { timeAgo } from '@guardian/libs';
+import { textSansBold12 } from '@guardian/source/foundations';
 import { palette } from '../../../palette';
 import ClockIcon from '../../../static/icons/clock.svg';
 import { DateTime } from '../../DateTime';
 
 type Props = {
-	format: ArticleFormat;
 	absoluteServerTimes: boolean;
 	webPublication: {
 		date: string;
@@ -18,18 +16,9 @@ type Props = {
 	isTagPage: boolean;
 };
 
-const ageStyles = (format: ArticleFormat, isOnwardsContent?: boolean) => {
+const ageStyles = (isOnwardsContent?: boolean) => {
 	return css`
-		${textSans12};
-		/**
-		 * Typography preset styles should not be overridden.
-		 * This has been done because the styles do not directly map to the new presets.
-		 * Please speak to your team's designer and update this to use a more appropriate preset.
-		 */
-		line-height: 1.25;
-		${from.tablet} {
-			line-height: 1.15;
-		}
+		${textSansBold12};
 
 		color: ${isOnwardsContent
 			? palette('--card-footer-onwards-content')
@@ -46,15 +35,10 @@ const ageStyles = (format: ArticleFormat, isOnwardsContent?: boolean) => {
 			width: 11px;
 			margin-right: 2px;
 		}
-
-		> time {
-			${cardHasDarkBackground(format) ? textSansBold12 : textSans12};
-		}
 	`;
 };
 
 export const CardAge = ({
-	format,
 	webPublication,
 	showClock,
 	isOnwardContent,
@@ -66,7 +50,7 @@ export const CardAge = ({
 	}
 
 	return (
-		<span css={ageStyles(format, isOnwardContent)}>
+		<span css={ageStyles(isOnwardContent)}>
 			{showClock && <ClockIcon />}
 			{isTagPage ? (
 				<DateTime

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -7,27 +7,20 @@ type Props = {
 	age?: JSX.Element;
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
-	supportingContent?: JSX.Element;
 	showLivePlayable?: boolean;
 	topAlign?: boolean;
 };
 
-const spacing = css`
+const marginStyles = (topAlign: boolean) => css`
+	margin-top: ${topAlign ? `${space[3]}px` : `auto`};
+`;
+
+const contentStyles = css`
 	padding-top: ${space[1]}px;
 	display: flex;
 	justify-content: 'flex-start';
 	align-items: center;
-`;
-
-const margins = (topAlign: boolean) => css`
-	margin-top: ${topAlign ? `${space[3]}px` : `auto`};
-`;
-
-const fontStyles = css`
 	${textSansBold12}
-`;
-
-const borderStyles = css`
 	> {
 		/* The dividing line is applied only to the second child. This ensures that no dividing line is added when there is only one child in the container. */
 		:nth-child(2) {
@@ -53,23 +46,19 @@ export const CardFooter = ({
 	age,
 	commentCount,
 	cardBranding,
-	supportingContent,
 	showLivePlayable = false,
 	topAlign = false,
 }: Props) => {
 	if (showLivePlayable) return null;
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
-		return <footer css={margins(topAlign)}>{cardBranding}</footer>;
+		return <footer css={marginStyles(topAlign)}>{cardBranding}</footer>;
 	}
 
 	return (
-		<footer css={margins(topAlign)}>
-			{supportingContent}
-			<div css={[spacing, fontStyles, borderStyles]}>
-				{age}
-				{commentCount}
-			</div>
+		<footer css={[marginStyles(topAlign), contentStyles]}>
+			{age}
+			{commentCount}
 		</footer>
 	);
 };

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -41,6 +41,10 @@ const contentStyles = css`
 	}
 `;
 
+const labStyles = css`
+	margin-top: ${space[1]}px;
+`;
+
 export const CardFooter = ({
 	format,
 	age,
@@ -52,7 +56,7 @@ export const CardFooter = ({
 	if (showLivePlayable) return null;
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
-		return <footer css={marginStyles(topAlign)}>{cardBranding}</footer>;
+		return <footer css={labStyles}>{cardBranding}</footer>;
 	}
 
 	return (

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { type ArticleFormat, ArticleSpecial } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
+import { palette, space, textSansBold12 } from '@guardian/source/foundations';
 
 type Props = {
 	format: ArticleFormat;
@@ -8,28 +8,44 @@ type Props = {
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	supportingContent?: JSX.Element;
-	leftAlign?: boolean;
 	showLivePlayable?: boolean;
+	topAlign?: boolean;
 };
 
-const spacing = (leftAlign: boolean) => css`
+const spacing = css`
+	padding-top: ${space[1]}px;
 	display: flex;
-	justify-content: ${leftAlign ? 'flex-start' : 'space-between'};
+	justify-content: 'flex-start';
 	align-items: center;
+`;
+
+const margins = (topAlign: boolean) => css`
+	margin-top: ${topAlign ? `${space[3]}px` : `auto`};
+`;
+
+const fontStyles = css`
+	${textSansBold12}
+`;
+
+const borderStyles = css`
 	> {
-		*:not(:first-child) {
+		/* The dividing line is applied only to the second child. This ensures that no dividing line is added when there is only one child in the container. */
+		:nth-child(2) {
+			::before {
+				content: '';
+				display: block;
+				width: 1px;
+				height: 12px;
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				background-color: ${palette.neutral[60]};
+				margin-right: ${space[1]}px;
+			}
 			margin-left: ${space[1]}px;
+			padding-left: ${space[1]}px;
 		}
 	}
-`;
-
-const margins = css`
-	margin-top: ${space[1]}px;
-`;
-
-const flexEnd = css`
-	display: flex;
-	justify-content: flex-end;
 `;
 
 export const CardFooter = ({
@@ -38,32 +54,21 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	supportingContent,
-	leftAlign = false,
 	showLivePlayable = false,
+	topAlign = false,
 }: Props) => {
 	if (showLivePlayable) return null;
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
-		return <footer css={margins}>{cardBranding}</footer>;
-	}
-
-	if (age) {
-		return (
-			<footer css={margins}>
-				{supportingContent}
-				<div css={spacing(leftAlign)}>
-					{age}
-					{commentCount}
-				</div>
-			</footer>
-		);
+		return <footer css={margins(topAlign)}>{cardBranding}</footer>;
 	}
 
 	return (
-		<footer css={margins}>
+		<footer css={margins(topAlign)}>
 			{supportingContent}
-			<div css={flexEnd}>
-				<>{commentCount}</>
+			<div css={[spacing, fontStyles, borderStyles]}>
+				{age}
+				{commentCount}
 			</div>
 		</footer>
 	);

--- a/dotcom-rendering/src/components/CardCommentCount.importable.tsx
+++ b/dotcom-rendering/src/components/CardCommentCount.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	between,
-	textSans12,
+	textSansBold12,
 	visuallyHidden,
 } from '@guardian/source/foundations';
 import { formatCount } from '../lib/formatCount';
@@ -35,7 +35,7 @@ const getCommentCountColour = (
 const containerStyles = (isDynamo?: boolean, isOnwardContent?: boolean) => css`
 	display: flex;
 	flex-direction: row;
-	${textSans12};
+	${textSansBold12};
 	/**
 	 * Typography preset styles should not be overridden.
 	 * This has been done because the styles do not directly map to the new presets.
@@ -43,8 +43,6 @@ const containerStyles = (isDynamo?: boolean, isOnwardContent?: boolean) => css`
 	 */
 	line-height: 1.15;
 	margin-top: -4px;
-	padding-left: 5px;
-	padding-right: 5px;
 	color: ${getCommentCountColour(isDynamo, isOnwardContent)};
 `;
 


### PR DESCRIPTION
## What does this change?
Updates the style of the card footer.

The style changes are:
- The card footer is now always left aligned. 
- If there are 2 children in the footer (age and comment) then a diving line is rendered between them with added spacing. 
- We always use textSans Bold size 12 for text. 
- We now have the option to decide if the card footer should be aligned to the top or not. 

As well as style changes, this PR uses this opportunity to refactor the component, removing unused properties and returns.

## Why?
This is aligns with new designs for cards and helps break down the ticket into smaller areas for review.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/2e55782c-5ecd-46b1-b123-0d796498187c
[after]: https://github.com/user-attachments/assets/8421e134-1ee6-4d3e-8915-5b6e451d1fd6

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
