### PR TITLE
Create US marketing card component

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCard.stories.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.stories.tsx
@@ -1,0 +1,32 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { leftColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { ExpandableMarketingCard } from './ExpandableMarketingCard';
+
+const meta = {
+	component: ExpandableMarketingCard,
+	title: 'Components/ExpandableMarketingCard',
+} satisfies Meta<typeof ExpandableMarketingCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		guardianBaseURL: 'https://www.theguardian.com',
+		heading: 'Sample Heading',
+		kicker: 'Sample Kicker',
+		isExpanded: false,
+		setIsExpanded: fn(),
+		setIsClosed: fn(),
+	},
+	decorators: [leftColumnDecorator],
+} satisfies Story;
+
+export const Expanded = {
+	...Default,
+	args: {
+		...Default.args,
+		isExpanded: true,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.stories.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.stories.tsx
@@ -1,6 +1,10 @@
+import { breakpoints } from '@guardian/source/foundations';
 import { type Meta, type StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { leftColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import {
+	centreColumnDecorator,
+	leftColumnDecorator,
+} from '../../.storybook/decorators/gridDecorators';
 import { ExpandableMarketingCard } from './ExpandableMarketingCard';
 
 const meta = {
@@ -14,19 +18,62 @@ type Story = StoryObj<typeof meta>;
 export const Default = {
 	args: {
 		guardianBaseURL: 'https://www.theguardian.com',
-		heading: 'Sample Heading',
-		kicker: 'Sample Kicker',
+		heading: 'Pop your US news bubble',
+		kicker: 'How the Guardian is different',
+		isExpanded: false,
+		setIsExpanded: fn(),
+		setIsClosed: fn(),
+	},
+	decorators: [centreColumnDecorator],
+	parameters: {
+		viewport: {
+			defaultViewport: 'mobile',
+		},
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileMedium,
+				breakpoints.phablet,
+				breakpoints.tablet,
+				breakpoints.desktop,
+			],
+		},
+	},
+} satisfies Story;
+
+// LeftCol and larger screen sizes
+export const DefaultLargeScreens = {
+	args: {
+		guardianBaseURL: 'https://www.theguardian.com',
+		heading: 'Pop your US news bubble',
+		kicker: 'How the Guardian is different',
 		isExpanded: false,
 		setIsExpanded: fn(),
 		setIsClosed: fn(),
 	},
 	decorators: [leftColumnDecorator],
+	parameters: {
+		viewport: {
+			defaultViewport: 'leftCol',
+		},
+		chromatic: {
+			viewports: [breakpoints.leftCol, breakpoints.wide],
+		},
+	},
 } satisfies Story;
 
 export const Expanded = {
 	...Default,
 	args: {
 		...Default.args,
+		isExpanded: true,
+	},
+} satisfies Story;
+
+export const ExpandedLargeScreens = {
+	...DefaultLargeScreens,
+	args: {
+		...DefaultLargeScreens.args,
 		isExpanded: true,
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -1,0 +1,265 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold17,
+	headlineBold20,
+	neutral,
+	palette as sourcePalette,
+	space,
+	textSans15,
+	textSansBold12,
+	textSansBold14,
+} from '@guardian/source/foundations';
+import {
+	LinkButton,
+	SvgChevronDownSingle,
+	SvgCross,
+} from '@guardian/source/react-components';
+import type { Dispatch, SetStateAction } from 'react';
+import { getZIndex } from '../lib/getZIndex';
+import { palette } from '../palette';
+import { useConfig } from './ConfigContext';
+
+interface BannersLogoProps {
+	type: 'faded' | 'top' | 'bottom';
+	styles?: SerializedStyles;
+}
+
+const BannersLogo = ({ type, styles }: BannersLogoProps) => {
+	const { assetOrigin } = useConfig();
+	const src = `${assetOrigin}static/frontend/logos/red-blue-banner-${type}.svg`;
+	return <img src={src} alt="Guardian logo held up by hands" css={styles} />;
+};
+
+const fillBarStyles = css`
+	background-color: ${palette('--expandable-marketing-card-fill-background')};
+	width: 100%;
+	margin-top: -1px;
+	margin-bottom: -1px;
+
+	height: 6px;
+	${from.desktop} {
+		height: 4px;
+	}
+`;
+
+const containerStyles = css`
+	${getZIndex('expandableMarketingCardOverlay')}
+	position: sticky;
+	top: 0;
+	padding-bottom: ${space[5]}px;
+	margin-right: -1px; /* To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead */
+`;
+
+const contentStyles = css`
+	position: relative;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	gap: ${space[1]}px;
+	width: 100%;
+	padding: ${space[2]}px;
+	border-radius: 0 0 ${space[2]}px ${space[2]}px;
+	background-color: ${palette('--expandable-marketing-card-background')};
+	color: ${neutral[100]};
+
+	${from.leftCol} {
+		flex-direction: column;
+		align-items: start;
+		gap: ${space[4]}px;
+		height: auto;
+		width: auto;
+	}
+`;
+
+const summaryStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[3]}px;
+	z-index: 1;
+	width: 100%;
+
+	${headlineBold17};
+	${from.desktop} {
+		${headlineBold20};
+	}
+`;
+
+const headingStyles = css`
+	display: flex;
+	gap: ${space[2]}px;
+	justify-content: space-between;
+`;
+
+const kickerStyles = css`
+	${textSans15};
+`;
+
+const arrowStyles = css`
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	border: none;
+	vertical-align: middle;
+	justify-content: center;
+	padding: 0;
+	width: 24px;
+	height: 24px;
+	background-color: ${sourcePalette.neutral[100]};
+	border-radius: 50%;
+	cursor: pointer;
+
+	svg {
+		flex: 0 0 auto;
+		display: block;
+		fill: ${sourcePalette.neutral[0]};
+		position: relative;
+		width: 20px;
+		height: auto;
+	}
+`;
+
+const detailsStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[4]}px;
+	margin-bottom: ${space[2]}px;
+
+	h2 {
+		${headlineBold17};
+	}
+
+	p {
+		${textSans15}
+		margin-right: ${space[4]}px;
+		z-index: 1;
+	}
+`;
+
+const sectionStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[3]}px;
+	border-top: 1px solid ${neutral[100]};
+	padding-top: ${space[2]}px;
+`;
+
+const imageTopStyles = css`
+	position: absolute;
+	top: 0;
+	right: 0;
+`;
+const imageBottomStyles = css`
+	position: absolute;
+	right: 0;
+	bottom: 0;
+`;
+
+const buttonStyles = css`
+	z-index: 1;
+`;
+
+interface Props {
+	heading: string;
+	kicker: string;
+	guardianBaseURL: string;
+	isExpanded: boolean;
+	setIsExpanded: Dispatch<SetStateAction<boolean>>;
+	setIsClosed: Dispatch<SetStateAction<boolean>>;
+}
+
+// todo - semantic html accordion-details?
+export const ExpandableMarketingCard = ({
+	guardianBaseURL,
+	heading,
+	kicker,
+	isExpanded,
+	setIsExpanded,
+	setIsClosed,
+}: Props) => {
+	return (
+		<div
+			css={containerStyles}
+			data-component="us-expandable-marketing-card"
+		>
+			<div css={fillBarStyles} />
+			<div css={contentStyles}>
+				{!isExpanded ? (
+					<BannersLogo type="faded" styles={imageTopStyles} />
+				) : (
+					<>
+						<BannersLogo type="top" styles={imageTopStyles} />
+						<BannersLogo type="bottom" styles={imageBottomStyles} />
+					</>
+				)}
+				<div css={summaryStyles}>
+					<div css={headingStyles}>
+						{heading}
+						<button
+							onClick={() => {
+								if (!isExpanded) {
+									setIsExpanded(true);
+								} else {
+									setIsClosed(true);
+								}
+							}}
+							type="button"
+							css={arrowStyles}
+						>
+							{isExpanded ? (
+								<SvgCross />
+							) : (
+								<SvgChevronDownSingle />
+							)}
+						</button>
+					</div>
+					<div css={kickerStyles}>{kicker}</div>
+				</div>
+				{isExpanded && (
+					<div css={detailsStyles}>
+						<div css={sectionStyles}>
+							<h2>We're independent</h2>
+							<p>
+								With no billionaire owner or shareholders, our
+								journalisms is funded by readers
+							</p>
+						</div>
+						<div css={sectionStyles}>
+							<h2>We're open</h2>
+							<p>
+								With misinformation threatening democracy, we
+								keep our fact-based news paywall-free
+							</p>
+						</div>
+						<div css={sectionStyles}>
+							<h2>We're global</h2>
+							<p>
+								With 200 years of history and staff across
+								America and the world, we offer an outsider
+								perspective on US news
+							</p>
+						</div>
+						<div css={buttonStyles}>
+							<LinkButton
+								priority="tertiary"
+								size="xsmall"
+								href={`${guardianBaseURL}/email-newsletters`}
+								cssOverrides={css`
+									background-color: white;
+									${textSansBold12};
+									${from.wide} {
+										${textSansBold14};
+									}
+								`}
+							>
+								View newsletters
+							</LinkButton>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -5,7 +5,6 @@ import {
 	headlineBold17,
 	headlineBold20,
 	neutral,
-	palette as sourcePalette,
 	space,
 	textSans15,
 	textSansBold12,
@@ -21,15 +20,15 @@ import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
 
-interface BannersLogoProps {
+interface BannersIllustrationProps {
 	type: 'faded' | 'top' | 'bottom';
 	styles?: SerializedStyles;
 }
 
-const BannersLogo = ({ type, styles }: BannersLogoProps) => {
+const BannersIllustration = ({ type, styles }: BannersIllustrationProps) => {
 	const { assetOrigin } = useConfig();
 	const src = `${assetOrigin}static/frontend/logos/red-blue-banner-${type}.svg`;
-	return <img src={src} alt="Guardian logo held up by hands" css={styles} />;
+	return <img src={src} alt="" css={styles} />;
 };
 
 const fillBarStyles = css`
@@ -48,8 +47,11 @@ const containerStyles = css`
 	${getZIndex('expandableMarketingCardOverlay')}
 	position: sticky;
 	top: 0;
-	padding-bottom: ${space[5]}px;
-	margin-right: -1px; /* To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead */
+
+	${from.leftCol} {
+		padding-bottom: ${space[5]}px;
+		margin-right: -1px; /* To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead */
+	}
 `;
 
 const contentStyles = css`
@@ -100,14 +102,14 @@ const arrowStyles = css`
 	padding: 0;
 	width: ${space[6]}px;
 	height: ${space[6]}px;
-	background-color: ${sourcePalette.neutral[100]};
+	background-color: ${palette('--expandable-marketing-card-svg-background')};
 	border-radius: 50%;
 	cursor: pointer;
 
 	svg {
 		flex: 0 0 auto;
 		display: block;
-		fill: ${sourcePalette.neutral[0]};
+		fill: ${palette('--expandable-marketing-card-svg-fill')};
 		position: relative;
 		width: ${space[5]}px;
 		height: auto;
@@ -180,11 +182,17 @@ export const ExpandableMarketingCard = ({
 			<div css={fillBarStyles} />
 			<div css={contentStyles}>
 				{!isExpanded ? (
-					<BannersLogo type="faded" styles={imageTopStyles} />
+					<BannersIllustration type="faded" styles={imageTopStyles} />
 				) : (
 					<>
-						<BannersLogo type="top" styles={imageTopStyles} />
-						<BannersLogo type="bottom" styles={imageBottomStyles} />
+						<BannersIllustration
+							type="top"
+							styles={imageTopStyles}
+						/>
+						<BannersIllustration
+							type="bottom"
+							styles={imageBottomStyles}
+						/>
 					</>
 				)}
 				<div css={summaryStyles}>
@@ -216,7 +224,7 @@ export const ExpandableMarketingCard = ({
 							<h2>We're independent</h2>
 							<p>
 								With no billionaire owner or shareholders, our
-								journalisms is funded by readers
+								journalism is funded by readers
 							</p>
 						</div>
 						<div css={sectionStyles}>

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -55,23 +55,16 @@ const containerStyles = css`
 const contentStyles = css`
 	position: relative;
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	justify-content: space-between;
-	align-items: center;
-	gap: ${space[1]}px;
-	width: 100%;
+	align-items: start;
+	gap: ${space[4]}px;
+	height: auto;
+	width: auto;
 	padding: ${space[2]}px;
 	border-radius: 0 0 ${space[2]}px ${space[2]}px;
 	background-color: ${palette('--expandable-marketing-card-background')};
 	color: ${neutral[100]};
-
-	${from.leftCol} {
-		flex-direction: column;
-		align-items: start;
-		gap: ${space[4]}px;
-		height: auto;
-		width: auto;
-	}
 `;
 
 const summaryStyles = css`
@@ -80,17 +73,17 @@ const summaryStyles = css`
 	gap: ${space[3]}px;
 	z-index: 1;
 	width: 100%;
-
-	${headlineBold17};
-	${from.desktop} {
-		${headlineBold20};
-	}
 `;
 
 const headingStyles = css`
 	display: flex;
 	gap: ${space[2]}px;
 	justify-content: space-between;
+
+	${headlineBold17};
+	${from.leftCol} {
+		${headlineBold20};
+	}
 `;
 
 const kickerStyles = css`
@@ -105,8 +98,8 @@ const arrowStyles = css`
 	vertical-align: middle;
 	justify-content: center;
 	padding: 0;
-	width: 24px;
-	height: 24px;
+	width: ${space[6]}px;
+	height: ${space[6]}px;
 	background-color: ${sourcePalette.neutral[100]};
 	border-radius: 50%;
 	cursor: pointer;
@@ -116,7 +109,7 @@ const arrowStyles = css`
 		display: block;
 		fill: ${sourcePalette.neutral[0]};
 		position: relative;
-		width: 20px;
+		width: ${space[5]}px;
 		height: auto;
 	}
 `;

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,33 +2,34 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 30;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 29;');
-		expect(getZIndex('banner')).toBe('z-index: 28;');
-		expect(getZIndex('dropdown')).toBe('z-index: 27;');
-		expect(getZIndex('burger')).toBe('z-index: 26;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 31;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
+		expect(getZIndex('banner')).toBe('z-index: 29;');
+		expect(getZIndex('dropdown')).toBe('z-index: 28;');
+		expect(getZIndex('burger')).toBe('z-index: 27;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 25;',
+			'z-index: 26;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 24;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 23;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
 		expect(getZIndex('fullPageInteractiveHeaderWrapper')).toBe(
-			'z-index: 22;',
+			'z-index: 23;',
 		);
-		expect(getZIndex('mobileSticky')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 19;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 18;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 17;');
-		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 16;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 15;');
-		expect(getZIndex('summaryDetails')).toBe('z-index: 14;');
-		expect(getZIndex('toast')).toBe('z-index: 13;');
-		expect(getZIndex('onwardsCarousel')).toBe('z-index: 12;');
-		expect(getZIndex('myAccountDropdown')).toBe('z-index: 11;');
-		expect(getZIndex('searchHeaderLink')).toBe('z-index: 10;');
-		expect(getZIndex('TheGuardian')).toBe('z-index: 9;');
-		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 8;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 19;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 18;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 17;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 16;');
+		expect(getZIndex('summaryDetails')).toBe('z-index: 15;');
+		expect(getZIndex('toast')).toBe('z-index: 14;');
+		expect(getZIndex('onwardsCarousel')).toBe('z-index: 13;');
+		expect(getZIndex('myAccountDropdown')).toBe('z-index: 12;');
+		expect(getZIndex('searchHeaderLink')).toBe('z-index: 11;');
+		expect(getZIndex('TheGuardian')).toBe('z-index: 10;');
+		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 9;');
+		expect(getZIndex('expandableMarketingCardOverlay')).toBe('z-index: 8;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 7;');
 		expect(getZIndex('immersiveBlackBox')).toBe('z-index: 6;');
 		expect(getZIndex('bodyArea')).toBe('z-index: 5;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -73,6 +73,9 @@ const indices = [
 	// and the myAccount dropdown in the nav
 	'editionSwitcherBanner',
 
+	// Overlay for expandable marketing card (currently US only)
+	'expandableMarketingCardOverlay',
+
 	// Article headline (should be above main media)
 	'articleHeadline',
 	'immersiveBlackBox',

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5522,6 +5522,12 @@ const pinnedPostBorderDark: PaletteFunction = ({ theme }) => {
 const expandableMarketingCardBackground: PaletteFunction = () =>
 	sourcePalette.brand[400];
 
+const expandableMarketingCardSvgFill: PaletteFunction = () =>
+	sourcePalette.neutral[0];
+
+const expandableMarketingCardSvgBackground: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+
 const expandableMarketingCardFillBackgroundLight: PaletteFunction = (
 	format,
 ) => {
@@ -6249,6 +6255,14 @@ const paletteColours = {
 	'--expandable-marketing-card-fill-background': {
 		light: expandableMarketingCardFillBackgroundLight,
 		dark: expandableMarketingCardFillBackgroundDark,
+	},
+	'--expandable-marketing-card-svg-background': {
+		light: expandableMarketingCardSvgBackground,
+		dark: expandableMarketingCardSvgBackground,
+	},
+	'--expandable-marketing-card-svg-fill': {
+		light: expandableMarketingCardSvgFill,
+		dark: expandableMarketingCardSvgFill,
 	},
 	'--explainer-atom-accent': {
 		light: explainerAtomAccentLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5519,6 +5519,19 @@ const pinnedPostBorderDark: PaletteFunction = ({ theme }) => {
 	}
 };
 
+const expandableMarketingCardBackground: PaletteFunction = () =>
+	sourcePalette.brand[400];
+
+const expandableMarketingCardFillBackgroundLight: PaletteFunction = (
+	format,
+) => {
+	return articleBackgroundLight(format) === 'transparent'
+		? sourcePalette.neutral[100]
+		: articleBackgroundLight(format);
+};
+const expandableMarketingCardFillBackgroundDark: PaletteFunction = (format) =>
+	articleBackgroundDark(format);
+
 const youtubeOverlayKicker: PaletteFunction = ({ theme }: ArticleFormat) => {
 	switch (theme) {
 		case Pillar.News:
@@ -6228,6 +6241,14 @@ const paletteColours = {
 	'--expandable-atom-text-hover': {
 		light: expandableAtomTextHoverLight,
 		dark: expandableAtomTextHoverDark,
+	},
+	'--expandable-marketing-card-background': {
+		light: expandableMarketingCardBackground,
+		dark: expandableMarketingCardBackground,
+	},
+	'--expandable-marketing-card-fill-background': {
+		light: expandableMarketingCardFillBackgroundLight,
+		dark: expandableMarketingCardFillBackgroundDark,
 	},
 	'--explainer-atom-accent': {
 		light: explainerAtomAccentLight,

--- a/dotcom-rendering/src/static/logos/red-blue-banner-bottom.svg
+++ b/dotcom-rendering/src/static/logos/red-blue-banner-bottom.svg
@@ -1,0 +1,43 @@
+<svg width="100" height="290" viewBox="0 0 100 290" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1306_2445)">
+<path d="M68.7684 294.086C140.5 239.823 7.27133 134.279 145.774 19.2807" stroke="#F0513B" stroke-width="12"/>
+</g>
+<g filter="url(#filter1_d_1306_2445)">
+<path d="M64.9962 299.597C135.343 242.999 1.6164 181.651 137.167 62.1661" stroke="#F2EADC" stroke-width="12"/>
+</g>
+<g filter="url(#filter2_d_1306_2445)">
+<path d="M63.1257 301.042C133.468 244.442 -0.122651 182.998 135.418 63.508" stroke="#066DA1" stroke-width="12"/>
+</g>
+<defs>
+<filter id="filter0_d_1306_2445" x="61.0781" y="15.4131" width="92.6543" height="290.753" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2445"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2445" result="shape"/>
+</filter>
+<filter id="filter1_d_1306_2445" x="57.1855" y="58.4492" width="88.0547" height="253.086" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2445"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2445" result="shape"/>
+</filter>
+<filter id="filter2_d_1306_2445" x="55.3145" y="59.791" width="88.1777" height="253.189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2445"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2445" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/dotcom-rendering/src/static/logos/red-blue-banner-faded.svg
+++ b/dotcom-rendering/src/static/logos/red-blue-banner-faded.svg
@@ -1,0 +1,45 @@
+<svg width="155" height="91" viewBox="0 0 155 91" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3">
+<g filter="url(#filter0_d_1306_2459)">
+<path d="M260.645 67.9769C233.088 -14.3703 101.439 101.4 39.1706 -59.442" stroke="#F0513B" stroke-width="12"/>
+</g>
+<g filter="url(#filter1_d_1306_2459)">
+<path d="M264.449 72.7874C234.426 -8.57944 141.798 115.657 74.7086 -43.0061" stroke="#F2EADC" stroke-width="12"/>
+</g>
+<g filter="url(#filter2_d_1306_2459)">
+<path d="M265.194 74.9409C235.172 -6.42593 142.498 117.654 75.4091 -41.0093" stroke="#066DA1" stroke-width="12"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_1306_2459" x="30.3789" y="-61.8799" width="239.186" height="139.94" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2459"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2459" result="shape"/>
+</filter>
+<filter id="filter1_d_1306_2459" x="65.9863" y="-45.5879" width="207.324" height="128.606" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2459"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2459" result="shape"/>
+</filter>
+<filter id="filter2_d_1306_2459" x="66.6855" y="-43.5908" width="207.371" height="128.763" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2459"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2459" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/dotcom-rendering/src/static/logos/red-blue-banner-top.svg
+++ b/dotcom-rendering/src/static/logos/red-blue-banner-top.svg
@@ -1,0 +1,43 @@
+<svg width="158" height="132" viewBox="0 0 158 132" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1306_2436)">
+<path d="M260.645 63.9764C233.088 -18.3708 101.439 97.3995 39.1706 -63.4425" stroke="#F0513B" stroke-width="12"/>
+</g>
+<g filter="url(#filter1_d_1306_2436)">
+<path d="M264.449 68.7869C234.426 -12.5799 141.798 111.657 74.7086 -47.0066" stroke="#F2EADC" stroke-width="12"/>
+</g>
+<g filter="url(#filter2_d_1306_2436)">
+<path d="M265.194 70.94C235.172 -10.4269 142.498 113.653 75.4091 -45.0103" stroke="#066DA1" stroke-width="12"/>
+</g>
+<defs>
+<filter id="filter0_d_1306_2436" x="30.3789" y="-65.8809" width="239.186" height="139.941" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2436"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2436" result="shape"/>
+</filter>
+<filter id="filter1_d_1306_2436" x="65.9863" y="-49.5879" width="207.324" height="128.606" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2436"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2436" result="shape"/>
+</filter>
+<filter id="filter2_d_1306_2436" x="66.6855" y="-47.5918" width="207.371" height="128.763" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1306_2436"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1306_2436" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
## What does this change?

Adds a US marketing card component.

## Why?

So we can AB test displaying this component in the left column of article pages

## Screenshots

| <img width=200/> | Default | Expanded |
| - | - | - |
| mobile | ![mobile-Default] | ![mobile-Expanded] |
| desktop | ![desktop-Default] | ![desktop-Expanded] |
| leftCol | ![leftCol-Default] | ![leftCol-Expanded] |
| wide | ![wide-Default] | ![wide-Expanded] |

[mobile-Default]: https://github.com/user-attachments/assets/11f54ff2-084d-4691-ba8c-46462b190833
[mobile-Expanded]: https://github.com/user-attachments/assets/de2312e6-3c0c-4c19-9e46-3d6c50ae8dc1
[desktop-Default]: https://github.com/user-attachments/assets/e91fb9ff-fd1f-45bb-bafe-0b7563fd4dc8
[desktop-Expanded]: https://github.com/user-attachments/assets/6b436493-782d-4b61-9ff3-4e1739efa0ce
[leftCol-Default]: https://github.com/user-attachments/assets/3b8dc3bd-8d33-4c81-a671-5481d64089fd
[leftCol-Expanded]: https://github.com/user-attachments/assets/bb3b7efe-44f0-4133-9081-daab090b76ab
[wide-Default]: https://github.com/user-attachments/assets/88afcf48-a4c1-4cd1-a9cd-5688ec7cdb14
[wide-Expanded]: https://github.com/user-attachments/assets/571141be-bda9-4e28-9faf-ab6dcedc9fdd

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
