### PR TITLE
refactor: use product qs params for banner CTAs

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -22,7 +22,10 @@ import {
 	ChoiceCardTestData_REGULAR,
 	ChoiceCardTestData_US,
 } from './ThreeTierChoiceCardData';
-import type { SupportTier } from './utils/threeTierChoiceCardAmounts';
+import type {
+	SupportRatePlan,
+	SupportTier,
+} from './utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';
 
 const supportTierChoiceCardStyles = (selected: boolean) => css`
@@ -103,9 +106,10 @@ export type ChoiceInfo = {
 
 function getChoiceAmount(
 	supportTier: SupportTier,
+	ratePlan: SupportRatePlan,
 	countryGroupId: CountryGroupId,
 ): number {
-	return threeTierChoiceCardAmounts[countryGroupId][supportTier];
+	return threeTierChoiceCardAmounts[ratePlan][countryGroupId][supportTier];
 }
 
 const SupportingBenefits = ({
@@ -183,6 +187,7 @@ export const ThreeTierChoiceCards = ({
 					}) => {
 						const choiceAmount = getChoiceAmount(
 							supportTier,
+							'Monthly',
 							countryGroupId,
 						);
 						const selected = selectedProduct === supportTier;

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
@@ -208,7 +208,8 @@ export const ContributionsEpicButtons = ({
 			const countryGroupId = countryCodeToCountryGroupId(countryCode);
 			const contributionAmount =
 				threeTierChoiceCardSelectedProduct === 'Contribution'
-					? threeTierChoiceCardAmounts[countryGroupId].Contribution
+					? threeTierChoiceCardAmounts['Monthly'][countryGroupId]
+							.Contribution
 					: undefined;
 
 			return {

--- a/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/threeTierChoiceCardAmounts.ts
@@ -1,42 +1,85 @@
 import { type CountryGroupId } from '@guardian/support-dotcom-components';
 
 export type SupportTier = 'Contribution' | 'SupporterPlus' | 'OneOff';
+export type SupportRatePlan = 'Monthly' | 'Annual';
 
 // ToDo: fetch this in a way that isn't hardcoded
 export const threeTierChoiceCardAmounts = {
-	GBPCountries: {
-		Contribution: 4,
-		SupporterPlus: 12,
-		OneOff: 0,
+	Monthly: {
+		GBPCountries: {
+			Contribution: 4,
+			SupporterPlus: 12,
+			OneOff: 0,
+		},
+		UnitedStates: {
+			Contribution: 5,
+			SupporterPlus: 15,
+			OneOff: 0,
+		},
+		AUDCountries: {
+			Contribution: 10,
+			SupporterPlus: 20,
+			OneOff: 0,
+		},
+		EURCountries: {
+			Contribution: 4,
+			SupporterPlus: 12,
+			OneOff: 0,
+		},
+		NZDCountries: {
+			Contribution: 10,
+			SupporterPlus: 20,
+			OneOff: 0,
+		},
+		Canada: {
+			Contribution: 5,
+			SupporterPlus: 15,
+			OneOff: 0,
+		},
+		International: {
+			Contribution: 3,
+			SupporterPlus: 15,
+			OneOff: 0,
+		},
 	},
-	UnitedStates: {
-		Contribution: 5,
-		SupporterPlus: 15,
-		OneOff: 0,
+	Annual: {
+		GBPCountries: {
+			Contribution: 50,
+			SupporterPlus: 120,
+			OneOff: 0,
+		},
+		UnitedStates: {
+			Contribution: 60,
+			SupporterPlus: 150,
+			OneOff: 0,
+		},
+		AUDCountries: {
+			Contribution: 80,
+			SupporterPlus: 200,
+			OneOff: 0,
+		},
+		EURCountries: {
+			Contribution: 50,
+			SupporterPlus: 120,
+			OneOff: 0,
+		},
+		NZDCountries: {
+			Contribution: 80,
+			SupporterPlus: 200,
+			OneOff: 0,
+		},
+		Canada: {
+			Contribution: 60,
+			SupporterPlus: 150,
+			OneOff: 0,
+		},
+		International: {
+			Contribution: 30,
+			SupporterPlus: 150,
+			OneOff: 0,
+		},
 	},
-	AUDCountries: {
-		Contribution: 10,
-		SupporterPlus: 20,
-		OneOff: 0,
-	},
-	EURCountries: {
-		Contribution: 4,
-		SupporterPlus: 12,
-		OneOff: 0,
-	},
-	NZDCountries: {
-		Contribution: 10,
-		SupporterPlus: 20,
-		OneOff: 0,
-	},
-	Canada: {
-		Contribution: 5,
-		SupporterPlus: 15,
-		OneOff: 0,
-	},
-	International: {
-		Contribution: 3,
-		SupporterPlus: 15,
-		OneOff: 0,
-	},
-} as const satisfies Record<CountryGroupId, Record<SupportTier, number>>;
+} as const satisfies Record<
+	SupportRatePlan,
+	Record<CountryGroupId, Record<SupportTier, number>>
+>;

--- a/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
+++ b/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
@@ -3,17 +3,44 @@
  * This file was migrated from:
  * https://github.com/guardian/support-dotcom-components/blob/0a2439b701586a7a2cc60dce10b4d96cf7a828db/packages/modules/src/hooks/useChoiceCards.ts
  */
-import { getLocalCurrencySymbol } from '@guardian/support-dotcom-components';
+import {
+	countryCodeToCountryGroupId,
+	getLocalCurrencySymbol,
+} from '@guardian/support-dotcom-components';
 import type {
 	ContributionFrequency,
 	SelectedAmountsVariant,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
 import type { BannerTextContent } from '../banners/common/types';
+import type { SupportTier } from '../epics/utils/threeTierChoiceCardAmounts';
+import { threeTierChoiceCardAmounts } from '../epics/utils/threeTierChoiceCardAmounts';
 import type { ChoiceCardSelection } from '../lib/choiceCards';
-import { addChoiceCardsParams } from '../lib/tracking';
+import { addChoiceCardsProductParams } from '../lib/tracking';
 
 export type ContentType = 'mainContent' | 'mobileContent';
+
+function transformChoiceCardsAmountsToProduct(
+	countryCode: string | undefined,
+	frequency: ContributionFrequency,
+	amount: number,
+): { product: SupportTier; ratePlan: string } {
+	const countryGroupId = countryCodeToCountryGroupId(countryCode);
+	const ratePlan = frequency === 'ANNUAL' ? 'Annual' : 'Monthly';
+
+	const product =
+		frequency === 'ONE_OFF'
+			? 'OneOff'
+			: amount >=
+			  threeTierChoiceCardAmounts[ratePlan][countryGroupId].SupporterPlus
+			? 'SupporterPlus'
+			: 'Contribution';
+
+	return {
+		product,
+		ratePlan,
+	};
+}
 
 const useChoiceCards = (
 	choiceCardAmounts: SelectedAmountsVariant | undefined,
@@ -47,20 +74,27 @@ const useChoiceCards = (
 	}, [choiceCardAmounts]);
 
 	const getCtaText = (contentType: ContentType): string => {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the types and data fetched from the API are out of sync
 		const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
 
 		return primaryCtaText ? primaryCtaText : 'Contribute';
 	};
 	const getCtaUrl = (contentType: ContentType): string => {
 		const primaryCtaUrl =
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the types and data fetched from the API are out of sync
 			content?.[contentType]?.primaryCta?.ctaUrl ??
 			'https://support.theguardian.com/contribute';
 
-		if (choiceCardSelection) {
-			return addChoiceCardsParams(
-				primaryCtaUrl,
+		if (choiceCardSelection && choiceCardSelection.amount !== 'other') {
+			const { product, ratePlan } = transformChoiceCardsAmountsToProduct(
+				countryCode,
 				choiceCardSelection.frequency,
 				choiceCardSelection.amount,
+			);
+			return addChoiceCardsProductParams(
+				primaryCtaUrl,
+				product,
+				ratePlan,
 			);
 		} else {
 			return primaryCtaUrl;


### PR DESCRIPTION
## What does this change?

Uses the `URLSearchParams` `product` and `ratePlan` when navigating from the Banner to support.theguardian.com.

## Why?

We are deprecating the `URLSearchParams` `selected-contribution-type` and `selected-amount` as we are consolidating our models around the [Product API](https://product-catalog.guardianapis.com/product-catalog.json).

## Screenshots

https://github.com/user-attachments/assets/3f936e25-ebb3-4721-8d66-ca80de368290

