### PR TITLE
[Fairground 🎡] live link design

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -882,9 +882,7 @@ export const Card = ({
 							containerPalette={containerPalette}
 							absoluteServerTimes={absoluteServerTimes}
 							displayHeader={isFlexibleContainer}
-							directionOnMobile={
-								isFlexibleContainer ? 'horizontal' : undefined
-							}
+							directionOnMobile={'horizontal'}
 						></LatestLinks>
 					</Island>
 				)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -97,6 +97,7 @@ export type Props = {
 	dataLinkName?: string;
 	/** Only used on Labs cards */
 	branding?: Branding;
+	/** Supporting content refers to sublinks */
 	supportingContent?: DCRSupportingContent[];
 	supportingContentAlignment?: Alignment;
 	supportingContentPosition?: Position;
@@ -107,10 +108,13 @@ export type Props = {
 	discussionApiUrl: string;
 	discussionId?: string;
 	/** The first card in a dynamic package is ”Dynamo” and gets special styling */
-	isDynamo?: true;
+	isDynamo?: boolean;
 	isExternalLink: boolean;
 	slideshowImages?: DCRSlideshowImage[];
+	/** Determines if liveblog update links are displayed on a card */
 	showLivePlayable?: boolean;
+	liveUpdatesAlignment?: Alignment;
+	liveUpdatesPosition?: Position;
 	onwardsSource?: OnwardsSource;
 	pauseOffscreenVideo?: boolean;
 	showMainVideo?: boolean;
@@ -304,6 +308,8 @@ export const Card = ({
 	isExternalLink,
 	slideshowImages,
 	showLivePlayable = false,
+	liveUpdatesAlignment = 'vertical',
+	liveUpdatesPosition = 'inner',
 	onwardsSource,
 	pauseOffscreenVideo = false,
 	showMainVideo = true,
@@ -810,29 +816,39 @@ export const Card = ({
 									showLivePlayable={showLivePlayable}
 								/>
 							)}
+							{showLivePlayable &&
+								liveUpdatesPosition === 'inner' && (
+									<Island
+										priority="feature"
+										defer={{ until: 'visible' }}
+									>
+										<LatestLinks
+											id={linkTo}
+											isDynamo={isDynamo}
+											direction={
+												isFlexibleContainer
+													? liveUpdatesAlignment
+													: supportingContentAlignment
+											}
+											containerPalette={containerPalette}
+											absoluteServerTimes={
+												absoluteServerTimes
+											}
+											displayHeader={isFlexibleContainer}
+											directionOnMobile={
+												isFlexibleContainer
+													? 'horizontal'
+													: undefined
+											}
+										></LatestLinks>
+									</Island>
+								)}
 						</div>
 
 						{/* This div is needed to push this content to the bottom of the card */}
 						<div
 							style={isOnwardContent ? { marginTop: 'auto' } : {}}
 						>
-							{showLivePlayable && (
-								<Island
-									priority="feature"
-									defer={{ until: 'visible' }}
-								>
-									<LatestLinks
-										id={linkTo}
-										isDynamo={isDynamo}
-										direction={supportingContentAlignment}
-										containerPalette={containerPalette}
-										absoluteServerTimes={
-											absoluteServerTimes
-										}
-										displayHeader={isFlexibleContainer}
-									></LatestLinks>
-								</Island>
-							)}
 							{decideInnerSublinks()}
 						</div>
 
@@ -853,6 +869,25 @@ export const Card = ({
 							: 0,
 				}}
 			>
+				{showLivePlayable && liveUpdatesPosition === 'outer' && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<LatestLinks
+							id={linkTo}
+							isDynamo={isDynamo}
+							direction={
+								isFlexibleContainer
+									? liveUpdatesAlignment
+									: supportingContentAlignment
+							}
+							containerPalette={containerPalette}
+							absoluteServerTimes={absoluteServerTimes}
+							displayHeader={isFlexibleContainer}
+							directionOnMobile={
+								isFlexibleContainer ? 'horizontal' : undefined
+							}
+						></LatestLinks>
+					</Island>
+				)}
 				{decideOuterSublinks()}
 
 				{showCommentFooter && (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -58,7 +58,7 @@ import {
 	TrailTextWrapper,
 } from './components/TrailTextWrapper';
 
-type Position = 'inner' | 'outer' | 'none';
+export type Position = 'inner' | 'outer' | 'none';
 
 export type Props = {
 	linkTo: string;

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -5,6 +5,7 @@ import type {
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
+import { Position } from './Card/Card';
 import type {
 	ImagePositionType,
 	ImageSizeType,
@@ -199,6 +200,7 @@ export const SplashCardLayout = ({
 					imageLoading={imageLoading}
 					aspectRatio="5:4"
 					kickerText={card.kickerText}
+					showLivePlayable={card.showLivePlayable}
 					liveUpdatesAlignment={liveUpdatesAlignment}
 					boostedFontSizes={true}
 					isFlexSplash={true}
@@ -216,7 +218,7 @@ type BoostedCardProperties = {
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imageSize: ImageSizeType;
-	liveUpdatesPosition: 'inner' | 'outer';
+	liveUpdatesPosition: Position;
 	supportingContentAlignment: Alignment;
 };
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -5,7 +5,7 @@ import type {
 	DCRFrontCard,
 	DCRGroupedTrails,
 } from '../types/front';
-import { Position } from './Card/Card';
+import type { Position } from './Card/Card';
 import type {
 	ImagePositionType,
 	ImageSizeType,

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -74,6 +74,7 @@ type BoostedSplashProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	imageSize: ImageSizeType;
 	supportingContentAlignment: Alignment;
+	liveUpdatesAlignment: Alignment;
 	trailTextSize: TrailTextSize;
 };
 
@@ -96,6 +97,7 @@ const decideSplashCardProperties = (
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
+				liveUpdatesAlignment: 'vertical',
 				trailTextSize: 'regular',
 			};
 		case 'boost':
@@ -108,6 +110,7 @@ const decideSplashCardProperties = (
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
+				liveUpdatesAlignment: 'vertical',
 				trailTextSize: 'regular',
 			};
 		case 'megaboost':
@@ -119,6 +122,7 @@ const decideSplashCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				liveUpdatesAlignment: 'horizontal',
 				trailTextSize: 'large',
 			};
 		case 'gigaboost':
@@ -130,6 +134,7 @@ const decideSplashCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				liveUpdatesAlignment: 'horizontal',
 				trailTextSize: 'large',
 			};
 	}
@@ -159,6 +164,7 @@ export const SplashCardLayout = ({
 		imagePositionOnMobile,
 		imageSize,
 		supportingContentAlignment,
+		liveUpdatesAlignment,
 		trailTextSize,
 	} = decideSplashCardProperties(
 		card.boostLevel ?? 'default',
@@ -193,7 +199,7 @@ export const SplashCardLayout = ({
 					imageLoading={imageLoading}
 					aspectRatio="5:4"
 					kickerText={card.kickerText}
-					showLivePlayable={card.showLivePlayable}
+					liveUpdatesAlignment={liveUpdatesAlignment}
 					boostedFontSizes={true}
 					isFlexSplash={true}
 					showTopBarDesktop={false}
@@ -210,6 +216,7 @@ type BoostedCardProperties = {
 	headlineSizeOnMobile: SmallHeadlineSize;
 	headlineSizeOnTablet: SmallHeadlineSize;
 	imageSize: ImageSizeType;
+	liveUpdatesPosition: 'inner' | 'outer';
 	supportingContentAlignment: Alignment;
 };
 
@@ -226,6 +233,7 @@ const decideCardProperties = (
 				headlineSizeOnMobile: 'small',
 				headlineSizeOnTablet: 'tiny',
 				imageSize: 'jumbo',
+				liveUpdatesPosition: 'outer',
 				supportingContentAlignment: 'horizontal',
 			};
 		case 'boost':
@@ -235,7 +243,8 @@ const decideCardProperties = (
 				headlineSizeOnMobile: 'tiny',
 				headlineSizeOnTablet: 'tiny',
 				imageSize: 'medium',
-				supportingContentAlignment: 'vertical',
+				liveUpdatesPosition: 'inner',
+				supportingContentAlignment: 'horizontal',
 			};
 	}
 };
@@ -262,6 +271,7 @@ export const BoostedCardLayout = ({
 		headlineSizeOnTablet,
 		imageSize,
 		supportingContentAlignment,
+		liveUpdatesPosition,
 	} = decideCardProperties(card.boostLevel);
 	return (
 		<UL padBottom={true} isFlexibleContainer={true} showTopBar={true}>
@@ -292,9 +302,11 @@ export const BoostedCardLayout = ({
 					aspectRatio="5:4"
 					kickerText={card.kickerText}
 					showLivePlayable={card.showLivePlayable}
+					liveUpdatesAlignment="horizontal"
 					showTopBarDesktop={false}
 					showTopBarMobile={true}
 					boostedFontSizes={true}
+					liveUpdatesPosition={liveUpdatesPosition}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -31,6 +31,7 @@ type BoostProperties = {
 	imagePositionOnMobile: ImagePositionType;
 	imageSize: ImageSizeType;
 	supportingContentAlignment: Alignment;
+	liveUpdatesAlignment: Alignment;
 	trailTextSize: TrailTextSize;
 };
 
@@ -53,6 +54,7 @@ const determineCardProperties = (
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+				liveUpdatesAlignment: 'vertical',
 				trailTextSize: 'regular',
 			};
 
@@ -66,6 +68,7 @@ const determineCardProperties = (
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
+				liveUpdatesAlignment: 'horizontal',
 				trailTextSize: 'regular',
 			};
 		case 'megaboost':
@@ -77,6 +80,7 @@ const determineCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				liveUpdatesAlignment: 'horizontal',
 				trailTextSize: 'large',
 			};
 		case 'gigaboost':
@@ -88,6 +92,7 @@ const determineCardProperties = (
 				imagePositionOnMobile: 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
+				liveUpdatesAlignment: 'horizontal',
 				trailTextSize: 'large',
 			};
 	}
@@ -116,6 +121,7 @@ export const OneCardLayout = ({
 		imagePositionOnMobile,
 		imageSize,
 		supportingContentAlignment,
+		liveUpdatesAlignment,
 		trailTextSize,
 	} = determineCardProperties(
 		card.boostLevel ?? 'default',
@@ -143,6 +149,7 @@ export const OneCardLayout = ({
 					aspectRatio="5:4"
 					kickerText={card.kickerText}
 					showLivePlayable={card.showLivePlayable}
+					liveUpdatesAlignment={liveUpdatesAlignment}
 					boostedFontSizes={true}
 					isFlexSplash={true}
 					showTopBarDesktop={false}

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -4,6 +4,7 @@ import {
 	textSans14,
 	textSansBold14,
 	textSansBold17,
+	until,
 } from '@guardian/source/foundations';
 import { DottedLines } from '@guardian/source-development-kitchen/react-components';
 import { revealStyles } from '../lib/revealStyles';
@@ -22,6 +23,7 @@ type Props = {
 	isDynamo?: boolean;
 	containerPalette?: DCRContainerPalette;
 	displayHeader?: boolean;
+	directionOnMobile?: Alignment;
 };
 
 const header = css`
@@ -63,6 +65,20 @@ const bold = css`
 	}
 `;
 
+const directionOnMobileStyles = (direction: Alignment) => {
+	return direction === 'horizontal'
+		? css`
+				${until.tablet} {
+					${horizontal}
+				}
+		  `
+		: css`
+				${until.tablet} {
+					${vertical}
+				}
+		  `;
+};
+
 const transparent = css`
 	color: transparent;
 `;
@@ -102,6 +118,7 @@ export const LatestLinks = ({
 	containerPalette,
 	absoluteServerTimes,
 	displayHeader = false,
+	directionOnMobile,
 }: Props) => {
 	const { data } = useApi<{
 		blocks: Array<{
@@ -149,6 +166,8 @@ export const LatestLinks = ({
 					!!isDynamo || direction === 'horizontal'
 						? horizontal
 						: vertical,
+					directionOnMobile &&
+						directionOnMobileStyles(directionOnMobile),
 					css`
 						color: ${themePalette('--card-trail-text')};
 					`,


### PR DESCRIPTION
## What does this change?
Separates out live link position and alignment from sublinks when in a new container and introduces inner and outer variants of the live links.

## Why?
This is due to the fairground redesign which requires the live links to have different positions and alignments to sublinks. This is also the first design that features live links in the outer position. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/58dcb86c-5f04-4d8e-81e8-ffbf7f4b311d
[after]: https://github.com/user-attachments/assets/f95ad62b-8339-485c-adc2-e9e1da6a808b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
