### PR TITLE
Epic choice card test variants

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -326,6 +326,20 @@ export const WithThreeTierChoiceCards: Story = {
 	},
 };
 
+export const WithThreeTierChoiceCardsForUS: Story = {
+	name: 'ContributionsEpic with three tier choice cards for US',
+	args: {
+		...meta.args,
+		countryCode: 'US',
+		variant: {
+			...props.variant,
+			name: 'THREE_TIER_CHOICE_CARDS',
+			secondaryCta: undefined,
+			showChoiceCards: true,
+		},
+	},
+};
+
 export const WithChoiceCardsAndSignInLink: Story = {
 	name: 'ContributionsEpic with choice cards and sign-in link',
 	args: {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -15,7 +15,6 @@ import {
 import {
 	containsNonArticleCountPlaceholder,
 	epicPropsSchema,
-	getLocalCurrencySymbol,
 	replaceNonArticleCountPlaceholders,
 } from '@guardian/support-dotcom-components';
 import type {
@@ -39,7 +38,6 @@ import type { OphanTracking } from '../shared/ArticleCountOptOutPopup';
 import { withParsedProps } from '../shared/ModuleWrapper';
 import { BylineWithHeadshot } from './BylineWithHeadshot';
 import { ContributionsEpicArticleCountAboveWithOptOut } from './ContributionsEpicArticleCountAboveWithOptOut';
-import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ContributionsEpicSignInCta } from './ContributionsEpicSignInCta';
@@ -330,8 +328,6 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 			});
 		}
 	}, [showChoiceCards, choiceCardAmounts]);
-
-	const currencySymbol = getLocalCurrencySymbol(countryCode);
 
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -311,20 +311,10 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 		setThreeTierChoiceCardSelectedAmount,
 	] = useState<number>(defaultThreeTierAmount);
 
