### PR TITLE
Swap Highlights test for Europe beta test

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -166,14 +166,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const { abTests, isPreview } = front.config;
 
-	// If viewing a front through the internal preview tool, we want to automatically opt-in to this test.
-	const isInEuropeBetaTest =
-		abTests.europeBetaFrontVariant === 'variant' || isPreview;
-
 	const { absoluteServerTimes = false } = front.config.switches;
 
 	const Highlights = () => {
-		const showHighlights = front.isNetworkFront && isInEuropeBetaTest;
+		const showHighlights =
+			// Must be opted into the Europe beta test or in preview
+			(abTests.europeBetaFrontVariant === 'variant' || isPreview) &&
+			// Must either be a network front or the Europe beta front (or training version of it) in order to see Highlights
+			(front.isNetworkFront || front.pageId.startsWith('europe-beta'));
 
 		const highlightsCollection =
 			front.pressedPage.collections.find(isHighlights);


### PR DESCRIPTION
## What does this change?

In the logic to determine when to render the highlights container, this PR swaps the AB test referenced from `masthead-with-highlights` to `europe-beta-front`

Additionally reworks the logic for when to display the Highlights container if one is configured in the fronts tool. Now both of the following must be true in order to see the Highlights container:
- must be opted into the Europe beta front test OR in the preview tool
- must be on a network front OR a front with page ID starting with `"europe-beta"` (this allows previewing the `europe-beta` and `europe-beta-training` fronts, ahead of the full AB test since europe-beta is not a network front)

## Why?

The highlights test has ended now, and we are preparing for the next AB test, Europe beta, where we will show a different version of the front depending on whether you are in the AB test or not.

