### PR TITLE
Update `BlockquoteBlockComponent` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.stories.tsx
@@ -1,194 +1,120 @@
-import { css } from '@emotion/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
 import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleSpecial,
+	getAllDesigns,
+	getAllThemes,
 	Pillar,
 } from '../lib/format';
 import { BlockquoteBlockComponent } from './BlockquoteBlockComponent';
 
-const shortQuoteHtml =
-	'<blockquote class="quoted"> \n <p>We’ve now got evidence</p> \n<p>A second paragraph</p> \n</blockquote>';
-const blockquoteHtml =
-	'<blockquote class="quoted"> \n <p>We’ve now got evidence that under <a href="https://www.theguardian.com/politics/boris-johnson">Boris Johnson</a> the NHS is on the table and will be up for sale. He tried to cover it up in a secret agenda but today it’s been exposed.</p> \n<p>A second paragraph</p> \n</blockquote>';
-
-export default {
+const meta = {
 	component: BlockquoteBlockComponent,
-	title: 'Components/BlockquoteComponent',
-};
+	title: 'Components/Blockquote Block Component',
+	parameters: {
+		viewport: {
+			defaultViewport: 'mobileMedium',
+		},
+		chromatic: {
+			modes: {
+				horizontal: allModes['horizontal tablet'],
+			},
+		},
+	},
+	decorators: [centreColumnDecorator],
+} satisfies Meta<typeof BlockquoteBlockComponent>;
 
-const containerStyles = css`
-	max-width: 620px;
-	margin: 20px;
-`;
+export default meta;
 
-export const Unquoted = () => {
-	return (
-		<div css={containerStyles}>
-			<h1>Long</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} />
-			<h1>Short</h1>
-			<BlockquoteBlockComponent html={shortQuoteHtml} />
-		</div>
-	);
-};
-Unquoted.storyName = 'Unquoted';
-Unquoted.decorators = [
-	splitTheme([
-		{
+type Story = StoryObj<typeof meta>;
+
+export const UnquotedLong = {
+	args: {
+		html: '<blockquote class="quoted"> \n <p>We’ve now got evidence that under <a href="https://www.theguardian.com/politics/boris-johnson">Boris Johnson</a> the NHS is on the table and will be up for sale. He tried to cover it up in a secret agenda but today it’s been exposed.</p> \n<p>A second paragraph</p> \n</blockquote>',
+	},
+} satisfies Story;
+
+export const UnquotedShort = {
+	args: {
+		html: '<blockquote class="quoted"> \n <p>We’ve now got evidence</p> \n<p>A second paragraph</p> \n</blockquote>',
+	},
+} satisfies Story;
+
+export const QuotedStandardDesignAllThemes = {
+	args: {
+		...UnquotedLong.args,
+		quoted: true,
+	},
+	parameters: {
+		formats: getAllThemes({
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-		},
-	]),
-];
+		}),
+	},
+} satisfies Story;
 
