### PR TITLE
Update background colour for hard coded test, added similar for heading.

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -33,45 +33,24 @@ import { ContributionsEpicCtasContainer } from './ctas/ContributionsEpicCtasCont
 
 // Hard-coded AB TEST - picking up ab test name and variant name from the tracking object
 // then applying a different colour if it matches, or the default colour if it doesn't.
-const getBackgroundColour = (tracking: Tracking) => {
-	if (
-		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
-		tracking.abTestVariant === 'VARIANT'
-	) {
-		return palette.brand[800];
-	} else {
-		return palette.neutral[100];
-	}
+const getBackgroundColour = (isInTestVariant: boolean) => {
+	return isInTestVariant ? palette.brand[800] : palette.neutral[100];
 };
 
-const getHeadingBackgroundColour = (tracking: Tracking) => {
-	if (
-		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
-		tracking.abTestVariant === 'VARIANT'
-	) {
-		return palette.brand[400];
-	} else {
-		return palette.brandAlt[400];
-	}
+const getHeadingBackgroundColour = (isInTestVariant: boolean) => {
+	return isInTestVariant ? palette.brand[400] : palette.brandAlt[400];
 };
 
-const getHeadingColour = (tracking: Tracking) => {
-	if (
-		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
-		tracking.abTestVariant === 'VARIANT'
-	) {
-		return palette.neutral[100];
-	} else {
-		return palette.neutral[7];
-	}
+const getHeadingColour = (isInTestVariant: boolean) => {
+	return isInTestVariant ? palette.neutral[100] : palette.neutral[7];
 };
 
-const container = (tracking: Tracking) => css`
+const container = (tracking: Tracking, isInTestVariant: boolean) => css`
 	padding: 6px 10px 28px 10px;
 	border-top: 1px solid ${palette.brandAlt[400]};
 	border-bottom: 1px solid ${palette.neutral[86]};
 
-	background: ${getBackgroundColour(tracking)};
+	background: ${getBackgroundColour(isInTestVariant)};
 
 	border: 1px solid ${palette.neutral[0]};
 
@@ -115,11 +94,11 @@ const textContainer = css`
 	}
 `;
 
-const yellowHeading = (tracking: Tracking) => css`
+const yellowHeading = (tracking: Tracking, isInTestVariant: boolean) => css`
 	${headlineBold34};
 	font-size: 28px;
-	color: ${getHeadingColour(tracking)};
-	background-color: ${getHeadingBackgroundColour(tracking)};
+	color: ${getHeadingColour(isInTestVariant)};
+	background-color: ${getHeadingBackgroundColour(isInTestVariant)};
 	border-top: 1px solid ${palette.neutral[0]};
 	border-left: 1px solid ${palette.neutral[0]};
 	border-right: 1px solid ${palette.neutral[0]};
@@ -177,6 +156,10 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 }: EpicProps): JSX.Element => {
 	const { newsletterSignup } = variant;
 
+	const isColourInTestVariant: boolean =
+		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
+		tracking.abTestVariant === 'VARIANT';
+
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
 	});
@@ -223,9 +206,11 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 	return (
 		<div data-testid="contributions-liveblog-epic" ref={setNode}>
 			{!!cleanHeading && (
-				<div css={yellowHeading(tracking)}>{cleanHeading}</div>
+				<div css={yellowHeading(tracking, isColourInTestVariant)}>
+					{cleanHeading}
+				</div>
 			)}
-			<section css={container(tracking)}>
+			<section css={container(tracking, isColourInTestVariant)}>
 				<LiveblogEpicBody
 					paragraphs={cleanParagraphs}
 					numArticles={articleCounts.forTargetedWeeks}

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -38,9 +38,31 @@ const getBackgroundColour = (tracking: Tracking) => {
 		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
 		tracking.abTestVariant === 'VARIANT'
 	) {
-		return palette.neutral[100]; // COLOUR CHANGE TO GO HERE
+		return palette.brand[800];
 	} else {
 		return palette.neutral[100];
+	}
+};
+
+const getHeadingBackgroundColour = (tracking: Tracking) => {
+	if (
+		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
+		tracking.abTestVariant === 'VARIANT'
+	) {
+		return palette.brand[400];
+	} else {
+		return palette.brandAlt[400];
+	}
+};
+
+const getHeadingColour = (tracking: Tracking) => {
+	if (
+		tracking.abTestName.includes('_LB_EPIC_BG_COLOUR') &&
+		tracking.abTestVariant === 'VARIANT'
+	) {
+		return palette.neutral[100];
+	} else {
+		return palette.neutral[7];
 	}
 };
 
@@ -93,17 +115,18 @@ const textContainer = css`
 	}
 `;
 
-const yellowHeading = (clientName: string) => css`
+const yellowHeading = (tracking: Tracking) => css`
 	${headlineBold34};
 	font-size: 28px;
-	background-color: ${palette.brandAlt[400]};
+	color: ${getHeadingColour(tracking)};
+	background-color: ${getHeadingBackgroundColour(tracking)};
 	border-top: 1px solid ${palette.neutral[0]};
 	border-left: 1px solid ${palette.neutral[0]};
 	border-right: 1px solid ${palette.neutral[0]};
 
 	padding: 8px 10px 12px 10px;
 	${from.tablet} {
-		padding-left: ${clientName === 'dcr' ? '60px' : '80px'};
+		padding-left: ${tracking.clientName === 'dcr' ? '60px' : '80px'};
 		padding-right: 20px;
 	}
 `;
@@ -200,9 +223,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 	return (
 		<div data-testid="contributions-liveblog-epic" ref={setNode}>
 			{!!cleanHeading && (
-				<div css={yellowHeading(tracking.clientName)}>
-					{cleanHeading}
-				</div>
+				<div css={yellowHeading(tracking)}>{cleanHeading}</div>
 			)}
 			<section css={container(tracking)}>
 				<LiveblogEpicBody


### PR DESCRIPTION
## What does this change?

This changes the colour of the liveblog background (and heading).  It is hard coded to correspond to an AB Test created in the RRCP with the same name.

## Why?

We believe that making the liveblog epic stand out more from the general text of the liveblog may help to increase engagement and therefore revenue.

Note that this will change nothing until the test is created in RRCP.

Related PRs (already merged): 
- [Change the background of the unselected choice cards so that they don't pick up the background colour](https://github.com/guardian/dotcom-rendering/pull/12350).
- [As above but for the secondary CTA](https://github.com/guardian/dotcom-rendering/pull/12368).
- [Initial logic change](https://github.com/guardian/dotcom-rendering/pull/12380)

## Screenshots

| Control (like existing)      | Variant      |
| ----------- | ---------- |
| ![control](https://github.com/user-attachments/assets/e0a4f9b3-2432-436c-94f8-7984f65295c7) | ![variant](https://github.com/user-attachments/assets/b527bf27-d747-4136-8455-f39f72f7d1d8) |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
