### PR TITLE
Remove `decidePalette` from `CricketScoreboard`

### DIFF
--- a/dotcom-rendering/src/components/CricketScoreboard.stories.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.stories.tsx
@@ -1,4 +1,3 @@
-import { ArticleDesign, ArticleDisplay, Pillar } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { match } from '../../fixtures/manual/cricket-scoreboard';
@@ -19,11 +18,6 @@ type Story = StoryObj<typeof CricketScoreboard>;
 export const defaultStory: Story = {
 	name: 'Cricket Scoreboard',
 	args: {
-		format: {
-			display: ArticleDisplay.Standard,
-			design: ArticleDesign.LiveBlog,
-			theme: Pillar.Sport,
-		},
 		match,
 		scorecardUrl: '/test',
 	},

--- a/dotcom-rendering/src/components/CricketScoreboard.tsx
+++ b/dotcom-rendering/src/components/CricketScoreboard.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	between,
 	space,
 	textSans14,
 	until,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
-import type { Palette } from '../types/palette';
+import { palette } from '../palette';
 import type { CricketInnings, CricketMatch } from '../types/sport';
 import { DateTime } from './DateTime';
 
@@ -16,7 +14,6 @@ const ALL_OUT_WICKETS = 10;
 type Props = {
 	scorecardUrl: string;
 	match: CricketMatch;
-	format: ArticleFormat;
 };
 
 const screenReaderOnlyStyle = css`
@@ -44,17 +41,17 @@ const tableStyle = css`
 	${textSans14}
 `;
 
-const captionStyle = (palette: Palette) => css`
+const captionStyle = css`
 	text-align: left;
 	font-weight: bold;
-	border-top: 1px solid ${palette.border.cricketScoreboardTop};
+	border-top: 1px solid ${palette('--cricket-scoreboard-border-top')};
 	border-collapse: inherit;
 	padding-top: ${space[2]}px;
 	padding-bottom: ${space[2]}px;
 `;
 
-const rowStyle = (palette: Palette) => css`
-	border-top: 1px solid ${palette.border.cricketScoreboardDivider};
+const rowStyle = css`
+	border-top: 1px solid ${palette('--cricket-scoreboard-divider')};
 `;
 
 const cellStyle = css`
@@ -71,12 +68,12 @@ const linkPaddingStlye = css`
 	padding-bottom: ${space[2]}px;
 `;
 
-const linkStyle = (palette: Palette) => css`
-	color: ${palette.text.cricketScoreboardLink};
+const linkStyle = css`
+	color: ${palette('--cricket-scoreboard-link-text')};
 	text-decoration: none;
 
 	:hover {
-		color: ${palette.text.cricketScoreboardLink};
+		color: ${palette('--cricket-scoreboard-link-text')};
 		text-decoration: underline;
 	}
 `;
@@ -136,8 +133,7 @@ export const CricketInningsScores = ({
 	return <p>Yet to bat</p>;
 };
 
-export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
-	const palette = decidePalette(format);
+export const CricketScoreboard = ({ scorecardUrl, match }: Props) => {
 	const date = new Date(match.gameDate);
 	return (
 		<div css={containerStyle}>
@@ -159,7 +155,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 				</thead>
 				<tbody>
 					{/* Home team */}
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={[cellStyle, boldStlye]}>
 							{match.teams.find((team) => !!team.home)?.name}
 						</td>
@@ -168,7 +164,7 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 						</td>
 					</tr>
 					{/* Away team */}
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={[cellStyle, boldStlye]}>
 							{match.teams.find((team) => !team.home)?.name}
 						</td>
@@ -177,13 +173,13 @@ export const CricketScoreboard = ({ scorecardUrl, match, format }: Props) => {
 						</td>
 					</tr>
 				</tbody>
-				<caption css={captionStyle(palette)}>
+				<caption css={captionStyle}>
 					{match.competitionName}, {match.venueName}
 				</caption>
 				<tfoot>
-					<tr css={rowStyle(palette)}>
+					<tr css={rowStyle}>
 						<td css={linkPaddingStlye} colSpan={2}>
-							<a css={linkStyle(palette)} href={scorecardUrl}>
+							<a css={linkStyle} href={scorecardUrl}>
 								View full scorecard
 							</a>
 						</td>

--- a/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
+++ b/dotcom-rendering/src/components/GetCricketScoreboard.importable.tsx
@@ -38,7 +38,6 @@ export const GetCricketScoreboard = ({ matchUrl, format }: Props) => {
 			<CricketScoreboard
 				match={data.match}
 				scorecardUrl={data.scorecardUrl}
-				format={format}
 			/>
 		);
 	}

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -93,10 +93,6 @@ const textStandfirstLink = (format: ArticleFormat): string => {
 	}
 };
 
-const textCricketScoreboardLink = (): string => {
-	return sport[300];
-};
-
 const backgroundBullet = (format: ArticleFormat): string => {
 	if (format.theme === ArticleSpecial.Labs) return BLACK;
 	if (format.theme === ArticleSpecial.SpecialReport) {
@@ -355,14 +351,6 @@ const borderLines = (format: ArticleFormat): string => {
 	return neutral[86];
 };
 
-const borderCricketScoreboardTop = (): string => {
-	return sport[300];
-};
-
-const borderCricketScoreboardDivider = (): string => {
-	return neutral[86];
-};
-
 const borderFilterButton = (): string => neutral[60];
 
 const backgroundAnalysisContrastColour = (): string => '#F2E8E6';
@@ -460,7 +448,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			standfirst: textStandfirst(format),
 			standfirstLink: textStandfirstLink(format),
 			disclaimerLink: textDisclaimerLink(format),
-			cricketScoreboardLink: textCricketScoreboardLink(),
 			filterButton: textFilterButton(),
 			filterButtonHover: textFilterButtonHover(),
 			filterButtonActive: textFilterButtonActive(),
@@ -490,8 +477,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			headline: borderHeadline(format),
 			navPillar: borderNavPillar(format),
 			lines: borderLines(format),
-			cricketScoreboardTop: borderCricketScoreboardTop(),
-			cricketScoreboardDivider: borderCricketScoreboardDivider(),
 			cardSupporting: borderCardSupporting(format),
 			filterButton: borderFilterButton(),
 		},

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5572,15 +5572,15 @@ const designTagBackground: PaletteFunction = ({ theme }) => {
 	}
 };
 
-const cricketScoreboardBorderTop = () => {
+const cricketScoreboardBorderTop: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 
-const cricketScoreboardDivider = () => {
+const cricketScoreboardDivider: PaletteFunction = () => {
 	return sourcePalette.neutral[86];
 };
 
-const cricketScoreboardLinkText = () => {
+const cricketScoreboardLinkText: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5572,6 +5572,18 @@ const designTagBackground: PaletteFunction = ({ theme }) => {
 	}
 };
 
+const cricketScoreboardBorderTop = () => {
+	return sourcePalette.sport[300];
+};
+
+const cricketScoreboardDivider = () => {
+	return sourcePalette.neutral[86];
+};
+
+const cricketScoreboardLinkText = () => {
+	return sourcePalette.sport[300];
+};
+
 // ----- Palette ----- //
 
 /**
@@ -5980,6 +5992,18 @@ const paletteColours = {
 	'--comment-form-input-background': {
 		light: commentFormInputBackgroundLight,
 		dark: commentFormInputBackgroundDark,
+	},
+	'--cricket-scoreboard-border-top': {
+		light: cricketScoreboardBorderTop,
+		dark: cricketScoreboardBorderTop,
+	},
+	'--cricket-scoreboard-divider': {
+		light: cricketScoreboardDivider,
+		dark: cricketScoreboardDivider,
+	},
+	'--cricket-scoreboard-link-text': {
+		light: cricketScoreboardLinkText,
+		dark: cricketScoreboardLinkText,
 	},
 	'--dateline': {
 		light: datelineLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -6,7 +6,6 @@ export type Palette = {
 		standfirst: Colour;
 		standfirstLink: Colour;
 		disclaimerLink: Colour;
-		cricketScoreboardLink: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
@@ -36,8 +35,6 @@ export type Palette = {
 		headline: Colour;
 		navPillar: Colour;
 		lines: Colour;
-		cricketScoreboardTop: Colour;
-		cricketScoreboardDivider: Colour;
 		cardSupporting: Colour;
 		filterButton: Colour;
 	};


### PR DESCRIPTION
## What does this change?

Updates `CricketScoreboard` component to remove use of `decidePalette` and migrate to the [`palette` module](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/palette.ts)

## Why?

This is part of a larger body of work to deprecate and remove `decidePalette`