### PR TITLE
WIP/POC: crossword page in DCR

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -1,3 +1,5 @@
+type GuardianCrossword = import('mycrossword').GuardianCrossword;
+
 type SharePlatform =
 	| 'facebook'
 	| 'twitter'

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -188,6 +188,12 @@ declare module '*.svg' {
 	export default content;
 }
 
+declare module '!to-string-loader*' {
+	const value: any;
+	// eslint-disable-next-line import/no-default-export -- This is how we import mycrossword's CSS bundle
+	export default value;
+}
+
 // Extend PerformanceEntry from lib.dom.ts with current 'In Draft' properties (to allow access as use in browsers that support)
 // lib.dom.ts: https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.performanceentry.html
 // Draft: https://wicg.github.io/element-timing/#sec-performance-element-timing

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -157,6 +157,7 @@
 		"lz-string": "1.5.0",
 		"mockdate": "3.0.5",
 		"node-fetch": "3.3.2",
+		"mycrossword": "1.2.4",
 		"postcss-styled-syntax": "0.6.3",
 		"preact": "10.15.1",
 		"preact-render-to-string": "6.0.2",

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -27,6 +27,9 @@ const articleWidth = (format: ArticleFormat) => {
 				}
 			`;
 		}
+		case ArticleDesign.Crossword:
+			/* The crossword player manages its own width; */
+			return null;
 		case ArticleDesign.Video:
 		case ArticleDesign.Audio:
 			return css`

--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -159,6 +159,10 @@ const getRenderedTokens = (
 		);
 	}
 
+	if (design === ArticleDesign.Crossword && renderedTokens.length > 0) {
+		return [(<>Set by: </>), ...renderedTokens];
+	}
+
 	return renderedTokens;
 };
 

--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -1,6 +1,7 @@
 import { ArticleDesign, type ArticleFormat, isString } from '@guardian/libs';
 import { Hide } from '@guardian/source/react-components';
 import { DottedLines } from '@guardian/source-development-kitchen/react-components';
