### PR TITLE
Remove ad slot support message from apps

### DIFF
--- a/apps-rendering/src/adSlot.tsx
+++ b/apps-rendering/src/adSlot.tsx
@@ -1,14 +1,12 @@
 import type { SerializedStyles } from '@emotion/react';
-import { css, ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/react';
 import type { ArticleFormat } from 'articleFormat';
 import {
 	from,
-	headlineMedium17,
 	remSpace,
 	textSans14,
 	until,
 } from '@guardian/source/foundations';
-import { Button, buttonThemeBrandAlt } from '@guardian/source/react-components';
 import { background, text } from 'palette';
 import type { ReactElement } from 'react';
 import { darkModeCss, wideContentWidth } from 'styles';
@@ -37,24 +35,6 @@ const adLabelsStyles = (format: ArticleFormat): SerializedStyles => css`
 		color: ${text.adLabelDark(format)};
 	`}
 	}
-`;
-
-const supportBannerStyles = (format: ArticleFormat): SerializedStyles => css`
-	padding: ${remSpace[3]};
-	background-color: ${background.supportBanner(format)};
-
-	p {
-		${headlineMedium17};
-		margin-top: 0;
-	}
-
-	button {
-		margin-top: ${remSpace[3]};
-	}
-
-	${darkModeCss`
-		background-color: ${background.supportBannerDark(format)};
-	`}
 `;
 
 const styles = (format: ArticleFormat): SerializedStyles => css`
@@ -117,12 +97,6 @@ const AdSlot = ({ className, paragraph, format }: Props): ReactElement => (
 			<p>Advertisement</p>
 		</div>
 		<div css={adSlotStyles} className="ad-slot"></div>
-		<div css={supportBannerStyles(format)} className="support-banner">
-			<p>Support the Guardian and enjoy the app ad-free.</p>
-			<ThemeProvider theme={buttonThemeBrandAlt}>
-				<Button>Support the Guardian</Button>
-			</ThemeProvider>
-		</div>
 	</aside>
 );
 

--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -1,5 +1,4 @@
 import { AdSlot as BridgetAdSlot } from '@guardian/bridget/AdSlot';
-import { PurchaseScreenReason } from '@guardian/bridget/PurchaseScreenReason';
 import type { IRect as BridgetRect } from '@guardian/bridget/Rect';
 import { isUndefined } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