-const blockQuoteStoryVariations = [
-	ArticleDesign.Standard,
-	ArticleDesign.Profile,
-	ArticleDesign.Explainer,
-	ArticleDesign.Timeline,
-	ArticleDesign.LiveBlog,
-	ArticleDesign.DeadBlog,
-	ArticleDesign.Analysis,
-	ArticleDesign.Feature,
-	ArticleDesign.Interview,
-	ArticleDesign.Recipe,
-	ArticleDesign.Review,
-	ArticleDesign.Obituary,
-	ArticleDesign.Comment,
-	ArticleDesign.Editorial,
-] as const satisfies ReadonlyArray<ArticleDesign>;
-
-const themeVariations = [
-	Pillar.Sport,
-	Pillar.News,
-	Pillar.Culture,
-	Pillar.Opinion,
-	Pillar.Lifestyle,
-	ArticleSpecial.SpecialReport,
-	ArticleSpecial.SpecialReportAlt,
-	ArticleSpecial.Labs,
-];
-
-const allThemeStandardVariations = themeVariations.map((theme) => ({
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-	theme,
-}));
-
-const allLiveBlogVariations = themeVariations.map((theme) => ({
-	design: ArticleDesign.LiveBlog,
-	display: ArticleDisplay.Standard,
-	theme,
-}));
-
-const allDeadBlogVariations = themeVariations.map((theme) => ({
-	design: ArticleDesign.DeadBlog,
-	display: ArticleDisplay.Standard,
-	theme,
-}));
-
-const allNewsVariations = blockQuoteStoryVariations.map((design) => ({
-	design,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.News,
-}));
-
-const allCultureVariations = blockQuoteStoryVariations.map((design) => ({
-	design,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.Culture,
-}));
-
-const allSportVariations = blockQuoteStoryVariations.map((design) => ({
-	design,
-	display: ArticleDisplay.Standard,
-	theme: Pillar.Sport,
-}));
-
-export const StandardDesign = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-StandardDesign.storyName = 'Standard Design - All theme variations';
-StandardDesign.decorators = [splitTheme(allThemeStandardVariations)];
-
-export const DesignVariationsNews = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-DesignVariationsNews.storyName = 'News Pillar - Design variations';
-DesignVariationsNews.decorators = [splitTheme(allNewsVariations)];
-
-export const DesignVariationsCulture = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-DesignVariationsCulture.storyName = 'Culture Pillar - Design variations';
-DesignVariationsCulture.decorators = [splitTheme(allCultureVariations)];
-
-export const DesignVariationsSport = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-DesignVariationsSport.storyName = 'Sport Pillar - Design variations';
-DesignVariationsSport.decorators = [splitTheme(allSportVariations)];
-
-export const LiveBlogDesign = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-LiveBlogDesign.storyName = 'LiveBlog Design - All theme variations';
-LiveBlogDesign.decorators = [splitTheme(allLiveBlogVariations)];
-
-export const DeadBlogDesign = () => {
-	return (
-		<div>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-
-DeadBlogDesign.storyName = 'DeadBlog Design - All theme variations';
-DeadBlogDesign.decorators = [splitTheme(allDeadBlogVariations)];
-
-export const SpecialReportAltComment = () => {
-	return (
-		<div css={containerStyles}>
-			<h1>SpecialReportAlt Comment</h1>
-			<BlockquoteBlockComponent html={blockquoteHtml} quoted={true} />
-		</div>
-	);
-};
-SpecialReportAltComment.storyName = 'SpecialReportAltComment';
-SpecialReportAltComment.decorators = [
-	splitTheme([
-		{
-			design: ArticleDesign.Comment,
+export const QuotedLiveBlogDesignAllThemes = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: getAllThemes({
+			design: ArticleDesign.LiveBlog,
 			display: ArticleDisplay.Standard,
-			theme: ArticleSpecial.SpecialReportAlt,
-		},
-	]),
-];
+		}),
+	},
+} satisfies Story;
+
+export const QuotedDeadBlogDesignAllThemes = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: getAllThemes({
+			design: ArticleDesign.DeadBlog,
+			display: ArticleDisplay.Standard,
+		}),
+	},
+} satisfies Story;
+
+export const QuotedAllDesignsNewsTheme = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: getAllDesigns({
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		}),
+	},
+} satisfies Story;
+
+export const QuotedAllDesignsCultureTheme = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: getAllDesigns({
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		}),
+	},
+} satisfies Story;
+
+export const QuotedAllDesignsSportTheme = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: getAllDesigns({
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Sport,
+		}),
+	},
+} satisfies Story;
+
+export const QuotedCommentDesignSpecialReportAltTheme = {
+	args: QuotedStandardDesignAllThemes.args,
+	parameters: {
+		formats: [
+			{
+				design: ArticleDesign.Comment,
+				display: ArticleDisplay.Standard,
+				theme: ArticleSpecial.SpecialReportAlt,
+			},
+		],
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+, and integrates better with some of its features[^1].

Using `satisfies` gives better type safety for args[^2]. Removed the `splitTheme` decorator, as this is now handled by the "global colour scheme" toolbar item[^3] and a Chromatic mode[^4]. Added the `centreColumnDecorator`, so the stories better reflect the layout commonly used in articles. Removed the custom design and theme generating functions in favour of the ones exported by `format.ts`.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
[^3]: https://storybook.js.org/docs/essentials/toolbars-and-globals
[^4]: https://www.chromatic.com/docs/modes/
