### PR TITLE
Use source headlineMedium64 in boostedFontStyles

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -11,6 +11,7 @@ import {
 	headlineMedium34,
 	headlineMedium42,
 	headlineMedium50,
+	headlineMedium64,
 	space,
 	textSans12,
 	textSans15,
@@ -52,11 +53,7 @@ const boostedFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 		// we don't have a ginormous size in designs. For now this defaults to huge.
 		case 'ginormous':
 		case 'huge':
-			// this needs to be updated to font size 64 once this is available in source.
-			return `
-				${headlineMedium50}
-				font-size: 64px;
-			`;
+			return `${headlineMedium64}`;
 
 		case 'large':
 			return `${headlineMedium50}`;


### PR DESCRIPTION
## What does this change?

Tiny change that uses the newly available source style. Looks the same as before as we were manually setting the font-size to 64px.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/214b9884-ccbd-42a5-b562-f645b29b72d5
[after]: https://github.com/user-attachments/assets/bd5e8cf9-f87d-4061-b9d4-47a9134596df

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
