### PR TITLE
Position headline based on live links

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -216,6 +216,27 @@ const decideSublinkPosition = (
 	return alignment === 'vertical' ? 'inner' : 'outer';
 };
 
+const getHeadlinePosition = ({
+	isFlexSplash,
+	containerType,
+	showLivePlayable,
+}: {
+	containerType?: DCRContainerType;
+	isFlexSplash?: boolean;
+	showLivePlayable: boolean;
+}) => {
+	if (containerType === 'flexible/special' && isFlexSplash) return 'outer';
+
+	if (
+		containerType === 'flexible/general' &&
+		isFlexSplash &&
+		showLivePlayable
+	)
+		return 'outer';
+
+	return 'inner';
+};
+
 const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	const timeDiffMs = Math.abs(
 		new Date().getTime() - new Date(webPublicationDate).getTime(),
@@ -389,10 +410,11 @@ export const Card = ({
 		containerType === 'flexible/special' ||
 		containerType === 'flexible/general';
 
-	const isFlexibleSpecialContainer = containerType === 'flexible/special';
-
-	const headlinePosition =
-		isFlexSplash && isFlexibleSpecialContainer ? 'outer' : 'inner';
+	const headlinePosition = getHeadlinePosition({
+		containerType,
+		isFlexSplash,
+		showLivePlayable,
+	});
 
 	/** Determines the gap of between card components based on card properties */
 	const getGapSize = (): GapSize => {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -225,14 +225,17 @@ const getHeadlinePosition = ({
 	isFlexSplash?: boolean;
 	showLivePlayable: boolean;
 }) => {
-	if (containerType === 'flexible/special' && isFlexSplash) return 'outer';
+	if (containerType === 'flexible/special' && isFlexSplash) {
+		return 'outer';
+	}
 
 	if (
 		containerType === 'flexible/general' &&
 		isFlexSplash &&
 		showLivePlayable
-	)
+	) {
 		return 'outer';
+	}
 
 	return 'inner';
 };


### PR DESCRIPTION
## What does this change?
extends the headline position logic of cards so that a flexible general splash card that has live links will have an outer headline.

## Why?
This is as per designs for the new fairground containers

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[after]: https://github.com/user-attachments/assets/80679a20-496d-4a5b-94e3-09020b38b012
[before]: https://github.com/user-attachments/assets/582c19b1-edc3-458b-b8bd-2ddd7f1a6145


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
