### PR TITLE
Remove Custom Headline Colour For Print Shop

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -89,8 +89,6 @@ const headlineTextLight: PaletteFunction = ({ design, display, theme }) => {
 				case ArticleDesign.Interview:
 				case ArticleDesign.Picture:
 				case ArticleDesign.Audio:
-				case ArticleDesign.PrintShop:
-					return sourcePalette.neutral[97];
 				case ArticleDesign.Video:
 					switch (theme) {
 						case ArticleSpecial.Labs:


### PR DESCRIPTION
When print shop is immersive, the colour will be handled by the immersive case above. When it's not immersive, the headline looks like a standard article headline, so we don't want to set a separate colour.

| Before | After |
|--------|--------|
| ![print-shop-before](https://github.com/user-attachments/assets/e3eba5b6-d8dc-49e4-8a05-2a6f3869d8e4) | ![print-shop-after](https://github.com/user-attachments/assets/616e4f61-ae06-4c7f-9de9-baaf1015f82f) | 
