### PR TITLE
Discount choice cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -330,6 +330,24 @@ export const WithThreeTierChoiceCardsForUS: Story = {
 	},
 };
 
+export const WithThreeTierDiscountChoiceCards: Story = {
+	name: 'ContributionsEpic with discounted three tier choice cards',
+	args: {
+		...meta.args,
+		countryCode: 'GB',
+		variant: {
+			...props.variant,
+			name: 'THREE_TIER_CHOICE_CARDS',
+			secondaryCta: undefined,
+			showChoiceCards: true,
+			cta: {
+				baseUrl:
+					'https://support.theguardian.com/uk/contribute?promoCode=MY_PROMO',
+			},
+		},
+	},
+};
+
 export const WithChoiceCardsAndSignInLink: Story = {
 	name: 'ContributionsEpic with choice cards and sign-in link',
 	args: {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -341,6 +341,7 @@ export const WithThreeTierDiscountChoiceCards: Story = {
 			secondaryCta: undefined,
 			showChoiceCards: true,
 			cta: {
+				text: 'Support the Guardian',
 				baseUrl:
 					'https://support.theguardian.com/uk/contribute?promoCode=MY_PROMO',
 			},

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -311,7 +311,7 @@ export const WithThreeTierDiscountChoiceCards: Story = {
 			cta: {
 				text: 'Support the Guardian',
 				baseUrl:
-					'https://support.theguardian.com/uk/contribute?promoCode=MY_PROMO',
+					'https://support.theguardian.com/uk/contribute?promoCode=OCT_DISCOUNT_50_3_MONTHS',
 			},
 		},
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -1,3 +1,4 @@
+import { isUndefined } from '@guardian/libs';
 import type { ChoiceInfo } from './ThreeTierChoiceCards';
 
 export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
@@ -13,8 +14,28 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 	},
 	{
 		supportTier: 'SupporterPlus',
-		label: (amount: number, currencySymbol: string): string =>
-			`Support ${currencySymbol}${amount}/month`,
+		label: (
+			amount: number,
+			currencySymbol: string,
+			discount?: number,
+		): JSX.Element | string => {
+			if (!isUndefined(discount)) {
+				return (
+					<>
+						{' '}
+						Support{' '}
+						<s>
+							{currencySymbol}
+							{amount}
+						</s>{' '}
+						{currencySymbol}
+						{amount * discount}/month{' '}
+					</>
+				);
+			} else {
+				return `Support ${currencySymbol}${amount}/month`;
+			}
+		},
 		benefitsLabel: 'All-access digital',
 		benefits: () => [
 			'Unlimited access to the Guardian app',
@@ -32,6 +53,8 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 		recommended: false,
 	},
 ];
+
+//new discount set of choice cards and pass through the choice card variant
 
 export const ChoiceCardTestData_US: ChoiceInfo[] = [
 	{

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -22,7 +22,6 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 			if (!isUndefined(discount)) {
 				return (
 					<>
-						{' '}
 						Support{' '}
 						<s>
 							{currencySymbol}
@@ -53,8 +52,6 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 		recommended: false,
 	},
 ];
-
-//new discount set of choice cards and pass through the choice card variant
 
 export const ChoiceCardTestData_US: ChoiceInfo[] = [
 	{

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import {
 	palette,
 	space,
 	textSans15,
+	textSansBold14,
 	textSansBold15,
 	until,
 } from '@guardian/source/foundations';
@@ -75,6 +77,9 @@ const benefitsLabelStyles = css`
 const labelOverrideStyles = css`
 	+ label div {
 		font-weight: bold;
+		s {
+			font-weight: normal;
+		}
 	}
 `;
 
@@ -86,7 +91,7 @@ const recommendedPillStyles = css`
 	border-radius: 4px;
 	padding: ${space[1]}px ${space[2]}px;
 	background-color: ${palette.brand[400]};
-	${textSansBold15};
+	${textSansBold14};
 	color: ${palette.neutral[100]};
 	position: absolute;
 	top: -${space[2]}px;
@@ -100,7 +105,7 @@ const discountedPillStyles = css`
 	border-radius: 4px;
 	padding: ${space[1]}px ${space[2]}px;
 	background-color: ${palette.error[400]};
-	${textSansBold15};
+	${textSansBold14};
 	color: ${palette.neutral[100]};
 	position: absolute;
 	top: -${space[2]}px;
@@ -115,8 +120,8 @@ export type ChoiceInfo = {
 	label: (
 		amount: number,
 		currencySymbol: string,
-		discount?: string,
-	) => string;
+		discount?: number,
+	) => JSX.Element | string;
 	benefitsLabel?: string;
 	benefits: (currencySymbol: string) => string[];
 	recommended: boolean;
@@ -170,6 +175,7 @@ type ThreeTierChoiceCardsProps = {
 	setSelectedProduct: Dispatch<SetStateAction<SupportTier>>;
 	countryCode?: string;
 	variantOfChoiceCard: string;
+	supporterPlusDiscount?: number;
 };
 
 const getChoiceCardData = (choiceCardVariant: string): ChoiceInfo[] => {
@@ -188,6 +194,7 @@ export const ThreeTierChoiceCards = ({
 	selectedProduct,
 	setSelectedProduct,
 	variantOfChoiceCard,
+	supporterPlusDiscount,
 }: ThreeTierChoiceCardsProps) => {
 	const currencySymbol = getLocalCurrencySymbol(countryCode);
 	const countryGroupId = countryCodeToCountryGroupId(countryCode);
@@ -216,6 +223,10 @@ export const ThreeTierChoiceCards = ({
 						);
 						const selected = selectedProduct === supportTier;
 
+						const hasDiscount =
+							!isUndefined(supporterPlusDiscount) &&
+							supportTier === 'SupporterPlus';
+
 						return (
 							<div
 								key={supportTier}
@@ -223,7 +234,10 @@ export const ThreeTierChoiceCards = ({
 									position: relative;
 								`}
 							>
-								{recommended && <RecommendedPill />}
+								{hasDiscount && <DiscountedPill />}
+								{recommended && !hasDiscount && (
+									<RecommendedPill />
+								)}
 								<div
 									css={supportTierChoiceCardStyles(selected)}
 								>
@@ -231,6 +245,7 @@ export const ThreeTierChoiceCards = ({
 										label={label(
 											choiceAmount,
 											currencySymbol,
+											supporterPlusDiscount,
 										)}
 										id={`choicecard-${supportTier}`}
 										value={supportTier}

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -166,8 +166,8 @@ const RecommendedPill = () => {
 	return <div css={recommendedPillStyles}>Recommended</div>;
 };
 
-const DiscountedPill = () => {
-	return <div css={discountedPillStyles}>50% off</div>; //TODO confirm wording on button
+const DiscountedPill = ({ discount }: { discount: number }) => {
+	return <div css={discountedPillStyles}>{discount}% off</div>;
 };
 
 type ThreeTierChoiceCardsProps = {
@@ -234,7 +234,11 @@ export const ThreeTierChoiceCards = ({
 									position: relative;
 								`}
 							>
-								{hasDiscount && <DiscountedPill />}
+								{hasDiscount && (
+									<DiscountedPill
+										discount={supporterPlusDiscount * 100}
+									/>
+								)}
 								{recommended && !hasDiscount && (
 									<RecommendedPill />
 								)}

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -96,9 +96,27 @@ const recommendedPillStyles = css`
 	right: ${space[5]}px;
 `;
 
+const discountedPillStyles = css`
+	border-radius: 4px;
+	padding: ${space[1]}px ${space[2]}px;
+	background-color: ${palette.error[400]};
+	${textSansBold15};
+	color: ${palette.neutral[100]};
+	position: absolute;
+	top: -${space[2]}px;
+	${until.phablet} {
+		right: ${space[3]}px;
+	}
+	right: ${space[5]}px;
+`;
+
 export type ChoiceInfo = {
 	supportTier: SupportTier;
-	label: (amount: number, currencySymbol: string) => string;
+	label: (
+		amount: number,
+		currencySymbol: string,
+		discount?: string,
+	) => string;
 	benefitsLabel?: string;
 	benefits: (currencySymbol: string) => string[];
 	recommended: boolean;
@@ -141,6 +159,10 @@ const SupportingBenefits = ({
 
 const RecommendedPill = () => {
 	return <div css={recommendedPillStyles}>Recommended</div>;
+};
+
+const DiscountedPill = () => {
+	return <div css={discountedPillStyles}>50% off</div>; //TODO confirm wording on button
 };
 
 type ThreeTierChoiceCardsProps = {

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -56,7 +56,7 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 		showChoiceCards && variant.name.includes('US_CHECKOUT_PAGE');
 
 	const hasSupporterPlusPromoCode =
-		variant.cta?.baseUrl.includes('promoCode=MY_PROMO') ?? false; //TODO replace with actual promo code
+		variant.cta?.baseUrl.includes('OCT_DISCOUNT_50_3_MONTHS') ?? false;
 
 	const variantOfChoiceCard =
 		countryCode === 'US' && showUSSupportCheckout

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -55,6 +55,9 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 	const showUSSupportCheckout =
 		showChoiceCards && variant.name.includes('US_CHECKOUT_PAGE');
 
+	const hasSupporterPlusPromoCode =
+		variant.cta.baseUrl.includes('promoCode=MY_PROMO'); //TODO replace with actual promo code
+
 	const variantOfChoiceCard =
 		countryCode === 'US' && showUSSupportCheckout
 			? 'US_CHECKOUT_THREE_TIER_CHOICE_CARDS'
@@ -70,6 +73,9 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 					selectedProduct={threeTierChoiceCardSelectedProduct}
 					setSelectedProduct={setThreeTierChoiceCardSelectedProduct}
 					variantOfChoiceCard={variantOfChoiceCard}
+					supporterPlusDiscount={
+						hasSupporterPlusPromoCode ? 0.5 : undefined
+					}
 				/>
 			)}
 			<ContributionsEpicButtons

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -56,7 +56,7 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 		showChoiceCards && variant.name.includes('US_CHECKOUT_PAGE');
 
 	const hasSupporterPlusPromoCode =
-		variant.cta.baseUrl.includes('promoCode=MY_PROMO'); //TODO replace with actual promo code
+		variant.cta?.baseUrl.includes('promoCode=MY_PROMO') ?? false; //TODO replace with actual promo code
 
 	const variantOfChoiceCard =
 		countryCode === 'US' && showUSSupportCheckout


### PR DESCRIPTION
## What does this change?
Adds logic to calculate and display new discounted amounts for Support+ on the three tier choice cards

## Why?
Acquisitions have been a bit low, so we are hoping we can attract more people to sign up to Support+ at a discounted amount

https://trello.com/c/pB51sDky/718-discount-on-epic-choice-cards

## Screenshots
![image](https://github.com/user-attachments/assets/3be7750c-ff89-4892-9b93-d1dae0261c05)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
