### PR TITLE
Update the paid content article data for Playwright test

### DIFF
--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -6,7 +6,7 @@ import { expectToBeVisible } from '../lib/locators';
 import { ADDITIONAL_REQUEST_PATH, interceptOphanRequest } from '../lib/ophan';
 
 const paidContentPage =
-	'https://www.theguardian.com/chase-the-snow-with-sunweb/2024/sep/16/al-pining-for-the-slopes-why-the-french-alps-is-our-favourite-family-ski-destination';
+	'https://www.theguardian.com/cook-up-a-feast-with-tesco-finest/2024/sep/13/peach-and-burrata-bruschetta-recipe';
 
 /**
  * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
@@ -29,8 +29,9 @@ test.describe('Paid content tests', () => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
-					clickComponent === 'labs-logo | article-meta-paypal' &&
-					clickLinkNames === '["labs-logo-article-meta-paypal"]'
+					clickComponent ===
+						'labs-logo | article-meta-tesco-finest' &&
+					clickLinkNames === '["labs-logo-article-meta-tesco-finest"]'
 				);
 			},
 		});
@@ -57,9 +58,9 @@ test.describe('Paid content tests', () => {
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
 					clickComponent ===
-						'labs-logo | article-related-content-paypal' &&
+						'labs-logo | article-related-content-tesco-finest' &&
 					clickLinkNames ===
-						'["labs-logo-article-related-content-paypal","related-content"]'
+						'["labs-logo-article-related-content-tesco-finest","related-content"]'
 				);
 			},
 		});


### PR DESCRIPTION
## What does this change?

Updates the URL and click event data used in the paid content playwright tests

## Why?

The previous page had been taken down 
