### PR TITLE
Small story carousel: Navigation button state

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -11,7 +11,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useEffect, useRef /* useState */, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { palette } from '../palette';
 import type {
 	DCRContainerPalette,

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -273,6 +273,7 @@ export const ScrollableSmallContainer = ({
 										: themeButtonDisabled
 								}
 								size="small"
+								disabled={!previousButtonEnabled}
 								// TODO
 								// aria-label="Move stories backwards"
 								// data-link-name="container left chevron"
@@ -290,6 +291,7 @@ export const ScrollableSmallContainer = ({
 										: themeButtonDisabled
 								}
 								size="small"
+								disabled={!nextButtonEnabled}
 								// TODO
 								// aria-label="Move stories forwards"
 								// data-link-name="container right chevron"

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -11,7 +11,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useEffect, useRef /* useState */ } from 'react';
+import { useEffect, useRef /* useState */, useState } from 'react';
 import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
@@ -161,9 +161,8 @@ export const ScrollableSmallContainer = ({
 }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
-
-	// const [previousButtonState, setShowPreviousButton] = useState(false);
-	// const [nextButtonState, setShowNextButton] = useState(true);
+	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
+	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
 
 	const scrollTo = (direction: 'left' | 'right') => {
 		if (!carouselRef.current) return;
@@ -178,22 +177,23 @@ export const ScrollableSmallContainer = ({
 	};
 
 	/**
-	 * TODO - should update the style of the navigation buttons based on the carousel's scroll position.
+	 * Updates state of navigation buttons based on carousel's scroll position.
 	 *
-	 * This function checks the current scroll position of the carousel and sets the styles
-	 * of the previous and next buttons accordingly. The previous button is disabled if the carousel
-	 * is at the start, and the next button is disabled if the carousel is at the end.
+	 * This function checks the current scroll position of the carousel and sets
+	 * the styles of the previous and next buttons accordingly. The previous
+	 * button is disabled if the carousel is at the start, and the next button
+	 * is disabled if the carousel is at the end.
 	 */
 	const updateButtonVisibilityOnScroll = () => {
 		const carouselElement = carouselRef.current;
 		if (!carouselElement) return;
 
-		// const scrollLeft = carouselElement.scrollLeft;
-		// const maxScrollLeft =
-		// 	carouselElement.scrollWidth - carouselElement.clientWidth;
+		const scrollLeft = carouselElement.scrollLeft;
+		const maxScrollLeft =
+			carouselElement.scrollWidth - carouselElement.clientWidth;
 
-		// setShowPreviousButton(scrollLeft > 0);
-		// setShowNextButton(scrollLeft < maxScrollLeft);
+		setPreviousButtonEnabled(scrollLeft > 0);
+		setNextButtonEnabled(scrollLeft < maxScrollLeft);
 	};
 
 	useEffect(() => {
@@ -267,7 +267,11 @@ export const ScrollableSmallContainer = ({
 								icon={<SvgChevronLeftSingle />}
 								onClick={() => scrollTo('left')}
 								priority="tertiary"
-								theme={themeButtonDisabled}
+								theme={
+									previousButtonEnabled
+										? themeButton
+										: themeButtonDisabled
+								}
 								size="small"
 								// TODO
 								// aria-label="Move stories backwards"
@@ -280,7 +284,11 @@ export const ScrollableSmallContainer = ({
 								icon={<SvgChevronRightSingle />}
 								onClick={() => scrollTo('right')}
 								priority="tertiary"
-								theme={themeButton}
+								theme={
+									nextButtonEnabled
+										? themeButton
+										: themeButtonDisabled
+								}
 								size="small"
 								// TODO
 								// aria-label="Move stories forwards"

--- a/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallContainer.importable.tsx
@@ -42,6 +42,16 @@ const titlePreset = headlineMedium24Object;
 const gridColumnWidth = '60px';
 const gridGap = '20px';
 
+const themeButton = {
+	borderTertiary: palette('--carousel-chevron-border'),
+	textTertiary: palette('--carousel-chevron'),
+};
+
+const themeButtonDisabled = {
+	borderTertiary: palette('--carousel-chevron-border-disabled'),
+	textTertiary: palette('--carousel-chevron-disabled'),
+};
+
 const carouselContainerStyles = css`
 	display: flex;
 	flex-direction: column-reverse;
@@ -257,18 +267,11 @@ export const ScrollableSmallContainer = ({
 								icon={<SvgChevronLeftSingle />}
 								onClick={() => scrollTo('left')}
 								priority="tertiary"
-								// TODO use better colour name
-								theme={{
-									borderTertiary:
-										palette('--card-border-top'),
-									textTertiary: palette(
-										'--card-headline-trail-text',
-									),
-								}}
+								theme={themeButtonDisabled}
+								size="small"
 								// TODO
 								// aria-label="Move stories backwards"
 								// data-link-name="container left chevron"
-								size="small"
 							/>
 
 							<Button
@@ -277,18 +280,11 @@ export const ScrollableSmallContainer = ({
 								icon={<SvgChevronRightSingle />}
 								onClick={() => scrollTo('right')}
 								priority="tertiary"
-								// TODO use better colour name
-								theme={{
-									borderTertiary:
-										palette('--card-border-top'),
-									textTertiary: palette(
-										'--card-headline-trail-text',
-									),
-								}}
+								theme={themeButton}
+								size="small"
 								// TODO
 								// aria-label="Move stories forwards"
 								// data-link-name="container right chevron"
-								size="small"
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4360,6 +4360,21 @@ const carouselTitleHighlightDark: PaletteFunction = ({ theme, design }) => {
 	}
 };
 
+const carouselChevronLight: PaletteFunction = () => sourcePalette.neutral[7];
+const carouselChevronDark: PaletteFunction = () => sourcePalette.neutral[86];
+const carouselChevronBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[73];
+const carouselChevronBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[73];
+const carouselChevronDisabledLight: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[7], 0.32);
+const carouselChevronDisabledDark: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[86], 0.32);
+const carouselChevronBorderDisabledLight: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[73], 0.32);
+const carouselChevronBorderDisabledDark: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[73], 0.32);
+
 const mostViewedFooterHoverLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
 const mostViewedFooterHoverDark: PaletteFunction = () =>
@@ -5980,6 +5995,22 @@ const paletteColours = {
 	'--carousel-border': {
 		light: carouselBorderLight,
 		dark: carouselBorderDark,
+	},
+	'--carousel-chevron': {
+		light: carouselChevronLight,
+		dark: carouselChevronDark,
+	},
+	'--carousel-chevron-border': {
+		light: carouselChevronBorderLight,
+		dark: carouselChevronBorderDark,
+	},
+	'--carousel-chevron-border-disabled': {
+		light: carouselChevronBorderDisabledLight,
+		dark: carouselChevronBorderDisabledDark,
+	},
+	'--carousel-chevron-disabled': {
+		light: carouselChevronDisabledLight,
+		dark: carouselChevronDisabledDark,
 	},
 	'--carousel-dot': {
 		light: carouselDotLight,


### PR DESCRIPTION
## What does this change?

Adds carousel button colours to palette and enables / disables navigation buttons as carousel is scrolled:
- At start of carousel, _previous_ button is disabled and _next_ enabled
- In middle of carousel, both buttons enabled
- At end of carousel, _previous_ button is enabled and _next_ disabled

## Why?

To support the new small story carousel container type in DCR

Part of [this Trello ticket](https://trello.com/c/JioYmzBd/473-web-small-story-carousel)

## Screenshots

| Start     | Middle      | End   | 
| ----------- | ---------- | ---------- |
| ![start][] | ![middle][] | ![end][] |

[start]: https://github.com/user-attachments/assets/c98eb037-e8ef-44db-bb87-9b74ea7cdab7
[middle]: https://github.com/user-attachments/assets/14bb698e-0a87-4ed4-9a28-03c8a66456d1
[end]: https://github.com/user-attachments/assets/d23e12d8-eaf5-41d9-bfe0-e588efca7a17
