### PR TITLE
Remove `decidePalette` from `ImageComponent` and `LightboxCaption`

### DIFF
--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -14,7 +14,6 @@ import {
 	palette as srcPalette,
 	until,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
 import { getLargest, getMaster } from '../lib/image';
 import { palette as themePalette } from '../palette';
 import type {
@@ -22,7 +21,6 @@ import type {
 	StarRating as Rating,
 	RoleType,
 } from '../types/content';
-import type { Palette } from '../types/palette';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
 import { useConfig } from './ConfigContext';
@@ -144,7 +142,7 @@ const immersiveTitleWrapper = css`
 		${headlineLight34};
 	}
 `;
-const titleWrapper = (palette: Palette) => css`
+const titleWrapper = css`
 	position: absolute;
 	bottom: 0;
 	width: 100%;
@@ -163,7 +161,7 @@ const titleWrapper = (palette: Palette) => css`
 	background: linear-gradient(transparent, ${srcPalette.neutral[0]});
 
 	:before {
-		background-color: ${palette.background.imageTitle};
+		background-color: ${themePalette('--image-title-background')};
 		display: block;
 		content: '';
 		width: 8.75rem;
@@ -178,31 +176,19 @@ const titleWrapper = (palette: Palette) => css`
 	}
 `;
 
-const ImageTitle = ({
-	title,
-	role,
-	palette,
-}: {
-	title: string;
-	role: RoleType;
-	palette: Palette;
-}) => {
+const ImageTitle = ({ title, role }: { title: string; role: RoleType }) => {
 	switch (role) {
 		case 'inline':
 		case 'thumbnail':
 		case 'halfWidth':
 		case 'supporting':
-			return (
-				<h2 css={[titleWrapper(palette), basicTitlePadding]}>
-					{title}
-				</h2>
-			);
+			return <h2 css={[titleWrapper, basicTitlePadding]}>{title}</h2>;
 		case 'showcase':
 		case 'immersive':
 			return (
 				<h2
 					css={[
-						titleWrapper(palette),
+						titleWrapper,
 						immersiveTitleWrapper,
 						moreTitlePadding,
 					]}
@@ -318,8 +304,6 @@ export const ImageComponent = ({
 	const imageWidth = parseInt(image.fields.width, 10);
 	const imageHeight = parseInt(image.fields.height, 10);
 
-	const palette = decidePalette(format);
-
 	const loading = isMainMedia ? 'eager' : 'lazy';
 
 	if (
@@ -382,9 +366,7 @@ export const ImageComponent = ({
 					/>
 				)}
 
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink
 						role={role}
@@ -450,9 +432,7 @@ export const ImageComponent = ({
 				{!isUndefined(starRating) ? (
 					<PositionStarRating rating={starRating} />
 				) : null}
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink
 						role={role}
@@ -556,9 +536,7 @@ export const ImageComponent = ({
 				{!isUndefined(starRating) ? (
 					<PositionStarRating rating={starRating} />
 				) : null}
-				{!!title && (
-					<ImageTitle title={title} role={role} palette={palette} />
-				)}
+				{!!title && <ImageTitle title={title} role={role} />}
 
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink

--- a/dotcom-rendering/src/components/Lightbox.stories.tsx
+++ b/dotcom-rendering/src/components/Lightbox.stories.tsx
@@ -6,9 +6,43 @@ import {
 	storage,
 } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useEffect } from 'react';
 import type { ImageForLightbox } from '../types/content';
 import { LightboxLayout } from './LightboxLayout.importable';
+
+const Initialise = ({ children }: { children: React.ReactNode }) => {
+	useEffect(() => {
+		const lightbox =
+			document.querySelector<HTMLDialogElement>('#gu-lightbox');
+		lightbox?.removeAttribute('hidden');
+		storage.local.clear();
+	}, []);
+
+	return <div style={{ height: '100vh' }}>{children}</div>;
+};
+
+const meta = {
+	title: 'Components/LightboxLayout',
+	component: LightboxLayout,
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.desktop],
+		},
+		viewport: {
+			disable: true,
+		},
+	},
+	decorators: (Story) => (
+		<Initialise>
+			<Story />
+		</Initialise>
+	),
+} satisfies Meta<typeof LightboxLayout>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 const testImage: ImageForLightbox = {
 	position: 1,
@@ -24,274 +58,210 @@ const testImage: ImageForLightbox = {
 	displayCredit: false,
 };
 
-export default {
-	component: LightboxLayout,
-	title: 'Components/LightboxLayout',
-	parameters: {
-		chromatic: {
-			viewports: [breakpoints.mobile, breakpoints.desktop],
+export const Default = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
 		},
-		viewport: {
-			// This has the effect of turning off the viewports addon by default
-			defaultViewport: 'doesNotExist',
-		},
+		images: [{ ...testImage }],
 	},
-};
+} satisfies Story;
 
-const Initialise = ({ children }: { children: React.ReactNode }) => {
-	useEffect(() => {
-		const lightbox =
-			document.querySelector<HTMLDialogElement>('#gu-lightbox');
-		lightbox?.removeAttribute('hidden');
-		storage.local.clear();
-	}, []);
-
-	return <div style={{ height: '100vh' }}>{children}</div>;
-};
-
-export const Default = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	};
-	const images = [{ ...testImage }];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
-
-export const WithTitle = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	};
-	const images = [{ ...testImage, title: 'Title' }];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
-
-export const WithCredit = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	};
-	const images = [{ ...testImage, displayCredit: true }];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
-
-export const WithRating = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	};
-	const images = [{ ...testImage, starRating: 3 }];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
-
-export const WhenLiveBlog = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.LiveBlog,
-		theme: Pillar.News,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
-			firstPublished: 1643816168535,
-			blockId: 'mockId',
+export const WithTitle = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [{ ...testImage, title: 'Title' }],
+	},
+} satisfies Story;
 
-export const WithEverything = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.News,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithCredit = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [{ ...testImage, displayCredit: true }],
+	},
+} satisfies Story;
 
-export const WithSport = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.Sport,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithRating = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [{ ...testImage, starRating: 3 }],
+	},
+} satisfies Story;
 
-export const WithCulture = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.Culture,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WhenLiveBlog = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.LiveBlog,
+			theme: Pillar.News,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+				firstPublished: 1643816168535,
+				blockId: 'mockId',
+			},
+		],
+	},
+} satisfies Story;
 
-export const WithLifestyle = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.Lifestyle,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithEverything = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
 
-export const WithOpinion = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: Pillar.Opinion,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithSport = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Sport,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
 
-export const WithSpecialReport = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReport,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithCulture = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Culture,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
 
-export const WithSpecialReportAlt = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReportAlt,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithLifestyle = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Lifestyle,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
 
-export const WithLabs = () => {
-	const format = {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.Labs,
-	};
-	const images = [
-		{
-			...testImage,
-			starRating: 3,
-			title: 'Title',
-			displayCredit: true,
+export const WithOpinion = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Opinion,
 		},
-	];
-	return (
-		<Initialise>
-			<LightboxLayout format={format} images={images} />
-		</Initialise>
-	);
-};
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
+
+export const WithSpecialReport = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReport,
+		},
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
+
+export const WithSpecialReportAlt = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.SpecialReportAlt,
+		},
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;
+
+export const WithLabs = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: ArticleSpecial.Labs,
+		},
+		images: [
+			{
+				...testImage,
+				starRating: 3,
+				title: 'Title',
+				displayCredit: true,
+			},
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/LightboxCaption.tsx
+++ b/dotcom-rendering/src/components/LightboxCaption.tsx
@@ -1,27 +1,22 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	space,
 	palette as srcPalette,
 	textSans14,
 } from '@guardian/source/foundations';
-import { decidePalette } from '../lib/decidePalette';
+import { palette } from '../palette';
 
 type Props = {
 	captionText?: string;
-	format: ArticleFormat;
 	credit?: string;
 	displayCredit?: boolean;
 };
 
 export const LightboxCaption = ({
 	captionText,
-	format,
 	credit,
 	displayCredit,
 }: Props) => {
-	const palette = decidePalette(format);
-
 	return (
 		<figcaption
 			css={css`
@@ -30,7 +25,7 @@ export const LightboxCaption = ({
 				overflow-wrap: break-all;
 				padding-top: ${space[2]}px;
 				padding-bottom: ${space[2]}px;
-				border-top: 3px solid ${palette.background.lightboxDivider};
+				border-top: 3px solid ${palette('--lightbox-divider')};
 			`}
 		>
 			{!!captionText && (

--- a/dotcom-rendering/src/components/LightboxImages.tsx
+++ b/dotcom-rendering/src/components/LightboxImages.tsx
@@ -270,7 +270,6 @@ export const LightboxImages = ({ format, images }: Props) => {
 								</Hide>
 								<LightboxCaption
 									captionText={image.caption}
-									format={format}
 									credit={image.credit}
 									displayCredit={image.displayCredit}
 								/>

--- a/dotcom-rendering/src/lib/decidePalette.ts
+++ b/dotcom-rendering/src/lib/decidePalette.ts
@@ -134,20 +134,6 @@ const backgroundBulletStandfirst = (format: ArticleFormat): string => {
 	return neutral[86]; // default previously defined in Standfirst.tsx
 };
 
-const backgroundImageTitle = (format: ArticleFormat): string => {
-	if (format.design === ArticleDesign.Analysis) {
-		switch (format.theme) {
-			case Pillar.News:
-				return news[300];
-			default:
-				return pillarPalette[format.theme].main;
-		}
-	}
-	return pillarPalette[format.theme].main;
-};
-
-const backgroundLightboxDivider = backgroundImageTitle;
-
 const backgroundSpeechBubble = (format: ArticleFormat): string => {
 	if (format.design === ArticleDesign.Analysis) {
 		switch (format.theme) {
@@ -449,8 +435,6 @@ export const decidePalette = (format: ArticleFormat): Palette => {
 			analysisContrastHover: backgroundAnalysisContrastHoverColour(),
 			bullet: backgroundBullet(format),
 			bulletStandfirst: backgroundBulletStandfirst(format),
-			imageTitle: backgroundImageTitle(format),
-			lightboxDivider: backgroundLightboxDivider(format),
 			speechBubble: backgroundSpeechBubble(format),
 			filterButton: backgroundFilterButton(),
 			filterButtonHover: backgroundFilterButtonHover(format),

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5591,6 +5591,34 @@ const cricketScoreboardLinkText: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 
+const imageTitleBackground: PaletteFunction = ({ design, theme }) => {
+	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
+		return sourcePalette.news[300];
+	}
+
+	switch (theme) {
+		case Pillar.News:
+			return sourcePalette.news[400];
+		case Pillar.Opinion:
+			return sourcePalette.opinion[300];
+		case Pillar.Sport:
+			return sourcePalette.sport[400];
+		case Pillar.Culture:
+			return sourcePalette.culture[400];
+		case Pillar.Lifestyle:
+			return sourcePalette.lifestyle[400];
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[400];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.specialReport[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[200];
+	}
+};
+
+const lightboxDivider: PaletteFunction = (format) =>
+	imageTitleBackground(format);
+
 // ----- Palette ----- //
 
 /**
@@ -6268,6 +6296,10 @@ const paletteColours = {
 		light: highlightContainerStartFade,
 		dark: highlightContainerStartFade,
 	},
+	'--image-title-background': {
+		light: imageTitleBackground,
+		dark: imageTitleBackground,
+	},
 	'--interactive-atom-background': {
 		light: interactiveAtomBackgroundLight,
 		dark: interactiveAtomBackgroundDark,
@@ -6335,6 +6367,10 @@ const paletteColours = {
 	'--last-updated-text': {
 		light: lastUpdatedTextLight,
 		dark: lastUpdatedTextDark,
+	},
+	'--lightbox-divider': {
+		light: lightboxDivider,
+		dark: lightboxDivider,
 	},
 	'--link-kicker-text': {
 		light: linkKickerTextLight,

--- a/dotcom-rendering/src/types/palette.ts
+++ b/dotcom-rendering/src/types/palette.ts
@@ -18,13 +18,11 @@ export type Palette = {
 		analysisContrastHover: Colour;
 		bullet: Colour;
 		bulletStandfirst: Colour;
-		imageTitle: Colour;
 		speechBubble: Colour;
 		filterButton: Colour;
 		filterButtonHover: Colour;
 		filterButtonActive: Colour;
 		treat: Colour;
-		lightboxDivider: Colour;
 	};
 	fill: {
 		guardianLogo: Colour;


### PR DESCRIPTION
## What does this change?

Updates `ImageComponent` and `LightboxCaption` components to remove use of `decidePalette` and migrate to the [`palette` module](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/palette.ts)

## Why?

This is part of a larger body of work to deprecate and remove `decidePalette`