### PR TITLE
Refactor epic ctas

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -21,7 +21,7 @@ import type {
 	EpicProps,
 	Stage,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useIsInView } from '../../../lib/useIsInView';
 import { useArticleCountOptOut } from '../hooks/useArticleCountOptOut';
 import type { ReactComponent } from '../lib/ReactComponent';
@@ -37,12 +37,10 @@ import type { OphanTracking } from '../shared/ArticleCountOptOutPopup';
 import { withParsedProps } from '../shared/ModuleWrapper';
 import { BylineWithHeadshot } from './BylineWithHeadshot';
 import { ContributionsEpicArticleCountAboveWithOptOut } from './ContributionsEpicArticleCountAboveWithOptOut';
-import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ContributionsEpicSignInCta } from './ContributionsEpicSignInCta';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
-import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
-import { getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
+import { ContributionsEpicCtasContainer } from './ctas/ContributionsEpicCtasContainer';
 
 // CSS Styling
 // -------------------------------------------
@@ -293,23 +291,6 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	const { image, tickerSettings, choiceCardAmounts, newsletterSignup } =
 		variant;
 
-	const defaultThreeTierAmount = getDefaultThreeTierAmount(countryCode);
-	const [
-		threeTierChoiceCardSelectedAmount,
-		setThreeTierChoiceCardSelectedAmount,
-	] = useState<number>(defaultThreeTierAmount);
-
-	const variantOfChoiceCard =
-		countryCode === 'US'
-			? 'US_THREE_TIER_CHOICE_CARDS'
-			: 'THREE_TIER_CHOICE_CARDS';
-
-	const isNonVatCompliantCountry =
-		variant.choiceCardAmounts?.testName === 'VAT_COMPLIANCE';
-
-	const showChoiceCards =
-		variant.showChoiceCards && !isNonVatCompliantCountry;
-
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();
 
@@ -450,15 +431,6 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 				<BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
 			)}
 
-			{showChoiceCards && (
-				<ThreeTierChoiceCards
-					countryCode={countryCode}
-					selectedAmount={threeTierChoiceCardSelectedAmount}
-					setSelectedAmount={setThreeTierChoiceCardSelectedAmount}
-					variantOfChoiceCard={variantOfChoiceCard}
-				/>
-			)}
-
 			{newsletterSignup ? (
 				<ContributionsEpicNewsletterSignup
 					newsletterId={newsletterSignup.newsletterId}
@@ -466,7 +438,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					tracking={tracking}
 				/>
 			) : (
-				<ContributionsEpicCtas
+				<ContributionsEpicCtasContainer
 					variant={variant}
 					tracking={tracking}
 					countryCode={countryCode}
@@ -474,13 +446,8 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					onReminderOpen={onReminderOpen}
 					fetchEmail={fetchEmail}
 					submitComponentEvent={submitComponentEvent}
-					showChoiceCards={showChoiceCards}
 					amountsTestName={choiceCardAmounts?.testName}
 					amountsVariantName={choiceCardAmounts?.variantName}
-					threeTierChoiceCardSelectedAmount={
-						threeTierChoiceCardSelectedAmount
-					}
-					variantOfChoiceCard={variantOfChoiceCard}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -19,7 +19,7 @@ import type {
 	EpicProps,
 	Tracking,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useIsInView } from '../../../lib/useIsInView';
 import type { ReactComponent } from '../lib/ReactComponent';
 import { replaceArticleCount } from '../lib/replaceArticleCount';
@@ -28,10 +28,8 @@ import {
 	createViewEventFromTracking,
 } from '../lib/tracking';
 import { logEpicView } from '../lib/viewLog';
-import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
-import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
-import { getDefaultThreeTierAmount } from './utils/threeTierChoiceCardAmounts';
+import { ContributionsEpicCtasContainer } from './ctas/ContributionsEpicCtasContainer';
 
 // Hard-coded AB TEST - picking up ab test name and variant name from the tracking object
 // then applying a different colour if it matches, or the default colour if it doesn't.
@@ -156,12 +154,6 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 }: EpicProps): JSX.Element => {
 	const { newsletterSignup } = variant;
 
-	const isNonVatCompliantCountry =
-		variant.choiceCardAmounts?.testName === 'VAT_COMPLIANCE';
-
-	const showChoiceCards =
-		variant.showChoiceCards && !isNonVatCompliantCountry;
-
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
 	});
@@ -198,23 +190,12 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 		replaceNonArticleCountPlaceholders(variant.heading) ||
 		'Support the Guardian';
 
-	const defaultThreeTierAmount = getDefaultThreeTierAmount(countryCode);
-	const [
-		threeTierChoiceCardSelectedAmount,
-		setThreeTierChoiceCardSelectedAmount,
-	] = useState<number>(defaultThreeTierAmount);
-
 	if (
 		cleanParagraphs.some(containsNonArticleCountPlaceholder) ||
 		containsNonArticleCountPlaceholder(cleanHeading)
 	) {
 		return <></>;
 	}
