### PR TITLE
[Fairground 🎡] Flexible special boost styles

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -452,7 +452,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
-						fontGroup={isSplash ? 'large' : 'standard'}
+						fontGroup={isSplash ? 'headline' : 'regular'}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent
@@ -660,7 +660,7 @@ export const Card = ({
 										showByline={showByline}
 										isExternalLink={isExternalLink}
 										fontGroup={
-											isSplash ? 'large' : 'standard'
+											isSplash ? 'headline' : 'regular'
 										}
 									/>
 									{!isUndefined(starRating) ? (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -452,7 +452,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
-						fontGroup={isSplash ? 'headline' : 'regular'}
+						fontRange={isSplash ? 'headline' : 'regular'}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent
@@ -659,7 +659,7 @@ export const Card = ({
 										byline={byline}
 										showByline={showByline}
 										isExternalLink={isExternalLink}
-										fontGroup={
+										fontRange={
 											isSplash ? 'headline' : 'regular'
 										}
 									/>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -109,9 +109,10 @@ export type Props = {
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
 	isTagPage?: boolean;
-	//** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
+	/** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
 	aspectRatio?: AspectRatio;
-	isSplash?: boolean;
+	/** Alows the consumer to use a larger font size group for boost styling*/
+	boostedFontSizes?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -253,7 +254,7 @@ export const Card = ({
 	absoluteServerTimes,
 	isTagPage = false,
 	aspectRatio,
-	isSplash,
+	boostedFontSizes,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -452,7 +453,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
-						fontRange={isSplash ? 'headline' : 'regular'}
+						boostedFontSizes={boostedFontSizes}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent
@@ -659,9 +660,7 @@ export const Card = ({
 										byline={byline}
 										showByline={showByline}
 										isExternalLink={isExternalLink}
-										fontRange={
-											isSplash ? 'headline' : 'regular'
-										}
+										boostedFontSizes={boostedFontSizes}
 									/>
 									{!isUndefined(starRating) ? (
 										<StarRatingComponent

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -62,6 +62,7 @@ export type Props = {
 	headlineText: string;
 	headlineSize?: SmallHeadlineSize;
 	headlineSizeOnMobile?: SmallHeadlineSize;
+	headlineSizeOnTablet?: SmallHeadlineSize;
 	showQuotedHeadline?: boolean;
 	byline?: string;
 	showByline?: boolean;
@@ -110,6 +111,7 @@ export type Props = {
 	isTagPage?: boolean;
 	//** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
 	aspectRatio?: AspectRatio;
+	isSplash?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -210,6 +212,7 @@ export const Card = ({
 	headlineText,
 	headlineSize,
 	headlineSizeOnMobile,
+	headlineSizeOnTablet,
 	showQuotedHeadline,
 	byline,
 	showByline,
@@ -250,6 +253,7 @@ export const Card = ({
 	absoluteServerTimes,
 	isTagPage = false,
 	aspectRatio,
+	isSplash,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -433,6 +437,7 @@ export const Card = ({
 						format={format}
 						size={headlineSize}
 						sizeOnMobile={headlineSizeOnMobile}
+						sizeOnTablet={headlineSizeOnTablet}
 						showQuotes={showQuotes}
 						kickerText={
 							format.design === ArticleDesign.LiveBlog &&
@@ -447,6 +452,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
+						isSplash={isSplash}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -452,7 +452,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
-						isSplash={isSplash}
+						fontGroup={isSplash ? 'large' : 'standard'}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent
@@ -659,6 +659,9 @@ export const Card = ({
 										byline={byline}
 										showByline={showByline}
 										isExternalLink={isExternalLink}
+										fontGroup={
+											isSplash ? 'large' : 'standard'
+										}
 									/>
 									{!isUndefined(starRating) ? (
 										<StarRatingComponent

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -36,8 +36,8 @@ type Props = {
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 	sizeOnTablet?: SmallHeadlineSize;
-	/* Controls which group of font sizes to use. Each group maps internally to the smallHeadlineSize type*/
-	fontRange?: 'regular' | 'headline';
+	/* Controls which font size group to use, regular or boosted. Each group maps internally to the smallHeadlineSize type*/
+	boostedFontSizes?: boolean;
 	byline?: string;
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
@@ -47,7 +47,7 @@ type Props = {
 };
 
 /** These represent a new set of fonts. They are extra large font sizes that, as a group, are only used on headlines */
-const headlineFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
+const boostedFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	switch (size) {
 		// we don't have a ginormous size in designs. For now this defaults to huge.
 		case 'ginormous':
@@ -74,123 +74,113 @@ const headlineFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 
 const fontStyles = ({
 	size,
-	fontRange,
+	boostedFontSizes,
 }: {
 	size: SmallHeadlineSize;
-	fontRange: 'regular' | 'headline';
+	boostedFontSizes: boolean;
 }) => {
-	switch (fontRange) {
-		case 'headline':
-			return headlineFontStyles({ size });
-		case 'regular':
-		default:
-			switch (size) {
-				case 'ginormous':
-					return css`
-						${from.desktop} {
-							${headlineMedium50}
-						}
-					`;
-				case 'huge':
-					return css`
-						${headlineMedium28}
-					`;
-				case 'large':
-					return css`
-						${headlineMedium24}
-					`;
-				case 'medium':
-					return css`
-						${headlineMedium20}
-					`;
-				case 'small':
-					return css`
-						${headlineMedium17}
-					`;
-				case 'tiny':
-					return css`
-						${headlineMedium14}
-					`;
-			}
+	if (boostedFontSizes) return boostedFontStyles({ size });
+
+	switch (size) {
+		case 'ginormous':
+			return css`
+				${from.desktop} {
+					${headlineMedium50}
+				}
+			`;
+		case 'huge':
+			return css`
+				${headlineMedium28}
+			`;
+		case 'large':
+			return css`
+				${headlineMedium24}
+			`;
+		case 'medium':
+			return css`
+				${headlineMedium20}
+			`;
+		case 'small':
+			return css`
+				${headlineMedium17}
+			`;
+		case 'tiny':
+			return css`
+				${headlineMedium14}
+			`;
 	}
 };
-
 const fontStylesOnTablet = ({
 	size,
-	fontRange,
+	boostedFontSizes,
 }: {
-	size?: SmallHeadlineSize;
-	fontRange: 'regular' | 'headline';
+	size: SmallHeadlineSize;
+	boostedFontSizes: boolean;
 }) => {
-	if (!size) return;
-	if (fontRange === 'headline') {
+	/* Currently, tablet-specific headline sizing only applies to boosted fonts where a tablet font size has been supplied */
+	if (size && boostedFontSizes)
 		return css`
 			${between.tablet.and.desktop} {
-				${headlineFontStyles({ size })}
+				${boostedFontStyles({ size })}
 			}
 		`;
-	}
-	return;
+	return null;
 };
 
 const fontStylesOnMobile = ({
 	size,
-	fontRange,
+	boostedFontSizes,
 }: {
 	size: SmallHeadlineSize;
-	fontRange: 'regular' | 'headline';
+	boostedFontSizes: boolean;
 }) => {
-	switch (fontRange) {
-		case 'headline': {
+	if (boostedFontSizes) {
+		return css`
+			${until.tablet} {
+				${boostedFontStyles({ size })}
+			}
+		`;
+	}
+
+	switch (size) {
+		case 'ginormous':
 			return css`
-				${until.tablet} {
-					${headlineFontStyles({ size })}
+				${until.mobileLandscape} {
+					${headlineMedium34}
+				}
+				${between.mobileLandscape.and.desktop} {
+					${headlineMedium42}
 				}
 			`;
-		}
-
-		case 'regular':
+		case 'huge':
+			return css`
+				${until.desktop} {
+					${headlineMedium24}
+				}
+			`;
+		case 'large':
+			return css`
+				${until.desktop} {
+					${headlineMedium20}
+				}
+			`;
+		case 'medium':
+			return css`
+				${until.desktop} {
+					${headlineMedium17}
+				}
+			`;
+		case 'small':
+			return css`
+				${until.mobileMedium} {
+					${headlineMedium14}
+				}
+				${between.mobileMedium.and.desktop} {
+					${headlineMedium17}
+				}
+			`;
 		default:
-			switch (size) {
-				case 'ginormous':
-					return css`
-						${until.mobileLandscape} {
-							${headlineMedium34}
-						}
-						${between.mobileLandscape.and.desktop} {
-							${headlineMedium42}
-						}
-					`;
-				case 'huge':
-					return css`
-						${until.desktop} {
-							${headlineMedium24}
-						}
-					`;
-				case 'large':
-					return css`
-						${until.desktop} {
-							${headlineMedium20}
-						}
-					`;
-				case 'medium':
-					return css`
-						${until.desktop} {
-							${headlineMedium17}
-						}
-					`;
-				case 'small':
-					return css`
-						${until.mobileMedium} {
-							${headlineMedium14}
-						}
-						${between.mobileMedium.and.desktop} {
-							${headlineMedium17}
-						}
-					`;
-				default:
-					return undefined;
-			}
+			return undefined;
 	}
 };
 
@@ -291,7 +281,7 @@ export const CardHeadline = ({
 	size = 'medium',
 	sizeOnMobile,
 	sizeOnTablet,
-	fontRange = 'regular',
+	boostedFontSizes = false,
 	byline,
 	showByline,
 	linkTo,
@@ -312,17 +302,14 @@ export const CardHeadline = ({
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
 							size: sizeOnMobile ?? size,
-							fontRange,
+							boostedFontSizes,
 						}),
 
 					format.theme !== ArticleSpecial.Labs &&
-						fontStylesOnTablet({
-							size: sizeOnTablet,
-							fontRange,
-						}),
+						fontStylesOnTablet({ size, boostedFontSizes }),
 					format.theme === ArticleSpecial.Labs
 						? labTextStyles(size)
-						: fontStyles({ size, fontRange }),
+						: fontStyles({ size, boostedFontSizes }),
 				]}
 			>
 				{!!kickerText && (

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -36,7 +36,7 @@ type Props = {
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 	sizeOnTablet?: SmallHeadlineSize;
-	fontGroup?: 'regular' | 'headline';
+	fontRange?: 'regular' | 'headline';
 	byline?: string;
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
@@ -45,7 +45,7 @@ type Props = {
 	isHighlights?: boolean;
 };
 
-/** These represent a new set of fonts. They are extra large font sizes that, as a set, are only used on headlines */
+/** These represent a new set of fonts. They are extra large font sizes that, as a group, are only used on headlines */
 const headlineFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	switch (size) {
 		// we don't have a ginormous size in designs. For now this defaults to huge.
@@ -73,12 +73,12 @@ const headlineFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 
 const fontStyles = ({
 	size,
-	fontGroup,
+	fontRange,
 }: {
 	size: SmallHeadlineSize;
-	fontGroup: 'regular' | 'headline';
+	fontRange: 'regular' | 'headline';
 }) => {
-	switch (fontGroup) {
+	switch (fontRange) {
 		case 'headline':
 			return headlineFontStyles({ size });
 		case 'regular':
@@ -116,13 +116,13 @@ const fontStyles = ({
 
 const fontStylesOnTablet = ({
 	size,
-	fontGroup,
+	fontRange,
 }: {
 	size?: SmallHeadlineSize;
-	fontGroup: 'regular' | 'headline';
+	fontRange: 'regular' | 'headline';
 }) => {
 	if (!size) return;
-	if (fontGroup === 'headline') {
+	if (fontRange === 'headline') {
 		return css`
 			${between.tablet.and.desktop} {
 				${headlineFontStyles({ size })}
@@ -134,12 +134,12 @@ const fontStylesOnTablet = ({
 
 const fontStylesOnMobile = ({
 	size,
-	fontGroup,
+	fontRange,
 }: {
 	size: SmallHeadlineSize;
-	fontGroup: 'regular' | 'headline';
+	fontRange: 'regular' | 'headline';
 }) => {
-	switch (fontGroup) {
+	switch (fontRange) {
 		case 'headline': {
 			return css`
 				${until.tablet} {
@@ -290,7 +290,7 @@ export const CardHeadline = ({
 	size = 'medium',
 	sizeOnMobile,
 	sizeOnTablet,
-	fontGroup = 'regular',
+	fontRange = 'regular',
 	byline,
 	showByline,
 	linkTo,
@@ -311,17 +311,17 @@ export const CardHeadline = ({
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
 							size: sizeOnMobile ?? size,
-							fontGroup,
+							fontRange,
 						}),
 
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnTablet({
 							size: sizeOnTablet,
-							fontGroup,
+							fontRange,
 						}),
 					format.theme === ArticleSpecial.Labs
 						? labTextStyles(size)
-						: fontStyles({ size, fontGroup }),
+						: fontStyles({ size, fontRange }),
 				]}
 			>
 				{!!kickerText && (

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -114,16 +114,17 @@ const fontStylesOnTablet = ({
 	size,
 	boostedFontSizes,
 }: {
-	size: SmallHeadlineSize;
+	size?: SmallHeadlineSize;
 	boostedFontSizes: boolean;
 }) => {
 	/* Currently, tablet-specific headline sizing only applies to boosted fonts where a tablet font size has been supplied */
-	if (size && boostedFontSizes)
+	if (size && boostedFontSizes) {
 		return css`
 			${between.tablet.and.desktop} {
 				${boostedFontStyles({ size })}
 			}
 		`;
+	}
 	return null;
 };
 
@@ -306,7 +307,10 @@ export const CardHeadline = ({
 						}),
 
 					format.theme !== ArticleSpecial.Labs &&
-						fontStylesOnTablet({ size, boostedFontSizes }),
+						fontStylesOnTablet({
+							size: sizeOnTablet,
+							boostedFontSizes,
+						}),
 					format.theme === ArticleSpecial.Labs
 						? labTextStyles(size)
 						: fontStyles({ size, boostedFontSizes }),

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -36,16 +36,17 @@ type Props = {
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 	sizeOnTablet?: SmallHeadlineSize;
+	fontGroup?: 'standard' | 'large';
 	byline?: string;
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isExternalLink?: boolean;
 	/** Is the headline inside a Highlights card? */
 	isHighlights?: boolean;
-	isSplash?: boolean;
 };
 
-const flexibleSplashFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
+/** These represent a new set of fonts. They are large font sizes  */
+const largeFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	switch (size) {
 		// we don't have a ginormous size in designs. For now this defaults to huge.
 		case 'ginormous':
@@ -72,60 +73,59 @@ const flexibleSplashFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 
 const fontStyles = ({
 	size,
-	isSplash,
+	fontGroup,
 }: {
 	size: SmallHeadlineSize;
-	isSplash: boolean;
+	fontGroup: 'standard' | 'large';
 }) => {
-	if (isSplash) {
-		return css`
-			${from.desktop} {
-				${flexibleSplashFontStyles({ size })}
-			}
-		`;
-	}
-	switch (size) {
-		case 'ginormous':
-			return css`
-				${from.desktop} {
-					${headlineMedium50}
-				}
-			`;
-		case 'huge':
-			return css`
-				${headlineMedium28}
-			`;
+	switch (fontGroup) {
 		case 'large':
-			return css`
-				${headlineMedium24}
-			`;
-		case 'medium':
-			return css`
-				${headlineMedium20}
-			`;
-		case 'small':
-			return css`
-				${headlineMedium17}
-			`;
-		case 'tiny':
-			return css`
-				${headlineMedium14}
-			`;
+			return largeFontStyles({ size });
+		case 'standard':
+		default:
+			switch (size) {
+				case 'ginormous':
+					return css`
+						${from.desktop} {
+							${headlineMedium50}
+						}
+					`;
+				case 'huge':
+					return css`
+						${headlineMedium28}
+					`;
+				case 'large':
+					return css`
+						${headlineMedium24}
+					`;
+				case 'medium':
+					return css`
+						${headlineMedium20}
+					`;
+				case 'small':
+					return css`
+						${headlineMedium17}
+					`;
+				case 'tiny':
+					return css`
+						${headlineMedium14}
+					`;
+			}
 	}
 };
 
 const fontStylesOnTablet = ({
 	size,
-	isSplash,
+	fontGroup,
 }: {
 	size?: SmallHeadlineSize;
-	isSplash: boolean;
+	fontGroup: 'standard' | 'large';
 }) => {
 	if (!size) return;
-	if (isSplash) {
+	if (fontGroup === 'large') {
 		return css`
 			${between.tablet.and.desktop} {
-				${flexibleSplashFontStyles({ size })}
+				${largeFontStyles({ size })}
 			}
 		`;
 	}
@@ -134,57 +134,62 @@ const fontStylesOnTablet = ({
 
 const fontStylesOnMobile = ({
 	size,
-	isSplash,
+	fontGroup,
 }: {
 	size: SmallHeadlineSize;
-	isSplash: boolean;
+	fontGroup: 'standard' | 'large';
 }) => {
-	if (isSplash) {
-		return css`
-			${until.tablet} {
-				${flexibleSplashFontStyles({ size })}
-			}
-		`;
-	}
-	switch (size) {
-		case 'ginormous':
+	switch (fontGroup) {
+		case 'large': {
 			return css`
-				${until.mobileLandscape} {
-					${headlineMedium34}
-				}
-				${between.mobileLandscape.and.desktop} {
-					${headlineMedium42}
+				${until.tablet} {
+					${largeFontStyles({ size })}
 				}
 			`;
-		case 'huge':
-			return css`
-				${until.desktop} {
-					${headlineMedium24}
-				}
-			`;
-		case 'large':
-			return css`
-				${until.desktop} {
-					${headlineMedium20}
-				}
-			`;
-		case 'medium':
-			return css`
-				${until.desktop} {
-					${headlineMedium17}
-				}
-			`;
-		case 'small':
-			return css`
-				${until.mobileMedium} {
-					${headlineMedium14}
-				}
-				${between.mobileMedium.and.desktop} {
-					${headlineMedium17}
-				}
-			`;
+		}
+
+		case 'standard':
 		default:
-			return undefined;
+			switch (size) {
+				case 'ginormous':
+					return css`
+						${until.mobileLandscape} {
+							${headlineMedium34}
+						}
+						${between.mobileLandscape.and.desktop} {
+							${headlineMedium42}
+						}
+					`;
+				case 'huge':
+					return css`
+						${until.desktop} {
+							${headlineMedium24}
+						}
+					`;
+				case 'large':
+					return css`
+						${until.desktop} {
+							${headlineMedium20}
+						}
+					`;
+				case 'medium':
+					return css`
+						${until.desktop} {
+							${headlineMedium17}
+						}
+					`;
+				case 'small':
+					return css`
+						${until.mobileMedium} {
+							${headlineMedium14}
+						}
+						${between.mobileMedium.and.desktop} {
+							${headlineMedium17}
+						}
+					`;
+				default:
+					return undefined;
+			}
 	}
 };
 
@@ -285,12 +290,12 @@ export const CardHeadline = ({
 	size = 'medium',
 	sizeOnMobile,
 	sizeOnTablet,
+	fontGroup = 'standard',
 	byline,
 	showByline,
 	linkTo,
 	isExternalLink,
 	isHighlights = false,
-	isSplash = false,
 }: Props) => {
 	const kickerColour = isHighlights
 		? palette('--highlights-card-kicker-text')
@@ -306,17 +311,17 @@ export const CardHeadline = ({
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
 							size: sizeOnMobile ?? size,
-							isSplash,
+							fontGroup,
 						}),
 
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnTablet({
 							size: sizeOnTablet,
-							isSplash,
+							fontGroup,
 						}),
 					format.theme === ArticleSpecial.Labs
 						? labTextStyles(size)
-						: fontStyles({ size, isSplash }),
+						: fontStyles({ size, fontGroup }),
 				]}
 			>
 				{!!kickerText && (

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -35,15 +35,55 @@ type Props = {
 	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
+	sizeOnTablet?: SmallHeadlineSize;
 	byline?: string;
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
 	isExternalLink?: boolean;
 	/** Is the headline inside a Highlights card? */
 	isHighlights?: boolean;
+	isSplash?: boolean;
 };
 
-const fontStyles = ({ size }: { size: SmallHeadlineSize }) => {
+const flexibleSplashFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
+	switch (size) {
+		// we don't have a ginormous size in designs. For now this defaults to huge.
+		case 'ginormous':
+		case 'huge':
+			// this needs to be updated to font size 64 once this is available in source.
+			return `
+				${headlineMedium50}
+				font-size: 64px;
+			`;
+
+		case 'large':
+			return `${headlineMedium50}`;
+
+		case 'medium':
+			return `${headlineMedium42}`;
+
+		case 'small':
+			return `${headlineMedium34}`;
+
+		case 'tiny':
+			return `${headlineMedium28}`;
+	}
+};
+
+const fontStyles = ({
+	size,
+	isSplash,
+}: {
+	size: SmallHeadlineSize;
+	isSplash: boolean;
+}) => {
+	if (isSplash) {
+		return css`
+			${from.desktop} {
+				${flexibleSplashFontStyles({ size })}
+			}
+		`;
+	}
 	switch (size) {
 		case 'ginormous':
 			return css`
@@ -74,7 +114,38 @@ const fontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	}
 };
 
-const fontStylesOnMobile = ({ size }: { size: SmallHeadlineSize }) => {
+const fontStylesOnTablet = ({
+	size,
+	isSplash,
+}: {
+	size?: SmallHeadlineSize;
+	isSplash: boolean;
+}) => {
+	if (!size) return;
+	if (isSplash) {
+		return css`
+			${between.tablet.and.desktop} {
+				${flexibleSplashFontStyles({ size })}
+			}
+		`;
+	}
+	return;
+};
+
+const fontStylesOnMobile = ({
+	size,
+	isSplash,
+}: {
+	size: SmallHeadlineSize;
+	isSplash: boolean;
+}) => {
+	if (isSplash) {
+		return css`
+			${until.tablet} {
+				${flexibleSplashFontStyles({ size })}
+			}
+		`;
+	}
 	switch (size) {
 		case 'ginormous':
 			return css`
@@ -213,11 +284,13 @@ export const CardHeadline = ({
 	hideLineBreak,
 	size = 'medium',
 	sizeOnMobile,
+	sizeOnTablet,
 	byline,
 	showByline,
 	linkTo,
 	isExternalLink,
 	isHighlights = false,
+	isSplash = false,
 }: Props) => {
 	const kickerColour = isHighlights
 		? palette('--highlights-card-kicker-text')
@@ -230,13 +303,20 @@ export const CardHeadline = ({
 					linkTo ? 'card-sublink-headline' : 'card-headline'
 				}`}
 				css={[
-					format.theme === ArticleSpecial.Labs
-						? labTextStyles(size)
-						: fontStyles({ size }),
 					format.theme !== ArticleSpecial.Labs &&
 						fontStylesOnMobile({
 							size: sizeOnMobile ?? size,
+							isSplash,
 						}),
+
+					format.theme !== ArticleSpecial.Labs &&
+						fontStylesOnTablet({
+							size: sizeOnTablet,
+							isSplash,
+						}),
+					format.theme === ArticleSpecial.Labs
+						? labTextStyles(size)
+						: fontStyles({ size, isSplash }),
 				]}
 			>
 				{!!kickerText && (

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -36,7 +36,7 @@ type Props = {
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 	sizeOnTablet?: SmallHeadlineSize;
-	fontGroup?: 'standard' | 'large';
+	fontGroup?: 'regular' | 'headline';
 	byline?: string;
 	showByline?: boolean;
 	linkTo?: string; // If provided, the headline is wrapped in a link
@@ -45,8 +45,8 @@ type Props = {
 	isHighlights?: boolean;
 };
 
-/** These represent a new set of fonts. They are large font sizes  */
-const largeFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
+/** These represent a new set of fonts. They are extra large font sizes that, as a set, are only used on headlines */
+const headlineFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	switch (size) {
 		// we don't have a ginormous size in designs. For now this defaults to huge.
 		case 'ginormous':
@@ -76,12 +76,12 @@ const fontStyles = ({
 	fontGroup,
 }: {
 	size: SmallHeadlineSize;
-	fontGroup: 'standard' | 'large';
+	fontGroup: 'regular' | 'headline';
 }) => {
 	switch (fontGroup) {
-		case 'large':
-			return largeFontStyles({ size });
-		case 'standard':
+		case 'headline':
+			return headlineFontStyles({ size });
+		case 'regular':
 		default:
 			switch (size) {
 				case 'ginormous':
@@ -119,13 +119,13 @@ const fontStylesOnTablet = ({
 	fontGroup,
 }: {
 	size?: SmallHeadlineSize;
-	fontGroup: 'standard' | 'large';
+	fontGroup: 'regular' | 'headline';
 }) => {
 	if (!size) return;
-	if (fontGroup === 'large') {
+	if (fontGroup === 'headline') {
 		return css`
 			${between.tablet.and.desktop} {
-				${largeFontStyles({ size })}
+				${headlineFontStyles({ size })}
 			}
 		`;
 	}
@@ -137,18 +137,18 @@ const fontStylesOnMobile = ({
 	fontGroup,
 }: {
 	size: SmallHeadlineSize;
-	fontGroup: 'standard' | 'large';
+	fontGroup: 'regular' | 'headline';
 }) => {
 	switch (fontGroup) {
-		case 'large': {
+		case 'headline': {
 			return css`
 				${until.tablet} {
-					${largeFontStyles({ size })}
+					${headlineFontStyles({ size })}
 				}
 			`;
 		}
 
-		case 'standard':
+		case 'regular':
 		default:
 			switch (size) {
 				case 'ginormous':
@@ -290,7 +290,7 @@ export const CardHeadline = ({
 	size = 'medium',
 	sizeOnMobile,
 	sizeOnTablet,
-	fontGroup = 'standard',
+	fontGroup = 'regular',
 	byline,
 	showByline,
 	linkTo,

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -36,6 +36,7 @@ type Props = {
 	size?: SmallHeadlineSize;
 	sizeOnMobile?: SmallHeadlineSize;
 	sizeOnTablet?: SmallHeadlineSize;
+	/* Controls which group of font sizes to use. Each group maps internally to the smallHeadlineSize type*/
 	fontRange?: 'regular' | 'headline';
 	byline?: string;
 	showByline?: boolean;

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -52,7 +52,7 @@ const determineCardProperties = (
 			};
 		case 'megaboost':
 			return {
-				headlineSize: 'huge',
+				headlineSize: 'large',
 				headlineSizeOnMobile: 'medium',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
@@ -60,7 +60,7 @@ const determineCardProperties = (
 			};
 		case 'gigaboost':
 			return {
-				headlineSize: 'ginormous',
+				headlineSize: 'huge',
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,9 +1,10 @@
+import { BoostLevel } from 'src/types/content';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
-import { ImagePositionType } from './Card/components/ImageWrapper';
+import type { ImagePositionType } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
@@ -25,13 +26,12 @@ type boostProperties = {
 	imagePositionOnMobile: ImagePositionType;
 };
 
-type BoostLevel = 'default' | 'boost' | 'megaBoost' | 'gigaBoost';
-
 /**
  * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */
 const determineCardProperties = (boostLevel: BoostLevel): boostProperties => {
 	switch (boostLevel) {
+		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
 			return {
 				headlineSize: 'medium',
@@ -48,7 +48,7 @@ const determineCardProperties = (boostLevel: BoostLevel): boostProperties => {
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'top',
 			};
-		case 'megaBoost':
+		case 'megaboost':
 			return {
 				headlineSize: 'huge',
 				headlineSizeOnMobile: 'medium',
@@ -56,7 +56,7 @@ const determineCardProperties = (boostLevel: BoostLevel): boostProperties => {
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'top',
 			};
-		case 'gigaBoost':
+		case 'gigaboost':
 			return {
 				headlineSize: 'ginormous',
 				headlineSizeOnMobile: 'large',
@@ -86,7 +86,7 @@ export const OneCardLayout = ({
 		headlineSizeOnTablet,
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
-	} = determineCardProperties('default');
+	} = determineCardProperties(cards[0].boostLevel || 'default');
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -92,10 +92,10 @@ export const OneCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 }) => {
-	if (!cards[0]) return null;
+	const card = cards[0];
+	if (!card) return null;
 
-	const longSupportingContent =
-		(cards[0]?.supportingContent?.length ?? 0) >= 3;
+	const longSupportingContent = (card?.supportingContent?.length ?? 0) >= 3;
 
 	const {
 		headlineSize,
@@ -104,12 +104,12 @@ export const OneCardLayout = ({
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
 		supportingContentAlignment,
-	} = determineCardProperties(cards[0].boostLevel, longSupportingContent);
+	} = determineCardProperties(card.boostLevel, longSupportingContent);
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>
 				<FrontCard
-					trail={cards[0]}
+					trail={card}
 					containerPalette={containerPalette}
 					containerType="flexible/special"
 					showAge={showAge}
@@ -120,13 +120,13 @@ export const OneCardLayout = ({
 					imagePositionOnDesktop={imagePositionOnDesktop}
 					imagePositionOnMobile={imagePositionOnMobile}
 					imageSize="jumbo"
-					trailText={cards[0].trailText}
-					supportingContent={cards[0].supportingContent}
+					trailText={card.trailText}
+					supportingContent={card.supportingContent}
 					supportingContentAlignment={supportingContentAlignment}
 					imageLoading={imageLoading}
 					aspectRatio="5:4"
-					kickerText={cards[0].kickerText}
-					showLivePlayable={cards[0].showLivePlayable}
+					kickerText={card.kickerText}
+					showLivePlayable={card.showLivePlayable}
 					isSplash={true}
 				/>
 			</LI>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -126,7 +126,7 @@ export const OneCardLayout = ({
 					aspectRatio="5:4"
 					kickerText={card.kickerText}
 					showLivePlayable={card.showLivePlayable}
-					isSplash={true}
+					boostedFontSizes={true}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -9,7 +9,7 @@ import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
-import { Alignment } from './SupportingContent';
+import type { Alignment } from './SupportingContent';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -33,7 +33,7 @@ type boostProperties = {
  */
 const determineCardProperties = (
 	boostLevel: BoostLevel = 'default',
-	longSupportingContent: boolean,
+	supportingContentLength: number,
 ): boostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
@@ -44,9 +44,8 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'top',
-				supportingContentAlignment: longSupportingContent
-					? 'horizontal'
-					: 'vertical',
+				supportingContentAlignment:
+					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
 		case 'boost':
 			return {
@@ -55,9 +54,8 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'top',
-				supportingContentAlignment: longSupportingContent
-					? 'horizontal'
-					: 'vertical',
+				supportingContentAlignment:
+					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
 		case 'megaboost':
 			return {
@@ -95,8 +93,6 @@ export const OneCardLayout = ({
 	const card = cards[0];
 	if (!card) return null;
 
-	const longSupportingContent = (card?.supportingContent?.length ?? 0) >= 3;
-
 	const {
 		headlineSize,
 		headlineSizeOnMobile,
@@ -104,7 +100,10 @@ export const OneCardLayout = ({
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
 		supportingContentAlignment,
-	} = determineCardProperties(card.boostLevel, longSupportingContent);
+	} = determineCardProperties(
+		card.boostLevel,
+		card?.supportingContent?.length ?? 0,
+	);
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,4 +1,4 @@
-import { BoostLevel } from 'src/types/content';
+import type { BoostLevel } from '../types/content';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
@@ -47,7 +47,7 @@ const determineCardProperties = (
 				headlineSize: 'large',
 				headlineSizeOnMobile: 'small',
 				headlineSizeOnTablet: 'medium',
-				imagePositionOnDesktop: 'bottom',
+				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'top',
 			};
 		case 'megaboost':

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -9,6 +9,7 @@ import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
+import { Alignment } from './SupportingContent';
 
 type Props = {
 	groupedTrails: DCRGroupedTrails;
@@ -24,6 +25,7 @@ type boostProperties = {
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
+	supportingContentAlignment: Alignment;
 };
 
 /**
@@ -31,6 +33,7 @@ type boostProperties = {
  */
 const determineCardProperties = (
 	boostLevel: BoostLevel = 'default',
+	longSupportingContent: boolean,
 ): boostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
@@ -41,6 +44,9 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'top',
+				supportingContentAlignment: longSupportingContent
+					? 'horizontal'
+					: 'vertical',
 			};
 		case 'boost':
 			return {
@@ -49,6 +55,9 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'top',
+				supportingContentAlignment: longSupportingContent
+					? 'horizontal'
+					: 'vertical',
 			};
 		case 'megaboost':
 			return {
@@ -57,6 +66,7 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'top',
+				supportingContentAlignment: 'horizontal',
 			};
 		case 'gigaboost':
 			return {
@@ -65,6 +75,7 @@ const determineCardProperties = (
 				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'top',
+				supportingContentAlignment: 'horizontal',
 			};
 	}
 };
@@ -82,13 +93,18 @@ export const OneCardLayout = ({
 	absoluteServerTimes: boolean;
 }) => {
 	if (!cards[0]) return null;
+
+	const longSupportingContent =
+		(cards[0]?.supportingContent?.length ?? 0) >= 3;
+
 	const {
 		headlineSize,
 		headlineSizeOnMobile,
 		headlineSizeOnTablet,
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
-	} = determineCardProperties(cards[0].boostLevel);
+		supportingContentAlignment,
+	} = determineCardProperties(cards[0].boostLevel, longSupportingContent);
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>
@@ -106,12 +122,7 @@ export const OneCardLayout = ({
 					imageSize="jumbo"
 					trailText={cards[0].trailText}
 					supportingContent={cards[0].supportingContent}
-					supportingContentAlignment={
-						cards[0].supportingContent &&
-						cards[0].supportingContent.length > 3
-							? 'horizontal'
-							: 'vertical'
-					}
+					supportingContentAlignment={supportingContentAlignment}
 					imageLoading={imageLoading}
 					aspectRatio="5:4"
 					kickerText={cards[0].kickerText}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -3,6 +3,7 @@ import type {
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
+import { ImagePositionType } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
@@ -16,6 +17,55 @@ type Props = {
 	absoluteServerTimes: boolean;
 };
 
+type boostProperties = {
+	headlineSize: SmallHeadlineSize;
+	headlineSizeOnMobile: SmallHeadlineSize;
+	headlineSizeOnTablet: SmallHeadlineSize;
+	imagePositionOnDesktop: ImagePositionType;
+	imagePositionOnMobile: ImagePositionType;
+};
+
+type BoostLevel = 'default' | 'boost' | 'megaBoost' | 'gigaBoost';
+
+/**
+ * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ */
+const determineCardProperties = (boostLevel: BoostLevel): boostProperties => {
+	switch (boostLevel) {
+		case 'default':
+			return {
+				headlineSize: 'medium',
+				headlineSizeOnMobile: 'tiny',
+				headlineSizeOnTablet: 'small',
+				imagePositionOnDesktop: 'right',
+				imagePositionOnMobile: 'top',
+			};
+		case 'boost':
+			return {
+				headlineSize: 'large',
+				headlineSizeOnMobile: 'small',
+				headlineSizeOnTablet: 'medium',
+				imagePositionOnDesktop: 'bottom',
+				imagePositionOnMobile: 'top',
+			};
+		case 'megaBoost':
+			return {
+				headlineSize: 'huge',
+				headlineSizeOnMobile: 'medium',
+				headlineSizeOnTablet: 'medium',
+				imagePositionOnDesktop: 'bottom',
+				imagePositionOnMobile: 'top',
+			};
+		case 'gigaBoost':
+			return {
+				headlineSize: 'ginormous',
+				headlineSizeOnMobile: 'large',
+				headlineSizeOnTablet: 'large',
+				imagePositionOnDesktop: 'bottom',
+				imagePositionOnMobile: 'top',
+			};
+	}
+};
 export const OneCardLayout = ({
 	cards,
 	containerPalette,
@@ -30,7 +80,13 @@ export const OneCardLayout = ({
 	absoluteServerTimes: boolean;
 }) => {
 	if (!cards[0]) return null;
-
+	const {
+		headlineSize,
+		headlineSizeOnMobile,
+		headlineSizeOnTablet,
+		imagePositionOnDesktop,
+		imagePositionOnMobile,
+	} = determineCardProperties('default');
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>
@@ -40,10 +96,11 @@ export const OneCardLayout = ({
 					containerType="flexible/special"
 					showAge={showAge}
 					absoluteServerTimes={absoluteServerTimes}
-					headlineSize="large"
-					headlineSizeOnMobile="medium"
-					imagePositionOnDesktop="right"
-					imagePositionOnMobile="top"
+					headlineSize={headlineSize}
+					headlineSizeOnMobile={headlineSizeOnMobile}
+					headlineSizeOnTablet={headlineSizeOnTablet}
+					imagePositionOnDesktop={imagePositionOnDesktop}
+					imagePositionOnMobile={imagePositionOnMobile}
 					imageSize="jumbo"
 					trailText={cards[0].trailText}
 					supportingContent={cards[0].supportingContent}
@@ -57,6 +114,7 @@ export const OneCardLayout = ({
 					aspectRatio="5:4"
 					kickerText={cards[0].kickerText}
 					showLivePlayable={cards[0].showLivePlayable}
+					isSplash={true}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -29,7 +29,9 @@ type boostProperties = {
 /**
  * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */
-const determineCardProperties = (boostLevel: BoostLevel): boostProperties => {
+const determineCardProperties = (
+	boostLevel: BoostLevel = 'default',
+): boostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
@@ -86,7 +88,7 @@ export const OneCardLayout = ({
 		headlineSizeOnTablet,
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
-	} = determineCardProperties(cards[0].boostLevel || 'default');
+	} = determineCardProperties(cards[0].boostLevel);
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>


### PR DESCRIPTION
## What does this change?
Adds a new subset of fonts which represent a large font group which are used by boosted headlines across flexible special and flexible general

It also then implements different boost styling in the flexible layout.

## Why?
Boost headlines use a different range of font sizing to standard cards. 

## Screenshots

| default      | boost      |
| ----------- | ---------- |
| ![default][] | ![boost][] |

| megaboost      | gigaboost      |
| ----------- | ---------- |
| ![megaboost][] | ![gigaboost][] |

[default]: https://github.com/user-attachments/assets/cbe2e983-45a1-4311-9ce8-aba89c7ff539
[boost]: https://github.com/user-attachments/assets/0e550266-6a2a-493a-b9aa-515f3f78a7ad
[megaboost]: https://github.com/user-attachments/assets/8376ff61-527c-48e6-bd07-c53acfb3c152
[gigaboost]: https://github.com/user-attachments/assets/14db46d9-d802-4a4a-ad13-b33f620ad8ee

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
