### PR TITLE
Add expandable marketing card component to standard articles on desktop behind 0% test

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -142,7 +142,9 @@ const imageBottomStyles = css`
 
 const buttonStyles = css`
 	z-index: 1;
-	background-color: white;
+	background-color: ${palette(
+		'--expandable-marketing-card-button-background',
+	)};
 	width: fit-content;
 
 	${textSansBold12};

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -47,11 +47,6 @@ const containerStyles = css`
 	${getZIndex('expandableMarketingCardOverlay')}
 	position: sticky;
 	top: 0;
-
-	${from.leftCol} {
-		padding-bottom: ${space[5]}px;
-		margin-right: -1px; /* To align with rich link - if we move this feature to production, we should remove this and make rich link align with everything instead */
-	}
 `;
 
 const contentStyles = css`

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -109,16 +109,6 @@ const detailsStyles = css`
 	flex-direction: column;
 	gap: ${space[4]}px;
 	margin-bottom: ${space[2]}px;
-
-	h2 {
-		${headlineBold17};
-	}
-
-	p {
-		${textSans15}
-		margin-right: ${space[4]}px;
-		z-index: 1;
-	}
 `;
 
 const sectionStyles = css`
@@ -127,6 +117,16 @@ const sectionStyles = css`
 	gap: ${space[3]}px;
 	border-top: 1px solid ${neutral[100]};
 	padding-top: ${space[2]}px;
+
+	h3 {
+		${headlineBold17};
+	}
+
+	p {
+		${textSans15}
+		margin-right: ${space[4]}px;
+		z-index: 1;
+	}
 `;
 
 const imageTopStyles = css`
@@ -142,6 +142,13 @@ const imageBottomStyles = css`
 
 const buttonStyles = css`
 	z-index: 1;
+	background-color: white;
+	width: fit-content;
+
+	${textSansBold12};
+	${from.wide} {
+		${textSansBold14};
+	}
 `;
 
 interface Props {
@@ -180,9 +187,9 @@ export const ExpandableMarketingCard = ({
 						/>
 					</>
 				)}
-				<div css={summaryStyles}>
+				<section css={summaryStyles}>
 					<div css={headingStyles}>
-						{heading}
+						<h2>{heading}</h2>
 						<button
 							onClick={() => {
 								if (!isExpanded) {
@@ -202,47 +209,39 @@ export const ExpandableMarketingCard = ({
 						</button>
 					</div>
 					<div css={kickerStyles}>{kicker}</div>
-				</div>
+				</section>
 				{isExpanded && (
 					<div css={detailsStyles}>
-						<div css={sectionStyles}>
-							<h2>We're independent</h2>
+						<section css={sectionStyles}>
+							<h3>We're independent</h3>
 							<p>
 								With no billionaire owner or shareholders, our
 								journalism is funded by readers
 							</p>
-						</div>
-						<div css={sectionStyles}>
-							<h2>We're open</h2>
+						</section>
+						<section css={sectionStyles}>
+							<h3>We're open</h3>
 							<p>
 								With misinformation threatening democracy, we
 								keep our fact-based news paywall-free
 							</p>
-						</div>
-						<div css={sectionStyles}>
-							<h2>We're global</h2>
+						</section>
+						<section css={sectionStyles}>
+							<h3>We're global</h3>
 							<p>
 								With 200 years of history and staff across
 								America and the world, we offer an outsider
 								perspective on US news
 							</p>
-						</div>
-						<div css={buttonStyles}>
-							<LinkButton
-								priority="tertiary"
-								size="xsmall"
-								href={`${guardianBaseURL}/email-newsletters`}
-								cssOverrides={css`
-									background-color: white;
-									${textSansBold12};
-									${from.wide} {
-										${textSansBold14};
-									}
-								`}
-							>
-								View newsletters
-							</LinkButton>
-						</div>
+						</section>
+						<LinkButton
+							priority="tertiary"
+							size="xsmall"
+							href={`${guardianBaseURL}/email-newsletters`}
+							cssOverrides={buttonStyles}
+						>
+							View newsletters
+						</LinkButton>
 					</div>
 				)}
 			</div>

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -174,7 +174,36 @@ export const ExpandableMarketingCard = ({
 			<div css={fillBarStyles} />
 			<div css={contentStyles}>
 				{!isExpanded ? (
-					<BannersIllustration type="faded" styles={imageTopStyles} />
+					<>
+						<BannersIllustration
+							type="faded"
+							styles={imageTopStyles}
+						/>
+						<section
+							css={summaryStyles}
+							role="button"
+							tabIndex={0}
+							onClick={() => {
+								setIsExpanded(true);
+							}}
+							onKeyDown={(event) => {
+								if (event.key === 'Enter') {
+									setIsExpanded(true);
+								}
+								if (event.key === 'Escape') {
+									setIsClosed(true);
+								}
+							}}
+						>
+							<div css={headingStyles}>
+								<h2>{heading}</h2>
+								<div css={arrowStyles}>
+									<SvgChevronDownSingle />
+								</div>
+							</div>
+							<div css={kickerStyles}>{kicker}</div>
+						</section>
+					</>
 				) : (
 					<>
 						<BannersIllustration
@@ -185,64 +214,54 @@ export const ExpandableMarketingCard = ({
 							type="bottom"
 							styles={imageBottomStyles}
 						/>
+						<section css={summaryStyles}>
+							<div css={headingStyles}>
+								<h2>{heading}</h2>
+								<button
+									onClick={() => {
+										setIsClosed(true);
+									}}
+									type="button"
+									css={arrowStyles}
+								>
+									<SvgCross />
+								</button>
+							</div>
+							<div css={kickerStyles}>{kicker}</div>
+						</section>
+						<div css={detailsStyles}>
+							<section css={sectionStyles}>
+								<h3>We're independent</h3>
+								<p>
+									With no billionaire owner or shareholders,
+									our journalism is funded by readers
+								</p>
+							</section>
+							<section css={sectionStyles}>
+								<h3>We're open</h3>
+								<p>
+									With misinformation threatening democracy,
+									we keep our fact-based news paywall-free
+								</p>
+							</section>
+							<section css={sectionStyles}>
+								<h3>We're global</h3>
+								<p>
+									With 200 years of history and staff across
+									America and the world, we offer an outsider
+									perspective on US news
+								</p>
+							</section>
+							<LinkButton
+								priority="tertiary"
+								size="xsmall"
+								href={`${guardianBaseURL}/email-newsletters`}
+								cssOverrides={buttonStyles}
+							>
+								View newsletters
+							</LinkButton>
+						</div>
 					</>
-				)}
-				<section css={summaryStyles}>
-					<div css={headingStyles}>
-						<h2>{heading}</h2>
-						<button
-							onClick={() => {
-								if (!isExpanded) {
-									setIsExpanded(true);
-								} else {
-									setIsClosed(true);
-								}
-							}}
-							type="button"
-							css={arrowStyles}
-						>
-							{isExpanded ? (
-								<SvgCross />
-							) : (
-								<SvgChevronDownSingle />
-							)}
-						</button>
-					</div>
-					<div css={kickerStyles}>{kicker}</div>
-				</section>
-				{isExpanded && (
-					<div css={detailsStyles}>
-						<section css={sectionStyles}>
-							<h3>We're independent</h3>
-							<p>
-								With no billionaire owner or shareholders, our
-								journalism is funded by readers
-							</p>
-						</section>
-						<section css={sectionStyles}>
-							<h3>We're open</h3>
-							<p>
-								With misinformation threatening democracy, we
-								keep our fact-based news paywall-free
-							</p>
-						</section>
-						<section css={sectionStyles}>
-							<h3>We're global</h3>
-							<p>
-								With 200 years of history and staff across
-								America and the world, we offer an outsider
-								perspective on US news
-							</p>
-						</section>
-						<LinkButton
-							priority="tertiary"
-							size="xsmall"
-							href={`${guardianBaseURL}/email-newsletters`}
-							cssOverrides={buttonStyles}
-						>
-							View newsletters
-						</LinkButton>
-					</div>
 				)}
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -233,21 +233,21 @@ export const ExpandableMarketingCard = ({
 						</section>
 						<div css={detailsStyles}>
 							<section css={sectionStyles}>
-								<h3>We're independent</h3>
+								<h3>We’re independent</h3>
 								<p>
 									With no billionaire owner or shareholders,
 									our journalism is funded by readers
 								</p>
 							</section>
 							<section css={sectionStyles}>
-								<h3>We're open</h3>
+								<h3>We’re open</h3>
 								<p>
 									With misinformation threatening democracy,
 									we keep our fact-based news paywall-free
 								</p>
 							</section>
 							<section css={sectionStyles}>
-								<h3>We're global</h3>
+								<h3>We’re global</h3>
 								<p>
 									With 200 years of history and staff across
 									America and the world, we offer an outsider

--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -16,7 +16,6 @@ import {
 	SvgCross,
 } from '@guardian/source/react-components';
 import type { Dispatch, SetStateAction } from 'react';
-import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
 
@@ -41,12 +40,6 @@ const fillBarStyles = css`
 	${from.desktop} {
 		height: 4px;
 	}
-`;
-
-const containerStyles = css`
-	${getZIndex('expandableMarketingCardOverlay')}
-	position: sticky;
-	top: 0;
 `;
 
 const contentStyles = css`
@@ -170,10 +163,7 @@ export const ExpandableMarketingCard = ({
 	setIsClosed,
 }: Props) => {
 	return (
-		<div
-			css={containerStyles}
-			data-component="us-expandable-marketing-card"
-		>
+		<div data-component="us-expandable-marketing-card">
 			<div css={fillBarStyles} />
 			<div css={contentStyles}>
 				{!isExpanded ? (

--- a/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
@@ -1,0 +1,82 @@
+import { getCookie } from '@guardian/libs';
+import { useEffect, useState } from 'react';
+import type { DailyArticle } from '../lib/dailyArticleCount';
+import { getDailyArticleCount } from '../lib/dailyArticleCount';
+import { getLocaleCode } from '../lib/getCountryCode';
+import { useAB } from '../lib/useAB';
+import { ExpandableMarketingCard } from './ExpandableMarketingCard';
+
+interface Props {
+	guardianBaseURL: string;
+}
+
+const isFirstArticle = () => {
+	const [dailyCount = {} as DailyArticle] = getDailyArticleCount() ?? [];
+	return Object.keys(dailyCount).length === 0 || dailyCount.count <= 1;
+};
+
+const isNewUSUser = async () => {
+	const isUserInUS = (await getLocaleCode()) === 'US';
+	if (!isUserInUS) {
+		return false;
+	}
+
+	// Exclude users who have selected a non-US edition.
+	const editionCookie = getCookie({ name: 'GU_EDITION' });
+	const hasUserSelectedNonUSEdition =
+		!!editionCookie && editionCookie !== 'US';
+
+	// This check must happen AFTER we've ensured that the user is in the US.
+	const isNewUser = isFirstArticle();
+
+	return !hasUserSelectedNonUSEdition && !isNewUser;
+};
+
+// todo - semantic html accordion-details?
+export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [isClosed, setIsClosed] = useState(false);
+	const [isApplicableUser, setIsApplicableUser] = useState(false);
+
+	const abTestAPI = useAB()?.api;
+	const isInVariantFree = !!abTestAPI?.isUserInVariant(
+		'UsaExpandableMarketingCard',
+		'variant-free',
+	);
+	const isInVariantBubble = !!abTestAPI?.isUserInVariant(
+		'UsaExpandableMarketingCard',
+		'variant-bubble',
+	);
+	const isInEitherVariant = isInVariantFree || isInVariantBubble;
+
+	useEffect(() => {
+		void isNewUSUser().then((show) => {
+			if (show) {
+				setIsApplicableUser(true);
+			}
+		});
+	}, []);
+
+	if (!isInEitherVariant || !isApplicableUser || isClosed) {
+		return null;
+	}
+
+	const heading = isInVariantBubble
+		? 'Pop your US news bubble'
+		: 'Yes, this story is free';
+
+	const kicker = isInVariantBubble
+		? 'How the Guardian is different'
+		: 'Why the Guardian has no paywall';
+
+	return (
+		<ExpandableMarketingCard
+			guardianBaseURL={guardianBaseURL}
+			heading={heading}
+			kicker={kicker}
+			isExpanded={isExpanded}
+			setIsExpanded={setIsExpanded}
+			setIsClosed={setIsClosed}
+		/>
+	);
+};

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -30,6 +30,11 @@ const bodyStyles = css`
 `;
 
 const usCardStyles = css`
+	align-self: start;
+	position: sticky;
+	top: 0;
+	${getZIndex('expandableMarketingCardOverlay')}
+
 	${from.leftCol} {
 		margin-top: ${space[6]}px;
 		margin-bottom: ${space[9]}px;

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -32,7 +32,11 @@ const bodyStyles = css`
 const usCardStyles = css`
 	${from.leftCol} {
 		margin-top: ${space[6]}px;
-		margin-left: 1px; /* To align with rich links */
+		margin-bottom: ${space[9]}px;
+
+		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
+		margin-left: 1px;
+		margin-right: -1px;
 	}
 
 	${from.wide} {

--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { from, space } from '@guardian/source/foundations';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
@@ -28,6 +29,17 @@ const bodyStyles = css`
 	${getZIndex('bodyArea')}
 `;
 
+const usCardStyles = css`
+	${from.leftCol} {
+		margin-top: ${space[6]}px;
+		margin-left: 1px; /* To align with rich links */
+	}
+
+	${from.wide} {
+		margin-left: 0;
+	}
+`;
+
 const gridArea = css`
 	grid-area: var(--grid-area);
 `;
@@ -41,6 +53,7 @@ export const GridItem = ({
 		css={[
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
+			area === 'uscard' && usCardStyles,
 			gridArea,
 		]}
 		style={{

--- a/dotcom-rendering/src/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRule.ts
@@ -1,7 +1,6 @@
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
 import { onConsent } from '@guardian/libs';
-import type { ConsentState } from '@guardian/libs';
-import type { CountryCode } from '@guardian/libs';
+import type { ConsentState, CountryCode } from '@guardian/libs';
 import type { DailyArticle } from '../../lib/dailyArticleCount';
 import { getDailyArticleCount } from '../../lib/dailyArticleCount';
 import type { TagType } from '../../types/tag';

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -7,6 +7,7 @@ import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { optimiseSpacefinderInline } from './tests/optimise-spacefinder-inline';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { UsaExpandableMarketingCard } from './tests/usa-expandable-marketing-card';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -19,4 +20,5 @@ export const tests: ABTest[] = [
 	mpuWhenNoEpic,
 	adBlockAsk,
 	optimiseSpacefinderInline,
+	UsaExpandableMarketingCard,
 ];

--- a/dotcom-rendering/src/experiments/tests/usa-expandable-marketing-card.ts
+++ b/dotcom-rendering/src/experiments/tests/usa-expandable-marketing-card.ts
@@ -1,0 +1,35 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const UsaExpandableMarketingCard: ABTest = {
+	id: 'UsaExpandableMarketingCard',
+	start: '2024-10-02',
+	expiry: '2024-12-18',
+	author: 'dotcom.platform@guardian.co.uk',
+	description:
+		'Test the impact of showing the user a component that highlights the Guardians journalism.',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'US-based users that see the US edition.',
+	successMeasure: 'Users are more likely to engage with the site.',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant-free',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant-bubble',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -21,6 +21,7 @@ import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { ContributorAvatar } from '../components/ContributorAvatar';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { ExpandableMarketingCardWrapper } from '../components/ExpandableMarketingCardWrapper.importable';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -96,18 +97,20 @@ const StandardGrid = ({
 									'title      border  headline   headline   headline'
 									'lines      border  headline   headline   headline'
 									'meta       border  standfirst standfirst standfirst'
-									'meta       border  media      media      media'
-									'.          border  body       .          right-column'
-									'.          border  .          .          right-column';
+									'uscard     border  standfirst standfirst standfirst'
+									'uscard     border  media      media      media'
+									'uscard     border  body       .          right-column'
+									'uscard     border  .          .          right-column';
 						  `
 						: css`
 								grid-template-areas:
 									'title      border  headline   . right-column'
 									'lines      border  headline   . right-column'
 									'meta       border  standfirst . right-column'
-									'meta       border  media      . right-column'
-									'.          border  body       . right-column'
-									'.          border  .          . right-column';
+									'uscard     border  standfirst . right-column'
+									'uscard     border  media      . right-column'
+									'uscard     border  body       . right-column'
+									'uscard     border  .          . right-column';
 						  `}
 				}
 
@@ -125,21 +128,23 @@ const StandardGrid = ({
 					${display === ArticleDisplay.Showcase
 						? css`
 								grid-template-areas:
-									'title      border  headline    headline'
-									'lines      border  headline    headline'
-									'meta       border  standfirst  standfirst'
-									'meta       border  media       media'
-									'.          border  body        right-column'
-									'.          border  .           right-column';
+									'title   border  headline    headline'
+									'lines   border  headline    headline'
+									'meta    border  standfirst  standfirst'
+									'uscard  border  standfirst  standfirst'
+									'uscard  border  media       media'
+									'uscard  border  body        right-column'
+									'uscard  border  .           right-column';
 						  `
 						: css`
 								grid-template-areas:
-									'title      border  headline    right-column'
-									'lines      border  headline    right-column'
-									'meta       border  standfirst  right-column'
-									'meta       border  media       right-column'
-									'.          border  body        right-column'
-									'.          border  .           right-column';
+									'title   border  headline    right-column'
+									'lines   border  headline    right-column'
+									'meta    border  standfirst  right-column'
+									'uscard  border  standfirst  right-column'
+									'uscard  border  media       right-column'
+									'uscard  border  body        right-column'
+									'uscard  border  .           right-column';
 						  `}
 				}
 
@@ -547,6 +552,22 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								)}
 							</div>
 						</GridItem>
+						{isWeb && (
+							<GridItem area="uscard" element="aside">
+								<Hide when="below" breakpoint="leftCol">
+									<Island
+										priority="enhancement"
+										defer={{ until: 'visible' }}
+									>
+										<ExpandableMarketingCardWrapper
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
+										/>
+									</Island>
+								</Hide>
+							</GridItem>
+						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<div css={maxWidth}>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -108,7 +108,7 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
-					Vertical grey borders
+					Vertical grey border
 					Main content
 					Right Column
 

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -24,6 +24,7 @@ import { Caption } from '../components/Caption';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { ExpandableMarketingCardWrapper } from '../components/ExpandableMarketingCardWrapper.importable';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
 import { GuardianLabsLines } from '../components/GuardianLabsLines';
@@ -84,6 +85,8 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Vertical grey border
 					Main content
 					Right Column
+
+					Duplicate lines are required to ensure the left column does not have extra vertical space.
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
@@ -95,18 +98,21 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      byline     . right-column'
 						'lines      border      body       . right-column'
 						'meta       border      body       . right-column'
-						'meta       border      body       . right-column'
-						'.          border      body       . right-column'
-						'.          border      .          . right-column';
+						'uscard     border      body       . right-column'
+						'uscard     border      .          . right-column'
+						'uscard     border      .          . right-column'
+						'uscard     border      .          . right-column';
 				}
 
 				/*
 					Explanation of each unit of grid-template-columns
 
 					Left Column (220 - 1px border)
-					Vertical grey border
+					Vertical grey borders
 					Main content
 					Right Column
+
+					Duplicate lines are required to ensure the left column does not have extra vertical space.
 				*/
 				${until.wide} {
 					grid-column-gap: 10px;
@@ -118,9 +124,10 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      byline      right-column'
 						'lines      border      body        right-column'
 						'meta       border      body        right-column'
-						'meta       border      body        right-column'
-						'.          border      body        right-column'
-						'.          border      .           right-column';
+						'uscard     border      body        right-column'
+						'uscard     border      .           right-column'
+						'uscard     border      .           right-column'
+						'uscard     border      .           right-column';
 				}
 
 				/*
@@ -641,6 +648,22 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								)}
 							</div>
 						</GridItem>
+						{isWeb && (
+							<GridItem area="uscard" element="aside">
+								<Hide when="below" breakpoint="leftCol">
+									<Island
+										priority="enhancement"
+										defer={{ until: 'visible' }}
+									>
+										<ExpandableMarketingCardWrapper
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
+										/>
+									</Island>
+								</Hide>
+							</GridItem>
+						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -397,7 +397,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 									standfirst={article.standfirst}
 								/>
 							</GridItem>
-
 							<GridItem area="lines">
 								<div css={maxWidth}>
 									<div css={stretchLines}>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -22,6 +22,7 @@ import { Carousel } from '../components/Carousel.importable';
 import { ContributorAvatar } from '../components/ContributorAvatar';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { ExpandableMarketingCardWrapper } from '../components/ExpandableMarketingCardWrapper.importable';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -67,7 +68,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 				display: grid;
 				width: 100%;
 				margin-left: 0;
-
 				grid-column-gap: 10px;
 
 				/*
@@ -78,6 +78,7 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					Main content
 					Right Column
 
+					Duplicate lines are required to ensure the left column does not have extra vertical space.
 				*/
 				${from.wide} {
 					grid-template-columns: 219px 1px 1020px;
@@ -86,7 +87,10 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 						'.      border  standfirst'
 						'lines  border  media'
 						'meta   border  media'
-						'meta   border  submeta';
+						'uscard border  media'
+						'uscard border  submeta'
+						'uscard border  .'
+						'uscard border  .';
 				}
 
 				${until.wide} {
@@ -96,7 +100,10 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 						'.      border  standfirst  standfirst standfirst'
 						'lines  border  media       media      media'
 						'meta   border  media       media      media'
-						'meta   border  submeta     submeta    submeta';
+						'uscard border  media       media      media'
+						'uscard border  submeta     submeta    submeta'
+						'uscard border  .           .          .'
+						'uscard border  .           .          .';
 				}
 
 				/*
@@ -566,6 +573,22 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								/>
 							</ArticleContainer>
 						</GridItem>
+						{isWeb && (
+							<GridItem area="uscard" element="aside">
+								<Hide until="leftCol">
+									<Island
+										priority="enhancement"
+										defer={{ until: 'visible' }}
+									>
+										<ExpandableMarketingCardWrapper
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
+										/>
+									</Island>
+								</Hide>
+							</GridItem>
+						)}
 					</PictureGrid>
 				</Section>
 

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -23,6 +23,7 @@ import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { ExpandableMarketingCardWrapper } from '../components/ExpandableMarketingCardWrapper.importable';
 import { Footer } from '../components/Footer';
 import { GridItem } from '../components/GridItem';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -90,9 +91,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'
 						'meta   border  media      media    media'
-						'meta   border  standfirst .        right-column'
-						'.      border  body       .        right-column'
-						'.      border  .          .        right-column';
+						'uscard border  media      media    media'
+						'uscard border  standfirst .        right-column'
+						'uscard border  body       .        right-column'
+						'uscard border  .          .        right-column';
 				}
 
 				${until.wide} {
@@ -101,9 +103,10 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
-						'meta   border  standfirst  right-column'
-						'.      border  body        right-column'
-						'.      border  .           right-column';
+						'uscard border  media       media'
+						'uscard border  standfirst  right-column'
+						'uscard border  body        right-column'
+						'uscard border  .           right-column';
 				}
 
 				/*
@@ -536,6 +539,22 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								)}
 							</div>
 						</GridItem>
+						{isWeb && (
+							<GridItem area="uscard" element="aside">
+								<Hide until="leftCol">
+									<Island
+										priority="enhancement"
+										defer={{ until: 'visible' }}
+									>
+										<ExpandableMarketingCardWrapper
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
+										/>
+									</Island>
+								</Hide>
+							</GridItem>
+						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -24,6 +24,7 @@ import { Border } from '../components/Border';
 import { Carousel } from '../components/Carousel.importable';
 import { DecideLines } from '../components/DecideLines';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { ExpandableMarketingCardWrapper } from '../components/ExpandableMarketingCardWrapper.importable';
 import { Footer } from '../components/Footer';
 import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { GetMatchStats } from '../components/GetMatchStats.importable';
@@ -85,7 +86,6 @@ const StandardGrid = ({
 				display: grid;
 				width: 100%;
 				margin-left: 0;
-
 				grid-column-gap: 10px;
 
 				/*
@@ -108,8 +108,9 @@ const StandardGrid = ({
 									'.      border  standfirst . right-column'
 									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
-									'meta   border  body       . right-column'
-									'.      border  .          . right-column';
+									'uscard border  media      . right-column'
+									'uscard border  body       . right-column'
+									'uscard border  .          . right-column';
 						  `
 						: isMedia
 						? css`
@@ -118,9 +119,10 @@ const StandardGrid = ({
 									'.      border  disclaimer disclaimer right-column'
 									'lines  border  media      media      right-column'
 									'meta   border  media      media      right-column'
-									'meta   border  standfirst standfirst right-column'
-									'.      border  body       body       right-column'
-									'.      border  .          .          right-column';
+									'uscard border  media      media      right-column'
+									'uscard border  standfirst standfirst right-column'
+									'uscard border  body       body       right-column'
+									'uscard border  .          .          right-column';
 						  `
 						: css`
 								grid-template-areas:
@@ -128,8 +130,9 @@ const StandardGrid = ({
 									'.      border  standfirst . right-column'
 									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
-									'meta   border  body       . right-column'
-									'.      border  .          . right-column';
+									'uscard border  media      . right-column'
+									'uscard border  body       . right-column'
+									'uscard border  .          . right-column';
 						  `}
 				}
 			}
@@ -154,8 +157,9 @@ const StandardGrid = ({
 								'.      border  standfirst   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'meta   border  body         right-column'
-								'.      border  .            right-column';
+								'uscard border  media        right-column'
+								'uscard border  body         right-column'
+								'uscard border  .            right-column';
 					  `
 					: isMedia
 					? css`
@@ -164,9 +168,9 @@ const StandardGrid = ({
 								'.      border  disclaimer   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'meta   border  standfirst   right-column'
-								'.      border  body         right-column'
-								'.      border  .            right-column';
+								'uscard border  standfirst   right-column'
+								'uscard border  body         right-column'
+								'uscard border  .            right-column';
 					  `
 					: css`
 							grid-template-areas:
@@ -175,8 +179,9 @@ const StandardGrid = ({
 								'.      border  disclaimer   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'meta   border  body         right-column'
-								'.      border  .            right-column';
+								'uscard border  media        right-column'
+								'uscard border  body         right-column'
+								'uscard border  .            right-column';
 					  `}
 			}
 
@@ -697,6 +702,22 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								</div>
 							)}
 						</GridItem>
+						{isWeb && (
+							<GridItem area="uscard" element="aside">
+								<Hide until="leftCol">
+									<Island
+										priority="enhancement"
+										defer={{ until: 'visible' }}
+									>
+										<ExpandableMarketingCardWrapper
+											guardianBaseURL={
+												article.guardianBaseURL
+											}
+										/>
+									</Island>
+								</Hide>
+							</GridItem>
+						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -5540,6 +5540,9 @@ const expandableMarketingCardBackground: PaletteFunction = () =>
 const expandableMarketingCardSvgFill: PaletteFunction = () =>
 	sourcePalette.neutral[0];
 
+const expandableMarketingCardButtonBackground: PaletteFunction = () =>
+	sourcePalette.neutral[100];
+
 const expandableMarketingCardSvgBackground: PaletteFunction = () =>
 	sourcePalette.neutral[100];
 
@@ -6282,6 +6285,10 @@ const paletteColours = {
 	'--expandable-marketing-card-background': {
 		light: expandableMarketingCardBackground,
 		dark: expandableMarketingCardBackground,
+	},
+	'--expandable-marketing-card-button-background': {
+		light: expandableMarketingCardButtonBackground,
+		dark: expandableMarketingCardButtonBackground,
 	},
 	'--expandable-marketing-card-fill-background': {
 		light: expandableMarketingCardFillBackgroundLight,


### PR DESCRIPTION
## What does this change?

Displays the [Expandable Marketing Card](https://github.com/guardian/dotcom-rendering/pull/12521) component on standard articles (excluding interactives) behind a 0% client-side AB test. This component will only be rendered for US users reading their first article. US users that have selected another edition are excluded from this test. Only for breakpoints 1140px (`leftCol`) and above: another PR for smaller screens to follow.

## Why?

So that we can test the effectiveness of this component for US users.

## Screenshots

| <img width=250/> | Default | Expanded |
| - | - | - |
| leftCol | ![leftCol-Default] | ![leftCol-Expanded] |
| wide | ![wide-Default] | ![wide-Expanded] |

[leftCol-Default]: https://github.com/user-attachments/assets/a848db6e-4010-4db0-97fa-3b299b46c5ee
[leftCol-Expanded]: https://github.com/user-attachments/assets/81a4e639-afab-4187-afdf-bf98c2ff543c
[wide-Default]: https://github.com/user-attachments/assets/a625528f-8a96-46f5-ac5c-da9ed353a81f
[wide-Expanded]: https://github.com/user-attachments/assets/d3074414-92d0-4099-b9b3-5671dcc2c2cb


https://github.com/user-attachments/assets/f46234b4-7de1-4ffb-b921-7aa39f3bd6fe


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
