### PR TITLE
[Fairground 🎡] Set state of live links on cards to be splash only

### DIFF
--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -56,6 +56,7 @@ export const OneCardLayout = ({
 					imageLoading={imageLoading}
 					aspectRatio="5:4"
 					kickerText={cards[0].kickerText}
+					showLivePlayable={cards[0].showLivePlayable}
 				/>
 			</LI>
 		</UL>
@@ -105,6 +106,7 @@ const TwoCardOrFourCardLayout = ({
 							imageSize={'medium'}
 							aspectRatio="5:4"
 							kickerText={card.kickerText}
+							showLivePlayable={false}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
## What does this change?
Explicitly sets the state of showLivePlayable* on cards in the flexible container. 

The desired state for flexible containers are:
- If available, show latest links on a splash card 
- If available, show latest links on a boosted card 
- Do not show latest links on a standard card 

*showLivePlayable === show latest 3 updates from a live blog 

## Why?
This is a design requirement of flex containers to prevent standard cards growing too much.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/58572264-f4d5-40e0-9855-3e76cff4f3e8
[after]: https://github.com/user-attachments/assets/ae61ac8e-50e5-4c87-9359-af0610d861d9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
