### PR TITLE
Fix gap in immersive articles when there is no main media

### DIFF
--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -427,9 +427,12 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 				<div
 					css={[
 						mainMedia && hasMainMediaStyles,
-						mainMedia && showsUpdatedHeaderDesign
-							? mainMediaUpdatedHeaderStyles
-							: mainMediaOldHeaderStyles,
+						mainMedia &&
+							showsUpdatedHeaderDesign &&
+							mainMediaUpdatedHeaderStyles,
+						mainMedia &&
+							!showsUpdatedHeaderDesign &&
+							mainMediaOldHeaderStyles,
 						css`
 							display: flex;
 							flex-direction: column;


### PR DESCRIPTION
## What does this change?
Fixes a bug above desktop in immersive articles without a main image.

## Why?
Bug was introduced here: https://github.com/guardian/dotcom-rendering/pull/12232

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/6317e6e7-fe52-4cec-991b-f0c6586c377f) | ![image](https://github.com/user-attachments/assets/e46116ae-3964-4bf3-93e7-d5c9b35807c4) |
| ![image](https://github.com/user-attachments/assets/c13e9e04-8a04-49e4-a844-eddf5cf7e9f8) | ![image](https://github.com/user-attachments/assets/962870c5-34af-4fc6-bc7d-5a59965b9114) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
