### PR TITLE
Bump `@guardian/source` library from v2 to v3

### DIFF
--- a/apps-rendering/src/components/EmailSignupForm/index.tsx
+++ b/apps-rendering/src/components/EmailSignupForm/index.tsx
@@ -16,8 +16,8 @@ import {
 	InlineSuccess,
 	Label,
 	Link,
+	Spinner,
 	SvgReload,
-	SvgSpinner,
 	TextInput,
 	userFeedbackThemeDefault,
 } from '@guardian/source/react-components';
@@ -155,7 +155,7 @@ const EmailSignupForm = ({
 					>
 						Sign up
 						<span className="js-signup-form__feedback js-signup-form__feedback--waiting">
-							<SvgSpinner size="small" />
+							<Spinner size="small" />
 						</span>
 					</Button>
 				</div>

--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -10,8 +10,8 @@ import {
 	InlineError,
 	InlineSuccess,
 	Link,
+	Spinner,
 	SvgReload,
-	SvgSpinner,
 	TextInput,
 } from '@guardian/source/react-components';
 import type { CSSProperties, FormEvent, ReactEventHandler } from 'react';
@@ -391,8 +391,8 @@ export const SecureSignup = ({
 				</Button>
 			</form>
 			{isWaitingForResponse && (
-				<div>
-					<SvgSpinner isAnnouncedByScreenReader={true} size="small" />
+				<div aria-label="loading">
+					<Spinner size="small" />
 				</div>
 			)}
 

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -16,7 +16,7 @@
 		}
 	},
 	"dependencies": {
-		"CSNX_SOURCE": "npm:@guardian/source@2.0.0"
+		"CSNX_SOURCE": "npm:@guardian/source@3.0.0"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,8 +842,8 @@ importers:
         specifier: ^18.2.11
         version: 18.3.1
       CSNX_SOURCE:
-        specifier: npm:@guardian/source@2.0.0
-        version: /@guardian/source@2.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: npm:@guardian/source@3.0.0
+        version: /@guardian/source@3.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -4482,8 +4482,8 @@ packages:
       typescript: 5.3.3
     dev: false
 
-  /@guardian/source@2.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-8WeAxeNWGJPaY5jw1pW7jC/ZkyW/V+FzVQoGssYHrlN9heqotHaYaE9ko9TPHyWkz4AbeTdc4zkwI8vWndBWMA==}
+  /@guardian/source@3.0.0(@emotion/react@11.11.1)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-ocdnSojiVmPaDXnPSMo9FQbPgP00JzR74AftgCDqcLTo9uXgLmO0w9TADMHm48MhNsHqH1RDqgDdStd37Qbctw==}
     peerDependencies:
       '@emotion/react': ^11.11.1
       '@types/react': ^18.2.11


### PR DESCRIPTION
## What does this change?

Bumps `@guardian/source` library from v2 to v3

- [source@3.0.0](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fsource%403.0.0)
  - https://github.com/guardian/csnx/commit/a2754312edecbfbe0386e32a9cb735cb16b9b293: Removes SvgSpinner from icon library and replaces with dedicated Spinner component. The size prop supports the existing set of named icon sizes for backwards compatibility, but also allows setting a custom size in pixels. The default colour scheme can be overridden with the theme prop.
    ```
    <>
	    <Spinner size="small" />
	    <Spinner size={40} />
	    <Spinner theme={{ background: 'transparent', color: 'currentColor' }} />
    </>
    ```

## Why?

We are several major versions behind in DCR and so are unable to use newer source features until we get up to date

This PR is a re-implementation of https://github.com/guardian/dotcom-rendering/pull/12063 to break it down into smaller chunks for review