### PR TITLE
Adjust flex general gigaboosted splash properties

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -685,6 +685,7 @@ export const Card = ({
 										format={format}
 										size={headlineSize}
 										sizeOnMobile={headlineSizeOnMobile}
+										sizeOnTablet={headlineSizeOnTablet}
 										showQuotes={showQuotes}
 										kickerText={
 											format.design ===

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -115,9 +115,9 @@ const decideSplashCardProperties = (
 			return {
 				headlineSize: 'large',
 				headlineSizeOnMobile: 'large',
-				headlineSizeOnTablet: 'large',
+				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'top',
+				imagePositionOnMobile: 'bottom',
 				supportingContentAlignment: 'horizontal',
 			};
 	}


### PR DESCRIPTION
## What does this change?

Updates a couple of the gigaboosted properties to match designs. 

Separate PR coming up for the trail text on mobile.	

## Why?

Part of this [ticket](https://trello.com/c/PYM1H3GH/524-flexible-general-card-design-updates)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[Before]: https://github.com/user-attachments/assets/11c4c18d-076f-4649-9010-afea29395184
[After ]: https://github.com/user-attachments/assets/b8da16eb-bcb7-49c4-93a2-618c4595048d

| TBefore      | TAfter      |
| ----------- | ---------- |
| ![tbefore][] | ![tafter][] |

[TBefore]: https://github.com/user-attachments/assets/490649e7-343b-4c0a-bd9a-e068855d30e1
[TAfter ]: https://github.com/user-attachments/assets/b593c418-573d-4e2a-a50d-275d1abde4db



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
