### PR TITLE
Adjust carousel spacing to allow for media cards

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	between,
 	from,
 	headlineMedium24Object,
 	space,
@@ -111,6 +112,10 @@ const carouselStyles = css`
 	}
 	scrollbar-width: none; /* Firefox */
 	position: relative;
+
+	${between.tablet.and.wide} {
+		margin-top: ${space[2]}px;
+	}
 
 	padding-left: 10px;
 	scroll-padding-left: 10px;

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	between,
 	from,
 	headlineMedium24Object,
 	space,
@@ -55,8 +54,12 @@ const themeButtonDisabled = {
 const carouselContainerStyles = css`
 	display: flex;
 	flex-direction: column-reverse;
+	${from.tablet} {
+		gap: ${space[2]}px;
+	}
 	${from.wide} {
 		flex-direction: row;
+		gap: ${space[1]}px;
 	}
 
 	/* Extend carousel into outer margins on mobile */
@@ -113,10 +116,6 @@ const carouselStyles = css`
 	scrollbar-width: none; /* Firefox */
 	position: relative;
 
-	${between.tablet.and.wide} {
-		margin-top: ${space[2]}px;
-	}
-
 	padding-left: 10px;
 	scroll-padding-left: 10px;
 	${from.mobileLandscape} {
@@ -166,9 +165,6 @@ const verticalLineStyles = css`
 
 const buttonContainerStyles = css`
 	margin-left: auto;
-	${from.wide} {
-		margin-left: ${space[1]}px;
-	}
 `;
 
 const buttonLayoutStyles = css`


### PR DESCRIPTION
## What does this change?

Adds 8px of spacing to the top of the carousel between tablet and wide breakpoints

## Why?

The top edge of the carousel is currently flush with the bottom of the navigation buttons. This isn't immediately apparent when the carousel is static or the cards have a transparent background, but it becomes obvious when the carousel is in motion (as the images and buttons touch) or a card has a solid background colour such as a media card.

## Screenshots

| Tablet      | leftCol      |
| ----------- | ---------- |
| ![tablet][] | ![leftcol][] |

[tablet]: https://github.com/user-attachments/assets/750e85e1-1994-4964-a886-0d8e14dc5c1f
[leftcol]: https://github.com/user-attachments/assets/85edbb22-844e-4578-a1e3-c7acf5099592
