### PR TITLE
Fix tag page chevron

### DIFF
--- a/dotcom-rendering/src/components/FrontPagination.tsx
+++ b/dotcom-rendering/src/components/FrontPagination.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source/react-components';
 import { Fragment } from 'react';
 import { formatCount } from '../lib/formatCount';
+import { palette as schemedPalette } from '../palette';
 
 type Props = {
 	pageId: string;
@@ -89,7 +90,7 @@ const paginationArrowsCss = css`
 	padding: 2px;
 
 	svg {
-		color: ${palette.neutral[86]};
+		fill: ${schemedPalette('--tag-page-chevron')};
 	}
 `;
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6757,6 +6757,10 @@ const paletteColours = {
 		light: tagLinkFillBackgroundLight,
 		dark: tagLinkFillBackgroundDark,
 	},
+	'--tag-page-chevron': {
+		light: () => sourcePalette.neutral[0],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--timeline-atom-bullet': {
 		light: timelineAtomBulletLight,
 		dark: timelineAtomBulletDark,


### PR DESCRIPTION
## What does this change?
Fix use `fill` for the svg and adds dark mode styles
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/12149
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/bc292357-0e92-4967-a3eb-581ee3de2bf3
[after]: https://github.com/user-attachments/assets/7abf73f6-32e3-4a7a-8b26-1d4619e6002c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
