### PR TITLE
Enable opt out in banner article count

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
@@ -50,7 +50,7 @@ export function CustomArticleCountCopy({
 				nextWord={` ${nextWord}`}
 				settings={settings}
 			/>{' '}
-			{rest.slice(1).join(' ')}
+			{rest.join(' ')}
 		</p>
 	);
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
@@ -31,8 +31,16 @@ export function CustomArticleCountCopy({
 	numArticles,
 	settings,
 }: CustomArticleCountProps): JSX.Element {
+	/**
+	 * E.g. the string:
+	 *   "You’ve read %%ARTICLE_COUNT%% articles in the last few weeks."
+	 * needs to be split into:
+	 * - "You’ve read"
+	 * - "articles"
+	 * - "in the last few weeks."
+	 */
 	const [copyHead, copyTail] = copy.split('%%ARTICLE_COUNT%%');
-	const [nextWord, ...rest] = copyTail.trim().split(' ');
+	const [nextWord, ...rest] = (copyTail ?? '').trim().split(' ');
 
 	return (
 		<p css={styles.container}>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/CustomArticleCountCopy.tsx
@@ -5,6 +5,8 @@
  */
 import { css } from '@emotion/react';
 import { from, headline, space } from '@guardian/source/foundations';
+import type { BannerTemplateSettings } from '../settings';
+import { DesignableBannerArticleCountOptOut } from './DesignableBannerArticleCountOptOut';
 
 const styles = {
 	container: css`
@@ -21,21 +23,26 @@ const styles = {
 interface CustomArticleCountProps {
 	copy: string;
 	numArticles: number;
+	settings: BannerTemplateSettings;
 }
 
 export function CustomArticleCountCopy({
 	copy,
 	numArticles,
+	settings,
 }: CustomArticleCountProps): JSX.Element {
 	const [copyHead, copyTail] = copy.split('%%ARTICLE_COUNT%%');
+	const [nextWord, ...rest] = copyTail.trim().split(' ');
 
 	return (
 		<p css={styles.container}>
-			{copyHead}
-			<span>{numArticles}&nbsp;articles</span>
-			{copyTail?.substring(1, 9) === 'articles'
-				? copyTail.substring(9)
-				: copyTail}
+			{copyHead}{' '}
+			<DesignableBannerArticleCountOptOut
+				numArticles={numArticles}
+				nextWord={` ${nextWord}`}
+				settings={settings}
+			/>{' '}
+			{rest.slice(1).join(' ')}
 		</p>
 	);
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -26,7 +26,13 @@ export function DesignableBannerArticleCount({
 }: DesignableBannerArticleCountProps): JSX.Element {
 	if (copy && containsArticleCountTemplate(copy)) {
 		// Custom article count message
-		return <CustomArticleCountCopy numArticles={numArticles} copy={copy} />;
+		return (
+			<CustomArticleCountCopy
+				numArticles={numArticles}
+				copy={copy}
+				settings={settings}
+			/>
+		);
 	} else if (numArticles >= 50) {
 		return (
 			<div css={styles.container(settings.articleCountTextColour)}>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -480,7 +480,7 @@ export const ArticleCountSubheadingDefaultCopy: Story = {
 };
 
 export const ArticleCountSubheadingCustomCopy: Story = {
-	name: 'DesignableBanner with article count subheading, default copy',
+	name: 'DesignableBanner with article count subheading, custom copy',
 	args: {
 		...meta.args,
 		separateArticleCountSettings: {
@@ -489,6 +489,20 @@ export const ArticleCountSubheadingCustomCopy: Story = {
 		},
 		articleCounts: {
 			for52Weeks: 12,
+			forTargetedWeeks: 12,
+		},
+	},
+};
+
+export const ArticleCountSubheadingTopReader: Story = {
+	name: 'DesignableBanner with article count subheading, top reader',
+	args: {
+		...meta.args,
+		separateArticleCountSettings: {
+			type: 'above',
+		},
+		articleCounts: {
+			for52Weeks: 51,
 			forTargetedWeeks: 51,
 		},
 	},

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -468,3 +468,28 @@ export const WithRemindMeLater: Story = {
 		choiceCardAmounts: regularChoiceCardAmounts,
 	},
 };
+
+export const ArticleCountSubheadingDefaultCopy: Story = {
+	name: 'DesignableBanner with article count subheading, default copy',
+	args: {
+		...meta.args,
+		separateArticleCountSettings: {
+			type: 'above',
+		},
+	},
+};
+
+export const ArticleCountSubheadingCustomCopy: Story = {
+	name: 'DesignableBanner with article count subheading, default copy',
+	args: {
+		...meta.args,
+		separateArticleCountSettings: {
+			type: 'above',
+			copy: 'You’ve read %%ARTICLE_COUNT%% articles in the last year.',
+		},
+		articleCounts: {
+			for52Weeks: 12,
+			forTargetedWeeks: 51,
+		},
+	},
+};

--- a/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
@@ -146,9 +146,8 @@ export const props: BannerProps = {
 	tracking,
 	content,
 	tickerSettings,
-	separateArticleCount: true,
 	separateArticleCountSettings: {
-		// copy: 'You’ve read %%ARTICLE_COUNT%% articles in the last few weeks.',
+		copy: 'You’ve read %%ARTICLE_COUNT%% articles in the last few weeks.',
 		type: 'above',
 	},
 	articleCounts: {

--- a/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
@@ -146,10 +146,6 @@ export const props: BannerProps = {
 	tracking,
 	content,
 	tickerSettings,
-	separateArticleCountSettings: {
-		copy: 'You’ve read %%ARTICLE_COUNT%% articles in the last few weeks.',
-		type: 'above',
-	},
 	articleCounts: {
 		for52Weeks: 12,
 		forTargetedWeeks: 12,


### PR DESCRIPTION
## What does this change?
The RRCP banner can display the user's article count in a subheading.
In general the copy for this is hardcoded, but a while back this was made configurable from the RRCP.
Currently, if the copy has been configured then the opt-out link is not rendered. We should always allow users to opt out when we display the article count.

Before:
![Screenshot 2024-08-27 at 16 18 03](https://github.com/user-attachments/assets/87e36c8c-dde6-4191-b429-8346b56a71f6)


After:
![Screenshot 2024-08-28 at 09 03 37](https://github.com/user-attachments/assets/5b9e919d-3938-434d-8920-36089629d2e2)

when link is clicked -
![Screenshot 2024-08-27 at 15 53 56](https://github.com/user-attachments/assets/480f3de6-569e-4ec6-80e5-bc0046b3c34d)
