### PR TITLE
Datawrapper embed styling

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -110,7 +110,7 @@ If you get lint errors, you can attempt to automatically fix them with:
 $ make fix
 ```
 
-See [the makefile](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/makefile) for the full list.
+See [the makefile](./makefile) for the full list.
 
 [Read about testing tools and testing strategy](docs/testing.md).
 

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -17,8 +17,8 @@ type Props = {
 const roleCss = (isDatawrapperGraphic: boolean) => {
 	return {
 		inline: css`
-			margin-top: ${space[3]}px;
-			margin-bottom: ${space[3]}px;
+			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
 		`,
 
 		supporting: css`
@@ -72,8 +72,8 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 		`,
 
 		showcase: css`
-			margin-top: ${space[3]}px;
-			margin-bottom: ${space[3]}px;
+			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
 			position: relative;
 			${from.leftCol} {
 				margin-left: -160px;

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -29,7 +29,9 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			${isDatawrapperGraphic
 				? `border-bottom: 1px solid ${themePalette(
 						'--branding-border',
-				  )};`
+				  )};
+                  padding-bottom: ${space[4]}px;
+				`
 				: ''}
 
 			${from.tablet} {
@@ -55,7 +57,9 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			${isDatawrapperGraphic
 				? `border-bottom: 1px solid ${themePalette(
 						'--branding-border',
-				  )};`
+				  )};
+                  padding-bottom: ${space[4]}px;
+				`
 				: ''}
 
 			${until.tablet} {
@@ -91,7 +95,9 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			${isDatawrapperGraphic
 				? `border-bottom: 1px solid ${themePalette(
 						'--branding-border',
-				  )};`
+				  )};
+                  padding-bottom: ${space[4]}px;
+				`
 				: ''}
 
 			${from.leftCol} {

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -18,21 +18,14 @@ type Props = {
 const roleCss = (isDatawrapperGraphic: boolean) => {
 	return {
 		inline: css`
-			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
+			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
 		`,
 
 		supporting: css`
 			clear: left;
