### PR TITLE
Fix issue with transparent fronts containers when a pageskin is active

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -849,6 +849,10 @@ const containerColours = {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
 	},
+	'--front-container-background': {
+		light: sectionBackgroundLight,
+		dark: sectionBackgroundDark,
+	},
 	'--article-border': {
 		light: articleBorderLight,
 		dark: articleBorderDark,

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source/foundations';
+import type { ReactNode } from 'react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { LI } from './Card/components/LI';
 import { FrontSection } from './FrontSection';
@@ -69,6 +70,17 @@ const LeftColPlaceholder = ({
 		`}
 	>
 		{text}
+	</div>
+);
+
+const PageSkinWrapper = ({ children }: { children: ReactNode }) => (
+	<div
+		css={css`
+			background-image: url('https://adimage.theguardian.com/pageskins/puppies-pageskin.jpg');
+			background-size: contain;
+		`}
+	>
+		{children}
 	</div>
 );
 
@@ -432,14 +444,16 @@ WithPaidContentForWholeFront.storyName = 'with paid content for whole front';
 
 export const PageSkinStory = () => {
 	return (
-		<FrontSection
-			title="Page Skin"
-			hasPageSkin={true}
-			discussionApiUrl={discussionApiUrl}
-			editionId={'UK'}
-		>
-			<Placeholder text="Page skins constrain my layout to desktop" />
-		</FrontSection>
+		<PageSkinWrapper>
+			<FrontSection
+				title="Page Skin"
+				hasPageSkin={true}
+				discussionApiUrl={discussionApiUrl}
+				editionId={'UK'}
+			>
+				<Placeholder text="Page skins constrain my layout to desktop" />
+			</FrontSection>
+		</PageSkinWrapper>
 	);
 };
 

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -471,7 +471,9 @@ export const FrontSection = ({
 					hasPageSkin && pageSkinContainer,
 				]}
 				style={{
-					backgroundColor: schemePalette('--section-background'),
+					backgroundColor: schemePalette(
+						'--front-container-background',
+					),
 				}}
 			>
 				<div

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6248,6 +6248,10 @@ const paletteColours = {
 		light: followTextLight,
 		dark: followTextDark,
 	},
+	'--front-container-background': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[10],
+	},
 	'--heading-line': {
 		light: headingLineLight,
 		dark: headingLineDark,
@@ -6653,8 +6657,8 @@ const paletteColours = {
 		dark: richLinkTextDark,
 	},
 	'--section-background': {
-		light: () => sourcePalette.neutral[100],
-		dark: () => sourcePalette.neutral[7],
+		light: () => 'transparent',
+		dark: () => 'transparent',
 	},
 	'--section-background-left': {
 		light: () => 'transparent',

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6654,7 +6654,7 @@ const paletteColours = {
 	},
 	'--section-background': {
 		light: () => sourcePalette.neutral[100],
-		dark: () => sourcePalette.neutral[10],
+		dark: () => sourcePalette.neutral[7],
 	},
 	'--section-background-left': {
 		light: () => 'transparent',

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6653,8 +6653,8 @@ const paletteColours = {
 		dark: richLinkTextDark,
 	},
 	'--section-background': {
-		light: () => 'transparent',
-		dark: () => 'transparent',
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[10],
 	},
 	'--section-background-left': {
 		light: () => 'transparent',


### PR DESCRIPTION
## What does this change?

This specifies a default light/dark background colour for fronts sections rather than relying on transparency and falling through to a base background colour.

It also adds an image to the page skin story for FrontSection to make it easier to detect this kind of issue in future.

## Why?

With a page skin active transparent backgrounds make the sections unreadable.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before](https://github.com/user-attachments/assets/4291da4a-847a-46e9-ae74-3ded96268d77) | ![after](https://github.com/user-attachments/assets/93ffe60a-caa7-4f61-971f-189462021ada) |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
