### PR TITLE
Revert "[Fairground 🎡] Redesign sublinks as grid layout"

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -139,25 +139,6 @@ const StarRatingComponent = ({
 	</div>
 );
 
-const HorizontalDivider = () => (
-	<div
-		css={css`
-			${from.tablet} {
-				border-top: 1px solid ${themePalette('--card-border-top')};
-				height: 1px;
-				width: 50%;
-				${from.tablet} {
-					width: 100px;
-				}
-				${from.desktop} {
-					width: 140px;
-				}
-				margin-top: ${space[3]}px;
-			}
-		`}
-	/>
-);
-
 const getMedia = ({
 	imageUrl,
 	imageAltText,
@@ -410,7 +391,7 @@ export const Card = ({
 	 *
 	 */
 	const decideOuterSublinks = () => {
-		if (!hasSublinks) return null;
+		if (!supportingContent) return null;
 		if (sublinkPosition === 'none') return null;
 		if (sublinkPosition === 'outer') {
 			return (
@@ -419,35 +400,16 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
 				/>
 			);
 		}
 		return (
-			<Hide from={isFlexibleContainer ? 'tablet' : 'desktop'}>
+			<Hide from="tablet">
 				<SupportingContent
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
-				/>
-			</Hide>
-		);
-	};
-
-	const decideInnerSublinks = () => {
-		if (!hasSublinks) return null;
-		if (sublinkPosition !== 'inner') return null;
-		return (
-			<Hide until={isFlexibleContainer ? 'tablet' : 'desktop'}>
-				<SupportingContent
-					supportingContent={supportingContent}
-					/* inner links are always vertically stacked */
-					alignment="vertical"
-					containerPalette={containerPalette}
-					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
 				/>
 			</Hide>
 		);
@@ -758,12 +720,6 @@ export const Card = ({
 									showLivePlayable={showLivePlayable}
 								/>
 							)}
-							{sublinkPosition === 'outer' &&
-								supportingContentAlignment === 'horizontal' &&
-								(imagePositionOnDesktop === 'right' ||
-									imagePositionOnDesktop === 'left') && (
-									<HorizontalDivider />
-								)}
 						</div>
 
 						{/* This div is needed to push this content to the bottom of the card */}
@@ -787,7 +743,16 @@ export const Card = ({
 								</Island>
 							)}
 
-							{decideInnerSublinks()}
+							{hasSublinks && sublinkPosition === 'inner' && (
+								<Hide until="tablet">
+									<SupportingContent
+										supportingContent={supportingContent}
+										alignment="vertical"
+										containerPalette={containerPalette}
+										isDynamo={isDynamo}
+									/>
+								</Hide>
+							)}
 						</div>
 					</ContentWrapper>
 				)}

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -235,6 +235,9 @@ const sublinkStyles = css`
 	font-family: inherit;
 	font-size: inherit;
 	line-height: inherit;
+	@media (pointer: coarse) {
+		min-height: 44px;
+	}
 
 	/* This css is used to remove any underline from the kicker but still
 	 * have it applied to the headline when the kicker is hovered */

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -32,19 +32,6 @@ describe('FlexibleGeneral', () => {
 		]);
 	});
 
-	it('Should return a one card row layout if one card without boost level is provided', () => {
-		const cardWithoutBoostLevel = {
-			...standardCard,
-			boostLevel: undefined,
-		};
-		expect(decideCardPositions([cardWithoutBoostLevel])).toEqual([
-			{
-				layout: 'oneCard',
-				cards: [cardWithoutBoostLevel],
-			},
-		]);
-	});
-
 	it('Should return two rows of two card row layouts if four standard cards are provided', () => {
 		expect(
 			decideCardPositions([

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -46,7 +46,7 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 
 	return cards.reduce<GroupedCards>((acc, card) => {
 		// Early return if the card is boosted since it takes up a whole row
-		if (card.boostLevel && card.boostLevel !== 'default') {
+		if (card.boostLevel !== 'default') {
 			return [...acc, createNewRow('oneCardBoosted', card)];
 		}
 
@@ -64,7 +64,11 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	}, []);
 };
 
-type BoostedSplashProperties = {
+/**
+ * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ */
+
+type boostedSplashProperties = {
 	headlineSize: SmallHeadlineSize;
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
@@ -72,14 +76,10 @@ type BoostedSplashProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	supportingContentAlignment: Alignment;
 };
-
-/**
- * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
- */
 const decideSplashCardProperties = (
-	boostLevel: BoostLevel,
+	boostLevel: BoostLevel = 'default',
 	supportingContentLength: number,
-): BoostedSplashProperties => {
+): boostedSplashProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
@@ -147,10 +147,9 @@ export const SplashCardLayout = ({
 		imagePositionOnMobile,
 		supportingContentAlignment,
 	} = decideSplashCardProperties(
-		card.boostLevel ?? 'default',
-		card.supportingContent?.length ?? 0,
+		card.boostLevel,
+		card?.supportingContent?.length ?? 0,
 	);
-
 	return (
 		<UL padBottom={true}>
 			<LI padSides={true}>
@@ -180,19 +179,19 @@ export const SplashCardLayout = ({
 	);
 };
 
-type BoostedCardProperties = {
+/**
+ * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ */
+
+type boostedCardProperties = {
 	headlineSize: SmallHeadlineSize;
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imageSize: ImageSizeType;
 };
-
-/**
- * Boosting a standard card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
- */
 const decideCardProperties = (
 	boostLevel: BoostLevel = 'boost',
-): BoostedCardProperties => {
+): boostedCardProperties => {
 	switch (boostLevel) {
 		case 'megaboost':
 			return {
@@ -319,7 +318,7 @@ export const FlexibleGeneral = ({
 	imageLoading,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
-	const cards = [...groupedTrails.standard].slice(0, 8);
+	const cards = [...groupedTrails.standard].slice(0, 8); // TODO check maximum number of cards
 	const groupedCards = decideCardPositions(cards);
 
 	return (

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -19,7 +19,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 };
 
-type BoostProperties = {
+type boostProperties = {
 	headlineSize: SmallHeadlineSize;
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
@@ -32,9 +32,9 @@ type BoostProperties = {
  * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */
 const determineCardProperties = (
-	boostLevel: BoostLevel,
+	boostLevel: BoostLevel = 'default',
 	supportingContentLength: number,
-): BoostProperties => {
+): boostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
@@ -43,7 +43,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'tiny',
 				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: 'top',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
@@ -53,7 +53,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'small',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: 'top',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
@@ -63,7 +63,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'medium',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: 'top',
 				supportingContentAlignment: 'horizontal',
 			};
 		case 'gigaboost':
@@ -72,7 +72,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: 'top',
 				supportingContentAlignment: 'horizontal',
 			};
 	}
@@ -101,8 +101,8 @@ export const OneCardLayout = ({
 		imagePositionOnMobile,
 		supportingContentAlignment,
 	} = determineCardProperties(
-		card.boostLevel ?? 'default',
-		card.supportingContent?.length ?? 0,
+		card.boostLevel,
+		card?.supportingContent?.length ?? 0,
 	);
 	return (
 		<UL padBottom={true}>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { from, space, until } from '@guardian/source/foundations';
+import { between, from, space } from '@guardian/source/foundations';
 import { isMediaCard } from '../lib/cardHelpers';
 import { palette } from '../palette';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
@@ -12,139 +12,80 @@ export type Alignment = 'vertical' | 'horizontal';
 
 type Props = {
 	supportingContent: DCRSupportingContent[];
-	/** Determines if the content is arranged vertically or horizontally */
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
-	fillBackground?: boolean;
 };
-
-/**
- * Returns the column span for the grid layout based on the number of supporting content items.
- *
- * @param {number} contentLength - The number of supporting content items.
- * @returns {number} The column span to use in the grid layout.
- */
-const getColumnSpan = (contentLength: number): number => {
-	switch (contentLength) {
-		case 1:
-		case 2:
-			return 6;
-		case 3:
-			return 4;
-		case 4:
-		default:
-			return 3; // Default column span for 4 or more items
-	}
-};
-const baseGrid = css`
-	display: grid;
-	grid-template-rows: auto;
-	grid-template-columns: auto;
-	row-gap: ${space[2]}px;
-`;
-
-const horizontalGrid = css`
-	${from.tablet} {
-		grid-template-columns: repeat(12, 1fr);
-		column-gap: ${space[5]}px;
-	}
-`;
-
-const horizontalLineStyle = css`
-	margin-top: ${space[3]}px;
-	:before {
-		position: absolute;
-		top: -${space[2]}px;
-		left: 0;
-		content: '';
-		border-top: 1px solid ${palette('--card-border-top')};
-		height: 1px;
-		width: 50%;
-		${from.tablet} {
-			width: 100px;
-		}
-		${from.desktop} {
-			width: 140px;
-		}
-	}
-`;
-
-const verticalLineStyle = css`
-	/* The last child doesn't need a dividing right line */
-	:not(:last-child):after {
-		content: '';
-		position: absolute;
-		top: 0;
-		right: -10px; /* Half of the column-gap to center the line */
-		height: 100%;
-		width: 1px;
-		background-color: ${palette('--card-border-supporting')};
-	}
-`;
-
-const sublinkBaseStyles = css`
-	position: relative;
-	grid-row: span 1;
-`;
-
-const verticalSublinkStyles = css`
-	:not(:first-child) {
-		${horizontalLineStyle}
-	}
-
-	${from.tablet} {
-		:first-child {
-			${horizontalLineStyle}
-		}
-	}
-`;
-
-const horizontalSublinkStyles = (totalColumns: number) => css`
-	grid-column: span ${totalColumns};
-	${until.tablet} {
-		:not(:first-child) {
-			${horizontalLineStyle}
-		}
-	}
-
-	${from.tablet} {
-		${verticalLineStyle}
-	}
-`;
 
 const wrapperStyles = css`
 	position: relative;
+	display: flex;
 	padding-top: ${space[2]}px;
+
 	@media (pointer: coarse) {
 		padding-bottom: 0;
 	}
 `;
 
-const backgroundFill = css`
-	/** background fill should only apply to sublinks on mobile breakpoints */
-	${until.tablet} {
-		padding: ${space[2]}px;
-		padding-bottom: ${space[3]}px;
-		background-color: ${palette('--card-sublinks-background')};
+const flexColumn = css`
+	flex-direction: column;
+`;
+
+const flexRowFromTablet = css`
+	${from.tablet} {
+		flex-direction: row;
 	}
 `;
+
+const lineStyles = css`
+	:before {
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
+		content: '';
+		border-top: 1px solid ${palette('--card-border-supporting')};
+		height: 1px;
+
+		width: 120px;
+		${between.tablet.and.desktop} {
+			width: 100px;
+		}
+	}
+`;
+
+const liStyles = css`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+
+	a {
+		flex: 1;
+		padding-top: ${space[1]}px;
+		padding-bottom: ${space[2]}px;
+		padding-right: ${space[2]}px;
+	}
+
+	/** Remove right padding for last sublink */
+	&:last-of-type a {
+		padding-right: 0;
+	}
+`;
+
 export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
 	isDynamo,
-	fillBackground = false,
 }: Props) => {
-	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
 		<ul
 			className="sublinks"
 			css={[
 				wrapperStyles,
-				baseGrid,
-				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				fillBackground && backgroundFill,
+				flexColumn,
+				(isDynamo ?? alignment === 'horizontal') && flexRowFromTablet,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {
@@ -164,12 +105,7 @@ export const SupportingContent = ({
 				return (
 					<li
 						key={subLink.url}
-						css={[
-							sublinkBaseStyles,
-							isDynamo ?? alignment === 'horizontal'
-								? horizontalSublinkStyles(columnSpan)
-								: verticalSublinkStyles,
-						]}
+						css={[liStyles, lineStyles]}
 						data-link-name={`sublinks | ${index + 1}`}
 					>
 						<FormatBoundary format={subLinkFormat}>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5619,10 +5619,6 @@ const imageTitleBackground: PaletteFunction = ({ design, theme }) => {
 const lightboxDivider: PaletteFunction = (format) =>
 	imageTitleBackground(format);
 
-const cardSublinksBackgroundLight: PaletteFunction = () =>
-	sourcePalette.neutral[97];
-const cardSublinksBackgroundDark: PaletteFunction = () =>
-	sourcePalette.neutral[10];
 // ----- Palette ----- //
 
 /**
@@ -5943,10 +5939,6 @@ const paletteColours = {
 	'--card-kicker-text': {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
-	},
-	'--card-sublinks-background': {
-		light: cardSublinksBackgroundLight,
-		dark: cardSublinksBackgroundDark,
 	},
 	'--carousel-active-dot': {
 		light: carouselActiveDotLight,


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#12346