### PR TITLE
Temporarily Skip Commercial Test

### DIFF
--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -4,7 +4,9 @@ import { loadPage } from '../lib/load-page';
 import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
-	test(`It should load the expected number of ad slots`, async ({ page }) => {
+	test.skip(`It should load the expected number of ad slots`, async ({
+		page,
+	}) => {
 		await loadPage(
 			page,
 			`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,


### PR DESCRIPTION
## What does this change?
Skip Commercial Playwright Test

## Why?

https://github.com/guardian/dotcom-rendering/pull/12232 breaks it when the page is rendered with the updated header. This means there's a 50% likelihood this test will fail. For now we're skipping. Next step is to make sure the test is rendering the page with the old header only.

