### PR TITLE
Liveblog key line dark scheme

### DIFF
--- a/dotcom-rendering/src/components/FilterKeyEventsToggle.importable.tsx
+++ b/dotcom-rendering/src/components/FilterKeyEventsToggle.importable.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
-import { from, palette, remSpace, until } from '@guardian/source/foundations';
+import { from, remSpace, until } from '@guardian/source/foundations';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
 import { useState } from 'react';
+import { palette as schemedPalette } from '../palette';
 
 const cssOverrides = css`
 	display: inline-flex;
@@ -27,7 +28,8 @@ const toggleWrapperStyles = css`
 		padding-top: ${remSpace[3]};
 	}
 	${from.desktop} {
-		border-top: 1px solid ${palette.neutral[86]};
+		border-top: 1px solid
+			${schemedPalette('--filter-key-events-toggle-border-top')};
 	}
 `;
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -700,7 +700,12 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								{/* Lines */}
 								<Hide until="desktop">
 									<div css={[maxWidth, sidePaddingDesktop]}>
-										<DecideLines format={format} />
+										<DecideLines
+											format={format}
+											color={themePalette(
+												'--straight-lines',
+											)}
+										/>
 									</div>
 								</Hide>
 								{/* Meta */}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6153,6 +6153,10 @@ const paletteColours = {
 		light: explainerAtomBackgroundLight,
 		dark: explainerAtomBackgroundDark,
 	},
+	'--filter-key-events-toggle-border-top': {
+		light: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[20],
+	},
 	'--follow-icon-background': {
 		light: followIconBackgroundLight,
 		dark: followIconBackgroundDark,


### PR DESCRIPTION
## What does this change?
Adds dark scheme colours for key lines on liveblogs
## Why?
Requested by design
![image](https://github.com/user-attachments/assets/8a5b514c-8b69-49ef-8261-87354f6940be)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0f0b0a5b-f5f0-400f-94a4-52ce84ffbf0a
[after]: https://github.com/user-attachments/assets/f04d8d67-15c7-4909-839d-bc2e7032fa4a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
