### PR TITLE
Update `BigNumber` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/BigNumber.stories.tsx
+++ b/dotcom-rendering/src/components/BigNumber.stories.tsx
@@ -1,55 +1,57 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
-import type { Meta } from '@storybook/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
-import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/format';
+import type { Meta, StoryObj } from '@storybook/react';
+import { allModes } from '../../.storybook/modes';
 import { palette } from '../palette';
-import { BigNumber } from './BigNumber';
+import { BigNumber as BigNumberComponent } from './BigNumber';
 
-const meta: Meta<typeof BigNumber> = {
-	title: 'components/BigNumber',
-	component: BigNumber,
-};
+const meta = {
+	title: 'Components/BigNumber',
+	component: BigNumberComponent,
+	parameters: {
+		chromatic: {
+			modes: {
+				horizontal: allModes.splitHorizontal,
+			},
+		},
+	},
+} satisfies Meta<typeof BigNumberComponent>;
 
 export default meta;
 
-export const AllNumbers = () => (
-	<div
-		css={css`
-			padding: ${space[2]}px;
-			font-size: 3rem;
-			fill: ${palette('--article-text')};
-		`}
-	>
-		<BigNumber index={0} />
-		<br />
-		<BigNumber index={1} />
-		<br />
-		<BigNumber index={2} />
-		<br />
-		<BigNumber index={3} />
-		<br />
-		<BigNumber index={4} />
-		<br />
-		<BigNumber index={5} />
-		<br />
-		<BigNumber index={6} />
-		<br />
-		<BigNumber index={7} />
-		<br />
-		<BigNumber index={8} />
-		<br />
-		<BigNumber index={9} />
-		<br />
-		<BigNumber index={10} />
-	</div>
-);
-AllNumbers.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+type Story = StoryObj<typeof meta>;
+
+export const BigNumber = {
+	args: { index: 0 },
+	render: () => (
+		<div
+			css={css`
+				padding: ${space[2]}px;
+				font-size: 3rem;
+				fill: ${palette('--article-text')};
+			`}
+		>
+			<BigNumberComponent index={0} />
+			<br />
+			<BigNumberComponent index={1} />
+			<br />
+			<BigNumberComponent index={2} />
+			<br />
+			<BigNumberComponent index={3} />
+			<br />
+			<BigNumberComponent index={4} />
+			<br />
+			<BigNumberComponent index={5} />
+			<br />
+			<BigNumberComponent index={6} />
+			<br />
+			<BigNumberComponent index={7} />
+			<br />
+			<BigNumberComponent index={8} />
+			<br />
+			<BigNumberComponent index={9} />
+			<br />
+			<BigNumberComponent index={10} />
+		</div>
+	),
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+, and integrates better with some of its features[^1].

Using `satisfies` gives better type safety for args[^2]. Replaced the function-based story with the CSFv3 `render` method[^3]. Removed the `splitTheme` decorator, as this is now handled by the "global colour scheme" toolbar item[^4] and a Chromatic mode[^5]. As there's only one story, renamed the story to have the same name as the component, which allows storybook to hoist the story in the UI[^6].

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
[^3]: https://storybook.js.org/docs/api/csf#custom-render-functions
[^4]: https://storybook.js.org/docs/essentials/toolbars-and-globals
[^5]: https://www.chromatic.com/docs/modes/
[^6]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting
