### PR TITLE
Small story carousel 'chevron' button positioning

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { from, space, until } from '@guardian/source/foundations';
+import {
+	from,
+	headlineMedium24Object,
+	space,
+	until,
+} from '@guardian/source/foundations';
 import {
 	Button,
 	Hide,
@@ -23,6 +28,12 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 };
+
+/**
+ * This needs to match the `FrontSection` title font and is used to calculate
+ * the negative margin that aligns the navigation buttons with the title.
+ */
+const titlePreset = headlineMedium24Object;
 
 const carouselContainerStyles = css`
 	display: flex;
@@ -59,11 +70,6 @@ const itemStyles = css`
 	grid-area: span 1;
 	position: relative;
 	margin: ${space[3]}px 10px;
-	/* :first-child {
-		${from.tablet} {
-			margin-left: 0px;
-		}
-	} */
 `;
 
 const verticalLineStyles = css`
@@ -81,6 +87,15 @@ const verticalLineStyles = css`
 
 const buttonContainerStyles = css`
 	margin-left: auto;
+	${from.tablet} {
+		margin-top: calc(
+			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
+				${space[3]}px
+		);
+	}
+	${from.leftCol} {
+		margin-top: 0;
+	}
 `;
 
 const buttonLayoutStyles = css`

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -35,6 +35,13 @@ type Props = {
  */
 const titlePreset = headlineMedium24Object;
 
+/**
+ * Grid sizing to calculate negative margin used to pull navigation buttons
+ * out side of `FrontSection` container at `wide` breakpoint.
+ */
+const gridColumnWidth = '60px';
+const gridGap = '20px';
+
 const carouselContainerStyles = css`
 	display: flex;
 	flex-direction: column-reverse;
@@ -95,6 +102,10 @@ const buttonContainerStyles = css`
 	}
 	${from.leftCol} {
 		margin-top: 0;
+	}
+	${from.wide} {
+		margin-left: ${space[2]}px;
+		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
 	}
 `;
 

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -24,6 +24,14 @@ type Props = {
 	containerType: DCRContainerType;
 };
 
+const carouselContainerStyles = css`
+	display: flex;
+	flex-direction: column-reverse;
+	${from.wide} {
+		flex-direction: row;
+	}
+`;
+
 const carouselStyles = css`
 	display: grid;
 	grid-auto-columns: 1fr;
@@ -51,11 +59,11 @@ const itemStyles = css`
 	grid-area: span 1;
 	position: relative;
 	margin: ${space[3]}px 10px;
-	:first-child {
+	/* :first-child {
 		${from.tablet} {
 			margin-left: 0px;
 		}
-	}
+	} */
 `;
 
 const verticalLineStyles = css`
@@ -69,6 +77,15 @@ const verticalLineStyles = css`
 		background-color: ${palette('--card-border-top')};
 		transform: translateX(-50%);
 	}
+`;
+
+const buttonContainerStyles = css`
+	margin-left: auto;
+`;
+
+const buttonLayoutStyles = css`
+	display: flex;
+	gap: ${space[1]}px;
 `;
 
 /**
@@ -161,7 +178,7 @@ export const ScrollableSmallContainer = ({
 	}, []);
 
 	return (
-		<div>
+		<div css={carouselContainerStyles}>
 			<ol
 				// TODO
 				// data-component=""
@@ -203,11 +220,10 @@ export const ScrollableSmallContainer = ({
 				})}
 			</ol>
 
-			{/** TODO - put these buttons on the top right of the container */}
-			<Hide until={'tablet'}>
-				{carouselLength > 2 && (
-					<>
-						<div>
+			<div css={buttonContainerStyles}>
+				<Hide until={'tablet'}>
+					{carouselLength > 2 && (
+						<div css={buttonLayoutStyles}>
 							<Button
 								hideLabel={true}
 								iconSide="left"
@@ -227,9 +243,7 @@ export const ScrollableSmallContainer = ({
 								// data-link-name="container left chevron"
 								size="small"
 							/>
-						</div>
 
-						<div>
 							<Button
 								hideLabel={true}
 								iconSide="left"
@@ -250,9 +264,9 @@ export const ScrollableSmallContainer = ({
 								size="small"
 							/>
 						</div>
-					</>
-				)}
-			</Hide>
+					)}
+				</Hide>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## What does this change?

Positions the 'chevron' navigation buttons in the correct location for the current viewport size.

## Why?

To support the new small story carousel container type in DCR

Part of [this Trello ticket](https://trello.com/c/JioYmzBd/473-web-small-story-carousel)

## Screenshots

### Mobile

<img width="375" alt="Screenshot 2024-10-08 at 17 16 51" src="https://github.com/user-attachments/assets/972cabe5-d13c-49d2-8171-0938e00ca785">

### Tablet / Small desktop

<img width="738" alt="Screenshot 2024-10-08 at 17 17 17" src="https://github.com/user-attachments/assets/9716f0c4-ae3a-487c-a73e-644513868f64">

### Medium desktop

<img width="1139" alt="Screenshot 2024-10-08 at 17 17 27" src="https://github.com/user-attachments/assets/eec39783-137a-4c56-9ef8-d8613bfcafc4">

### Large desktop

<img width="1298" alt="Screenshot 2024-10-08 at 17 17 40" src="https://github.com/user-attachments/assets/7ea64bf5-a702-405f-83ea-cd63ba4bef04">

### Tablet with browser set to 'very large' font size

<img width="740" alt="Screenshot 2024-10-08 at 17 18 01" src="https://github.com/user-attachments/assets/33208a9c-3ead-492c-9683-aab2e1b06c8d">

### Tablet with browser set to 'very small' font size

<img width="738" alt="Screenshot 2024-10-08 at 17 18 21" src="https://github.com/user-attachments/assets/f191facb-999f-461c-8811-1b76f1f401c3">
