### PR TITLE
Remove uses of `decidePalette`

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -19,7 +19,6 @@ import {
 } from '@guardian/source/foundations';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import { getAgeWarning } from '../lib/age-warning';
-import { decidePalette } from '../lib/decidePalette';
 import { getZIndex } from '../lib/getZIndex';
 import { palette as themePalette } from '../palette';
 import type { TagType } from '../types/tag';
@@ -359,7 +358,6 @@ export const ArticleHeadline = ({
 	hasAvatar,
 	isMatch,
 }: Props) => {
-	const palette = decidePalette(format);
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
@@ -752,7 +750,9 @@ export const ArticleHeadline = ({
 											: headlineFont(format),
 										css`
 											color: ${isMatch
-												? palette.text.headlineWhenMatch
+												? themePalette(
+														'--series-title-match-text',
+												  )
 												: themePalette(
 														'--headline-colour',
 												  )};

--- a/dotcom-rendering/src/components/CricketScoreboard.stories.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.stories.tsx
@@ -1,4 +1,3 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { match } from '../../fixtures/manual/cricket-scoreboard';
@@ -19,11 +18,6 @@ type Story = StoryObj<typeof CricketScoreboard>;
 export const defaultStory: Story = {
 	name: 'Cricket Scoreboard',
 	args: {
-		format: {
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.LiveBlog,
-			theme: Pillar.Sport,
-		},
 		match,
 		scorecardUrl: '/test',
 	},

--- a/dotcom-rendering/src/components/CricketScoreboard.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	between,
 	space,
 	textSans14,
 	until,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
+import { palette } from '../palette';
 import type { CricketInnings, CricketMatch } from '../types/sport';
 import { DateTime } from './DateTime';
 
@@ -16,7 +14,6 @@ const ALL_OUT_WICKETS = 10;
 type Props = {
 	scorecardUrl: string;
 	match: CricketMatch;
-	format: ArticleFormat;
 };
 
 const screenReaderOnlyStyle = css`
@@ -44,17 +41,17 @@ const tableStyle = css`
 	${textSans14}
 `;
 
-const captionStyle = (palette: Palette) => css`
+const captionStyle = css`
 	text-align: left;
 	font-weight: bold;
-	border-top: 1px solid ${palette.border.cricketScoreboardTop};
+	border-top: 1px solid ${palette('--cricket-scoreboard-border-top')};
 	border-collapse: inherit;
 	padding-top: ${space[2]}px;
 	padding-bottom: ${space[2]}px;
 `;
 
-const rowStyle = (palette: Palette) => css`
-	border-top: 1px solid ${palette.border.cricketScoreboardDivider};
+const rowStyle = css`
+	border-top: 1px solid ${palette('--cricket-scoreboard-divider')};
 `;
 
 const cellStyle = css`
@@ -71,12 +68,12 @@ const linkPaddingStlye = css`
 	padding-bottom: ${space[2]}px;
 `;
 
-const linkStyle = (palette: Palette) => css`
-	color: ${palette.text.cricketScoreboardLink};
+const linkStyle = css`
+	color: ${palette('--cricket-scoreboard-link-text')};
 	text-decoration: none;
 
 	:hover {
-		color: ${palette.text.cricketScoreboardLink};
+		color: ${palette('--cricket-scoreboard-link-text')};
 		text-decoration: underline;
 	}
 `;
@@ -136,8 +133,7 @@ export const CricketInningsScores = ({
 	return <p>Yet to bat</p>;
 };
 
-export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
-	const palette = decidePalette(format);
+export const CricketScoreboard = ({ scorecardUrl, match }: Props) => {
 	const date = new Date(match.gameDate);
 	return (
 		<div css={containerStyle}>
@@ -159,7 +155,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 				</thead>
 				<tbody>
 					{/* Home team */}
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={[cellStyle, boldStlye]}>
 							{match.teams.find((team) => !!team.home)?.name}
 						</td>
@@ -168,7 +164,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 						</td>
 					</tr>
 					{/* Away team */}
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={[cellStyle, boldStlye]}>
 							{match.teams.find((team) => !team.home)?.name}
 						</td>
@@ -177,13 +173,13 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 						</td>
 					</tr>
 				</tbody>
-				<caption css={captionStyle(palette)}>
+				<caption css={captionStyle}>
 					{match.competitionName}, {match.venueName}
 				</caption>
 				<tfoot>
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={linkPaddingStlye} colSpan={2}>
-							<a css={linkStyle(palette)} href={scorecardUrl}>
+							<a css={linkStyle} href={scorecardUrl}>
 								View full scorecard
 							</a>
 						</td>

--- a/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
+++ b/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
@@ -38,7 +38,6 @@ export const GetCricketScoreboard = ({ matchUrl, format }: Props) => {
 			<CricketScoreboard
 				match={data.match}
 				scorecardUrl={data.scorecardUrl}
-				format={format}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -14,7 +14,6 @@ import {
 	palette as srcPalette,
 	until,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { palette as themePalette } from '../palette';
 import type {
@@ -22,7 +21,6 @@ import type {
 	StarRating as Rating,
 	RoleType,
 } from '../types/content';
-import type { Palette } from '../types/palette';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
 import { useConfig } from './ConfigContext';
@@ -144,7 +142,7 @@ const immersiveTitleWrapper = css`
 		${headlineLight34};
 	}
 `;
-const titleWrapper = (palette: Palette) => css`
+const titleWrapper = css`
 	position: absolute;
 	bottom: 0;
 	width: 100%;
@@ -163,7 +161,7 @@ const titleWrapper = (palette: Palette) => css`
 	background: linear-gradient(transparent, ${srcPalette.neutral[0]});
 
 	:before {
-		background-color: ${palette.background.imageTitle};
+		background-color: ${themePalette('--image-title-background')};
 		display: block;
 		content: '';
 		width: 8.75rem;
@@ -178,31 +176,19 @@ const titleWrapper = (palette: Palette) => css`
 	}
 `;
 
-const ImageTitle = ({
-	title,
-	role,
-	palette,
-}: {
-	title: string;
-	role: RoleType;
-	palette: Palette;
-}) => {
+const ImageTitle = ({ title, role }: { title: string; role: RoleType }) => {
 	switch (role) {
 		case 'inline':
 		case 'thumbnail':
 		case 'halfWidth':
 		case 'supporting':
-			return (
-				<h2 css={[titleWrapper(palette), basicTitlePadding]}>
-					{title}
-				</h2>
-			);
+			return <h2 css={[titleWrapper, basicTitlePadding]}>{title}</h2>;
 		case 'showcase':
 		case 'immersive':
 			return (
 				<h2
 					css={[
-						titleWrapper(palette),
+						titleWrapper,
 						immersiveTitleWrapper,
 						moreTitlePadding,
 					]}
@@ -318,8 +304,6 @@ export const ImageComponent = ({
 	const imageWidth = parseInt(image.fields.width, 10);
 	const imageHeight = parseInt(image.fields.height, 10);
 
-	const palette = decidePalette(format);
-
 	const loading = isMainMedia ? 'eager' : 'lazy';
 
 	if (
@@ -382,9 +366,7 @@ export const ImageComponent = ({
 					/>
 				)}
 
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink
 						role={role}
@@ -450,9 +432,7 @@ export const ImageComponent = ({
 				{!isUndefined(starRating) ? (
 					<PositionStarRating rating={starRating} />
 				) : null}
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink
 						role={role}
@@ -556,9 +536,7 @@ export const ImageComponent = ({
 				{!isUndefined(starRating) ? (
 					<PositionStarRating rating={starRating} />
 				) : null}
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink

--- a/dotcom-rendering/src/components/LightboxCaption.tsx
+++ b/dotcom-rendering/src/components/LightboxCaption.tsx
@@ -1,27 +1,22 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	space,
 	palette as srcPalette,
 	textSans14,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
+import { palette } from '../palette';
 
 type Props = {
 	captionText?: string;
-	format: ArticleFormat;
 	credit?: string;
 	displayCredit?: boolean;
 };
 
 export const LightboxCaption = ({
 	captionText,
-	format,
 	credit,
 	displayCredit,
 }: Props) => {
-	const palette = decidePalette(format);
-
 	return (
 		<figcaption
 			css={css`
@@ -30,7 +25,7 @@ export const LightboxCaption = ({
 				overflow-wrap: break-all;
 				padding-top: ${space[2]}px;
 				padding-bottom: ${space[2]}px;
-				border-top: 3px solid ${palette.background.lightboxDivider};
+				border-top: 3px solid ${palette('--lightbox-divider')};
 			`}
 		>
 			{!!captionText && (

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -270,7 +270,6 @@ export const LightboxImages = ({ format, images }: Props) => {
 								</Hide>
 								<LightboxCaption
 									captionText={image.caption}
-									format={format}
 									credit={image.credit}
 									displayCredit={image.displayCredit}
 								/>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -3,7 +3,6 @@ import { ArticleDesign, ArticleSpecial, Pillar } from '@guardian/libs';
 import { brandAltBackground, palette } from '@guardian/source/foundations';
 // Here is the one place where we use `pillarPalette`
 import { pillarPalette_DO_NOT_USE as pillarPalette } from '../lib/pillars';
-import { palette as themePalette } from '../palette';
 import type { Palette } from '../types/palette';
 import { transparentColour } from './transparentColour';
 
@@ -21,16 +20,6 @@ const {
 
 const WHITE = neutral[100];
 const BLACK = neutral[7];
-
-const textHeadlineWhenMatch = (format: ArticleFormat): string => {
-	switch (format.design) {
-		case ArticleDesign.MatchReport:
-		case ArticleDesign.LiveBlog:
-			return BLACK;
-		default:
-			return themePalette('--series-title-text');
-	}
-};
 
 const textStandfirst = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.LiveBlog) return WHITE;
@@ -444,7 +433,6 @@ const textExpandableAtomHover = (format: ArticleFormat) => {
 export const decidePalette = (format: ArticleFormat): Palette => {
 	return {
 		text: {
-			headlineWhenMatch: textHeadlineWhenMatch(format),
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
 			disclaimerLink: textDisclaimerLink(format),

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -134,20 +134,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
 
-const backgroundImageTitle = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
-		}
-	}
-	return pillarPalette[format.theme].main;
-};
-
-const backgroundLightboxDivider = backgroundImageTitle;
-
 const backgroundSpeechBubble = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
@@ -449,8 +435,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			analysisContrastHover: backgroundAnalysisContrastHoverColour(),
 			bullet: backgroundBullet(format),
 			bulletStandfirst: backgroundBulletStandfirst(format),
-			imageTitle: backgroundImageTitle(format),
-			lightboxDivider: backgroundLightboxDivider(format),
 			speechBubble: backgroundSpeechBubble(format),
 			filterButton: backgroundFilterButton(),
 			filterButtonHover: backgroundFilterButtonHover(format),

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -93,10 +93,6 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 	}
 };
 
-const textCricketScoreboardLink = (): string => {
-	return sport[300];
-};
-
 const backgroundBullet = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport) {
@@ -355,14 +351,6 @@ const borderLines = (format: ArticleFormat): string => {
 	return neutral[86];
 };
 
-const borderCricketScoreboardTop = (): string => {
-	return sport[300];
-};
-
-const borderCricketScoreboardDivider = (): string => {
-	return neutral[86];
-};
-
 const borderFilterButton = (): string => neutral[60];
 
 const backgroundAnalysisContrastColour = (): string => '#F2E8E6';
@@ -460,7 +448,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
 			disclaimerLink: textDisclaimerLink(format),
-			cricketScoreboardLink: textCricketScoreboardLink(),
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
@@ -490,8 +477,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			headline: borderHeadline(format),
 			navPillar: borderNavPillar(format),
 			lines: borderLines(format),
-			cricketScoreboardTop: borderCricketScoreboardTop(),
-			cricketScoreboardDivider: borderCricketScoreboardDivider(),
 			cardSupporting: borderCardSupporting(format),
 			filterButton: borderFilterButton(),
 		},

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5569,17 +5569,45 @@ const designTagBackground: PaletteFunction = ({ theme }) => {
 	}
 };
 
-const cricketScoreboardBorderTop = () => {
+const cricketScoreboardBorderTop: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 
-const cricketScoreboardDivider = () => {
+const cricketScoreboardDivider: PaletteFunction = () => {
 	return sourcePalette.neutral[86];
 };
 
-const cricketScoreboardLinkText = () => {
+const cricketScoreboardLinkText: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
+
+const imageTitleBackground: PaletteFunction = ({ design, theme }) => {
+	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
+		return sourcePalette.news[300];
+	}
+
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[400];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[300];
+		case Pillar.Sport:
+			return sourcePalette.sport[400];
+		case Pillar.Culture:
+			return sourcePalette.culture[400];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[400];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[200];
+	}
+};
+
+const lightboxDivider: PaletteFunction = (format) =>
+	imageTitleBackground(format);
 
 // ----- Palette ----- //
 
@@ -6254,6 +6282,10 @@ const paletteColours = {
 		light: highlightContainerStartFade,
 		dark: highlightContainerStartFade,
 	},
+	'--image-title-background': {
+		light: imageTitleBackground,
+		dark: imageTitleBackground,
+	},
 	'--interactive-atom-background': {
 		light: interactiveAtomBackgroundLight,
 		dark: interactiveAtomBackgroundDark,
@@ -6321,6 +6353,10 @@ const paletteColours = {
 	'--last-updated-text': {
 		light: lastUpdatedTextLight,
 		dark: lastUpdatedTextDark,
+	},
+	'--lightbox-divider': {
+		light: lightboxDivider,
+		dark: lightboxDivider,
 	},
 	'--link-kicker-text': {
 		light: linkKickerTextLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5569,6 +5569,18 @@ const designTagBackground: PaletteFunction = ({ theme }) => {
 	}
 };
 
+const cricketScoreboardBorderTop = () => {
+	return sourcePalette.sport[300];
+};
+
+const cricketScoreboardDivider = () => {
+	return sourcePalette.neutral[86];
+};
+
+const cricketScoreboardLinkText = () => {
+	return sourcePalette.sport[300];
+};
+
 // ----- Palette ----- //
 
 /**
@@ -5977,6 +5989,18 @@ const paletteColours = {
 	'--comment-form-input-background': {
 		light: commentFormInputBackgroundLight,
 		dark: commentFormInputBackgroundDark,
+	},
+	'--cricket-scoreboard-border-top': {
+		light: cricketScoreboardBorderTop,
+		dark: cricketScoreboardBorderTop,
+	},
+	'--cricket-scoreboard-divider': {
+		light: cricketScoreboardDivider,
+		dark: cricketScoreboardDivider,
+	},
+	'--cricket-scoreboard-link-text': {
+		light: cricketScoreboardLinkText,
+		dark: cricketScoreboardLinkText,
 	},
 	'--dateline': {
 		light: datelineLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -18,13 +18,11 @@ export type Palette = {
 		analysisContrastHover: Colour;
 		bullet: Colour;
 		bulletStandfirst: Colour;
-		imageTitle: Colour;
 		speechBubble: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
 		treat: Colour;
-		lightboxDivider: Colour;
 	};
 	fill: {
 		guardianLogo: Colour;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -2,7 +2,6 @@ export type Colour = string;
 
 export type Palette = {
 	text: {
-		headlineWhenMatch: Colour;
 		standfirst: Colour;
 		standfirstLink: Colour;
 		disclaimerLink: Colour;

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -6,7 +6,6 @@ export type Palette = {
 		standfirst: Colour;
 		standfirstLink: Colour;
 		disclaimerLink: Colour;
-		cricketScoreboardLink: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
@@ -36,8 +35,6 @@ export type Palette = {
 		headline: Colour;
 		navPillar: Colour;
 		lines: Colour;
-		cricketScoreboardTop: Colour;
-		cricketScoreboardDivider: Colour;
 		cardSupporting: Colour;
 		filterButton: Colour;
 	};


### PR DESCRIPTION
## What does this change?

Updates more components to remove use of `decidePalette` and migrate to the [`palette` module](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/palette.ts)

- `CricketScoreboard`
- `ArticleHeadline`
- `ImageComponent`
- `LightboxCaption`

## Why?

This is part of a larger body of work to deprecate and remove `decidePalette`