### PR TITLE
Revert "Remove dynamo from supporting content"

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -397,6 +397,7 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
+					isDynamo={isDynamo}
 				/>
 			);
 		}
@@ -406,6 +407,7 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
+					isDynamo={isDynamo}
 				/>
 			</Hide>
 		);
@@ -743,6 +745,7 @@ export const Card = ({
 										supportingContent={supportingContent}
 										alignment="vertical"
 										containerPalette={containerPalette}
+										isDynamo={isDynamo}
 									/>
 								</Hide>
 							)}

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -14,6 +14,7 @@ type Props = {
 	supportingContent: DCRSupportingContent[];
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
+	isDynamo?: boolean;
 };
 
 const wrapperStyles = css`
@@ -76,6 +77,7 @@ export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
+	isDynamo,
 }: Props) => {
 	return (
 		<ul
@@ -83,7 +85,7 @@ export const SupportingContent = ({
 			css={[
 				wrapperStyles,
 				flexColumn,
-				alignment === 'horizontal' && flexRowFromTablet,
+				(isDynamo ?? alignment === 'horizontal') && flexRowFromTablet,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#12393 as we *do* still use dynamo