### PR TITLE
[Fairground 🎡] Add a split top bar variant for containers

### DIFF
--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -38,7 +38,7 @@ const marginBottomStyles = (isFlexibleContainer: boolean) => css`
 	margin-bottom: ${isFlexibleContainer ? space[6] : space[3]}px;
 `;
 
-const topBarStyles = css`
+const topBarStyles = (splitTopBar: boolean) => css`
 	${from.tablet} {
 		padding-top: 8px;
 		::before {
@@ -49,7 +49,17 @@ const topBarStyles = css`
 			left: 10px;
 			width: calc(100% - 20px);
 			height: 1px;
-			background-color: ${palette('--card-border-top')};
+			${splitTopBar
+				? `background-image: linear-gradient(
+				to right,
+				${palette('--card-border-top')},
+				${palette('--card-border-top')} calc(50% - 10px),
+				rgba(0, 0, 0, 0) calc(50% - 10px),
+				rgba(0, 0, 0, 0) calc(50% + 10px),
+				${palette('--card-border-top')} calc(50% + 10px),
+				${palette('--card-border-top')}
+			)`
+				: `background-color: ${palette('--card-border-top')};`}
 		}
 	}
 `;
@@ -66,6 +76,8 @@ type Props = {
 	wrapCards?: boolean;
 	/** Used to display a full width bar along the top of the container */
 	showTopBar?: boolean;
+	/** Used to add a gap in the center of the top bar */
+	splitTopBar?: boolean;
 	/** Used to give flexible container stories additional space */
 	isFlexibleContainer?: boolean;
 };
@@ -78,6 +90,7 @@ export const UL = ({
 	wrapCards = false,
 	showTopBar = false,
 	isFlexibleContainer = false,
+	splitTopBar = false,
 }: Props) => {
 	return (
 		<ul
@@ -86,7 +99,7 @@ export const UL = ({
 				showDivider && verticalDivider(palette('--section-border')),
 				padBottom && marginBottomStyles(isFlexibleContainer),
 				wrapCards && wrapStyles,
-				showTopBar && topBarStyles,
+				showTopBar && topBarStyles(splitTopBar),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -287,9 +287,11 @@ export const StandardCardLayout = ({
 	absoluteServerTimes,
 	showImage = true,
 	imageLoading,
+	isFirstRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
+	isFirstRow: boolean;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
@@ -301,6 +303,7 @@ export const StandardCardLayout = ({
 			padBottom={true}
 			isFlexibleContainer={true}
 			showTopBar={true}
+			splitTopBar={!isFirstRow}
 		>
 			{cards.map((card, cardIndex) => {
 				return (
@@ -359,7 +362,7 @@ export const FlexibleGeneral = ({
 				/>
 			)}
 
-			{groupedCards.map((row) => {
+			{groupedCards.map((row, i) => {
 				switch (row.layout) {
 					case 'oneCardBoosted':
 						return (
@@ -382,6 +385,7 @@ export const FlexibleGeneral = ({
 								showAge={showAge}
 								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
+								isFirstRow={i === 0}
 							/>
 						);
 				}


### PR DESCRIPTION
## What does this change?
Adds a variant of a container top bar that has a 20px gap in the middle. This is built using a linear gradient on a background image in css. 

## Why?
Design want to create a visual divider between splash cards and unboosted cards in flexible general containers. In order to prevent each row from needing context of the row before it, the rules state that the first row of standard cards in a flexible general container will always have a full width top bar on the container. Any following row of standard cards have a "split" top bar with a 20px gap where the vertical divider sits.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/be3d308b-f1f7-4124-abfd-18661980185e
[after]: https://github.com/user-attachments/assets/c6cfb921-064a-48b4-bac0-792bc602cf78

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
