### PR TITLE
[Fairground 🎡]  Reintroduce the video media icon

### DIFF
--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -1,5 +1,9 @@
 import { css } from '@emotion/react';
-import { SvgAudio, SvgCamera } from '@guardian/source/react-components';
+import {
+	SvgAudio,
+	SvgCamera,
+	SvgVideo,
+} from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
 
 type Props = {
@@ -39,7 +43,7 @@ export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 		case 'Gallery':
 			return <SvgCamera />;
 		case 'Video':
-			return null;
+			return <SvgVideo />;
 		case 'Audio':
 			return <SvgAudio />;
 	}


### PR DESCRIPTION
## What does this change?
Puts the video media icon back into the media meta component so that it appears on the highlights card.

## Why?

The video icon was removed from the mediameta component during a consolidation of video flags across the site. However, there's now a desire to display this icon on highlights cards. 

We already prevent the component displaying if it is a standard video card [here](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/Card/Card.tsx#L561) so we can safely reintroduce the icon in the media meta component and allow it to pipe through to the highlights card.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0e147cfd-0650-40fe-8056-507e68ca884d
[after]: https://github.com/user-attachments/assets/dda083b3-3fd2-4209-b6ab-41aa4a4d9d4b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
