### PR TITLE
Add support for new scrollable and static containers #27508

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -249,6 +249,13 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 				/>
 			);
+		case 'scrollable/small':
+		case 'scrollable/medium':
+		case 'scrollable/feature':
+		case 'static/feature/2':
+		case 'static/medium/4':
+			// Not implemented yet
+			return null;
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -254,8 +254,6 @@ export const DecideContainer = ({
 		case 'scrollable/feature':
 		case 'static/feature/2':
 		case 'static/medium/4':
-			// Not implemented yet
-			return null;
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -13,11 +13,20 @@ const FORBIDDEN_CONTAINERS = [
 	'qatar treat',
 ];
 
+const UNSUPPORTED_CONTAINERS = [
+	'scrollable/small',
+	'scrollable/medium',
+	'scrollable/feature',
+	'static/feature/2',
+	'static/medium/4',
+];
+
 const PALETTE_STYLES_URI =
 	'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default';
 
 const isSupported = (collection: FECollectionType): boolean =>
 	!(
+		UNSUPPORTED_CONTAINERS.includes(collection.collectionType) ||
 		FORBIDDEN_CONTAINERS.includes(collection.displayName) ||
 		collection.curated.some(
 			(card) => card.properties.embedUri === PALETTE_STYLES_URI,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3223,7 +3223,12 @@
                 "nav/list",
                 "nav/media-list",
                 "news/most-popular",
-                "scrollable/highlights"
+                "scrollable/feature",
+                "scrollable/highlights",
+                "scrollable/medium",
+                "scrollable/small",
+                "static/feature/2",
+                "static/medium/4"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -92,7 +92,12 @@ type FEContainerType =
 	| 'news/most-popular'
 	| 'scrollable/highlights'
 	| 'flexible/special'
-	| 'flexible/general';
+	| 'flexible/general'
+	| 'scrollable/small'
+	| 'scrollable/medium'
+	| 'scrollable/feature'
+	| 'static/feature/2'
+	| 'static/medium/4';
 
 export type FEContainerPalette =
 	| 'EventPalette'


### PR DESCRIPTION
## What does this change?

Adds some of the upcoming and unsupported containers to DCR, as these are being added in the fronts tool. 


[Companion Frontend PR](https://github.com/guardian/frontend/pull/27508)

[Companion facia tool PR](https://github.com/guardian/facia-tool/pull/1675)

`enhanceCollections` already includes some logic to filter out some forbidden containers, we also now add a check to filter out these new ones, as otherwise we end up with a container looking like this: 
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/4732f2c5-dcf8-43f3-852e-e65bb02f646e">



## Why?

The apps team is starting to test new containers on some of the code fronts, this'll make it easier for us to develop alongside.

