### PR TITLE
Trailtext: pad top only if the header is "inner"

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -788,6 +788,7 @@ export const Card = ({
 									shouldHide={isFlexSplash ? false : true}
 									trailTextColour={trailTextColour}
 									trailTextSize={trailTextSize}
+									padTop={headlinePosition === 'inner'}
 								>
 									<div
 										dangerouslySetInnerHTML={{

--- a/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailTextWrapper.tsx
@@ -21,6 +21,7 @@ type Props = {
 	trailTextSize?: TrailTextSize;
 	/** Optionally overrides the trail text colour */
 	trailTextColour?: string;
+	padTop: boolean;
 };
 
 /**
@@ -55,7 +56,11 @@ const decideVisibilityStyles = (
 const trailTextStyles = css`
 	display: flex;
 	flex-direction: column;
-	padding: ${space[2]}px 0;
+	padding-bottom: ${space[2]}px;
+`;
+
+const topPadding = css`
+	padding-top: ${space[2]}px;
 `;
 
 const fontStyles = (trailTextSize: TrailTextSize) => css`
@@ -76,6 +81,7 @@ export const TrailTextWrapper = ({
 	shouldHide = true,
 	trailTextSize = 'regular',
 	trailTextColour = palette('--card-trail-text'),
+	padTop,
 }: Props) => {
 	return (
 		<div
@@ -91,6 +97,7 @@ export const TrailTextWrapper = ({
 						imageSize,
 						imageType,
 					),
+				padTop && topPadding,
 			]}
 		>
 			{children}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c5d26fc2-20e1-47ef-97e8-eb23b74d6ac7
[after]: https://github.com/user-attachments/assets/bd954bd0-4344-4997-a861-61026f7f31a1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
