### PR TITLE
Rm/add multi byline

### DIFF
--- a/dotcom-rendering/src/components/MultiByline.stories.tsx
+++ b/dotcom-rendering/src/components/MultiByline.stories.tsx
@@ -39,7 +39,7 @@ export const ThemeVariations = {
 	args: {
 		multiBylineItems: [
 			{
-				title: 'The first byline',
+				title: 'This subheading is quite long so is likely to run on to multiple lines',
 				bio: testBioText,
 				body: [testTextElement],
 				byline: 'Richard Hillgrove Political Editor',
@@ -54,10 +54,10 @@ export const ThemeVariations = {
 				],
 			},
 			{
-				title: 'The first byline',
+				title: 'My hot take',
 				bio: testBioText,
 				body: [testTextElement],
-				byline: 'Richard Hillgrove Guardian Contributor',
+				byline: 'Guardian Contributor',
 				bylineHtml:
 					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a>",
 				contributors: [
@@ -71,7 +71,7 @@ export const ThemeVariations = {
 					'https://i.guim.co.uk/img/uploads/2024/09/17/Maurice_Casey.png?width=180&dpr=1&s=none',
 			},
 			{
-				title: 'The second byline',
+				title: 'A further subheading',
 				body: [testTextElement],
 			},
 		],

--- a/dotcom-rendering/src/components/MultiByline.stories.tsx
+++ b/dotcom-rendering/src/components/MultiByline.stories.tsx
@@ -1,0 +1,233 @@
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
+import { images } from '../../fixtures/generated/images';
+import { getAllDesigns, getAllThemes } from '../lib/format';
+import { RenderArticleElement } from '../lib/renderElement';
+import type { TextBlockElement } from '../types/content';
+import { MultiByline } from './MultiByline';
+
+const meta = {
+	component: MultiByline,
+	title: 'Components/MultiByline',
+} satisfies Meta<typeof MultiByline>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const testTextElement: TextBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+	elementId: 'test-text-element-id-1',
+	dropCap: 'on', // this should be overruled by multi byline which always sets forceDropCap="off"
+	html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesquepharetra libero nec varius feugiat. Nulla commodo sagittis erat amalesuada. Ut iaculis interdum eros, et tristique ex. In veldignissim arcu. Nulla nisi urna, laoreet a aliquam at, viverra eueros. Proin imperdiet pellentesque turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus. Etiam pretium, odioeget accumsan venenatis, tortor mi aliquet nisl, vel ullamcorperneque nulla vel elit. Etiam porta mauris nec sagittis luctus.</p>',
+};
+
+const testParagraph =
+	'<p>Proin <strong>imperdiet</strong> pellentesque <a href="#">adipiscing</a> turpis sed luctus. Donecdignissim lacus in risus fermentum maximus eu vel justo. Duis nontortor ac elit dapibus imperdiet ut at risus.</p>';
+const testListHtml =
+	'<ul><li><p>This is the <em>first</em> item in the list</p></li><li><p>The second item has a <a href="#">hyperlink</a>.</p></li></ul>';
+const testBioText = testParagraph + testListHtml;
+
+export const ThemeVariations = {
+	args: {
+		multiBylineItems: [
+			{
+				title: 'The first byline',
+				bio: testBioText,
+				body: [testTextElement],
+				byline: 'Richard Hillgrove Guardian Contributor',
+				bylineHtml:
+					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a>",
+				contributors: [
+					{
+						name: 'Richard Hillgrove',
+						imageUrl:
+							'https://i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2011/5/24/1306249890287/Richard-Hillgrove.jpg?width=100&dpr=2&s=none',
+					},
+				],
+			},
+			{
+				title: 'The first byline',
+				bio: testBioText,
+				body: [testTextElement],
+				byline: 'Richard Hillgrove Guardian Contributor',
+				bylineHtml:
+					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a>",
+				contributors: [
+					{
+						name: 'Richard Hillgrove',
+						imageUrl:
+							'https://i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2011/5/24/1306249890287/Richard-Hillgrove.jpg?width=100&dpr=2&s=none',
+					},
+				],
+				imageOverrideUrl:
+					'https://i.guim.co.uk/img/uploads/2024/09/17/Maurice_Casey.png?width=180&dpr=1&s=none',
+			},
+			{
+				title: 'The second byline',
+				body: [testTextElement],
+			},
+		],
+		isLastElement: true,
+		/**
+		 * This will be replaced by the `formats` parameter, but it's
+		 * required by the type.
+		 */
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+		abTests: {},
+		/**
+		 * This is used for rich links. An empty string isn't technically valid,
+		 * but there are no rich links in this example.
+		 */
+		ajaxUrl: '',
+		editionId: 'UK',
+		isAdFreeUser: false,
+		isSensitive: false,
+		pageId: 'testID',
+		switches: {},
+		RenderArticleElement,
+	},
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: getAllThemes({
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+		}),
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const DesignVariations = {
+	args: ThemeVariations.args,
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: getAllDesigns({
+			theme: Pillar.News,
+			display: ArticleDisplay.Standard,
+		}),
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const OtherVariations = {
+	args: ThemeVariations.args,
+	decorators: [centreColumnDecorator],
+	parameters: {
+		formats: [
+			{
+				design: ArticleDesign.Obituary,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Review,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Sport,
+			},
+			{
+				design: ArticleDesign.Recipe,
+				display: ArticleDisplay.Immersive,
+				theme: Pillar.Lifestyle,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReport,
+			},
+			{
+				design: ArticleDesign.Feature,
+				display: ArticleDisplay.Immersive,
+				theme: ArticleSpecial.SpecialReportAlt,
+			},
+		],
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Story;
+
+export const Images = {
+	args: {
+		...ThemeVariations.args,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+		multiBylineItems: [
+			{
+				title: 'The first byline',
+				bio: testBioText,
+				body: [
+					testTextElement,
+					{ ...images[0], displayCredit: true, role: 'inline' },
+					{ ...images[1], displayCredit: true, role: 'thumbnail' },
+					testTextElement,
+				],
+				byline: 'Richard Hillgrove Guardian Contributor',
+				bylineHtml:
+					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a>",
+				contributors: [
+					{
+						name: 'Richard Hillgrove',
+						imageUrl:
+							'https://i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2011/5/24/1306249890287/Richard-Hillgrove.jpg?width=100&dpr=2&s=none',
+					},
+				],
+			},
+			{
+				title: 'The second byline',
+				body: [
+					testTextElement,
+					{
+						...images[2],
+						displayCredit: true,
+						data: { ...images[2].data, caption: 'Sunset' },
+					},
+				],
+			},
+		],
+	},
+	decorators: [centreColumnDecorator],
+	parameters: {
+		chromatic: {
+			modes: {
+				vertical: allModes.splitVertical,
+			},
+		},
+	},
+} satisfies Story;
+
+export const WithSeparatorLine = {
+	args: {
+		...ThemeVariations.args,
+		isLastElement: false,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+	},
+	decorators: [centreColumnDecorator],
+} satisfies Story;

--- a/dotcom-rendering/src/components/MultiByline.stories.tsx
+++ b/dotcom-rendering/src/components/MultiByline.stories.tsx
@@ -42,9 +42,9 @@ export const ThemeVariations = {
 				title: 'The first byline',
 				bio: testBioText,
 				body: [testTextElement],
-				byline: 'Richard Hillgrove Guardian Contributor',
+				byline: 'Richard Hillgrove Political Editor',
 				bylineHtml:
-					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a>",
+					"<a href='/profile/richard-hillgrove'>Richard Hillgrove</a> Political Editor",
 				contributors: [
 					{
 						name: 'Richard Hillgrove',

--- a/dotcom-rendering/src/components/MultiByline.tsx
+++ b/dotcom-rendering/src/components/MultiByline.tsx
@@ -52,7 +52,6 @@ export const MultiByline = ({
 	return (
 		<ol data-ignore="global-ol-styling">
 			{multiBylineItems.map((multiBylineItem, index) => (
-				// eslint-disable-next-line react/no-array-index-key -- Title should usually be identical, but in case it isn't, also use array index
 				<MultiBylineItemComponent
 					multiBylineItem={multiBylineItem}
 					format={format}

--- a/dotcom-rendering/src/components/MultiByline.tsx
+++ b/dotcom-rendering/src/components/MultiByline.tsx
@@ -1,0 +1,88 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { palette } from '@guardian/source/foundations';
+import type { EditionId } from '../lib/edition';
+import type { ArticleElementRenderer } from '../lib/renderElement';
+import type { ServerSideTests, Switches } from '../types/config';
+import type { MultiBylineItem, StarRating } from '../types/content';
+import { MultiBylineItem as MultiBylineItemComponent } from './MultiBylineItem';
+
+interface MiniProfilesProps {
+	format: ArticleFormat;
+	ajaxUrl: string;
+	host?: string;
+	pageId: string;
+	isAdFreeUser: boolean;
+	isSensitive: boolean;
+	abTests: ServerSideTests;
+	switches: Switches;
+	editionId: EditionId;
+	hideCaption?: boolean;
+	starRating?: StarRating;
+	multiBylineItems: MultiBylineItem[];
+	RenderArticleElement: ArticleElementRenderer;
+	/**
+	 * Whether this is the last element in the article. If true, no separator will be rendered.
+	 */
+	isLastElement: boolean;
+}
+
+const separatorStyles = css`
+	width: 140px;
+	margin: 8px 0 2px 0;
+	border-top: 1px solid ${palette.neutral[86]};
+`;
+
+export const MultiByline = ({
+	multiBylineItems,
+	format,
+	ajaxUrl,
+	host,
+	pageId,
+	isAdFreeUser,
+	isSensitive,
+	switches,
+	abTests,
+	editionId,
+	hideCaption,
+	starRating,
+	RenderArticleElement,
+	isLastElement,
+}: MiniProfilesProps) => {
+	return (
+		<ol data-ignore="global-ol-styling">
+			{multiBylineItems.map((multiBylineItem, index) => (
+				// eslint-disable-next-line react/no-array-index-key -- Title should usually be identical, but in case it isn't, also use array index
+				<MultiBylineItemComponent
+					multiBylineItem={multiBylineItem}
+					format={format}
+					key={`${multiBylineItem.title}-${index}`}
+				>
+					{multiBylineItem.body.map((element) => (
+						// eslint-disable-next-line react/jsx-key -- The element array should remain consistent as it's derived from the order of elements in CAPI
+						<RenderArticleElement
+							format={format}
+							element={element}
+							ajaxUrl={ajaxUrl}
+							host={host}
+							index={index}
+							isMainMedia={false}
+							pageId={pageId}
+							webTitle={multiBylineItem.title}
+							isAdFreeUser={isAdFreeUser}
+							isSensitive={isSensitive}
+							switches={switches}
+							abTests={abTests}
+							editionId={editionId}
+							hideCaption={hideCaption}
+							starRating={starRating}
+							forceDropCap="off"
+							isListElement={true}
+						/>
+					))}
+				</MultiBylineItemComponent>
+			))}
+			{!isLastElement && <hr css={separatorStyles} />}
+		</ol>
+	);
+};

--- a/dotcom-rendering/src/components/MultiBylineItem.tsx
+++ b/dotcom-rendering/src/components/MultiBylineItem.tsx
@@ -1,0 +1,112 @@
+import { css } from '@emotion/react';
+import { type ArticleFormat } from '@guardian/libs';
+import { neutral, space, textSans14 } from '@guardian/source/foundations';
+import sanitise from 'sanitize-html';
+import { slugify } from '../model/enhance-H2s';
+import { palette } from '../palette';
+import type { MultiBylineItem as MultiBylineItemModel } from '../types/content';
+import { headingLineStyles } from './KeyTakeaway';
+import { subheadingStyles } from './Subheading';
+
+const multiBylineItemStyles = css`
+	padding-top: 8px;
+`;
+
+/** Nesting is necessary in the bio styles because we receive a string of html from the
+ * field. This can contain the following tags:
+ * Blocks: p, ul, li
+ * Inline: strong, em, a
+ */
+const bioStyles = css`
+	${textSans14};
+	padding: ${space[1]}px 0;
+	color: ${palette('--mini-profiles-text-subdued')};
+	p {
+		margin-bottom: ${space[2]}px;
+	}
+	a {
+		color: ${palette('--link-kicker-text')};
+		text-underline-offset: 3px;
+	}
+	a:not(:hover) {
+		text-decoration-color: ${neutral[86]};
+	}
+	a:hover {
+		text-decoration: underline;
+	}
+	ul {
+		list-style: none;
+		margin: 0 0 ${space[2]}px;
+		padding: 0;
+	}
+	ul li {
+		padding-left: ${space[5]}px;
+	}
+	ul li p {
+		display: inline-block;
+		margin-bottom: 0;
+	}
+	ul li:before {
+		display: inline-block;
+		content: '';
+		border-radius: 0.375rem;
+		height: 10px;
+		width: 10px;
+		margin: 0 ${space[2]}px 0 -${space[5]}px;
+		background-color: ${palette('--bullet-fill')};
+	}
+	strong {
+		font-weight: bold;
+	}
+`;
+
+const bottomBorderStyles = css`
+	border-top: 1px solid ${palette('--article-border')};
+	margin-bottom: ${space[2]}px;
+`;
+
+const headingMarginStyle = css`
+	margin-bottom: ${space[2]}px;
+`;
+
+interface MultiBylineItemProps {
+	multiBylineItem: MultiBylineItemModel;
+	format: ArticleFormat;
+	children: React.ReactNode;
+}
+
+export const MultiBylineItem = ({
+	multiBylineItem,
+	format,
+	children,
+}: MultiBylineItemProps) => {
+	return (
+		<>
+			<li css={multiBylineItemStyles} data-spacefinder-role="nested">
+				<hr css={headingLineStyles} />
+				<h3
+					id={slugify(multiBylineItem.title)}
+					css={[subheadingStyles(format), headingMarginStyle]}
+				>
+					{multiBylineItem.title}
+				</h3>
+				<Bio html={multiBylineItem.bio} />
+				{children}
+			</li>
+		</>
+	);
+};
+
+const Bio = ({ html }: { html?: string }) => {
+	if (!html) return null;
+	const sanitizedHtml = sanitise(html, {});
+	return (
+		<>
+			<div
+				css={bioStyles}
+				dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+			/>
+			<div css={bottomBorderStyles} />
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/MultiBylineItem.tsx
+++ b/dotcom-rendering/src/components/MultiBylineItem.tsx
@@ -207,7 +207,7 @@ export const multiBylineBylineStyles = (format: ArticleFormat) => css`
 	color: ${neutral[46]};
 	a {
 		${subheadingStyles(format)}
-		color: ${palette('--byline-anchor')};
+		color: ${palette('--link-kicker-text')};
 		text-decoration: none;
 		font-style: normal;
 		:hover {
@@ -229,12 +229,20 @@ const bylineTextStyles = css`
 `;
 
 const bylineImageStyles = css`
-	width: 140px;
+	width: 80px;
 	border-radius: 50%;
-	margin-bottom: -16px;
-	height: 140px;
+	margin-bottom: -8px;
+	height: 80px;
+	min-width: 80px;
+	// TODO: make this different size based on screen size
 	overflow: hidden;
 	align-self: flex-end;
+	${from.tablet} {
+		height: 120px;
+		min-width: 120px;
+		width: 120px;
+		margin-bottom: -12px;
+	}
 `;
 
 interface MultiBylineItemProps {
@@ -251,7 +259,6 @@ export const MultiBylineItem = ({
 	return (
 		<>
 			<li css={multiBylineItemStyles} data-spacefinder-role="nested">
-				<hr css={headingLineStyles} />
 				<Byline
 					title={multiBylineItem.title}
 					byline={multiBylineItem.byline ?? ''}
@@ -288,6 +295,7 @@ const Byline = ({
 	return (
 		<div css={bylineWrapperStyles}>
 			<div css={bylineTextStyles}>
+				<hr css={headingLineStyles} />
 				<h3
 					id={slugify(title)}
 					css={[subheadingStyles(format), headingMarginStyle]}

--- a/dotcom-rendering/src/components/MultiBylineItem.tsx
+++ b/dotcom-rendering/src/components/MultiBylineItem.tsx
@@ -1,15 +1,45 @@
 import { css } from '@emotion/react';
-import { type ArticleFormat } from '@guardian/libs';
-import { neutral, space, textSans14 } from '@guardian/source/foundations';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '@guardian/libs';
+import {
+	from,
+	headlineLightItalic24,
+	headlineLightItalic28,
+	headlineLightItalic34,
+	headlineMediumItalic24,
+	headlineMediumItalic28,
+	neutral,
+	space,
+	textSans14,
+	textSans24,
+	textSans28,
+	textSans34,
+	textSansItalic17,
+} from '@guardian/source/foundations';
 import sanitise from 'sanitize-html';
 import { slugify } from '../model/enhance-H2s';
 import { palette } from '../palette';
 import type { MultiBylineItem as MultiBylineItemModel } from '../types/content';
-import { headingLineStyles } from './KeyTakeaway';
 import { subheadingStyles } from './Subheading';
 
 const multiBylineItemStyles = css`
 	padding-top: 8px;
+`;
+
+const labsBylineStyles = css`
+	${textSansItalic17};
+	line-height: 1.4;
+`;
+
+const headingLineStyles = css`
+	width: 140px;
+	margin: 8px 0 2px 0;
+	border: none;
+	border-top: 4px solid ${palette('--heading-line')};
 `;
 
 /** Nesting is necessary in the bio styles because we receive a string of html from the
@@ -69,6 +99,144 @@ const headingMarginStyle = css`
 	margin-bottom: ${space[2]}px;
 `;
 
+export const nonAnchorHeadlineStyles = ({
+	format,
+	fontWeight,
+}: {
+	format: ArticleFormat;
+	fontWeight: 'light' | 'medium' | 'bold';
+}) => css`
+	${format.display === ArticleDisplay.Immersive
+		? headlineLightItalic28
+		: `
+			/**
+			 * Typography preset styles should not be overridden.
+			 * This has been done because the styles do not directly map to the new presets.
+			 * Please speak to your team's designer and update this to use a more appropriate preset.
+			 */
+			${fontWeight === 'light' && headlineLightItalic24};
+			${fontWeight === 'medium' && headlineMediumItalic24};
+			${fontWeight === 'bold' && headlineLightItalic24};
+		`};
+
+	${from.tablet} {
+		${format.display === ArticleDisplay.Immersive
+			? headlineLightItalic34
+			: `
+				/**
+				 * Typography preset styles should not be overridden.
+				 * This has been done because the styles do not directly map to the new presets.
+				 * Please speak to your team's designer and update this to use a more appropriate preset.
+				 */
+				${fontWeight === 'light' && headlineLightItalic28};
+				${fontWeight === 'medium' && headlineMediumItalic28};
+				${fontWeight === 'bold' && headlineLightItalic28};
+			`};
+	}
+
+	/** Labs uses sans text */
+	${format.theme === ArticleSpecial.Labs &&
+	css`
+		${format.display === ArticleDisplay.Immersive
+			? `
+				/**
+				 * Typography preset styles should not be overridden.
+				 * This has been done because the styles do not directly map to the new presets.
+				 * Please speak to your team's designer and update this to use a more appropriate preset.
+				 */
+				${textSans28};
+				font-weight: 300;
+				line-height: 1.15;
+			`
+			: `
+				/**
+				 * Typography preset styles should not be overridden.
+				 * This has been done because the styles do not directly map to the new presets.
+				 * Please speak to your team's designer and update this to use a more appropriate preset.
+				 */
+				${textSans24};
+				${fontWeight === 'light' && 'font-weight: 300;'};
+				${fontWeight === 'medium' && 'font-weight: 500;'};
+				${fontWeight === 'bold' && 'font-weight: 700;'};
+				line-height: 1.15;
+			`};
+
+		${from.tablet} {
+			${format.display === ArticleDisplay.Immersive
+				? `
+					/**
+					 * Typography preset styles should not be overridden.
+					 * This has been done because the styles do not directly map to the new presets.
+					 * Please speak to your team's designer and update this to use a more appropriate preset.
+					 */
+					${textSans34};
+					font-weight: 300;
+					line-height: 1.15;
+				`
+				: `
+					/**
+					 * Typography preset styles should not be overridden.
+					 * This has been done because the styles do not directly map to the new presets.
+					 * Please speak to your team's designer and update this to use a more appropriate preset.
+					 */
+					${textSans28};
+					${fontWeight === 'light' && 'font-weight: 300;'};
+					${fontWeight === 'medium' && 'font-weight: 500;'};
+					${fontWeight === 'bold' && 'font-weight: 700;'};
+					line-height: 1.15;
+				`};
+		}
+	`}
+
+	color: ${palette('--subheading-text')};
+
+	/* We don't allow additional font weight inside h2 tags except for immersive articles */
+	strong {
+		font-weight: ${format.display === ArticleDisplay.Immersive
+			? 'bold'
+			: 'inherit'};
+	}
+`;
+
+export const multiBylineBylineStyles = (format: ArticleFormat) => css`
+	${nonAnchorHeadlineStyles({ format, fontWeight: 'light' })}
+	padding-bottom: 8px;
+	font-style: italic !important;
+	margin-top: -4px;
+	font-weight: 300 !important;
+	color: ${neutral[46]};
+	a {
+		${subheadingStyles(format)}
+		color: ${palette('--byline-anchor')};
+		text-decoration: none;
+		font-style: normal;
+		:hover {
+			text-decoration: underline;
+		}
+	}
+`;
+
+const bylineWrapperStyles = css`
+	display: flex;
+	width: 100%;
+	overflow: hidden;
+	border-bottom: 1px solid ${palette('--article-border')};
+	margin-bottom: ${space[2]}px;
+`;
+
+const bylineTextStyles = css`
+	flex-grow: 1;
+`;
+
+const bylineImageStyles = css`
+	width: 140px;
+	border-radius: 50%;
+	margin-bottom: -16px;
+	height: 140px;
+	overflow: hidden;
+	align-self: flex-end;
+`;
+
 interface MultiBylineItemProps {
 	multiBylineItem: MultiBylineItemModel;
 	format: ArticleFormat;
@@ -118,8 +286,8 @@ const Byline = ({
 	const sanitizedHtml = sanitise(bylineHtml, {});
 
 	return (
-		<div>
-			<div>
+		<div css={bylineWrapperStyles}>
+			<div css={bylineTextStyles}>
 				<h3
 					id={slugify(title)}
 					css={[subheadingStyles(format), headingMarginStyle]}
@@ -128,7 +296,12 @@ const Byline = ({
 				</h3>
 				{bylineHtml ? (
 					<h3
-						css={[subheadingStyles(format), headingMarginStyle]}
+						css={[
+							multiBylineBylineStyles(format),
+							format.theme === ArticleSpecial.Labs &&
+								labsBylineStyles,
+							format.design === ArticleDesign.LiveBlog,
+						]}
 						dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
 					/>
 				) : null}
@@ -137,6 +310,7 @@ const Byline = ({
 				<img
 					src={imageOverrideUrl ?? contributors[0]?.imageUrl}
 					alt={byline}
+					css={bylineImageStyles}
 				></img>
 			) : null}
 		</div>

--- a/dotcom-rendering/src/components/MultiBylineItem.tsx
+++ b/dotcom-rendering/src/components/MultiBylineItem.tsx
@@ -84,16 +84,62 @@ export const MultiBylineItem = ({
 		<>
 			<li css={multiBylineItemStyles} data-spacefinder-role="nested">
 				<hr css={headingLineStyles} />
-				<h3
-					id={slugify(multiBylineItem.title)}
-					css={[subheadingStyles(format), headingMarginStyle]}
-				>
-					{multiBylineItem.title}
-				</h3>
+				<Byline
+					title={multiBylineItem.title}
+					byline={multiBylineItem.byline ?? ''}
+					bylineHtml={multiBylineItem.bylineHtml ?? ''}
+					contributors={multiBylineItem.contributors ?? []}
+					format={format}
+				/>
 				<Bio html={multiBylineItem.bio} />
 				{children}
 			</li>
 		</>
+	);
+};
+
+type BylineProps = {
+	title: string;
+	bylineHtml: string;
+	byline: string;
+	imageOverrideUrl?: string;
+	contributors: BlockContributor[];
+	format: ArticleFormat;
+};
+
+const Byline = ({
+	title,
+	bylineHtml,
+	byline,
+	imageOverrideUrl,
+	contributors,
+	format,
+}: BylineProps) => {
+	const sanitizedHtml = sanitise(bylineHtml, {});
+
+	return (
+		<div>
+			<div>
+				<h3
+					id={slugify(title)}
+					css={[subheadingStyles(format), headingMarginStyle]}
+				>
+					{title}
+				</h3>
+				{bylineHtml ? (
+					<h3
+						css={[subheadingStyles(format), headingMarginStyle]}
+						dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+					/>
+				) : null}
+			</div>
+			{imageOverrideUrl ?? contributors[0]?.imageUrl ? (
+				<img
+					src={imageOverrideUrl ?? contributors[0]?.imageUrl}
+					alt={byline}
+				></img>
+			) : null}
+		</div>
 	);
 };
 

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -330,6 +330,15 @@ export interface MiniProfile {
 	endNote?: string;
 }
 
+export interface MultiBylineItem {
+	title: string;
+	body: FEElement[];
+	bio?: string;
+	endNote?: string;
+	imageOverrideUrl?: string;
+	contributors?: BlockContributor[];
+}
+
 export interface KeyTakeawaysBlockElement {
 	_type: 'model.dotcomrendering.pageElements.KeyTakeawaysBlockElement';
 	keyTakeaways: KeyTakeaway[];

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -337,6 +337,8 @@ export interface MultiBylineItem {
 	endNote?: string;
 	imageOverrideUrl?: string;
 	contributors?: BlockContributor[];
+	byline?: string;
+	bylineHtml?: string;
 }
 
 export interface KeyTakeawaysBlockElement {


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
