### PR TITLE
YoutubeAtom refactors - pass index, extract components and event emitters

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -113,6 +113,7 @@ export type Props = {
 	aspectRatio?: AspectRatio;
 	/** Alows the consumer to use a larger font size group for boost styling*/
 	boostedFontSizes?: boolean;
+	index?: number;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -255,6 +256,7 @@ export const Card = ({
 	isTagPage = false,
 	aspectRatio,
 	boostedFontSizes,
+	index = 0,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -524,6 +526,7 @@ export const Card = ({
 												assetId={
 													media.mainMedia.videoId
 												}
+												index={index}
 												duration={
 													media.mainMedia.duration
 												}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -453,6 +453,7 @@ const Title = ({
 	);
 type CarouselCardProps = {
 	isFirst: boolean;
+	index: number;
 	format: ArticleFormat;
 	linkTo: string;
 	headlineText: string;
@@ -493,6 +494,7 @@ const CarouselCard = ({
 	isOnwardContent,
 	absoluteServerTimes,
 	starRating,
+	index,
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	const cardImagePosition = isOnwardContent ? 'bottom' : 'top';
@@ -537,6 +539,7 @@ const CarouselCard = ({
 				imagePositionOnMobile={cardImagePosition}
 				absoluteServerTimes={absoluteServerTimes}
 				starRating={starRating}
+				index={index}
 			/>
 		</LI>
 	);
@@ -994,6 +997,7 @@ export const Carousel = ({
 							return (
 								<CarouselCard
 									key={`${trail.url}${i}`}
+									index={i}
 									isFirst={i === 0}
 									format={trailFormat}
 									linkTo={linkTo}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -132,8 +132,8 @@ const imagePositionOnMobile: ImagePositionType = 'none';
 const imageSize: ImageSizeType = 'large';
 
 const baseConfiguration = {
-	index: 123,
 	videoId: '-ZCvZmYlQD8',
+	uniqueId: '-ZCvZmYlQD8-1',
 	alt: '',
 	eventEmitters: [
 		// eslint-disable-next-line no-console -- check event emitters are called
@@ -303,7 +303,7 @@ export const DuplicateVideos = {
 		<>
 			<YoutubeAtom {...args} />
 			<br />
-			<YoutubeAtom {...args} index={345} />
+			<YoutubeAtom {...args} uniqueId="ZCvZmYlQD8-2" />
 		</>
 	),
 	decorators: [SmallContainer],
@@ -333,8 +333,16 @@ export const MultipleStickyVideos = {
 			`}
 		>
 			<YoutubeAtom {...args} />
-			<YoutubeAtom {...args} index={456} videoId="pcMiS6PW8aQ" />
-			<YoutubeAtom {...args} index={789} videoId="3jpXAMwRSu4" />
+			<YoutubeAtom
+				{...args}
+				uniqueId="pcMiS6PW8aQ-1"
+				videoId="pcMiS6PW8aQ"
+			/>
+			<YoutubeAtom
+				{...args}
+				uniqueId="3jpXAMwRSu4-1"
+				videoId="3jpXAMwRSu4"
+			/>
 		</div>
 	),
 	parameters: {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -132,6 +132,7 @@ const imagePositionOnMobile: ImagePositionType = 'none';
 const imageSize: ImageSizeType = 'large';
 
 const baseConfiguration = {
+	atomId: 'a2502abd-1373-45a2-b508-3e5a2ec050be',
 	videoId: '-ZCvZmYlQD8',
 	uniqueId: '-ZCvZmYlQD8-1',
 	alt: '',

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -33,9 +33,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -70,9 +70,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -116,9 +116,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -154,9 +154,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -194,9 +194,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -232,9 +232,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -269,9 +269,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					index={123}
-					title="My Youtube video!"
 					videoId="ZCvZmYlQD8"
+					uniqueId="ZCvZmYlQD8-1"
+					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
@@ -310,9 +310,9 @@ describe('YoutubeAtom', () => {
 					}}
 				>
 					<YoutubeAtom
-						index={123}
-						title="My Youtube video!"
 						videoId="ZCvZmYlQD8"
+						uniqueId="ZCvZmYlQD8-1"
+						title="My Youtube video!"
 						alt=""
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
@@ -330,9 +330,9 @@ describe('YoutubeAtom', () => {
 						renderingTarget="Web"
 					/>
 					<YoutubeAtom
-						index={123}
-						title="My Youtube video 2!"
 						videoId="ZCvZmYlQD8"
+						uniqueId="ZCvZmYlQD8-2"
+						title="My Youtube video 2!"
 						alt=""
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -33,8 +33,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -55,7 +56,7 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [playerDiv] = getAllByTestId(/^youtube-player-ZCvZmYlQD8-\d+$/);
+		const [playerDiv] = getAllByTestId(/^youtube-player-c_xtiZNDgGc-\d+$/);
 		expect(playerDiv).toBeInTheDocument();
 	});
 
@@ -70,8 +71,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -93,13 +95,13 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [overlay] = getAllByTestId(/^youtube-overlay-ZCvZmYlQD8-\d+$/);
+		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		expect(overlay).toBeInTheDocument();
 
 		overlay && fireEvent.click(overlay);
 		expect(overlay).not.toBeInTheDocument();
 
-		const [playerDiv] = getAllByTestId(/^youtube-player-ZCvZmYlQD8-\d+$/);
+		const [playerDiv] = getAllByTestId(/^youtube-player-c_xtiZNDgGc-\d+$/);
 		expect(playerDiv).toBeInTheDocument();
 	});
 
@@ -116,8 +118,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -138,7 +141,7 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [playerDiv] = getAllByTestId(/^youtube-player-ZCvZmYlQD8-\d+$/);
+		const [playerDiv] = getAllByTestId(/^youtube-player-c_xtiZNDgGc-\d+$/);
 		expect(playerDiv?.title).toBe(title);
 	});
 
@@ -154,8 +157,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -177,7 +181,7 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [overlay] = getAllByTestId(/^youtube-overlay-ZCvZmYlQD8-\d+$/);
+		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		const ariaLabel = overlay?.getAttribute('aria-label');
 
 		expect(ariaLabel).toBe(`Play video: ${title}`);
@@ -194,8 +198,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -216,7 +221,7 @@ describe('YoutubeAtom', () => {
 		);
 		const { getAllByTestId } = render(atom);
 		const [placeholder] = getAllByTestId(
-			/^youtube-placeholder-ZCvZmYlQD8-\d+$/,
+			/^youtube-placeholder-c_xtiZNDgGc-\d+$/,
 		);
 		expect(placeholder).toBeInTheDocument();
 	});
@@ -232,8 +237,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -254,7 +260,7 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [overlay] = getAllByTestId(/^youtube-overlay-ZCvZmYlQD8-\d+$/);
+		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		expect(overlay).toBeInTheDocument();
 	});
 
@@ -269,8 +275,9 @@ describe('YoutubeAtom', () => {
 				}}
 			>
 				<YoutubeAtom
-					videoId="ZCvZmYlQD8"
-					uniqueId="ZCvZmYlQD8-1"
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
 					alt=""
 					adTargeting={{ disableAds: true }}
@@ -291,7 +298,7 @@ describe('YoutubeAtom', () => {
 			</ConfigProvider>
 		);
 		const { getAllByTestId } = render(atom);
-		const [overlay] = getAllByTestId(/^youtube-overlay-ZCvZmYlQD8-\d+$/);
+		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		expect(overlay).toBeInTheDocument();
 
 		overlay && fireEvent.click(overlay);
@@ -310,8 +317,9 @@ describe('YoutubeAtom', () => {
 					}}
 				>
 					<YoutubeAtom
-						videoId="ZCvZmYlQD8"
-						uniqueId="ZCvZmYlQD8-1"
+						atomId="atom1"
+						videoId="c_xtiZNDgGc"
+						uniqueId="c_xtiZNDgGc-1"
 						title="My Youtube video!"
 						alt=""
 						adTargeting={{ disableAds: true }}
@@ -330,8 +338,9 @@ describe('YoutubeAtom', () => {
 						renderingTarget="Web"
 					/>
 					<YoutubeAtom
-						videoId="ZCvZmYlQD8"
-						uniqueId="ZCvZmYlQD8-2"
+						atomId="atom1"
+						videoId="c_xtiZNDgGc"
+						uniqueId="c_xtiZNDgGc-2"
 						title="My Youtube video 2!"
 						alt=""
 						adTargeting={{ disableAds: true }}
@@ -354,7 +363,7 @@ describe('YoutubeAtom', () => {
 		);
 		const { getAllByTestId } = render(atom);
 		const [overlay1, overlay2] = getAllByTestId(
-			/^youtube-overlay-ZCvZmYlQD8-\d+$/,
+			/^youtube-overlay-c_xtiZNDgGc-\d+$/,
 		);
 		expect(overlay1).toBeInTheDocument();
 

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,6 +1,5 @@
 import type { Participations } from '@guardian/ab-core';
 import type { ArticleFormat, ConsentState } from '@guardian/libs';
-import { isUndefined } from '@guardian/libs';
 import { useCallback, useState } from 'react';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import type {
@@ -26,8 +25,8 @@ export type VideoEventKey =
 	| 'pause';
 
 export type Props = {
-	index?: number;
 	videoId: string;
+	uniqueId: string;
 	overrideImage?: string | undefined;
 	posterImage?: string | undefined;
 	adTargeting?: AdTargeting;
@@ -53,8 +52,8 @@ export type Props = {
 };
 
 export const YoutubeAtom = ({
-	index,
 	videoId,
+	uniqueId,
 	overrideImage,
 	posterImage,
 	adTargeting,
@@ -83,8 +82,6 @@ export const YoutubeAtom = ({
 	const [isActive, setIsActive] = useState<boolean>(false);
 	const [isClosed, setIsClosed] = useState<boolean>(false);
 	const [pauseVideo, setPauseVideo] = useState<boolean>(false);
-
-	const uniqueId = `${videoId}-${index ?? 'server'}`;
 
 	/**
 	 * Consent and ad targeting are initially undefined and set by subsequent re-renders
@@ -169,10 +166,6 @@ export const YoutubeAtom = ({
 		// load the player if the overlay has been clicked
 		loadPlayer = true;
 	} else {
-		loadPlayer = false;
-	}
-
-	if (isUndefined(index)) {
 		loadPlayer = false;
 	}
 

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -25,6 +25,7 @@ export type VideoEventKey =
 	| 'pause';
 
 export type Props = {
+	atomId: string;
 	videoId: string;
 	uniqueId: string;
 	overrideImage?: string | undefined;
@@ -52,6 +53,7 @@ export type Props = {
 };
 
 export const YoutubeAtom = ({
+	atomId,
 	videoId,
 	uniqueId,
 	overrideImage,
@@ -175,74 +177,81 @@ export const YoutubeAtom = ({
 	const playerReadyCallback = useCallback(() => setPlayerReady(true), []);
 
 	return (
-		<YoutubeAtomSticky
-			uniqueId={uniqueId}
-			videoId={videoId}
-			shouldStick={shouldStick}
-			isActive={isActive}
-			eventEmitters={eventEmitters}
-			setPauseVideo={setPauseVideo}
-			isMainMedia={isMainMedia}
-			isClosed={isClosed}
-			setIsClosed={setIsClosed}
-			shouldPauseOutOfView={shouldPauseOutOfView}
+		<div
+			data-component="youtube-atom"
+			data-atom-id={atomId}
+			data-video-id={videoId}
+			data-video-unique-id={uniqueId}
 		>
-			<MaintainAspectRatio height={height} width={width}>
-				{
-					/**
-					 * Consent and ad targeting are initially undefined and set by subsequent re-renders
-					 * Wait until they are defined before rendering the player
-					 */
-					loadPlayer && consentState && adTargeting && (
-						<YoutubeAtomPlayer
-							videoId={videoId}
+			<YoutubeAtomSticky
+				uniqueId={uniqueId}
+				videoId={videoId}
+				shouldStick={shouldStick}
+				isActive={isActive}
+				eventEmitters={eventEmitters}
+				setPauseVideo={setPauseVideo}
+				isMainMedia={isMainMedia}
+				isClosed={isClosed}
+				setIsClosed={setIsClosed}
+				shouldPauseOutOfView={shouldPauseOutOfView}
+			>
+				<MaintainAspectRatio height={height} width={width}>
+					{
+						/**
+						 * Consent and ad targeting are initially undefined and set by subsequent re-renders
+						 * Wait until they are defined before rendering the player
+						 */
+						loadPlayer && consentState && adTargeting && (
+							<YoutubeAtomPlayer
+								videoId={videoId}
+								uniqueId={uniqueId}
+								height={height}
+								width={width}
+								title={title}
+								origin={origin}
+								eventEmitters={compositeEventEmitters}
+								/**
+								 * If there is an overlay we want to autoplay
+								 * If there isn't an overlay the user will use the YouTube player UI to play
+								 */
+								autoPlay={hasOverlay}
+								onReady={playerReadyCallback}
+								pauseVideo={pauseVideo}
+								deactivateVideo={() => {
+									setIsActive(false);
+								}}
+								enableAds={adTargetingEnabled}
+								adTargeting={adTargeting}
+								consentState={consentState}
+								abTestParticipations={abTestParticipations}
+								renderingTarget={renderingTarget}
+							/>
+						)
+					}
+					{showOverlay && (
+						<YoutubeAtomOverlay
 							uniqueId={uniqueId}
+							overrideImage={overrideImage}
+							posterImage={posterImage}
 							height={height}
 							width={width}
+							alt={alt}
+							duration={duration}
 							title={title}
-							origin={origin}
-							eventEmitters={compositeEventEmitters}
-							/**
-							 * If there is an overlay we want to autoplay
-							 * If there isn't an overlay the user will use the YouTube player UI to play
-							 */
-							autoPlay={hasOverlay}
-							onReady={playerReadyCallback}
-							pauseVideo={pauseVideo}
-							deactivateVideo={() => {
-								setIsActive(false);
-							}}
-							enableAds={adTargetingEnabled}
-							adTargeting={adTargeting}
-							consentState={consentState}
-							abTestParticipations={abTestParticipations}
-							renderingTarget={renderingTarget}
+							onClick={() => setOverlayClicked(true)}
+							videoCategory={videoCategory}
+							kicker={kicker}
+							format={format}
+							showTextOverlay={showTextOverlay}
+							imageSize={imageSize}
+							imagePositionOnMobile={imagePositionOnMobile}
 						/>
-					)
-				}
-				{showOverlay && (
-					<YoutubeAtomOverlay
-						uniqueId={uniqueId}
-						overrideImage={overrideImage}
-						posterImage={posterImage}
-						height={height}
-						width={width}
-						alt={alt}
-						duration={duration}
-						title={title}
-						onClick={() => setOverlayClicked(true)}
-						videoCategory={videoCategory}
-						kicker={kicker}
-						format={format}
-						showTextOverlay={showTextOverlay}
-						imageSize={imageSize}
-						imagePositionOnMobile={imagePositionOnMobile}
-					/>
-				)}
-				{showPlaceholder && (
-					<YoutubeAtomPlaceholder uniqueId={uniqueId} />
-				)}
-			</MaintainAspectRatio>
-		</YoutubeAtomSticky>
+					)}
+					{showPlaceholder && (
+						<YoutubeAtomPlaceholder uniqueId={uniqueId} />
+					)}
+				</MaintainAspectRatio>
+			</YoutubeAtomSticky>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomExpiredOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomExpiredOverlay.tsx
@@ -1,0 +1,95 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { body, palette, space } from '@guardian/source/foundations';
+import { SvgAlertRound } from '@guardian/source/react-components';
+import { Caption } from '../Caption';
+
+type Props = {
+	format: ArticleFormat;
+	hideCaption?: boolean;
+	isMainMedia?: boolean;
+	mediaTitle?: string;
+	overrideImage?: string;
+};
+
+const expiredOverlayStyles = (overrideImage?: string) =>
+	overrideImage
+		? css`
+				height: 0px;
+				position: relative;
+				background-image: url(${overrideImage});
+				background-size: cover;
+				background-position: 49% 49%;
+				background-repeat: no-repeat;
+				padding-bottom: 56%;
+				color: ${palette.neutral[100]};
+				background-color: ${palette.neutral[20]};
+		  `
+		: undefined;
+
+const expiredTextWrapperStyles = css`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	padding-top: ${space[4]}px;
+	padding-bottom: ${space[4]}px;
+	padding-left: ${space[1]}px;
+	padding-right: ${space[12]}px;
+	color: ${palette.neutral[100]};
+	background-color: ${palette.neutral[20]};
+`;
+
+const expiredSVGWrapperStyles = css`
+	padding-right: ${space[1]}px;
+	svg {
+		width: ${space[12]}px;
+		height: ${space[12]}px;
+		fill: ${palette.neutral[100]};
+	}
+`;
+
+export const YoutubeAtomExpiredOverlay = ({
+	format,
+	hideCaption,
+	isMainMedia,
+	mediaTitle,
+	overrideImage,
+}: Props) => {
+	return (
+		<figure
+			css={css`
+				margin-top: 16px;
+				margin-bottom: 16px;
+			`}
+		>
+			<div css={expiredOverlayStyles(overrideImage)}>
+				<div css={expiredTextWrapperStyles}>
+					<div css={expiredSVGWrapperStyles}>
+						<SvgAlertRound />
+					</div>
+					<p
+						css={css`
+							${body.medium({
+								lineHeight: 'tight',
+							})}
+						`}
+					>
+						This video has been removed. This could be because it
+						launched early, our rights have expired, there was a
+						legal issue, or for another reason.
+					</p>
+				</div>
+			</div>
+			{!hideCaption && (
+				<Caption
+					captionText={mediaTitle ?? ''}
+					format={format}
+					displayCredit={false}
+					mediaType="Video"
+					isMainMedia={isMainMedia}
+				/>
+			)}
+		</figure>
+	);
+};

--- a/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
@@ -1,0 +1,66 @@
+import { MediaEvent } from '@guardian/bridget';
+import { isUndefined, log } from '@guardian/libs';
+import type { EventPayload, VideoEvent } from '@guardian/ophan-tracker-js';
+import { getOphan } from '../../client/ophan/ophan';
+import { getVideoClient } from '../../lib/bridgetApi';
+import type { VideoEventKey } from './YoutubeAtom';
+
+const getAppsMediaEvent = (
+	trackingEvent: VideoEventKey,
+): MediaEvent | undefined => {
+	switch (trackingEvent) {
+		case 'cued':
+			return MediaEvent.ready;
+		case 'play':
+			return MediaEvent.play;
+		case '25':
+			return MediaEvent.percent25;
+		case '50':
+			return MediaEvent.percent50;
+		case '75':
+			return MediaEvent.percent75;
+		case 'end':
+			return MediaEvent.end;
+		default:
+			return undefined;
+	}
+};
+
+const ophanTrackerWeb = (id: string) => {
+	return (trackingEvent: VideoEventKey): void => {
+		void getOphan('Web').then((ophan) => {
+			const event = {
+				video: {
+					id: `gu-video-youtube-${id}`,
+					eventType: `video:content:${trackingEvent}`,
+				} satisfies VideoEvent,
+			} satisfies EventPayload;
+			log('dotcom', {
+				from: 'YoutubeAtom event emitter web',
+				id,
+				event,
+			});
+			ophan.record(event);
+		});
+	};
+};
+
+const ophanTrackerApps = (id: string) => {
+	return (trackingEvent: VideoEventKey): void => {
+		const appsMediaEvent = getAppsMediaEvent(trackingEvent);
+		if (!isUndefined(appsMediaEvent)) {
+			const event = {
+				videoId: id,
+				event: appsMediaEvent,
+			};
+			log('dotcom', {
+				from: 'YoutubeAtom event emitter apps',
+				id,
+				event,
+			});
+			void getVideoClient().sendVideoEvent(event);
+		}
+	};
+};
+
+export { ophanTrackerApps, ophanTrackerWeb };

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -91,6 +91,11 @@ export const YoutubeBlockComponent = ({
 	const abTests = useAB();
 	const abTestParticipations = abTests?.participations ?? {};
 
+	/**
+	 * It's possible to have duplicate video atoms on the same page
+	 * For example liveblogs can have the same video for the main media and in a subsequent block
+	 * We need to ensure a unique id for each YouTube player on the page.
+	 */
 	const uniqueId = `${assetId}-${index}`;
 
 	useEffect(() => {
@@ -133,8 +138,9 @@ export const YoutubeBlockComponent = ({
 	}
 
 	return (
-		<div data-chromatic="ignore" data-component="youtube-atom">
+		<div data-chromatic="ignore">
 			<YoutubeAtom
+				atomId={id}
 				videoId={assetId}
 				uniqueId={uniqueId}
 				overrideImage={overrideImage}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -1,7 +1,4 @@
-import { css } from '@emotion/react';
 import { type ArticleFormat, type ConsentState } from '@guardian/libs';
-import { body, palette, space } from '@guardian/source/foundations';
-import { SvgAlertRound } from '@guardian/source/react-components';
 import { useEffect, useState } from 'react';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
@@ -13,6 +10,7 @@ import type {
 import { useConfig } from './ConfigContext';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
+import { YoutubeAtomExpiredOverlay } from './YoutubeAtom/YoutubeAtomExpiredOverlay';
 
 type Props = {
 	id: string;
@@ -42,43 +40,6 @@ type Props = {
 	imagePositionOnMobile?: ImagePositionType;
 	enableAds: boolean;
 };
-
-const expiredOverlayStyles = (overrideImage?: string) =>
-	overrideImage
-		? css`
-				height: 0px;
-				position: relative;
-				background-image: url(${overrideImage});
-				background-size: cover;
-				background-position: 49% 49%;
-				background-repeat: no-repeat;
-				padding-bottom: 56%;
-				color: ${palette.neutral[100]};
-				background-color: ${palette.neutral[20]};
-		  `
-		: undefined;
-
-const expiredTextWrapperStyles = css`
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-
-	padding-top: ${space[4]}px;
-	padding-bottom: ${space[4]}px;
-	padding-left: ${space[1]}px;
-	padding-right: ${space[12]}px;
-	color: ${palette.neutral[100]};
-	background-color: ${palette.neutral[20]};
-`;
-
-const expiredSVGWrapperStyles = css`
-	padding-right: ${space[1]}px;
-	svg {
-		width: ${space[12]}px;
-		height: ${space[12]}px;
-		fill: ${palette.neutral[100]};
-	}
-`;
 
 /**
  * We do our own image optimization in DCR and only need 1 image. Pick the largest image available to
@@ -161,40 +122,13 @@ export const YoutubeBlockComponent = ({
 
 	if (expired) {
 		return (
-			<figure
-				css={css`
-					margin-top: 16px;
-					margin-bottom: 16px;
-				`}
-			>
-				<div css={expiredOverlayStyles(overrideImage)}>
-					<div css={expiredTextWrapperStyles}>
-						<div css={expiredSVGWrapperStyles}>
-							<SvgAlertRound />
-						</div>
-						<p
-							css={css`
-								${body.medium({
-									lineHeight: 'tight',
-								})}
-							`}
-						>
-							This video has been removed. This could be because
-							it launched early, our rights have expired, there
-							was a legal issue, or for another reason.
-						</p>
-					</div>
-				</div>
-				{!hideCaption && (
-					<Caption
-						captionText={mediaTitle ?? ''}
-						format={format}
-						displayCredit={false}
-						mediaType="Video"
-						isMainMedia={isMainMedia}
-					/>
-				)}
-			</figure>
+			<YoutubeAtomExpiredOverlay
+				format={format}
+				hideCaption={hideCaption}
+				isMainMedia={isMainMedia}
+				mediaTitle={mediaTitle}
+				overrideImage={overrideImage}
+			/>
 		);
 	}
 

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -24,9 +24,10 @@ import { type VideoEventKey, YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
 
 type Props = {
 	id: string;
+	assetId: string;
+	index: number;
 	mediaTitle?: string;
 	altText?: string;
-	assetId: string;
 	expired: boolean;
 	format: ArticleFormat;
 	hideCaption?: boolean;
@@ -101,9 +102,6 @@ const getLargestImageSize = (
 	}[],
 ) => [...images].sort((a, b) => a.width - b.width).pop();
 
-/** always undefined on the server */
-let counter: number | undefined;
-
 const adTargetingDisabled: AdTargeting = { disableAds: true };
 
 const getAppsMediaEvent = (
@@ -130,6 +128,7 @@ const getAppsMediaEvent = (
 export const YoutubeBlockComponent = ({
 	id,
 	assetId,
+	index,
 	mediaTitle,
 	altText,
 	format,
@@ -160,12 +159,7 @@ export const YoutubeBlockComponent = ({
 	const abTests = useAB();
 	const abTestParticipations = abTests?.participations ?? {};
 
-	const [index, setIndex] = useState<number>();
-
-	useEffect(() => {
-		counter ??= 0;
-		setIndex(++counter);
-	}, []);
+	const uniqueId = `${assetId}-${index}`;
 
 	useEffect(() => {
 		if (renderingTarget === 'Web') {
@@ -275,8 +269,8 @@ export const YoutubeBlockComponent = ({
 	return (
 		<div data-chromatic="ignore" data-component="youtube-atom">
 			<YoutubeAtom
-				index={index}
 				videoId={assetId}
+				uniqueId={uniqueId}
 				overrideImage={overrideImage}
 				posterImage={getLargestImageSize(posterImage)?.url}
 				alt={altText ?? mediaTitle ?? ''}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -50,6 +50,7 @@ export const Default = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				stickyVideos={false}
 				enableAds={false}
@@ -83,6 +84,7 @@ export const Vertical = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				height={259}
 				width={460}
@@ -118,6 +120,7 @@ export const Expired = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={true}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				height={259}
@@ -154,6 +157,7 @@ export const WithOverlayImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				duration={333}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
@@ -191,6 +195,7 @@ export const WithPosterImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				duration={333}
 				posterImage={[
@@ -249,6 +254,7 @@ export const WithPosterAndOverlayImage = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				duration={333}
@@ -308,6 +314,7 @@ export const WithShowMainVideoFlagOff = () => {
 				assetId="d2Q5bXvEgMg"
 				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
+				index={0}
 				expired={false}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				duration={333}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -820,12 +820,13 @@ export const renderElement = ({
 			return (
 				<Island priority="critical" defer={{ until: 'visible' }}>
 					<YoutubeBlockComponent
-						format={format}
-						key={index}
-						hideCaption={hideCaption}
-						isMainMedia={isMainMedia}
 						id={element.id}
 						assetId={element.assetId}
+						key={index}
+						index={index}
+						format={format}
+						hideCaption={hideCaption}
+						isMainMedia={isMainMedia}
 						expired={element.expired}
 						overrideImage={element.overrideImage}
 						posterImage={element.posterImage}


### PR DESCRIPTION
## What does this change?

A collection of small refactors to the YoutubeAtom.

1. Replace the module level index within YoutubeAtom with an index passed from ancestor components that map over YoutubeAtom. This was initially put in place [here](https://github.com/guardian/dotcom-rendering/pull/10252) to remove usage of elementId which is not stable across rendering requests and would therefore cause cache instability by invalidating the eTag on every render.
  However a module level index is not idiomatic React and we can replace this by passing an index from any ancestors that generate YoutubeAtoms.
  The atom id and index are stable across requests. The index will only change if the page structure changes which is expected.
    https://github.com/guardian/dotcom-rendering/commit/774a2fc24f4b6773e709a9ca2e7b678b37100c7b
  
2. Extract `YouTubeExpiredOverlay` component
    https://github.com/guardian/dotcom-rendering/commit/77aa0ac6c1e7973b30c99b1bcee6021c97fb305a
3. Extract event emitters into their own module
    https://github.com/guardian/dotcom-rendering/commit/e2904c5a57b09ede6284b914ea8d1b837a915771
4. Add data attributes for the atomId, videoId and uniqueId to aid inspection
    https://github.com/guardian/dotcom-rendering/commit/bf067d1381bb2ea08a8e3d81ec2c45496a15e9a5
6. Update tests to reflect above changes

## Why?

Simplify the code and make it easier to understand