### PR TITLE
Ensure flexible general is counted as a flexible container in card component

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -380,6 +380,8 @@ export const Card = ({
 		containerType === 'flexible/special' ||
 		containerType === 'flexible/general';
 
+	const isFlexibleSpecialContainer = containerType === 'flexible/special';
+
 	const headlinePosition =
 		isFlexSplash && isFlexibleContainer ? 'outer' : 'inner';
 
@@ -452,8 +454,8 @@ export const Card = ({
 	return (
 		<CardWrapper
 			format={format}
-			showTopBar={!isOnwardContent && !isFlexibleContainer}
-			showMobileTopBar={isFlexibleContainer}
+			showTopBar={!isOnwardContent && !isFlexibleSpecialContainer}
+			showMobileTopBar={isFlexibleSpecialContainer}
 			containerPalette={containerPalette}
 			isOnwardContent={isOnwardContent}
 		>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -376,7 +376,7 @@ export const Card = ({
 	const hasBackgroundColour = !containerPalette && isMediaCard(format);
 
 	/* Whilst we migrate to the new container types, we need to check which container we are in. */
-	const isFlexibleContainer = containerType === 'flexible/special';
+	const isFlexibleContainer = containerType?.includes('flexible');
 
 	const headlinePosition =
 		isFlexSplash && isFlexibleContainer ? 'outer' : 'inner';

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -376,7 +376,9 @@ export const Card = ({
 	const hasBackgroundColour = !containerPalette && isMediaCard(format);
 
 	/* Whilst we migrate to the new container types, we need to check which container we are in. */
-	const isFlexibleContainer = containerType?.includes('flexible');
+	const isFlexibleContainer =
+		containerType === 'flexible/special' ||
+		containerType === 'flexible/general';
 
 	const headlinePosition =
 		isFlexSplash && isFlexibleContainer ? 'outer' : 'inner';


### PR DESCRIPTION
## What does this change?

Updates the `isFlexibleCheck` to include both flexible containers, which enables, e.g. the supporting content on flexible/general containers to also have a grey background. 

## Why?

Part of this [ticket](https://trello.com/c/PYM1H3GH/524-flexible-general-card-design-updates)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/af60813d-f4f3-48b5-910b-e3978ababe18
[after]: https://github.com/user-attachments/assets/ea74cc51-c985-4f37-9a74-ea228a280aa7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
