### PR TITLE
Remove console logs in favour of disabling eslint for unimplemented Titlepiece immersive handling

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
@@ -39,12 +39,6 @@ const columnsStyle = css`
 	}
 `;
 
-const immersiveColumnStyle = css`
-	${from.desktop} {
-		border-right: none;
-	}
-`;
-
 const columnsStyleFromLeftCol = css`
 	${from.leftCol} {
 		max-width: 1140px;
@@ -115,6 +109,7 @@ type Props = {
 };
 
 export const Sections = ({
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: add slim nav version for immersives
 	isImmersive = false,
 	nav,
 	editionId,
@@ -122,11 +117,7 @@ export const Sections = ({
 }: Props) => {
 	return (
 		<ul
-			css={[
-				columnsStyle,
-				isImmersive && immersiveColumnStyle,
-				!hasPageSkin && columnsStyleFromLeftCol,
-			]}
+			css={[columnsStyle, !hasPageSkin && columnsStyleFromLeftCol]}
 			role="menubar"
 			data-testid="nav-menu-columns"
 		>

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
@@ -213,14 +213,10 @@ export const Pillars = ({
 	nav,
 	selectedPillar,
 	dataLinkName,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- TODO: add slim nav version for immersives
 	isImmersive = false,
 	hasPageSkin = false,
 }: Props) => {
-	// TEMPORARY - to stop the linter freaking out
-	// TODO - handle immersive displayed articles and fronts with page skins
-	const needsAdapting = isImmersive || hasPageSkin;
-	console.log({ needsAdapting });
-
 	return (
 		<ul id="navigation" css={pillarsContainer}>
 			{nav.pillars.map((p, i) => {


### PR DESCRIPTION
## What does this change?

Removes console log and unwanted styles related to `isImmersive` prop and use `eslint-disable-next-line` to indicate TODO item for handling the Titlepiece immersive version

## Why?

It's generating unwanted logs and creating unnecessary noise. As flagged to Fairground project chat [here](https://chat.google.com/room/AAAAPt9dYOM/mb3Tx5kH494/mb3Tx5kH494?cls=10)
