### PR TITLE
Remove dynamo from supporting content

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -747,7 +747,6 @@ export const Card = ({
 										supportingContent={supportingContent}
 										alignment="vertical"
 										containerPalette={containerPalette}
-										isDynamo={isDynamo}
 									/>
 								</Hide>
 							)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -397,7 +397,6 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
-					isDynamo={isDynamo}
 				/>
 			);
 		}
@@ -407,7 +406,6 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
-					isDynamo={isDynamo}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -14,7 +14,6 @@ type Props = {
 	supportingContent: DCRSupportingContent[];
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
-	isDynamo?: boolean;
 };
 
 const wrapperStyles = css`
@@ -77,7 +76,6 @@ export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
-	isDynamo,
 }: Props) => {
 	return (
 		<ul
@@ -85,7 +83,7 @@ export const SupportingContent = ({
 			css={[
 				wrapperStyles,
 				flexColumn,
-				(isDynamo ?? alignment === 'horizontal') && flexRowFromTablet,
+				alignment === 'horizontal' && flexRowFromTablet,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {


### PR DESCRIPTION
## What does this change?
Removes references to dynamo from supporting content.

## Why?
Dynamo refers to the first card in a dynamic package and is no longer used.

