### PR TITLE
Better Grid for articles

### DIFF
--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -8,6 +8,7 @@ type Props = {
 	 * The element type to use.
 	 */
 	element?: 'div' | 'article' | 'main' | 'aside' | 'section';
+	leftBorder?: boolean;
 };
 
 const rightColumnStyles = css`
@@ -30,15 +31,31 @@ const bodyStyles = css`
 
 const gridArea = css`
 	grid-area: var(--grid-area);
+	position: relative;
+`;
+
+const leftBorderStyles = css`
+	:before {
+		content: '';
+		display: block;
+		position: absolute;
+		top: 0;
+		left: -10px;
+		width: 1px;
+		height: 100%;
+		border-left: 1px solid var(--section-border);
+	}
 `;
 
 export const GridItem = ({
 	children,
 	area,
 	element: Element = 'div',
+	leftBorder = false,
 }: Props) => (
 	<Element
 		css={[
+			leftBorder && leftBorderStyles,
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
 			gridArea,

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -89,51 +89,46 @@ const StandardGrid = ({
 				display: grid;
 				width: 100%;
 				margin-left: 0;
+				grid-column-gap: 20px;
 
-				grid-column-gap: 10px;
-
-				/*
-					Explanation of each unit of grid-template-columns
-
-					Left Column (220 - 1px border)
-					Vertical grey border
-					Main content
-					Right Column
-				*/
 				${from.wide} {
-					grid-template-columns: 219px 1px 620px 80px 300px;
+					grid-template-columns:
+						repeat(3, 60px)
+						repeat(8, 60px)
+						60px
+						repeat(4, 60px);
 
 					${isMatchReport
 						? css`
 								grid-template-areas:
-									'title  border  matchNav   . right-column'
-									'title  border  matchtabs  . right-column'
-									'.      border  headline   . right-column'
-									'.      border  standfirst . right-column'
-									'lines  border  media      . right-column'
-									'meta   border  media      . right-column'
-									'meta   border  body       . right-column'
-									'.      border  .          . right-column';
+									'title title title  matchNav   matchNav   matchNav   matchNav   matchNav   matchNav   matchNav   matchNav   . right-column right-column right-column right-column'
+									'title title title  matchtabs  matchtabs  matchtabs  matchtabs  matchtabs  matchtabs  matchtabs  matchtabs  . right-column right-column right-column right-column'
+									'.     .     .      headline   headline   headline   headline   headline   headline   headline   headline   . right-column right-column right-column right-column'
+									'.     .     .      standfirst standfirst standfirst standfirst standfirst standfirst standfirst standfirst . right-column right-column right-column right-column'
+									'lines lines lines  media      media      media      media      media      media      media      media      . right-column right-column right-column right-column'
+									'meta  meta  meta   media      media      media      media      media      media      media      media      . right-column right-column right-column right-column'
+									'meta  meta  meta   body       body       body       body       body       body       body       body       . right-column right-column right-column right-column'
+									'.     .     .      .          .          .          .          .          .          .          .          . right-column right-column right-column right-column';
 						  `
 						: isMedia
 						? css`
 								grid-template-areas:
-									'title  border  headline   headline   .'
-									'.      border  disclaimer disclaimer right-column'
-									'lines  border  media      media      right-column'
-									'meta   border  media      media      right-column'
-									'meta   border  standfirst standfirst right-column'
-									'.      border  body       body       right-column'
-									'.      border  .          .          right-column';
+									'title title title headline   headline   headline   headline   headline   headline   headline   headline   headline   .            .            .            .           '
+									'.     .     .     disclaimer disclaimer disclaimer disclaimer disclaimer disclaimer disclaimer disclaimer disclaimer right-column right-column right-column right-column'
+									'lines lines lines media      media      media      media      media      media      media      media      media      right-column right-column right-column right-column'
+									'meta  meta  meta  media      media      media      media      media      media      media      media      media      right-column right-column right-column right-column'
+									'meta  meta  meta  standfirst standfirst standfirst standfirst standfirst standfirst standfirst standfirst standfirst right-column right-column right-column right-column'
+									'.     .     .     body       body       body       body       body       body       body       body       body       right-column right-column right-column right-column'
+									'.     .     .     .          .          .          .          .          .          .          .          .          right-column right-column right-column right-column';
 						  `
 						: css`
 								grid-template-areas:
-									'title  border  headline   . right-column'
-									'.      border  standfirst . right-column'
-									'lines  border  media      . right-column'
-									'meta   border  media      . right-column'
-									'meta   border  body       . right-column'
-									'.      border  .          . right-column';
+									'title title title headline   headline   headline   headline   headline   headline   headline   headline   . right-column right-column right-column right-column'
+									'.     .     .     standfirst standfirst standfirst standfirst standfirst standfirst standfirst standfirst . right-column right-column right-column right-column'
+									'lines lines lines media      media      media      media      media      media      media      media      . right-column right-column right-column right-column'
+									'meta  meta  meta  media      media      media      media      media      media      media      media      . right-column right-column right-column right-column'
+									'meta  meta  meta  body       body       body       body       body       body       body       body       . right-column right-column right-column right-column'
+									'.     .     .     .          .          .          .          .          .          .          .          . right-column right-column right-column right-column';
 						  `}
 				}
 			}
@@ -497,7 +492,11 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						isMatchReport={isMatchReport}
 						isMedia={isMedia}
 					>
-						<GridItem area="matchNav" element="aside">
+						<GridItem
+							area="matchNav"
+							element="aside"
+							leftBorder={true}
+						>
 							<div css={maxWidth}>
 								{isMatchReport && (
 									<Island
@@ -517,7 +516,11 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								)}
 							</div>
 						</GridItem>
-						<GridItem area="matchtabs" element="aside">
+						<GridItem
+							area="matchtabs"
+							element="aside"
+							leftBorder={true}
+						>
 							<div css={maxWidth}>
 								{isMatchReport && (
 									<Island
@@ -532,7 +535,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								)}
 							</div>
 						</GridItem>
-						<GridItem area="media">
+						<GridItem area="media" leftBorder={true}>
 							<div css={!isMedia && maxWidth}>
 								<MainMedia
 									format={format}
@@ -567,7 +570,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								<Border />
 							)}
 						</GridItem>
-						<GridItem area="headline">
+						<GridItem area="headline" leftBorder={true}>
 							<div css={maxWidth}>
 								<ArticleHeadline
 									format={format}
@@ -580,7 +583,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								/>
 							</div>
 						</GridItem>
-						<GridItem area="standfirst">
+						<GridItem area="standfirst" leftBorder={true}>
 							{!isUndefined(article.starRating) ? (
 								<div css={starWrapper}>
 									<StarRating
@@ -701,7 +704,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								</div>
 							)}
 						</GridItem>
-						<GridItem area="body">
+						<GridItem area="body" leftBorder={true}>
 							<ArticleContainer format={format}>
 								<ArticleBody
 									format={format}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
