### PR TITLE
Update reportError Function to support Custom Tags in window Object

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -12,74 +12,79 @@ type ErrorQueue = Array<{
 	tags?: ReportErrorTags;
 }>;
 
+const injectSentryCreator = () => {
+	// Downloading and initialising Sentry is asynchronous so we need a way
+	// to ensure injection only happens once and to capture any other errors that
+	// might happen while this script is loading
+	let injected = false;
+	const errorQueue: ErrorQueue = [];
+
+	// Function that gets called when an error happens before Sentry is ready
+	const injectSentry = async (
+		error: Error | undefined,
+		feature: string = 'unknown',
+		tags?: { [key: string]: string },
+	) => {
+		const { endPerformanceMeasure } = startPerformanceMeasure(
+			'dotcom',
+			'sentryLoader',
+			'inject',
+		);
+		// Remember this error for later
+		if (error) errorQueue.push({ error, feature, tags });
+
+		// Only inject once
+		if (injected) {
+			return;
+		}
+		injected = true;
+
+		// Make this call blocking. We are queing errors while we wait for this code to run
+		// so we won't miss any and by waiting here we ensure we will never make calls we
+		// expect to be blocked
+		// Ad blocker detection can be expensive so it is checked here rather than in init
+		// to avoid blocking of the init flow
+		const adBlockInUse: boolean = await isAdBlockInUse();
+		if (adBlockInUse) {
+			// Ad Blockers prevent calls to Sentry from working so don't try to load the lib
+			return;
+		}
+
+		// Load sentry.ts
+		const { reportError } = await import(
+			/* webpackChunkName: "lazy" */
+			/* webpackChunkName: "sentry" */ './sentry'
+		);
+
+		// Sentry takes over control of the window.onerror and
+		// window.onunhandledrejection listeners but we need to
+		// manually redefine our own custom error reporting function
+		window.guardian.modules.sentry.reportError = reportError;
+
+		// Now that we have the real reportError function available,
+		// send any queued errors
+		while (errorQueue.length) {
+			const queuedError = errorQueue.shift();
+			if (queuedError) {
+				reportError(
+					queuedError.error,
+					queuedError.feature,
+					queuedError.tags,
+				);
+			}
+		}
+		log('dotcom', `Injected Sentry in ${endPerformanceMeasure()}ms`);
+	};
+	return injectSentry;
+};
+
 /**
  * Set up error handlers to inject and call Sentry.
  * If no error happen, Sentry is not loaded.
  */
 const loadSentryOnError = (): void => {
 	try {
-		// Downloading and initialising Sentry is asynchronous so we need a way
-		// to ensure injection only happens once and to capture any other errors that
-		// might happen while this script is loading
-		let injected = false;
-		const errorQueue: ErrorQueue = [];
-
-		// Function that gets called when an error happens before Sentry is ready
-		const injectSentry = async (
-			error: Error | undefined,
-			feature: string = 'unknown',
-			tags?: { [key: string]: string },
-		) => {
-			const { endPerformanceMeasure } = startPerformanceMeasure(
-				'dotcom',
-				'sentryLoader',
-				'inject',
-			);
-			// Remember this error for later
-			if (error) errorQueue.push({ error, feature, tags });
-
-			// Only inject once
-			if (injected) {
-				return;
-			}
-			injected = true;
-
-			// Make this call blocking. We are queing errors while we wait for this code to run
-			// so we won't miss any and by waiting here we ensure we will never make calls we
-			// expect to be blocked
-			// Ad blocker detection can be expensive so it is checked here rather than in init
-			// to avoid blocking of the init flow
-			const adBlockInUse: boolean = await isAdBlockInUse();
-			if (adBlockInUse) {
-				// Ad Blockers prevent calls to Sentry from working so don't try to load the lib
-				return;
-			}
-
-			// Load sentry.ts
-			const { reportError } = await import(
-				/* webpackChunkName: "lazy" */
-				/* webpackChunkName: "sentry" */ './sentry'
-			);
-
-			// Sentry takes over control of the window.onerror and
-			// window.onunhandledrejection listeners but we need to
-			// manually redefine our own custom error reporting function
-			window.guardian.modules.sentry.reportError = reportError;
-
-			// Now that we have the real reportError function available,
-			// send any queued errors
-			while (errorQueue.length) {
-				const queuedError = errorQueue.shift();
-				if (queuedError) {
-					reportError(
-						queuedError.error,
-						queuedError.feature,
-						queuedError.tags,
-					);
-				}
-			}
-			log('dotcom', `Injected Sentry in ${endPerformanceMeasure()}ms`);
-		};
+		const injectSentry = injectSentryCreator();
 
 		// This is how we lazy load Sentry. We setup custom functions and
 		// listeners to inject Sentry when an error happens

--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -1,11 +1,12 @@
 import { isAdBlockInUse } from '@guardian/commercial';
 import { log, startPerformanceMeasure } from '@guardian/libs';
 import '../webpackPublicPath';
-import type { ReportError } from './sentry';
 
+type ReportError = typeof window.guardian.modules.sentry.reportError;
 type ReportErrorError = Parameters<ReportError>[0];
 type ReportErrorFeature = Parameters<ReportError>[1];
 type ReportErrorTags = Parameters<ReportError>[2];
+
 type ErrorQueue = Array<{
 	error: ReportErrorError;
 	feature: ReportErrorFeature;
@@ -25,9 +26,9 @@ const loadSentryCreator = () => {
 	 * Function that gets called when an error happens before Sentry is ready
 	 */
 	const loadSentry = async (
-		error: Error | undefined,
-		feature: string = 'unknown',
-		tags?: { [key: string]: string },
+		error: ReportErrorError | undefined,
+		feature: ReportErrorFeature = 'unknown',
+		tags?: ReportErrorTags,
 	) => {
 		const { endPerformanceMeasure } = startPerformanceMeasure(
 			'dotcom',

--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -25,6 +25,7 @@ const loadSentryOnError = (): void => {
 		const injectSentry = async (
 			error: Error | undefined,
 			feature: string,
+			tags?: { [key: string]: string },
 		) => {
 			const { endPerformanceMeasure } = startPerformanceMeasure(
 				'dotcom',
@@ -80,8 +81,8 @@ const loadSentryOnError = (): void => {
 		) =>
 			event?.reason instanceof Error &&
 			injectSentry(event.reason, 'unknown');
-		window.guardian.modules.sentry.reportError = (error, feature) => {
-			injectSentry(error, feature).catch((e) =>
+		window.guardian.modules.sentry.reportError = (error, feature, tags) => {
+			injectSentry(error, feature, tags).catch((e) =>
 				console.error(`injectSentry - error: ${String(e)}`),
 			);
 		};

--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -1,8 +1,8 @@
 import { isAdBlockInUse } from '@guardian/commercial';
 import { log, startPerformanceMeasure } from '@guardian/libs';
 import '../webpackPublicPath';
+import type { ReportError } from '../../types/sentry';
 
-type ReportError = typeof window.guardian.modules.sentry.reportError;
 type ReportErrorError = Parameters<ReportError>[0];
 type ReportErrorFeature = Parameters<ReportError>[1];
 type ReportErrorTags = Parameters<ReportError>[2];

--- a/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/loadSentry.ts
@@ -3,13 +3,6 @@ import { log, startPerformanceMeasure } from '@guardian/libs';
 import '../webpackPublicPath';
 import type { ReportError } from './sentry';
 
-/** Sentry errors are only sent to the console */
-const stubSentry = (): void => {
-	window.guardian.modules.sentry.reportError = (error) => {
-		console.error(error);
-	};
-};
-
 type ReportErrorError = Parameters<ReportError>[0];
 type ReportErrorFeature = Parameters<ReportError>[1];
 type ReportErrorTags = Parameters<ReportError>[2];
@@ -106,4 +99,4 @@ const loadSentryOnError = (): void => {
 	}
 };
 
-export { loadSentryOnError, stubSentry };
+export { loadSentryOnError };

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -55,13 +55,15 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export const reportError = (
+export type ReportError = (
 	error: Error,
 	feature: string,
 	tags?: {
 		[key: string]: string;
 	},
-): void => {
+) => void;
+
+export const reportError: ReportError = (error, feature, tags) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 import type { BrowserOptions } from '@sentry/browser';
 import { CaptureConsole } from '@sentry/integrations';
 import { BUILD_VARIANT, dcrJavascriptBundle } from '../../../webpack/bundles';
+import type { ReportError } from '../../types/sentry';
 
 const allowUrls: BrowserOptions['allowUrls'] = [
 	/webpack-internal/,
@@ -55,11 +56,7 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export const reportError: typeof window.guardian.modules.sentry.reportError = (
-	error,
-	feature,
-	tags,
-) => {
+export const reportError: ReportError = (error, feature, tags) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -55,15 +55,11 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export type ReportError = (
-	error: Error,
-	feature: string,
-	tags?: {
-		[key: string]: string;
-	},
-) => void;
-
-export const reportError: ReportError = (error, feature, tags) => {
+export const reportError: typeof window.guardian.modules.sentry.reportError = (
+	error,
+	feature,
+	tags,
+) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -34,9 +34,9 @@ const isSentryEnabled = ({
 
 /** When stubbed errors are only sent to the console */
 const stubSentry = (): void => {
-	window.guardian.modules.sentry.reportError = (error) => {
+	window.guardian.modules.sentry.reportError = (error, feature, tags) => {
 		// eslint-disable-next-line no-console -- fallback to console.error
-		console.error(error);
+		console.error(error, feature, tags);
 	};
 };
 

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -1,5 +1,5 @@
 import { BUILD_VARIANT, dcrJavascriptBundle } from '../../../webpack/bundles';
-import { loadSentryOnError, stubSentry } from './loadSentry';
+import { loadSentryOnError } from './loadSentry';
 
 type IsSentryEnabled = {
 	enableSentryReporting: boolean;
@@ -30,6 +30,14 @@ const isSentryEnabled = ({
 	// to prevent the Sentry script from ever loading.
 	if (random <= 99 / 100) return false;
 	return true;
+};
+
+/** When stubbed errors are only sent to the console */
+const stubSentry = (): void => {
+	window.guardian.modules.sentry.reportError = (error) => {
+		// eslint-disable-next-line no-console -- fallback to console.error
+		console.error(error);
+	};
 };
 
 export const sentryLoader = (): Promise<void> => {

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -1,5 +1,6 @@
 import type { EditionId } from '../lib/edition';
 import type { ConfigType, ServerSideTests, Switches } from '../types/config';
+import type { ReportError } from '../types/sentry';
 
 export interface Guardian {
 	polyfilled: boolean;
@@ -47,13 +48,7 @@ export interface Guardian {
 	};
 	modules: {
 		sentry: {
-			reportError: (
-				error: Error,
-				feature: string,
-				tags?: {
-					[key: string]: string;
-				},
-			) => void;
+			reportError: ReportError;
 		};
 	};
 	adBlockers: unknown;

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -47,7 +47,13 @@ export interface Guardian {
 	};
 	modules: {
 		sentry: {
-			reportError: (error: Error, feature: string) => void;
+			reportError: (
+				error: Error,
+				feature: string,
+				tags?: {
+					[key: string]: string;
+				},
+			) => void;
 		};
 	};
 	adBlockers: unknown;

--- a/dotcom-rendering/src/types/sentry.ts
+++ b/dotcom-rendering/src/types/sentry.ts
@@ -1,0 +1,7 @@
+export type ReportError = (
+	error: Error,
+	feature: string,
+	tags?: {
+		[key: string]: string;
+	},
+) => void;


### PR DESCRIPTION
## What does this change?
This PR aims to update the reportError function (which is ultimately added the window).

Previously, the custom tags added to reportError were not being passed to the window object. This update ensures that the tags are now properly sent.

Overview of changes:
- Updated the Guardian window interface.
- Added more robust types for error reporting.
- Introduced a Sentry type module.
- Updated the stub function.
- Ensured that features and tags are pushed onto the error queue used for storing errors.

## Why?

In a previous related PR [here](https://github.com/guardian/dotcom-rendering/pull/12280#discussion_r1758919964) to add custom tags to the reportError function, we found that the window.reportError method is still missing the custom tags. As a result, we cannot yet use them in the commercial context.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
