### PR TITLE
Reinstate sticky liveblog ask component into Liveblog

### DIFF
--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -47,6 +47,7 @@ import { Section } from '../components/Section';
 import { Standfirst } from '../components/Standfirst';
 import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { StickyLiveblogAskWrapper } from '../components/StickyLiveblogAskWrapper.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
 import { canRenderAds } from '../lib/canRenderAds';
@@ -720,6 +721,22 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 										/>
 									</div>
 								</Hide>
+
+								{isWeb && (
+									<Hide until="desktop">
+										<Island
+											priority="feature"
+											defer={{ until: 'visible' }}
+										>
+											<StickyLiveblogAskWrapper
+												referrerUrl={article.webURL}
+												shouldHideReaderRevenueOnArticle={
+													article.shouldHideReaderRevenue
+												}
+											/>
+										</Island>
+									</Hide>
+								)}
 
 								{/* Match stats */}
 								{!!footballMatchUrl && (


### PR DESCRIPTION
## What does this change?

This reinstates the sticky liveblog ask into the left margin of liveblogs.

## Why?

This was removed ([PR12397](https://github.com/guardian/dotcom-rendering/pull/12397)) after the announcement of the offer to buy the Observer.  We have since had approval to reinstate it unchanged.

## Screenshots
### Before (without)
![Before (without)](https://github.com/user-attachments/assets/066fabda-c946-4d0a-80c2-c62458b2e07c)
### After (with)
![After (with)](https://github.com/user-attachments/assets/4546079a-ea15-4a31-a3e2-369de76593ef)

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
