### PR TITLE
Update boosted headline font sizes

### DIFF
--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -92,7 +92,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 			`;
 		}
 		case 'tiny':
-			return undefined;
+			return css`
+				${headlineMediumItalic17};
+			`;
 	}
 };
 

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -51,22 +51,18 @@ type Props = {
 /** These represent a new set of fonts. They are extra large font sizes that, as a group, are only used on headlines */
 const boostedFontStyles = ({ size }: { size: SmallHeadlineSize }) => {
 	switch (size) {
-		// we don't have a ginormous size in designs. For now this defaults to huge.
 		case 'ginormous':
-		case 'huge':
 			return `${headlineMedium64}`;
-
-		case 'large':
+		case 'huge':
 			return `${headlineMedium50}`;
-
-		case 'medium':
+		case 'large':
 			return `${headlineMedium42}`;
-
-		case 'small':
+		case 'medium':
 			return `${headlineMedium34}`;
-
-		case 'tiny':
+		case 'small':
 			return `${headlineMedium28}`;
+		case 'tiny':
+			return `${headlineMedium24}`;
 	}
 };
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -199,6 +199,8 @@ type BoostedCardProperties = {
 
 /**
  * Boosting a standard card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ * Megaboosted cards will make use of the boosted font sizes specified in card headline.
+ * Boosted cards will use the regular font sizes, to enable the correct headline size on mobile.
  */
 const decideCardProperties = (
 	boostLevel: BoostLevel = 'boost',

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -213,9 +213,9 @@ const decideCardProperties = (
 		case 'boost':
 		default:
 			return {
-				headlineSize: 'large',
-				headlineSizeOnMobile: 'large',
-				headlineSizeOnTablet: 'large',
+				headlineSize: 'tiny',
+				headlineSizeOnMobile: 'tiny',
+				headlineSizeOnTablet: 'tiny',
 				imageSize: 'medium',
 			};
 	}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -200,7 +200,7 @@ type BoostedCardProperties = {
  * Boosting a standard card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
  */
 const decideCardProperties = (
-	boostLevel: BoostLevel = 'boost',
+	boostLevel: Omit<BoostLevel, 'default' | 'gigaboost'> = 'boost',
 ): BoostedCardProperties => {
 	switch (boostLevel) {
 		case 'megaboost':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -194,6 +194,7 @@ type BoostedCardProperties = {
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imageSize: ImageSizeType;
+	useBoostedFontSizes: boolean;
 };
 
 /**
@@ -205,10 +206,11 @@ const decideCardProperties = (
 	switch (boostLevel) {
 		case 'megaboost':
 			return {
-				headlineSize: 'huge',
-				headlineSizeOnMobile: 'huge',
-				headlineSizeOnTablet: 'huge',
+				headlineSize: 'small',
+				headlineSizeOnMobile: 'small',
+				headlineSizeOnTablet: 'tiny',
 				imageSize: 'jumbo',
+				useBoostedFontSizes: true,
 			};
 		case 'boost':
 		default:
@@ -217,6 +219,7 @@ const decideCardProperties = (
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imageSize: 'medium',
+				useBoostedFontSizes: false,
 			};
 	}
 };
@@ -242,6 +245,7 @@ export const BoostedCardLayout = ({
 		headlineSizeOnMobile,
 		headlineSizeOnTablet,
 		imageSize,
+		useBoostedFontSizes,
 	} = decideCardProperties(card.boostLevel);
 	return (
 		<UL padBottom={true} isFlexibleContainer={true} showTopBar={true}>
@@ -266,6 +270,7 @@ export const BoostedCardLayout = ({
 					showLivePlayable={card.showLivePlayable}
 					showTopBarDesktop={false}
 					showTopBarMobile={true}
+					boostedFontSizes={useBoostedFontSizes}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -194,13 +194,10 @@ type BoostedCardProperties = {
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imageSize: ImageSizeType;
-	useBoostedFontSizes: boolean;
 };
 
 /**
  * Boosting a standard card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
- * Megaboosted cards will make use of the boosted font sizes specified in card headline.
- * Boosted cards will use the regular font sizes, to enable the correct headline size on mobile.
  */
 const decideCardProperties = (
 	boostLevel: BoostLevel = 'boost',
@@ -212,7 +209,6 @@ const decideCardProperties = (
 				headlineSizeOnMobile: 'small',
 				headlineSizeOnTablet: 'tiny',
 				imageSize: 'jumbo',
-				useBoostedFontSizes: true,
 			};
 		case 'boost':
 		default:
@@ -221,7 +217,6 @@ const decideCardProperties = (
 				headlineSizeOnMobile: 'large',
 				headlineSizeOnTablet: 'large',
 				imageSize: 'medium',
-				useBoostedFontSizes: false,
 			};
 	}
 };
@@ -247,7 +242,6 @@ export const BoostedCardLayout = ({
 		headlineSizeOnMobile,
 		headlineSizeOnTablet,
 		imageSize,
-		useBoostedFontSizes,
 	} = decideCardProperties(card.boostLevel);
 	return (
 		<UL padBottom={true} isFlexibleContainer={true} showTopBar={true}>
@@ -272,7 +266,7 @@ export const BoostedCardLayout = ({
 					showLivePlayable={card.showLivePlayable}
 					showTopBarDesktop={false}
 					showTopBarMobile={true}
-					boostedFontSizes={useBoostedFontSizes}
+					boostedFontSizes={true}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -85,9 +85,9 @@ const decideSplashCardProperties = (
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
 			return {
-				headlineSize: 'tiny',
-				headlineSizeOnMobile: 'tiny',
-				headlineSizeOnTablet: 'tiny',
+				headlineSize: 'small',
+				headlineSizeOnMobile: 'small',
+				headlineSizeOnTablet: 'small',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'large',
@@ -96,9 +96,9 @@ const decideSplashCardProperties = (
 			};
 		case 'boost':
 			return {
-				headlineSize: 'small',
-				headlineSizeOnMobile: 'small',
-				headlineSizeOnTablet: 'small',
+				headlineSize: 'medium',
+				headlineSizeOnMobile: 'medium',
+				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
@@ -107,9 +107,9 @@ const decideSplashCardProperties = (
 			};
 		case 'megaboost':
 			return {
-				headlineSize: 'medium',
-				headlineSizeOnMobile: 'medium',
-				headlineSizeOnTablet: 'medium',
+				headlineSize: 'large',
+				headlineSizeOnMobile: 'large',
+				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
@@ -117,9 +117,9 @@ const decideSplashCardProperties = (
 			};
 		case 'gigaboost':
 			return {
-				headlineSize: 'large',
-				headlineSizeOnMobile: 'large',
-				headlineSizeOnTablet: 'medium',
+				headlineSize: 'huge',
+				headlineSizeOnMobile: 'huge',
+				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -43,9 +43,9 @@ const determineCardProperties = (
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
 			return {
-				headlineSize: 'medium',
-				headlineSizeOnMobile: 'tiny',
-				headlineSizeOnTablet: 'small',
+				headlineSize: 'large',
+				headlineSizeOnMobile: 'small',
+				headlineSizeOnTablet: 'medium',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'large',
@@ -54,9 +54,9 @@ const determineCardProperties = (
 			};
 		case 'boost':
 			return {
-				headlineSize: 'large',
-				headlineSizeOnMobile: 'small',
-				headlineSizeOnTablet: 'medium',
+				headlineSize: 'huge',
+				headlineSizeOnMobile: 'medium',
+				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'right',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
@@ -65,9 +65,9 @@ const determineCardProperties = (
 			};
 		case 'megaboost':
 			return {
-				headlineSize: 'large',
-				headlineSizeOnMobile: 'medium',
-				headlineSizeOnTablet: 'medium',
+				headlineSize: 'huge',
+				headlineSizeOnMobile: 'large',
+				headlineSizeOnTablet: 'large',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
@@ -75,9 +75,9 @@ const determineCardProperties = (
 			};
 		case 'gigaboost':
 			return {
-				headlineSize: 'huge',
-				headlineSizeOnMobile: 'large',
-				headlineSizeOnTablet: 'large',
+				headlineSize: 'ginormous',
+				headlineSizeOnMobile: 'huge',
+				headlineSizeOnTablet: 'huge',
 				imagePositionOnDesktop: 'bottom',
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',


### PR DESCRIPTION
## What does this change?

Updates the boosted headline font sizes by shifting the current sizes up a level, i.e. a huge boosted font previously returned `headlineMedium64`, now it returns `headlineMedium50` and a ginormous boosted font now handles the `headlineMedium64` case. This allows the tiny case to return headlineMedium24, which is part of the megaboosted standard story designs. 

Values in the flex general and flex special splashes are updated accordingly. 

## Why?

Part of this [ticket](https://trello.com/c/PYM1H3GH/524-flexible-general-card-design-updates)

## Screenshots

| Mobile before      | Mobile after (28px)      |
| ----------- | ---------- |
| ![mbefore][] | ![mafter][] |

[mbefore]: https://github.com/user-attachments/assets/ed535773-6c11-4c9c-b533-330d583ec783
[mafter]: https://github.com/user-attachments/assets/3d32cbfc-58a8-4585-a622-0063cc535286

| Tablet before      | Tablet after (24px)      |
| ----------- | ---------- |
| ![tbefore][] | ![tafter][] |

[tbefore]: https://github.com/user-attachments/assets/62a448fe-4194-4b1c-a616-5f516a709af8
[tafter]: https://github.com/user-attachments/assets/10f25577-447f-43e2-8ebd-f3cbef0bc098

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
