### PR TITLE
[Fairground 🎡] Flexible Container QA Tweaks

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -521,6 +521,7 @@ export const Card = ({
 						imagePositionOnDesktop={imagePositionOnDesktop}
 						imagePositionOnMobile={imagePositionOnMobile}
 						showPlayIcon={showPlayIcon}
+						isFlexibleContainer={isFlexibleContainer}
 					>
 						{media.type === 'slideshow' && (
 							<Slideshow

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -413,7 +413,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
+					isFlexibleContainer={isFlexibleContainer}
 				/>
 			);
 		}
@@ -424,7 +424,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
+					isFlexibleContainer={isFlexibleContainer}
 				/>
 			</Hide>
 		);
@@ -441,7 +441,7 @@ export const Card = ({
 					alignment="vertical"
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
-					fillBackground={isFlexibleContainer}
+					isFlexibleContainer={isFlexibleContainer}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -723,6 +723,7 @@ export const Card = ({
 									imageSize={imageSize}
 									imageType={media?.type}
 									shouldHide={isFlexSplash ? false : true}
+									isFlexSplash={isFlexSplash}
 								>
 									<div
 										dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -14,6 +14,8 @@ type Props = {
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
+	/** Flexible containers require different styling */
+	isFlexibleContainer?: boolean;
 };
 
 /**
@@ -52,6 +54,16 @@ const flexBasisStyles = ({
 			`;
 	}
 };
+/** Below tablet, we fix the size of the image and add a margin
+around it. The corresponding content flex grows to fill the space */
+const fixedImageWidth = (isFlexibleContainer: boolean) => css`
+	${until.tablet} {
+		width: ${isFlexibleContainer ? '97.5px' : '125px'};
+		flex-shrink: 0;
+		flex-basis: unset;
+		align-self: flex-start;
+	}
+`;
 
 export const ImageWrapper = ({
 	children,
@@ -60,6 +72,7 @@ export const ImageWrapper = ({
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	showPlayIcon,
+	isFlexibleContainer = false,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -90,17 +103,8 @@ export const ImageWrapper = ({
 							display: none;
 						}
 					`,
-				/* Below tablet, we fix the size of the image and add a margin
-				   around it. The corresponding content flex grows to fill the space */
-				isHorizontalOnMobile &&
-					css`
-						${until.tablet} {
-							width: 125px;
-							flex-shrink: 0;
-							flex-basis: unset;
-							align-self: flex-start;
-						}
-					`,
+				isHorizontalOnMobile && fixedImageWidth(isFlexibleContainer),
+
 				isHorizontalOnDesktop &&
 					css`
 						${from.tablet} {

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -10,6 +10,8 @@ type Props = {
 	imageType?: CardImageType | undefined;
 	/** By default, trail text is hidden at specific breakpoints. This prop allows consumers to show trails across all breakpoints if set to false */
 	shouldHide?: boolean;
+	/** If the card is a flexible splash card, the trail text will be styled differently */
+	isFlexSplash?: boolean;
 };
 
 /**
@@ -52,12 +54,17 @@ const trailTextStyles = css`
 	}
 `;
 
+const flexibleSplashStyles = css`
+	color: ${palette('--flexible-splash-card-standfirst')};
+`;
+
 export const TrailTextWrapper = ({
 	children,
 	imagePositionOnDesktop,
 	imageSize,
 	imageType,
 	shouldHide = true,
+	isFlexSplash,
 }: Props) => {
 	return (
 		<div
@@ -69,6 +76,7 @@ export const TrailTextWrapper = ({
 						imageSize,
 						imageType,
 					),
+				isFlexSplash && flexibleSplashStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -5,7 +5,7 @@ import { palette } from '../../../palette';
 
 type Direction = 'row' | 'column' | 'row-reverse';
 
-const ulStyles = (direction: Direction) => css`
+const ulStyles = (direction: Direction, isFlexibleContainer: boolean) => css`
 	width: 100%;
 	position: relative;
 	display: flex;
@@ -16,7 +16,7 @@ const ulStyles = (direction: Direction) => css`
 	}
 
 	& > li {
-		margin-bottom: ${space[3]}px;
+		margin-bottom: ${isFlexibleContainer ? space[6] : space[3]}px;
 	}
 
 	@supports (row-gap: 1em) {
@@ -24,7 +24,7 @@ const ulStyles = (direction: Direction) => css`
 			margin-bottom: 0;
 		}
 		/* Supported in flex layout is lacking: https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap#browser_compatibility */
-		row-gap: ${space[3]}px;
+		row-gap: ${isFlexibleContainer ? space[6] : space[3]}px;
 	}
 `;
 
@@ -34,11 +34,8 @@ const wrapStyles = css`
 	}
 `;
 
-const flexibleMarginBottomStyles = css`
-	margin-bottom: ${space[6]}px;
-`;
-const marginBottomStyles = css`
-	margin-bottom: ${space[3]}px;
+const marginBottomStyles = (isFlexibleContainer: boolean) => css`
+	margin-bottom: ${isFlexibleContainer ? space[6] : space[3]}px;
 `;
 
 const topBarStyles = css`
@@ -85,12 +82,9 @@ export const UL = ({
 	return (
 		<ul
 			css={[
-				ulStyles(direction),
+				ulStyles(direction, isFlexibleContainer),
 				showDivider && verticalDivider(palette('--section-border')),
-				padBottom &&
-					(isFlexibleContainer
-						? flexibleMarginBottomStyles
-						: marginBottomStyles),
+				padBottom && marginBottomStyles(isFlexibleContainer),
 				wrapCards && wrapStyles,
 				showTopBar && topBarStyles,
 			]}

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -34,6 +34,9 @@ const wrapStyles = css`
 	}
 `;
 
+const flexibleMarginBottomStyles = css`
+	margin-bottom: ${space[6]}px;
+`;
 const marginBottomStyles = css`
 	margin-bottom: ${space[3]}px;
 `;
@@ -66,6 +69,8 @@ type Props = {
 	wrapCards?: boolean;
 	/** Used to display a full width bar along the top of the container */
 	showTopBar?: boolean;
+	/** Used to give flexible container stories additional space */
+	isFlexibleContainer?: boolean;
 };
 
 export const UL = ({
@@ -75,13 +80,17 @@ export const UL = ({
 	padBottom = false,
 	wrapCards = false,
 	showTopBar = false,
+	isFlexibleContainer = false,
 }: Props) => {
 	return (
 		<ul
 			css={[
 				ulStyles(direction),
 				showDivider && verticalDivider(palette('--section-border')),
-				padBottom && marginBottomStyles,
+				padBottom &&
+					(isFlexibleContainer
+						? flexibleMarginBottomStyles
+						: marginBottomStyles),
 				wrapCards && wrapStyles,
 				showTopBar && topBarStyles,
 			]}

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -14,6 +14,7 @@ import {
 	headlineMedium64,
 	space,
 	textSans12,
+	textSans14,
 	textSans15,
 	textSans17,
 	textSans20,
@@ -45,6 +46,8 @@ type Props = {
 	isExternalLink?: boolean;
 	/** Is the headline inside a Highlights card? */
 	isHighlights?: boolean;
+	/** if the headline is within a flexible container it gets a different visual treatment */
+	isFlexibleContainer?: boolean;
 };
 
 /** These represent a new set of fonts. They are extra large font sizes that, as a group, are only used on headlines */
@@ -282,6 +285,7 @@ export const CardHeadline = ({
 	linkTo,
 	isExternalLink,
 	isHighlights = false,
+	isFlexibleContainer = false,
 }: Props) => {
 	const kickerColour = isHighlights
 		? palette('--highlights-card-kicker-text')
@@ -320,11 +324,17 @@ export const CardHeadline = ({
 				)}
 				{showQuotes && <QuoteIcon colour={kickerColour} />}
 				<span
-					css={css`
-						color: ${isHighlights
-							? palette('--highlights-card-headline')
-							: palette('--card-headline-trail-text')};
-					`}
+					css={[
+						isFlexibleContainer &&
+							css`
+								${textSans14}
+							`,
+						css`
+							color: ${isHighlights
+								? palette('--highlights-card-headline')
+								: palette('--card-headline-trail-text')};
+						`,
+					]}
 					className="show-underline"
 				>
 					{headlineText}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -151,7 +151,7 @@ export const SplashCardLayout = ({
 		card?.supportingContent?.length ?? 0,
 	);
 	return (
-		<UL padBottom={true}>
+		<UL padBottom={true} isFlexibleContainer={true}>
 			<LI padSides={true}>
 				<FrontCard
 					trail={card}
@@ -234,7 +234,7 @@ export const BoostedCardLayout = ({
 		imageSize,
 	} = decideCardProperties(card.boostLevel);
 	return (
-		<UL padBottom={true}>
+		<UL padBottom={true} isFlexibleContainer={true}>
 			<LI padSides={true}>
 				<FrontCard
 					trail={card}
@@ -278,7 +278,7 @@ export const StandardCardLayout = ({
 	padBottom?: boolean;
 }) => {
 	return (
-		<UL direction="row" padBottom={padBottom}>
+		<UL direction="row" padBottom={padBottom} isFlexibleContainer={true}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -266,7 +266,6 @@ export const StandardCardLayout = ({
 	showAge,
 	absoluteServerTimes,
 	showImage = true,
-	padBottom,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
@@ -275,10 +274,9 @@ export const StandardCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
-	padBottom?: boolean;
 }) => {
 	return (
-		<UL direction="row" padBottom={padBottom} isFlexibleContainer={true}>
+		<UL direction="row" padBottom={true} isFlexibleContainer={true}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -140,7 +140,6 @@ const TwoCardOrFourCardLayout = ({
 	showAge,
 	absoluteServerTimes,
 	showImage = true,
-	padBottom,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
@@ -149,13 +148,12 @@ const TwoCardOrFourCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
-	padBottom?: boolean;
 }) => {
 	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
 		<UL
 			direction="row"
-			padBottom={padBottom}
+			padBottom={true}
 			showTopBar={true}
 			isFlexibleContainer={true}
 		>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -105,7 +105,7 @@ export const OneCardLayout = ({
 		card?.supportingContent?.length ?? 0,
 	);
 	return (
-		<UL padBottom={true}>
+		<UL padBottom={true} isFlexibleContainer={true}>
 			<LI padSides={true}>
 				<FrontCard
 					trail={card}
@@ -153,7 +153,12 @@ const TwoCardOrFourCardLayout = ({
 }) => {
 	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
-		<UL direction="row" padBottom={padBottom} showTopBar={true}>
+		<UL
+			direction="row"
+			padBottom={padBottom}
+			showTopBar={true}
+			isFlexibleContainer={true}
+		>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,7 +16,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
-	fillBackground?: boolean;
+	isFlexibleContainer?: boolean;
 };
 
 /**
@@ -134,7 +134,7 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
-	fillBackground = false,
+	isFlexibleContainer = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -144,7 +144,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				fillBackground && backgroundFill,
+				isFlexibleContainer && backgroundFill,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {
@@ -187,7 +187,7 @@ export const SupportingContent = ({
 									}
 									headlineText={subLink.headline}
 									kickerText={subLink.kickerText}
-									isFlexibleContainer={true}
+									isFlexibleContainer={isFlexibleContainer}
 								/>
 							</ContainerOverrides>
 						</FormatBoundary>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -187,6 +187,7 @@ export const SupportingContent = ({
 									}
 									headlineText={subLink.headline}
 									kickerText={subLink.kickerText}
+									isFlexibleContainer={true}
 								/>
 							</ContainerOverrides>
 						</FormatBoundary>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -124,7 +124,8 @@ const wrapperStyles = css`
 const backgroundFill = css`
 	/** background fill should only apply to sublinks on mobile breakpoints */
 	${until.tablet} {
-		padding: 8px;
+		padding: ${space[2]}px;
+		padding-bottom: ${space[3]}px;
 		background-color: ${palette('--card-sublinks-background')};
 	}
 `;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5623,6 +5623,11 @@ const cardSublinksBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
 const cardSublinksBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
+
+const flexibleSplashCardStandfirstLight: PaletteFunction = () =>
+	sourcePalette.neutral[38];
+const flexibleSplashCardStandfirstDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
 // ----- Palette ----- //
 
 /**
@@ -6235,6 +6240,11 @@ const paletteColours = {
 	'--filter-key-events-toggle-border-top': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],
+	},
+
+	'--flexible-splash-card-standfirst': {
+		light: flexibleSplashCardStandfirstLight,
+		dark: flexibleSplashCardStandfirstDark,
 	},
 	'--follow-icon-background': {
 		light: followIconBackgroundLight,


### PR DESCRIPTION
## What does this change?
Updates the appearance of components that are used in flexible containers. 

The changes are as follows:

1. Sublinks headline (but not kicker) should be text sans 14
2. Standfirst text colour to use neutral.38
3. Spacing between stories on mobile should have a 24px row gap 
4. Small card fixed image size should be 97.5x78px 

## Why?
These requests came out of design QA

## Screenshots

| Mobile Before      | Mobile After      |
| ----------- | ---------- |
| ![m-before][] | ![m-after][] |

[m-before]: https://github.com/user-attachments/assets/f0cd5e0e-b6f5-4bca-85d8-b4e740f82839
[m-after]: https://github.com/user-attachments/assets/e9fa549f-2c8b-48dd-97ba-b38a6b128246


| Desktop Before      | Desktop After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c79913f5-42d1-4445-8478-89256610b933
[after]: https://github.com/user-attachments/assets/7fa69e06-66ea-4f78-8192-7f050335f736

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
