### PR TITLE
[Fairground 🎡] Add container top bar as well as card topbar

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -416,7 +416,8 @@ export const Card = ({
 	return (
 		<CardWrapper
 			format={format}
-			showTopBar={!isOnwardContent}
+			showTopBar={!isOnwardContent && !isFlexibleContainer}
+			showMobileTopBar={isFlexibleContainer}
 			containerPalette={containerPalette}
 			isOnwardContent={isOnwardContent}
 		>

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
 import type { ArticleFormat } from '@guardian/libs';
-import { palette as sourcePalette, space } from '@guardian/source/foundations';
+import {
+	palette as sourcePalette,
+	space,
+	until,
+} from '@guardian/source/foundations';
 import { palette } from '../../../palette';
 import type { DCRContainerPalette } from '../../../types/front';
 import { ContainerOverrides } from '../../ContainerOverrides';
@@ -11,6 +15,7 @@ type Props = {
 	format: ArticleFormat;
 	containerPalette?: DCRContainerPalette;
 	showTopBar?: boolean;
+	showMobileTopBar?: boolean;
 	isOnwardContent?: boolean;
 };
 
@@ -76,6 +81,12 @@ const topBarStyles = css`
 	}
 `;
 
+const mobileTopBarStyles = css`
+	${until.tablet} {
+		${topBarStyles}
+	}
+`;
+
 const onwardContentStyles = css`
 	border-radius: ${space[2]}px;
 	overflow: hidden;
@@ -90,6 +101,7 @@ export const CardWrapper = ({
 	format,
 	containerPalette,
 	showTopBar = true,
+	showMobileTopBar = false,
 	isOnwardContent = false,
 }: Props) => {
 	return (
@@ -101,6 +113,7 @@ export const CardWrapper = ({
 						hoverStyles,
 						sublinkHoverStyles,
 						showTopBar && topBarStyles,
+						showMobileTopBar && mobileTopBarStyles,
 						isOnwardContent && onwardContentStyles,
 					]}
 				>

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -38,6 +38,22 @@ const marginBottomStyles = css`
 	margin-bottom: ${space[3]}px;
 `;
 
+const topBarStyles = css`
+	${from.tablet} {
+		padding-top: 8px;
+		::before {
+			content: '';
+			display: block;
+			position: absolute;
+			top: 0px;
+			left: 10px;
+			width: calc(100% - 20px);
+			height: 1px;
+			background-color: ${palette('--card-border-top')};
+		}
+	}
+`;
+
 type Props = {
 	children: React.ReactNode;
 	/** Passed to flex-direction */
@@ -48,6 +64,8 @@ type Props = {
 	padBottom?: boolean;
 	/** Used to keep cards aligned in adjacent columns */
 	wrapCards?: boolean;
+	/** Used to display a full width bar along the top of the container */
+	showTopBar?: boolean;
 };
 
 export const UL = ({
@@ -56,6 +74,7 @@ export const UL = ({
 	showDivider = false,
 	padBottom = false,
 	wrapCards = false,
+	showTopBar = false,
 }: Props) => {
 	return (
 		<ul
@@ -64,6 +83,7 @@ export const UL = ({
 				showDivider && verticalDivider(palette('--section-border')),
 				padBottom && marginBottomStyles,
 				wrapCards && wrapStyles,
+				showTopBar && topBarStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -152,7 +152,7 @@ const TwoCardOrFourCardLayout = ({
 }) => {
 	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
-		<UL direction="row" padBottom={padBottom}>
+		<UL direction="row" padBottom={padBottom} showTopBar={true}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI
@@ -173,7 +173,8 @@ const TwoCardOrFourCardLayout = ({
 							imagePositionOnDesktop={
 								hasTwoOrFewerCards ? 'left' : 'bottom'
 							}
-							supportingContent={undefined} // we don't want to support sublinks on standard cards here so we hard code to undefined.
+							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
+							supportingContent={undefined}
 							imageSize={'medium'}
 							aspectRatio="5:4"
 							kickerText={card.kickerText}


### PR DESCRIPTION
## What does this change?
add support for a top bar divider at the container level, as well as at the card level and extends the card offering to a mobile only topbar.

## Why?
This aligns with modern designs for the flexible containers. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/57d603fa-343c-459e-823c-cd3978e2f139
[after]: https://github.com/user-attachments/assets/42d280f3-d632-49b9-af4c-25b7e592176a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
