### PR TITLE
Reinstate failing expanded menu tests

### DIFF
--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -247,7 +247,7 @@ test.describe('Interactivity', () => {
 			});
 
 			/* TODO - @guardian/fairground-web-devs This is a bug with the new expanded menu */
-			test.skip('should transfer focus to sub menu items when tabbing from section header', async ({
+			test('should transfer focus to sub menu items when tabbing from section header', async ({
 				context,
 				page,
 			}) => {
@@ -269,7 +269,7 @@ test.describe('Interactivity', () => {
 			});
 
 			/* TODO - @guardian/fairground-web-devs This is a bug with the new expanded menu */
-			test.skip('should let reader traverse section titles using keyboard', async ({
+			test('should let reader traverse section titles using keyboard', async ({
 				context,
 				page,
 			}) => {

--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -164,7 +164,7 @@ test.describe('Interactivity', () => {
 
 	test.describe('Navigating the pillar menu', () => {
 		/* TODO - @guardian/fairground-web-devs This is a bug with the new expanded menu */
-		test.skip('should expand and close the desktop pillar menu when the VeggieBurger is clicked', async ({
+		test('should expand and close the desktop pillar menu when the VeggieBurger is clicked', async ({
 			context,
 			page,
 		}) => {

--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -232,8 +232,7 @@ test.describe('Interactivity', () => {
 				).toBeFocused();
 			});
 
-			/* TODO - @guardian/fairground-web-devs This is a bug with the new expanded menu */
-			test.skip('should immediately focus on the News menu item when the menu first opens', async ({
+			test('should immediately focus on the News menu item when the menu first opens', async ({
 				context,
 				page,
 			}) => {

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/constants.ts
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/constants.ts
@@ -4,6 +4,7 @@ export const navInputCheckboxId = 'header-nav-input-checkbox';
 export const veggieBurgerId = 'header-veggie-burger';
 export const expandedMenuRootId = 'header-expanded-menu-root';
 export const expandedMenuId = 'header-expanded-menu';
+export const handleMenuClickID = 'header-nav-input-checkbox';
 
 export const pillarLeftMarginPx = 6;
 

--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -15,6 +15,7 @@ import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import {
 	expandedMenuRootId,
+	handleMenuClickID,
 	navInputCheckboxId,
 	pageMargin,
 	smallMobilePageMargin,
@@ -388,6 +389,7 @@ export const Titlepiece = ({
 			<script
 				dangerouslySetInnerHTML={{
 					__html: `document.addEventListener('DOMContentLoaded', function () {
+					console.log("running script")
 
 					/** The checkbox input element used to toggle the navigation menu. */
 					const navInputCheckbox = document.getElementById('${navInputCheckboxId}');
@@ -405,11 +407,14 @@ export const Titlepiece = ({
 
 					/** The label for the first column in the menu, assumed to be "News".*/
 					const firstColLabel = document.getElementById('News-button');
+					console.log("first col label", firstColLabel)
 
 					/** The link element in the second list item under news links. */
 					const firstColLink = document.querySelector(
 						'#newsLinks > li:nth-of-type(2) > a',
 					);
+
+					console.log("first col link", firstColLink)
 
 					/**
 					 * Focuses on the first navigation element depending on whether the first column label is visible.
@@ -418,12 +423,18 @@ export const Titlepiece = ({
 					 * Otherwise, it focuses on the first column label.
 					 */
 					const focusOnFirstNavElement = () => {
+					console.log("focusOnFirstNavElement")
+					console.log("window.getComputedStyle(firstColLabel).display", window.getComputedStyle(firstColLabel).display)
 						if (window.getComputedStyle(firstColLabel).display === 'none') {
+						console.log("firstCollink if display none", firstColLink)
 							firstColLink.focus();
 						} else {
+						 console.log("firstColLabel if display none", firstColLabel)
 							firstColLabel.focus();
 						}
 					};
+
+
 
 					/**
 					 * Updates ARIA attributes and tabindex values based on whether the menu is open or closed.
@@ -462,11 +473,31 @@ export const Titlepiece = ({
 					 *
 					 * - Toggles the menu open/close state when the menu button (veggieBurger) is clicked.
 					 */
+
 						const handleMenuClick = (e) => {
+							console.log("handleMenuClick")
+							console.log("e", e.target)  //e.target.label or soemthin?
+							console.log("e id", e.target.id)
+							console.log("veggieBurger", veggieBurger)
+								const associatedLabel = document.querySelector('label[for=${handleMenuClickID}]');
+
+							console.log("associatedLabel", associatedLabel)
+							if (${handleMenuClickID} === e.target.id) {console.log("thishere")}
+
+							//e.target asks for the input element, not the label
+							// find the label associated with the input element and search for that in menuButtonClicked
+
+
 							const menuButtonClicked = veggieBurger.contains(e.target);
 							const clickInsideMenu = expandedMenu.contains(e.target);
 							const menuIsOpen = navInputCheckbox.checked
+
+							console.log("menuButtonClicked", menuButtonClicked)
+							console.log("clickInsideMenu", clickInsideMenu)
+							console.log("menuIsOpen", menuIsOpen)
+
 							if (menuButtonClicked && !menuIsOpen) {
+							console.log("here")
 						    document.body.classList.toggle('nav-is-open')
 
 							firstColLabel.setAttribute('aria-expanded', 'false')
@@ -475,12 +506,14 @@ export const Titlepiece = ({
                                 $selectableElement.setAttribute('tabindex','-1')
                             })
                           } else if (menuButtonClicked && menuIsOpen) {
+						   console.log("there")
 						    document.body.classList.toggle('nav-is-open')
 							firstColLabel.setAttribute('aria-expanded', 'true')
                             veggieBurger.setAttribute('data-link-name','header : veggie-burger : hide')
                             expandedMenuClickableTags.forEach(function($selectableElement){
                                 $selectableElement.setAttribute('tabindex','0')
                             })
+
                             focusOnFirstNavElement()
 							}
 						};

--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -15,7 +15,6 @@ import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import {
 	expandedMenuRootId,
-	handleMenuClickID,
 	navInputCheckboxId,
 	pageMargin,
 	smallMobilePageMargin,
@@ -389,7 +388,6 @@ export const Titlepiece = ({
 			<script
 				dangerouslySetInnerHTML={{
 					__html: `document.addEventListener('DOMContentLoaded', function () {
-					console.log("running script")
 
 					/** The checkbox input element used to toggle the navigation menu. */
 					const navInputCheckbox = document.getElementById('${navInputCheckboxId}');
@@ -407,14 +405,11 @@ export const Titlepiece = ({
 
 					/** The label for the first column in the menu, assumed to be "News".*/
 					const firstColLabel = document.getElementById('News-button');
-					console.log("first col label", firstColLabel)
 
 					/** The link element in the second list item under news links. */
 					const firstColLink = document.querySelector(
 						'#newsLinks > li:nth-of-type(2) > a',
 					);
-
-					console.log("first col link", firstColLink)
 
 					/**
 					 * Focuses on the first navigation element depending on whether the first column label is visible.
@@ -423,13 +418,9 @@ export const Titlepiece = ({
 					 * Otherwise, it focuses on the first column label.
 					 */
 					const focusOnFirstNavElement = () => {
-					console.log("focusOnFirstNavElement")
-					console.log("window.getComputedStyle(firstColLabel).display", window.getComputedStyle(firstColLabel).display)
 						if (window.getComputedStyle(firstColLabel).display === 'none') {
-						console.log("firstCollink if display none", firstColLink)
 							firstColLink.focus();
 						} else {
-						 console.log("firstColLabel if display none", firstColLabel)
 							firstColLabel.focus();
 						}
 					};
@@ -475,29 +466,11 @@ export const Titlepiece = ({
 					 */
 
 						const handleMenuClick = (e) => {
-							console.log("handleMenuClick")
-							console.log("e", e.target)  //e.target.label or soemthin?
-							console.log("e id", e.target.id)
-							console.log("veggieBurger", veggieBurger)
-								const associatedLabel = document.querySelector('label[for=${handleMenuClickID}]');
-
-							console.log("associatedLabel", associatedLabel)
-							if (${handleMenuClickID} === e.target.id) {console.log("thishere")}
-
-							//e.target asks for the input element, not the label
-							// find the label associated with the input element and search for that in menuButtonClicked
-
-
-							const menuButtonClicked = veggieBurger.contains(e.target);
+							const menuButtonClicked = navInputCheckbox === e.target;
 							const clickInsideMenu = expandedMenu.contains(e.target);
 							const menuIsOpen = navInputCheckbox.checked
 
-							console.log("menuButtonClicked", menuButtonClicked)
-							console.log("clickInsideMenu", clickInsideMenu)
-							console.log("menuIsOpen", menuIsOpen)
-
 							if (menuButtonClicked && !menuIsOpen) {
-							console.log("here")
 						    document.body.classList.toggle('nav-is-open')
 
 							firstColLabel.setAttribute('aria-expanded', 'false')
@@ -506,7 +479,6 @@ export const Titlepiece = ({
                                 $selectableElement.setAttribute('tabindex','-1')
                             })
                           } else if (menuButtonClicked && menuIsOpen) {
-						   console.log("there")
 						    document.body.classList.toggle('nav-is-open')
 							firstColLabel.setAttribute('aria-expanded', 'true')
                             veggieBurger.setAttribute('data-link-name','header : veggie-burger : hide')


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
