### PR TITLE
Use isFlexSplash to determine sublink background fill

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -421,7 +421,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					isFlexibleContainer={isFlexibleContainer}
+					isFlexSplash={isFlexSplash}
 				/>
 			);
 		}
@@ -432,7 +432,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					isFlexibleContainer={isFlexibleContainer}
+					isFlexSplash={isFlexSplash}
 				/>
 			</Hide>
 		);
@@ -449,7 +449,7 @@ export const Card = ({
 					alignment="vertical"
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
-					isFlexibleContainer={isFlexibleContainer}
+					isFlexSplash={isFlexSplash}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,7 +16,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
-	isFlexibleContainer?: boolean;
+	isFlexSplash?: boolean;
 };
 
 /**
@@ -134,7 +134,7 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
-	isFlexibleContainer = false,
+	isFlexSplash = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -144,7 +144,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				isFlexibleContainer && backgroundFill,
+				isFlexSplash && backgroundFill,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {


### PR DESCRIPTION
## What does this change?

Rather than using `isFlexibleContainer` to determine the sublink background style, we use `isFlexSplash` instead, which removes the grey background from standard stories on mobile breakpoints in the flexible general containers. 

## Why?

Closes this [ticket](https://trello.com/c/3lsSLHs4/589-flexible-general-mobile-sublinks-should-not-have-grey-background-for-standard-cards)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e9a55f66-5b86-4369-af8b-545c75211e9c
[after]: https://github.com/user-attachments/assets/e3ac613c-2d8c-4a0d-93fc-97a3265f2652

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
