### PR TITLE
Revert "Fix immersive main media height with the updated header"

### DIFF
--- a/dotcom-rendering/src/components/Nav/Nav.tsx
+++ b/dotcom-rendering/src/components/Nav/Nav.tsx
@@ -19,7 +19,6 @@ type Props = {
 	isImmersive?: boolean;
 	selectedPillar?: Pillar;
 	hasPageSkin?: boolean;
-	showsUpdatedHeaderDesign?: boolean;
 };
 
 const clearFixStyle = css`
@@ -32,10 +31,9 @@ const rowStyles = css`
 	justify-content: space-between;
 `;
 
-export const minNavHeightPx = (showsUpdatedHeaderDesign: boolean) =>
-	showsUpdatedHeaderDesign ? 191 : 48;
-export const minNavHeight = (showsUpdatedHeaderDesign: boolean) => css`
-	min-height: ${minNavHeightPx(showsUpdatedHeaderDesign)}px;
+export const minNavHeightPx = 48;
+export const minNavHeight = css`
+	min-height: ${minNavHeightPx}px;
 `;
 
 const PositionRoundel = ({ children }: { children: React.ReactNode }) => (
@@ -63,7 +61,6 @@ export const Nav = ({
 	isImmersive,
 	selectedPillar,
 	hasPageSkin,
-	showsUpdatedHeaderDesign = false,
 }: Props) => {
 	return (
 		<div css={rowStyles}>
@@ -173,11 +170,7 @@ export const Nav = ({
 				}}
 			/>
 			<div
-				css={[
-					clearFixStyle,
-					rowStyles,
-					isImmersive && minNavHeight(showsUpdatedHeaderDesign),
-				]}
+				css={[clearFixStyle, rowStyles, isImmersive && minNavHeight]}
 				data-component="nav2"
 			>
 				{isImmersive && (

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -142,18 +142,6 @@ const standardImmersiveNewsFixture: DCRArticle = {
 	},
 };
 
-const standardImmersiveNewsWithUpdatedHeaderFixture: DCRArticle = {
-	...StandardStandardNewsFixture,
-	format: {
-		...StandardStandardNewsFixture.format,
-		display: 'ImmersiveDisplay',
-	},
-	config: {
-		...StandardStandardNewsFixture.config,
-		abTests: { updatedHeaderDesignVariant: 'variant' },
-	},
-};
-
 export const AppsStandardImmersiveNewsLight: Story = {
 	args: {
 		article: standardImmersiveNewsFixture,
@@ -165,22 +153,6 @@ export const AppsStandardImmersiveNewsLight: Story = {
 export const AppsStandardImmersiveNewsDark: Story = {
 	args: {
 		article: standardImmersiveNewsFixture,
-		colourScheme: 'dark',
-	},
-	parameters: appsParameters,
-};
-
-export const AppsStandardImmersiveNewsLightWithUpdatedHeader: Story = {
-	args: {
-		article: standardImmersiveNewsWithUpdatedHeaderFixture,
-		colourScheme: 'light',
-	},
-	parameters: appsParameters,
-};
-
-export const AppsStandardImmersiveNewsDarkWithUpdatedHeader: Story = {
-	args: {
-		article: standardImmersiveNewsWithUpdatedHeaderFixture,
 		colourScheme: 'dark',
 	},
 	parameters: appsParameters,
@@ -244,24 +216,9 @@ export const AppsPictureShowcaseOpinionDark: Story = {
 	parameters: appsParameters,
 };
 
-const PhotoEssayImmersiveLabsWithUpdatedHeaderFixture: DCRArticle = {
-	...PhotoEssayImmersiveLabsFixture,
-	config: {
-		...PhotoEssayImmersiveLabsFixture.config,
-		abTests: { updatedHeaderDesignVariant: 'variant' },
-	},
-};
-
 export const WebPhotoEssayImmersiveLabsLight: Story = {
 	args: {
 		article: PhotoEssayImmersiveLabsFixture,
-	},
-	parameters: webParameters,
-};
-
-export const WebPhotoEssayImmersiveLabsLightWithUpdatedHeader: Story = {
-	args: {
-		article: PhotoEssayImmersiveLabsWithUpdatedHeaderFixture,
 	},
 	parameters: webParameters,
 };

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -269,38 +269,17 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
-	const showsUpdatedHeaderDesign: boolean =
-		article.config.abTests.updatedHeaderDesignVariant === 'variant' &&
-		article.config.abTests.updatedHeaderDesignVariant !== undefined;
-
 	/**
 	We need change the height values depending on whether the labs header is there or not to keep
 	the headlines appearing at a consistent height between labs and non labs immersive articles.
 	*/
 
 	const labsHeaderHeight = LABS_HEADER_HEIGHT;
-	const combinedHeight = (
-		minNavHeightPx(showsUpdatedHeaderDesign) + labsHeaderHeight
-	).toString();
+	const combinedHeight = (minNavHeightPx + labsHeaderHeight).toString();
 
 	const navAndLabsHeaderHeight = isLabs
 		? `${combinedHeight}px`
-		: `${minNavHeightPx(showsUpdatedHeaderDesign)}px`;
-
-	const mainMediaUpdatedHeaderStyles = css`
-		${from.desktop} {
-			height: calc(80vh - ${navAndLabsHeaderHeight});
-		}
-	`;
-
-	const mainMediaOldHeaderStyles = css`
-		${from.desktop} {
-			height: calc(100vh - ${navAndLabsHeaderHeight});
-		}
-		${from.wide} {
-			min-height: calc(50rem - ${navAndLabsHeaderHeight});
-		}
-	`;
+		: `${minNavHeightPx}px`;
 
 	const hasMainMediaStyles = css`
 		height: calc(80vh - ${navAndLabsHeaderHeight});
@@ -310,7 +289,11 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 		*/
 		min-height: calc(25rem - ${navAndLabsHeaderHeight});
 		${from.desktop} {
+			height: calc(100vh - ${navAndLabsHeaderHeight});
 			min-height: calc(31.25rem - ${navAndLabsHeaderHeight});
+		}
+		${from.wide} {
+			min-height: calc(50rem - ${navAndLabsHeaderHeight});
 		}
 	`;
 	const LeftColCaption = () => (
@@ -395,9 +378,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											.contribute
 									}
 									editionId={article.editionId}
-									showsUpdatedHeaderDesign={
-										showsUpdatedHeaderDesign
-									}
 								/>
 							</Section>
 						</div>
@@ -427,12 +407,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 				<div
 					css={[
 						mainMedia && hasMainMediaStyles,
-						mainMedia &&
-							showsUpdatedHeaderDesign &&
-							mainMediaUpdatedHeaderStyles,
-						mainMedia &&
-							!showsUpdatedHeaderDesign &&
-							mainMediaOldHeaderStyles,
 						css`
 							display: flex;
 							flex-direction: column;


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#12232

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3c3d86cd-1167-44b7-b648-a746c0089024) | ![image](https://github.com/user-attachments/assets/a7268eeb-daa5-4182-bd15-539a442e7a56) |
| ![image](https://github.com/user-attachments/assets/a200d43f-8bd8-415e-99dc-47828eb42fea) | ![image](https://github.com/user-attachments/assets/ce7fba8a-8abb-43ac-9799-cc1c25bf16d8) |
| ![image](https://github.com/user-attachments/assets/04027f82-d47b-458d-a26b-6822c15523a3) | ![image](https://github.com/user-attachments/assets/604db5ad-e979-474d-94a6-aed892a4699f) |
