### PR TITLE
Bump `@guardian/source` library from v1 to v2

### DIFF
--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -16,7 +16,7 @@
 		}
 	},
 	"dependencies": {
-		"CSNX_SOURCE": "npm:@guardian/source@1.0.3"
+		"CSNX_SOURCE": "npm:@guardian/source@2.0.0"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,8 +842,8 @@ importers:
         specifier: ^18.2.11
         version: 18.3.1
       CSNX_SOURCE:
-        specifier: npm:@guardian/source@1.0.3
-        version: /@guardian/source@1.0.3(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: npm:@guardian/source@2.0.0
+        version: /@guardian/source@2.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -4458,6 +4458,32 @@ packages:
 
   /@guardian/source@1.0.3(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-LUAaEcwBGdTGVWOXzT/Y6MW4TAgY8Ag/DwrYjbuPKRzAaEGp5B9+GGBl9v9mFhzPArQyKamgEGSQEzTbWfMR3A==}
+    peerDependencies:
+      '@emotion/react': ^11.11.1
+      '@types/react': ^18.2.11
+      react: ^18.2.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@emotion/react': 11.11.1(@types/react@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.1
+      mini-svg-data-uri: 1.4.4
+      react: 18.3.1
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: false
+
+  /@guardian/source@2.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-8WeAxeNWGJPaY5jw1pW7jC/ZkyW/V+FzVQoGssYHrlN9heqotHaYaE9ko9TPHyWkz4AbeTdc4zkwI8vWndBWMA==}
     peerDependencies:
       '@emotion/react': ^11.11.1
       '@types/react': ^18.2.11


### PR DESCRIPTION
## What does this change?

Bump `@guardian/source` library from v1 to v2

- [source@2.0.0](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fsource%402.0.0) 
  - https://github.com/guardian/csnx/commit/637d12758a68fc41e8259dd23bbe752da3a12196:
    - Adds collapseUntil option to Inline layout component to allow collapsing into a single column below a given breakpoint.
    - Text and icons are now horizontally centred within buttons. Visually this is only apparent if a button's styles have been overridden and it is stretched beyond it's natural intrinsic width. (Previously the text and icon would be pushed to the edges of the button.)

## Why?

We are several major versions behind in DCR and so are unable to use newer source features until we get up to date

This PR is a re-implementation of https://github.com/guardian/dotcom-rendering/pull/12063 to break it down into smaller chunks for review 