### PR TITLE
Show trail text on standard cards in `flexible/general` containers if the image has been removed

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -356,6 +356,8 @@ export const StandardCardLayout = ({
 							showLivePlayable={false}
 							showTopBarDesktop={false}
 							showTopBarMobile={true}
+							// On standard cards, we only show the trail text if the trail image has been hidden
+							trailText={!card.image ? card.trailText : undefined}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
## What does this change?

Displays the `trailText` on standard (unboosted) cards within `flexible/general` containers if the image has been removed

## Why?

As per designs for Fairground. Resolves part of [this ticket](https://trello.com/c/Q9aGFZ5u/612-flexible-general-handle-image-removal)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/79956fb9-9025-4e63-ae25-470044181d91
[after]: https://github.com/user-attachments/assets/ba7a111c-568b-4b31-8cfc-6c09538eb9ae
