### PR TITLE
Bump `@guardian/source` library from v3 to v4

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -37,7 +37,7 @@
 		"@emotion/react": "11.11.1",
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "8.0.0",
-		"@guardian/braze-components": "20.0.0",
+		"@guardian/braze-components": "20.1.0",
 		"@guardian/bridget": "7.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,8 +329,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/braze-components':
-        specifier: 20.0.0
-        version: 20.0.0(@emotion/react@11.11.1)(@guardian/libs@18.0.0)(@guardian/source@4.0.0)(react@18.3.1)
+        specifier: 20.1.0
+        version: 20.1.0(@emotion/react@11.11.1)(@guardian/libs@18.0.0)(@guardian/source@4.0.0)(react@18.3.1)
       '@guardian/bridget':
         specifier: 7.0.0
         version: 7.0.0
@@ -3955,13 +3955,13 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@20.0.0(@emotion/react@11.11.1)(@guardian/libs@18.0.0)(@guardian/source@4.0.0)(react@18.3.1):
-    resolution: {integrity: sha512-/ENh0v7GUJcrQ8U0fXffAPWGvyOZxRCN1IPOf89PFLnM5Y0RCBIT2095hfYHxu3LgmvWz30QyuMB6HKN/oo9uQ==}
-    engines: {node: ^18.15 || ^20.9}
+  /@guardian/braze-components@20.1.0(@emotion/react@11.11.1)(@guardian/libs@18.0.0)(@guardian/source@4.0.0)(react@18.3.1):
+    resolution: {integrity: sha512-fL9rXdTwK/Ix3pCpgxCc3fR+xOB5sBQy44YQpLCMQGRXYsroxS0G3//UYIDJbNCD0Ju4PaAdqSCP4JfM54L1sw==}
+    engines: {node: ^18.15 || ^20.8}
     peerDependencies:
       '@emotion/react': ^11.1.2
       '@guardian/libs': ^16.0.0
-      '@guardian/source': ^1.0.1
+      '@guardian/source': '>= 1.0.1 < 7'
       react: 17.0.2 || 18.2.0
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.3.1)(react@18.3.1)


### PR DESCRIPTION
## What does this change?

Bumps `@guardian/source` library from v3 to v4

- [source@4.0.0](https://github.com/guardian/csnx/releases/tag/%40guardian%2Fsource%404.0.0)
  - https://github.com/guardian/csnx/commit/dc790482f6a822dfa569dff781a4f35c2f073c24: Adds Guardian Headline 64px typography presets and removes Guardian Headline 70px presets.
  ```
  headlineBold64
  headlineLight64
  headlineLightItalic64
  headlineMedium64
  headlineMediumItalic64
  ```
  - https://github.com/guardian/csnx/commit/490384d3696f99f64741428377f3b9dedd11b1f5: Now has a peer dependency of @emotion/react@^11.11.3 (from ^11.11.1).

Fixes conflicting types between Emotion's deps, as outlined in https://github.com/emotion-js/emotion/pull/3141.

## Why?

We are several major versions behind in DCR and so are unable to use newer source features until we get up to date

This PR is a re-implementation of https://github.com/guardian/dotcom-rendering/pull/12063 to break it down into smaller chunks for review