### PR TITLE
Move sticky tag from Olympics to Paralympics coverage

### DIFF
--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -30,7 +30,7 @@ const bodyStyles = css`
 `;
 
 const titleStyles = css`
-	.sticky-tag-link-test & {
+	.sticky-tag-link & {
 		${getZIndex('tagLinkOverlay')}
 		position: sticky;
 		top: 0;

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -201,8 +201,8 @@ export const SeriesSectionLink = ({
 	if (shouldShowTagLink) {
 		return (
 			<TagLink
-				sectionUrl="sport/olympic-games-2024"
-				sectionLabel="Paris Olympic Games 2024"
+				sectionUrl="sport/paralympic-games-2024"
+				sectionLabel="Paris Paralympic Games 2024"
 				guardianBaseURL={guardianBaseURL}
 				format={format}
 			/>

--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -212,7 +212,7 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 	 *  and not added later.  It's a balancing act between adding a useEffect that will run
 	 *  each time a tag is added to check (less performant) and doing it on load. */
 	const shouldHideBasedOnTags = tags.some((a) => {
-		return a.id === 'sport/olympic-games-2024';
+		return a.id === 'sport/paralympic-games-2024';
 	});
 
 	const canShow =

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -315,7 +315,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	return (
 		<>
@@ -473,7 +473,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 
 			<main
 				data-layout="CommentLayout"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link' : ''}
 			>
 				{isApps && (
 					<>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -320,7 +320,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	const inUpdatedHeaderABTest =
 		article.config.abTests.updatedHeaderDesignVariant === 'variant';
@@ -491,7 +491,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="ImmersiveLayout"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link' : ''}
 			>
 				{isApps && (
 					<>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -306,7 +306,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -297,7 +297,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -454,7 +454,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 			<main
 				data-layout="PictureLayout"
 				id="maincontent"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link' : ''}
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}
 			>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -257,7 +257,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	const { absoluteServerTimes = false } = article.config.switches;
 
@@ -532,7 +532,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 			)}
 			<main
 				data-layout="ShowcaseLayout"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link' : ''}
 				id="maincontent"
 				lang={decideLanguage(article.lang)}
 				dir={decideLanguageDirection(article.isRightToLeftLang)}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -418,7 +418,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 	const shouldShowTagLink =
 		isWeb &&
-		article.tags.some(({ id }) => id === 'sport/olympic-games-2024');
+		article.tags.some(({ id }) => id === 'sport/paralympic-games-2024');
 
 	return (
 		<>
@@ -599,7 +599,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="StandardLayout"
-				className={shouldShowTagLink ? 'sticky-tag-link-test' : ''}
+				className={shouldShowTagLink ? 'sticky-tag-link' : ''}
 			>
 				{isApps && (
 					<>


### PR DESCRIPTION
Closes #12239

## What does this change?

Stops using the sticky tag link on Olympics pages.

Starts using the sticky tag link on Paralympics pages.

## Why?

The Olympics has finished and the Paralympics has begun.

Analysis has shown that we receive more click-throughs with the sticky tag over the normal tag.

We are planning to use a similar "sticky tag" feature for the US elections, so this is another chance to familiarise the user.

## Screenshots

<img width="600" alt="Screenshot 2024-08-29 at 09 53 46" src="https://github.com/user-attachments/assets/d4b14a49-bd8b-448c-ac13-0ee630ac229b">

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3e513d56-19fe-4e92-a3e6-5992931a2ced">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
