### PR TITLE
Fix immersive main media height with the updated header

### DIFF
--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -19,6 +19,7 @@ type Props = {
 	isImmersive?: boolean;
 	selectedPillar?: Pillar;
 	hasPageSkin?: boolean;
+	showsUpdatedHeaderDesign?: boolean;
 };
 
 const clearFixStyle = css`
@@ -31,9 +32,10 @@ const rowStyles = css`
 	justify-content: space-between;
 `;
 
-export const minNavHeightPx = 48;
-export const minNavHeight = css`
-	min-height: ${minNavHeightPx}px;
+export const minNavHeightPx = (showsUpdatedHeaderDesign: boolean) =>
+	showsUpdatedHeaderDesign ? 191 : 48;
+export const minNavHeight = (showsUpdatedHeaderDesign: boolean) => css`
+	min-height: ${minNavHeightPx(showsUpdatedHeaderDesign)}px;
 `;
 
 const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
@@ -61,6 +63,7 @@ export const Nav = ({
 	isImmersive,
 	selectedPillar,
 	hasPageSkin,
+	showsUpdatedHeaderDesign = false,
 }: Props) => {
 	return (
 		<div css={rowStyles}>
@@ -170,7 +173,11 @@ export const Nav = ({
 				}}
 			/>
 			<div
-				css={[clearFixStyle, rowStyles, isImmersive && minNavHeight]}
+				css={[
+					clearFixStyle,
+					rowStyles,
+					isImmersive && minNavHeight(showsUpdatedHeaderDesign),
+				]}
 				data-component="nav2"
 			>
 				{isImmersive && (

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -142,6 +142,18 @@ const standardImmersiveNewsFixture: DCRArticle = {
 	},
 };
 
+const standardImmersiveNewsWithUpdatedHeaderFixture: DCRArticle = {
+	...StandardStandardNewsFixture,
+	format: {
+		...StandardStandardNewsFixture.format,
+		display: 'ImmersiveDisplay',
+	},
+	config: {
+		...StandardStandardNewsFixture.config,
+		abTests: { updatedHeaderDesignVariant: 'variant' },
+	},
+};
+
 export const AppsStandardImmersiveNewsLight: Story = {
 	args: {
 		article: standardImmersiveNewsFixture,
@@ -153,6 +165,22 @@ export const AppsStandardImmersiveNewsLight: Story = {
 export const AppsStandardImmersiveNewsDark: Story = {
 	args: {
 		article: standardImmersiveNewsFixture,
+		colourScheme: 'dark',
+	},
+	parameters: appsParameters,
+};
+
+export const AppsStandardImmersiveNewsLightWithUpdatedHeader: Story = {
+	args: {
+		article: standardImmersiveNewsWithUpdatedHeaderFixture,
+		colourScheme: 'light',
+	},
+	parameters: appsParameters,
+};
+
+export const AppsStandardImmersiveNewsDarkWithUpdatedHeader: Story = {
+	args: {
+		article: standardImmersiveNewsWithUpdatedHeaderFixture,
 		colourScheme: 'dark',
 	},
 	parameters: appsParameters,
@@ -216,9 +244,24 @@ export const AppsPictureShowcaseOpinionDark: Story = {
 	parameters: appsParameters,
 };
 
+const PhotoEssayImmersiveLabsWithUpdatedHeaderFixture: DCRArticle = {
+	...PhotoEssayImmersiveLabsFixture,
+	config: {
+		...PhotoEssayImmersiveLabsFixture.config,
+		abTests: { updatedHeaderDesignVariant: 'variant' },
+	},
+};
+
 export const WebPhotoEssayImmersiveLabsLight: Story = {
 	args: {
 		article: PhotoEssayImmersiveLabsFixture,
+	},
+	parameters: webParameters,
+};
+
+export const WebPhotoEssayImmersiveLabsLightWithUpdatedHeader: Story = {
+	args: {
+		article: PhotoEssayImmersiveLabsWithUpdatedHeaderFixture,
 	},
 	parameters: webParameters,
 };

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -269,17 +269,38 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
+	const showsUpdatedHeaderDesign: boolean =
+		article.config.abTests.updatedHeaderDesignVariant === 'variant' &&
+		article.config.abTests.updatedHeaderDesignVariant !== undefined;
+
 	/**
 	We need change the height values depending on whether the labs header is there or not to keep
 	the headlines appearing at a consistent height between labs and non labs immersive articles.
 	*/
 
 	const labsHeaderHeight = LABS_HEADER_HEIGHT;
-	const combinedHeight = (minNavHeightPx + labsHeaderHeight).toString();
+	const combinedHeight = (
+		minNavHeightPx(showsUpdatedHeaderDesign) + labsHeaderHeight
+	).toString();
 
 	const navAndLabsHeaderHeight = isLabs
 		? `${combinedHeight}px`
-		: `${minNavHeightPx}px`;
+		: `${minNavHeightPx(showsUpdatedHeaderDesign)}px`;
+
+	const mainMediaUpdatedHeaderStyles = css`
+		${from.desktop} {
+			height: calc(80vh - ${navAndLabsHeaderHeight});
+		}
+	`;
+
+	const mainMediaOldHeaderStyles = css`
+		${from.desktop} {
+			height: calc(100vh - ${navAndLabsHeaderHeight});
+		}
+		${from.wide} {
+			min-height: calc(50rem - ${navAndLabsHeaderHeight});
+		}
+	`;
 
 	const hasMainMediaStyles = css`
 		height: calc(80vh - ${navAndLabsHeaderHeight});
@@ -289,11 +310,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 		*/
 		min-height: calc(25rem - ${navAndLabsHeaderHeight});
 		${from.desktop} {
-			height: calc(100vh - ${navAndLabsHeaderHeight});
 			min-height: calc(31.25rem - ${navAndLabsHeaderHeight});
-		}
-		${from.wide} {
-			min-height: calc(50rem - ${navAndLabsHeaderHeight});
 		}
 	`;
 	const LeftColCaption = () => (
@@ -378,6 +395,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											.contribute
 									}
 									editionId={article.editionId}
+									showsUpdatedHeaderDesign={
+										showsUpdatedHeaderDesign
+									}
 								/>
 							</Section>
 						</div>
@@ -407,6 +427,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 				<div
 					css={[
 						mainMedia && hasMainMediaStyles,
+						mainMedia && showsUpdatedHeaderDesign
+							? mainMediaUpdatedHeaderStyles
+							: mainMediaOldHeaderStyles,
 						css`
 							display: flex;
 							flex-direction: column;


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/12233

## What does this change?
Decreases the height of the main media in immersive articles when the page is rendered with the updated header.

## Why?
The updated header is higher than the previous and the headline gets pushed down.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/92fbf604-942a-4afc-826d-38331bb308bc) | ![image](https://github.com/user-attachments/assets/e04a9cdf-b7d5-4ad9-8fb0-3b14b9482ee2) |
| ![image](https://github.com/user-attachments/assets/b70f66e5-4a3d-4e8c-bd65-0abb79639e20) | ![image](https://github.com/user-attachments/assets/c5fca9b6-d23e-4135-ac0d-779c35a0e8b7) |
| ![image](https://github.com/user-attachments/assets/d38c6451-414d-4d2f-a269-009a84e0f918)  | ![image](https://github.com/user-attachments/assets/cdbf25cc-1186-4b8f-bce4-3ac8af9fcb1d) |


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
