### PR TITLE
[Fairground 🎡] Remove top align on card footer

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -699,10 +699,6 @@ export const Card = ({
 							{!showCommentFooter && (
 								<CardFooter
 									format={format}
-									topAlign={
-										isFlexibleContainer &&
-										imageSize === 'jumbo'
-									}
 									age={decideAge()}
 									commentCount={<CommentCount />}
 									cardBranding={

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -8,14 +8,10 @@ type Props = {
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	showLivePlayable?: boolean;
-	topAlign?: boolean;
 };
 
-const marginStyles = (topAlign: boolean) => css`
-	margin-top: ${topAlign ? `${space[3]}px` : `auto`};
-`;
-
 const contentStyles = css`
+	margin-top: auto;
 	padding-top: ${space[1]}px;
 	display: flex;
 	justify-content: 'flex-start';
@@ -51,7 +47,6 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	showLivePlayable = false,
-	topAlign = false,
 }: Props) => {
 	if (showLivePlayable) return null;
 
@@ -60,7 +55,7 @@ export const CardFooter = ({
 	}
 
 	return (
-		<footer css={[marginStyles(topAlign), contentStyles]}>
+		<footer css={contentStyles}>
 			{age}
 			{commentCount}
 		</footer>


### PR DESCRIPTION
## What does this change?
Removes the ability to top align the card footer on a card. 

## Why?
This was only required for flexible containers. The design requirements have now changed meaning that all card meta is bottom aligned so we can remove this code.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/66b90ee0-c74c-4486-b7c7-bd752c1b64df
[after]: https://github.com/user-attachments/assets/53ea2c21-6b45-4358-b953-9378a7842be0


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
