### PR TITLE
Move titlepiece component to components folder to ensure hydration

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Masthead.tsx
+++ b/dotcom-rendering/src/components/Masthead/Masthead.tsx
@@ -4,8 +4,8 @@ import type { NavType } from '../../model/extract-nav';
 import { palette as themePalette } from '../../palette';
 import { Island } from '../Island';
 import { Section } from '../Section';
+import { Titlepiece } from '../Titlepiece.importable';
 import { TopBar } from '../TopBar.importable';
-import { Titlepiece } from './Titlepiece/Titlepiece.importable';
 
 type Props = {
 	nav: NavType;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, space, textSans17 } from '@guardian/source/foundations';
-import { Island } from '../../../components/Island';
 import type { EditionId } from '../../../lib/edition';
 import { editionList, getEditionFromId } from '../../../lib/edition';
 import { getZIndex } from '../../../lib/getZIndex';
@@ -89,15 +88,13 @@ export const EditionDropdown = ({
 
 	return (
 		<div css={editionDropdownStyles}>
-			<Island priority="critical">
-				<Dropdown
-					label={label}
-					links={linksToDisplay}
-					id="masthead-edition"
-					dataLinkName={dataLinkName}
-					cssOverrides={dropDownOverrides}
-				/>
-			</Island>
+			<Dropdown
+				label={label}
+				links={linksToDisplay}
+				id="masthead-edition"
+				dataLinkName={dataLinkName}
+				cssOverrides={dropDownOverrides}
+			/>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -8,25 +8,25 @@ import {
 	until,
 	visuallyHidden,
 } from '@guardian/source/foundations';
-import type { EditionId } from '../../../lib/edition';
-import { nestedOphanComponents } from '../../../lib/ophan-helpers';
-import { useEditionSwitcherBanner } from '../../../lib/useUserPreferredEdition';
-import type { NavType } from '../../../model/extract-nav';
-import { palette as themePalette } from '../../../palette';
+import type { EditionId } from '../lib/edition';
+import { nestedOphanComponents } from '../lib/ophan-helpers';
+import { useEditionSwitcherBanner } from '../lib/useUserPreferredEdition';
+import type { NavType } from '../model/extract-nav';
+import { palette as themePalette } from '../palette';
 import {
 	expandedMenuRootId,
 	navInputCheckboxId,
 	pageMargin,
 	smallMobilePageMargin,
 	veggieBurgerId,
-} from './constants';
-import { EditionDropdown } from './EditionDropdown';
-import { ExpandedNav } from './ExpandedNav/ExpandedNav';
-import { Grid } from './Grid';
-import { Logo } from './Logo';
-import { Pillars, verticalDivider } from './Pillars';
-import { SubNav } from './SubNav';
-import { VeggieBurger } from './VeggieBurger';
+} from './Masthead/Titlepiece/constants';
+import { EditionDropdown } from './Masthead/Titlepiece/EditionDropdown';
+import { ExpandedNav } from './Masthead/Titlepiece/ExpandedNav/ExpandedNav';
+import { Grid } from './Masthead/Titlepiece/Grid';
+import { Logo } from './Masthead/Titlepiece/Logo';
+import { Pillars, verticalDivider } from './Masthead/Titlepiece/Pillars';
+import { SubNav } from './Masthead/Titlepiece/SubNav';
+import { VeggieBurger } from './Masthead/Titlepiece/VeggieBurger';
 
 interface Props {
 	nav: NavType;

--- a/dotcom-rendering/src/components/Titlepiece.stories.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { nav } from '../../Nav/Nav.mock';
+import { nav } from './Nav/Nav.mock';
 import { Titlepiece } from './Titlepiece.importable';
 
 const meta = {


### PR DESCRIPTION
## What does this change?

Moves `Titlepiece.importable.tsx` to components folder, should resolve this hydration error: 
<img width="658" alt="image" src="https://github.com/user-attachments/assets/081b1d5e-2c4a-4a92-a6f7-56c28dce43a8">

