### PR TITLE
Remove `surveys` switch

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -300,14 +300,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						</Stuck>
 					)}
 
-					{renderAds &&
-						article.config.switches.surveys &&
-						hasSurveyAd && (
-							<AdSlot
-								position="survey"
-								display={format.display}
-							/>
-						)}
+					{renderAds && hasSurveyAd && (
+						<AdSlot position="survey" display={format.display} />
+					)}
 				</>
 			)}
 			<main data-layout="InteractiveLayout">

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -249,7 +249,7 @@ export const NewsletterSignupLayout = ({ article, NAV, format }: Props) => {
 				/>
 			</div>
 
-			{renderAds && !!article.config.switches.surveys && hasSurveyAd && (
+			{renderAds && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -461,7 +461,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			)}
 
-			{renderAds && article.config.switches.surveys && hasSurveyAd && (
+			{renderAds && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
 			)}
 


### PR DESCRIPTION
## What does this change?

This PR removes the survey switch conditions and instead replace it with `hasSurveyAd` in the page config as we now show survey ads programmatically. Frontend PR https://github.com/guardian/frontend/pull/27489

## Why?

More efficient and we just show survey ad based on certain conditions instead of relying on a switch.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
