### PR TITLE
Skip two more header interactivity tests

### DIFF
--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -114,7 +114,7 @@ test.describe('Interactivity', () => {
 			);
 		});
 
-		test('should render the reader revenue links in the header', async ({
+		test.skip('should render the reader revenue links in the header', async ({
 			context,
 			page,
 		}) => {
@@ -295,7 +295,7 @@ test.describe('Interactivity', () => {
 				).toBeFocused();
 			});
 
-			test('should expand the subnav when "More" is clicked', async ({
+			test.skip('should expand the subnav when "More" is clicked', async ({
 				context,
 				page,
 			}) => {


### PR DESCRIPTION
## What does this change?

Skips a couple more tests which (AFAICT) likely rely on the previous header design. 

Prompted by these [tests failing](https://github.com/guardian/dotcom-rendering/actions/runs/10581057062/job/29317621064) when the [previous PR](https://github.com/guardian/dotcom-rendering/pull/12210) was merged to main. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
