### PR TITLE
Remove code text from chromatic snapshot

### DIFF
--- a/dotcom-rendering/fixtures/manual/discussion.ts
+++ b/dotcom-rendering/fixtures/manual/discussion.ts
@@ -40,7 +40,7 @@ export const discussion = {
 			},
 			{
 				id: 37678414,
-				body: '<p>This is how <code>code</code> looks. And this is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote><p>blockquote</p></blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p><p>And this is what get withareallyreallyreallylonglonglongwordthatissupersuperlonglikelonnnnngggggggggImeanreallylong</p></p>',
+				body: '<p>This is how <del>strikethrough</del> looks</p><p><strong>strong</strong></p><p><i>italic</i></p><p><blockquote><p>blockquote</p></blockquote></p><p><a href="http://www.mydomain.com">link to mydomain.com</a></p><p>And this is what get withareallyreallyreallylonglonglongwordthatissupersuperlonglikelonnnnngggggggggImeanreallylong</p></p>',
 				date: '02 July 2014 11:20am',
 				isoDateTime: '2014-07-02T10:20:56Z',
 				status: 'visible',


### PR DESCRIPTION
## What does this change?

Remove `code` text from chromatic snapshot. Chromatic falsely reports changes very regularly when there is text within a `<code>` tag in the comments.

## Why?

This should stop Chromatic reporting changes in the Comments snapshots when there are none.
