### PR TITLE
Move the US Expandable Marketing Card out of the grid

### DIFF
--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
@@ -29,26 +28,6 @@ const bodyStyles = css`
 	${getZIndex('bodyArea')}
 `;
 
-const usCardStyles = css`
-	align-self: start;
-	position: sticky;
-	top: 0;
-	${getZIndex('expandableMarketingCardOverlay')}
-
-	${from.leftCol} {
-		margin-top: ${space[6]}px;
-		margin-bottom: ${space[9]}px;
-
-		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
-		margin-left: 1px;
-		margin-right: -1px;
-	}
-
-	${from.wide} {
-		margin-left: 0;
-	}
-`;
-
 const gridArea = css`
 	grid-area: var(--grid-area);
 `;
@@ -62,7 +41,6 @@ export const GridItem = ({
 		css={[
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
-			area === 'uscard' && usCardStyles,
 			gridArea,
 		]}
 		style={{

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -182,7 +182,6 @@ const StandardGrid = ({
 
 				${until.tablet} {
 					grid-column-gap: 0px;
-
 					grid-template-columns: 100%; /* Main content */
 					grid-template-areas:
 						'title'

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
+	space,
 	until,
 } from '@guardian/source/foundations';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
@@ -48,6 +49,7 @@ import {
 	ArticleDisplay,
 	type ArticleFormat,
 } from '../lib/format';
+import { getZIndex } from '../lib/getZIndex';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -101,20 +103,18 @@ const StandardGrid = ({
 									'title      border  headline   headline   headline'
 									'lines      border  headline   headline   headline'
 									'meta       border  standfirst standfirst standfirst'
-									'uscard     border  standfirst standfirst standfirst'
-									'uscard     border  media      media      media'
-									'uscard     border  body       .          right-column'
-									'uscard     border  .          .          right-column';
+									'meta       border  media      media      media'
+									'meta       border  body       .          right-column'
+									'.          border  .          .          right-column';
 						  `
 						: css`
 								grid-template-areas:
 									'title      border  headline   . right-column'
 									'lines      border  headline   . right-column'
 									'meta       border  standfirst . right-column'
-									'uscard     border  standfirst . right-column'
-									'uscard     border  media      . right-column'
-									'uscard     border  body       . right-column'
-									'uscard     border  .          . right-column';
+									'meta       border  media      . right-column'
+									'meta       border  body       . right-column'
+									'.          border  .          . right-column';
 						  `}
 				}
 
@@ -132,23 +132,21 @@ const StandardGrid = ({
 					${display === ArticleDisplay.Showcase
 						? css`
 								grid-template-areas:
-									'title   border  headline    headline'
-									'lines   border  headline    headline'
-									'meta    border  standfirst  standfirst'
-									'uscard  border  standfirst  standfirst'
-									'uscard  border  media       media'
-									'uscard  border  body        right-column'
-									'uscard  border  .           right-column';
+									'title      border  headline    headline'
+									'lines      border  headline    headline'
+									'meta       border  standfirst  standfirst'
+									'meta       border  media       media'
+									'meta       border  body        right-column'
+									'.          border  .           right-column';
 						  `
 						: css`
 								grid-template-areas:
-									'title   border  headline    right-column'
-									'lines   border  headline    right-column'
-									'meta    border  standfirst  right-column'
-									'uscard  border  standfirst  right-column'
-									'uscard  border  media       right-column'
-									'uscard  border  body        right-column'
-									'uscard  border  .           right-column';
+									'title      border  headline    right-column'
+									'lines      border  headline    right-column'
+									'meta       border  standfirst  right-column'
+									'meta       border  media       right-column'
+									'meta       border  body        right-column'
+									'.          border  .           right-column';
 						  `}
 				}
 
@@ -207,6 +205,25 @@ const maxWidth = css`
 	}
 `;
 
+const usCardStyles = css`
+	align-self: start;
+	position: sticky;
+	top: 0;
+	${getZIndex('expandableMarketingCardOverlay')}
+
+	${from.leftCol} {
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[9]}px;
+
+		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
+		margin-left: 1px;
+		margin-right: -1px;
+	}
+
+	${from.wide} {
+		margin-left: 0;
+	}
+`;
 const avatarHeadlineWrapper = css`
 	display: flex;
 	flex-direction: column;
@@ -534,44 +551,55 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 										</Hide>
 									</>
 								) : (
-									<ArticleMeta
-										branding={branding}
-										format={format}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										byline={article.byline}
-										tags={article.tags}
-										primaryDateline={
-											article.webPublicationDateDisplay
-										}
-										secondaryDateline={
-											article.webPublicationSecondaryDateDisplay
-										}
-										isCommentable={article.isCommentable}
-										discussionApiUrl={
-											article.config.discussionApiUrl
-										}
-										shortUrlId={article.config.shortUrlId}
-									/>
+									<>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											tags={article.tags}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												article.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
+											}
+										/>
+										{isWeb && (
+											<div css={usCardStyles}>
+												<Hide
+													when="below"
+													breakpoint="leftCol"
+												>
+													<Island
+														priority="enhancement"
+														defer={{
+															until: 'visible',
+														}}
+													>
+														<ExpandableMarketingCardWrapper
+															guardianBaseURL={
+																article.guardianBaseURL
+															}
+														/>
+													</Island>
+												</Hide>
+											</div>
+										)}
+									</>
 								)}
 							</div>
 						</GridItem>
-						{isWeb && (
-							<GridItem area="uscard" element="aside">
-								<Hide when="below" breakpoint="leftCol">
-									<Island
-										priority="enhancement"
-										defer={{ until: 'visible' }}
-									>
-										<ExpandableMarketingCardWrapper
-											guardianBaseURL={
-												article.guardianBaseURL
-											}
-										/>
-									</Island>
-								</Hide>
-							</GridItem>
-						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<div css={maxWidth}>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -89,8 +89,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Vertical grey border
 					Main content
 					Right Column
-
-					Duplicate lines are required to ensure the left column does not have extra vertical space.
 				*/
 				${from.wide} {
 					grid-column-gap: 10px;
@@ -102,10 +100,8 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      byline     . right-column'
 						'lines      border      body       . right-column'
 						'meta       border      body       . right-column'
-						'uscard     border      body       . right-column'
-						'uscard     border      .          . right-column'
-						'uscard     border      .          . right-column'
-						'uscard     border      .          . right-column';
+						'meta       border      body       . right-column'
+						'.          border      .          . right-column';
 				}
 
 				/*
@@ -115,8 +111,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 					Vertical grey border
 					Main content
 					Right Column
-
-					Duplicate lines are required to ensure the left column does not have extra vertical space.
 				*/
 				${until.wide} {
 					grid-column-gap: 10px;
@@ -128,10 +122,8 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      byline      right-column'
 						'lines      border      body        right-column'
 						'meta       border      body        right-column'
-						'uscard     border      body        right-column'
-						'uscard     border      .           right-column'
-						'uscard     border      .           right-column'
-						'uscard     border      .           right-column';
+						'meta       border      body        right-column'
+						'.          border      .           right-column';
 				}
 
 				/*
@@ -177,6 +169,26 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 const maxWidth = css`
 	${from.desktop} {
 		max-width: 620px;
+	}
+`;
+
+const usCardStyles = css`
+	align-self: start;
+	position: sticky;
+	top: 0;
+	${getZIndex('expandableMarketingCardOverlay')}
+
+	${from.leftCol} {
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[9]}px;
+
+		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
+		margin-left: 1px;
+		margin-right: -1px;
+	}
+
+	${from.wide} {
+		margin-left: 0;
 	}
 `;
 
@@ -648,26 +660,31 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										{!!article.affiliateLinksDisclaimer && (
 											<AffiliateDisclaimer />
 										)}
+										{isWeb && (
+											<div css={usCardStyles}>
+												<Hide
+													when="below"
+													breakpoint="leftCol"
+												>
+													<Island
+														priority="enhancement"
+														defer={{
+															until: 'visible',
+														}}
+													>
+														<ExpandableMarketingCardWrapper
+															guardianBaseURL={
+																article.guardianBaseURL
+															}
+														/>
+													</Island>
+												</Hide>
+											</div>
+										)}
 									</>
 								)}
 							</div>
 						</GridItem>
-						{isWeb && (
-							<GridItem area="uscard" element="aside">
-								<Hide when="below" breakpoint="leftCol">
-									<Island
-										priority="enhancement"
-										defer={{ until: 'visible' }}
-									>
-										<ExpandableMarketingCardWrapper
-											guardianBaseURL={
-												article.guardianBaseURL
-											}
-										/>
-									</Island>
-								</Hide>
-							</GridItem>
-						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -98,7 +98,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      headline   . right-column'
 						'.          border      standfirst . right-column'
 						'.          border      byline     . right-column'
-						'lines      border      body       . right-column'
 						'meta       border      body       . right-column'
 						'meta       border      body       . right-column'
 						'.          border      .          . right-column';
@@ -120,7 +119,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'.          border      headline    right-column'
 						'.          border      standfirst  right-column'
 						'.          border      byline      right-column'
-						'lines      border      body        right-column'
 						'meta       border      body        right-column'
 						'meta       border      body        right-column'
 						'.          border      .           right-column';
@@ -141,7 +139,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'standfirst  right-column'
 						'byline      right-column'
 						'caption     right-column'
-						'lines       right-column'
 						'meta        right-column'
 						'body        right-column';
 				}
@@ -155,7 +152,6 @@ const ImmersiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'standfirst'
 						'byline'
 						'caption'
-						'lines'
 						'meta'
 						'body';
 				}
@@ -555,7 +551,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								/>
 							)}
 						</GridItem>
-						<GridItem area="lines">
+						<GridItem area="meta" element="aside">
 							{format.design === ArticleDesign.PhotoEssay &&
 							!isLabs ? (
 								<></>
@@ -576,8 +572,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 									</div>
 								</div>
 							)}
-						</GridItem>
-						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								{isApps ? (
 									<>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -85,7 +85,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title  border  headline'
 						'.      border  standfirst'
-						'lines  border  media'
 						'meta   border  media'
 						'uscard border  media'
 						'uscard border  submeta'
@@ -98,7 +97,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title  border  headline    headline   headline'
 						'.      border  standfirst  standfirst standfirst'
-						'lines  border  media       media      media'
 						'meta   border  media       media      media'
 						'uscard border  media       media      media'
 						'uscard border  submeta     submeta    submeta'
@@ -118,7 +116,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title     '
 						'headline  '
-						'lines     '
 						'meta      '
 						'standfirst'
 						'media     '
@@ -132,7 +129,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title'
 						'headline'
-						'lines'
 						'meta'
 						'standfirst'
 						'media'
@@ -145,7 +141,6 @@ const PictureGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-areas:
 						'title'
 						'headline'
-						'lines'
 						'meta'
 						'standfirst'
 						'media'
@@ -456,7 +451,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								/>
 							</div>
 						</GridItem>
-						<GridItem area="lines">
+						<GridItem area="meta" element="aside">
 							<div
 								css={[
 									LeftColLines(displayAvatarUrl),
@@ -471,8 +466,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									color={themePalette('--straight-lines')}
 								/>
 							</div>
-						</GridItem>
-						<GridItem area="meta" element="aside">
 							<div>
 								{isApps ? (
 									<>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -95,7 +95,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 219px 1px 620px 80px 300px;
 					grid-template-areas:
 						'title  border  headline   headline headline'
-						'lines  border  media      media    media'
 						'meta   border  media      media    media'
 						'meta   border  standfirst .        right-column'
 						'meta   border  body       .        right-column'
@@ -106,7 +105,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 140px 1px 620px 300px;
 					grid-template-areas:
 						'title  border  headline    headline'
-						'lines  border  media       media'
 						'meta   border  media       media'
 						'meta   border  standfirst  right-column'
 						'meta   border  body        right-column'
@@ -126,7 +124,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'headline   right-column'
 						'standfirst right-column'
 						'media      right-column'
-						'lines      right-column'
 						'meta       right-column'
 						'body       right-column'
 						'.          right-column';
@@ -140,7 +137,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'headline'
 						'standfirst'
 						'media'
-						'lines'
 						'meta'
 						'body';
 				}
@@ -153,7 +149,6 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title'
 						'headline'
 						'standfirst'
-						'lines'
 						'meta'
 						'body';
 				}
@@ -470,7 +465,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								standfirst={article.standfirst}
 							/>
 						</GridItem>
-						<GridItem area="lines">
+						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								<div css={stretchLines}>
 									<DecideLines
@@ -479,8 +474,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									/>
 								</div>
 							</div>
-						</GridItem>
-						<GridItem area="meta" element="aside">
 							<div css={[maxWidth, fullHeight]}>
 								{isApps ? (
 									<>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
+	space,
 	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
@@ -49,6 +50,7 @@ import {
 	type ArticleFormat,
 	ArticleSpecial,
 } from '../lib/format';
+import { getZIndex } from '../lib/getZIndex';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
@@ -95,10 +97,9 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title  border  headline   headline headline'
 						'lines  border  media      media    media'
 						'meta   border  media      media    media'
-						'uscard border  media      media    media'
-						'uscard border  standfirst .        right-column'
-						'uscard border  body       .        right-column'
-						'uscard border  .          .        right-column';
+						'meta   border  standfirst .        right-column'
+						'meta   border  body       .        right-column'
+						'.      border  .          .        right-column';
 				}
 
 				${until.wide} {
@@ -107,10 +108,9 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 						'title  border  headline    headline'
 						'lines  border  media       media'
 						'meta   border  media       media'
-						'uscard border  media       media'
-						'uscard border  standfirst  right-column'
-						'uscard border  body        right-column'
-						'uscard border  .           right-column';
+						'meta   border  standfirst  right-column'
+						'meta   border  body        right-column'
+						'.      border  .           right-column';
 				}
 
 				/*
@@ -167,6 +167,30 @@ const ShowcaseGrid = ({ children }: { children: React.ReactNode }) => (
 const maxWidth = css`
 	${from.desktop} {
 		max-width: 620px;
+	}
+`;
+
+const fullHeight = css`
+	height: 100%;
+`;
+
+const usCardStyles = css`
+	align-self: start;
+	position: sticky;
+	top: 0;
+	${getZIndex('expandableMarketingCardOverlay')}
+
+	${from.leftCol} {
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[9]}px;
+
+		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
+		margin-left: 1px;
+		margin-right: -1px;
+	}
+
+	${from.wide} {
+		margin-left: 0;
 	}
 `;
 
@@ -457,7 +481,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 							</div>
 						</GridItem>
 						<GridItem area="meta" element="aside">
-							<div css={maxWidth}>
+							<div css={[maxWidth, fullHeight]}>
 								{isApps ? (
 									<>
 										<Hide from="leftCol">
@@ -539,26 +563,29 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										{!!article.affiliateLinksDisclaimer && (
 											<AffiliateDisclaimer />
 										)}
+
+										{isWeb && (
+											<div css={usCardStyles}>
+												<Hide until="leftCol">
+													<Island
+														priority="enhancement"
+														defer={{
+															until: 'visible',
+														}}
+													>
+														<ExpandableMarketingCardWrapper
+															guardianBaseURL={
+																article.guardianBaseURL
+															}
+														/>
+													</Island>
+												</Hide>
+											</div>
+										)}
 									</>
 								)}
 							</div>
 						</GridItem>
-						{isWeb && (
-							<GridItem area="uscard" element="aside">
-								<Hide until="leftCol">
-									<Island
-										priority="enhancement"
-										defer={{ until: 'visible' }}
-									>
-										<ExpandableMarketingCardWrapper
-											guardianBaseURL={
-												article.guardianBaseURL
-											}
-										/>
-									</Island>
-								</Hide>
-							</GridItem>
-						)}
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -112,7 +112,6 @@ const StandardGrid = ({
 									'title  border  matchtabs  . right-column'
 									'.      border  headline   . right-column'
 									'.      border  standfirst . right-column'
-									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
 									'meta   border  body       . right-column'
 									'.      border  .          . right-column';
@@ -122,7 +121,6 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  headline   headline   .'
 									'.      border  disclaimer disclaimer right-column'
-									'lines  border  media      media      right-column'
 									'meta   border  media      media      right-column'
 									'meta   border  standfirst standfirst right-column'
 									'.      border  body       body       right-column'
@@ -132,7 +130,6 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  headline   . right-column'
 									'.      border  standfirst . right-column'
-									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
 									'meta   border  body       . right-column'
 									'.      border  .          . right-column';
@@ -158,7 +155,6 @@ const StandardGrid = ({
 								'title  border  matchtabs    right-column'
 								'.      border  headline     right-column'
 								'.      border  standfirst   right-column'
-								'lines  border  media        right-column'
 								'meta   border  media        right-column'
 								'meta   border  body         right-column'
 								'.      border  .            right-column';
@@ -168,7 +164,6 @@ const StandardGrid = ({
 							grid-template-areas:
 								'title  border  headline     .'
 								'.      border  disclaimer   right-column'
-								'lines  border  media        right-column'
 								'meta   border  media        right-column'
 								'meta   border  standfirst   right-column'
 								'meta   border  body         right-column'
@@ -179,7 +174,6 @@ const StandardGrid = ({
 								'title  border  headline     right-column'
 								'.      border  standfirst   right-column'
 								'.      border  disclaimer   right-column'
-								'lines  border  media        right-column'
 								'meta   border  media        right-column'
 								'meta   border  body         right-column'
 								'.      border  .            right-column';
@@ -203,7 +197,6 @@ const StandardGrid = ({
 								'headline      right-column'
 								'standfirst    right-column'
 								'media         right-column'
-								'lines         right-column'
 								'meta          right-column'
 								'body          right-column'
 								'.             right-column';
@@ -216,7 +209,6 @@ const StandardGrid = ({
 								'disclaimer    right-column'
 								'media         right-column'
 								'standfirst    right-column'
-								'lines         right-column'
 								'meta          right-column'
 								'body          right-column'
 								'.             right-column';
@@ -228,7 +220,6 @@ const StandardGrid = ({
 								'standfirst    right-column'
 								'disclaimer    right-column'
 								'media         right-column'
-								'lines         right-column'
 								'meta          right-column'
 								'body          right-column'
 								'.             right-column';
@@ -246,7 +237,6 @@ const StandardGrid = ({
 								'headline'
 								'standfirst'
 								'media'
-								'lines'
 								'meta'
 								'body';
 					  `
@@ -258,7 +248,6 @@ const StandardGrid = ({
 								'disclaimer'
 								'media'
 								'standfirst'
-								'lines'
 								'meta'
 								'body';
 					  `
@@ -269,7 +258,6 @@ const StandardGrid = ({
 								'standfirst'
 								'disclaimer'
 								'media'
-								'lines'
 								'meta'
 								'body';
 					  `}
@@ -288,7 +276,6 @@ const StandardGrid = ({
 								'title'
 								'headline'
 								'standfirst'
-								'lines'
 								'meta'
 								'body';
 					  `
@@ -300,7 +287,6 @@ const StandardGrid = ({
 								'disclaimer'
 								'media'
 								'standfirst'
-								'lines'
 								'meta'
 								'body';
 					  `
@@ -311,7 +297,6 @@ const StandardGrid = ({
 								'headline'
 								'standfirst'
 								'disclaimer'
-								'lines'
 								'meta'
 								'body';
 					  `}
@@ -618,7 +603,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								standfirst={article.standfirst}
 							/>
 						</GridItem>
-						<GridItem area="lines">
+						<GridItem area="meta" element="aside">
 							<div css={maxWidth}>
 								<div css={stretchLines}>
 									{isWeb &&
@@ -635,8 +620,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									)}
 								</div>
 							</div>
-						</GridItem>
-						<GridItem area="meta" element="aside">
 							{isApps ? (
 								<>
 									<Hide from="leftCol">

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
+	space,
 	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
@@ -55,6 +56,7 @@ import {
 	type ArticleFormat,
 	ArticleSpecial,
 } from '../lib/format';
+import { getZIndex } from '../lib/getZIndex';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -112,9 +114,8 @@ const StandardGrid = ({
 									'.      border  standfirst . right-column'
 									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
-									'uscard border  media      . right-column'
-									'uscard border  body       . right-column'
-									'uscard border  .          . right-column';
+									'meta   border  body       . right-column'
+									'.      border  .          . right-column';
 						  `
 						: isMedia
 						? css`
@@ -123,10 +124,9 @@ const StandardGrid = ({
 									'.      border  disclaimer disclaimer right-column'
 									'lines  border  media      media      right-column'
 									'meta   border  media      media      right-column'
-									'uscard border  media      media      right-column'
-									'uscard border  standfirst standfirst right-column'
-									'uscard border  body       body       right-column'
-									'uscard border  .          .          right-column';
+									'meta   border  standfirst standfirst right-column'
+									'.      border  body       body       right-column'
+									'.      border  .          .          right-column';
 						  `
 						: css`
 								grid-template-areas:
@@ -134,9 +134,8 @@ const StandardGrid = ({
 									'.      border  standfirst . right-column'
 									'lines  border  media      . right-column'
 									'meta   border  media      . right-column'
-									'uscard border  media      . right-column'
-									'uscard border  body       . right-column'
-									'uscard border  .          . right-column';
+									'meta   border  body       . right-column'
+									'.      border  .          . right-column';
 						  `}
 				}
 			}
@@ -161,9 +160,8 @@ const StandardGrid = ({
 								'.      border  standfirst   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'uscard border  media        right-column'
-								'uscard border  body         right-column'
-								'uscard border  .            right-column';
+								'meta   border  body         right-column'
+								'.      border  .            right-column';
 					  `
 					: isMedia
 					? css`
@@ -172,9 +170,9 @@ const StandardGrid = ({
 								'.      border  disclaimer   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'uscard border  standfirst   right-column'
-								'uscard border  body         right-column'
-								'uscard border  .            right-column';
+								'meta   border  standfirst   right-column'
+								'meta   border  body         right-column'
+								'.      border  .            right-column';
 					  `
 					: css`
 							grid-template-areas:
@@ -183,9 +181,8 @@ const StandardGrid = ({
 								'.      border  disclaimer   right-column'
 								'lines  border  media        right-column'
 								'meta   border  media        right-column'
-								'uscard border  media        right-column'
-								'uscard border  body         right-column'
-								'uscard border  .            right-column';
+								'meta   border  body         right-column'
+								'.      border  .            right-column';
 					  `}
 			}
 
@@ -328,6 +325,26 @@ const StandardGrid = ({
 const maxWidth = css`
 	${from.desktop} {
 		max-width: 620px;
+	}
+`;
+
+const usCardStyles = css`
+	align-self: start;
+	position: sticky;
+	top: 0;
+	${getZIndex('expandableMarketingCardOverlay')}
+
+	${from.leftCol} {
+		margin-top: ${space[6]}px;
+		margin-bottom: ${space[9]}px;
+
+		/* To align with rich links - if we move this feature to production, we should remove this and make rich link align with everything instead */
+		margin-left: 1px;
+		margin-right: -1px;
+	}
+
+	${from.wide} {
+		margin-left: 0;
 	}
 `;
 
@@ -679,49 +696,58 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									</Hide>
 								</>
 							) : (
-								<div css={maxWidth}>
-									<ArticleMeta
-										branding={branding}
-										format={format}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										byline={article.byline}
-										source={article.config.source}
-										tags={article.tags}
-										primaryDateline={
-											article.webPublicationDateDisplay
-										}
-										secondaryDateline={
-											article.webPublicationSecondaryDateDisplay
-										}
-										isCommentable={article.isCommentable}
-										discussionApiUrl={
-											article.config.discussionApiUrl
-										}
-										shortUrlId={article.config.shortUrlId}
-									/>
-									{!!article.affiliateLinksDisclaimer && (
-										<AffiliateDisclaimer />
-									)}
-								</div>
-							)}
-						</GridItem>
-						{isWeb && (
-							<GridItem area="uscard" element="aside">
-								<Hide until="leftCol">
-									<Island
-										priority="enhancement"
-										defer={{ until: 'visible' }}
-									>
-										<ExpandableMarketingCardWrapper
-											guardianBaseURL={
-												article.guardianBaseURL
+								<>
+									<div css={maxWidth}>
+										<ArticleMeta
+											branding={branding}
+											format={format}
+											pageId={article.pageId}
+											webTitle={article.webTitle}
+											byline={article.byline}
+											source={article.config.source}
+											tags={article.tags}
+											primaryDateline={
+												article.webPublicationDateDisplay
+											}
+											secondaryDateline={
+												article.webPublicationSecondaryDateDisplay
+											}
+											isCommentable={
+												article.isCommentable
+											}
+											discussionApiUrl={
+												article.config.discussionApiUrl
+											}
+											shortUrlId={
+												article.config.shortUrlId
 											}
 										/>
-									</Island>
-								</Hide>
-							</GridItem>
-						)}
+										{!!article.affiliateLinksDisclaimer && (
+											<AffiliateDisclaimer />
+										)}
+									</div>
+
+									{isWeb && (
+										<div css={usCardStyles}>
+											<Hide until="leftCol">
+												<Island
+													priority="enhancement"
+													defer={{
+														until: 'visible',
+													}}
+												>
+													<ExpandableMarketingCardWrapper
+														guardianBaseURL={
+															article.guardianBaseURL
+														}
+													/>
+												</Island>
+											</Hide>
+										</div>
+									)}
+								</>
+							)}
+						</GridItem>
 						<GridItem area="body">
 							<ArticleContainer format={format}>
 								<ArticleBody


### PR DESCRIPTION
Fixes #12560 

## What does this change?

Moves the US Expandable Marketing Card component out of its own grid element and into the "meta" grid element.

Moves `lines` into the `meta` css grid section where possible. This reduces complexity of the grid and avoids a bug where the meta section is displayed half-way down the page due to it wanting to fill the space of the left column.

## Why?

Fixes a CSS grid bug where extra whitespace between heading and body, e.g.: https://www.theguardian.com/news/2024/oct/15/corrections-and-clarifications