### PR TITLE
Set the background colour of unselected choice cards 

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -29,7 +29,7 @@ const supportTierChoiceCardStyles = (selected: boolean) => css`
 	border: ${selected
 		? `2px solid ${palette.brand['500']}`
 		: `1px solid ${palette.neutral[46]}`};
-	background-color: ${selected ? palette.sport[800] : ''};
+	background-color: ${selected ? palette.sport[800] : palette.neutral[100]};
 	border-radius: 10px;
 	padding: ${selected
 		? `${space[4]}px ${space[5]}px ${space[2]}px ${space[5]}px`


### PR DESCRIPTION
## What does this change?
This fixes the background colour of unselected choice cards in epics to white so that they are uncoupled from background colour of the epic itself.  

## Why?
This is in preparation for an AB test on the liveblog epic background colours ready for the US end of year campaign and potential future AB testing of background colours.

## Screenshots
There is no visual difference since they are currently transparent and therefore showing the white background colour of the epic.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
