### PR TITLE
Render survey slot conditionally

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -218,7 +218,7 @@ interface AppsProps extends CommonProps {
 export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	const { article, format, renderingTarget } = props;
 	const {
-		config: { isPaidContent, host },
+		config: { isPaidContent, host, hasSurveyAd },
 		editionId,
 	} = article;
 
@@ -300,9 +300,14 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						</Stuck>
 					)}
 
-					{renderAds && article.config.switches.surveys && (
-						<AdSlot position="survey" display={format.display} />
-					)}
+					{renderAds &&
+						article.config.switches.surveys &&
+						hasSurveyAd && (
+							<AdSlot
+								position="survey"
+								display={format.display}
+							/>
+						)}
 				</>
 			)}
 			<main data-layout="InteractiveLayout">

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -185,7 +185,7 @@ const getMainMediaCaptions = (article: Article): (string | undefined)[] =>
 export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 	const {
 		promotedNewsletter,
-		config: { host },
+		config: { host, hasSurveyAd },
 	} = article;
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
@@ -247,7 +247,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 				/>
 			</div>
 
-			{renderAds && !!article.config.switches.surveys && (
+			{renderAds && !!article.config.switches.surveys && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -366,7 +366,7 @@ interface AppProps extends Props {
 export const StandardLayout = (props: WebProps | AppProps) => {
 	const { article, format, renderingTarget } = props;
 	const {
-		config: { isPaidContent, host },
+		config: { isPaidContent, host, hasSurveyAd },
 		editionId,
 	} = article;
 
@@ -461,7 +461,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			)}
 
-			{renderAds && article.config.switches.surveys && (
+			{renderAds && article.config.switches.surveys && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4350,6 +4350,9 @@
                 },
                 "hasLiveBlogTopAd": {
                     "type": "boolean"
+                },
+                "hasSurveyAd": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -23,6 +23,7 @@ type BaseProps = {
 	canonicalUrl?: string;
 	hasPageSkin?: boolean;
 	hasLiveBlogTopAd?: boolean;
+	hasSurveyAd?: boolean;
 	weAreHiring: boolean;
 	onlyLightColourScheme?: boolean;
 };

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -229,6 +229,7 @@ window.twttr = (function(d, s, id) {
 		weAreHiring: !!article.config.switches.weAreHiring,
 		config,
 		hasLiveBlogTopAd: !!article.config.hasLiveBlogTopAd,
+		hasSurveyAd: !!article.config.hasSurveyAd,
 		onlyLightColourScheme:
 			format.design === ArticleDesign.FullPageInteractive ||
 			format.design === ArticleDesign.Interactive,

--- a/dotcom-rendering/src/types/config.ts
+++ b/dotcom-rendering/src/types/config.ts
@@ -15,6 +15,7 @@ export interface CommercialConfigType {
 	contentType: string;
 	ampIframeUrl: string;
 	hasLiveBlogTopAd?: boolean;
+	hasSurveyAd?: boolean;
 }
 
 /**


### PR DESCRIPTION
Frontend PR: https://github.com/guardian/frontend/pull/27472

## What does this change?

This renders the survey ad slot conditionally based on a new article schema property

## Why?

The survey slot is rarely used but is currently rendered 100% of the time unless manually switched off. These changes enable us to render it only when a survey campaign is actually running.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
