### PR TITLE
Move full page interactive header wrapper z-index up

### DIFF
--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -143,7 +143,7 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 		return (
 			<div
 				css={css`
-					${getZIndex('headerWrapper')}
+					${getZIndex('fullPageInteractiveHeaderWrapper')}
 					order: 0;
 				`}
 			>
@@ -179,7 +179,7 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 		<section
 			/* Note, some interactives require this - e.g. https://www.theguardian.com/environment/ng-interactive/2015/jun/05/carbon-bomb-the-coal-boom-choking-china. */
 			css={css`
-				${getZIndex('headerWrapper')};
+				${getZIndex('fullPageInteractiveHeaderWrapper')};
 				position: relative;
 			`}
 		>

--- a/dotcom-rendering/src/layouts/lib/stickiness.tsx
+++ b/dotcom-rendering/src/layouts/lib/stickiness.tsx
@@ -25,11 +25,6 @@ const background = css`
 	background-color: ${palette('--stuck-background')};
 `;
 
-const headerWrapper = css`
-	position: relative;
-	${getZIndex('headerWrapper')}
-`;
-
 // The css overrides here are necessary because ad-takeovers can inject css that breaks the banner
 const bannerWrapper = css`
 	/* stylelint-disable-next-line declaration-no-important */
@@ -48,10 +43,6 @@ const bannerWrapper = css`
 
 export const Stuck = ({ children, zIndex }: StuckProps) => (
 	<div css={[stickyStyles, addZindex(zIndex), background]}>{children}</div>
-);
-
-export const SendToBack = ({ children }: Props) => (
-	<div css={headerWrapper}>{children}</div>
 );
 
 export const BannerWrapper = ({ children }: Props) => (

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,13 +2,13 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 30;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 29;');
-		expect(getZIndex('banner')).toBe('z-index: 28;');
-		expect(getZIndex('dropdown')).toBe('z-index: 27;');
-		expect(getZIndex('burger')).toBe('z-index: 26;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 31;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
+		expect(getZIndex('banner')).toBe('z-index: 29;');
+		expect(getZIndex('dropdown')).toBe('z-index: 28;');
+		expect(getZIndex('burger')).toBe('z-index: 27;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 25;',
+			'z-index: 26;',
 		);
 		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
 		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -12,7 +12,9 @@ describe('getZIndex', () => {
 		);
 		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
 		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
-		expect(getZIndex('headerWrapper')).toBe('z-index: 23;');
+		expect(getZIndex('fullPageInteractiveHeaderWrapper')).toBe(
+			'z-index: 23;',
+		);
 		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
 		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -10,8 +10,9 @@ describe('getZIndex', () => {
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
 			'z-index: 25;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 24;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 23;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
+		expect(getZIndex('headerWrapper')).toBe('z-index: 23;');
 		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
 		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
 		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');
@@ -26,7 +27,7 @@ describe('getZIndex', () => {
 		expect(getZIndex('searchHeaderLink')).toBe('z-index: 11;');
 		expect(getZIndex('TheGuardian')).toBe('z-index: 10;');
 		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 9;');
-		expect(getZIndex('headerWrapper')).toBe('z-index: 8;');
+		expect(getZIndex('tagLinkOverlay')).toBe('z-index: 8;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 7;');
 		expect(getZIndex('immersiveBlackBox')).toBe('z-index: 6;');
 		expect(getZIndex('bodyArea')).toBe('z-index: 5;');

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,34 +2,33 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 31;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
-		expect(getZIndex('banner')).toBe('z-index: 29;');
-		expect(getZIndex('dropdown')).toBe('z-index: 28;');
-		expect(getZIndex('burger')).toBe('z-index: 27;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 30;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 29;');
+		expect(getZIndex('banner')).toBe('z-index: 28;');
+		expect(getZIndex('dropdown')).toBe('z-index: 27;');
+		expect(getZIndex('burger')).toBe('z-index: 26;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 26;',
+			'z-index: 25;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 24;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 23;');
 		expect(getZIndex('fullPageInteractiveHeaderWrapper')).toBe(
-			'z-index: 23;',
+			'z-index: 22;',
 		);
-		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 19;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 18;');
-		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 17;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 16;');
-		expect(getZIndex('summaryDetails')).toBe('z-index: 15;');
-		expect(getZIndex('toast')).toBe('z-index: 14;');
-		expect(getZIndex('onwardsCarousel')).toBe('z-index: 13;');
-		expect(getZIndex('myAccountDropdown')).toBe('z-index: 12;');
-		expect(getZIndex('searchHeaderLink')).toBe('z-index: 11;');
-		expect(getZIndex('TheGuardian')).toBe('z-index: 10;');
-		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 9;');
-		expect(getZIndex('tagLinkOverlay')).toBe('z-index: 8;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 20;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 19;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 18;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 17;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 16;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 15;');
+		expect(getZIndex('summaryDetails')).toBe('z-index: 14;');
+		expect(getZIndex('toast')).toBe('z-index: 13;');
+		expect(getZIndex('onwardsCarousel')).toBe('z-index: 12;');
+		expect(getZIndex('myAccountDropdown')).toBe('z-index: 11;');
+		expect(getZIndex('searchHeaderLink')).toBe('z-index: 10;');
+		expect(getZIndex('TheGuardian')).toBe('z-index: 9;');
+		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 8;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 7;');
 		expect(getZIndex('immersiveBlackBox')).toBe('z-index: 6;');
 		expect(getZIndex('bodyArea')).toBe('z-index: 5;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -73,9 +73,6 @@ const indices = [
 	// and the myAccount dropdown in the nav
 	'editionSwitcherBanner',
 
-	// Overlay for sticky tag link
-	'tagLinkOverlay',
-
 	// Article headline (should be above main media)
 	'articleHeadline',
 	'immersiveBlackBox',

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -36,7 +36,7 @@ const indices = [
 	'expanded-veggie-menu',
 
 	//header wrapper needs to be in line with veggie menus to ensure it stands above various banners
-	'headerWrapper',
+	'fullPageInteractiveHeaderWrapper',
 
 	// Mobile sticky appears below banners
 	'mobileSticky',

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -35,6 +35,9 @@ const indices = [
 	'expanded-veggie-menu-wrapper',
 	'expanded-veggie-menu',
 
+	//header wrapper needs to be in line with veggie menus to ensure it stands above various banners
+	'headerWrapper',
+
 	// Mobile sticky appears below banners
 	'mobileSticky',
 
@@ -70,8 +73,8 @@ const indices = [
 	// and the myAccount dropdown in the nav
 	'editionSwitcherBanner',
 
-	// Wrapper after nav stuff
-	'headerWrapper',
+	// Overlay for sticky tag link
+	'tagLinkOverlay',
 
 	// Article headline (should be above main media)
 	'articleHeadline',


### PR DESCRIPTION
## Why?

In response to some feedback from US marketing teams, specifically about interactive Labs articles -- the nav disappears behind the teal banner when you click on the hamburger, e.g. on this page: https://www.theguardian.com/business-briefs/ng-interactive/2024/aug/28/what-surprising-skills-do-leaders-need-to-innovate-with-generative-ai

## What does this change?

Looks like the teal banner currently has a z-index of 21, and only gets obscured by the expanded menu when this is brought under the header wrapper. It feels safer to move the wrapper up, and AFAICT header functionality is still working as intended. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

(In the second screenshot the teal banner is now hidden under the expanded menu)

[before]: https://github.com/user-attachments/assets/23efa76a-0303-4006-a517-2335505b198d
[after]: https://github.com/user-attachments/assets/8f3b2459-0181-4e38-936d-69bcb5f28cf4

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
