### PR TITLE
Add audio section title colours to palette

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4618,8 +4618,20 @@ const seriesTitleTextLight: PaletteFunction = ({ theme, display, design }) => {
 					return sourcePalette.neutral[7];
 				case ArticleDesign.Picture:
 				case ArticleDesign.Video:
-				case ArticleDesign.Audio:
 					return sourcePalette.neutral[86];
+				case ArticleDesign.Audio:
+					switch (theme) {
+						case Pillar.Opinion:
+						case Pillar.News:
+						case Pillar.Sport:
+						case Pillar.Culture:
+						case Pillar.Lifestyle:
+							return pillarPalette(theme, 500);
+						case ArticleSpecial.Labs:
+							return sourcePalette.labs[400];
+						case ArticleSpecial.SpecialReportAlt:
+							return sourcePalette.specialReportAlt[200];
+					}
 				default:
 					switch (theme) {
 						case Pillar.Opinion:


### PR DESCRIPTION
## What does this change?

Adds section title colours for audio article pages.

## Why?

They were missing previously.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/7a6902ab-365b-44a9-a24f-f69a483ae68b
[after]: https://github.com/user-attachments/assets/ab2e399e-bdbe-438a-8f3d-3256b589a269

[before2]: https://github.com/user-attachments/assets/78ec40a4-af1a-47d9-9798-278a9cf8cec0
[after2]: https://github.com/user-attachments/assets/a548a0df-1868-4441-bb6f-f564170ec848

[before3]: https://github.com/user-attachments/assets/18aff878-0faf-4b9d-9190-0636b7eba302
[after3]: https://github.com/user-attachments/assets/b82712e3-0937-4b98-bb40-2d7b13d81a8f


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
