### PR TITLE
Reorganise Storybook stories for front containers

### DIFF
--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: DecideContainerByTrails,
-	title: 'Components/DecideContainerByTrails',
+	title: 'Components/Containers/DecideContainerByTrails',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: DynamicFast,
-	title: 'Components/DynamicFast',
+	title: 'Components/Containers/DynamicFast',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -18,7 +18,7 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 
 const meta = {
 	component: DynamicPackage,
-	title: 'Components/DynamicPackage',
+	title: 'Components/Containers/DynamicPackage',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -23,7 +23,7 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 
 export default {
 	component: DynamicSlow,
-	title: 'Components/DynamicSlow',
+	title: 'Components/Containers/DynamicSlow',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: DynamicSlowMPU,
-	title: 'Components/DynamicSlowMPU',
+	title: 'Components/Containers/DynamicSlowMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedLargeSlowXIV,
-	title: 'Components/FixedLargeSlowXIV',
+	title: 'Components/Containers/FixedLargeSlowXIV',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumFastXI,
-	title: 'Components/FixedMediumFastXI',
+	title: 'Components/Containers/FixedMediumFastXI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumFastXII,
-	title: 'Components/FixedMediumFastXII',
+	title: 'Components/Containers/FixedMediumFastXII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowVI,
-	title: 'Components/FixedMediumSlowVI',
+	title: 'Components/Containers/FixedMediumSlowVI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowVII,
-	title: 'Components/FixedMediumSlowVII',
+	title: 'Components/Containers/FixedMediumSlowVII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowXIIMPU,
-	title: 'Components/FixedMediumSlowXIIMPU',
+	title: 'Components/Containers/FixedMediumSlowXIIMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallFastVIII,
-	title: 'Components/FixedSmallFastVIII',
+	title: 'Components/Containers/FixedSmallFastVIII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowI,
-	title: 'Components/FixedSmallSlowI',
+	title: 'Components/Containers/FixedSmallSlowI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowIII,
-	title: 'Components/FixedSmallSlowIII',
+	title: 'Components/Containers/FixedSmallSlowIII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowIV,
-	title: 'Components/FixedSmallSlowIV',
+	title: 'Components/Containers/FixedSmallSlowIV',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVHalf,
-	title: 'Components/FixedSmallSlowVHalf',
+	title: 'Components/Containers/FixedSmallSlowVHalf',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVMPU,
-	title: 'Components/FixedSmallSlowVMPU',
+	title: 'Components/Containers/FixedSmallSlowVMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVThird,
-	title: 'Components/FixedSmallSlowVThird',
+	title: 'Components/Containers/FixedSmallSlowVThird',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -127,7 +127,7 @@ type FlexibleGeneralArgsAndCustomArgs = React.ComponentProps<
 
 const meta = {
 	component: FlexibleGeneral,
-	title: 'Components/FlexibleGeneral',
+	title: 'Components/Containers/FlexibleGeneral',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -17,7 +17,7 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 
 const meta = {
 	component: FlexibleSpecial,
-	title: 'Components/FlexibleSpecial',
+	title: 'Components/Containers/FlexibleSpecial',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/NavList.stories.tsx
+++ b/dotcom-rendering/src/components/NavList.stories.tsx
@@ -6,7 +6,7 @@ import { NavList } from './NavList';
 
 export default {
 	component: NavList,
-	title: 'Components/NavList',
+	title: 'Components/Containers/NavList',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -5,7 +5,7 @@ import { FrontSection } from './FrontSection';
 import { ScrollableSmall } from './ScrollableSmall.importable';
 
 export default {
-	title: 'Components/ScrollableSmall',
+	title: 'Components/Containers/ScrollableSmall',
 	component: ScrollableSmall,
 	args: {
 		trails,


### PR DESCRIPTION
## What does this change?

Groups stories representing front containers in a "Containers" area in Storybook

## Why?

To make it easier to find layouts for front containers in Storybook

## Screenshots
<img width="290" alt="image" src="https://github.com/user-attachments/assets/22000e82-5b0d-49bb-a172-a0e75b16646e">
