### PR TITLE
Remove deprecated `fixed/highlights` container

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -222,7 +222,6 @@ export const DecideContainer = ({
 			return <NavList trails={trails} showImage={false} />;
 		case 'nav/media-list':
 			return <NavList trails={trails} showImage={true} />;
-		case 'fixed/highlights':
 		case 'scrollable/highlights':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -70,7 +70,6 @@ const isNavList = (collection: DCRCollectionType) => {
 };
 
 const isHighlights = ({ collectionType }: DCRCollectionType) =>
-	collectionType === 'fixed/highlights' ||
 	collectionType === 'scrollable/highlights';
 
 const isToggleable = (
@@ -392,10 +391,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						  }))
 						: trails;
 
-					if (
-						collection.collectionType === 'fixed/highlights' ||
-						collection.collectionType === 'scrollable/highlights'
-					) {
+					if (collection.collectionType === 'scrollable/highlights') {
 						// Highlights are rendered in the Masthead component
 						return null;
 					}

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -30,11 +30,9 @@ const findCollectionSuitableForFrontBranding = (
 	// Find the lowest indexed collection that COULD display branding
 	const index = collections.findIndex(
 		({ collectionType }) =>
-			![
-				'fixed/thrasher',
-				'fixed/highlights',
-				'scrollable/highlights',
-			].includes(collectionType),
+			!['fixed/thrasher', 'scrollable/highlights'].includes(
+				collectionType,
+			),
 	);
 	// `findIndex` returns -1 when no element is found
 	// Treat that instead as undefined

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3184,7 +3184,6 @@
                 "dynamic/package",
                 "dynamic/slow",
                 "dynamic/slow-mpu",
-                "fixed/highlights",
                 "fixed/large/slow-XIV",
                 "fixed/medium/fast-XI",
                 "fixed/medium/fast-XII",

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -90,7 +90,6 @@ type FEContainerType =
 	| 'nav/list'
 	| 'nav/media-list'
 	| 'news/most-popular'
-	| 'fixed/highlights'
 	| 'scrollable/highlights'
 	| 'flexible/special';
 


### PR DESCRIPTION
## What does this change?

As a follow-up from https://github.com/guardian/dotcom-rendering/pull/12236, this PR removes the `fixed/highlights` container now that usages have been migrated to the scrollable/highlights type

## Why?

Production uses of `fixed/highlights` have now been converted to `scrollable/highlights` so we are safe to remove the old `fixed/highlights` container now
