### PR TITLE
[Fairground 🎡] Style cards differently if card isFlexSplash

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -426,7 +426,7 @@ export const Card = ({
 			{headlinePosition === 'outer' && (
 				<div
 					css={css`
-						padding-bottom: 8px;
+						padding-bottom: ${space[5]}px;
 					`}
 					style={{ backgroundColor: cardBackgroundColour }}
 				>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -398,7 +398,7 @@ export const Card = ({
 			);
 		}
 		return (
-			<Hide from={isFlexSplash ? 'tablet' : 'desktop'}>
+			<Hide from={isFlexSplash ? 'desktop' : 'tablet'}>
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
@@ -737,7 +737,7 @@ export const Card = ({
 
 							{hasSublinks && sublinkPosition === 'inner' && (
 								<Hide
-									until={isFlexSplash ? 'tablet' : 'desktop'}
+									until={isFlexSplash ? 'desktop' : 'tablet'}
 								>
 									<SupportingContent
 										supportingContent={supportingContent}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -114,6 +114,8 @@ export type Props = {
 	/** Alows the consumer to use a larger font size group for boost styling*/
 	boostedFontSizes?: boolean;
 	index?: number;
+	/** The Splash card in a flexible container gets a different visual treatment to other cards*/
+	isFlexSplash?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -197,17 +199,6 @@ const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	return timeDiffHours <= 12;
 };
 
-const decideHeadlinePosition = (
-	imageSize?: ImageSizeType,
-	containerType?: DCRContainerType,
-) => {
-	if (imageSize === 'jumbo' && containerType === 'flexible/special') {
-		return 'outer';
-	}
-
-	return 'inner';
-};
-
 export const Card = ({
 	linkTo,
 	format,
@@ -257,6 +248,7 @@ export const Card = ({
 	aspectRatio,
 	boostedFontSizes,
 	index = 0,
+	isFlexSplash,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -264,8 +256,6 @@ export const Card = ({
 		imagePositionOnDesktop,
 		supportingContentAlignment,
 	);
-	const headlinePosition = decideHeadlinePosition(imageSize, containerType);
-
 	const showQuotes = !!showQuotedHeadline;
 
 	const isOpinion =
@@ -369,10 +359,14 @@ export const Card = ({
 	/* Whilst we migrate to the new container types, we need to check which container we are in. */
 	const isFlexibleContainer = containerType === 'flexible/special';
 
+	const headlinePosition =
+		isFlexSplash && isFlexibleContainer ? 'outer' : 'inner';
+
 	/** Determines the gap of between card components based on card properties */
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
 		if (hasBackgroundColour) return 'small';
+		if (isFlexSplash) return 'medium';
 		if (
 			isFlexibleContainer &&
 			(imagePositionOnDesktop === 'left' ||
@@ -404,7 +398,7 @@ export const Card = ({
 			);
 		}
 		return (
-			<Hide from="tablet">
+			<Hide from={isFlexSplash ? 'tablet' : 'desktop'}>
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
@@ -689,9 +683,7 @@ export const Card = ({
 									}
 									imageSize={imageSize}
 									imageType={media?.type}
-									shouldHide={
-										isFlexibleContainer ? false : true
-									}
+									shouldHide={isFlexSplash ? false : true}
 								>
 									<div
 										dangerouslySetInnerHTML={{
@@ -744,7 +736,9 @@ export const Card = ({
 							)}
 
 							{hasSublinks && sublinkPosition === 'inner' && (
-								<Hide until="tablet">
+								<Hide
+									until={isFlexSplash ? 'tablet' : 'desktop'}
+								>
 									<SupportingContent
 										supportingContent={supportingContent}
 										alignment="vertical"

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -127,6 +127,7 @@ export const OneCardLayout = ({
 					kickerText={card.kickerText}
 					showLivePlayable={card.showLivePlayable}
 					boostedFontSizes={true}
+					isFlexSplash={true}
 				/>
 			</LI>
 		</UL>


### PR DESCRIPTION
## What does this change?
Adds an isFlexSplash property to Card to allow us to set styles and layout specifically for this card type.
This follows the same pattern as the isDynamo prop. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b996c08b-48ed-4968-868c-98454194042d
[after]: https://github.com/user-attachments/assets/e8bb366e-b42e-4631-bae7-3ca1563e096f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
