### PR TITLE
Trail text font size

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -53,7 +53,10 @@ import type {
 	ImageSizeType,
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
-import { TrailTextSize, TrailTextWrapper } from './components/TrailTextWrapper';
+import {
+	type TrailTextSize,
+	TrailTextWrapper,
+} from './components/TrailTextWrapper';
 
 export type Props = {
 	linkTo: string;

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -53,7 +53,7 @@ import type {
 	ImageSizeType,
 } from './components/ImageWrapper';
 import { ImageWrapper } from './components/ImageWrapper';
-import { TrailTextWrapper } from './components/TrailTextWrapper';
+import { TrailTextSize, TrailTextWrapper } from './components/TrailTextWrapper';
 
 export type Props = {
 	linkTo: string;
@@ -118,6 +118,7 @@ export type Props = {
 	isFlexSplash?: boolean;
 	showTopBarDesktop?: boolean;
 	showTopBarMobile?: boolean;
+	trailTextSize?: TrailTextSize;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -272,6 +273,7 @@ export const Card = ({
 	isFlexSplash,
 	showTopBarDesktop = true,
 	showTopBarMobile = false,
+	trailTextSize,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -733,6 +735,7 @@ export const Card = ({
 									imageType={media?.type}
 									shouldHide={isFlexSplash ? false : true}
 									isFlexSplash={isFlexSplash}
+									trailTextSize={trailTextSize}
 								>
 									<div
 										dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -20,7 +20,6 @@ type Props = {
 	shouldHide?: boolean;
 	/** If the card is a flexible splash card, the trail text will be styled differently */
 	isFlexSplash?: boolean;
-	/** If the card is in a flexible container, the font size can be change */
 	trailTextSize?: TrailTextSize;
 };
 
@@ -57,18 +56,20 @@ const trailTextStyles = css`
 	display: flex;
 	flex-direction: column;
 	color: ${palette('--card-headline-trail-text')};
-	${textSans14};
 	padding: ${space[2]}px 0;
-	strong {
-		font-weight: bold;
-	}
 `;
 
-const flexibleSplashStyles = (fontSize: 'regular' | 'large') => css`
+const flexibleSplashStyles = css`
 	color: ${palette('--flexible-splash-card-standfirst')};
+`;
+
+const fontStyles = (trailTextSize: TrailTextSize) => css`
 	${textSans14}
 	${from.desktop} {
-		${fontSize === 'large' && textSans17}
+		${trailTextSize === 'large' && textSans17}
+	}
+	strong {
+		font-weight: bold;
 	}
 `;
 
@@ -78,20 +79,21 @@ export const TrailTextWrapper = ({
 	imageSize,
 	imageType,
 	shouldHide = true,
-	isFlexSplash,
+	isFlexSplash = false,
 	trailTextSize = 'regular',
 }: Props) => {
 	return (
 		<div
 			css={[
 				trailTextStyles,
+				fontStyles(trailTextSize),
 				shouldHide &&
 					decideVisibilityStyles(
 						imagePositionOnDesktop,
 						imageSize,
 						imageType,
 					),
-				isFlexSplash && flexibleSplashStyles(trailTextSize),
+				isFlexSplash && flexibleSplashStyles,
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -1,7 +1,15 @@
 import { css } from '@emotion/react';
-import { space, textSans14, until } from '@guardian/source/foundations';
+import {
+	from,
+	space,
+	textSans14,
+	textSans17,
+	until,
+} from '@guardian/source/foundations';
 import { palette } from '../../../palette';
 import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
+
+export type TrailTextSize = 'regular' | 'large';
 
 type Props = {
 	children: string | React.ReactNode;
@@ -12,6 +20,8 @@ type Props = {
 	shouldHide?: boolean;
 	/** If the card is a flexible splash card, the trail text will be styled differently */
 	isFlexSplash?: boolean;
+	/** If the card is in a flexible container, the font size can be change */
+	trailTextSize?: TrailTextSize;
 };
 
 /**
@@ -54,8 +64,12 @@ const trailTextStyles = css`
 	}
 `;
 
-const flexibleSplashStyles = css`
+const flexibleSplashStyles = (fontSize: 'regular' | 'large') => css`
 	color: ${palette('--flexible-splash-card-standfirst')};
+	${textSans14}
+	${from.desktop} {
+		${fontSize === 'large' && textSans17}
+	}
 `;
 
 export const TrailTextWrapper = ({
@@ -65,6 +79,7 @@ export const TrailTextWrapper = ({
 	imageType,
 	shouldHide = true,
 	isFlexSplash,
+	trailTextSize = 'regular',
 }: Props) => {
 	return (
 		<div
@@ -76,7 +91,7 @@ export const TrailTextWrapper = ({
 						imageSize,
 						imageType,
 					),
-				isFlexSplash && flexibleSplashStyles,
+				isFlexSplash && flexibleSplashStyles(trailTextSize),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -9,7 +9,7 @@ import type {
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
-import { TrailTextSize } from './Card/components/TrailTextWrapper';
+import type { TrailTextSize } from './Card/components/TrailTextWrapper';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -9,6 +9,7 @@ import type {
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
+import { TrailTextSize } from './Card/components/TrailTextWrapper';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
@@ -72,6 +73,7 @@ type BoostedSplashProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	imageSize: ImageSizeType;
 	supportingContentAlignment: Alignment;
+	trailTextSize: TrailTextSize;
 };
 
 /**
@@ -93,6 +95,7 @@ const decideSplashCardProperties = (
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
+				trailTextSize: 'regular',
 			};
 		case 'boost':
 			return {
@@ -104,6 +107,7 @@ const decideSplashCardProperties = (
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
+				trailTextSize: 'regular',
 			};
 		case 'megaboost':
 			return {
@@ -114,6 +118,7 @@ const decideSplashCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				trailTextSize: 'large',
 			};
 		case 'gigaboost':
 			return {
@@ -124,6 +129,7 @@ const decideSplashCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				trailTextSize: 'large',
 			};
 	}
 };
@@ -152,6 +158,7 @@ export const SplashCardLayout = ({
 		imagePositionOnMobile,
 		imageSize,
 		supportingContentAlignment,
+		trailTextSize,
 	} = decideSplashCardProperties(
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
@@ -183,6 +190,7 @@ export const SplashCardLayout = ({
 					isFlexSplash={true}
 					showTopBarDesktop={false}
 					showTopBarMobile={true}
+					trailTextSize={trailTextSize}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -9,6 +9,7 @@ import type {
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
+import { TrailTextSize } from './Card/components/TrailTextWrapper';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
@@ -30,6 +31,7 @@ type BoostProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	imageSize: ImageSizeType;
 	supportingContentAlignment: Alignment;
+	trailTextSize?: TrailTextSize;
 };
 
 /**
@@ -51,7 +53,9 @@ const determineCardProperties = (
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+				trailTextSize: 'regular',
 			};
+
 		case 'boost':
 			return {
 				headlineSize: 'large',
@@ -62,6 +66,7 @@ const determineCardProperties = (
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+				trailTextSize: 'regular',
 			};
 		case 'megaboost':
 			return {
@@ -72,6 +77,7 @@ const determineCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				trailTextSize: 'large',
 			};
 		case 'gigaboost':
 			return {
@@ -82,6 +88,7 @@ const determineCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				trailTextSize: 'large',
 			};
 	}
 };
@@ -109,6 +116,7 @@ export const OneCardLayout = ({
 		imagePositionOnMobile,
 		imageSize,
 		supportingContentAlignment,
+		trailTextSize,
 	} = determineCardProperties(
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
@@ -139,6 +147,7 @@ export const OneCardLayout = ({
 					isFlexSplash={true}
 					showTopBarDesktop={false}
 					showTopBarMobile={true}
+					trailTextSize={trailTextSize}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -9,7 +9,7 @@ import type {
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
 import { LI } from './Card/components/LI';
-import { TrailTextSize } from './Card/components/TrailTextWrapper';
+import type { TrailTextSize } from './Card/components/TrailTextWrapper';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
@@ -31,7 +31,7 @@ type BoostProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	imageSize: ImageSizeType;
 	supportingContentAlignment: Alignment;
-	trailTextSize?: TrailTextSize;
+	trailTextSize: TrailTextSize;
 };
 
 /**


### PR DESCRIPTION
## What does this change?
Increases the font size on desktop to 17px for flexible splash cards (Special and General) that have been megaboosted or gigaboosted

## Why?
Without this, the font difference between the headline and trail is too great. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/84914727-319f-4852-9f55-588a5cd5247c
[after]: https://github.com/user-attachments/assets/ca80dbdd-b6f9-495b-8673-773b840e837a


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