-			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
-			${isDatawrapperGraphic
-				? `border-bottom: 1px solid ${themePalette(
-						'--branding-border',
-				  )};
-                  padding-bottom: ${space[4]}px;
-				`
-				: ''}
+			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
 
 			${from.tablet} {
 				position: relative;
@@ -41,10 +34,17 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 				margin-right: 20px;
 				line-height: 0;
 				margin-top: ${space[2]}px;
-				${isDatawrapperGraphic ? `margin-bottom: ${space[5]}px;` : ''}
 			}
 			${from.leftCol} {
 				margin-left: -160px;
+
+				${isDatawrapperGraphic ? `margin-bottom: ${space[2]}px;` : ''}
+				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
+				${isDatawrapperGraphic
+					? `border-bottom: 1px solid ${themePalette(
+							'--branding-border',
+					  )};`
+					: ''}
 			}
 			${from.wide} {
 				width: 380px;
@@ -53,15 +53,8 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 		`,
 
 		immersive: css`
-			margin-top: ${space[3]}px;
-			margin-bottom: ${space[3]}px;
-			${isDatawrapperGraphic
-				? `border-bottom: 1px solid ${themePalette(
-						'--branding-border',
-				  )};
-                  padding-bottom: ${space[4]}px;
-				`
-				: ''}
+			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
 
 			${until.tablet} {
 				margin-left: -20px;
@@ -82,6 +75,14 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			${from.leftCol} {
 				margin-left: -160px;
 				margin-right: -320px;
+
+				${isDatawrapperGraphic ? `margin-bottom: ${space[4]}px;` : ''}
+				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
+				${isDatawrapperGraphic
+					? `border-bottom: 1px solid ${themePalette(
+							'--branding-border',
+					  )};`
+					: ''}
 			}
 			${from.wide} {
 				margin-left: -240px;
@@ -90,19 +91,20 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 		`,
 
 		showcase: css`
-			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
+			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
 			position: relative;
-			${isDatawrapperGraphic
-				? `border-bottom: 1px solid ${themePalette(
-						'--branding-border',
-				  )};
-                  padding-bottom: ${space[4]}px;
-				`
-				: ''}
 
 			${from.leftCol} {
 				margin-left: -160px;
+
+				${isDatawrapperGraphic ? `margin-bottom: ${space[4]}px;` : ''}
+				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
+				${isDatawrapperGraphic
+					? `border-bottom: 1px solid ${themePalette(
+							'--branding-border',
+					  )};`
+					: ''}
 			}
 			${from.wide} {
 				margin-left: -240px;

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
-import { palette as themePalette } from '../palette';
 import type { FEElement, RoleType } from '../types/content';
 
 type Props = {
@@ -15,182 +14,152 @@ type Props = {
 	isTimeline?: boolean;
 };
 
-const roleCss = (isDatawrapperGraphic: boolean) => {
-	return {
-		inline: css`
-			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-		`,
+const roleCss = {
+	inline: css`
+		margin-top: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+	`,
 
-		supporting: css`
-			clear: left;
-			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-
-			${from.tablet} {
-				position: relative;
-				float: left;
-				width: 300px;
-				margin-right: 20px;
-				line-height: 0;
-				margin-top: ${space[2]}px;
-			}
-			${from.leftCol} {
-				margin-left: -160px;
-
-				${isDatawrapperGraphic ? `margin-bottom: ${space[2]}px;` : ''}
-				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
-				${isDatawrapperGraphic
-					? `border-bottom: 1px solid ${themePalette(
-							'--branding-border',
-					  )};`
-					: ''}
-			}
-			${from.wide} {
-				width: 380px;
-				margin-left: -240px;
-			}
-		`,
-
-		immersive: css`
-			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-
-			${until.tablet} {
-				margin-left: -20px;
-				margin-right: -20px;
-			}
-			${until.mobileLandscape} {
-				margin-left: -10px;
-				margin-right: -10px;
-			}
-			${from.tablet} {
-				margin-left: -20px;
-				margin-right: -100px;
-			}
-			${from.desktop} {
-				margin-left: -20px;
-				margin-right: -340px;
-			}
-			${from.leftCol} {
-				margin-left: -160px;
-				margin-right: -320px;
-
-				${isDatawrapperGraphic ? `margin-bottom: ${space[4]}px;` : ''}
-				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
-				${isDatawrapperGraphic
-					? `border-bottom: 1px solid ${themePalette(
-							'--branding-border',
-					  )};`
-					: ''}
-			}
-			${from.wide} {
-				margin-left: -240px;
-				margin-right: -400px;
-			}
-		`,
-
-		showcase: css`
-			margin-top: ${space[isDatawrapperGraphic ? 6 : 3]}px;
-			margin-bottom: ${space[isDatawrapperGraphic ? 6 : 3]}px;
+	supporting: css`
+		clear: left;
+		margin-top: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+		${from.tablet} {
 			position: relative;
-
-			${from.leftCol} {
-				margin-left: -160px;
-
-				${isDatawrapperGraphic ? `margin-bottom: ${space[4]}px;` : ''}
-				${isDatawrapperGraphic ? `padding-bottom: ${space[4]}px;` : ''}
-				${isDatawrapperGraphic
-					? `border-bottom: 1px solid ${themePalette(
-							'--branding-border',
-					  )};`
-					: ''}
-			}
-			${from.wide} {
-				margin-left: -240px;
-			}
-		`,
-
-		thumbnail: css`
+			float: left;
+			width: 300px;
+			margin-right: 20px;
+			line-height: 0;
 			margin-top: ${space[2]}px;
-			margin-bottom: ${space[2]}px;
-			float: left;
-			clear: left;
-			width: 120px;
-			margin-right: 20px;
-			${from.tablet} {
-				width: 140px;
-			}
-			${from.wide} {
-				margin-left: -240px;
-			}
-			${from.leftCol} {
-				position: relative;
-				margin-left: -160px;
-			}
-		`,
+		}
+		${from.leftCol} {
+			margin-left: -160px;
+		}
+		${from.wide} {
+			width: 380px;
+			margin-left: -240px;
+		}
+	`,
 
-		// This is a special use case where we want RichLinks to appear wider when in the left col
-		richLink: css`
-			margin-bottom: ${space[1]}px;
-			float: left;
-			clear: left;
-			width: 8.75rem;
-			margin-right: 20px;
+	immersive: css`
+		margin-top: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+		${until.tablet} {
+			margin-left: -20px;
+			margin-right: -20px;
+		}
+		${until.mobileLandscape} {
+			margin-left: -10px;
+			margin-right: -10px;
+		}
+		${from.tablet} {
+			margin-left: -20px;
+			margin-right: -100px;
+		}
+		${from.desktop} {
+			margin-left: -20px;
+			margin-right: -340px;
+		}
+		${from.leftCol} {
+			margin-left: -160px;
+			margin-right: -320px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			margin-right: -400px;
+		}
+	`,
 
-			/*
+	showcase: css`
+		margin-top: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+		position: relative;
+		${from.leftCol} {
+			margin-left: -160px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+		}
+	`,
+
+	thumbnail: css`
+		margin-top: ${space[2]}px;
+		margin-bottom: ${space[2]}px;
+		float: left;
+		clear: left;
+		width: 120px;
+		margin-right: 20px;
+		${from.tablet} {
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+		}
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+		}
+	`,
+
+	// This is a special use case where we want RichLinks to appear wider when in the left col
+	richLink: css`
+		margin-bottom: ${space[1]}px;
+		float: left;
+		clear: left;
+		width: 8.75rem;
+		margin-right: 20px;
+
+		/*
 		 Acts as until.mobileMedium but accounts for font scaling. On small screens and/or
 		 at certain font sizes, the RichLink will change to a full width version
 		*/
-			@media (max-width: 23.4rem) {
-				width: 100%;
-				box-sizing: border-box;
+		@media (max-width: 23.4rem) {
+			width: 100%;
+			box-sizing: border-box;
 
-				img,
-				.avatar {
-					display: none;
-				}
+			img,
+			.avatar {
+				display: none;
 			}
+		}
 
-			${from.tablet} {
-				width: 140px;
-			}
-			${from.leftCol} {
-				position: relative;
-				margin-left: -160px;
-				width: 140px;
-			}
-			${from.wide} {
-				margin-left: -240px;
-				width: 220px;
-			}
-		`,
+		${from.tablet} {
+			width: 140px;
+		}
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			width: 220px;
+		}
+	`,
 
-		halfWidth: css`
-			margin-top: ${space[3]}px;
-			margin-bottom: ${space[3]}px;
-			width: 50%;
-			float: left;
-			clear: left;
-			margin-right: 16px;
-		`,
-	};
+	halfWidth: css`
+		margin-top: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+		width: 50%;
+		float: left;
+		clear: left;
+		margin-right: 16px;
+	`,
 };
 
 // Used for vast majority of layouts.
 export const defaultRoleStyles = (
 	role: RoleType | 'richLink',
 	format: ArticleFormat,
-	isDatawrapperGraphic: boolean,
 	isTimeline = false,
 ) => {
 	switch (role) {
 		case 'inline':
-			return roleCss(isDatawrapperGraphic).inline;
+			return roleCss.inline;
 		case 'supporting':
-			return roleCss(isDatawrapperGraphic).supporting;
+			return roleCss.supporting;
 		case 'immersive':
-			return roleCss(isDatawrapperGraphic).immersive;
+			return roleCss.immersive;
 		case 'showcase':
 			if (isTimeline) {
 				return css`
@@ -206,28 +175,28 @@ export const defaultRoleStyles = (
 					}
 				`;
 			}
-			return roleCss(isDatawrapperGraphic).showcase;
+			return roleCss.showcase;
 		case 'thumbnail':
 			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 					// In blogs we don't want to use negative left margins
 					return css`
-						${roleCss(isDatawrapperGraphic).thumbnail}
+						${roleCss.thumbnail}
 						/* It's important we use the media query here to ensure we override the default values */
 						${from.leftCol} {
 							margin-left: 0px;
 						}
 					`;
 				default:
-					return roleCss(isDatawrapperGraphic).thumbnail;
+					return roleCss.thumbnail;
 			}
 		case 'richLink':
-			return roleCss(isDatawrapperGraphic).richLink;
+			return roleCss.richLink;
 		case 'halfWidth':
-			return roleCss(isDatawrapperGraphic).halfWidth;
+			return roleCss.halfWidth;
 		default:
-			return roleCss(isDatawrapperGraphic).inline;
+			return roleCss.inline;
 	}
 };
 
@@ -261,7 +230,7 @@ export const Figure = ({
 	return (
 		<figure
 			id={id}
-			css={defaultRoleStyles(role, format, false, isTimeline)}
+			css={defaultRoleStyles(role, format, isTimeline)}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}
 			className={className}

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
+import { palette as themePalette } from '../palette';
 import type { FEElement, RoleType } from '../types/content';
 
 type Props = {
@@ -25,6 +26,12 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			clear: left;
 			margin-top: ${space[3]}px;
 			margin-bottom: ${isDatawrapperGraphic ? space[5] : space[3]}px;
+			${isDatawrapperGraphic
+				? `border-bottom: 1px solid ${themePalette(
+						'--branding-border',
+				  )};`
+				: ''}
+
 			${from.tablet} {
 				position: relative;
 				float: left;
@@ -45,6 +52,12 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 		immersive: css`
 			margin-top: ${space[3]}px;
 			margin-bottom: ${space[3]}px;
+			${isDatawrapperGraphic
+				? `border-bottom: 1px solid ${themePalette(
+						'--branding-border',
+				  )};`
+				: ''}
+
 			${until.tablet} {
 				margin-left: -20px;
 				margin-right: -20px;
@@ -75,6 +88,12 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
 			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
 			position: relative;
+			${isDatawrapperGraphic
+				? `border-bottom: 1px solid ${themePalette(
+						'--branding-border',
+				  )};`
+				: ''}
+
 			${from.leftCol} {
 				margin-left: -160px;
 			}

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -14,152 +14,155 @@ type Props = {
 	isTimeline?: boolean;
 };
 
-const roleCss = {
-	inline: css`
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-	`,
+const roleCss = (isDatawrapperGraphic: boolean) => {
+	return {
+		inline: css`
+			margin-top: ${space[3]}px;
+			margin-bottom: ${space[3]}px;
+		`,
 
-	supporting: css`
-		clear: left;
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-		${from.tablet} {
+		supporting: css`
+			clear: left;
+			margin-top: ${space[3]}px;
+			margin-bottom: ${isDatawrapperGraphic ? space[5] : space[3]}px;
+			${from.tablet} {
+				position: relative;
+				float: left;
+				width: 300px;
+				margin-right: 20px;
+				line-height: 0;
+				margin-top: ${space[2]}px;
+			}
+			${from.leftCol} {
+				margin-left: -160px;
+			}
+			${from.wide} {
+				width: 380px;
+				margin-left: -240px;
+			}
+		`,
+
+		immersive: css`
+			margin-top: ${space[3]}px;
+			margin-bottom: ${space[3]}px;
+			${until.tablet} {
+				margin-left: -20px;
+				margin-right: -20px;
+			}
+			${until.mobileLandscape} {
+				margin-left: -10px;
+				margin-right: -10px;
+			}
+			${from.tablet} {
+				margin-left: -20px;
+				margin-right: -100px;
+			}
+			${from.desktop} {
+				margin-left: -20px;
+				margin-right: -340px;
+			}
+			${from.leftCol} {
+				margin-left: -160px;
+				margin-right: -320px;
+			}
+			${from.wide} {
+				margin-left: -240px;
+				margin-right: -400px;
+			}
+		`,
+
+		showcase: css`
+			margin-top: ${space[3]}px;
+			margin-bottom: ${space[3]}px;
 			position: relative;
-			float: left;
-			width: 300px;
-			margin-right: 20px;
-			line-height: 0;
+			${from.leftCol} {
+				margin-left: -160px;
+			}
+			${from.wide} {
+				margin-left: -240px;
+			}
+		`,
+
+		thumbnail: css`
 			margin-top: ${space[2]}px;
-		}
-		${from.leftCol} {
-			margin-left: -160px;
-		}
-		${from.wide} {
-			width: 380px;
-			margin-left: -240px;
-		}
-	`,
+			margin-bottom: ${space[2]}px;
+			float: left;
+			clear: left;
+			width: 120px;
+			margin-right: 20px;
+			${from.tablet} {
+				width: 140px;
+			}
+			${from.wide} {
+				margin-left: -240px;
+			}
+			${from.leftCol} {
+				position: relative;
+				margin-left: -160px;
+			}
+		`,
 
-	immersive: css`
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-		${until.tablet} {
-			margin-left: -20px;
-			margin-right: -20px;
-		}
-		${until.mobileLandscape} {
-			margin-left: -10px;
-			margin-right: -10px;
-		}
-		${from.tablet} {
-			margin-left: -20px;
-			margin-right: -100px;
-		}
-		${from.desktop} {
-			margin-left: -20px;
-			margin-right: -340px;
-		}
-		${from.leftCol} {
-			margin-left: -160px;
-			margin-right: -320px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-			margin-right: -400px;
-		}
-	`,
+		// This is a special use case where we want RichLinks to appear wider when in the left col
+		richLink: css`
+			margin-bottom: ${space[1]}px;
+			float: left;
+			clear: left;
+			width: 8.75rem;
+			margin-right: 20px;
 
-	showcase: css`
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-		position: relative;
-		${from.leftCol} {
-			margin-left: -160px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-		}
-	`,
-
-	thumbnail: css`
-		margin-top: ${space[2]}px;
-		margin-bottom: ${space[2]}px;
-		float: left;
-		clear: left;
-		width: 120px;
-		margin-right: 20px;
-		${from.tablet} {
-			width: 140px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-		}
-		${from.leftCol} {
-			position: relative;
-			margin-left: -160px;
-		}
-	`,
-
-	// This is a special use case where we want RichLinks to appear wider when in the left col
-	richLink: css`
-		margin-bottom: ${space[1]}px;
-		float: left;
-		clear: left;
-		width: 8.75rem;
-		margin-right: 20px;
-
-		/*
+			/*
 		 Acts as until.mobileMedium but accounts for font scaling. On small screens and/or
 		 at certain font sizes, the RichLink will change to a full width version
 		*/
-		@media (max-width: 23.4rem) {
-			width: 100%;
-			box-sizing: border-box;
+			@media (max-width: 23.4rem) {
+				width: 100%;
+				box-sizing: border-box;
 
-			img,
-			.avatar {
-				display: none;
+				img,
+				.avatar {
+					display: none;
+				}
 			}
-		}
 
-		${from.tablet} {
-			width: 140px;
-		}
-		${from.leftCol} {
-			position: relative;
-			margin-left: -160px;
-			width: 140px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-			width: 220px;
-		}
-	`,
+			${from.tablet} {
+				width: 140px;
+			}
+			${from.leftCol} {
+				position: relative;
+				margin-left: -160px;
+				width: 140px;
+			}
+			${from.wide} {
+				margin-left: -240px;
+				width: 220px;
+			}
+		`,
 
-	halfWidth: css`
-		margin-top: ${space[3]}px;
-		margin-bottom: ${space[3]}px;
-		width: 50%;
-		float: left;
-		clear: left;
-		margin-right: 16px;
-	`,
+		halfWidth: css`
+			margin-top: ${space[3]}px;
+			margin-bottom: ${space[3]}px;
+			width: 50%;
+			float: left;
+			clear: left;
+			margin-right: 16px;
+		`,
+	};
 };
 
 // Used for vast majority of layouts.
 export const defaultRoleStyles = (
 	role: RoleType | 'richLink',
 	format: ArticleFormat,
+	isDatawrapperGraphic: boolean,
 	isTimeline = false,
 ) => {
 	switch (role) {
 		case 'inline':
-			return roleCss.inline;
+			return roleCss(isDatawrapperGraphic).inline;
 		case 'supporting':
-			return roleCss.supporting;
+			return roleCss(isDatawrapperGraphic).supporting;
 		case 'immersive':
-			return roleCss.immersive;
+			return roleCss(isDatawrapperGraphic).immersive;
 		case 'showcase':
 			if (isTimeline) {
 				return css`
@@ -175,28 +178,28 @@ export const defaultRoleStyles = (
 					}
 				`;
 			}
-			return roleCss.showcase;
+			return roleCss(isDatawrapperGraphic).showcase;
 		case 'thumbnail':
 			switch (format.design) {
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
 					// In blogs we don't want to use negative left margins
 					return css`
-						${roleCss.thumbnail}
+						${roleCss(isDatawrapperGraphic).thumbnail}
 						/* It's important we use the media query here to ensure we override the default values */
 						${from.leftCol} {
 							margin-left: 0px;
 						}
 					`;
 				default:
-					return roleCss.thumbnail;
+					return roleCss(isDatawrapperGraphic).thumbnail;
 			}
 		case 'richLink':
-			return roleCss.richLink;
+			return roleCss(isDatawrapperGraphic).richLink;
 		case 'halfWidth':
-			return roleCss.halfWidth;
+			return roleCss(isDatawrapperGraphic).halfWidth;
 		default:
-			return roleCss.inline;
+			return roleCss(isDatawrapperGraphic).inline;
 	}
 };
 
@@ -230,7 +233,7 @@ export const Figure = ({
 	return (
 		<figure
 			id={id}
-			css={defaultRoleStyles(role, format, isTimeline)}
+			css={defaultRoleStyles(role, format, false, isTimeline)}
 			data-spacefinder-role={role}
 			data-spacefinder-type={type}
 			className={className}

--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -24,8 +24,8 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 
 		supporting: css`
 			clear: left;
-			margin-top: ${space[3]}px;
-			margin-bottom: ${isDatawrapperGraphic ? space[5] : space[3]}px;
+			margin-top: ${space[isDatawrapperGraphic ? 8 : 3]}px;
+			margin-bottom: ${space[isDatawrapperGraphic ? 8 : 3]}px;
 			${isDatawrapperGraphic
 				? `border-bottom: 1px solid ${themePalette(
 						'--branding-border',
@@ -41,6 +41,7 @@ const roleCss = (isDatawrapperGraphic: boolean) => {
 				margin-right: 20px;
 				line-height: 0;
 				margin-top: ${space[2]}px;
+				${isDatawrapperGraphic ? `margin-bottom: ${space[5]}px;` : ''}
 			}
 			${from.leftCol} {
 				margin-left: -160px;

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -116,8 +116,6 @@ const wrapperStyle = ({
 		? `
 	border-top: 1px solid #dcdcdc;
 	padding-top: 8px;
-    margin-top: 32px;
-    margin-bottom: 32px;
 	`
 		: ''}
 `;

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -116,6 +116,7 @@ const wrapperStyle = ({
 		? `
 	border-top: 1px solid #dcdcdc;
 	padding-top: 8px;
+    margin-top: 32px;
 	`
 		: ''}
 `;

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -1,4 +1,5 @@
-import { SerializedStyles, css } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
 	article17,

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -115,7 +115,7 @@ const wrapperStyle = ({
 	${isDatawrapperGraphic
 		? `
 	border-top: 1px solid ${themePalette('--branding-border')};
-	padding-top: 8px;
+	padding-top: ${space[2]}px;
 	`
 		: ''}
 `;

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -1,6 +1,11 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { article17, space, textSans17 } from '@guardian/source/foundations';
+import {
+	article17,
+	from,
+	space,
+	textSans17,
+} from '@guardian/source/foundations';
 import libDebounce from 'lodash.debounce';
 import { useRef, useState } from 'react';
 import { interactiveLegacyFigureClasses } from '../layouts/lib/interactiveLegacyStyling';
@@ -119,6 +124,71 @@ const wrapperStyle = ({
 	`
 		: ''}
 `;
+
+const datawrapperRoleStyles = (role: RoleType) => {
+	switch (role) {
+		case 'inline':
+			return datawrapperRoleCss.inline;
+		case 'supporting':
+			return datawrapperRoleCss.supporting;
+		case 'immersive':
+			return datawrapperRoleCss.immersive;
+		case 'showcase':
+			return datawrapperRoleCss.showcase;
+		case 'thumbnail':
+			return datawrapperRoleCss.thumbnail;
+		case 'halfWidth':
+			return datawrapperRoleCss.halfWidth;
+	}
+};
+
+const datawrapperRoleCss = {
+	inline: css`
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[6]}px;
+	`,
+
+	supporting: css`
+		clear: left;
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[6]}px;
+
+		${from.leftCol} {
+			margin-bottom: ${space[2]}px;
+			padding-bottom: ${space[4]}px;
+			border-bottom: 1px solid ${themePalette('--branding-border')};
+		}
+		${from.wide} {
+			width: 380px;
+			margin-left: -240px;
+		}
+	`,
+
+	immersive: css`
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[6]}px;
+
+		${from.leftCol} {
+			margin-bottom: ${space[4]}px;
+			padding-bottom: ${space[4]}px;
+			border-bottom: 1px solid ${themePalette('--branding-border')};
+		}
+	`,
+
+	showcase: css`
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[6]}px;
+
+		${from.leftCol} {
+			margin-bottom: ${space[4]}px;
+			padding-bottom: ${space[4]}px;
+			border-bottom: 1px solid ${themePalette('--branding-border')};
+		}
+	`,
+
+	thumbnail: css``,
+	halfWidth: css``,
+};
 
 const placeholderLinkStyle = css`
 	position: absolute;
@@ -318,7 +388,8 @@ export const InteractiveBlockComponent = ({
 				css={[
 					isMainMedia
 						? mainMediaFigureStyles
-						: defaultRoleStyles(role, format, isDatawrapperGraphic),
+						: defaultRoleStyles(role, format),
+					isDatawrapperGraphic ? datawrapperRoleStyles(role) : '',
 					wrapperStyle({
 						format,
 						role,

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -99,10 +99,12 @@ const wrapperStyle = ({
 	format,
 	role,
 	loaded,
+	url,
 }: {
 	format: ArticleFormat;
 	role: RoleType;
 	loaded: boolean;
+	url?: string;
 }) => css`
 	${format.theme === ArticleSpecial.Labs ? textSans17 : article17}
 	background-color: ${themePalette('--interactive-block-background')};
@@ -110,6 +112,14 @@ const wrapperStyle = ({
 	position: relative;
 	display: flex;
 	flex-direction: column;
+	${url?.match(
+		/^https?:\/\/interactive\.guim\.co\.uk\/datawrapper(-test)?\/embed/,
+	)
+		? `
+	border-top: 1px solid #dcdcdc;
+	padding-top: 8px;
+	`
+		: ''}
 `;
 
 const placeholderLinkStyle = css`
@@ -304,7 +314,7 @@ export const InteractiveBlockComponent = ({
 					isMainMedia
 						? mainMediaFigureStyles
 						: defaultRoleStyles(role, format),
-					wrapperStyle({ format, role, loaded }),
+					wrapperStyle({ format, role, loaded, url }),
 				]}
 				className={interactiveLegacyFigureClasses(
 					'model.dotcomrendering.pageElements.InteractiveBlockElement',

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -117,6 +117,7 @@ const wrapperStyle = ({
 	border-top: 1px solid #dcdcdc;
 	padding-top: 8px;
     margin-top: 32px;
+    margin-bottom: 32px;
 	`
 		: ''}
 `;

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
 	article17,
@@ -125,7 +125,7 @@ const wrapperStyle = ({
 		: ''}
 `;
 
-const datawrapperRoleStyles = (role: RoleType) => {
+const datawrapperRoleStyles = (role: RoleType): SerializedStyles | null => {
 	switch (role) {
 		case 'inline':
 			return datawrapperRoleCss.inline;
@@ -136,9 +136,8 @@ const datawrapperRoleStyles = (role: RoleType) => {
 		case 'showcase':
 			return datawrapperRoleCss.showcase;
 		case 'thumbnail':
-			return datawrapperRoleCss.thumbnail;
 		case 'halfWidth':
-			return datawrapperRoleCss.halfWidth;
+			return null;
 	}
 };
 
@@ -185,9 +184,6 @@ const datawrapperRoleCss = {
 			border-bottom: 1px solid ${themePalette('--branding-border')};
 		}
 	`,
-
-	thumbnail: css``,
-	halfWidth: css``,
 };
 
 const placeholderLinkStyle = css`
@@ -389,7 +385,7 @@ export const InteractiveBlockComponent = ({
 					isMainMedia
 						? mainMediaFigureStyles
 						: defaultRoleStyles(role, format),
-					isDatawrapperGraphic ? datawrapperRoleStyles(role) : '',
+					isDatawrapperGraphic ? datawrapperRoleStyles(role) : null,
 					wrapperStyle({
 						format,
 						role,

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -99,12 +99,12 @@ const wrapperStyle = ({
 	format,
 	role,
 	loaded,
-	url,
+	isDatawrapperGraphic,
 }: {
 	format: ArticleFormat;
 	role: RoleType;
 	loaded: boolean;
-	url?: string;
+	isDatawrapperGraphic: boolean;
 }) => css`
 	${format.theme === ArticleSpecial.Labs ? textSans17 : article17}
 	background-color: ${themePalette('--interactive-block-background')};
@@ -112,9 +112,7 @@ const wrapperStyle = ({
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	${url?.match(
-		/^https?:\/\/interactive\.guim\.co\.uk\/datawrapper(-test)?\/embed/,
-	)
+	${isDatawrapperGraphic
 		? `
 	border-top: 1px solid #dcdcdc;
 	padding-top: 8px;
@@ -305,6 +303,13 @@ export const InteractiveBlockComponent = ({
 		}
 	}, [loaded]);
 
+	const isDatawrapperGraphic =
+		url == undefined
+			? false
+			: /^https?:\/\/interactive\.guim\.co\.uk\/datawrapper(-test)?\/embed/.test(
+					url,
+			  );
+
 	return (
 		<>
 			<figure
@@ -313,8 +318,13 @@ export const InteractiveBlockComponent = ({
 				css={[
 					isMainMedia
 						? mainMediaFigureStyles
-						: defaultRoleStyles(role, format),
-					wrapperStyle({ format, role, loaded, url }),
+						: defaultRoleStyles(role, format, isDatawrapperGraphic),
+					wrapperStyle({
+						format,
+						role,
+						loaded,
+						isDatawrapperGraphic,
+					}),
 				]}
 				className={interactiveLegacyFigureClasses(
 					'model.dotcomrendering.pageElements.InteractiveBlockElement',

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -114,7 +114,7 @@ const wrapperStyle = ({
 	flex-direction: column;
 	${isDatawrapperGraphic
 		? `
-	border-top: 1px solid #dcdcdc;
+	border-top: 1px solid ${themePalette('--branding-border')};
 	padding-top: 8px;
 	`
 		: ''}

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
@@ -181,7 +181,7 @@ export const DatawrapperInline = ({ format }: StoryProps) => {
 			<SomeText />
 			<SomeText />
 			<InteractiveBlockComponent
-				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/5ApVq/1/"
 				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 				alt="map"
 				role="inline"
@@ -205,7 +205,7 @@ export const DatawrapperSupporting = ({ format }: StoryProps) => {
 			<SomeText />
 			<SomeText />
 			<InteractiveBlockComponent
-				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/5ApVq/1/"
 				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 				alt="map"
 				role="supporting"
@@ -229,7 +229,7 @@ export const DatawrapperShowcase = ({ format }: StoryProps) => {
 			<SomeText />
 			<SomeText />
 			<InteractiveBlockComponent
-				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/5ApVq/1/"
 				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 				alt="map"
 				role="showcase"
@@ -253,7 +253,7 @@ export const DatawrapperThumbnail = ({ format }: StoryProps) => {
 			<SomeText />
 			<SomeText />
 			<InteractiveBlockComponent
-				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/5ApVq/1/"
 				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 				alt="map"
 				role="thumbnail"
@@ -277,7 +277,7 @@ export const DatawrapperImmersive = ({ format }: StoryProps) => {
 			<SomeText />
 			<SomeText />
 			<InteractiveBlockComponent
-				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/5ApVq/1/"
 				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
 				alt="map"
 				role="immersive"

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
@@ -1,9 +1,13 @@
-import { css } from '@emotion/react';
 import type { StoryObj } from '@storybook/react';
 import type { StoryProps } from '../../.storybook/decorators/splitThemeDecorator';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { ArticleContainer } from './ArticleContainer';
+import { Flex } from './Flex';
 import { InteractiveBlockComponent } from './InteractiveBlockComponent.importable';
+import { LeftColumn } from './LeftColumn';
+import { RightColumn } from './RightColumn';
+import { Section } from './Section';
 import { TextBlockComponent } from './TextBlockComponent';
 
 export default {
@@ -26,14 +30,25 @@ const SomeText = () => (
 );
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			padding-left: 250px;
-			padding-right: 20px;
-		`}
-	>
-		{children}
-	</div>
+	<Section fullWidth={true} showTopBorder={false}>
+		<Flex>
+			<LeftColumn>
+				<></>
+			</LeftColumn>
+			<ArticleContainer
+				format={{
+					display: ArticleDisplay.Standard,
+					design: ArticleDesign.Standard,
+					theme: Pillar.News,
+				}}
+			>
+				{children}
+			</ArticleContainer>
+			<RightColumn>
+				<></>
+			</RightColumn>
+		</Flex>
+	</Section>
 );
 
 const defaultFormat = {
@@ -157,5 +172,125 @@ export const NonBootJs: StoryObj = ({ format }: StoryProps) => {
 };
 NonBootJs.storyName = 'Non-boot.js interactive element';
 NonBootJs.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
+
+export const DatawrapperInline = ({ format }: StoryProps) => {
+	return (
+		<Wrapper>
+			<SomeText />
+			<SomeText />
+			<InteractiveBlockComponent
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
+				alt="map"
+				role="inline"
+				format={format}
+				isMainMedia={false}
+			/>
+			<SomeText />
+			<SomeText />
+			<SomeText />
+		</Wrapper>
+	);
+};
+DatawrapperInline.storyName = 'Datawrapper Inline role';
+DatawrapperInline.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
+
+export const DatawrapperSupporting = ({ format }: StoryProps) => {
+	return (
+		<Wrapper>
+			<SomeText />
+			<SomeText />
+			<InteractiveBlockComponent
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
+				alt="map"
+				role="supporting"
+				format={format}
+				isMainMedia={false}
+			/>
+			<SomeText />
+			<SomeText />
+			<SomeText />
+		</Wrapper>
+	);
+};
+DatawrapperSupporting.storyName = 'Datawrapper Supporting role';
+DatawrapperSupporting.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
+
+export const DatawrapperShowcase = ({ format }: StoryProps) => {
+	return (
+		<Wrapper>
+			<SomeText />
+			<SomeText />
+			<InteractiveBlockComponent
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
+				alt="map"
+				role="showcase"
+				format={format}
+				isMainMedia={false}
+			/>
+			<SomeText />
+			<SomeText />
+			<SomeText />
+		</Wrapper>
+	);
+};
+DatawrapperShowcase.storyName = 'Datawrapper Showcase role';
+DatawrapperShowcase.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
+
+export const DatawrapperThumbnail = ({ format }: StoryProps) => {
+	return (
+		<Wrapper>
+			<SomeText />
+			<SomeText />
+			<InteractiveBlockComponent
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
+				alt="map"
+				role="thumbnail"
+				format={format}
+				isMainMedia={false}
+			/>
+			<SomeText />
+			<SomeText />
+			<SomeText />
+		</Wrapper>
+	);
+};
+DatawrapperThumbnail.storyName = 'Datawrapper Thumbnail role';
+DatawrapperThumbnail.decorators = [
+	splitTheme([defaultFormat], { orientation: 'vertical' }),
+];
+
+export const DatawrapperImmersive = ({ format }: StoryProps) => {
+	return (
+		<Wrapper>
+			<SomeText />
+			<SomeText />
+			<InteractiveBlockComponent
+				url="https://interactive.guim.co.uk/datawrapper-test/embed/IIdJx/25/"
+				scriptUrl="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js"
+				alt="map"
+				role="immersive"
+				format={format}
+				isMainMedia={false}
+			/>
+			<SomeText />
+			<SomeText />
+			<SomeText />
+		</Wrapper>
+	);
+};
+DatawrapperImmersive.storyName = 'Datawrapper Immersive role';
+DatawrapperImmersive.decorators = [
 	splitTheme([defaultFormat], { orientation: 'vertical' }),
 ];


### PR DESCRIPTION
## What does this change?

This PR tweaks the styling of `InteractiveBlockComponents` when they’re used for datawrapper graphics, i.e. when the URL starts with `https://interactive.guim.co.uk/datawrapper-test/embed` or `https://interactive.guim.co.uk/datawrapper/embed`.

## Why?

These styling tweaks have been requested by the visuals team

## Screenshots

I have added some before and after screenshots in coments on this PR, and here they are reproduced in a table:

| Role & Breakpoint  | Before                         | After                         |
|--------------------|--------------------------------|-------------------------------|
| Inline Mobile      | ![inline-mobile-before][]      | ![inline-mobile-after][]      |
| Inline Desktop     | ![inline-desktop-before][]     | ![inline-desktop-after][]     |
| Showcase Mobile    | ![showcase-mobile-before][]    | ![showcase-mobile-after][]    |
| Showcase Desktop   | ![showcase-desktop-before][]   | ![showcase-desktop-after][]   |
| Supporting Mobile  | ![supporting-mobile-before][]  | ![supporting-mobile-after][]  |
| Supporting Desktop | ![supporting-desktop-before][] | ![supporting-desktop-after][] |
| Thumbnail Mobile   | ![thumbnail-mobile-before][]   | ![thumbnail-mobile-after][]   |
| Thumbnail Desktop  | ![thumbnail-desktop-before][]  | ![thumbnail-desktop-after][]  |
| Immersive Mobile   | ![immersive-mobile-before][]   | ![immersive-mobile-after][]   |
| Immersive Desktop  | ![immersive-desktop-before][]  | ![immersive-desktop-after][]  |

[inline-desktop-after]: https://github.com/user-attachments/assets/e6591ab7-e60c-4f66-a181-c951717a7fd6
[inline-mobile-after]: https://github.com/user-attachments/assets/5e71052e-7cd4-46a8-9c0f-de3efd27ee8a
[supporting-desktop-after]: https://github.com/user-attachments/assets/f891fbf1-c296-4761-9789-32c0aa1b2e80
[supporting-mobile-after]: https://github.com/user-attachments/assets/302da6ee-7356-43bc-a5e4-9ded27e6106d
[showcase-desktop-after]: https://github.com/user-attachments/assets/994858e7-1628-4231-bb9a-fc3c0dd3dfe8
[showcase-mobile-after]: https://github.com/user-attachments/assets/fc5f631d-a145-49e5-bc00-20fee4cc3b04
[thumbnail-desktop-after]: https://github.com/user-attachments/assets/9868bd6d-0fc5-4034-a880-1fa75e841e83
[thumbnail-mobile-after]: https://github.com/user-attachments/assets/7160097b-536f-43bd-8460-9d9f5458dc57
[immersive-desktop-after]: https://github.com/user-attachments/assets/833af351-eaee-41a5-9f99-4a901f07ff9c
[immersive-mobile-after]: https://github.com/user-attachments/assets/62ace8bc-a103-4175-8429-9ef72c93f587
[inline-desktop-before]: https://github.com/user-attachments/assets/7839c68d-fc57-407a-b37c-e61ad7f2b705
[inline-mobile-before]: https://github.com/user-attachments/assets/b7aa5ee6-fbec-4ef4-bbcb-a57dc78b6f6b
[supporting-desktop-before]: https://github.com/user-attachments/assets/3813a600-df6f-4502-87a8-8f3c5f0ebc94
[supporting-mobile-before]: https://github.com/user-attachments/assets/128871f8-f661-48e2-af11-39eca44f2136
[showcase-desktop-before]: https://github.com/user-attachments/assets/3569d336-150f-4e57-8fd3-ea45d638a0c6
[showcase-mobile-before]: https://github.com/user-attachments/assets/d66a1420-091d-47d9-acaf-20519f0b3a2f
[thumbnail-desktop-before]: https://github.com/user-attachments/assets/ac82d205-a4ce-4b98-9cb9-29552e34487e
[thumbnail-mobile-before]: https://github.com/user-attachments/assets/a2fc9304-e8f1-4489-9897-cea7a5ec5184
[immersive-desktop-before]: https://github.com/user-attachments/assets/9dadf2a6-9455-4a3e-923b-12a3a65d3a25
[immersive-mobile-before]: https://github.com/user-attachments/assets/801b4c1c-8767-4709-8a35-45dd9e1baa4f

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
