### PR TITLE
Remove CSTI from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # By default all files are owned by these teams:
-* 												@guardian/dotcom-platform @guardian/client-side-infra
+* 												@guardian/dotcom-platform
 
 # These folders and all their contents are owned by the following teams.
 /dotcom-rendering/ 								@guardian/dotcom-platform
@@ -11,5 +11,5 @@
 /dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
 
 # These file types, wherever they are, are co-owned by the following teams.
-package.json 									@guardian/dotcom-platform @guardian/client-side-infra
-tsconfig.json 									@guardian/dotcom-platform @guardian/client-side-infra
+package.json 									@guardian/dotcom-platform
+tsconfig.json 									@guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

removes @guardian/client-side-infra from the CODEOWNERS file

## Why?

CSTI no longer exists, and the focus of e2e does not seem include this kind of work, so there's no point this team being codeowners.

If that changes, we can always add it back