-
-	const variantOfChoiceCard =
-		countryCode === 'US'
-			? 'US_THREE_TIER_CHOICE_CARDS'
-			: 'THREE_TIER_CHOICE_CARDS';
 
 	return (
 		<div data-testid="contributions-liveblog-epic" ref={setNode}>
@@ -235,34 +216,15 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 						tracking={tracking}
 					/>
 				) : (
-					<>
-						{showChoiceCards && (
-							<ThreeTierChoiceCards
-								countryCode={countryCode}
-								selectedAmount={
-									threeTierChoiceCardSelectedAmount
-								}
-								setSelectedAmount={
-									setThreeTierChoiceCardSelectedAmount
-								}
-								variantOfChoiceCard={variantOfChoiceCard}
-							/>
-						)}
-						<ContributionsEpicCtas
-							variant={variant}
-							tracking={tracking}
-							countryCode={countryCode}
-							articleCounts={articleCounts}
-							onReminderOpen={onReminderOpen}
-							fetchEmail={fetchEmail}
-							submitComponentEvent={submitComponentEvent}
-							showChoiceCards={showChoiceCards}
-							threeTierChoiceCardSelectedAmount={
-								threeTierChoiceCardSelectedAmount
-							}
-							variantOfChoiceCard={variantOfChoiceCard}
-						/>
-					</>
+					<ContributionsEpicCtasContainer
+						variant={variant}
+						tracking={tracking}
+						countryCode={countryCode}
+						articleCounts={articleCounts}
+						onReminderOpen={onReminderOpen}
+						fetchEmail={fetchEmail}
+						submitComponentEvent={submitComponentEvent}
+					/>
 				)}
 			</section>
 		</div>

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
@@ -15,19 +15,19 @@ import type {
 	Tracking,
 } from '@guardian/support-dotcom-components/dist/shared/src/types/props/shared';
 import { useEffect } from 'react';
