### PR TITLE
Update `small` card headline styles for mobile

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -184,8 +184,6 @@ const fontStylesOnMobile = ({
 					${headlineMedium17}
 				}
 			`;
-		default:
-			return undefined;
 	}
 };
 

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -301,27 +301,27 @@ export const CardHeadline = ({
 				className={`${
 					isSublink ? 'card-sublink-headline' : 'card-headline'
 				}`}
-				css={[
-					format.theme !== ArticleSpecial.Labs &&
-						fontStylesOnMobile({
-							size: sizeOnMobile ?? size,
-							boostedFontSizes,
-						}),
-
-					format.theme !== ArticleSpecial.Labs &&
-						fontStylesOnTablet({
-							size: sizeOnTablet,
-							boostedFontSizes,
-						}),
-					format.theme === ArticleSpecial.Labs
-						? labTextStyles(size)
-						: fontStyles({ size, boostedFontSizes }),
-					isSublink &&
-						size === 'tiny' &&
-						css`
-							${textSans14}
-						`,
-				]}
+				css={
+					isSublink && size === 'tiny'
+						? css`
+								${textSans14}
+						  `
+						: [
+								format.theme !== ArticleSpecial.Labs &&
+									fontStylesOnMobile({
+										size: sizeOnMobile ?? size,
+										boostedFontSizes,
+									}),
+								format.theme !== ArticleSpecial.Labs &&
+									fontStylesOnTablet({
+										size: sizeOnTablet,
+										boostedFontSizes,
+									}),
+								format.theme === ArticleSpecial.Labs
+									? labTextStyles(size)
+									: fontStyles({ size, boostedFontSizes }),
+						  ]
+				}
 			>
 				{!!kickerText && (
 					<Kicker

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -3,6 +3,7 @@ import {
 	between,
 	from,
 	headlineMedium14,
+	headlineMedium15,
 	headlineMedium17,
 	headlineMedium20,
 	headlineMedium24,
@@ -166,6 +167,15 @@ const fontStylesOnMobile = ({
 				}
 			`;
 		case 'small':
+			return css`
+				${until.desktop} {
+					${headlineMedium15}
+				}
+				${between.tablet.and.desktop} {
+					${headlineMedium17}
+				}
+			`;
+		case 'tiny':
 			return css`
 				${until.mobileMedium} {
 					${headlineMedium14}

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -482,6 +482,12 @@ const Card75_ColumnOfCards25 = ({
 											? 'medium'
 											: 'small'
 									}
+									headlineSizeOnMobile={
+										cardIndex === 0 ||
+										remaining.length === 2
+											? undefined
+											: 'tiny'
+									}
 									supportingContent={limitSupportingContent(
 										card,
 									)}

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -54,6 +54,7 @@ export const FixedSmallSlowVThird = ({
 									showAge={showAge}
 									absoluteServerTimes={absoluteServerTimes}
 									headlineSize="small"
+									headlineSizeOnMobile="tiny"
 									imagePositionOnDesktop="left"
 									imagePositionOnMobile="none"
 									imageSize="small"

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -153,7 +153,7 @@ export const HighlightsCard = ({
 						headlineText={headlineText}
 						format={format}
 						size="medium"
-						sizeOnMobile="small"
+						sizeOnMobile="tiny"
 						showPulsingDot={
 							format.design === ArticleDesign.LiveBlog
 						}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -285,7 +285,6 @@ export const ScrollableSmall = ({
 								showAge={!!showAge}
 								headlineSize="small"
 								headlineSizeOnMobile="small"
-								headlineSizeOnTablet="small"
 								imagePositionOnDesktop="left"
 								imagePositionOnMobile="left"
 								imageSize="small" // TODO - needs fixed width images

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -176,6 +176,7 @@ export const ShowMore = ({
 											containerPalette={containerPalette}
 											showAge={showAge}
 											headlineSize="small"
+											headlineSizeOnMobile="tiny"
 											imageLoading="eager"
 											absoluteServerTimes={false}
 										/>

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -804,6 +804,7 @@ export const CardDefault = ({
 			imageLoading={'lazy'}
 			avatarUrl={undefined}
 			headlineSize="small"
+			headlineSizeOnMobile="tiny"
 			isPlayableMediaCard={false}
 			isTagPage={isTagPage}
 		/>
@@ -842,6 +843,7 @@ export const CardDefaultMedia = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSize="small"
+			headlineSizeOnMobile="tiny"
 			isPlayableMediaCard={false}
 		/>
 	);
@@ -879,6 +881,7 @@ export const CardDefaultMediaMobile = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSize="small"
+			headlineSizeOnMobile="tiny"
 			isPlayableMediaCard={false}
 		/>
 	);


### PR DESCRIPTION
## What does this change?

Updates `small` card headline styles for mobile. `headlineMedium15` is applied up to the `tablet` breakpoint where it switches to `headlineMedium17`. The existing `small` style added for the highlights container has been renamed to `tiny` to reflect the smaller font size.

### Mapping

| Before | After |
| --- | --- |
| size="small" | size="small" sizeOnMobile="tiny" |
| size="medium" sizeOnMobile="small" | size="medium" sizeOnMobile="tiny" |

### Before

`size="small`

```
< mobileMedium: 14
> mobileMedium < desktop: 17
desktop: 17
```

`size="medium"`

```
< desktop: 17
desktop: 20
```

`size="medium sizeOnMobile="small"`

```
< mobileMedium: 14
> mobileMedium < desktop: 17
desktop: 20
```

### After

`size="small"`

```
< tablet: 15
> tablet < desktop: 17
desktop: 17
```

`size="tiny"`

```
< mobileMedium: 14
> mobileMedium < desktop: 17
desktop: 14
```

`size="small" sizeOnMobile="tiny"`

```
< mobileMedium: 14
> mobileMedium < desktop: 17
desktop: 17
```

`size="medium" sizeOnMobile="small"`

```
< tablet: 15
> tablet < desktop: 17
desktop: 20
```

`size="medium" sizeOnMobile="tiny"`

```
< mobileMedium: 14
> mobileMedium < desktop: 17
default: 20
```

## Why?

This is required for the scrollable small container.

## Screenshots

| Mobile      | Tabet      |
| ----------- | ---------- |
| ![mobile][] | ![tablet][] |

[mobile]: https://github.com/user-attachments/assets/1040c79d-36de-4712-b407-f51f69817450
[tablet]: https://github.com/user-attachments/assets/210ac76d-25a9-4b65-a42e-8a7aab110143

