### PR TITLE
Feed data to scrollable small container

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -27,6 +27,7 @@ import { FlexibleSpecial } from './FlexibleSpecial';
 import { Island } from './Island';
 import { NavList } from './NavList';
 import { ScrollableHighlights } from './ScrollableHighlights.importable';
+import { ScrollableSmall } from './ScrollableSmall.importable';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -250,6 +251,15 @@ export const DecideContainer = ({
 				/>
 			);
 		case 'scrollable/small':
+			return (
+				<Island priority="critical">
+					<ScrollableSmall
+						trails={trails}
+						imageLoading={imageLoading}
+						containerType={'scrollable/small'}
+					/>
+				</Island>
+			);
 		case 'scrollable/medium':
 		case 'scrollable/feature':
 		case 'static/feature/2':

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -14,7 +14,6 @@ const FORBIDDEN_CONTAINERS = [
 ];
 
 const UNSUPPORTED_CONTAINERS = [
-	'scrollable/small',
 	'scrollable/medium',
 	'scrollable/feature',
 	'static/feature/2',


### PR DESCRIPTION
## What does this change?

Removes scrollable small from the list of unsupported containers and feeds data through in `decideContainer`. The component is wrapped in an island to ensure the carousel's arrows function correctly (for which they need javascript).

## Why?

Part of fairground, closes this [ticket](https://trello.com/c/YOOCvRv9/610-scrollable-small-feed-data-through-to-component)

## Screenshots

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/e2843896-203f-45b8-b978-7a0c2321c261">

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
