### PR TITLE
Request 5:4 crops from fastly directly 

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -92,7 +92,7 @@ const block = css`
  * This is due to replace the existing card ratio of 5:3
  * For now, we are keeping both ratios.
  */
-const decideAspectRatioStyles = (aspectRatio: AspectRatio) => {
+const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	return css`
 		padding-top: ${aspectRatio === '5:4'
 			? `${(4 / 5) * 100}%`
@@ -128,9 +128,13 @@ export const CardPicture = ({
 	loading,
 	roundedCorners,
 	isCircular,
-	aspectRatio = '5:3', // Default aspect ratio
+	aspectRatio,
 }: Props) => {
-	const sources = generateSources(mainImage, decideImageWidths(imageSize));
+	const sources = generateSources(
+		mainImage,
+		decideImageWidths(imageSize),
+		aspectRatio,
+	);
 
 	const fallbackSource = getFallbackSource(sources);
 

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -80,7 +80,6 @@ const decideImageWidths = (
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#styling_with_css
  *
- * We also add object-fit: cover to ensure the image fills the container and maintains its own aspect ratio.
  */
 const block = css`
 	display: block;

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -84,7 +84,6 @@ const decideImageWidths = (
  */
 const block = css`
 	display: block;
-	object-fit: cover;
 `;
 
 /**

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -28,6 +28,7 @@ type Props = {
 	isLightbox?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
+	crop?: string;
 };
 
 export type ImageWidthType = { breakpoint: number; width: number };
@@ -251,10 +252,12 @@ type ImageSource = {
  *
  * @param mainImage source image URL
  * @param imageWidths list of image widths
+ * @param crop - Aspect ratio that the image should be cropped to (e.g., 5:4). Optional.
  */
 export const generateSources = (
 	mainImage: string,
 	imageWidths: readonly [ImageWidthType, ...ImageWidthType[]],
+	crop?: string,
 ): ImageSource[] =>
 	imageWidths
 		.slice()
@@ -267,11 +270,13 @@ export const generateSources = (
 					mainImage,
 					imageWidth,
 					resolution: 'high',
+					crop,
 				}),
 				lowResUrl: generateImageURL({
 					mainImage,
 					imageWidth,
 					resolution: 'low',
+					crop,
 				}),
 			};
 		});
@@ -325,6 +330,7 @@ export const Picture = ({
 	isLightbox = false,
 	orientation = 'landscape',
 	onLoad,
+	crop,
 }: Props) => {
 	const [loaded, setLoaded] = useState(false);
 	const ref = useCallback((node: HTMLImageElement | null) => {
@@ -349,6 +355,7 @@ export const Picture = ({
 			isLightbox,
 			orientation,
 		}),
+		crop,
 	);
 
 	/** portrait if higher than 1 or landscape if lower than 1 */

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -28,7 +28,7 @@ type Props = {
 	isLightbox?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
-	crop?: string;
+	aspectRatio?: string;
 };
 
 export type ImageWidthType = { breakpoint: number; width: number };
@@ -252,12 +252,12 @@ type ImageSource = {
  *
  * @param mainImage source image URL
  * @param imageWidths list of image widths
- * @param crop - Aspect ratio that the image should be cropped to (e.g., 5:4). Optional.
+ * @param aspectRatio - Aspect ratio that the image should be cropped to (e.g., 5:4). Optional.
  */
 export const generateSources = (
 	mainImage: string,
 	imageWidths: readonly [ImageWidthType, ...ImageWidthType[]],
-	crop?: string,
+	aspectRatio?: string,
 ): ImageSource[] =>
 	imageWidths
 		.slice()
@@ -270,13 +270,13 @@ export const generateSources = (
 					mainImage,
 					imageWidth,
 					resolution: 'high',
-					crop,
+					aspectRatio,
 				}),
 				lowResUrl: generateImageURL({
 					mainImage,
 					imageWidth,
 					resolution: 'low',
-					crop,
+					aspectRatio,
 				}),
 			};
 		});
@@ -330,7 +330,7 @@ export const Picture = ({
 	isLightbox = false,
 	orientation = 'landscape',
 	onLoad,
-	crop,
+	aspectRatio,
 }: Props) => {
 	const [loaded, setLoaded] = useState(false);
 	const ref = useCallback((node: HTMLImageElement | null) => {
@@ -355,7 +355,7 @@ export const Picture = ({
 			isLightbox,
 			orientation,
 		}),
-		crop,
+		aspectRatio,
 	);
 
 	/** portrait if higher than 1 or landscape if lower than 1 */

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -37,12 +37,12 @@ export const generateImageURL = ({
 	mainImage,
 	imageWidth,
 	resolution,
-	crop,
+	aspectRatio,
 }: {
 	mainImage: string;
 	imageWidth: number;
 	resolution: 'low' | 'high';
-	crop?: string;
+	aspectRatio?: string;
 }): string => {
 	const url = new URL(mainImage);
 
@@ -55,7 +55,10 @@ export const generateImageURL = ({
 		s: 'none',
 	});
 
+	// Only append the crop parameter if it's provided
+	const cropParam = aspectRatio ? `&crop=${aspectRatio}` : '';
+
 	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${
 		url.pathname
-	}?${params.toString()}&crop=${crop}`;
+	}?${params.toString()}${cropParam}`;
 };

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -37,10 +37,12 @@ export const generateImageURL = ({
 	mainImage,
 	imageWidth,
 	resolution,
+	crop,
 }: {
 	mainImage: string;
 	imageWidth: number;
 	resolution: 'low' | 'high';
+	crop?: string;
 }): string => {
 	const url = new URL(mainImage);
 
@@ -55,5 +57,5 @@ export const generateImageURL = ({
 
 	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${
 		url.pathname
-	}?${params.toString()}`;
+	}?${params.toString()}&crop=${crop}`;
 };

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -37,7 +37,7 @@ export const generateImageURL = ({
 	mainImage,
 	imageWidth,
 	resolution,
-	aspectRatio,
+	aspectRatio = 'none',
 }: {
 	mainImage: string;
 	imageWidth: number;
@@ -53,12 +53,10 @@ export const generateImageURL = ({
 		width: imageWidth.toString(),
 		dpr: String(resolution === 'high' ? 2 : 1),
 		s: 'none',
+		crop: aspectRatio,
 	});
-
-	// Only append the crop parameter if it's provided
-	const cropParam = aspectRatio ? `&crop=${aspectRatio}` : '';
 
 	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${
 		url.pathname
-	}?${params.toString()}${cropParam}`;
+	}?${params.toString()}`;
 };


### PR DESCRIPTION
## What does this change?
Request 5:4 image crops from Fastly directly, rather than mutating the image on the platform with css. 


## Why?
The fairground redesign project requires images to be in a 5:4 aspect ratio. However, sometimes, editorial will use a 5:3 image instead. In this circumstance, we want to request a 5:4 crop of the image. Previously, this was being handled in css on the platform but this is inefficient as we are requesting an image that is too large for its use. 

This PR works in coupled with https://github.com/guardian/fastly-image-service/pull/88 which add the crop param to the list of accepted params in [Fastly Image Optimizer](https://www.fastly.com/documentation/reference/io/).

## Screenshots

| 5:4      | no crop | network requests |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![network][] |

[before]: https://github.com/user-attachments/assets/48303831-76dd-4e08-8ade-73e55e26d73a
[after]: https://github.com/user-attachments/assets/81cfb97d-87a6-4c0b-8af2-e5ce5ed886f1
[network]: https://github.com/user-attachments/assets/d7ea3ac4-cbc6-4432-bb74-1cfa53113416

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
