### PR TITLE
Add `onFullscreenToggled` listener for Android

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -7,6 +7,7 @@ import type {
 	ImagePositionType,
 	ImageSizeType,
 } from '../Card/components/ImageWrapper';
+import type { Props } from './YoutubeAtom';
 import { YoutubeAtom } from './YoutubeAtom';
 
 const meta = {
@@ -153,7 +154,8 @@ const baseConfiguration = {
 	imagePositionOnMobile,
 	imageSize,
 	consentState: consentGiven,
-};
+	renderingTarget: 'Web',
+} satisfies Partial<Props>;
 
 const NoConsent = {
 	args: {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -50,6 +50,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -87,6 +88,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -131,6 +133,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -169,6 +172,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -206,6 +210,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -244,6 +249,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -280,6 +286,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					imagePositionOnMobile="none"
 					imageSize="large"
+					renderingTarget="Web"
 				/>
 			</ConfigProvider>
 		);
@@ -320,6 +327,7 @@ describe('YoutubeAtom', () => {
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
+						renderingTarget="Web"
 					/>
 					<YoutubeAtom
 						index={123}
@@ -339,6 +347,7 @@ describe('YoutubeAtom', () => {
 						abTestParticipations={{}}
 						imagePositionOnMobile="left"
 						imageSize="small"
+						renderingTarget="Web"
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -2,6 +2,7 @@ import type { Participations } from '@guardian/ab-core';
 import type { ArticleFormat, ConsentState } from '@guardian/libs';
 import { isUndefined } from '@guardian/libs';
 import { useCallback, useState } from 'react';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type {
 	ImagePositionType,
 	ImageSizeType,
@@ -24,7 +25,7 @@ export type VideoEventKey =
 	| 'resume'
 	| 'pause';
 
-type Props = {
+export type Props = {
 	index?: number;
 	videoId: string;
 	overrideImage?: string | undefined;
@@ -48,6 +49,7 @@ type Props = {
 	showTextOverlay?: boolean;
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
+	renderingTarget: RenderingTarget;
 };
 
 export const YoutubeAtom = ({
@@ -74,6 +76,7 @@ export const YoutubeAtom = ({
 	showTextOverlay = false,
 	imageSize,
 	imagePositionOnMobile,
+	renderingTarget,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -220,6 +223,7 @@ export const YoutubeAtom = ({
 							adTargeting={adTargeting}
 							consentState={consentState}
 							abTestParticipations={abTestParticipations}
+							renderingTarget={renderingTarget}
 						/>
 					)
 				}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -10,7 +10,9 @@ import {
 	useRef,
 	useState,
 } from 'react';
+import { getVideoClient } from '../../lib/bridgetApi';
 import { getAuthStatus } from '../../lib/identity';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type { google } from './ima';
 import type { VideoEventKey } from './YoutubeAtom';
 import type { PlayerListenerName, YouTubePlayerArgs } from './YoutubePlayer';
@@ -32,6 +34,7 @@ type Props = {
 	adTargeting: AdTargeting;
 	consentState: ConsentState;
 	abTestParticipations: Participations;
+	renderingTarget: RenderingTarget;
 };
 
 type CustomPlayEventDetail = { uniqueId: string };
@@ -378,6 +381,7 @@ export const YoutubeAtomPlayer = ({
 	adTargeting,
 	consentState,
 	abTestParticipations,
+	renderingTarget,
 }: Props): JSX.Element => {
 	/**
 	 * useRef for player and progressEvents
@@ -451,9 +455,9 @@ export const YoutubeAtomPlayer = ({
 							playsinline: 1,
 							rel: 0,
 						},
-						// Since IMA ads the YouTube player API no longer accepts ad configuration
 						embedConfig: {
 							relatedChannels: [],
+							// Since IMA ads the YouTube player API no longer accepts ad configuration
 							adsConfig: { disableAds: true },
 							enableIma: enableAds,
 							// YouTube recommends disabling related videos when IMA ads are enabled
@@ -461,6 +465,16 @@ export const YoutubeAtomPlayer = ({
 						},
 						events: {
 							onStateChange: onStateChangeListener,
+							onFullscreenToggled: () => {
+								if (renderingTarget === 'Apps') {
+									log('dotcom', {
+										from: 'YoutubeAtomPlayer fullscreen',
+										videoId,
+									});
+									// For Android only, iOS will stub the method
+									void getVideoClient().fullscreen();
+								}
+							},
 						},
 					},
 					onReadyListener,
@@ -553,6 +567,7 @@ export const YoutubeAtomPlayer = ({
 			onReady,
 			origin,
 			playerReadyCallback,
+			renderingTarget,
 			uniqueId,
 			videoId,
 			width,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -448,7 +448,8 @@ export const YoutubeAtomPlayer = ({
 						playerVars: {
 							controls: 1,
 							// @ts-expect-error -- advised by YouTube for Android but does not exist in @types/youtube
-							external_fullscreen: 1,
+							external_fullscreen:
+								renderingTarget === 'Apps' ? 1 : 0,
 							fs: 1,
 							modestbranding: 1,
 							origin,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -23,6 +23,9 @@ declare global {
 				imaManager: ImaManager,
 			) => void,
 		) => void;
+		export interface Events {
+			onFullscreenToggled?: () => void;
+		}
 	}
 }
 
@@ -110,7 +113,7 @@ class YouTubePlayer {
 							{
 								youtubeOptions,
 							},
-							// onReady callback for YT.createPlayerForPublishers
+							// onReady callback for YT.createPlayerForPublishers must be passed separately
 							(player, imaManager) => {
 								this.player = player;
 								imaAdManagerListeners(imaManager);
@@ -128,6 +131,8 @@ class YouTubePlayer {
 								onReady: onReadyListener,
 								onStateChange:
 									youtubeOptions.events?.onStateChange,
+								onFullscreenToggled:
+									youtubeOptions.events?.onFullscreenToggled,
 							},
 						});
 						resolve({ player: this.player });

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -305,6 +305,7 @@ export const YoutubeBlockComponent = ({
 				showTextOverlay={showTextOverlay}
 				imageSize={imageSize}
 				imagePositionOnMobile={imagePositionOnMobile}
+				renderingTarget={renderingTarget}
 			/>
 			{!hideCaption && (
 				<Caption


### PR DESCRIPTION
## What does this change?

Add a `onFullscreenToggled` listener which invokes the `fullscreen` Bridget method.

Have tested on CODE web experience is not affected 

This change is okay to merge as the MAPI DCAR check does not yet support video content so the apps code path will not be invoked.

## Why?

The YouTube player does not automatically enter fullscreen mode on Android webviews. Instead we invoke the Bridget method `fullscreen` so the native layer can enable this by resizing the player.


