### PR TITLE
Adjust the headline height on immersive articles after introduction of new slim nav

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/constants.ts
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/constants.ts
@@ -15,3 +15,5 @@ export const pillarWidthsPx = {
 
 export const smallMobilePageMargin = '10px';
 export const pageMargin = `${space[5]}px`;
+
+export const minHeaderHeightPx = 126;

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -33,9 +33,9 @@ import { Island } from '../components/Island';
 import { LabsHeader } from '../components/LabsHeader';
 import { MainMedia } from '../components/MainMedia';
 import { Masthead } from '../components/Masthead/Masthead';
+import { minHeaderHeightPx } from '../components/Masthead/Titlepiece/constants';
 import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
 import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { minNavHeightPx } from '../components/Nav/Nav';
 import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
@@ -270,11 +270,11 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 	*/
 
 	const labsHeaderHeight = LABS_HEADER_HEIGHT;
-	const combinedHeight = (minNavHeightPx + labsHeaderHeight).toString();
+	const combinedHeight = (minHeaderHeightPx + labsHeaderHeight).toString();
 
 	const navAndLabsHeaderHeight = isLabs
 		? `${combinedHeight}px`
-		: `${minNavHeightPx}px`;
+		: `${minHeaderHeightPx}px`;
 
 	const hasMainMediaStyles = css`
 		height: calc(80vh - ${navAndLabsHeaderHeight});


### PR DESCRIPTION
## What does this change?

- Adjusts the height offset of the headline for immersive articles to reflect the increase in height of the new header
- Moves the definition of the min height out of the old `Nav` component and into the `constants` file within `Masthead`

## Why?

We want to ensure (some of) the headline is above the fold for immersive articles. Previous analysis has shown that engagement in the article is higher when part of the headline is visible on first load.

This PR is a re-implementation of https://github.com/guardian/dotcom-rendering/pull/12232 now that the new header has been launched fully, complete with slim nav (https://github.com/guardian/dotcom-rendering/pull/12332) for use in immersive articles.

## Screenshots

### Immersive News Article
| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

### Immersive Labs Article
| Before      | After      |
| ----------- | ---------- |
| ![before5][] | ![after5][] |
| ![before6][] | ![after6][] |
| ![before7][] | ![after7][] |


[before2]: https://github.com/user-attachments/assets/7203068b-5b95-431e-a1a0-5b5a19a76668
[after2]: https://github.com/user-attachments/assets/933a1ba5-2209-4d63-ad63-e39fe1cde61e
[before3]: https://github.com/user-attachments/assets/fa66e7b9-f041-46f1-bf8c-0527a557c2fe
[after3]: https://github.com/user-attachments/assets/cf19c588-f75e-4102-8882-2883afd9af3a
[before4]: https://github.com/user-attachments/assets/aad704ed-3fe4-41b0-908f-3ca50cbf5158
[after4]: https://github.com/user-attachments/assets/30aea58a-4ac4-4559-b422-6ac50068fafd

[before5]: https://github.com/user-attachments/assets/bbb5c7c6-f138-474e-9109-aca9eeb9332a
[after5]: https://github.com/user-attachments/assets/feb0ec08-6aac-409a-b8e2-9d38d27be649
[before6]: https://github.com/user-attachments/assets/ac330e82-0ff9-471b-bf8c-cd2868a5aaa0
[after6]: https://github.com/user-attachments/assets/9dc24e22-1eec-4aa3-a3c1-1802afdfa5e5
[before7]: https://github.com/user-attachments/assets/ec6c43d7-5330-4cce-8be2-c26598588f9c
[after7]: https://github.com/user-attachments/assets/580d1b1d-1d98-44b0-a9f3-49fd0ece6fa9

