### PR TITLE
[Fairground 🎡] Flexible special trail

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import {
 	from,
 	palette as sourcePalette,
 	space,
+	textSans14,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { isMediaCard } from '../../lib/cardHelpers';
@@ -203,6 +204,18 @@ const decideHeadlinePosition = (
 
 	return 'inner';
 };
+
+const trailTextOuterStyles = css`
+	color: ${themePalette('--card-headline-trail-text')};
+	${textSans14};
+	padding: ${space[2]}px 0;
+	strong {
+		font-weight: bold;
+	}
+	${from.tablet} {
+		display: none;
+	}
+`;
 
 export const Card = ({
 	linkTo,
@@ -428,8 +441,18 @@ export const Card = ({
 							hasKicker={!!kickerText}
 						/>
 					)}
+					{!!trailText && isFlexibleContainer && (
+						<div css={trailTextOuterStyles}>
+							<div
+								dangerouslySetInnerHTML={{
+									__html: trailText,
+								}}
+							/>
+						</div>
+					)}
 				</div>
 			)}
+
 			<CardLayout
 				cardBackgroundColour={cardBackgroundColour}
 				imagePositionOnDesktop={imagePositionOnDesktop}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -6,7 +6,7 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
-import { Link } from '@guardian/source/react-components';
+import { Hide, Link } from '@guardian/source/react-components';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
@@ -54,7 +54,7 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
-import { Hide } from '@guardian/source/react-components';
+
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
@@ -376,8 +376,16 @@ export const Card = ({
 		return 'medium';
 	};
 
+	/**
+	 * Determines how and when to render the `SupportingContent` component in the "outer" position:
+	 * - Returns `null` if `supportingContent` is unavailable or `sublinkPosition` is `none`.
+	 * - Renders `SupportingContent` for all breakpoints if `sublinkPosition` is `outer`.
+	 * - If `sublinkPosition` is `inner`, hides `SupportingContent` on desktop but displays it on smaller breakpoints.
+	 *
+	 */
 	const decideOuterSublinks = () => {
-		if (!supportingContent) return;
+		if (!supportingContent) return null;
+		if (sublinkPosition === 'none') return null;
 		if (sublinkPosition === 'outer') {
 			return (
 				<SupportingContent

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -391,7 +391,7 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
-					alignment={'horizontal'}
+					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
 				/>
 			);
@@ -401,7 +401,7 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
-					alignment={'horizontal'}
+					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
 				/>
 			</Hide>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -736,7 +736,7 @@ export const Card = ({
 							)}
 
 							{hasSublinks && sublinkPosition === 'inner' && (
-								<Hide until={'tablet'}>
+								<Hide until="tablet">
 									<SupportingContent
 										supportingContent={supportingContent}
 										alignment="vertical"

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,7 +5,6 @@ import {
 	from,
 	palette as sourcePalette,
 	space,
-	textSans14,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { isMediaCard } from '../../lib/cardHelpers';
@@ -55,7 +54,7 @@ import type {
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
 import { TrailTextWrapper } from './components/TrailTextWrapper';
-
+import { Hide } from '@guardian/source/react-components';
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
@@ -204,18 +203,6 @@ const decideHeadlinePosition = (
 
 	return 'inner';
 };
-
-const trailTextOuterStyles = css`
-	color: ${themePalette('--card-headline-trail-text')};
-	${textSans14};
-	padding: ${space[2]}px 0;
-	strong {
-		font-weight: bold;
-	}
-	${from.tablet} {
-		display: none;
-	}
-`;
 
 export const Card = ({
 	linkTo,
@@ -389,6 +376,30 @@ export const Card = ({
 		return 'medium';
 	};
 
+	const decideOuterSublinks = () => {
+		if (!supportingContent) return;
+		if (sublinkPosition === 'outer') {
+			return (
+				<SupportingContent
+					supportingContent={supportingContent}
+					containerPalette={containerPalette}
+					alignment={supportingContentAlignment}
+					isDynamo={isDynamo}
+				/>
+			);
+		}
+		return (
+			<Hide from="desktop">
+				<SupportingContent
+					supportingContent={supportingContent}
+					containerPalette={containerPalette}
+					alignment={supportingContentAlignment}
+					isDynamo={isDynamo}
+				/>
+			</Hide>
+		);
+	};
+
 	return (
 		<CardWrapper
 			format={format}
@@ -440,15 +451,6 @@ export const Card = ({
 							mediaType={mainMedia.type}
 							hasKicker={!!kickerText}
 						/>
-					)}
-					{!!trailText && (
-						<div css={trailTextOuterStyles}>
-							<div
-								dangerouslySetInnerHTML={{
-									__html: trailText,
-								}}
-							/>
-						</div>
 					)}
 				</div>
 			)}
@@ -667,6 +669,9 @@ export const Card = ({
 									}
 									imageSize={imageSize}
 									imageType={media?.type}
+									shouldHide={
+										isFlexibleContainer ? false : true
+									}
 								>
 									<div
 										dangerouslySetInnerHTML={{
@@ -723,12 +728,14 @@ export const Card = ({
 							)}
 
 							{hasSublinks && sublinkPosition === 'inner' && (
-								<SupportingContent
-									supportingContent={supportingContent}
-									alignment="vertical"
-									containerPalette={containerPalette}
-									isDynamo={isDynamo}
-								/>
+								<Hide until={'desktop'}>
+									<SupportingContent
+										supportingContent={supportingContent}
+										alignment="vertical"
+										containerPalette={containerPalette}
+										isDynamo={isDynamo}
+									/>
+								</Hide>
 							)}
 						</div>
 					</ContentWrapper>
@@ -743,14 +750,7 @@ export const Card = ({
 							: 0,
 				}}
 			>
-				{hasSublinks && sublinkPosition === 'outer' && (
-					<SupportingContent
-						supportingContent={supportingContent}
-						containerPalette={containerPalette}
-						alignment={supportingContentAlignment}
-						isDynamo={isDynamo}
-					/>
-				)}
+				{decideOuterSublinks()}
 
 				{showCommentFooter && (
 					<CardFooter

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -383,7 +383,7 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
-					alignment={supportingContentAlignment}
+					alignment={'horizontal'}
 					isDynamo={isDynamo}
 				/>
 			);
@@ -393,7 +393,7 @@ export const Card = ({
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
-					alignment={supportingContentAlignment}
+					alignment={'horizontal'}
 					isDynamo={isDynamo}
 				/>
 			</Hide>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -441,7 +441,7 @@ export const Card = ({
 							hasKicker={!!kickerText}
 						/>
 					)}
-					{!!trailText && isFlexibleContainer && (
+					{!!trailText && (
 						<div css={trailTextOuterStyles}>
 							<div
 								dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -397,7 +397,7 @@ export const Card = ({
 			);
 		}
 		return (
-			<Hide from="desktop">
+			<Hide from="tablet">
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
@@ -736,7 +736,7 @@ export const Card = ({
 							)}
 
 							{hasSublinks && sublinkPosition === 'inner' && (
-								<Hide until={'desktop'}>
+								<Hide until={'tablet'}>
 									<SupportingContent
 										supportingContent={supportingContent}
 										alignment="vertical"

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -380,7 +380,7 @@ export const Card = ({
 	 * Determines how and when to render the `SupportingContent` component in the "outer" position:
 	 * - Returns `null` if `supportingContent` is unavailable or `sublinkPosition` is `none`.
 	 * - Renders `SupportingContent` for all breakpoints if `sublinkPosition` is `outer`.
-	 * - If `sublinkPosition` is `inner`, hides `SupportingContent` on desktop but displays it on smaller breakpoints.
+	 * - If `sublinkPosition` is `inner`, hides `SupportingContent` from tablet but displays it on smaller breakpoints.
 	 *
 	 */
 	const decideOuterSublinks = () => {

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -8,9 +8,17 @@ type Props = {
 	imagePositionOnDesktop?: ImagePositionType;
 	imageSize?: ImageSizeType;
 	imageType?: CardImageType | undefined;
+	/** By default, trail text is hidden at specific breakpoints. This prop allows consumers to show trails across all breakpoints if set to false */
+	shouldHide?: boolean;
 };
 
-const showTrailText = (
+/**
+ * Determines the visibility state for the trail text based on the image size,
+ * position, and type. If the image is large, positioned on the right, and is not an avatar,
+ * the trail text will be hidden until the desktop breakpoint.
+ * Otherwise, it will be hidden until the tablet breakpoint.
+ */
+const decideVisibilityStyles = (
 	imagePosition?: ImagePositionType,
 	imageSize?: ImageSizeType,
 	imageType?: CardImageType | undefined,
@@ -33,26 +41,34 @@ const showTrailText = (
 	`;
 };
 
+const trailTextStyles = css`
+	display: flex;
+	flex-direction: column;
+	color: ${palette('--card-headline-trail-text')};
+	${textSans14};
+	padding: ${space[2]}px 0;
+	strong {
+		font-weight: bold;
+	}
+`;
+
 export const TrailTextWrapper = ({
 	children,
 	imagePositionOnDesktop,
 	imageSize,
 	imageType,
+	shouldHide = true,
 }: Props) => {
 	return (
 		<div
 			css={[
-				css`
-					display: flex;
-					flex-direction: column;
-					color: ${palette('--card-headline-trail-text')};
-					${textSans14};
-					padding: ${space[2]}px 0;
-					strong {
-						font-weight: bold;
-					}
-				`,
-				showTrailText(imagePositionOnDesktop, imageSize, imageType),
+				trailTextStyles,
+				shouldHide &&
+					decideVisibilityStyles(
+						imagePositionOnDesktop,
+						imageSize,
+						imageType,
+					),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -103,6 +103,7 @@ const TwoCardOrFourCardLayout = ({
 							imagePositionOnDesktop={
 								hasTwoOrFewerCards ? 'left' : 'bottom'
 							}
+							supportingContent={undefined} // we don't want to support sublinks on standard cards here so we hard code to undefined.
 							imageSize={'medium'}
 							aspectRatio="5:4"
 							kickerText={card.kickerText}


### PR DESCRIPTION
## What does this change?
Reworks the logic for supportingContent (sublinks) on cards.

The new logic dictates that we only display sublinks on an "inner" position on tablet breakpoint and above. Otherwise, they appear in the "outer" position which sits them below image and content unless there position is set to "none" in which case they do not appear at all.

## Why?
We do not show sublinks above images or content on breakpoints below tablet so this change codifies that design decision.

## Screenshots

| Wide      | Mobile      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e08a5dd9-7d9e-4eac-8b97-77f8b0981ff5
[after]: https://github.com/user-attachments/assets/c2cd7c9f-7f4b-4399-89c6-f148dea4fbcb


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
