### PR TITLE
Immersive headline font-weight 

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticleSpecial,
-	Pillar,
-} from '@guardian/libs';
+import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,


### PR DESCRIPTION
## What does this change?
Immersives should follow the same font-weight as other article display types but maintain the larger font-size.
## Why?
Requested by design
## Screenshots

| Before News Pillar      | After News Pillar      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5987a812-10e4-4f3a-89f4-1fc504e95dd1
[after]: https://github.com/user-attachments/assets/02b5a939-25a9-4f9d-9bb6-4da8d79ea0c4

| Before Arts Pillar      | After Arts Pillar      |
| ----------- | ---------- |
| ![beforea][] | ![aftera][] |

[beforea]: https://github.com/user-attachments/assets/c11d45bf-6004-4a94-a8c6-43b8135bdc9f
[aftera]: https://github.com/user-attachments/assets/c1f7e6ae-419f-48fb-890a-93f92594b257

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
