### PR TITLE
Ensure `scrollable/highlights` container does not render in the main section

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -192,7 +192,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			showHighlights &&
 			!!highlightsCollection && (
 				<DecideContainer
-					containerType="fixed/highlights"
+					containerType={highlightsCollection.collectionType}
 					trails={[
 						...highlightsCollection.curated,
 						...highlightsCollection.backfill,
@@ -392,7 +392,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						  }))
 						: trails;
 
-					if (collection.collectionType === 'fixed/highlights') {
+					if (
+						collection.collectionType === 'fixed/highlights' ||
+						collection.collectionType === 'scrollable/highlights'
+					) {
 						// Highlights are rendered in the Masthead component
 						return null;
 					}


### PR DESCRIPTION
## What does this change?

Prevents Highlights container with `scrollable/highlights` type appearing in the main section of the front page.

## Why?

This change was missed in https://github.com/guardian/dotcom-rendering/pull/12236 which ensures that when the Highlights container is swapped from `fixed/highlights` to `scrollable/highlights` that it is not rendered in the front main section
