### PR TITLE
[Fairground 🎡] Flexible/general container layout

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -22,7 +22,7 @@ import { FixedSmallSlowIV } from './FixedSmallSlowIV';
 import { FixedSmallSlowVHalf } from './FixedSmallSlowVHalf';
 import { FixedSmallSlowVMPU } from './FixedSmallSlowVMPU';
 import { FixedSmallSlowVThird } from './FixedSmallSlowVThird';
-// import { FlexibleGeneral } from './FlexibleGeneral';
+import { FlexibleGeneral } from './FlexibleGeneral';
 import { FlexibleSpecial } from './FlexibleSpecial';
 import { HighlightsContainer } from './HighlightsContainer.importable';
 import { Island } from './Island';
@@ -240,17 +240,15 @@ export const DecideContainer = ({
 				/>
 			);
 		case 'flexible/general':
-			// Not implemented yet
-			return null;
-		// return (
-		// 	<FlexibleGeneral
-		// 		groupedTrails={groupedTrails}
-		// 		containerPalette={containerPalette}
-		// 		showAge={showAge}
-		// 		absoluteServerTimes={absoluteServerTimes}
-		// 		imageLoading={imageLoading}
-		// 	/>
-		// );
+			return (
+				<FlexibleGeneral
+					groupedTrails={groupedTrails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+				/>
+			);
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -1,0 +1,27 @@
+import { trails } from 'fixtures/manual/trails';
+import { determineCardPositions } from './FlexibleGeneral';
+import { DCRFrontCard } from 'src/types/front';
+
+const standardCard = {
+	...trails[0],
+	boostLevel: 'default',
+} satisfies DCRFrontCard;
+
+const boostedCard = {
+	...trails[0],
+	boostLevel: 'boost',
+} satisfies DCRFrontCard;
+
+describe('FlexibleGeneral', () => {
+	it.skip('Should return a one card half width row if one standard card is provided', () => {
+		expect(determineCardPositions([standardCard])).toEqual([]);
+	});
+	it.skip('Should return a one full half width row if one standard boosted card is provided', () => {
+		expect(determineCardPositions([boostedCard])).toEqual([]);
+	});
+	it.skip('Should return a two card row if two standard cards are provided', () => {
+		expect(determineCardPositions([standardCard, standardCard])).toEqual(
+			[],
+		);
+	});
+});

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -1,6 +1,6 @@
-import { trails } from 'fixtures/manual/trails';
+import { trails } from '../../fixtures/manual/trails';
+import type { DCRFrontCard } from '../types/front';
 import { determineCardPositions } from './FlexibleGeneral';
-import { DCRFrontCard } from 'src/types/front';
 
 const standardCard = {
 	...trails[0],
@@ -13,15 +13,66 @@ const boostedCard = {
 } satisfies DCRFrontCard;
 
 describe('FlexibleGeneral', () => {
-	it.skip('Should return a one card half width row if one standard card is provided', () => {
-		expect(determineCardPositions([standardCard])).toEqual([]);
+	it('Should return a one card row layout if one standard card is provided', () => {
+		expect(determineCardPositions([standardCard])).toEqual([
+			{
+				rowLayout: 'oneCard',
+				cards: [standardCard],
+			},
+		]);
 	});
-	it.skip('Should return a one full half width row if one standard boosted card is provided', () => {
-		expect(determineCardPositions([boostedCard])).toEqual([]);
+	it('Should return a one card boosted row layout if one boosted card is provided', () => {
+		expect(determineCardPositions([boostedCard])).toEqual([
+			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
+		]);
 	});
-	it.skip('Should return a two card row if two standard cards are provided', () => {
-		expect(determineCardPositions([standardCard, standardCard])).toEqual(
-			[],
-		);
+	it('Should return a two card row layout if two standard cards are provided', () => {
+		expect(determineCardPositions([standardCard, standardCard])).toEqual([
+			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+		]);
+	});
+
+	it('Should return two rows of two card row layouts if four standard cards are provided', () => {
+		expect(
+			determineCardPositions([
+				standardCard,
+				standardCard,
+				standardCard,
+				standardCard,
+			]),
+		).toEqual([
+			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+		]);
+	});
+
+	it('Should return three rows of expected row layouts if a boosted card and three standard cards are provided', () => {
+		expect(
+			determineCardPositions([
+				boostedCard,
+				standardCard,
+				standardCard,
+				standardCard,
+			]),
+		).toEqual([
+			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
+			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+			{ rowLayout: 'oneCard', cards: [standardCard] },
+		]);
+	});
+
+	it('Should return three rows of expected row layouts if a standard, then boosted card and two standard cards are provided', () => {
+		expect(
+			determineCardPositions([
+				standardCard,
+				boostedCard,
+				standardCard,
+				standardCard,
+			]),
+		).toEqual([
+			{ rowLayout: 'oneCard', cards: [standardCard] },
+			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
+			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+		]);
 	});
 });

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -1,6 +1,6 @@
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRFrontCard } from '../types/front';
-import { determineCardPositions } from './FlexibleGeneral';
+import { decideCardPositions } from './FlexibleGeneral';
 
 const standardCard = {
 	...trails[0],
@@ -14,7 +14,7 @@ const boostedCard = {
 
 describe('FlexibleGeneral', () => {
 	it('Should return a one card row layout if one standard card is provided', () => {
-		expect(determineCardPositions([standardCard])).toEqual([
+		expect(decideCardPositions([standardCard])).toEqual([
 			{
 				layout: 'oneCard',
 				cards: [standardCard],
@@ -22,19 +22,19 @@ describe('FlexibleGeneral', () => {
 		]);
 	});
 	it('Should return a one card boosted row layout if one boosted card is provided', () => {
-		expect(determineCardPositions([boostedCard])).toEqual([
+		expect(decideCardPositions([boostedCard])).toEqual([
 			{ layout: 'oneCardBoosted', cards: [boostedCard] },
 		]);
 	});
 	it('Should return a two card row layout if two standard cards are provided', () => {
-		expect(determineCardPositions([standardCard, standardCard])).toEqual([
+		expect(decideCardPositions([standardCard, standardCard])).toEqual([
 			{ layout: 'twoCard', cards: [standardCard, standardCard] },
 		]);
 	});
 
 	it('Should return two rows of two card row layouts if four standard cards are provided', () => {
 		expect(
-			determineCardPositions([
+			decideCardPositions([
 				standardCard,
 				standardCard,
 				standardCard,
@@ -48,7 +48,7 @@ describe('FlexibleGeneral', () => {
 
 	it('Should return three rows of expected row layouts if a boosted card and three standard cards are provided', () => {
 		expect(
-			determineCardPositions([
+			decideCardPositions([
 				boostedCard,
 				standardCard,
 				standardCard,
@@ -63,7 +63,7 @@ describe('FlexibleGeneral', () => {
 
 	it('Should return three rows of expected row layouts if a standard, then boosted card and two standard cards are provided', () => {
 		expect(
-			determineCardPositions([
+			decideCardPositions([
 				standardCard,
 				boostedCard,
 				standardCard,

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -16,19 +16,19 @@ describe('FlexibleGeneral', () => {
 	it('Should return a one card row layout if one standard card is provided', () => {
 		expect(determineCardPositions([standardCard])).toEqual([
 			{
-				rowLayout: 'oneCard',
+				layout: 'oneCard',
 				cards: [standardCard],
 			},
 		]);
 	});
 	it('Should return a one card boosted row layout if one boosted card is provided', () => {
 		expect(determineCardPositions([boostedCard])).toEqual([
-			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'oneCardBoosted', cards: [boostedCard] },
 		]);
 	});
 	it('Should return a two card row layout if two standard cards are provided', () => {
 		expect(determineCardPositions([standardCard, standardCard])).toEqual([
-			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+			{ layout: 'twoCard', cards: [standardCard, standardCard] },
 		]);
 	});
 
@@ -41,8 +41,8 @@ describe('FlexibleGeneral', () => {
 				standardCard,
 			]),
 		).toEqual([
-			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
-			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+			{ layout: 'twoCard', cards: [standardCard, standardCard] },
+			{ layout: 'twoCard', cards: [standardCard, standardCard] },
 		]);
 	});
 
@@ -55,9 +55,9 @@ describe('FlexibleGeneral', () => {
 				standardCard,
 			]),
 		).toEqual([
-			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
-			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
-			{ rowLayout: 'oneCard', cards: [standardCard] },
+			{ layout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'twoCard', cards: [standardCard, standardCard] },
+			{ layout: 'oneCard', cards: [standardCard] },
 		]);
 	});
 
@@ -70,9 +70,9 @@ describe('FlexibleGeneral', () => {
 				standardCard,
 			]),
 		).toEqual([
-			{ rowLayout: 'oneCard', cards: [standardCard] },
-			{ rowLayout: 'oneCardBoosted', cards: [boostedCard] },
-			{ rowLayout: 'twoCard', cards: [standardCard, standardCard] },
+			{ layout: 'oneCard', cards: [standardCard] },
+			{ layout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'twoCard', cards: [standardCard, standardCard] },
 		]);
 	});
 });

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -119,7 +119,8 @@ const determineCardProperties = (
 			};
 	}
 };
-export const OneCardLayout = ({
+
+export const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -240,21 +241,15 @@ export const FlexibleGeneral = ({
 
 	return (
 		<>
-			<OneCardLayout
-				cards={splash}
-				containerPalette={containerPalette}
-				showAge={showAge}
-				absoluteServerTimes={absoluteServerTimes}
-				imageLoading={imageLoading}
-			/>
-
-			<TwoCardOrFourCardLayout
-				cards={cards}
-				containerPalette={containerPalette}
-				showAge={showAge}
-				absoluteServerTimes={absoluteServerTimes}
-				imageLoading={imageLoading}
-			/>
+			{splash.length > 0 && (
+				<SplashCardLayout
+					cards={splash}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+				/>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -28,6 +28,65 @@ type boostProperties = {
 	supportingContentAlignment: Alignment;
 };
 
+type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
+
+type GroupedRow = {
+	rowLayout: RowLayout;
+	cards: DCRFrontCard[];
+};
+type GroupedCards = GroupedRow[];
+
+export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
+	return cards.reduce(
+		(acc: GroupedCards, card: DCRFrontCard): GroupedCards => {
+			/// if, the accumulator is empty, add the card to a new row.
+			if (acc.length === 0) {
+				const firstRow: GroupedRow = {
+					rowLayout: 'oneCard',
+					cards: [card],
+				};
+				return [firstRow];
+			}
+
+			// If the new card is boosted, we always create a new row
+			if (card.boostLevel !== 'default') {
+				const newRow: GroupedRow = {
+					rowLayout: 'oneCardBoosted',
+					cards: [card],
+				};
+				return [...acc, newRow];
+			}
+
+			// If the new card is a standard, we need to check if there is
+			//  space in the current row before creating a new one
+
+			// Which row are we currently on?
+			const currentRow = acc[acc.length - 1];
+
+			if (!currentRow) {
+				return acc;
+			}
+
+			if (currentRow.cards.length < 2) {
+				const accWithoutCurrentRow = acc.slice(0, acc.length);
+				const updatedCurrentRow: GroupedRow = {
+					rowLayout: 'twoCard',
+					cards: [...currentRow.cards, card],
+				};
+				return [...accWithoutCurrentRow, updatedCurrentRow];
+			} else {
+				// we need to start a new row
+				const newRow: GroupedRow = {
+					rowLayout: 'oneCard',
+					cards: [card],
+				};
+				return [newRow];
+			}
+		},
+		[],
+	);
+};
+
 /**
  * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -119,6 +119,113 @@ const determineCardProperties = (
 			};
 	}
 };
+export const BoostedCardLayout = ({
+	cards,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	imageLoading,
+}: {
+	cards: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+}) => {
+	const card = cards[0];
+	if (!card) return null;
+
+	const {
+		headlineSize,
+		headlineSizeOnMobile,
+		headlineSizeOnTablet,
+		imagePositionOnDesktop,
+		imagePositionOnMobile,
+		supportingContentAlignment,
+	} = determineCardProperties(
+		card.boostLevel,
+		card?.supportingContent?.length ?? 0,
+	);
+	return (
+		<UL padBottom={true}>
+			<LI padSides={true}>
+				<FrontCard
+					trail={card}
+					containerPalette={containerPalette}
+					containerType="flexible/general"
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					headlineSize={headlineSize}
+					headlineSizeOnMobile={headlineSizeOnMobile}
+					headlineSizeOnTablet={headlineSizeOnTablet}
+					imagePositionOnDesktop={imagePositionOnDesktop}
+					imagePositionOnMobile={imagePositionOnMobile}
+					imageSize="medium"
+					trailText={card.trailText}
+					supportingContent={card.supportingContent}
+					supportingContentAlignment={supportingContentAlignment}
+					imageLoading={imageLoading}
+					aspectRatio="5:4"
+					kickerText={card.kickerText}
+					showLivePlayable={card.showLivePlayable}
+					boostedFontSizes={true}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
+export const StandardCardLayout = ({
+	cards,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	showImage = true,
+	padBottom,
+	imageLoading,
+}: {
+	cards: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+	showImage?: boolean;
+	padBottom?: boolean;
+}) => {
+	const card = cards[0];
+	if (!card) return null;
+	return (
+		<UL direction="row" padBottom={padBottom}>
+			{cards.map((card, cardIndex) => {
+				return (
+					<LI
+						stretch={false}
+						percentage={'50%'}
+						key={card.url}
+						padSides={true}
+						showDivider={cardIndex > 0}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="flexible/general"
+							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
+							image={showImage ? card.image : undefined}
+							imageLoading={imageLoading}
+							imagePositionOnDesktop={'left'}
+							supportingContent={undefined} // we don't want to support sublinks on standard cards here so we hard code to undefined.
+							imageSize={'medium'}
+							aspectRatio="5:4"
+							kickerText={card.kickerText}
+							showLivePlayable={false}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};
 
 export const SplashCardLayout = ({
 	cards,
@@ -176,59 +283,6 @@ export const SplashCardLayout = ({
 	);
 };
 
-const TwoCardOrFourCardLayout = ({
-	cards,
-	containerPalette,
-	showAge,
-	absoluteServerTimes,
-	showImage = true,
-	padBottom,
-	imageLoading,
-}: {
-	cards: DCRFrontCard[];
-	imageLoading: Loading;
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-	absoluteServerTimes: boolean;
-	showImage?: boolean;
-	padBottom?: boolean;
-}) => {
-	const hasTwoOrFewerCards = cards.length <= 2;
-	return (
-		<UL direction="row" padBottom={padBottom}>
-			{cards.map((card, cardIndex) => {
-				return (
-					<LI
-						stretch={false}
-						percentage={hasTwoOrFewerCards ? '50%' : '25%'}
-						key={card.url}
-						padSides={true}
-						showDivider={cardIndex > 0}
-					>
-						<FrontCard
-							trail={card}
-							containerPalette={containerPalette}
-							containerType="flexible/special"
-							showAge={showAge}
-							absoluteServerTimes={absoluteServerTimes}
-							image={showImage ? card.image : undefined}
-							imageLoading={imageLoading}
-							imagePositionOnDesktop={
-								hasTwoOrFewerCards ? 'left' : 'bottom'
-							}
-							supportingContent={undefined} // we don't want to support sublinks on standard cards here so we hard code to undefined.
-							imageSize={'medium'}
-							aspectRatio="5:4"
-							kickerText={card.kickerText}
-							showLivePlayable={false}
-						/>
-					</LI>
-				);
-			})}
-		</UL>
-	);
-};
-
 export const FlexibleGeneral = ({
 	groupedTrails,
 	containerPalette,
@@ -238,6 +292,7 @@ export const FlexibleGeneral = ({
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(0, 8); // TODO check maximum number of cards
+	const groupedCards = determineCardPositions(cards);
 
 	return (
 		<>
@@ -250,6 +305,34 @@ export const FlexibleGeneral = ({
 					imageLoading={imageLoading}
 				/>
 			)}
+
+			{groupedCards.map((row) => {
+				switch (row.layout) {
+					case 'oneCardBoosted':
+						return (
+							<BoostedCardLayout
+								cards={row.cards}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
+								imageLoading={imageLoading}
+							/>
+						);
+
+					case 'oneCard':
+					case 'twoCard':
+					default:
+						return (
+							<StandardCardLayout
+								cards={row.cards}
+								containerPalette={containerPalette}
+								showAge={showAge}
+								absoluteServerTimes={absoluteServerTimes}
+								imageLoading={imageLoading}
+							/>
+						);
+				}
+			})}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -4,7 +4,10 @@ import type {
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
-import type { ImagePositionType } from './Card/components/ImageWrapper';
+import type {
+	ImagePositionType,
+	ImageSizeType,
+} from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
@@ -19,15 +22,6 @@ type Props = {
 	absoluteServerTimes: boolean;
 };
 
-type boostProperties = {
-	headlineSize: SmallHeadlineSize;
-	headlineSizeOnMobile: SmallHeadlineSize;
-	headlineSizeOnTablet: SmallHeadlineSize;
-	imagePositionOnDesktop: ImagePositionType;
-	imagePositionOnMobile: ImagePositionType;
-	supportingContentAlignment: Alignment;
-};
-
 type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
 
 type GroupedRow = {
@@ -36,7 +30,7 @@ type GroupedRow = {
 };
 type GroupedCards = GroupedRow[];
 
-export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
+export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	const createNewRow = (
 		layout: RowLayout,
 		card: DCRFrontCard,
@@ -71,46 +65,55 @@ export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 };
 
 /**
- * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */
-const determineCardProperties = (
+
+type boostedSplashProperties = {
+	headlineSize: SmallHeadlineSize;
+	headlineSizeOnMobile: SmallHeadlineSize;
+	headlineSizeOnTablet: SmallHeadlineSize;
+	imagePositionOnDesktop: ImagePositionType;
+	imagePositionOnMobile: ImagePositionType;
+	supportingContentAlignment: Alignment;
+};
+const decideSplashCardProperties = (
 	boostLevel: BoostLevel = 'default',
 	supportingContentLength: number,
-): boostProperties => {
+): boostedSplashProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
 			return {
-				headlineSize: 'medium',
+				headlineSize: 'tiny',
 				headlineSizeOnMobile: 'tiny',
-				headlineSizeOnTablet: 'small',
+				headlineSizeOnTablet: 'tiny',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment:
-					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
 			};
 		case 'boost':
 			return {
-				headlineSize: 'large',
+				headlineSize: 'small',
 				headlineSizeOnMobile: 'small',
-				headlineSizeOnTablet: 'medium',
+				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment:
-					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
 			};
 		case 'megaboost':
 			return {
-				headlineSize: 'large',
+				headlineSize: 'medium',
 				headlineSizeOnMobile: 'medium',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment: 'horizontal',
 			};
 		case 'gigaboost':
 			return {
-				headlineSize: 'huge',
+				headlineSize: 'large',
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
@@ -119,7 +122,8 @@ const determineCardProperties = (
 			};
 	}
 };
-export const BoostedCardLayout = ({
+
+export const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -142,7 +146,7 @@ export const BoostedCardLayout = ({
 		imagePositionOnDesktop,
 		imagePositionOnMobile,
 		supportingContentAlignment,
-	} = determineCardProperties(
+	} = decideSplashCardProperties(
 		card.boostLevel,
 		card?.supportingContent?.length ?? 0,
 	);
@@ -160,7 +164,7 @@ export const BoostedCardLayout = ({
 					headlineSizeOnTablet={headlineSizeOnTablet}
 					imagePositionOnDesktop={imagePositionOnDesktop}
 					imagePositionOnMobile={imagePositionOnMobile}
-					imageSize="medium"
+					imageSize="jumbo"
 					trailText={card.trailText}
 					supportingContent={card.supportingContent}
 					supportingContentAlignment={supportingContentAlignment}
@@ -169,6 +173,87 @@ export const BoostedCardLayout = ({
 					kickerText={card.kickerText}
 					showLivePlayable={card.showLivePlayable}
 					boostedFontSizes={true}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
+/**
+ * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ */
+
+type boostedCardProperties = {
+	headlineSize: SmallHeadlineSize;
+	headlineSizeOnMobile: SmallHeadlineSize;
+	headlineSizeOnTablet: SmallHeadlineSize;
+	imageSize: ImageSizeType;
+};
+const decideCardProperties = (
+	boostLevel: BoostLevel = 'boost',
+): boostedCardProperties => {
+	switch (boostLevel) {
+		case 'megaboost':
+			return {
+				headlineSize: 'huge',
+				headlineSizeOnMobile: 'huge',
+				headlineSizeOnTablet: 'huge',
+				imageSize: 'jumbo',
+			};
+		case 'boost':
+		default:
+			return {
+				headlineSize: 'large',
+				headlineSizeOnMobile: 'large',
+				headlineSizeOnTablet: 'large',
+				imageSize: 'medium',
+			};
+	}
+};
+
+export const BoostedCardLayout = ({
+	cards,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	imageLoading,
+}: {
+	cards: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+}) => {
+	const card = cards[0];
+	if (!card) return null;
+
+	const {
+		headlineSize,
+		headlineSizeOnMobile,
+		headlineSizeOnTablet,
+		imageSize,
+	} = decideCardProperties(card.boostLevel);
+	return (
+		<UL padBottom={true}>
+			<LI padSides={true}>
+				<FrontCard
+					trail={card}
+					containerPalette={containerPalette}
+					containerType="flexible/general"
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					headlineSize={headlineSize}
+					headlineSizeOnMobile={headlineSizeOnMobile}
+					headlineSizeOnTablet={headlineSizeOnTablet}
+					imagePositionOnDesktop={'right'}
+					imagePositionOnMobile={'bottom'}
+					imageSize={imageSize}
+					trailText={card.trailText}
+					supportingContent={undefined}
+					imageLoading={imageLoading}
+					aspectRatio="5:4"
+					kickerText={card.kickerText}
+					showLivePlayable={card.showLivePlayable}
 				/>
 			</LI>
 		</UL>
@@ -227,62 +312,6 @@ export const StandardCardLayout = ({
 	);
 };
 
-export const SplashCardLayout = ({
-	cards,
-	containerPalette,
-	showAge,
-	absoluteServerTimes,
-	imageLoading,
-}: {
-	cards: DCRFrontCard[];
-	imageLoading: Loading;
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-	absoluteServerTimes: boolean;
-}) => {
-	const card = cards[0];
-	if (!card) return null;
-
-	const {
-		headlineSize,
-		headlineSizeOnMobile,
-		headlineSizeOnTablet,
-		imagePositionOnDesktop,
-		imagePositionOnMobile,
-		supportingContentAlignment,
-	} = determineCardProperties(
-		card.boostLevel,
-		card?.supportingContent?.length ?? 0,
-	);
-	return (
-		<UL padBottom={true}>
-			<LI padSides={true}>
-				<FrontCard
-					trail={card}
-					containerPalette={containerPalette}
-					containerType="flexible/general"
-					showAge={showAge}
-					absoluteServerTimes={absoluteServerTimes}
-					headlineSize={headlineSize}
-					headlineSizeOnMobile={headlineSizeOnMobile}
-					headlineSizeOnTablet={headlineSizeOnTablet}
-					imagePositionOnDesktop={imagePositionOnDesktop}
-					imagePositionOnMobile={imagePositionOnMobile}
-					imageSize="jumbo"
-					trailText={card.trailText}
-					supportingContent={card.supportingContent}
-					supportingContentAlignment={supportingContentAlignment}
-					imageLoading={imageLoading}
-					aspectRatio="5:4"
-					kickerText={card.kickerText}
-					showLivePlayable={card.showLivePlayable}
-					boostedFontSizes={true}
-				/>
-			</LI>
-		</UL>
-	);
-};
-
 export const FlexibleGeneral = ({
 	groupedTrails,
 	containerPalette,
@@ -292,7 +321,7 @@ export const FlexibleGeneral = ({
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(0, 8); // TODO check maximum number of cards
-	const groupedCards = determineCardPositions(cards);
+	const groupedCards = decideCardPositions(cards);
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -277,8 +277,6 @@ export const StandardCardLayout = ({
 	showImage?: boolean;
 	padBottom?: boolean;
 }) => {
-	const card = cards[0];
-	if (!card) return null;
 	return (
 		<UL direction="row" padBottom={padBottom}>
 			{cards.map((card, cardIndex) => {

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -31,23 +31,23 @@ type boostProperties = {
 type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
 
 type GroupedRow = {
-	rowLayout: RowLayout;
+	layout: RowLayout;
 	cards: DCRFrontCard[];
 };
 type GroupedCards = GroupedRow[];
 
 export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	const createNewRow = (
-		rowLayout: RowLayout,
+		layout: RowLayout,
 		card: DCRFrontCard,
 	): GroupedRow => ({
-		rowLayout,
+		layout,
 		cards: [card],
 	});
 
 	const addCardToRow = (row: GroupedRow, card: DCRFrontCard): GroupedRow => ({
 		cards: [...row.cards, card],
-		rowLayout: 'twoCard',
+		layout: 'twoCard',
 	});
 
 	return cards.reduce<GroupedCards>((acc, card) => {
@@ -61,7 +61,7 @@ export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 
 		// If the current row has one card, we can add one more standard card to it
 		// We change the row layout to 'twoCard' to indicate that it is now full
-		if (row && row.rowLayout === 'oneCard') {
+		if (row && row.layout === 'oneCard') {
 			return [...acc.slice(0, acc.length - 1), addCardToRow(row, card)];
 		} // Otherwise we consider the row to be 'full' and start a new row
 		else {

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -51,15 +51,20 @@ export const determineCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	});
 
 	return cards.reduce<GroupedCards>((acc, card) => {
+		// Early return if the card is boosted since it takes up a whole row
 		if (card.boostLevel !== 'default') {
 			return [...acc, createNewRow('oneCardBoosted', card)];
 		}
 
+		// Otherwise we need to check the status of the current row
 		const row = acc[acc.length - 1];
 
+		// If the current row has one card, we can add one more standard card to it
+		// We change the row layout to 'twoCard' to indicate that it is now full
 		if (row && row.rowLayout === 'oneCard') {
 			return [...acc.slice(0, acc.length - 1), addCardToRow(row, card)];
-		} else {
+		} // Otherwise we consider the row to be 'full' and start a new row
+		else {
 			return [...acc, createNewRow('oneCard', card)];
 		}
 	}, []);


### PR DESCRIPTION
## What does this change?
Renders the flexible/general container.

The layout applies a reducer to the cards to sort them into their respective rows. Flexible general cards can appear in one of three row types. These are:

- One Card
This is a row with one standard card that takes up 50% width above mobile. it takes up full with on mobile.

- Two Card
This is a row with two standard card that take up 50% width each above mobile. it takes up full with on mobile.

- One Card Boosted
This is a row with one boosted card that takes up 100% width above mobile. it takes up full with on mobile.

The container has an optional splash card, which can be boosted, and then standard cards which can also be boosted. 

## Why?
Flexible/general is a new container type that will replace dynamic/fast. 

## Screenshots

https://github.com/user-attachments/assets/d4b74418-51a0-4d9d-b0dd-f74d5a475c7c



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
