### PR TITLE
Restore/fix e2e header tests

### DIFF
--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -15,14 +15,13 @@ const articleUrl =
 test.describe('Interactivity', () => {
 	test.describe('Verify elements have been hydrated', () => {
 		/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
-		test.skip('should open the edition dropdown menu when clicked and hide when expected', async ({
+		test('should open the edition dropdown menu when clicked and hide when expected', async ({
 			context,
 			page,
 		}) => {
 			await disableCMP(context);
 			await loadPage(page, `/Article/${articleUrl}`);
 
-			await waitForIsland(page, 'Titlepiece');
 			// Open it
 			await page.locator('[data-testid=dropdown-button]').click();
 			await expectToBeVisible(page, '[data-testid=dropdown-options]');
@@ -116,7 +115,7 @@ test.describe('Interactivity', () => {
 		});
 
 		/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
-		test.skip('should render the reader revenue links in the header', async ({
+		test('should render the reader revenue links in the header', async ({
 			context,
 			page,
 		}) => {

--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -14,7 +14,6 @@ const articleUrl =
 
 test.describe('Interactivity', () => {
 	test.describe('Verify elements have been hydrated', () => {
-		/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
 		test('should open the edition dropdown menu when clicked and hide when expected', async ({
 			context,
 			page,
@@ -114,7 +113,6 @@ test.describe('Interactivity', () => {
 			);
 		});
 
-		/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
 		test('should render the reader revenue links in the header', async ({
 			context,
 			page,

--- a/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
@@ -50,7 +50,6 @@ test.describe('The web document renders with the correct meta and analytics elem
 		await expectToExist(page, `head link[rel="canonical"]`);
 	});
 
-	/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
 	test('Subnav links exists with correct values', async ({ page }) => {
 		await loadPage(
 			page,

--- a/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
@@ -51,7 +51,7 @@ test.describe('The web document renders with the correct meta and analytics elem
 	});
 
 	/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
-	test.skip('Subnav links exists with correct values', async ({ page }) => {
+	test('Subnav links exists with correct values', async ({ page }) => {
 		await loadPage(
 			page,
 			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,

--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -5,9 +5,7 @@ import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
 	/* TODO - @guardian/fairground-web-devs fix this when new Masthead is launched to 100% */
-	test.skip(`It should load the expected number of ad slots`, async ({
-		page,
-	}) => {
+	test(`It should load the expected number of ad slots`, async ({ page }) => {
 		await loadPage(
 			page,
 			`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,

--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -4,7 +4,6 @@ import { loadPage } from '../lib/load-page';
 import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
-	/* TODO - @guardian/fairground-web-devs fix this when new Masthead is launched to 100% */
 	test(`It should load the expected number of ad slots`, async ({ page }) => {
 		await loadPage(
 			page,
@@ -13,7 +12,7 @@ test.describe('Commercial E2E tests', () => {
 
 		await cmpAcceptAll(page);
 
-		const totalSlots = 16;
+		const totalSlots = 15;
 		const fixedSlots = 4;
 		const inlineSlots = totalSlots - fixedSlots;
 		// We are excluding survey slot as they can be switched off

--- a/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
@@ -68,7 +68,7 @@ test.describe('Signed in readers', () => {
 	});
 
 	/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
-	test.skip('should have the correct urls for the header links', async ({
+	test('should have the correct urls for the header links', async ({
 		context,
 		page,
 	}) => {

--- a/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/signedin.e2e.spec.ts
@@ -67,7 +67,6 @@ test.describe('Signed in readers', () => {
 		await expect(page.getByText('My account')).toBeVisible();
 	});
 
-	/* TODO - @guardian/fairground-web-devs enable this when new Masthead is launched to 100% */
 	test('should have the correct urls for the header links', async ({
 		context,
 		page,


### PR DESCRIPTION
## What does this change?

Our new header design was breaking these tests, but now that the new header has been rolled out to 100%, it's time to restore them. 

This PR sticks to restoring the tests that were broken with the header; there are still some which we've skipped due to legitimate bugs we still need to fix. 