### PR TITLE
Enure sublinks occupy entire area, instead of leaving gaps

### DIFF
--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -47,7 +47,6 @@ const baseGrid = css`
 const horizontalGrid = css`
 	${from.tablet} {
 		grid-template-columns: repeat(12, 1fr);
-		column-gap: ${space[5]}px;
 	}
 `;
 
@@ -76,7 +75,7 @@ const verticalLineStyle = css`
 		content: '';
 		position: absolute;
 		top: 0;
-		right: -10px; /* Half of the column-gap to center the line */
+		right: 0;
 		height: 100%;
 		width: 1px;
 		background-color: ${palette('--card-border-supporting')};


### PR DESCRIPTION
## What does this change?

Removes `column-gap` from the sublink grid and adjusts the vertical lines between sublinks accordingly

## Why?

The hoverable area does not occupy the entire `ul` of the sublink area, causing glitches when between sublinks. This could cause someone to click near to a sublink and be taken to the main article in the card rather than the desired article of the sublink.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7b30eae1-065c-4492-9f6e-52fa143b1618
[after]: https://github.com/user-attachments/assets/34af8295-8137-4aae-9e8d-fc37b2cff23e

### Before

https://github.com/user-attachments/assets/b293a5d5-e103-4cda-9245-c7a3261d9b6a


### After

https://github.com/user-attachments/assets/365e54b4-fbca-49c6-afa5-ddb74f67f15e