+import { Fragment } from 'react';
 import {
 	getBylineComponentsFromTokens,
 	getSoleContributor,
@@ -160,7 +161,7 @@ const getRenderedTokens = (
 	}
 
 	if (design === ArticleDesign.Crossword && renderedTokens.length > 0) {
-		return [(<>Set by: </>), ...renderedTokens];
+		return [(<Fragment key="set-by">Set by: </Fragment>), ...renderedTokens];
 	}
 
 	return renderedTokens;

--- a/dotcom-rendering/src/components/Crossword.importable.tsx
+++ b/dotcom-rendering/src/components/Crossword.importable.tsx
@@ -1,0 +1,15 @@
+import type { GuardianCrossword } from 'mycrossword';
+import { MyCrossword } from 'mycrossword/dist/cjs/components';
+import xwCss from '!to-string-loader!css-loader!mycrossword/dist/index.css';
+
+export type CrosswordProps = {
+	id: string;
+	crossword: GuardianCrossword;
+};
+
+export const Crossword = ({ crossword, id }: CrosswordProps) => (
+	<>
+		<style>{xwCss}</style>
+		<MyCrossword id={id} data={crossword} />
+	</>
+);

--- a/dotcom-rendering/src/components/CrosswordInstructions.tsx
+++ b/dotcom-rendering/src/components/CrosswordInstructions.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import {
+	textEgyptian17,
+	textEgyptianBold17,
+} from '@guardian/source/foundations';
+
+const instructionsStyles = css`
+	${textEgyptian17};
+	white-space: pre-line;
+`;
+const headerStyles = css`
+	${textEgyptianBold17};
+	white-space: pre-line;
+`;
+export const CrosswordInstructions = ({
+	instructions,
+	className,
+}: {
+	instructions: string;
+	className?: string;
+}) => (
+	<div css={instructionsStyles} className={className}>
+		<strong css={headerStyles}>Special instructions: </strong>
+		{instructions}
+	</div>
+);

--- a/dotcom-rendering/src/components/CrosswordLinks.tsx
+++ b/dotcom-rendering/src/components/CrosswordLinks.tsx
@@ -1,0 +1,49 @@
+import { css } from '@emotion/react';
+import { textSans15 } from '@guardian/source/foundations';
+import { palette } from '../palette';
+
+const crosswordLinkStyles = css`
+	${textSans15};
+
+	a {
+		color: ${palette('--standfirst-link-text')};
+		text-decoration: none;
+		:hover {
+			border-bottom: 1px solid ${palette('--standfirst-link-border')};
+		}
+	}
+`;
+
+export const CrosswordLinks = ({
+	crossword,
+	className,
+}: {
+	crossword: GuardianCrossword;
+	className?: string;
+}) => {
+	return (
+		<span css={crosswordLinkStyles} className={className}>
+			<a
+				target="_blank"
+				href={`/crosswords/${crossword.crosswordType}/${crossword.number}/print`}
+				rel="noreferrer"
+			>
+				Print
+			</a>{' '}
+			|{' '}
+			{!!crossword.pdf && (
+				<>
+					<a target="_blank" href={crossword.pdf} rel="noreferrer">
+						PDF version
+					</a>{' '}
+					|{' '}
+				</>
+			)}
+			<a
+				href={`/crosswords/accessible/${crossword.crosswordType}/${crossword.number}`}
+			>
+				Accessible version
+			</a>
+		</span>
+	);
+};

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -82,8 +82,8 @@ const CrosswordGrid = ({ children }: { children: React.ReactNode }) => (
 
 					grid-template-areas:
 						'title  headline                right-column'
-						'lines  crossword-links         right-column'
-						'meta   standfirst              right-column'
+						'.      crossword-links         right-column'
+						'lines  standfirst              right-column'
 						'meta   crossword-instructions  right-column'
 						'body   body                    right-column';
 				}

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -1,0 +1,792 @@
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import { ArticleSpecial } from '@guardian/libs';
+import {
+	from,
+	palette as sourcePalette,
+	until,
+} from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import React from 'react';
+import { AdPortals } from '../components/AdPortals.importable';
+import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
+import { AppsFooter } from '../components/AppsFooter.importable';
+import { ArticleBody } from '../components/ArticleBody';
+import { ArticleContainer } from '../components/ArticleContainer';
+import { ArticleHeadline } from '../components/ArticleHeadline';
+import { ArticleMetaApps } from '../components/ArticleMeta.apps';
+import { ArticleMeta } from '../components/ArticleMeta.web';
+import { ArticleTitle } from '../components/ArticleTitle';
+import { Carousel } from '../components/Carousel.importable';
+import { CrosswordInstructions } from '../components/CrosswordInstructions';
+import { CrosswordLinks } from '../components/CrosswordLinks';
+import { DecideLines } from '../components/DecideLines';
+import { DiscussionLayout } from '../components/DiscussionLayout';
+import { Footer } from '../components/Footer';
+import { GridItem } from '../components/GridItem';
+import { HeaderAdSlot } from '../components/HeaderAdSlot';
+import { Island } from '../components/Island';
+import { Masthead } from '../components/Masthead/Masthead';
+import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
+import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
+import { OnwardsUpper } from '../components/OnwardsUpper.importable';
+import { RightColumn } from '../components/RightColumn';
+import { Section } from '../components/Section';
+import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
+import { Standfirst } from '../components/Standfirst';
+import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
+import { SubMeta } from '../components/SubMeta';
+import { SubNav } from '../components/SubNav.importable';
+import { canRenderAds } from '../lib/canRenderAds';
+import { getContributionsServiceUrl } from '../lib/contributions';
+import { decideTrail } from '../lib/decideTrail';
+import type { NavType } from '../model/extract-nav';
+import { palette as themePalette } from '../palette';
+import type { ArticleDeprecated } from '../types/article';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { BannerWrapper, Stuck } from './lib/stickiness';
+
+const CrosswordGrid = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			/* IE Fallback */
+			display: flex;
+			flex-direction: column;
+			${until.leftCol} {
+				margin-left: 0px;
+			}
+			${from.leftCol} {
+				margin-left: 151px;
+			}
+			${from.wide} {
+				margin-left: 230px;
+			}
+
+			@supports (display: grid) {
+				display: grid;
+				width: 100%;
+				margin-left: 0;
+
+				grid-column-gap: 10px;
+
+				/*
+					Explanation of each unit of grid-template-columns
+
+					Left Column
+					Main content
+					Right Column
+				*/
+				${from.wide} {
+					grid-template-columns: 220px 1fr 300px;
+
+					grid-template-areas:
+						'title  headline                right-column'
+						'lines  crossword-links         right-column'
+						'meta   standfirst              right-column'
+						'meta   crossword-instructions  right-column'
+						'body   body                    right-column';
+				}
+
+				/*
+					Explanation of each unit of grid-template-columns
+
+					Left Column
+					Main content
+					Right Column
+				*/
+				${until.wide} {
+					grid-template-columns: 140px 1fr 300px;
+
+					grid-template-areas:
+						'title  headline                right-column'
+						'lines  crossword-links         right-column'
+						'meta   standfirst              right-column'
+						'meta   crossword-instructions  right-column'
+						'body   body                    right-column';
+				}
+
+				${until.leftCol} {
+					grid-template-columns: minmax(0, 1fr); /* Main content */
+					grid-template-areas:
+						'title'
+						'headline'
+						'crossword-links'
+						'standfirst'
+						'lines'
+						'meta'
+						'crossword-instructions'
+						'body';
+				}
+
+				${until.desktop} {
+					grid-template-columns: minmax(0, 1fr); /* Main content */
+					grid-template-areas:
+						'title'
+						'headline'
+						'crossword-links'
+						'standfirst'
+						'lines'
+						'meta'
+						'crossword-instructions'
+						'body';
+				}
+
+				${until.tablet} {
+					grid-column-gap: 0px;
+					grid-template-columns: minmax(0, 1fr); /* Main content */
+					grid-template-areas:
+						'title'
+						'headline'
+						'crossword-links'
+						'standfirst'
+						'lines'
+						'meta'
+						'crossword-instructions'
+						'body';
+				}
+			}
+		`}
+	>
+		{children}
+	</div>
+);
+
+const maxWidth = css`
+	${from.desktop} {
+		max-width: 620px;
+	}
+`;
+
+const stretchLines = css`
+	${until.phablet} {
+		margin-left: -20px;
+		margin-right: -20px;
+	}
+	${until.mobileLandscape} {
+		margin-left: -10px;
+		margin-right: -10px;
+	}
+`;
+
+interface CommonProps {
+	article: ArticleDeprecated;
+	format: ArticleFormat;
+	renderingTarget: RenderingTarget;
+}
+
+interface WebProps extends CommonProps {
+	NAV: NavType;
+	renderingTarget: 'Web';
+}
+
+interface AppsProps extends CommonProps {
+	renderingTarget: 'Apps';
+}
+
+export const CrosswordLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget } = props;
+	const {
+		config: { isPaidContent, host, hasSurveyAd },
+	} = article;
+
+	const isApps = renderingTarget === 'Apps';
+	const isWeb = renderingTarget === 'Web';
+
+	const showComments = article.isCommentable && !isPaidContent;
+
+	const { branding } = article.commercialProperties[article.editionId];
+
+	const contributionsServiceUrl = getContributionsServiceUrl(article);
+
+	const { absoluteServerTimes = false } = article.config.switches;
+
+	/**
+	 * This property currently only applies to the header and merchandising slots
+	 */
+	const renderAds = isWeb && canRenderAds(article);
+	return (
+		<>
+			{isWeb && (
+				<>
+					<div>
+						{renderAds && (
+							<Stuck>
+								<div data-print-layout="hide">
+									<Section
+										fullWidth={true}
+										showTopBorder={false}
+										showSideBorders={false}
+										padSides={false}
+										shouldCenter={false}
+									>
+										<HeaderAdSlot
+											isPaidContent={
+												!!article.config.isPaidContent
+											}
+											shouldHideReaderRevenue={
+												!!article.config
+													.shouldHideReaderRevenue
+											}
+										/>
+									</Section>
+								</div>
+							</Stuck>
+						)}
+
+						<Masthead
+							nav={props.NAV}
+							editionId={article.editionId}
+							idUrl={article.config.idUrl}
+							mmaUrl={article.config.mmaUrl}
+							discussionApiUrl={article.config.discussionApiUrl}
+							idApiUrl={article.config.idApiUrl}
+							contributionsServiceUrl={contributionsServiceUrl}
+							showSubNav={format.theme !== ArticleSpecial.Labs}
+							showSlimNav={false}
+							hasPageSkin={false}
+							hasPageSkinContentSelfConstrain={false}
+							pageId={article.pageId}
+						/>
+					</div>
+
+
+					{renderAds && hasSurveyAd && (
+						<AdSlot position="survey" display={format.display} />
+					)}
+				</>
+			)}
+			<main data-layout="InteractiveLayout">
+				{isApps && (
+					<>
+						<Island priority="critical">
+							<AdPortals />
+						</Island>
+					</>
+				)}
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					showTopBorder={false}
+					backgroundColour={themePalette('--article-background')}
+					borderColour={themePalette('--article-border')}
+					element="article"
+				>
+					<div>
+						<CrosswordGrid>
+							<GridItem area="title" element="aside">
+								<div>
+									<ArticleTitle
+										format={format}
+										tags={article.tags}
+										sectionLabel={article.sectionLabel}
+										sectionUrl={article.sectionUrl}
+										guardianBaseURL={
+											article.guardianBaseURL
+										}
+									/>
+								</div>
+							</GridItem>
+							<GridItem area="headline">
+								<div css={maxWidth}>
+									<ArticleHeadline
+										format={format}
+										headlineString={article.headline}
+										tags={article.tags}
+										byline={article.byline}
+										webPublicationDateDeprecated={
+											article.webPublicationDateDeprecated
+										}
+									/>
+								</div>
+							</GridItem>
+							{article.crossword && (
+								<GridItem area="crossword-links">
+									<CrosswordLinks
+										css={maxWidth}
+										crossword={article.crossword}
+									/>
+								</GridItem>
+							)}
+							<GridItem area="standfirst">
+								<Standfirst
+									format={format}
+									standfirst={
+										'Download the Guardian app for a puzzles experience'
+									}
+								/>
+							</GridItem>
+
+							<GridItem area="lines">
+								<div css={maxWidth}>
+									<div css={stretchLines}>
+										<DecideLines
+											format={format}
+											color={themePalette(
+												'--article-meta-lines',
+											)}
+										/>
+									</div>
+								</div>
+							</GridItem>
+							<GridItem area="meta" element="aside">
+								<div css={maxWidth}>
+									{isApps ? (
+										<>
+											<Hide from="leftCol">
+												<ArticleMetaApps
+													branding={branding}
+													format={format}
+													pageId={article.pageId}
+													byline={article.byline}
+													tags={article.tags}
+													primaryDateline={
+														article.webPublicationDateDisplay
+													}
+													secondaryDateline={
+														article.webPublicationSecondaryDateDisplay
+													}
+													isCommentable={
+														article.isCommentable
+													}
+													discussionApiUrl={
+														article.config
+															.discussionApiUrl
+													}
+													shortUrlId={
+														article.config
+															.shortUrlId
+													}
+												></ArticleMetaApps>
+											</Hide>
+											<Hide until="leftCol">
+												<ArticleMeta
+													branding={branding}
+													format={format}
+													pageId={article.pageId}
+													webTitle={article.webTitle}
+													byline={article.byline}
+													tags={article.tags}
+													primaryDateline={
+														article.webPublicationDateDisplay
+													}
+													secondaryDateline={
+														article.webPublicationSecondaryDateDisplay
+													}
+													isCommentable={
+														article.isCommentable
+													}
+													discussionApiUrl={
+														article.config
+															.discussionApiUrl
+													}
+													shortUrlId={
+														article.config
+															.shortUrlId
+													}
+												/>
+											</Hide>
+										</>
+									) : (
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											tags={article.tags}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												article.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
+											}
+										/>
+									)}
+								</div>
+							</GridItem>
+							{!!article.crossword?.instructions && (
+								<GridItem area="crossword-instructions">
+									<CrosswordInstructions
+										instructions={
+											article.crossword.instructions
+										}
+										css={maxWidth}
+									/>
+								</GridItem>
+							)}
+							<GridItem area="body" element="article">
+								<ArticleContainer format={format}>
+									<ArticleBody
+										format={format}
+										blocks={article.blocks}
+										host={host}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										abTests={article.config.abTests}
+										switches={article.config.switches}
+										isSensitive={article.config.isSensitive}
+										isAdFreeUser={article.isAdFreeUser}
+										sectionId={article.config.section}
+										shouldHideReaderRevenue={
+											article.shouldHideReaderRevenue
+										}
+										tags={article.tags}
+										isPaidContent={
+											!!article.config.isPaidContent
+										}
+										contributionsServiceUrl={
+											contributionsServiceUrl
+										}
+										contentType={article.contentType}
+										isPreview={article.config.isPreview}
+										idUrl={article.config.idUrl ?? ''}
+										isDev={!!article.config.isDev}
+										keywordIds={article.config.keywordIds}
+										tableOfContents={
+											article.tableOfContents
+										}
+										lang={article.lang}
+										isRightToLeftLang={
+											article.isRightToLeftLang
+										}
+										editionId={article.editionId}
+									/>
+								</ArticleContainer>
+							</GridItem>
+							<GridItem area="right-column">
+								<RightColumn>
+									{renderAds ? (
+										<AdSlot
+											position="right"
+											display={format.display}
+											isPaidContent={isPaidContent}
+											shouldHideReaderRevenue={
+												article.shouldHideReaderRevenue
+											}
+										/>
+									) : null}
+								</RightColumn>
+							</GridItem>
+						</CrosswordGrid>
+					</div>
+				</Section>
+
+				<Section
+					stretchRight={false}
+					showTopBorder={false}
+					backgroundColour={themePalette('--article-background')}
+					borderColour={themePalette('--article-border')}
+					fontColour={themePalette('--article-section-title')}
+					padContent={false}
+					verticalMargins={false}
+				>
+					<div
+						css={css`
+							max-width: 620px;
+						`}
+					>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<SlotBodyEnd
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								stage={article.config.stage}
+								tags={article.tags}
+								renderAds={renderAds}
+								isLabs={false}
+								articleEndSlot={
+									!!article.config.switches.articleEndSlot
+								}
+							/>
+						</Island>
+					</div>
+				</Section>
+
+				<Section
+					fullWidth={true}
+					showTopBorder={false}
+					padSides={false}
+					backgroundColour={themePalette('--article-background')}
+				>
+					<StraightLines
+						count={4}
+						data-print-layout="hide"
+						color={themePalette('--straight-lines')}
+						cssOverrides={css`
+							display: block;
+						`}
+					/>
+				</Section>
+
+				<Section
+					fullWidth={true}
+					showTopBorder={false}
+					backgroundColour={themePalette('--article-background')}
+				>
+					<SubMeta
+						format={format}
+						subMetaKeywordLinks={article.subMetaKeywordLinks}
+						subMetaSectionLinks={article.subMetaSectionLinks}
+						pageId={article.pageId}
+						webUrl={article.webURL}
+						webTitle={article.webTitle}
+						showBottomSocialButtons={
+							article.showBottomSocialButtons &&
+							renderingTarget === 'Web'
+						}
+					/>
+				</Section>
+				{renderAds && (
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={themePalette('--ad-background')}
+						element="aside"
+					>
+						<AdSlot
+							data-print-layout="hide"
+							position="merchandising-high"
+							display={format.display}
+						/>
+					</Section>
+				)}
+
+				{article.storyPackage && (
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
+						borderColour={themePalette('--article-border')}
+					>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<Carousel
+								heading={article.storyPackage.heading}
+								trails={article.storyPackage.trails.map(
+									decideTrail,
+								)}
+								onwardsSource="more-on-this-story"
+								format={format}
+								leftColSize={'compact'}
+								discussionApiUrl={
+									article.config.discussionApiUrl
+								}
+								absoluteServerTimes={absoluteServerTimes}
+							/>
+						</Island>
+					</Section>
+				)}
+
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<OnwardsUpper
+						ajaxUrl={article.config.ajaxUrl}
+						hasRelated={article.hasRelated}
+						hasStoryPackage={article.hasStoryPackage}
+						isAdFreeUser={article.isAdFreeUser}
+						pageId={article.pageId}
+						isPaidContent={!!article.config.isPaidContent}
+						showRelatedContent={article.config.showRelatedContent}
+						keywordIds={article.config.keywordIds}
+						contentType={article.contentType}
+						tags={article.tags}
+						format={format}
+						pillar={format.theme}
+						editionId={article.editionId}
+						shortUrlId={article.config.shortUrlId}
+						discussionApiUrl={article.config.discussionApiUrl}
+						absoluteServerTimes={absoluteServerTimes}
+					/>
+				</Island>
+
+				{showComments && (
+					<Section
+						fullWidth={true}
+						sectionId="comments"
+						data-print-layout="hide"
+						element="section"
+						backgroundColour={themePalette(
+							'--discussion-section-background',
+						)}
+						borderColour={themePalette('--article-border')}
+						fontColour={themePalette('--discussion-text')}
+					>
+						<DiscussionLayout
+							discussionApiUrl={article.config.discussionApiUrl}
+							shortUrlId={article.config.shortUrlId}
+							format={format}
+							discussionD2Uid={article.config.discussionD2Uid}
+							discussionApiClientHeader={
+								article.config.discussionApiClientHeader
+							}
+							enableDiscussionSwitch={
+								!!article.config.switches.enableDiscussionSwitch
+							}
+							isAdFreeUser={article.isAdFreeUser}
+							shouldHideAds={article.shouldHideAds}
+							idApiUrl={article.config.idApiUrl}
+						/>
+					</Section>
+				)}
+
+				{!isPaidContent && (
+					<Section
+						title="Most viewed"
+						padContent={false}
+						verticalMargins={false}
+						element="aside"
+						data-print-layout="hide"
+						data-link-name="most-popular"
+						data-component="most-popular"
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
+						borderColour={themePalette('--article-border')}
+						fontColour={themePalette('--article-section-title')}
+					>
+						<MostViewedFooterLayout renderAds={renderAds}>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<MostViewedFooterData
+									sectionId={article.config.section}
+									ajaxUrl={article.config.ajaxUrl}
+									edition={article.editionId}
+								/>
+							</Island>
+						</MostViewedFooterLayout>
+					</Section>
+				)}
+
+				{renderAds && (
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						showTopBorder={false}
+						showSideBorders={false}
+						backgroundColour={themePalette('--ad-background')}
+						element="aside"
+					>
+						<AdSlot
+							position="merchandising"
+							display={format.display}
+						/>
+					</Section>
+				)}
+			</main>
+
+			{isWeb && props.NAV.subNavSections && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					padSides={false}
+					element="aside"
+				>
+					<Island priority="enhancement" defer={{ until: 'visible' }}>
+						<SubNav
+							subNavSections={props.NAV.subNavSections}
+							currentNavLink={props.NAV.currentNavLink}
+							position="footer"
+						/>
+					</Island>
+				</Section>
+			)}
+
+			{isWeb && (
+				<>
+					<Section
+						fullWidth={true}
+						data-print-layout="hide"
+						padSides={false}
+						backgroundColour={sourcePalette.brand[400]}
+						borderColour={sourcePalette.brand[600]}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.footer}
+							editionId={article.editionId}
+						/>
+					</Section>
+
+					<BannerWrapper data-print-layout="hide">
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+					<MobileStickyContainer
+						data-print-layout="hide"
+						contentType={article.contentType}
+						pageId={article.pageId}
+					/>
+				</>
+			)}
+			{isApps && (
+				<Section
+					fullWidth={true}
+					data-print-layout="hide"
+					backgroundColour={themePalette('--apps-footer-background')}
+					borderColour={themePalette('--article-border')}
+					padSides={false}
+					showSideBorders={false}
+					element="footer"
+				>
+					<Island priority="critical">
+						<AppsFooter />
+					</Island>
+				</Section>
+			)}
+		</>
+	);
+};

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -4,6 +4,7 @@ import type { NavType } from '../model/extract-nav';
 import type { ArticleDeprecated } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { CommentLayout } from './CommentLayout';
+import { CrosswordLayout } from './CrosswordLayout';
 import { FullPageInteractiveLayout } from './FullPageInteractiveLayout';
 import { ImmersiveLayout } from './ImmersiveLayout';
 import { InteractiveLayout } from './InteractiveLayout';
@@ -259,6 +260,15 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+						/>
+					);
+				case ArticleDesign.Crossword:
+					return (
+						<CrosswordLayout
+							article={article}
+							NAV={NAV}
+							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				default:

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -22,6 +22,7 @@ import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
+import { Crossword } from '../components/Crossword.importable';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
@@ -699,41 +700,52 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						</GridItem>
 						<GridItem area="body">
 							<ArticleContainer format={format}>
-								<ArticleBody
-									format={format}
-									blocks={article.blocks}
-									pinnedPost={article.pinnedPost}
-									host={host}
-									pageId={article.pageId}
-									webTitle={article.webTitle}
-									ajaxUrl={article.config.ajaxUrl}
-									switches={article.config.switches}
-									isSensitive={article.config.isSensitive}
-									isAdFreeUser={article.isAdFreeUser}
-									sectionId={article.config.section}
-									shouldHideReaderRevenue={
-										article.shouldHideReaderRevenue
-									}
-									tags={article.tags}
-									isPaidContent={
-										!!article.config.isPaidContent
-									}
-									contributionsServiceUrl={
-										contributionsServiceUrl
-									}
-									contentType={article.contentType}
-									isPreview={article.config.isPreview}
-									idUrl={article.config.idUrl ?? ''}
-									isDev={!!article.config.isDev}
-									keywordIds={article.config.keywordIds}
-									abTests={article.config.abTests}
-									tableOfContents={article.tableOfContents}
-									lang={article.lang}
-									isRightToLeftLang={
-										article.isRightToLeftLang
-									}
-									editionId={article.editionId}
-								/>
+								{article.crossword ? (
+									<Island priority="critical">
+										<Crossword
+											id={article.crossword.id}
+											crossword={article.crossword}
+										/>
+									</Island>
+								) : (
+									<ArticleBody
+										format={format}
+										blocks={article.blocks}
+										pinnedPost={article.pinnedPost}
+										host={host}
+										pageId={article.pageId}
+										webTitle={article.webTitle}
+										ajaxUrl={article.config.ajaxUrl}
+										switches={article.config.switches}
+										isSensitive={article.config.isSensitive}
+										isAdFreeUser={article.isAdFreeUser}
+										sectionId={article.config.section}
+										shouldHideReaderRevenue={
+											article.shouldHideReaderRevenue
+										}
+										tags={article.tags}
+										isPaidContent={
+											!!article.config.isPaidContent
+										}
+										contributionsServiceUrl={
+											contributionsServiceUrl
+										}
+										contentType={article.contentType}
+										isPreview={article.config.isPreview}
+										idUrl={article.config.idUrl ?? ''}
+										isDev={!!article.config.isDev}
+										keywordIds={article.config.keywordIds}
+										abTests={article.config.abTests}
+										tableOfContents={
+											article.tableOfContents
+										}
+										lang={article.lang}
+										isRightToLeftLang={
+											article.isRightToLeftLang
+										}
+										editionId={article.editionId}
+									/>
+								)}
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (
 										<Island

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -22,7 +22,6 @@ import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
-import { Crossword } from '../components/Crossword.importable';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
 import { Footer } from '../components/Footer';
@@ -700,52 +699,42 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						</GridItem>
 						<GridItem area="body">
 							<ArticleContainer format={format}>
-								{article.crossword ? (
-									<Island priority="critical">
-										<Crossword
-											id={article.crossword.id}
-											crossword={article.crossword}
-										/>
-									</Island>
-								) : (
-									<ArticleBody
-										format={format}
-										blocks={article.blocks}
-										pinnedPost={article.pinnedPost}
-										host={host}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										ajaxUrl={article.config.ajaxUrl}
-										switches={article.config.switches}
-										isSensitive={article.config.isSensitive}
-										isAdFreeUser={article.isAdFreeUser}
-										sectionId={article.config.section}
-										shouldHideReaderRevenue={
-											article.shouldHideReaderRevenue
-										}
-										tags={article.tags}
-										isPaidContent={
-											!!article.config.isPaidContent
-										}
-										contributionsServiceUrl={
-											contributionsServiceUrl
-										}
-										contentType={article.contentType}
-										isPreview={article.config.isPreview}
-										idUrl={article.config.idUrl ?? ''}
-										isDev={!!article.config.isDev}
-										keywordIds={article.config.keywordIds}
-										abTests={article.config.abTests}
-										tableOfContents={
-											article.tableOfContents
-										}
-										lang={article.lang}
-										isRightToLeftLang={
-											article.isRightToLeftLang
-										}
-										editionId={article.editionId}
-									/>
-								)}
+								<ArticleBody
+									format={format}
+									blocks={article.blocks}
+									pinnedPost={article.pinnedPost}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									switches={article.config.switches}
+									isSensitive={article.config.isSensitive}
+									isAdFreeUser={article.isAdFreeUser}
+									sectionId={article.config.section}
+									shouldHideReaderRevenue={
+										article.shouldHideReaderRevenue
+									}
+									tags={article.tags}
+									isPaidContent={
+										!!article.config.isPaidContent
+									}
+									contributionsServiceUrl={
+										contributionsServiceUrl
+									}
+									contentType={article.contentType}
+									isPreview={article.config.isPreview}
+									idUrl={article.config.idUrl ?? ''}
+									isDev={!!article.config.isDev}
+									keywordIds={article.config.keywordIds}
+									abTests={article.config.abTests}
+									tableOfContents={article.tableOfContents}
+									lang={article.lang}
+									isRightToLeftLang={
+										article.isRightToLeftLang
+									}
+									editionId={article.editionId}
+								/>
+
 								{format.design === ArticleDesign.MatchReport &&
 									!!footballMatchUrl && (
 										<Island

--- a/dotcom-rendering/src/lib/decideDesign.ts
+++ b/dotcom-rendering/src/lib/decideDesign.ts
@@ -59,6 +59,8 @@ export const decideDesign = ({ design }: Partial<FEFormat>): ArticleDesign => {
 			return ArticleDesign.Timeline;
 		case 'ProfileDesign':
 			return ArticleDesign.Profile;
+		case 'CrosswordDesign':
+			return ArticleDesign.Crossword;
 		default:
 			return ArticleDesign.Standard;
 	}

--- a/dotcom-rendering/src/lib/format.ts
+++ b/dotcom-rendering/src/lib/format.ts
@@ -110,6 +110,8 @@ const designToFEDesign = (design: ArticleDesign): FEDesign => {
 			return 'TimelineDesign';
 		case ArticleDesign.Profile:
 			return 'ProfileDesign';
+		case ArticleDesign.Crossword:
+			return 'CrosswordDesign';
 	}
 };
 

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -11,6 +11,7 @@ import { CartoonComponent } from '../components/CartoonComponent';
 import { ChartAtom } from '../components/ChartAtom.importable';
 import { CodeBlockComponent } from '../components/CodeBlockComponent';
 import { CommentBlockComponent } from '../components/CommentBlockComponent';
+import { Crossword } from '../components/Crossword.importable';
 import { DividerBlockComponent } from '../components/DividerBlockComponent';
 import { DocumentBlockComponent } from '../components/DocumentBlockComponent.importable';
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper';
@@ -842,6 +843,17 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.DisclaimerBlockElement': {
 			return <AffiliateDisclaimerInline />;
 		}
+		case 'model.dotcomrendering.pageElements.CrosswordElement':
+			return (
+				<div>
+					<Island priority="critical" defer={{ until: 'visible' }}>
+						<Crossword
+							id={element.crossword.id}
+							crossword={element.crossword}
+						/>
+					</Island>
+				</div>
+			);
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':
 		case 'model.dotcomrendering.pageElements.ContentAtomBlockElement':
 		case 'model.dotcomrendering.pageElements.GenericAtomBlockElement':

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -48,6 +48,17 @@ export const handleInteractive: RequestHandler = ({ body }, res) => {
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };
 
+export const handleCrossword: RequestHandler = ({ body }, res) => {
+	recordTypeAndPlatform('crossword', 'web');
+
+	const article = enhanceArticleType(body, 'Web');
+	const { html, prefetchScripts } = renderHtml({
+		article,
+	});
+
+	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
+};
+
 export const handleBlocks: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('blocks');
 	const {

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -3,7 +3,7 @@ import { Standard as ExampleArticle } from '../../fixtures/generated/fe-articles
 import { decideFormat } from '../lib/decideFormat';
 import { enhanceBlocks } from '../model/enhanceBlocks';
 import { validateAsBlock } from '../model/validate';
-import { enhanceArticleType } from '../types/article';
+import { enhanceArticleType, enhanceCrossword } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
 import { recordTypeAndPlatform } from './lib/logging-store';
@@ -52,8 +52,9 @@ export const handleCrossword: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('crossword', 'web');
 
 	const article = enhanceArticleType(body, 'Web');
+	const xwArticle = enhanceCrossword(article);
 	const { html, prefetchScripts } = renderHtml({
-		article,
+		article: xwArticle,
 	});
 
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -9,6 +9,7 @@ import {
 	handleArticle,
 	handleArticleJson,
 	handleBlocks,
+	handleCrossword,
 	handleInteractive,
 } from './handler.article.web';
 import {
@@ -69,6 +70,8 @@ export const devServer = (): Handler => {
 				return handleInteractive(req, res, next);
 			case 'AMPInteractive':
 				return handleAMPArticle(req, res, next);
+			case 'Crossword':
+				return handleCrossword(req, res, next);
 			case 'Blocks':
 				return handleBlocks(req, res, next);
 			case 'Front':

--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -17,6 +17,7 @@ import {
 	handleArticleJson,
 	handleArticlePerfTest,
 	handleBlocks,
+	handleCrossword,
 	handleInteractive,
 } from './handler.article.web';
 import {
@@ -65,6 +66,7 @@ export const prodServer = (): void => {
 	app.post('/AMPArticle', logRenderTime, handleAMPArticle);
 	app.post('/Interactive', logRenderTime, handleInteractive);
 	app.post('/AMPInteractive', logRenderTime, handleAMPArticle);
+	app.post('/Crossword', logRenderTime, handleCrossword);
 	app.post('/Blocks', logRenderTime, handleBlocks);
 	app.post('/Front', logRenderTime, handleFront);
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -61,7 +61,7 @@ export const enhanceCrossword = (article: Article): Article => {
 		};
 		return {
 			...article,
-			format: { ...article.format, design: ArticleDesign.Interactive },
+			format: { ...article.format, design: ArticleDesign.Crossword },
 			frontendData: {
 				...article.frontendData,
 				blocks: [
@@ -78,7 +78,6 @@ export const enhanceCrossword = (article: Article): Article => {
 							article.frontendData.webPublicationSecondaryDateDisplay,
 					},
 				],
-				crossword: undefined,
 			}
 		};
 	}

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -1,4 +1,5 @@
-import type { ArticleFormat } from '@guardian/libs';
+import { randomUUID } from 'node:crypto';
+import { ArticleDesign, type ArticleFormat } from '@guardian/libs';
 import { decideFormat } from '../lib/decideFormat';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { appsLightboxImages } from '../model/appsLightboxImages';
@@ -50,6 +51,39 @@ const enhancePinnedPost = (
 		promotedNewsletter: undefined,
 		hasAffiliateLinksDisclaimer: false,
 	})[0];
+};
+
+export const enhanceCrossword = (article: Article): Article => {
+	if (article.frontendData.crossword) {
+		const element = {
+			_type: 'model.dotcomrendering.pageElements.CrosswordElement' as const,
+			crossword: article.frontendData.crossword,
+		};
+		return {
+			...article,
+			format: { ...article.format, design: ArticleDesign.Interactive },
+			frontendData: {
+				...article.frontendData,
+				blocks: [
+					{
+						id: randomUUID(),
+						elements: [element],
+						attributes: {
+							pinned: false,
+							keyEvent: false,
+							summary: false,
+						},
+						primaryDateLine: article.frontendData.webPublicationDateDisplay,
+						secondaryDateLine:
+							article.frontendData.webPublicationSecondaryDateDisplay,
+					},
+				],
+				crossword: undefined,
+			}
+		};
+	}
+
+	throw new TypeError('article did not contain a crossword');
 };
 
 export const enhanceArticleType = (

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -7,6 +7,8 @@ export type BoostLevel = 'default' | 'boost' | 'megaboost' | 'gigaboost';
 // -------------------------------------
 // Elements
 
+import type { GuardianCrossword } from 'mycrossword';
+
 // -------------------------------------
 interface ThirdPartyEmbeddedContent {
 	isThirdPartyTracking: boolean;
@@ -714,6 +716,12 @@ interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {
 		| WitnessTypeDataVideo
 		| WitnessTypeDataText;
 }
+
+export interface CrosswordElement {
+	_type: 'model.dotcomrendering.pageElements.CrosswordElement';
+	crossword: GuardianCrossword;
+}
+
 export type FEElement =
 	| AdPlaceholderBlockElement
 	| AudioAtomBlockElement
@@ -773,7 +781,8 @@ export type FEElement =
 	| VideoYoutubeBlockElement
 	| VineBlockElement
 	| YoutubeBlockElement
-	| WitnessTypeBlockElement;
+	| WitnessTypeBlockElement
+	| CrosswordElement;
 
 // -------------------------------------
 // Misc

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -717,7 +717,7 @@ interface WitnessTypeBlockElement extends ThirdPartyEmbeddedContent {
 
 export interface CrosswordElement {
 	_type: 'model.dotcomrendering.pageElements.CrosswordElement';
-	crossword: GuardianCrossword;
+	crossword: GuardianCrossword & { instructions?: string };
 }
 
 export type FEElement =

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -7,8 +7,6 @@ export type BoostLevel = 'default' | 'boost' | 'megaboost' | 'gigaboost';
 // -------------------------------------
 // Elements
 
-import type { GuardianCrossword } from 'mycrossword';
-
 // -------------------------------------
 interface ThirdPartyEmbeddedContent {
 	isThirdPartyTracking: boolean;

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,3 +1,4 @@
+import type { GuardianCrossword } from 'mycrossword';
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { FEArticleBadgeType } from './badge';
@@ -115,6 +116,7 @@ export interface FEArticleType {
 	showTableOfContents: boolean;
 	lang?: string;
 	isRightToLeftLang?: boolean;
+	crossword?: GuardianCrossword;
 }
 
 type PageTypeType = {

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,4 +1,3 @@
-import type { GuardianCrossword } from 'mycrossword';
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { FEArticleBadgeType } from './badge';

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -115,7 +115,7 @@ export interface FEArticleType {
 	showTableOfContents: boolean;
 	lang?: string;
 	isRightToLeftLang?: boolean;
-	crossword?: GuardianCrossword;
+	crossword?: GuardianCrossword & { instructions: string };
 }
 
 type PageTypeType = {
@@ -193,7 +193,8 @@ export type FEDesign =
 	| 'FullPageInteractiveDesign'
 	| 'NewsletterSignupDesign'
 	| 'TimelineDesign'
-	| 'ProfileDesign'; // FEDisplay is the display information passed through from frontend (originating in the capi scala client) and dictates the displaystyle of the content e.g. Immersive
+	| 'ProfileDesign'
+	| 'CrosswordDesign'; // FEDisplay is the display information passed through from frontend (originating in the capi scala client) and dictates the displaystyle of the content e.g. Immersive
 // https://github.com/guardian/content-api-scala-client/blob/master/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
 
 export type FEDisplay =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       mockdate:
         specifier: 3.0.5
         version: 3.0.5
+      mycrossword:
+        specifier: 1.2.4
+        version: 1.2.4(react-dom@18.3.1)(react@18.3.1)
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -5232,6 +5235,25 @@ packages:
     resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
     dev: false
 
+  /@reduxjs/toolkit@1.9.7(react-redux@7.2.9)(react@18.3.1):
+    resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18
+      react-redux: ^7.2.1 || ^8.0.2
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+    dependencies:
+      immer: 9.0.21
+      react: 18.3.1
+      react-redux: 7.2.9(react-dom@18.3.1)(react@18.3.1)
+      redux: 4.2.1
+      redux-thunk: 2.4.2(redux@4.2.1)
+      reselect: 4.1.8
+    dev: false
+
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: false
@@ -7334,6 +7356,13 @@ packages:
     resolution: {integrity: sha512-uH2smqTN4uGReAiKedIVzoLUAXIYLBTbSofhx3hbNqj74Ua6KqFsLYszduTrLCMEAEAozF73DbGi/SC1bzQq4g==}
     dev: false
 
+  /@types/hoist-non-react-statics@3.3.5:
+    resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
+    dependencies:
+      '@types/react': 18.3.1
+      hoist-non-react-statics: 3.3.2
+    dev: false
+
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
     dev: false
@@ -7551,6 +7580,15 @@ packages:
     resolution: {integrity: sha512-nT31LrBDuoSZJN4QuwtQSF3O89FVHC4jLhM+NtKEmVF5R1e8OY0Jo4//x2Yapn2aNHguwgX5doAq8Zo+Ehd0ug==}
     dependencies:
       '@types/react': 18.3.1
+    dev: false
+
+  /@types/react-redux@7.1.33:
+    resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.5
+      '@types/react': 18.3.1
+      hoist-non-react-statics: 3.3.2
+      redux: 4.2.1
     dev: false
 
   /@types/react-test-renderer@18.3.0:
@@ -9275,6 +9313,10 @@ packages:
 
   /cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+    dev: false
+
+  /classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
     dev: false
 
   /clean-css@5.3.3:
@@ -12865,6 +12907,10 @@ packages:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
     dev: false
 
+  /immer@9.0.21:
+    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
+    dev: false
+
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -15055,6 +15101,22 @@ packages:
       object-assign: 4.1.1
     dev: false
 
+  /mycrossword@1.2.4(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-wOc7acxT00h6BPtx5gyaBltgFOMajPtHuk3spWCy2TDwtnSssgpYP/l7IhM4R6gQEeJL/0h2PsIwLuyZQGTcFw==}
+    peerDependencies:
+      react: ^17.0.2
+      react-dom: ^17.0.2
+    dependencies:
+      '@reduxjs/toolkit': 1.9.7(react-redux@7.2.9)(react@18.3.1)
+      classnames: 2.5.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-redux: 7.2.9(react-dom@18.3.1)(react@18.3.1)
+      sanitize-html: 2.13.0
+    transitivePeerDependencies:
+      - react-native
+    dev: false
+
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -16262,6 +16324,28 @@ packages:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: false
 
+  /react-redux@7.2.9(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
+    peerDependencies:
+      react: ^16.8.3 || ^17 || ^18
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@types/react-redux': 7.1.33
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+    dev: false
+
   /react-shallow-renderer@16.15.0(react@18.3.1):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
@@ -16402,6 +16486,20 @@ packages:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
     dependencies:
       esprima: 4.0.1
+    dev: false
+
+  /redux-thunk@2.4.2(redux@4.2.1):
+    resolution: {integrity: sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==}
+    peerDependencies:
+      redux: ^4
+    dependencies:
+      redux: 4.2.1
+    dev: false
+
+  /redux@4.2.1:
+    resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
+    dependencies:
+      '@babel/runtime': 7.25.6
     dev: false
 
   /reflect.getprototypeof@1.0.4:
@@ -16570,6 +16668,10 @@ packages:
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
+
+  /reselect@4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
     dev: false
 
   /resolve-alpn@1.2.1:


### PR DESCRIPTION
## What does this change?

Add a crossword page and layout into DCR; uses https://github.com/t-blackwell/mycrossword for the crossword player.

Written by a first-time DCR contributor, and at-best novice frontend person trying to find the least-effort way to get the player to render on the frontend; probably needs many many changes to bring into good practice!

## Why?

## Screenshots

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/62b32b41-9e63-4978-b4c8-65f567b41e79">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
