### PR TITLE
Scaffold the small scrollable container

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -8,10 +8,21 @@ import {
 } from '@guardian/source/react-components';
 import { useEffect, useRef /* useState */ } from 'react';
 import { palette } from '../palette';
-import type { DCRFrontCard } from '../types/front';
+import type {
+	DCRContainerPalette,
+	DCRContainerType,
+	DCRFrontCard,
+} from '../types/front';
 import { FrontCard } from './FrontCard';
 
-type Props = { trails: DCRFrontCard[] };
+type Props = {
+	trails: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes?: boolean;
+	imageLoading: 'lazy' | 'eager';
+	containerType: DCRContainerType;
+};
 
 const carouselStyles = css`
 	display: grid;
@@ -73,12 +84,12 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		${until.tablet} {
 			grid-template-columns: repeat(
 				${totalCards},
-				calc((100% - ${peepingCardWidth}px) / 2)
+				calc((100% - ${peepingCardWidth}px))
 			);
 		}
 
 		${from.tablet} {
-			grid-template-columns: repeat(${totalCards}, 1fr);
+			grid-template-columns: repeat(${totalCards}, 50%);
 		}
 	`;
 };
@@ -87,10 +98,16 @@ const generateCarouselColumnStyles = (totalCards: number) => {
  * This is an island - todo
  *
  */
-export const ScrollableSmallContainer = ({ trails }: Props) => {
+export const ScrollableSmallContainer = ({
+	trails,
+	containerPalette,
+	containerType,
+	absoluteServerTimes,
+	imageLoading,
+	showAge,
+}: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
-	const imageLoading = 'eager'; //todo
 
 	// const [previousButtonState, setShowPreviousButton] = useState(false);
 	// const [nextButtonState, setShowNextButton] = useState(true);
@@ -164,7 +181,21 @@ export const ScrollableSmallContainer = ({ trails }: Props) => {
 							<FrontCard
 								trail={trail}
 								imageLoading={imageLoading}
-								absoluteServerTimes={false}
+								absoluteServerTimes={!!absoluteServerTimes}
+								containerPalette={containerPalette}
+								containerType={containerType}
+								showAge={!!showAge}
+								headlineSize="small"
+								headlineSizeOnMobile="small"
+								headlineSizeOnTablet="small"
+								imagePositionOnDesktop="left"
+								imagePositionOnMobile="left"
+								imageSize="small" // TODO - needs fixed width images
+								trailText={undefined} // unsupported
+								supportingContent={undefined} // unsupported
+								aspectRatio="5:4"
+								kickerText={trail.kickerText}
+								showLivePlayable={trail.showLivePlayable}
 								// TODO - specify card props
 							/>
 						</li>
@@ -182,6 +213,15 @@ export const ScrollableSmallContainer = ({ trails }: Props) => {
 								iconSide="left"
 								icon={<SvgChevronLeftSingle />}
 								onClick={() => scrollTo('left')}
+								priority="tertiary"
+								// TODO use better colour name
+								theme={{
+									borderTertiary:
+										palette('--card-border-top'),
+									textTertiary: palette(
+										'--card-headline-trail-text',
+									),
+								}}
 								// TODO
 								// aria-label="Move stories backwards"
 								// data-link-name="container left chevron"
@@ -195,6 +235,15 @@ export const ScrollableSmallContainer = ({ trails }: Props) => {
 								iconSide="left"
 								icon={<SvgChevronRightSingle />}
 								onClick={() => scrollTo('right')}
+								priority="tertiary"
+								// TODO use better colour name
+								theme={{
+									borderTertiary:
+										palette('--card-border-top'),
+									textTertiary: palette(
+										'--card-headline-trail-text',
+									),
+								}}
 								// TODO
 								// aria-label="Move stories forwards"
 								// data-link-name="container right chevron"

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/highlights-trails';
 import { FrontSection } from './FrontSection';
@@ -9,22 +9,27 @@ export default {
 	component: ScrollableSmallContainer,
 	args: {
 		trails,
+		containerPalette: undefined,
+		showAge: true,
+		absoluteServerTimes: true,
+		imageLoading: 'eager',
+		containerType: 'scrollable/small',
 	},
 } as Meta;
 
-// type Story = StoryObj<typeof ScrollableSmallContainer>;
+type Story = StoryObj<typeof ScrollableSmallContainer>;
 
 export const Default = {};
 
 export const WithFrontSection = {
-	render: () => (
+	render: (args) => (
 		<FrontSection
 			title="Scrollable small"
 			discussionApiUrl={discussionApiUrl}
 			editionId={'UK'}
 			showTopBorder={false}
 		>
-			<ScrollableSmallContainer trails={trails} />
+			<ScrollableSmallContainer {...args} />
 		</FrontSection>
 	),
-};
+} satisfies Story;


### PR DESCRIPTION
## What does this change?

Adds a basic level small story carousel component along with a Storybook story

Includes lots of commented out code and `TODO` comments to be implemented in future pull requests

This component has been developed in isolation and is not connected to `FrontLayout` yet

## Why?

To support the new small story carousel container type in DCR

Part of [this Trello ticket](https://trello.com/c/JioYmzBd/473-web-small-story-carousel)

## Screenshots

Desktop:
![Screenshot 2024-10-07 at 17 01 41](https://github.com/user-attachments/assets/85c0b691-7b99-4409-a274-5df3ef761880)

Tablet:
![Screenshot 2024-10-07 at 17 01 52](https://github.com/user-attachments/assets/92648c83-241b-456a-9fff-6909b60f6f88)

Mobile:
![Screenshot 2024-10-07 at 17 02 03](https://github.com/user-attachments/assets/6a9e8627-7604-4a30-ba14-7de1d8ad3bf7)


### Not included in this pull request

- Toggling the buttons between enabled and disabled states depending on the scroll position
- Chevron button orientation and location in the container (should be top right of container from tablet upwards)
- Image and headline sizing requirements
- Card top border removal and vertical divider styling
- Any adaptations to the `FrontSection` component to allow the entire front section to be styled as a "secondary" level container (ie container title font styles, container top border, top and bottom padding/margins)

<hr /> 

> Co-authored-by:
> @jamesmockett 
> @abeddow91 
> @Georges-GNM 
