### PR TITLE
[Fairground 🎡] Add background colour to mobile sublinks for flex special

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -417,6 +417,7 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
+					fillBackground={isFlexibleContainer}
 				/>
 			);
 		}
@@ -426,6 +427,7 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
+					fillBackground={isFlexibleContainer}
 				/>
 			</Hide>
 		);
@@ -442,6 +444,7 @@ export const Card = ({
 						'vertical'
 					} /* inner links are always vertically stacked */
 					containerPalette={containerPalette}
+					fillBackground={isFlexibleContainer}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -15,6 +15,7 @@ type Props = {
 	/** Determines if the content is arranged vertically or horizontally */
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
+	fillBackground?: boolean;
 };
 
 /**
@@ -119,10 +120,17 @@ const wrapperStyles = css`
 	}
 `;
 
+const mobileBackground = css`
+	${until.tablet} {
+		padding: 8px;
+		background-color: ${palette('--sublinks-background')};
+	}
+`;
 export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
+	fillBackground = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -132,6 +140,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				alignment === 'horizontal' && horizontalGrid,
+				fillBackground && mobileBackground,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -123,7 +123,7 @@ const wrapperStyles = css`
 const mobileBackground = css`
 	${until.tablet} {
 		padding: 8px;
-		background-color: ${palette('--sublinks-background')};
+		background-color: ${palette('--card-sublinks-background')};
 	}
 `;
 export const SupportingContent = ({

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -120,7 +120,8 @@ const wrapperStyles = css`
 	}
 `;
 
-const mobileBackground = css`
+const backgroundFill = css`
+	/** background fill should only apply to sublinks on mobile breakpoints */
 	${until.tablet} {
 		padding: 8px;
 		background-color: ${palette('--card-sublinks-background')};
@@ -140,7 +141,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				alignment === 'horizontal' && horizontalGrid,
-				fillBackground && mobileBackground,
+				fillBackground && backgroundFill,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5584,6 +5584,9 @@ const cricketScoreboardLinkText: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 
+const sublinksBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const sublinksBackgroundDark: PaletteFunction = () => sourcePalette.neutral[10];
 // ----- Palette ----- //
 
 /**
@@ -6752,6 +6755,10 @@ const paletteColours = {
 	'--subheading-text': {
 		light: subheadingTextLight,
 		dark: subheadingTextDark,
+	},
+	'--sublinks-background': {
+		light: sublinksBackgroundLight,
+		dark: sublinksBackgroundDark,
 	},
 	'--summary-event-bullet': {
 		light: summaryEventBulletLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5584,9 +5584,10 @@ const cricketScoreboardLinkText: PaletteFunction = () => {
 	return sourcePalette.sport[300];
 };
 
-const sublinksBackgroundLight: PaletteFunction = () =>
+const cardSublinksBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
-const sublinksBackgroundDark: PaletteFunction = () => sourcePalette.neutral[10];
+const cardSublinksBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
 // ----- Palette ----- //
 
 /**
@@ -5907,6 +5908,10 @@ const paletteColours = {
 	'--card-kicker-text': {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
+	},
+	'--card-sublinks-background': {
+		light: cardSublinksBackgroundLight,
+		dark: cardSublinksBackgroundDark,
 	},
 	'--carousel-active-dot': {
 		light: carouselActiveDotLight,
@@ -6755,10 +6760,6 @@ const paletteColours = {
 	'--subheading-text': {
 		light: subheadingTextLight,
 		dark: subheadingTextDark,
-	},
-	'--sublinks-background': {
-		light: sublinksBackgroundLight,
-		dark: sublinksBackgroundDark,
 	},
 	'--summary-event-bullet': {
 		light: summaryEventBulletLight,


### PR DESCRIPTION
## What does this change?
Adds optional background colour and padding to the sublinks that can be used by flexible special and general.
## Why?
This is as per designs.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6409fab2-f9e6-426f-9ede-c0fdbe545613
[after]: https://github.com/user-attachments/assets/d17ae462-b413-4583-a04d-4bad5e32ed8f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
