### PR TITLE
[Fairground 🎡]  Sublinks redesign

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -414,6 +414,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
+					fillBackground={isFlexibleContainer}
 				/>
 			);
 		}
@@ -424,6 +425,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
+					fillBackground={isFlexibleContainer}
 				/>
 			</Hide>
 		);
@@ -441,6 +443,7 @@ export const Card = ({
 					} /* inner links are always vertically stacked */
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
+					fillBackground={isFlexibleContainer}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -145,8 +145,7 @@ const HorizontalDivider = () => (
 	<div
 		css={css`
 			${from.tablet} {
-				border-top: 1px solid
-					${themePalette('--card-border-supporting')};
+				border-top: 1px solid ${themePalette('--card-border-top')};
 				height: 1px;
 				width: 50%;
 				${from.tablet} {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -158,7 +158,7 @@ const HorizontalDivider = () => (
 				margin-top: 12px;
 			}
 		`}
-	></div>
+	/>
 );
 
 const getMedia = ({

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -438,9 +438,8 @@ export const Card = ({
 			<Hide until={isFlexSplash ? 'desktop' : 'tablet'}>
 				<SupportingContent
 					supportingContent={supportingContent}
-					alignment={
-						'vertical'
-					} /* inner links are always vertically stacked */
+					/* inner links are always vertically stacked */
+					alignment="vertical"
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
 					fillBackground={isFlexibleContainer}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -385,7 +385,7 @@ export const Card = ({
 	 *
 	 */
 	const decideOuterSublinks = () => {
-		if (!supportingContent) return null;
+		if (!hasSublinks) return null;
 		if (sublinkPosition === 'none') return null;
 		if (sublinkPosition === 'outer') {
 			return (
@@ -403,6 +403,23 @@ export const Card = ({
 					supportingContent={supportingContent}
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
+					isDynamo={isDynamo}
+				/>
+			</Hide>
+		);
+	};
+
+	const decideInnerSublinks = () => {
+		if (!hasSublinks) return null;
+		if (sublinkPosition !== 'inner') return null;
+		return (
+			<Hide until={isFlexSplash ? 'desktop' : 'tablet'}>
+				<SupportingContent
+					supportingContent={supportingContent}
+					alignment={
+						'vertical'
+					} /* inner links are always vertically stacked */
+					containerPalette={containerPalette}
 					isDynamo={isDynamo}
 				/>
 			</Hide>
@@ -735,18 +752,7 @@ export const Card = ({
 								</Island>
 							)}
 
-							{hasSublinks && sublinkPosition === 'inner' && (
-								<Hide
-									until={isFlexSplash ? 'desktop' : 'tablet'}
-								>
-									<SupportingContent
-										supportingContent={supportingContent}
-										alignment="vertical"
-										containerPalette={containerPalette}
-										isDynamo={isDynamo}
-									/>
-								</Hide>
-							)}
+							{decideInnerSublinks()}
 						</div>
 					</ContentWrapper>
 				)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -141,6 +141,26 @@ const StarRatingComponent = ({
 	</div>
 );
 
+const HorizontalDivider = () => (
+	<div
+		css={css`
+			${from.tablet} {
+				border-top: 1px solid
+					${themePalette('--card-border-supporting')};
+				height: 1px;
+				width: 50%;
+				${from.tablet} {
+					width: 100px;
+				}
+				${from.desktop} {
+					width: 140px;
+				}
+				margin-top: 12px;
+			}
+		`}
+	></div>
+);
+
 const getMedia = ({
 	imageUrl,
 	imageAltText,
@@ -729,6 +749,12 @@ export const Card = ({
 									showLivePlayable={showLivePlayable}
 								/>
 							)}
+							{sublinkPosition === 'outer' &&
+								supportingContentAlignment === 'horizontal' &&
+								(imagePositionOnDesktop === 'right' ||
+									imagePositionOnDesktop === 'left') && (
+									<HorizontalDivider />
+								)}
 						</div>
 
 						{/* This div is needed to push this content to the bottom of the card */}

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -235,9 +235,6 @@ const sublinkStyles = css`
 	font-family: inherit;
 	font-size: inherit;
 	line-height: inherit;
-	@media (pointer: coarse) {
-		min-height: 44px;
-	}
 
 	/* This css is used to remove any underline from the kicker but still
 	 * have it applied to the headline when the kicker is hovered */

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -43,7 +43,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'tiny',
 				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
@@ -53,7 +53,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'small',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
 			};
@@ -63,7 +63,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'medium',
 				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment: 'horizontal',
 			};
 		case 'gigaboost':
@@ -72,7 +72,7 @@ const determineCardProperties = (
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment: 'horizontal',
 			};
 	}

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -165,7 +165,7 @@ export const SupportingContent = ({
 						key={subLink.url}
 						css={[
 							sublinkBaseStyles,
-							alignment === 'horizontal'
+							isDynamo ?? alignment === 'horizontal'
 								? horizontalSublinkStyles(columnSpan)
 								: verticalSublinkStyles,
 						]}

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,6 +16,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
+	fillBackground?: boolean;
 };
 
 /**
@@ -120,11 +121,19 @@ const wrapperStyles = css`
 	}
 `;
 
+const backgroundFill = css`
+	/** background fill should only apply to sublinks on mobile breakpoints */
+	${until.tablet} {
+		padding: 8px;
+		background-color: ${palette('--card-sublinks-background')};
+	}
+`;
 export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
 	isDynamo,
+	fillBackground = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -134,6 +143,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
+				fillBackground && backgroundFill,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticleDesign } from '@guardian/libs';
-import { between, from, space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { isMediaCard } from '../lib/cardHelpers';
 import { palette } from '../palette';
 import type { DCRContainerPalette, DCRSupportingContent } from '../types/front';
@@ -12,64 +12,111 @@ export type Alignment = 'vertical' | 'horizontal';
 
 type Props = {
 	supportingContent: DCRSupportingContent[];
+	/** Determines if the content is arranged vertically or horizontally */
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
 };
 
-const wrapperStyles = css`
-	position: relative;
-	display: flex;
-	padding-top: ${space[2]}px;
-
-	@media (pointer: coarse) {
-		padding-bottom: 0;
+/**
+ * Returns the column span for the grid layout based on the number of supporting content items.
+ *
+ * @param {number} contentLength - The number of supporting content items.
+ * @returns {number} The column span to use in the grid layout.
+ */
+const getColumnSpan = (contentLength: number): number => {
+	switch (contentLength) {
+		case 1:
+		case 2:
+			return 6;
+		case 3:
+			return 4;
+		case 4:
+		default:
+			return 3; // Default column span for 4 or more items
 	}
+};
+const baseGrid = css`
+	display: grid;
+	grid-template-rows: auto;
+	grid-template-columns: auto;
+	row-gap: ${space[2]}px;
 `;
 
-const flexColumn = css`
-	flex-direction: column;
-`;
-
-const flexRowFromTablet = css`
+const horizontalGrid = css`
 	${from.tablet} {
-		flex-direction: row;
+		grid-template-columns: repeat(12, 1fr);
+		column-gap: ${space[5]}px;
 	}
 `;
 
-const lineStyles = css`
+const horizontalLineStyle = css`
+	margin-top: ${space[3]}px;
 	:before {
-		display: block;
 		position: absolute;
-		top: 0;
+		top: -${space[2]}px;
 		left: 0;
 		content: '';
 		border-top: 1px solid ${palette('--card-border-supporting')};
 		height: 1px;
-
-		width: 120px;
-		${between.tablet.and.desktop} {
+		width: 50%;
+		${from.tablet} {
 			width: 100px;
+		}
+		${from.desktop} {
+			width: 140px;
 		}
 	}
 `;
 
-const liStyles = css`
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1;
+const verticalLineStyle = css`
+	/* The last child doesn't need a dividing right line */
+	:not(:last-child):after {
+		content: '';
+		position: absolute;
+		top: 0;
+		right: -10px; /* Half of the column-gap to center the line */
+		height: 100%;
+		width: 1px;
+		background-color: ${palette('--card-border-supporting')};
+	}
+`;
 
-	a {
-		flex: 1;
-		padding-top: ${space[1]}px;
-		padding-bottom: ${space[2]}px;
-		padding-right: ${space[2]}px;
+const sublinkBaseStyles = css`
+	position: relative;
+	grid-row: span 1;
+`;
+
+const verticalSublinkStyles = css`
+	:not(:first-child) {
+		${horizontalLineStyle}
 	}
 
-	/** Remove right padding for last sublink */
-	&:last-of-type a {
-		padding-right: 0;
+	${from.tablet} {
+		:first-child {
+			${horizontalLineStyle}
+		}
+	}
+`;
+
+const horizontalSublinkStyles = (totalColumns: number) => css`
+	grid-column: span ${totalColumns};
+	${until.tablet} {
+		:not(:first-child) {
+			${horizontalLineStyle}
+		}
+	}
+
+	${from.tablet} {
+		${verticalLineStyle}
+	}
+`;
+
+const wrapperStyles = css`
+	position: relative;
+	padding-top: ${space[2]}px;
+	@media (pointer: coarse) {
+		padding-bottom: 0;
 	}
 `;
 
@@ -79,13 +126,14 @@ export const SupportingContent = ({
 	containerPalette,
 	isDynamo,
 }: Props) => {
+	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
 		<ul
 			className="sublinks"
 			css={[
 				wrapperStyles,
-				flexColumn,
-				(isDynamo ?? alignment === 'horizontal') && flexRowFromTablet,
+				baseGrid,
+				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {
@@ -105,7 +153,12 @@ export const SupportingContent = ({
 				return (
 					<li
 						key={subLink.url}
-						css={[liStyles, lineStyles]}
+						css={[
+							sublinkBaseStyles,
+							alignment === 'horizontal'
+								? horizontalSublinkStyles(columnSpan)
+								: verticalSublinkStyles,
+						]}
 						data-link-name={`sublinks | ${index + 1}`}
 					>
 						<FormatBoundary format={subLinkFormat}>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -58,7 +58,7 @@ const horizontalLineStyle = css`
 		top: -${space[2]}px;
 		left: 0;
 		content: '';
-		border-top: 1px solid ${palette('--card-border-supporting')};
+		border-top: 1px solid ${palette('--card-border-top')};
 		height: 1px;
 		width: 50%;
 		${from.tablet} {

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5619,6 +5619,10 @@ const imageTitleBackground: PaletteFunction = ({ design, theme }) => {
 const lightboxDivider: PaletteFunction = (format) =>
 	imageTitleBackground(format);
 
+const cardSublinksBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const cardSublinksBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
 // ----- Palette ----- //
 
 /**
@@ -5939,6 +5943,10 @@ const paletteColours = {
 	'--card-kicker-text': {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
+	},
+	'--card-sublinks-background': {
+		light: cardSublinksBackgroundLight,
+		dark: cardSublinksBackgroundDark,
 	},
 	'--carousel-active-dot': {
 		light: carouselActiveDotLight,


### PR DESCRIPTION
## What does this change?
Reopens [PR12346](https://github.com/guardian/dotcom-rendering/pull/12346) that was merged and then reverted over concerns around the appearance of a single sublink. It was confirmed by design that having a single sublink take up 50% of a boosted third card is the correct visual display so this pr can be merged once again. 

