### PR TITLE
Remove `ArticleDesign.Picture` from `isMediaCard`

### DIFF
--- a/dotcom-rendering/src/lib/cardHelpers.test.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.test.ts
@@ -14,9 +14,9 @@ describe('cardHasDarkBackground', () => {
 		theme: Pillar.News,
 	};
 
-	const photoEssayFormat = {
+	const pictureFormat = {
 		...standardArticleFormat,
-		design: ArticleDesign.PhotoEssay,
+		design: ArticleDesign.Picture,
 	};
 
 	const galleryFormat = {
@@ -26,7 +26,7 @@ describe('cardHasDarkBackground', () => {
 
 	const testCases = [
 		{
-			format: photoEssayFormat,
+			format: pictureFormat,
 			containerPalette: undefined,
 			expectedResult: false,
 		},
@@ -36,7 +36,7 @@ describe('cardHasDarkBackground', () => {
 			expectedResult: true,
 		},
 		{
-			format: photoEssayFormat,
+			format: pictureFormat,
 			containerPalette: 'Branded',
 			expectedResult: false,
 		},
@@ -46,7 +46,7 @@ describe('cardHasDarkBackground', () => {
 			expectedResult: false,
 		},
 		{
-			format: photoEssayFormat,
+			format: pictureFormat,
 			containerPalette: 'SombrePalette',
 			expectedResult: true,
 		},

--- a/dotcom-rendering/src/lib/cardHelpers.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.ts
@@ -4,7 +4,6 @@ import type { DCRContainerPalette } from '../types/front';
 export const isMediaCard = (format: ArticleFormat): boolean => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
-		case ArticleDesign.Picture:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video: {
 			return true;


### PR DESCRIPTION
## What does this change?

- Removes `ArticleDesign.Picture` from `isMediaCard`

## Why?

Was a mistake. Picture articles are not represented by media cards

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6789cd89-05eb-4c3e-b747-f43fc23ec3e6
[after]: https://github.com/user-attachments/assets/0c613c8d-67d7-4b5c-a80c-18dc31582196
