### PR TITLE
Medium headlines for news pillar

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -47,32 +47,22 @@ const topPadding = css`
 	}
 `;
 
-const getHeadlineFontByDesign = (design: ArticleDesign, size: number) => {
+const getFontWeightByDesign = (
+	design: ArticleDesign,
+): 'light' | 'medium' | 'bold' => {
 	switch (design) {
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
-			return size === 50
-				? headlineLight50
-				: size === 34
-				? headlineLight34
-				: headlineLight28;
+			return 'light';
 		case ArticleDesign.Feature:
 		case ArticleDesign.Review:
 		case ArticleDesign.Recipe:
 		case ArticleDesign.Interview:
-			return size === 50
-				? headlineBold50
-				: size === 34
-				? headlineBold34
-				: headlineBold28;
+			return 'bold';
 		default:
-			return size === 50
-				? headlineMedium50
-				: size === 34
-				? headlineMedium34
-				: headlineMedium28;
+			return 'medium';
 	}
 };
 
@@ -86,7 +76,16 @@ const decideHeadlineFont = (format: ArticleFormat) => {
 	if (isNewsNotCommentOrRecipe(format)) {
 		return size === 50 ? headlineMedium50 : headlineMedium34;
 	}
-	return getHeadlineFontByDesign(format.design, size);
+
+	const fontWeight = getFontWeightByDesign(format.design);
+	switch (fontWeight) {
+		case 'light':
+			return size === 50 ? headlineLight50 : headlineLight34;
+		case 'bold':
+			return size === 50 ? headlineBold50 : headlineBold34;
+		default:
+			return size === 50 ? headlineMedium50 : headlineMedium34;
+	}
 };
 
 const decideMobileHeadlineFont = (format: ArticleFormat) => {
@@ -94,8 +93,18 @@ const decideMobileHeadlineFont = (format: ArticleFormat) => {
 	if (isNewsNotCommentOrRecipe(format)) {
 		return size === 34 ? headlineMedium34 : headlineMedium28;
 	}
-	return getHeadlineFontByDesign(format.design, size);
+
+	const fontWeight = getFontWeightByDesign(format.design);
+	switch (fontWeight) {
+		case 'light':
+			return size === 34 ? headlineLight34 : headlineLight28;
+		case 'bold':
+			return size === 34 ? headlineBold34 : headlineBold28;
+		default:
+			return size === 34 ? headlineMedium34 : headlineMedium28;
+	}
 };
+
 const headlineFont = (format: ArticleFormat) => css`
 	${decideMobileHeadlineFont(format)}
 

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -47,85 +47,52 @@ const topPadding = css`
 	}
 `;
 
-const decideHeadlineFont = (format: ArticleFormat) => {
-	switch (format.display) {
-		case ArticleDisplay.Immersive: {
-			if (format.theme === Pillar.News) {
-				return headlineMedium50;
-			}
-			switch (format.design) {
-				case ArticleDesign.Obituary:
-				case ArticleDesign.Comment:
-				case ArticleDesign.Editorial:
-				case ArticleDesign.Letter:
-					return headlineLight50;
-				case ArticleDesign.Feature:
-				case ArticleDesign.Review:
-				case ArticleDesign.Recipe:
-				case ArticleDesign.Interview:
-					return headlineBold50;
-				default:
-					return headlineMedium50;
-			}
-		}
+const isNewsNotComment = (format: ArticleFormat) =>
+	format.theme === Pillar.News && format.design !== ArticleDesign.Comment;
+
+const getHeadlineFontByDesign = (design: ArticleDesign, size: number) => {
+	switch (design) {
+		case ArticleDesign.Obituary:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Letter:
+			return size === 50
+				? headlineLight50
+				: size === 34
+				? headlineLight34
+				: headlineLight28;
+		case ArticleDesign.Feature:
+		case ArticleDesign.Review:
+		case ArticleDesign.Recipe:
+		case ArticleDesign.Interview:
+			return size === 50
+				? headlineBold50
+				: size === 34
+				? headlineBold34
+				: headlineBold28;
 		default:
-			if (format.theme === Pillar.News) {
-				return headlineMedium34;
-			}
-			switch (format.design) {
-				case ArticleDesign.Obituary:
-				case ArticleDesign.Comment:
-				case ArticleDesign.Editorial:
-				case ArticleDesign.Letter:
-					return headlineLight34;
-				case ArticleDesign.Feature:
-				case ArticleDesign.Review:
-				case ArticleDesign.Recipe:
-				case ArticleDesign.Interview:
-					return headlineBold34;
-				default:
-					return headlineMedium34;
-			}
+			return size === 50
+				? headlineMedium50
+				: size === 34
+				? headlineMedium34
+				: headlineMedium28;
 	}
 };
-const decideMobileHeadlineFont = (format: ArticleFormat) => {
-	switch (format.display) {
-		case ArticleDisplay.Immersive: {
-			if (format.theme === Pillar.News) {
-				return headlineMedium34;
-			}
-			switch (format.design) {
-				case ArticleDesign.Obituary:
-				case ArticleDesign.Comment:
-				case ArticleDesign.Editorial:
-					return headlineLight34;
-				case ArticleDesign.Feature:
-				case ArticleDesign.Review:
-				case ArticleDesign.Recipe:
-				case ArticleDesign.Interview:
-					return headlineBold34;
-				default:
-					return headlineMedium34;
-			}
-		}
-		default:
-			if (format.theme === Pillar.News) {
-				return headlineMedium28;
-			}
-			switch (format.design) {
-				case ArticleDesign.Obituary:
-				case ArticleDesign.Comment:
-				case ArticleDesign.Editorial:
-					return headlineLight28;
-				case ArticleDesign.Feature:
-				case ArticleDesign.Review:
-				case ArticleDesign.Recipe:
-				case ArticleDesign.Interview:
-					return headlineBold28;
-				default:
-					return headlineMedium28;
-			}
+
+const decideHeadlineFont = (format: ArticleFormat) => {
+	const size = format.display === ArticleDisplay.Immersive ? 50 : 34;
+	if (isNewsNotComment(format)) {
+		return size === 50 ? headlineMedium50 : headlineMedium34;
 	}
+	return getHeadlineFontByDesign(format.design, size);
+};
+
+const decideMobileHeadlineFont = (format: ArticleFormat) => {
+	const size = format.display === ArticleDisplay.Immersive ? 34 : 28;
+	if (isNewsNotComment(format)) {
+		return size === 34 ? headlineMedium34 : headlineMedium28;
+	}
+	return getHeadlineFontByDesign(format.design, size);
 };
 const headlineFont = (format: ArticleFormat) => css`
 	${decideMobileHeadlineFont(format)}

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -47,9 +47,6 @@ const topPadding = css`
 	}
 `;
 
-const isNewsNotComment = (format: ArticleFormat) =>
-	format.theme === Pillar.News && format.design !== ArticleDesign.Comment;
-
 const getHeadlineFontByDesign = (design: ArticleDesign, size: number) => {
 	switch (design) {
 		case ArticleDesign.Obituary:
@@ -79,9 +76,14 @@ const getHeadlineFontByDesign = (design: ArticleDesign, size: number) => {
 	}
 };
 
+const isNewsNotCommentOrRecipe = (format: ArticleFormat) =>
+	format.theme === Pillar.News &&
+	format.design !== ArticleDesign.Comment &&
+	format.design !== ArticleDesign.Recipe;
+
 const decideHeadlineFont = (format: ArticleFormat) => {
 	const size = format.display === ArticleDisplay.Immersive ? 50 : 34;
-	if (isNewsNotComment(format)) {
+	if (isNewsNotCommentOrRecipe(format)) {
 		return size === 50 ? headlineMedium50 : headlineMedium34;
 	}
 	return getHeadlineFontByDesign(format.design, size);
@@ -89,7 +91,7 @@ const decideHeadlineFont = (format: ArticleFormat) => {
 
 const decideMobileHeadlineFont = (format: ArticleFormat) => {
 	const size = format.display === ArticleDisplay.Immersive ? 34 : 28;
-	if (isNewsNotComment(format)) {
+	if (isNewsNotCommentOrRecipe(format)) {
 		return size === 34 ? headlineMedium34 : headlineMedium28;
 	}
 	return getHeadlineFontByDesign(format.design, size);

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { ArticleDesign, ArticleDisplay, ArticleSpecial } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
 import type { ArticleFormat } from '@guardian/libs';
 import {
 	from,
@@ -45,6 +50,9 @@ const topPadding = css`
 const decideHeadlineFont = (format: ArticleFormat) => {
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
+			if (format.theme === Pillar.News) {
+				return headlineMedium50;
+			}
 			switch (format.design) {
 				case ArticleDesign.Obituary:
 				case ArticleDesign.Comment:
@@ -61,6 +69,9 @@ const decideHeadlineFont = (format: ArticleFormat) => {
 			}
 		}
 		default:
+			if (format.theme === Pillar.News) {
+				return headlineMedium34;
+			}
 			switch (format.design) {
 				case ArticleDesign.Obituary:
 				case ArticleDesign.Comment:
@@ -80,6 +91,9 @@ const decideHeadlineFont = (format: ArticleFormat) => {
 const decideMobileHeadlineFont = (format: ArticleFormat) => {
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
+			if (format.theme === Pillar.News) {
+				return headlineMedium34;
+			}
 			switch (format.design) {
 				case ArticleDesign.Obituary:
 				case ArticleDesign.Comment:
@@ -95,6 +109,9 @@ const decideMobileHeadlineFont = (format: ArticleFormat) => {
 			}
 		}
 		default:
+			if (format.theme === Pillar.News) {
+				return headlineMedium28;
+			}
 			switch (format.design) {
 				case ArticleDesign.Obituary:
 				case ArticleDesign.Comment:


### PR DESCRIPTION
## What does this change?

Use a medium font weight for article headlines with news theme (unless they have a comment or recipe design) across all breakpoints

## Why?

Resolves https://github.com/guardian/dotcom-rendering/issues/12453

## Screenshots

| Before  (Immersive)    | After  (Immersive)      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/66c69318-2de6-4756-9b34-04fa03574a40
[after]: https://github.com/user-attachments/assets/d37c8371-f7e1-4b28-a192-2df204a0aa05

| Before     | After     |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

[before1]: https://github.com/user-attachments/assets/57d731f7-8f1d-453f-a312-b55f4fbc1bf4
[after1]: https://github.com/user-attachments/assets/25190ac8-c18b-456f-8ea3-c9098c5ed574

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
