### PR TITLE
Update paid content e2e test

### DIFF
--- a/dotcom-rendering/playwright/lib/ophan.ts
+++ b/dotcom-rendering/playwright/lib/ophan.ts
@@ -9,7 +9,7 @@ const interceptOphanRequest = ({
 	searchParamMatcher,
 }: {
 	page: Page;
-	path: string;
+	path: typeof IMPRESSION_REQUEST_PATH | typeof ADDITIONAL_REQUEST_PATH;
 	searchParamMatcher: (searchParams: URLSearchParams) => boolean;
 }): Promise<Request> => {
 	return page.waitForRequest((request) => {

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -6,7 +6,18 @@ import { expectToBeVisible } from '../lib/locators';
 import { ADDITIONAL_REQUEST_PATH, interceptOphanRequest } from '../lib/ophan';
 
 const paidContentPage =
-	'https://www.theguardian.com/cook-up-a-feast-with-tesco-finest/2024/sep/13/peach-and-burrata-bruschetta-recipe';
+	'https://www.theguardian.com/guardian-clearing/2021/jul/12/online-event-how-to-make-clearing-work-for-you-register-now';
+
+const metaLogoDataComponent =
+	'labs-logo | article-meta-the-guardian universities';
+
+const metaLogoDataLinkName = 'labs-logo-article-meta-the-guardian universities';
+
+const relatedContentLogoDataComponent =
+	'labs-logo | article-related-content-the-guardian universities';
+
+const relatedContentLogoDataLinkName =
+	'labs-logo-article-related-content-the-guardian universities';
 
 /**
  * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
@@ -29,9 +40,8 @@ test.describe('Paid content tests', () => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
-					clickComponent ===
-						'labs-logo | article-meta-tesco-finest' &&
-					clickLinkNames === '["labs-logo-article-meta-tesco-finest"]'
+					clickComponent === metaLogoDataComponent &&
+					clickLinkNames === `["${metaLogoDataLinkName}"]`
 				);
 			},
 		});
@@ -57,10 +67,9 @@ test.describe('Paid content tests', () => {
 				const clickComponent = searchParams.get('clickComponent');
 				const clickLinkNames = searchParams.get('clickLinkNames');
 				return (
-					clickComponent ===
-						'labs-logo | article-related-content-tesco-finest' &&
+					clickComponent === relatedContentLogoDataComponent &&
 					clickLinkNames ===
-						'["labs-logo-article-related-content-tesco-finest","related-content"]'
+						`["${relatedContentLogoDataLinkName}","related-content"]`
 				);
 			},
 		});

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -5,6 +5,19 @@ import { loadPage } from '../lib/load-page';
 import { expectToBeVisible } from '../lib/locators';
 import { ADDITIONAL_REQUEST_PATH, interceptOphanRequest } from '../lib/ophan';
 
+/**
+ * This test checks Ophan click events are sent for paid content labs campaigns.
+ * We have tried to use a long lived campaign however the content can be taken down.
+ *
+ * If the content is taken down you'll need to find a new paid content page.
+ * The article should have a sponsor logo in the article meta and related content section.
+ * You can find all paid content campaigns here:
+ * https://www.theguardian.com/tone/advertisement-features
+ *
+ * You need to edit the expected logo data-component name and data-link-name for both the meta and related content section
+ * You can grab the required attribute values in the dev tools for the page itself
+ */
+
 const paidContentPage =
 	'https://www.theguardian.com/guardian-clearing/2021/jul/12/online-event-how-to-make-clearing-work-for-you-register-now';
 
@@ -19,13 +32,6 @@ const relatedContentLogoDataComponent =
 const relatedContentLogoDataLinkName =
 	'labs-logo-article-related-content-the-guardian universities';
 
-/**
- * This test relies on labs campaigns, where the content is often taken down one the campaign is complete.
- * If this happens you'll need to find a new labs article with a brand badge, you can often find these here:
- * https://www.theguardian.com/tone/advertisement-features
- * You need to edit the link as well as the expected requestURL to include the new brand in the code below, where it states `expect(requestURL).to.include('el=<logo goes here>');`.
- * You can grab the required info in the dev tools network tab on the page itself.
- */
 test.describe('Paid content tests', () => {
 	test('should send Ophan component event on click of sponsor logo in article meta and related content section', async ({
 		page,

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -27,13 +27,14 @@ const relatedContentLogoDataLinkName =
  * You can grab the required info in the dev tools network tab on the page itself.
  */
 test.describe('Paid content tests', () => {
-	test('should send Ophan component event on click of sponsor logo in article meta', async ({
+	test('should send Ophan component event on click of sponsor logo in article meta and related content section', async ({
 		page,
 	}) => {
 		await loadPage(page, `/Article/${paidContentPage}`);
 		await cmpAcceptAll(page);
 
-		const clickEventRequest = interceptOphanRequest({
+		// meta logo
+		const metaClickEventRequest = interceptOphanRequest({
 			page,
 			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams) => {
@@ -51,16 +52,13 @@ test.describe('Paid content tests', () => {
 		await expectToBeVisible(page, '[data-testid=branding-logo]');
 		await page.locator('[data-testid=branding-logo]').click();
 
-		await clickEventRequest;
-	});
+		await metaClickEventRequest;
 
-	test('should send Ophan component event on click of sponsor logo in onwards section', async ({
-		page,
-	}) => {
-		await loadPage(page, `/Article/${paidContentPage}`);
-		await cmpAcceptAll(page);
+		// go back to the paid content page
+		await page.goBack();
 
-		const clickEventRequest = interceptOphanRequest({
+		// related content logo
+		const relatedClickEventRequest = interceptOphanRequest({
 			page,
 			path: ADDITIONAL_REQUEST_PATH,
 			searchParamMatcher: (searchParams) => {
@@ -79,7 +77,6 @@ test.describe('Paid content tests', () => {
 		await expectToBeVisible(page, '[data-testid=card-branding-logo]');
 		await page.locator('[data-testid=card-branding-logo]').first().click();
 
-		// Make sure the request to Ophan is made
-		await clickEventRequest;
+		await relatedClickEventRequest;
 	});
 });


### PR DESCRIPTION
## What does this change?

Update paid content e2e test to:

- use a [long lived paid content page](https://www.theguardian.com/guardian-clearing/2021/jul/12/online-event-how-to-make-clearing-work-for-you-register-now) from 2021
- move expected values to module level consts so more visible
- merge tests into a single test that clicks on the meta logo, goes back and then clicks on the related content card

## Why?

We were previously using paid content pages that had a relatively short life span.

This test would fail when that content was removed causing failed builds.

The new page used should be stable.

Thanks @emma-imber for the tip!

