### PR TITLE
Inline EditorialButton and EditorialLinkButton into DCR

### DIFF
--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
@@ -16,7 +16,7 @@ const defaultFormat = {
 };
 
 const meta: Meta<typeof EditorialButton> = {
-	title: 'React Components/EditorialButton',
+	title: 'Components/EditorialButton',
 	component: EditorialButton,
 	argTypes: {
 		format: {

--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
+import { SvgCross } from '@guardian/source/react-components';
+import type { Meta, StoryFn } from '@storybook/react';
 import {
 	ArticleDesign,
 	ArticleDisplay,
-	ArticlePillar,
+	Pillar as ArticlePillar,
 	ArticleSpecial,
-} from '@guardian/libs';
-import { SvgCross } from '@guardian/source/react-components';
-import type { Meta, StoryFn } from '@storybook/react';
+} from '../../lib/format';
 import { EditorialButton } from './EditorialButton';
 import type { EditorialButtonProps } from './EditorialButton';
 

--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.stories.tsx
@@ -1,0 +1,163 @@
+import { css } from '@emotion/react';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { SvgCross } from '@guardian/source/react-components';
+import type { Meta, StoryFn } from '@storybook/react';
+import { EditorialButton } from './EditorialButton';
+import type { EditorialButtonProps } from './EditorialButton';
+
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+};
+
+const meta: Meta<typeof EditorialButton> = {
+	title: 'React Components/EditorialButton',
+	component: EditorialButton,
+	argTypes: {
+		format: {
+			options: [
+				'news',
+				'sport',
+				'culture',
+				'lifestyle',
+				'opinion',
+				'special_report',
+				'labs',
+			],
+			mapping: {
+				news: { ...defaultFormat, theme: ArticlePillar.News },
+				sport: { ...defaultFormat, theme: ArticlePillar.Sport },
+				culture: { ...defaultFormat, theme: ArticlePillar.Culture },
+				lifestyle: { ...defaultFormat, theme: ArticlePillar.Lifestyle },
+				opinion: { ...defaultFormat, theme: ArticlePillar.Opinion },
+				special_report: {
+					...defaultFormat,
+					theme: ArticleSpecial.SpecialReport,
+				},
+				labs: { ...defaultFormat, theme: ArticleSpecial.Labs },
+			},
+			control: { type: 'radio' },
+		},
+		icon: {
+			options: ['undefined', 'cross'],
+			mapping: {
+				undefined,
+				cross: <SvgCross />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		size: 'default',
+		hideLabel: false,
+		icon: undefined,
+		priority: 'primary',
+		iconSide: 'left',
+		nudgeIcon: false,
+	},
+};
+
+export default meta;
+
+const Template: StoryFn<typeof EditorialButton> = (
+	args: EditorialButtonProps,
+) => {
+	// Providing any value for cssOverrides, even undefined, overrides the custom styles
+	// for the editorial button so only pass through if it's defined
+	const { cssOverrides, ...rest } = args;
+	const props = rest as EditorialButtonProps;
+
+	if (cssOverrides) {
+		props.cssOverrides = cssOverrides;
+	}
+
+	return <EditorialButton {...props}>Click me</EditorialButton>;
+};
+
+const pillars = [
+	ArticlePillar.News,
+	ArticlePillar.Sport,
+	ArticlePillar.Culture,
+	ArticlePillar.Lifestyle,
+	ArticlePillar.Opinion,
+	ArticleSpecial.SpecialReport,
+	ArticleSpecial.Labs,
+];
+
+const RowTemplate: StoryFn<typeof EditorialButton> = (
+	args: Partial<EditorialButtonProps>,
+) => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			width: 800px;
+		`}
+	>
+		{pillars.map((pillar) => (
+			<Template
+				key={pillar}
+				{...args}
+				format={{ ...defaultFormat, theme: pillar }}
+			/>
+		))}
+	</div>
+);
+
+export const WhenPrimary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
+WhenPrimary.args = {
+	priority: 'primary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenSecondary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
+WhenSecondary.args = {
+	priority: 'secondary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenTertiary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
+WhenTertiary.args = {
+	priority: 'tertiary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenSubdued: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
+WhenSubdued.args = {
+	priority: 'subdued',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WithOverrides: StoryFn<typeof EditorialButton> = Template.bind({});
+WithOverrides.args = {
+	cssOverrides: css`
+		background-color: pink;
+	`,
+};
+
+// *****************************************************************************
+
+export const WithDefaults: StoryFn<typeof EditorialButton> = Template.bind({});
+WithDefaults.args = {};

--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
@@ -13,10 +13,6 @@ export interface EditorialButtonProps
 		SharedEditorialButtonProps {}
 
 /**
- * [Storybook](https://guardian.github.io/storybooks/?path=/story/source-development-kitchen_react-components-editorialbutton--when-primary) •
- * [Design System](https://theguardian.design/2a1e5182b/p/435225-button) •
- * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source-development-kitchen/src/editorial-button/EditorialButton.tsx) •
- * [NPM](https://www.npmjs.com/package/@guardian/source-development-kitchen)
  *
  * This is the editorial version of the core Button component.
  * This editorial version requires the format prop and uses that to override Button styles based on `format.theme`

--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
@@ -1,0 +1,44 @@
+import type { ButtonProps as CoreButtonProps } from '@guardian/source/react-components';
+import { Button as CoreButton } from '@guardian/source/react-components';
+import {
+	decideBackground,
+	decideBorder,
+	decideFont,
+	defaultFormat,
+} from './styles';
+import type { SharedEditorialButtonProps } from './types';
+
+export interface EditorialButtonProps
+	extends CoreButtonProps,
+		SharedEditorialButtonProps {}
+
+/**
+ * [Storybook](https://guardian.github.io/storybooks/?path=/story/source-development-kitchen_react-components-editorialbutton--when-primary) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/435225-button) •
+ * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source-development-kitchen/src/editorial-button/EditorialButton.tsx) •
+ * [NPM](https://www.npmjs.com/package/@guardian/source-development-kitchen)
+ *
+ * This is the editorial version of the core Button component.
+ * This editorial version requires the format prop and uses that to override Button styles based on `format.theme`
+ *
+ */
+export const EditorialButton = ({
+	format = defaultFormat,
+	children,
+	priority = 'primary',
+	...props
+}: EditorialButtonProps) => {
+	const backgroundOverrides = decideBackground(format, priority);
+	const borderOverrides = decideBorder(format, priority);
+	const fontOverrides = decideFont(format, priority);
+
+	return (
+		<CoreButton
+			priority={priority}
+			cssOverrides={[backgroundOverrides, borderOverrides, fontOverrides]}
+			{...props}
+		>
+			{children}
+		</CoreButton>
+	);
+};

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
@@ -16,7 +16,7 @@ const defaultFormat = {
 };
 
 const meta: Meta<typeof EditorialLinkButton> = {
-	title: 'React Components/EditorialLinkButton',
+	title: 'Components/EditorialLinkButton',
 	component: EditorialLinkButton,
 	argTypes: {
 		format: {

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
@@ -1,0 +1,165 @@
+import { css } from '@emotion/react';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
+import { SvgCross } from '@guardian/source/react-components';
+import type { Meta, StoryFn } from '@storybook/react';
+import { EditorialLinkButton } from './EditorialLinkButton';
+import type { EditorialLinkButtonProps } from './EditorialLinkButton';
+
+const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+};
+
+const meta: Meta<typeof EditorialLinkButton> = {
+	title: 'React Components/EditorialLinkButton',
+	component: EditorialLinkButton,
+	argTypes: {
+		format: {
+			options: [
+				'news',
+				'sport',
+				'culture',
+				'lifestyle',
+				'opinion',
+				'special_report',
+				'labs',
+			],
+			mapping: {
+				news: { ...defaultFormat, theme: ArticlePillar.News },
+				sport: { ...defaultFormat, theme: ArticlePillar.Sport },
+				culture: { ...defaultFormat, theme: ArticlePillar.Culture },
+				lifestyle: { ...defaultFormat, theme: ArticlePillar.Lifestyle },
+				opinion: { ...defaultFormat, theme: ArticlePillar.Opinion },
+				special_report: {
+					...defaultFormat,
+					theme: ArticleSpecial.SpecialReport,
+				},
+				labs: { ...defaultFormat, theme: ArticleSpecial.Labs },
+			},
+			control: { type: 'radio' },
+		},
+		icon: {
+			options: ['undefined', 'cross'],
+			mapping: {
+				undefined,
+				cross: <SvgCross />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		size: 'default',
+		hideLabel: false,
+		icon: undefined,
+		priority: 'primary',
+		iconSide: 'left',
+		nudgeIcon: false,
+	},
+};
+
+export default meta;
+
+const Template: StoryFn<typeof EditorialLinkButton> = (
+	args: EditorialLinkButtonProps,
+) => {
+	// Providing any value for cssOverrides, even undefined, overrides the custom styles
+	// for the editorial button so only pass through if it's defined
+	const { cssOverrides, ...rest } = args;
+	const props = rest as EditorialLinkButtonProps;
+
+	if (cssOverrides) {
+		props.cssOverrides = cssOverrides;
+	}
+
+	return <EditorialLinkButton {...props}>Click me</EditorialLinkButton>;
+};
+
+// *****************************************************************************
+
+const pillars = [
+	ArticlePillar.News,
+	ArticlePillar.Sport,
+	ArticlePillar.Culture,
+	ArticlePillar.Lifestyle,
+	ArticlePillar.Opinion,
+	ArticleSpecial.SpecialReport,
+	ArticleSpecial.Labs,
+];
+
+const RowTemplate: StoryFn<typeof EditorialLinkButton> = (
+	args: Partial<EditorialLinkButtonProps>,
+) => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			width: 800px;
+		`}
+	>
+		{pillars.map((pillar) => (
+			<Template
+				key={pillar}
+				{...args}
+				format={{ ...defaultFormat, theme: pillar }}
+			/>
+		))}
+	</div>
+);
+
+export const WhenPrimary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
+WhenPrimary.args = {
+	priority: 'primary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenSecondary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
+WhenSecondary.args = {
+	priority: 'secondary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenTertiary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
+WhenTertiary.args = {
+	priority: 'tertiary',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WhenSubdued: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
+WhenSubdued.args = {
+	priority: 'subdued',
+	size: 'small',
+};
+
+// *****************************************************************************
+
+export const WithOverrides: StoryFn<typeof EditorialLinkButton> = Template.bind(
+	{},
+);
+WithOverrides.args = {
+	cssOverrides: css`
+		background-color: pink;
+	`,
+};
+
+// *****************************************************************************
+
+export const WithDefaults: StoryFn<typeof EditorialLinkButton> = Template.bind(
+	{},
+);
+WithDefaults.args = {};

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.stories.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
+import { SvgCross } from '@guardian/source/react-components';
+import type { Meta, StoryFn } from '@storybook/react';
 import {
 	ArticleDesign,
 	ArticleDisplay,
-	ArticlePillar,
+	Pillar as ArticlePillar,
 	ArticleSpecial,
-} from '@guardian/libs';
-import { SvgCross } from '@guardian/source/react-components';
-import type { Meta, StoryFn } from '@storybook/react';
+} from '../../lib/format';
 import { EditorialLinkButton } from './EditorialLinkButton';
 import type { EditorialLinkButtonProps } from './EditorialLinkButton';
 

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
@@ -1,0 +1,44 @@
+import type { LinkButtonProps as CoreLinkButtonProps } from '@guardian/source/react-components';
+import { LinkButton as CoreLinkButton } from '@guardian/source/react-components';
+import {
+	decideBackground,
+	decideBorder,
+	decideFont,
+	defaultFormat,
+} from './styles';
+import type { SharedEditorialButtonProps } from './types';
+
+export interface EditorialLinkButtonProps
+	extends CoreLinkButtonProps,
+		SharedEditorialButtonProps {}
+
+/**
+ * [Storybook](https://guardian.github.io/storybooks/?path=/story/source-development-kitchen_react-components-editoriallinkbutton--when-primary) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/435225-button) •
+ * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source-development-kitchen/src/editorial-button/EditorialLinkButton.tsx) •
+ * [NPM](https://www.npmjs.com/package/@guardian/source-development-kitchen)
+ *
+ * This is the editorial version of the core Button component.
+ * This editorial version requires the format prop and uses that to override Button styles based on `format.theme`
+ *
+ */
+export const EditorialLinkButton = ({
+	format = defaultFormat,
+	children,
+	priority = 'primary',
+	...props
+}: EditorialLinkButtonProps) => {
+	const backgroundOverrides = decideBackground(format, priority);
+	const borderOverrides = decideBorder(format, priority);
+	const fontOverrides = decideFont(format, priority);
+
+	return (
+		<CoreLinkButton
+			priority={priority}
+			cssOverrides={[backgroundOverrides, borderOverrides, fontOverrides]}
+			{...props}
+		>
+			{children}
+		</CoreLinkButton>
+	);
+};

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
@@ -13,10 +13,6 @@ export interface EditorialLinkButtonProps
 		SharedEditorialButtonProps {}
 
 /**
- * [Storybook](https://guardian.github.io/storybooks/?path=/story/source-development-kitchen_react-components-editoriallinkbutton--when-primary) •
- * [Design System](https://theguardian.design/2a1e5182b/p/435225-button) •
- * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source-development-kitchen/src/editorial-button/EditorialLinkButton.tsx) •
- * [NPM](https://www.npmjs.com/package/@guardian/source-development-kitchen)
  *
  * This is the editorial version of the core Button component.
  * This editorial version requires the format prop and uses that to override Button styles based on `format.theme`

--- a/dotcom-rendering/src/components/EditorialButton/styles.ts
+++ b/dotcom-rendering/src/components/EditorialButton/styles.ts
@@ -1,12 +1,5 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticleSpecial,
-	Pillar,
-} from '@guardian/libs';
 import {
 	culture,
 	labs,
@@ -19,6 +12,13 @@ import {
 	sport,
 } from '@guardian/source/foundations';
 import type { ButtonPriority } from '@guardian/source/react-components';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '../../lib/format';
+import type { ArticleFormat } from '../../lib/format';
 
 export const defaultFormat = {
 	display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/EditorialButton/styles.ts
+++ b/dotcom-rendering/src/components/EditorialButton/styles.ts
@@ -1,0 +1,170 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { ArticleFormat } from '@guardian/libs';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '@guardian/libs';
+import {
+	culture,
+	labs,
+	lifestyle,
+	neutral,
+	news,
+	opinion,
+	palette,
+	specialReport,
+	sport,
+} from '@guardian/source/foundations';
+import type { ButtonPriority } from '@guardian/source/react-components';
+
+export const defaultFormat = {
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: Pillar.News,
+};
+
+const WHITE = neutral[100];
+
+export const decideBackground = (
+	format: ArticleFormat,
+	priority: ButtonPriority,
+): SerializedStyles => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						background-color: ${news[300]};
+						:hover {
+							background-color: ${news[400]};
+							border: 1px solid ${news[400]};
+						}
+					`;
+				case Pillar.Culture:
+					return css`
+						background-color: ${culture[300]};
+						:hover {
+							background-color: ${culture[400]};
+							border: 1px solid ${culture[400]};
+						}
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						background-color: ${lifestyle[300]};
+						:hover {
+							background-color: ${lifestyle[400]};
+							border: 1px solid ${lifestyle[400]};
+						}
+					`;
+				case Pillar.Sport:
+					return css`
+						background-color: ${sport[300]};
+						:hover {
+							background-color: ${sport[400]};
+							border: 1px solid ${sport[400]};
+						}
+					`;
+				case Pillar.Opinion:
+					return css`
+						background-color: ${opinion[300]};
+						:hover {
+							background-color: ${opinion[400]};
+							border: 1px solid ${opinion[400]};
+						}
+					`;
+				case ArticleSpecial.Labs:
+					return css`
+						background-color: ${labs[300]};
+						:hover {
+							background-color: ${labs[400]};
+							border: 1px solid ${labs[400]};
+						}
+					`;
+				case ArticleSpecial.SpecialReport:
+				case ArticleSpecial.SpecialReportAlt:
+					return css`
+						background-color: ${specialReport[300]};
+						:hover {
+							background-color: ${specialReport[400]};
+							border: 1px solid ${specialReport[400]};
+						}
+					`;
+			}
+		case 'subdued':
+		case 'tertiary':
+			return css`
+				background-color: transparent;
+			`;
+	}
+};
+
+export const decideBorder = (
+	format: ArticleFormat,
+	priority: ButtonPriority,
+): SerializedStyles => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+		case 'tertiary':
+			return css`
+				border: 1px solid currentColor;
+			`;
+		case 'subdued':
+			return css`
+				border: none;
+			`;
+	}
+};
+
+export const decideFont = (
+	format: ArticleFormat,
+	priority: ButtonPriority,
+): SerializedStyles => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+			return css`
+				color: ${WHITE};
+			`;
+		case 'subdued':
+		case 'tertiary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						color: ${news[400]};
+					`;
+				case Pillar.Culture:
+					return css`
+						color: ${culture[400]};
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						color: ${lifestyle[400]};
+					`;
+				case Pillar.Sport:
+					return css`
+						color: ${sport[400]};
+					`;
+				case Pillar.Opinion:
+					return css`
+						color: ${opinion[400]};
+					`;
+				case ArticleSpecial.Labs:
+					return css`
+						color: ${labs[400]};
+					`;
+				case ArticleSpecial.SpecialReport:
+					return css`
+						color: ${specialReport[400]};
+					`;
+				case ArticleSpecial.SpecialReportAlt:
+					return css`
+						color: ${palette.specialReportAlt[200]};
+					`;
+			}
+	}
+};

--- a/dotcom-rendering/src/components/EditorialButton/types.ts
+++ b/dotcom-rendering/src/components/EditorialButton/types.ts
@@ -1,0 +1,19 @@
+import type { ArticleFormat } from '@guardian/libs';
+
+export interface SharedEditorialButtonProps {
+	/**
+	 * A format object denoting the style of the button using the enums
+	 * available from [@guardian/libs](https://github.com/guardian/libs/blob/main/src/format.ts).
+	 *
+	 * For example:
+	 *
+	 * ```ts
+	 * {
+	 *   display: Display.Standard,
+	 *   design: Design.Article,
+	 *   theme: Pillar.News,
+	 * }
+	 * ```
+	 */
+	format?: ArticleFormat;
+}

--- a/dotcom-rendering/src/components/EditorialButton/types.ts
+++ b/dotcom-rendering/src/components/EditorialButton/types.ts
@@ -1,9 +1,8 @@
-import type { ArticleFormat } from '@guardian/libs';
+import type { ArticleFormat } from '../../lib/format';
 
 export interface SharedEditorialButtonProps {
 	/**
-	 * A format object denoting the style of the button using the enums
-	 * available from [@guardian/libs](https://github.com/guardian/libs/blob/main/src/format.ts).
+	 * A format object denoting the style of the button.
 	 *
 	 * For example:
 	 *

--- a/dotcom-rendering/src/components/Toast.tsx
+++ b/dotcom-rendering/src/components/Toast.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
-import { EditorialButton } from '@guardian/source-development-kitchen/react-components';
 import type { ArticleFormat } from '../lib/format';
+import { EditorialButton } from './EditorialButton/EditorialButton';
 
 type Props = {
 	count: number;


### PR DESCRIPTION
## What does this change?

- Inlines the EditorialButton and EditorialLinkButton components into DCR

## Why?

These components are part of `@guardian/source-development-kitchen`, but have only been used in one place in 2 years. 

As editorial components, it only makes sense to use these buttons in an editorial context, for which DCR is becoming the single source of rendering truth.

I'm making this change in the context of the extraction of format-related types from the shared `@guardian/libs` package into DCR. See also #12461