-import { useIsInView } from '../../../lib/useIsInView';
-import { hasSetReminder } from '../lib/reminders';
+import { useIsInView } from '../../../../lib/useIsInView';
+import { hasSetReminder } from '../../lib/reminders';
 import {
 	addChoiceCardsParams,
 	addRegionIdAndTrackingParamsToSupportUrl,
 	isSupportUrl,
-} from '../lib/tracking';
-import { EpicButton } from './EpicButton';
+} from '../../lib/tracking';
 import {
 	getReminderViewEvent,
 	OPHAN_COMPONENT_EVENT_CTAS_VIEW,
 	OPHAN_COMPONENT_EVENT_REMINDER_OPEN,
-} from './utils/ophan';
+} from '../utils/ophan';
+import { EpicButton } from './EpicButton';
 
 const paymentImageStyles = css`
 	display: inline-block;

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicChoiceCards.tsx
@@ -14,10 +14,10 @@ import type {
 	SelectedAmountsVariant,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect } from 'react';
-import { useIsInView } from '../../../lib/useIsInView';
-import { contributionType } from '../lib/choiceCards';
-import type { ChoiceCardSelection } from '../lib/choiceCards';
-import type { ReactComponent } from '../lib/ReactComponent';
+import { useIsInView } from '../../../../lib/useIsInView';
+import { contributionType } from '../../lib/choiceCards';
+import type { ChoiceCardSelection } from '../../lib/choiceCards';
+import type { ReactComponent } from '../../lib/ReactComponent';
 
 // CSS Styling
 // -------------------------------------------

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -1,11 +1,8 @@
-/**
- * @file
- * This file was migrated from:
- * https://github.com/guardian/support-dotcom-components/blob/9c3eae7cb0b159db4a1c40679d6b37710b0bb937/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
- */
 import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/src/types/props/epic';
 import { useState } from 'react';
-import type { ReactComponent } from '../lib/ReactComponent';
+import type { ReactComponent } from '../../lib/ReactComponent';
+import { ThreeTierChoiceCards } from '../ThreeTierChoiceCards';
+import { getDefaultThreeTierAmount } from '../utils/threeTierChoiceCardAmounts';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 
@@ -13,17 +10,12 @@ interface OnReminderOpen {
 	buttonCopyAsString: string;
 }
 
-type ContributionsEpicCtasProps = EpicProps & {
-	showChoiceCards?: boolean;
-	threeTierChoiceCardSelectedAmount?: number;
+type Props = EpicProps & {
 	amountsTestName?: string;
 	amountsVariantName?: string;
-	variantOfChoiceCard?: string;
 };
 
-export const ContributionsEpicCtas: ReactComponent<
-	ContributionsEpicCtasProps
-> = ({
+export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 	variant,
 	countryCode,
 	articleCounts,
@@ -31,12 +23,10 @@ export const ContributionsEpicCtas: ReactComponent<
 	submitComponentEvent,
 	onReminderOpen,
 	fetchEmail,
-	showChoiceCards,
-	threeTierChoiceCardSelectedAmount,
 	amountsTestName,
 	amountsVariantName,
-	variantOfChoiceCard,
-}: ContributionsEpicCtasProps): JSX.Element => {
+}: Props): JSX.Element => {
+	// reminders
 	const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(
 		undefined,
 	);
@@ -46,8 +36,34 @@ export const ContributionsEpicCtas: ReactComponent<
 		setIsReminderActive(false);
 	};
 
+	// choice cards
+	const isNonVatCompliantCountry =
+		variant.choiceCardAmounts?.testName === 'VAT_COMPLIANCE';
+
+	const showChoiceCards =
+		variant.showChoiceCards && !isNonVatCompliantCountry;
+
+	const defaultThreeTierAmount = getDefaultThreeTierAmount(countryCode);
+	const [
+		threeTierChoiceCardSelectedAmount,
+		setThreeTierChoiceCardSelectedAmount,
+	] = useState<number>(defaultThreeTierAmount);
+
+	const variantOfChoiceCard =
+		countryCode === 'US'
+			? 'US_THREE_TIER_CHOICE_CARDS'
+			: 'THREE_TIER_CHOICE_CARDS';
+
 	return (
 		<>
+			{showChoiceCards && (
+				<ThreeTierChoiceCards
+					countryCode={countryCode}
+					selectedAmount={threeTierChoiceCardSelectedAmount}
+					setSelectedAmount={setThreeTierChoiceCardSelectedAmount}
+					variantOfChoiceCard={variantOfChoiceCard}
+				/>
+			)}
 			<ContributionsEpicButtons
 				variant={variant}
 				tracking={tracking}

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminder.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminder.tsx
@@ -5,14 +5,14 @@
  */
 import type { OphanComponentEvent } from '@guardian/libs';
 import type { ReminderFields } from '@guardian/support-dotcom-components/dist/shared/src/lib';
-import { useContributionsReminderSignup } from '../hooks/useContributionsReminderSignup';
-import type { ReactComponent } from '../lib/ReactComponent';
-import { ContributionsEpicReminderSignedIn } from './ContributionsEpicReminderSignedIn';
-import { ContributionsEpicReminderSignedOut } from './ContributionsEpicReminderSignedOut';
+import { useContributionsReminderSignup } from '../../hooks/useContributionsReminderSignup';
+import type { ReactComponent } from '../../lib/ReactComponent';
 import {
 	OPHAN_COMPONENT_EVENT_REMINDER_CLOSE,
 	OPHAN_COMPONENT_EVENT_REMINDER_SET,
-} from './utils/ophan';
+} from '../utils/ophan';
+import { ContributionsEpicReminderSignedIn } from './ContributionsEpicReminderSignedIn';
+import { ContributionsEpicReminderSignedOut } from './ContributionsEpicReminderSignedOut';
 
 // --- Types --- //
 

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedIn.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedIn.tsx
@@ -19,9 +19,9 @@ import {
 	SvgCross,
 } from '@guardian/source/react-components';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
-import { Hide } from '../../Hide';
-import type { ReactComponent } from '../lib/ReactComponent';
-import { ensureHasPreposition, ReminderStatus } from '../lib/reminders';
+import { Hide } from '../../../Hide';
+import type { ReactComponent } from '../../lib/ReactComponent';
+import { ensureHasPreposition, ReminderStatus } from '../../lib/reminders';
 
 // --- Styles --- //
 

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedOut.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedOut.tsx
@@ -21,9 +21,9 @@ import {
 	TextInput,
 } from '@guardian/source/react-components';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
-import { useContributionsReminderEmailForm } from '../hooks/useContributionsReminderEmailForm';
-import type { ReactComponent } from '../lib/ReactComponent';
-import { ensureHasPreposition, ReminderStatus } from '../lib/reminders';
+import { useContributionsReminderEmailForm } from '../../hooks/useContributionsReminderEmailForm';
+import type { ReactComponent } from '../../lib/ReactComponent';
+import { ensureHasPreposition, ReminderStatus } from '../../lib/reminders';
 
 // --- Styles --- //
 

--- a/dotcom-rendering/src/components/marketing/epics/ctas/EpicButton.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/EpicButton.tsx
@@ -14,11 +14,11 @@ import {
 	SvgArrowRightStraight,
 } from '@guardian/source/react-components';
 import React from 'react';
-import type { ReactComponent } from '../lib/ReactComponent';
+import type { ReactComponent } from '../../lib/ReactComponent';
 import {
 	OPHAN_COMPONENT_EVENT_PRIMARY_CTA,
 	OPHAN_COMPONENT_EVENT_SECONDARY_CTA,
-} from './utils/ophan';
+} from '../utils/ophan';
 
 // Custom theme for Button/LinkButton
 // See also `tertiaryButtonOverrides` below.


### PR DESCRIPTION
We have two epic components: the standard epic, and the liveblog epic. Currently we have some duplicated code relating to ctas.

### Before
Each epic component:
- renders `ContributionsEpicCtas`, which renders the primary/secondary ctas + reminders
- renders `ThreeTierChoiceCards`
- is responsible for managing choice cards state

### After
Each epic component renders `ContributionsEpicCtasContainer`.

The `ContributionsEpicCtasContainer` component:
- renders the primary/secondary ctas + reminders
- renders `ThreeTierChoiceCards`
- is responsible for managing choice cards state

I've also moved the various components in this area into a `/ctas` subdirectory.