### PR TITLE
Limit highlights trails to 6 cards

### DIFF
--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -161,7 +161,8 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 };
 
 export const HighlightsContainer = ({ trails }: Props) => {
-	const highlightsTrails = trails.slice(0, 5);
+	// temporary fix to only show 6 highlights, until we have a proper solution in the tools
+	const highlightsTrails = trails.slice(0, 6);
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
 	const imageLoading = 'eager';

--- a/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
+++ b/dotcom-rendering/src/components/HighlightsContainer.importable.tsx
@@ -161,6 +161,7 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 };
 
 export const HighlightsContainer = ({ trails }: Props) => {
+	const highlightsTrails = trails.slice(0, 5);
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
 	const imageLoading = 'eager';
@@ -240,7 +241,7 @@ export const HighlightsContainer = ({ trails }: Props) => {
 				]}
 				data-heatphan-type="carousel"
 			>
-				{trails.map((trail) => {
+				{highlightsTrails.map((trail) => {
 					return (
 						<li
 							key={trail.url}


### PR DESCRIPTION
## What does this change?

We've had reports of people seeing more than the intended 6 cards; this is a temporary fix until we can ensure the right number only come through. 