-	const showThreeTierChoiceCards =
-		showChoiceCards && variant.name.includes('THREE_TIER_CHOICE_CARDS');
-
-	const showThreeTierChoiceCardsV1 =
-		showChoiceCards && variant.name.includes('V1_THREE_TIER_CHOICE_CARDS');
-
-	const showThreeTierChoiceCardsV2 =
-		showChoiceCards && variant.name.includes('V2_THREE_TIER_CHOICE_CARDS');
-
-	const variantOfChoiceCard = showThreeTierChoiceCardsV1
-		? 'V1_THREE_TIER_CHOICE_CARDS'
-		: showThreeTierChoiceCardsV2
-		? 'V2_THREE_TIER_CHOICE_CARDS'
-		: 'THREE_TIER_CHOICE_CARDS';
+	const variantOfChoiceCard =
+		countryCode === 'US'
+			? 'US_THREE_TIER_CHOICE_CARDS'
+			: 'THREE_TIER_CHOICE_CARDS';
 
 	useEffect(() => {
 		if (showChoiceCards && choiceCardAmounts?.amountsCardData) {
@@ -483,16 +473,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 				<BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
 			)}
 
-			{choiceCardAmounts && !showThreeTierChoiceCards && (
-				<ContributionsEpicChoiceCards
-					setSelectionsCallback={setChoiceCardSelection}
-					selection={choiceCardSelection}
-					submitComponentEvent={submitComponentEvent}
-					currencySymbol={currencySymbol}
-					amountsTest={choiceCardAmounts}
-				/>
-			)}
-			{showThreeTierChoiceCards && (
+			{showChoiceCards && (
 				<ThreeTierChoiceCards
 					countryCode={countryCode}
 					selectedAmount={threeTierChoiceCardSelectedAmount}
@@ -520,7 +501,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					amountsTestName={choiceCardAmounts?.testName}
 					amountsVariantName={choiceCardAmounts?.variantName}
 					choiceCardSelection={choiceCardSelection}
-					showThreeTierChoiceCards={showThreeTierChoiceCards}
+					showThreeTierChoiceCards={showChoiceCards}
 					threeTierChoiceCardSelectedAmount={
 						threeTierChoiceCardSelectedAmount
 					}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -189,7 +189,7 @@ export const ContributionsEpicButtons = ({
 	const getChoiceCardCta = (cta: Cta): Cta => {
 		if (
 			showThreeTierChoiceCards &&
-			variantOfChoiceCard === 'US__THREE_TIER_CHOICE_CARDS' &&
+			variantOfChoiceCard === 'US_THREE_TIER_CHOICE_CARDS' &&
 			!isUndefined(threeTierChoiceCardSelectedAmount)
 		) {
 			if (threeTierChoiceCardSelectedAmount === 0) {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicButtons.tsx
@@ -189,11 +189,7 @@ export const ContributionsEpicButtons = ({
 	const getChoiceCardCta = (cta: Cta): Cta => {
 		if (
 			showThreeTierChoiceCards &&
-			variantOfChoiceCard &&
-			[
-				'V1_THREE_TIER_CHOICE_CARDS',
-				'V2_THREE_TIER_CHOICE_CARDS',
-			].includes(variantOfChoiceCard) &&
+			variantOfChoiceCard === 'US__THREE_TIER_CHOICE_CARDS' &&
 			!isUndefined(threeTierChoiceCardSelectedAmount)
 		) {
 			if (threeTierChoiceCardSelectedAmount === 0) {

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.ts
@@ -33,7 +33,7 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 	},
 ];
 
-export const ChoiceCardTestData_V1: ChoiceInfo[] = [
+export const ChoiceCardTestData_US: ChoiceInfo[] = [
 	{
 		supportTier: 'support',
 		label: (amount: number, currencySymbol: string): string =>
@@ -64,42 +64,6 @@ export const ChoiceCardTestData_V1: ChoiceInfo[] = [
 		benefitsLabel: undefined,
 		benefits: (currencySymbol: string) => [
 			`We welcome support of any size, any time - whether you choose to give ${currencySymbol}1 or more`,
-		],
-		recommended: false,
-	},
-];
-
-export const ChoiceCardTestData_V2: ChoiceInfo[] = [
-	{
-		supportTier: 'other',
-		label: (amount: number, currencySymbol: string): string =>
-			`Support once from just ${currencySymbol}1`,
-		benefitsLabel: undefined,
-		benefits: (currencySymbol: string) => [
-			`We welcome support of any size, any time - whether you choose to give ${currencySymbol}1 or more`,
-		],
-		recommended: false,
-	},
-	{
-		supportTier: 'support',
-		label: (amount: number, currencySymbol: string): string =>
-			`Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'Support',
-		benefits: () => [
-			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-		],
-		recommended: false,
-	},
-	{
-		supportTier: 'allAccess',
-		label: (amount: number, currencySymbol: string): string =>
-			`Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'All-access digital',
-		benefits: () => [
-			'Unlimited access to the Guardian app',
-			'Ad-free reading on all your devices',
-			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
-			'Far fewer asks for support',
 		],
 		recommended: false,
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -21,8 +21,6 @@ import type { Dispatch, SetStateAction } from 'react';
 import {
 	ChoiceCardTestData_REGULAR,
 	ChoiceCardTestData_US,
-	ChoiceCardTestData_V1,
-	ChoiceCardTestData_V2,
 } from './ThreeTierChoiceCardData';
 import type { SupportTier } from './utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -20,6 +20,7 @@ import {
 import type { Dispatch, SetStateAction } from 'react';
 import {
 	ChoiceCardTestData_REGULAR,
+	ChoiceCardTestData_US,
 	ChoiceCardTestData_V1,
 	ChoiceCardTestData_V2,
 } from './ThreeTierChoiceCardData';
@@ -149,12 +150,8 @@ type ThreeTierChoiceCardsProps = {
 
 export const getChoiceCardData = (variant: string): ChoiceInfo[] => {
 	switch (variant) {
-		case 'THREE_TIER_CHOICE_CARDS':
-			return ChoiceCardTestData_REGULAR;
-		case 'V1_THREE_TIER_CHOICE_CARDS':
-			return ChoiceCardTestData_V1;
-		case 'V2_THREE_TIER_CHOICE_CARDS':
-			return ChoiceCardTestData_V2;
+		case 'US_THREE_TIER_CHOICE_CARDS':
+			return ChoiceCardTestData_US;
 		default:
 			return ChoiceCardTestData_REGULAR;
 	}


### PR DESCRIPTION
## What does this change?

Roll out the epic choice card test variants
## Why?

[Trello card](https://trello.com/c/1ERijzJF/652-roll-out-choice-card-test-variants)
## Screenshots



[before]: https://example.com/before.png
[after]: https://example.com/after.png

## After the change

## The Epic choice cards in Non-US regions will be as below 
<img width="883" alt="image" src="https://github.com/user-attachments/assets/e9e71a9d-3fea-4753-8d73-e337235b1a0b">

### Clicking on the **Support £4/month** option takes you to  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e6018dde-b9d8-4078-94c2-d5c8b81327b9">


### Clicking on the **Support £12/month** option takes you to  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b56375b0-a455-48c1-a2ff-ebba7066b737">

### Clicking on the **Support with another amount** option takes you to  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/25550fdd-e5b2-4f4a-ac05-fb2118158495">

## The Epic choice card in US will be as below 
<img width="883" alt="image" src="https://github.com/user-attachments/assets/d3f1dd11-ac73-4d4f-875d-05488a78222d">

### In US, clicking on the **Support $5/month** option takes you to 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ecb4a6ca-56b0-4d1b-87a7-217c15b4e937">

### In US, clicking on the **Support $15/month** option takes you to 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/0fac6861-a1ce-4102-8a9d-1662442a9b69">

### In US, clicking on the **Support once from just $1** option takes you to 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2082b818-9856-4ead-aca1-888748cf2995">







<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
