### PR TITLE
Transparent Background Only On Interactive Articles

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -21,7 +21,6 @@ export const rootStyles = (
 		${paletteDeclarations(format, 'light')}
 		body {
 			color: ${sourcePalette.neutral[7]};
-			background: transparent;
 		}
 		/* Indicate whether UI can adapt https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
 		color-scheme: ${darkModeAvailable ? 'light dark' : 'light'};

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3021,6 +3021,9 @@ const articleBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[0];
 			}
 		}
+		case ArticleDesign.Interactive:
+		case ArticleDesign.FullPageInteractive:
+			return 'transparent';
 		default:
 			switch (theme) {
 				case ArticleSpecial.SpecialReport:
@@ -3030,12 +3033,12 @@ const articleBackgroundLight: PaletteFunction = ({
 				case ArticleSpecial.Labs:
 					switch (display) {
 						case ArticleDisplay.Immersive:
-							return 'transparent';
+							return sourcePalette.neutral[100];
 						default:
 							return sourcePalette.neutral[97];
 					}
 				default:
-					return 'transparent';
+					return sourcePalette.neutral[100];
 			}
 	}
 };

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4253,7 +4253,7 @@ const linkKickerTextDark: PaletteFunction = ({ theme }) => {
 const ageWarningWrapperBackground: PaletteFunction = (format) => {
 	switch (format.design) {
 		case ArticleDesign.Interview:
-			return articleBackgroundLight(format);
+			return 'transparent';
 		default:
 			return headlineBackgroundLight(format);
 	}


### PR DESCRIPTION
A transparent background was set on the body element to support interactives. However, it means that on the iOS app the background appears grey across most articles, not just interactives.

This change removes the rule setting a background colour on the body. It instead sets a background on the article: neutral.100 for most articles, whilst keeping 'transparent' for interactives only.

## Screenshots

| Before | After |
|--------|--------|
| ![background-before] | ![background-after] | 

[background-after]: https://github.com/user-attachments/assets/ded62044-d973-4abb-98a9-6562c23faf75
[background-before]: https://github.com/user-attachments/assets/0929c7cb-6ecc-4b60-8633-f27ede60f016
