### PR TITLE
Small story carousel spacing and grid alignment

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -59,8 +59,10 @@ const carouselContainerStyles = css`
 	}
 
 	/* Extend carousel into grid gutter on mobile */
+	margin-left: -10px;
 	margin-right: -10px;
 	${from.mobileLandscape} {
+		margin-left: -20px;
 		margin-right: -20px;
 	}
 
@@ -82,9 +84,9 @@ const carouselContainerStyles = css`
 	}
 	${from.leftCol} {
 		margin-top: 0;
+		margin-left: -10px;
 	}
 	${from.wide} {
-		margin-left: ${space[2]}px;
 		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
 	}
 `;
@@ -109,6 +111,21 @@ const carouselStyles = css`
 	}
 	scrollbar-width: none; /* Firefox */
 	position: relative;
+
+	padding-left: 10px;
+	scroll-padding-left: 10px;
+	${from.mobileLandscape} {
+		padding-left: 20px;
+		scroll-padding-left: 20px;
+	}
+	${from.tablet} {
+		padding-left: 0px;
+		scroll-padding-left: 0px;
+	}
+	${from.leftCol} {
+		padding-left: 20px;
+		scroll-padding-left: 20px;
+	}
 `;
 
 const itemStyles = css`
@@ -127,6 +144,18 @@ const verticalLineStyles = css`
 		width: 1px;
 		background-color: ${palette('--card-border-top')};
 		transform: translateX(-50%);
+	}
+	${from.leftCol} {
+		:first-child::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: -10px;
+			width: 1px;
+			background-color: ${palette('--card-border-top')};
+			transform: translateX(-50%);
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -58,19 +58,29 @@ const carouselContainerStyles = css`
 	${from.wide} {
 		flex-direction: row;
 	}
+
+	/* Extend carousel into grid gutter on mobile */
+	margin-right: -10px;
+	${from.mobileLandscape} {
+		margin-right: -20px;
+	}
+	${from.tablet} {
+		margin-left: 10px;
+		margin-right: 10px;
+	}
 `;
 
 const carouselStyles = css`
 	display: grid;
 	grid-auto-columns: 1fr;
 	grid-auto-flow: column;
+	gap: 20px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 	overscroll-behavior-x: contain;
 	overscroll-behavior-y: auto;
-	scroll-padding-left: 10px;
 	/**
 	 * Hide scrollbars
 	 * See: https://stackoverflow.com/a/38994837
@@ -80,24 +90,12 @@ const carouselStyles = css`
 	}
 	scrollbar-width: none; /* Firefox */
 	position: relative;
-
-	/* Extend carousel into grid gutter on mobile */
-	margin-left: -10px;
-	margin-right: -10px;
-	${from.mobileLandscape} {
-		margin-right: -20px;
-	}
-	${from.tablet} {
-		margin-left: 0px;
-		margin-right: 10px;
-	}
 `;
 
 const itemStyles = css`
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
-	margin: 0 10px;
 `;
 
 const verticalLineStyles = css`
@@ -148,12 +146,12 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		${until.tablet} {
 			grid-template-columns: repeat(
 				${totalCards},
-				calc((100% - ${peepingCardWidth}px))
+				calc((100% - ${peepingCardWidth}px - 20px))
 			);
 		}
 
 		${from.tablet} {
-			grid-template-columns: repeat(${totalCards}, calc(50% + 10px));
+			grid-template-columns: repeat(${totalCards}, calc(50% - 10px));
 		}
 	`;
 };

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -86,7 +86,8 @@ const carouselStyles = css`
 		margin-right: -20px;
 	}
 	${from.tablet} {
-		margin-right: 0;
+		margin-left: 10px;
+		margin-right: 10px;
 	}
 `;
 
@@ -150,7 +151,7 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 		}
 
 		${from.tablet} {
-			grid-template-columns: repeat(${totalCards}, 50%);
+			grid-template-columns: repeat(${totalCards}, calc(50% + 10px));
 		}
 	`;
 };

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -70,6 +70,7 @@ const carouselStyles = css`
 	scroll-behavior: smooth;
 	overscroll-behavior-x: contain;
 	overscroll-behavior-y: auto;
+	scroll-padding-left: 10px;
 	/**
 	 * Hide scrollbars
 	 * See: https://stackoverflow.com/a/38994837
@@ -81,12 +82,13 @@ const carouselStyles = css`
 	position: relative;
 
 	/* Extend carousel into grid gutter on mobile */
+	margin-left: -10px;
 	margin-right: -10px;
 	${from.mobileLandscape} {
 		margin-right: -20px;
 	}
 	${from.tablet} {
-		margin-left: 10px;
+		margin-left: 0px;
 		margin-right: 10px;
 	}
 `;

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -64,9 +64,29 @@ const carouselContainerStyles = css`
 	${from.mobileLandscape} {
 		margin-right: -20px;
 	}
