### PR TITLE
Support fixing image sizes at tablet and desktop

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1510,7 +1510,7 @@ export const WithNoGap = () => {
 	);
 };
 
-export const WithASmallGap = () => {
+export const WithATinyGap = () => {
 	return (
 		<>
 			<CardWrapper>
@@ -1534,6 +1534,30 @@ export const WithASmallGap = () => {
 	);
 };
 
+export const WithASmallGap = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						imagePositionOnDesktop="left"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Comment,
+							theme: Pillar.Opinion,
+						}}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};
+
 export const WithAMediumGap = () => {
 	return (
 		<>
@@ -1545,6 +1569,7 @@ export const WithAMediumGap = () => {
 				>
 					<Card
 						{...basicCardProps}
+						containerType={'scrollable/small'}
 						imagePositionOnDesktop="left"
 						format={{
 							display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -49,6 +49,7 @@ import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
 import { HeadlineWrapper } from './components/HeadlineWrapper';
 import type {
+	ImageFixedSizeOptions,
 	ImagePositionType,
 	ImageSizeType,
 } from './components/ImageWrapper';
@@ -429,10 +430,22 @@ export const Card = ({
 
 	const isSmallCard = containerType === 'scrollable/small';
 
-	const fixedImageSizeOnMobile = () => {
-		if (isSmallCard) return 'small';
-		if (isFlexibleContainer) return 'medium';
-		return 'large';
+	const imageFixedSizeOptions = (): ImageFixedSizeOptions => {
+		if (isSmallCard) {
+			return {
+				mobile: 'small',
+				tablet: 'medium',
+				desktop: 'medium',
+			};
+		}
+
+		if (isFlexibleContainer) {
+			return {
+				mobile: 'medium',
+			};
+		}
+
+		return { mobile: 'large' };
 	};
 
 	const headlinePosition = getHeadlinePosition({
@@ -588,17 +601,11 @@ export const Card = ({
 				{media && (
 					<ImageWrapper
 						imageSize={imageSize}
+						imageFixedSizes={imageFixedSizeOptions()}
 						imageType={media.type}
 						imagePositionOnDesktop={imagePositionOnDesktop}
 						imagePositionOnMobile={imagePositionOnMobile}
 						showPlayIcon={showPlayIcon}
-						fixedImageSizeOnMobile={fixedImageSizeOnMobile()}
-						fixedImageSizeOnTablet={
-							isSmallCard ? 'medium' : undefined
-						}
-						fixedImageSizeOnDesktop={
-							isSmallCard ? 'medium' : undefined
-						}
 					>
 						{media.type === 'slideshow' && (
 							<Slideshow

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -433,19 +433,19 @@ export const Card = ({
 	const imageFixedSizeOptions = (): ImageFixedSizeOptions => {
 		if (isSmallCard) {
 			return {
-				mobile: 'small',
-				tablet: 'medium',
-				desktop: 'medium',
+				mobile: 'tiny',
+				tablet: 'small',
+				desktop: 'small',
 			};
 		}
 
 		if (isFlexibleContainer) {
 			return {
-				mobile: 'medium',
+				mobile: 'small',
 			};
 		}
 
-		return { mobile: 'large' };
+		return { mobile: 'medium' };
 	};
 
 	const headlinePosition = getHeadlinePosition({

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -438,13 +438,7 @@ export const Card = ({
 				desktop: 'small',
 			};
 		}
-
-		if (isFlexibleContainer) {
-			return {
-				mobile: 'small',
-			};
-		}
-
+		if (isFlexibleContainer) return { mobile: 'small' };
 		return { mobile: 'medium' };
 	};
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -471,8 +471,9 @@ export const Card = ({
 	/** Determines the gap of between card components based on card properties */
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
-		if (hasBackgroundColour) return 'small';
-		if (isFlexSplash) return 'medium';
+		if (hasBackgroundColour) return 'tiny';
+		if (isFlexSplash) return 'small';
+		if (isSmallCard) return 'medium';
 		if (
 			isFlexibleContainer &&
 			(imagePositionOnDesktop === 'left' ||
@@ -480,7 +481,7 @@ export const Card = ({
 		) {
 			return 'large';
 		}
-		return 'medium';
+		return 'small';
 	};
 
 	/**

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -427,6 +427,14 @@ export const Card = ({
 		containerType === 'flexible/special' ||
 		containerType === 'flexible/general';
 
+	const isSmallCard = containerType === 'scrollable/small';
+
+	const fixedImageSizeOnMobile = () => {
+		if (isSmallCard) return 'small';
+		if (isFlexibleContainer) return 'medium';
+		return 'large';
+	};
+
 	const headlinePosition = getHeadlinePosition({
 		containerType,
 		isFlexSplash,
@@ -584,7 +592,13 @@ export const Card = ({
 						imagePositionOnDesktop={imagePositionOnDesktop}
 						imagePositionOnMobile={imagePositionOnMobile}
 						showPlayIcon={showPlayIcon}
-						isFlexibleContainer={isFlexibleContainer}
+						fixedImageSizeOnMobile={fixedImageSizeOnMobile()}
+						fixedImageSizeOnTablet={
+							isSmallCard ? 'medium' : undefined
+						}
+						fixedImageSizeOnDesktop={
+							isSmallCard ? 'medium' : undefined
+						}
 					>
 						{media.type === 'slideshow' && (
 							<Slideshow

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -6,7 +6,7 @@ import type { ImagePositionType } from './ImageWrapper';
 
 const padding = 20;
 
-export type GapSize = 'none' | 'small' | 'medium' | 'large';
+export type GapSize = 'none' | 'tiny' | 'small' | 'medium' | 'large';
 
 type Props = {
 	children: React.ReactNode;
@@ -103,10 +103,12 @@ const decideGap = (gapSize: GapSize) => {
 	switch (gapSize) {
 		case 'none':
 			return `0`;
-		case 'small':
+		case 'tiny':
 			return `${space[1]}px`;
-		case 'medium':
+		case 'small':
 			return `${space[2]}px`;
+		case 'medium':
+			return '10px';
 		case 'large':
 			return `${space[5]}px`;
 	}
@@ -120,7 +122,7 @@ export const CardLayout = ({
 	minWidthInPixels,
 	imageType,
 	containerType,
-	gapSize = 'medium',
+	gapSize = 'small',
 }: Props) => (
 	<div
 		css={[

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -3,11 +3,15 @@ import { css } from '@emotion/react';
 import { between, from, until } from '@guardian/source/foundations';
 import { PlayIcon } from './PlayIcon';
 
+const fixedImageSizes = {
+	small: 86,
+	medium: 97.5,
+	large: 125,
+};
+
+export type FixedImageSize = keyof typeof fixedImageSizes;
 export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
-
 export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
-
-export type FixedImageSizeType = 'small' | 'medium' | 'large';
 
 type Props = {
 	children: React.ReactNode;
@@ -16,9 +20,9 @@ type Props = {
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
-	fixedImageSizeOnMobile?: FixedImageSizeType;
-	fixedImageSizeOnTablet?: FixedImageSizeType;
-	fixedImageSizeOnDesktop?: FixedImageSizeType;
+	fixedImageSizeOnMobile?: FixedImageSize;
+	fixedImageSizeOnTablet?: FixedImageSize;
+	fixedImageSizeOnDesktop?: FixedImageSize;
 };
 
 /**
@@ -63,24 +67,13 @@ const flexBasisStyles = ({
  *
  * Fixed images sizes can optionally be applied at tablet and desktop.
  */
-const getFixedImageWidth = (imageSize: FixedImageSizeType) => {
-	switch (imageSize) {
-		case 'small':
-			return '86px';
-		case 'medium':
-			return '97.5px';
-		case 'large':
-			return '125px';
-	}
-};
-
 const fixedImageWidth = (
-	mobile: FixedImageSizeType,
-	tablet?: FixedImageSizeType,
-	desktop?: FixedImageSizeType,
+	mobile: FixedImageSize,
+	tablet?: FixedImageSize,
+	desktop?: FixedImageSize,
 ) => css`
 	${until.tablet} {
-		width: ${getFixedImageWidth(mobile)};
+		width: ${fixedImageSizes[mobile]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
@@ -88,7 +81,7 @@ const fixedImageWidth = (
 	${tablet &&
 	`
 	${between.tablet.and.desktop} {
-		width: ${getFixedImageWidth(tablet)};
+		width: ${fixedImageSizes[tablet]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
@@ -96,7 +89,7 @@ const fixedImageWidth = (
 	${desktop &&
 	`
 	${from.desktop} {
-		width: ${getFixedImageWidth(desktop)};
+		width: ${fixedImageSizes[desktop]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -7,6 +7,8 @@ export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
 
 export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
 
+export type FixedImageSizeType = 'small' | 'medium' | 'large';
+
 type Props = {
 	children: React.ReactNode;
 	imageSize: ImageSizeType;
@@ -14,8 +16,9 @@ type Props = {
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
-	/** Flexible containers require different styling */
-	isFlexibleContainer?: boolean;
+	fixedImageSizeOnMobile?: FixedImageSizeType;
+	fixedImageSizeOnTablet?: FixedImageSizeType;
+	fixedImageSizeOnDesktop?: FixedImageSizeType;
 };
 
 /**
@@ -54,15 +57,50 @@ const flexBasisStyles = ({
 			`;
 	}
 };
-/** Below tablet, we fix the size of the image and add a margin
-around it. The corresponding content flex grows to fill the space */
-const fixedImageWidth = (isFlexibleContainer: boolean) => css`
+/**
+ * Below tablet, we fix the size of the image and add a margin around it.
+ * The corresponding content flex grows to fill the space.
+ *
+ * Fixed images sizes can optionally be applied at tablet and desktop.
+ */
+const getFixedImageWidth = (imageSize: FixedImageSizeType) => {
+	switch (imageSize) {
+		case 'small':
+			return '86px';
+		case 'medium':
+			return '97.5px';
+		case 'large':
+			return '125px';
+	}
+};
+
+const fixedImageWidth = (
+	mobile: FixedImageSizeType,
+	tablet?: FixedImageSizeType,
+	desktop?: FixedImageSizeType,
+) => css`
 	${until.tablet} {
-		width: ${isFlexibleContainer ? '97.5px' : '125px'};
+		width: ${getFixedImageWidth(mobile)};
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
 	}
+	${tablet &&
+	`
+	${between.tablet.and.desktop} {
+		width: ${getFixedImageWidth(tablet)};
+		flex-shrink: 0;
+		flex-basis: unset;
+		align-self: flex-start;
+	}`}
+	${desktop &&
+	`
+	${from.desktop} {
+		width: ${getFixedImageWidth(desktop)};
+		flex-shrink: 0;
+		flex-basis: unset;
+		align-self: flex-start;
+	}`}
 `;
 
 export const ImageWrapper = ({
@@ -72,7 +110,9 @@ export const ImageWrapper = ({
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	showPlayIcon,
-	isFlexibleContainer = false,
+	fixedImageSizeOnMobile = 'large',
+	fixedImageSizeOnTablet,
+	fixedImageSizeOnDesktop,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -103,7 +143,12 @@ export const ImageWrapper = ({
 							display: none;
 						}
 					`,
-				isHorizontalOnMobile && fixedImageWidth(isFlexibleContainer),
+				isHorizontalOnMobile &&
+					fixedImageWidth(
+						fixedImageSizeOnMobile,
+						fixedImageSizeOnTablet,
+						fixedImageSizeOnDesktop,
+					),
 
 				isHorizontalOnDesktop &&
 					css`

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -4,9 +4,9 @@ import { between, from, until } from '@guardian/source/foundations';
 import { PlayIcon } from './PlayIcon';
 
 const imageFixedSize = {
-	small: 86,
-	medium: 97.5,
-	large: 125,
+	tiny: 86,
+	small: 122.5,
+	medium: 125,
 };
 
 type ImageFixedSize = keyof typeof imageFixedSize;
@@ -104,7 +104,7 @@ const imageFixedWidth = ({
 export const ImageWrapper = ({
 	children,
 	imageSize,
-	imageFixedSizes = { mobile: 'large' },
+	imageFixedSizes = { mobile: 'medium' },
 	imageType,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -72,33 +72,33 @@ const flexBasisStyles = ({
  *
  * Fixed images sizes can optionally be applied at tablet and desktop.
  */
-const imageFixedWidth = ({
+const fixImageWidthStyles = (width: number) => css`
+	width: ${width}px;
+	flex-shrink: 0;
+	flex-basis: unset;
+	align-self: flex-start;
+`;
+
+const fixImageWidth = ({
 	mobile,
 	tablet,
 	desktop,
 }: ImageFixedSizeOptions) => css`
 	${until.tablet} {
-		width: ${imageFixedSize[mobile]}px;
-		flex-shrink: 0;
-		flex-basis: unset;
-		align-self: flex-start;
+		${fixImageWidthStyles(imageFixedSize[mobile])}
 	}
 	${tablet &&
-	`
-	${between.tablet.and.desktop} {
-		width: ${imageFixedSize[tablet]}px;
-		flex-shrink: 0;
-		flex-basis: unset;
-		align-self: flex-start;
-	}`}
+	css`
+		${between.tablet.and.desktop} {
+			${fixImageWidthStyles(imageFixedSize[tablet])}
+		}
+	`}
 	${desktop &&
-	`
-	${from.desktop} {
-		width: ${imageFixedSize[desktop]}px;
-		flex-shrink: 0;
-		flex-basis: unset;
-		align-self: flex-start;
-	}`}
+	css`
+		${from.desktop} {
+			${fixImageWidthStyles(imageFixedSize[desktop])}
+		}
+	`}
 `;
 
 export const ImageWrapper = ({
@@ -139,7 +139,7 @@ export const ImageWrapper = ({
 							display: none;
 						}
 					`,
-				isHorizontalOnMobile && imageFixedWidth(imageFixedSizes),
+				isHorizontalOnMobile && fixImageWidth(imageFixedSizes),
 
 				isHorizontalOnDesktop &&
 					css`

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -9,15 +9,16 @@ const imageFixedSize = {
 	large: 125,
 };
 
-export type ImageFixedSize = keyof typeof imageFixedSize;
-export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
-export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
+type ImageFixedSize = keyof typeof imageFixedSize;
 
-type ImageFixedSizeOptions = {
+export type ImageFixedSizeOptions = {
 	mobile: ImageFixedSize;
 	tablet?: ImageFixedSize;
 	desktop?: ImageFixedSize;
 };
+
+export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
+export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -3,26 +3,30 @@ import { css } from '@emotion/react';
 import { between, from, until } from '@guardian/source/foundations';
 import { PlayIcon } from './PlayIcon';
 
-const fixedImageSizes = {
+const imageFixedSize = {
 	small: 86,
 	medium: 97.5,
 	large: 125,
 };
 
-export type FixedImageSize = keyof typeof fixedImageSizes;
+export type ImageFixedSize = keyof typeof imageFixedSize;
 export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
 export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
+
+type ImageFixedSizeOptions = {
+	mobile: ImageFixedSize;
+	tablet?: ImageFixedSize;
+	desktop?: ImageFixedSize;
+};
 
 type Props = {
 	children: React.ReactNode;
 	imageSize: ImageSizeType;
+	imageFixedSizes?: ImageFixedSizeOptions;
 	imageType?: CardImageType;
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	showPlayIcon: boolean;
-	fixedImageSizeOnMobile?: FixedImageSize;
-	fixedImageSizeOnTablet?: FixedImageSize;
-	fixedImageSizeOnDesktop?: FixedImageSize;
 };
 
 /**
@@ -67,13 +71,13 @@ const flexBasisStyles = ({
  *
  * Fixed images sizes can optionally be applied at tablet and desktop.
  */
-const fixedImageWidth = (
-	mobile: FixedImageSize,
-	tablet?: FixedImageSize,
-	desktop?: FixedImageSize,
-) => css`
+const imageFixedWidth = ({
+	mobile,
+	tablet,
+	desktop,
+}: ImageFixedSizeOptions) => css`
 	${until.tablet} {
-		width: ${fixedImageSizes[mobile]}px;
+		width: ${imageFixedSize[mobile]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
@@ -81,7 +85,7 @@ const fixedImageWidth = (
 	${tablet &&
 	`
 	${between.tablet.and.desktop} {
-		width: ${fixedImageSizes[tablet]}px;
+		width: ${imageFixedSize[tablet]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
@@ -89,7 +93,7 @@ const fixedImageWidth = (
 	${desktop &&
 	`
 	${from.desktop} {
-		width: ${fixedImageSizes[desktop]}px;
+		width: ${imageFixedSize[desktop]}px;
 		flex-shrink: 0;
 		flex-basis: unset;
 		align-self: flex-start;
@@ -99,13 +103,11 @@ const fixedImageWidth = (
 export const ImageWrapper = ({
 	children,
 	imageSize,
+	imageFixedSizes = { mobile: 'large' },
 	imageType,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	showPlayIcon,
-	fixedImageSizeOnMobile = 'large',
-	fixedImageSizeOnTablet,
-	fixedImageSizeOnDesktop,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -136,12 +138,7 @@ export const ImageWrapper = ({
 							display: none;
 						}
 					`,
-				isHorizontalOnMobile &&
-					fixedImageWidth(
-						fixedImageSizeOnMobile,
-						fixedImageSizeOnTablet,
-						fixedImageSizeOnDesktop,
-					),
+				isHorizontalOnMobile && imageFixedWidth(imageFixedSizes),
 
 				isHorizontalOnDesktop &&
 					css`

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/highlights-trails';
@@ -8,6 +9,15 @@ import { ScrollableSmall } from './ScrollableSmall.importable';
 export default {
 	title: 'Components/ScrollableSmall',
 	component: ScrollableSmall,
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
 	args: {
 		trails,
 		containerPalette: undefined,
@@ -19,8 +29,6 @@ export default {
 } as Meta;
 
 type Story = StoryObj<typeof ScrollableSmall>;
-
-export const Default = {};
 
 export const WithFrontSection = {
 	render: (args) => (


### PR DESCRIPTION
## What does this change?

- Adds `imageFixedSizes` prop to `ImageWrapper`, allowing fixed image sizes to be specified for `mobile`, `tablet` and `desktop` breakpoints
- Removes `isFlexibleContainer` prop from `ImageWrapper` and moves logic up to `Card` component
- Updates fixed image size already in place for flexible containers
- Adds a new 10px gap size to `CardLayout`

```
{
  mobile: 'tiny',
  tablet: 'small',
  desktop: 'medium',
}
```

## Why?

Image sizes were already fixed below `tablet` with a custom size for flexible containers toggled by the `isFlexibleContainer` prop on `ImageWrapper`. Fixed image sizes are also required for other containers such as scrollable small which, unlike the flexible containers, has fixed images sizes at all breakpoints.

## Screenshots

| mobileMedium (86px) | tablet (122.5px) |
| ----------- | ---------- |
| ![mobileMedium][] | ![tablet][] |

[mobileMedium]: https://github.com/user-attachments/assets/37905fad-7169-443a-aa94-8ea62f29019d
[tablet]: https://github.com/user-attachments/assets/440dc28c-0162-4d84-8028-7b5cd3faedc8
