### PR TITLE
Make all of Epic choice card clickable

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -31,6 +31,7 @@ import type {
 import { threeTierChoiceCardAmounts } from './utils/threeTierChoiceCardAmounts';
 
 const supportTierChoiceCardStyles = (selected: boolean) => css`
+	display: block;
 	border: ${selected
 		? `2px solid ${palette.brand['500']}`
 		: `1px solid ${palette.neutral[46]}`};
@@ -227,6 +228,8 @@ export const ThreeTierChoiceCards = ({
 							!isUndefined(supporterPlusDiscount) &&
 							supportTier === 'SupporterPlus';
 
+						const radioId = `choicecard-${supportTier}`;
+
 						return (
 							<div
 								key={supportTier}
@@ -242,8 +245,9 @@ export const ThreeTierChoiceCards = ({
 								{recommended && !hasDiscount && (
 									<RecommendedPill />
 								)}
-								<div
+								<label
 									css={supportTierChoiceCardStyles(selected)}
+									htmlFor={radioId}
 								>
 									<Radio
 										label={label(
@@ -251,7 +255,7 @@ export const ThreeTierChoiceCards = ({
 											currencySymbol,
 											supporterPlusDiscount,
 										)}
-										id={`choicecard-${supportTier}`}
+										id={radioId}
 										value={supportTier}
 										cssOverrides={labelOverrideStyles}
 										supporting={
@@ -271,7 +275,7 @@ export const ThreeTierChoiceCards = ({
 											setSelectedProduct(supportTier);
 										}}
 									/>
-								</div>
+								</label>
 							</div>
 						);
 					},


### PR DESCRIPTION
Currently only the label next to the radio input is clickable, but really the entire box should be -

![Screenshot 2024-10-10 at 09 24 39](https://github.com/user-attachments/assets/e16af90f-e6b2-4b5e-85bf-18341e49c1b0)
