### PR TITLE
Add `scrollable/highlights` container to replace `fixed/highlights`

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -223,6 +223,7 @@ export const DecideContainer = ({
 		case 'nav/media-list':
 			return <NavList trails={trails} showImage={true} />;
 		case 'fixed/highlights':
+		case 'scrollable/highlights':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<HighlightsContainer trails={trails} />

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -70,7 +70,8 @@ const isNavList = (collection: DCRCollectionType) => {
 };
 
 const isHighlights = ({ collectionType }: DCRCollectionType) =>
-	collectionType === 'fixed/highlights';
+	collectionType === 'fixed/highlights' ||
+	collectionType === 'scrollable/highlights';
 
 const isToggleable = (
 	index: number,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -30,7 +30,11 @@ const findCollectionSuitableForFrontBranding = (
 	// Find the lowest indexed collection that COULD display branding
 	const index = collections.findIndex(
 		({ collectionType }) =>
-			!['fixed/thrasher', 'fixed/highlights'].includes(collectionType),
+			![
+				'fixed/thrasher',
+				'fixed/highlights',
+				'scrollable/highlights',
+			].includes(collectionType),
 	);
 	// `findIndex` returns -1 when no element is found
 	// Treat that instead as undefined

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3204,7 +3204,8 @@
                 "flexible/special",
                 "nav/list",
                 "nav/media-list",
-                "news/most-popular"
+                "news/most-popular",
+                "scrollable/highlights"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -91,6 +91,7 @@ type FEContainerType =
 	| 'nav/media-list'
 	| 'news/most-popular'
 	| 'fixed/highlights'
+	| 'scrollable/highlights'
 	| 'flexible/special';
 
 export type FEContainerPalette =


### PR DESCRIPTION
## What does this change?

This PR adds `scrollable/highlights` with the same configuration as `fixed/highlights` so that we can begin migrating uses of `fixed/highlights` to `scrollable/highlights`. 

This PR deliberately avoids removing `fixed/highlights` as this will be done once we have confirmed uses have been migrated across. This is a necessary step due to this container type being used in production environments already.

## Why?

After [agreeing on a naming convention for the new front containers](https://docs.google.com/spreadsheets/d/1yVS2jFcZfCztJ3epLhsTcoShJWtdlzYyrpKLBZlYx94/edit?usp=sharing) we agreed to [rename `fixed/highlights` to `scrollable/highlights`](https://trello.com/c/YGbWyF1z/403-rename-fixed-highlights-to-scrollable-highlights)