@@ -7,11 +6,7 @@ import type { Breakpoint } from '@guardian/source/foundations';
 import libDebounce from 'lodash.debounce';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import {
-	getAcquisitionsClient,
-	getCommercialClient,
-	getUserClient,
-} from '../lib/bridgetApi';
+import { getCommercialClient, getUserClient } from '../lib/bridgetApi';
 import { useMatchMedia } from '../lib/useMatchMedia';
 import {
 	adPlaceholderClass,
@@ -222,17 +217,10 @@ export const AdPortals = ({
 		return () => resizeObserver?.disconnect();
 	}, [adPlaceholders, rightAdPlaceholder, tryRightAligned]);
 
-	const handleClickSupportButton = () => {
-		void getAcquisitionsClient()
-			.launchPurchaseScreen(PurchaseScreenReason.hideAds)
-			.catch(() => console.error('Error launching purchase screen'));
-	};
-
 	const renderAdSlot = (id: string, index: number) => (
 		<AdSlot
 			key={id}
 			isFirstAdSlot={index === 0}
-			onClickSupportButton={handleClickSupportButton}
 			ref={(node) => {
 				if (node !== null) {
 					adSlots.current = [...adSlots.current, node];

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
 import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { allModes } from '../../.storybook/modes';
 import { AdSlot } from './AdSlot.apps';
@@ -18,9 +17,6 @@ const meta = {
 		viewport: {
 			defaultViewport: 'mobileMedium',
 		},
-	},
-	args: {
-		onClickSupportButton: fn(),
 	},
 } satisfies Meta<typeof AdSlot>;
 

--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -14,6 +14,10 @@ const styles = css`
 	clear: both;
 	margin: ${remSpace[4]} 0;
 	background: ${palette('--ad-background')};
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
 
 	${until.phablet} {
 		margin: 1em 0px;
@@ -24,6 +28,8 @@ const adLabelsStyles = css`
 	${textSans14}
 	padding: ${remSpace[3]};
 	float: left;
+	display: flex;
+	justify-content: center;
 
 	/* We need to account for padding on both sides */
 	width: calc(100% - 2 * ${remSpace[3]});
@@ -40,6 +46,7 @@ const adLabelsStyles = css`
 const adSlotStyles = css`
 	clear: both;
 	padding-bottom: ${adHeightPx}px;
+	width: 100%;
 `;
 
 const adSlotSquareStyles = css`

--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -1,18 +1,11 @@
 import { css } from '@emotion/react';
-import {
-	remSpace,
-	textSans14,
-	textSans15,
-	until,
-} from '@guardian/source/foundations';
-import { Button } from '@guardian/source/react-components';
+import { remSpace, textSans14, until } from '@guardian/source/foundations';
 import { forwardRef } from 'react';
 import { palette } from '../palette';
 
 // Exported for Storybook use
 export interface Props {
 	isFirstAdSlot: boolean;
-	onClickSupportButton: () => void;
 }
 
 const adHeightPx = 258;
@@ -62,40 +55,6 @@ const adSlotSquareStyles = css`
 	padding-bottom: 0;
 `;
 
-const supportBannerStyles = css`
-	padding: ${remSpace[2]};
-	background-color: ${palette('--ad-support-banner-background')};
-
-	p {
-		${textSans15};
-		color: ${palette('--ad-support-banner-text')};
-		font-weight: bold;
-		margin-top: 0;
-	}
-
-	button {
-		margin-top: ${remSpace[2]};
-		color: ${palette('--ad-support-banner-button-text')};
-		background-color: ${palette('--ad-support-banner-button-background')};
-	}
-`;
-
-/**
- * Support banner component, used at the bottom of the ad slot
- *
- * @todo Allow this to be used with web ad slots
- */
-const SupportBanner = ({
-	onClickSupportButton,
-}: Pick<Props, 'onClickSupportButton'>) => (
-	<div css={supportBannerStyles}>
-		<p>Enjoy the Guardian ad-free</p>
-		<Button size="xsmall" priority="primary" onClick={onClickSupportButton}>
-			Support the Guardian
-		</Button>
-	</div>
-);
-
 /**
  * AdSlot component for in-article ads **on apps only**
  *
@@ -105,7 +64,7 @@ const SupportBanner = ({
  * the native layer, for it to "paint" an advert over the top of it.
  */
 export const AdSlot = forwardRef<HTMLDivElement, Props>(
-	({ isFirstAdSlot, onClickSupportButton }, ref) => (
+	({ isFirstAdSlot }, ref) => (
 		<aside css={styles}>
 			<div css={adLabelsStyles}>
 				<p>Advertisement</p>
@@ -114,7 +73,6 @@ export const AdSlot = forwardRef<HTMLDivElement, Props>(
 				css={isFirstAdSlot ? adSlotSquareStyles : adSlotStyles}
 				ref={ref}
 			></div>
-			<SupportBanner onClickSupportButton={onClickSupportButton} />
 		</aside>
 	),
 );


### PR DESCRIPTION
## What does this change?

Remove ad slot support message from apps rendered articles

Centre ad label text horizontally

Centre ad slot horizontally

## Screenshots

### iOS

| Before      | After      |
| ----------- | ---------- |
| inline1 | inline1 |
| <img src="https://github.com/user-attachments/assets/fb1172ef-b798-4a46-a189-c2a1bb402e09" width="300px" /> | <img src="https://github.com/user-attachments/assets/2675ca6f-3254-4c98-bdd4-5e942862ed91" width="300px" /> |
| inline2+ | inline2+ |
| <img src="https://github.com/user-attachments/assets/56217bd5-0f86-446b-973d-ba3913768d8f" width="300px" /> | <img src="https://github.com/user-attachments/assets/b8a7495e-b745-4378-9f7e-9d504c0bf497" width="300px" /> |
| tablet | tablet |
|<img src="https://github.com/user-attachments/assets/293aab75-e983-44f0-858f-b2452a978a44" width="300px" />|<img src="https://github.com/user-attachments/assets/499890ea-a220-4ddd-a0f9-fa602733324e" width="300px" />|

### Android

| Before      | After      |
| ----------- | ---------- |
| inline1 | inline1 |
| <img src="https://github.com/user-attachments/assets/1b5f4766-6daa-4b0a-b313-a5d29a18e7f6" width="300px" /> | <img src="https://github.com/user-attachments/assets/0439abb4-fa01-41ad-98e6-b0eddcd23546" width="300px" /> |
| inline2+ | inline2+ |
| <img src="https://github.com/user-attachments/assets/8cd87ace-7aba-427b-a1d4-b86fda400f12" width="300px" /> | <img src="https://github.com/user-attachments/assets/07912eb9-4028-43f6-b24b-02f91092e836" width="300px" /> |
| tablet | tablet |
|<img src="https://github.com/user-attachments/assets/3ab69cf0-8423-4f48-ba2f-a82972b13e74" width="300px" />|<img src="https://github.com/user-attachments/assets/a23a9d78-5d54-4b49-baaf-0267620004cf" width="300px" />|

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