+
+	/**
+	 * From tablet, pull container up so navigation buttons align with title.
+	 * The margin is calculated using the front section title font size and line
+	 * height, and the default spacing applied to the top of the container.
+	 *
+	 * From wide, the navigation buttons are pulled out of the main content area
+	 * into the right-hand column.
+	 */
 	${from.tablet} {
 		margin-left: 10px;
 		margin-right: 10px;
+		margin-top: calc(
+			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
+				${space[3]}px
+		);
+	}
+	${from.leftCol} {
+		margin-top: 0;
+	}
+	${from.wide} {
+		margin-left: ${space[2]}px;
+		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
 	}
 `;
 
@@ -113,18 +133,8 @@ const verticalLineStyles = css`
 
 const buttonContainerStyles = css`
 	margin-left: auto;
-	${from.tablet} {
-		margin-top: calc(
-			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
-				${space[3]}px
-		);
-	}
-	${from.leftCol} {
-		margin-top: 0;
-	}
 	${from.wide} {
-		margin-left: ${space[2]}px;
-		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
+		margin-left: ${space[1]}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -3,7 +3,6 @@ import {
 	from,
 	headlineMedium24Object,
 	space,
-	until,
 } from '@guardian/source/foundations';
 import {
 	Button,
@@ -153,13 +152,10 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 	const peepingCardWidth = space[8];
 
 	return css`
-		${until.tablet} {
-			grid-template-columns: repeat(
-				${totalCards},
-				calc((100% - ${peepingCardWidth}px - 20px))
-			);
-		}
-
+		grid-template-columns: repeat(
+			${totalCards},
+			calc((100% - ${peepingCardWidth}px - 20px))
+		);
 		${from.tablet} {
 			grid-template-columns: repeat(${totalCards}, calc(50% - 10px));
 		}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -58,7 +58,7 @@ const carouselContainerStyles = css`
 		flex-direction: row;
 	}
 
-	/* Extend carousel into grid gutter on mobile */
+	/* Extend carousel into outer margins on mobile */
 	margin-left: -10px;
 	margin-right: -10px;
 	${from.mobileLandscape} {
@@ -68,8 +68,8 @@ const carouselContainerStyles = css`
 
 	/**
 	 * From tablet, pull container up so navigation buttons align with title.
-	 * The margin is calculated using the front section title font size and line
-	 * height, and the default spacing applied to the top of the container.
+	 * The margin is calculated from the front section title font size and line
+	 * height, and the default container spacing.
 	 *
 	 * From wide, the navigation buttons are pulled out of the main content area
 	 * into the right-hand column.

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -70,23 +70,31 @@ const carouselStyles = css`
 	scroll-behavior: smooth;
 	overscroll-behavior-x: contain;
 	overscroll-behavior-y: auto;
-	scroll-padding-left: 10px;
 	/**
-	* Hide scrollbars
-	* See: https://stackoverflow.com/a/38994837
-	*/
+	 * Hide scrollbars
+	 * See: https://stackoverflow.com/a/38994837
+	 */
 	::-webkit-scrollbar {
 		display: none; /* Safari and Chrome */
 	}
 	scrollbar-width: none; /* Firefox */
 	position: relative;
+
+	/* Extend carousel into grid gutter on mobile */
+	margin-right: -10px;
+	${from.mobileLandscape} {
+		margin-right: -20px;
+	}
+	${from.tablet} {
+		margin-right: 0;
+	}
 `;
 
 const itemStyles = css`
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
-	margin: ${space[3]}px 10px;
+	margin: 0 10px;
 `;
 
 const verticalLineStyles = css`


### PR DESCRIPTION
## What does this change?

- Adjust spacing of carousel and cards to align with grid
- Mobile layout is now full bleed and extends to edges of viewport
- Desktop layout at `leftCol` and above adds a divider to the left of the first card (`FrontSection` has not yet been updated to remove the overlapping divider and change the title styles.)

## Why?

To support the new small story carousel container type in DCR

Part of [this Trello ticket](https://trello.com/c/JioYmzBd/473-web-small-story-carousel)

## Screenshots

### Mobile

<img width="319" alt="Screenshot 2024-10-14 at 17 44 25" src="https://github.com/user-attachments/assets/d7de50a9-f909-4bb7-bc95-27942b3e52cf">

#### Whilst being scrolled (showing how it extends into the outer margins)

<img width="319" alt="Screenshot 2024-10-14 at 17 53 59" src="https://github.com/user-attachments/assets/9b27a301-0e5f-4e0d-a38b-34232da3431f">

### Mobile landscape

<img width="480" alt="Screenshot 2024-10-14 at 17 44 40" src="https://github.com/user-attachments/assets/425190c4-3b7f-4d0a-88f0-7d84b3b2f326">

#### After scrolling (showing divider now visible in margin)

<img width="480" alt="Screenshot 2024-10-14 at 17 45 04" src="https://github.com/user-attachments/assets/a41b6ba5-10c2-44fb-850a-3d51ecb8e964">

### Tablet

<img width="738" alt="Screenshot 2024-10-14 at 17 45 25" src="https://github.com/user-attachments/assets/a5a076ff-c882-4bc8-9c7e-a8499388bc97">

### Desktop

<img width="979" alt="Screenshot 2024-10-14 at 18 08 03" src="https://github.com/user-attachments/assets/03c9ca74-dfa8-4cd7-91ff-faef3ca86a91">

### Medium desktop (`leftCol`)

<img width="1139" alt="Screenshot 2024-10-14 at 18 08 22" src="https://github.com/user-attachments/assets/e7854499-86de-42ac-b3a7-89e1090e07af">

### Large desktop (`wide`)

<img width="1299" alt="Screenshot 2024-10-14 at 18 08 34" src="https://github.com/user-attachments/assets/d0b32180-dd77-4db7-a834-2ce8a4334613">
