### PR TITLE
Update Ophan to 2.2.5

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -48,7 +48,7 @@
 		"@guardian/identity-auth": "2.1.0",
 		"@guardian/identity-auth-frontend": "4.0.0",
 		"@guardian/libs": "18.0.0",
-		"@guardian/ophan-tracker-js": "2.2.2",
+		"@guardian/ophan-tracker-js": "2.2.5",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "8.0.0",

--- a/dotcom-rendering/src/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardBranding.tsx
@@ -83,6 +83,8 @@ export const CardBranding = ({
 				rel="nofollow"
 				aria-label={`Visit the ${branding.sponsorName} website`}
 				data-testid="card-branding-logo"
+				data-component={dataAttributes?.ophanComponentName}
+				data-link-name={dataAttributes?.ophanComponentLink}
 			>
 				<picture>
 					{darkModeAvailable && branding.logoForDarkBackground && (
@@ -105,8 +107,6 @@ export const CardBranding = ({
 						alt={branding.sponsorName}
 						width={logo.dimensions.width}
 						height={logo.dimensions.height}
-						data-component={dataAttributes?.ophanComponentName}
-						data-link-name={dataAttributes?.ophanComponentLink}
 					/>
 				</picture>
 			</a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,8 +362,8 @@ importers:
         specifier: 18.0.0
         version: 18.0.0(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js':
-        specifier: 2.2.2
-        version: 2.2.2
+        specifier: 2.2.5
+        version: 2.2.5
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4464,8 +4464,8 @@ packages:
       typescript: 5.5.3
     dev: false
 
-  /@guardian/ophan-tracker-js@2.2.2:
-    resolution: {integrity: sha512-g+Xouc0bU1fC+8qltuLexBxK67V534ZFDQ/bGWQtYDFSJJJtyPIq6ytPcn4KULNOQc+zRsUcRIfO0uRnjJScbw==}
+  /@guardian/ophan-tracker-js@2.2.5:
+    resolution: {integrity: sha512-chfaV3hkFEVy7YYKRpGFmryH7ngWhgeMIu8vnC4UH7kkQCTGcF1pgLgbREdYArdgQezCnSO3o9/15nRX0VDolA==}
     engines: {node: '>=16'}
     dependencies:
       '@guardian/tsconfig': 1.0.0


### PR DESCRIPTION
## What does this change?

Updates `@guardian/ophan-tracker-js` to `2.2.5`

## Why?

This resolves an issue with tracking on the `VeggieBurger` menu. A change in Ophan's behaviour to [avoid tracking clicks on whitespace within containers](https://github.com/guardian/ophan/pull/6275) meant that the `data-link-name` attribute would only track events when applied to a link element. (The burger menu is a `label` element with `role="button"` applied.) This has now been expanded from links to all clickable elements.