### PR TITLE
Hide newsletter count on Australia edition

### DIFF
--- a/dotcom-rendering/src/components/NewsletterPageHeading.tsx
+++ b/dotcom-rendering/src/components/NewsletterPageHeading.tsx
@@ -7,11 +7,13 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Link, SvgChevronRightSingle } from '@guardian/source/react-components';
+import type { EditionId } from '../lib/edition';
 import { Section } from './Section';
 
 export interface NewslettersListProps {
 	mmaUrl?: string;
 	newsletterCount: number;
+	editionId: EditionId;
 }
 
 // To align the heading content with the carousel below
@@ -53,6 +55,7 @@ const manageLinkContainer = css`
 export const NewslettersPageHeading = ({
 	mmaUrl,
 	newsletterCount,
+	editionId,
 }: NewslettersListProps) => {
 	return (
 		<Section
@@ -68,8 +71,12 @@ export const NewslettersPageHeading = ({
 					<span>Newsletters</span>
 				</h1>
 				<p css={subtitleStyle}>
-					Choose from {newsletterCount} available newsletters. The
-					best Guardian journalism, free to your inbox
+					{editionId !== 'AU' && (
+						<>
+							Choose from {newsletterCount} available newsletters.{' '}
+						</>
+					)}
+					The best Guardian journalism, free to your inbox
 				</p>
 
 				{!!mmaUrl && (

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -76,6 +76,7 @@ export const AllEditorialNewslettersPageLayout = ({
 				<NewslettersPageHeading
 					mmaUrl={newslettersPage.config.mmaUrl}
 					newsletterCount={displayedNewslettersCount}
+					editionId={editionId}
 				/>
 				<GroupedNewslettersList
 					groupedNewsletters={newslettersPage.groupedNewsletters}


### PR DESCRIPTION
## What does this change?

Hides 'Choose from XX available newsletters' text on Australian version of newsletter page

## Why?

This was a request from Paddy and Toby who felt that the count may 'overwhelm people'

## Screenshots

| UK | Australia |
| ----------- | ---------- |
| ![uk][] | ![australia][] |

[uk]: https://github.com/user-attachments/assets/266b26af-4498-4f33-ac39-0d3cd6d6bc4f
[australia]: https://github.com/user-attachments/assets/38e7e694-d5ec-4e37-9d59-c98cf45f5bde