### PR TITLE
Tweak megaboosted standard story headline sizes

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -156,7 +156,7 @@ const fontStylesOnMobile = ({
 		case 'huge':
 			return css`
 				${until.desktop} {
-					${headlineMedium24}
+					${headlineMedium28}
 				}
 			`;
 		case 'large':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,9 +196,9 @@ const decideCardProperties = (
 	switch (boostLevel) {
 		case 'megaboost':
 			return {
-				headlineSize: 'large',
+				headlineSize: 'huge',
 				headlineSizeOnMobile: 'huge',
-				headlineSizeOnTablet: 'ginormous',
+				headlineSizeOnTablet: 'small',
 				imageSize: 'jumbo',
 			};
 		case 'boost':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,9 +196,9 @@ const decideCardProperties = (
 	switch (boostLevel) {
 		case 'megaboost':
 			return {
-				headlineSize: 'huge',
+				headlineSize: 'large',
 				headlineSizeOnMobile: 'huge',
-				headlineSizeOnTablet: 'huge',
+				headlineSizeOnTablet: 'ginormous',
 				imageSize: 'jumbo',
 			};
 		case 'boost':


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Mobile before      | Mobile after (28px)      |
| ----------- | ---------- |
| ![mbefore][] | ![mafter][] |

[mbefore]: https://github.com/user-attachments/assets/25bfa5c1-fe7a-43e5-99db-cf1f159f99bc
[mafter]: https://github.com/user-attachments/assets/a4fc39c1-9c12-4f69-836d-a3f370d00bc9


| Tablet before      | Tablet after (24px)      |
| ----------- | ---------- |
| ![tbefore][] | ![tafter][] |

[tbefore]: https://github.com/user-attachments/assets/b356e1b3-3086-4887-a1f2-34c1977cb8e5
[tafter]: https://github.com/user-attachments/assets/7b6e51ca-1ffb-4a56-8a19-4cc393665722


| Desktop before      | Desktop after (28px)      |
| ----------- | ---------- |
| ![dbefore][] | ![dafter][] |

[dbefore]: https://github.com/user-attachments/assets/25bfa5c1-fe7a-43e5-99db-cf1f159f99bc
[dafter]: https://github.com/user-attachments/assets/7b6e51ca-1ffb-4a56-8a19-4cc393665722





<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
