### PR TITLE
Fix Incorrect Imports In `gen-fixtures`

### DIFF
--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -7,7 +7,7 @@ const execa = require('execa');
 const { config } = require('../../fixtures/config');
 const { configOverrides } = require('../../fixtures/config-overrides');
 const { switchOverrides } = require('../../fixtures/switch-overrides');
-const { enhanceArticleType } = require('../../src/lib/article');
+const { enhanceArticleType } = require('../../src/types/article');
 
 const root = resolve(__dirname, '..', '..');
 
@@ -185,13 +185,9 @@ const requests = articles.map((article) => {
 
 			// Write the new DCR fixture data
 			const dcrContents = `${HEADER}
-				import type { DCRArticle } from '../../../src/types/frontend';
+				import type { Article } from '../../../src/types/article';
 
-				export const ${article.name}: DCRArticle = ${JSON.stringify(
-					dcrArticle,
-					null,
-					4,
-				)}
+				export const ${article.name}: Article = ${JSON.stringify(dcrArticle, null, 4)}
 			`;
 
 			const dcrTypeFile = fs.writeFile(


### PR DESCRIPTION
This file was moved in #12279. The main import didn't break the build because `gen-fixtures` isn't written in TypeScript. The auto-generated imports didn't break the build because `gen-fixtures` wasn't run.
