### PR TITLE
Scrollable small container: support for special palettes

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -1050,6 +1050,28 @@ const carouselArrowBackgroundHover: ContainerFunction = (containerPalette) => {
 	}
 };
 
+const carouselChevronLight: ContainerFunction = (containerPalette) =>
+	cardHeadlineLight(containerPalette);
+const carouselChevronDark: ContainerFunction = (containerPalette) =>
+	cardHeadlineDark(containerPalette);
+
+const carouselChevronBorderLight: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineLight(containerPalette), 0.2);
+const carouselChevronBorderDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.4);
+
+const carouselChevronDisabledLight: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineLight(containerPalette), 0.2);
+const carouselChevronDisabledDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.4);
+
+const carouselChevronBorderDisabledLight: ContainerFunction = (
+	containerPalette,
+) => transparentColour(cardHeadlineLight(containerPalette), 0.2);
+const carouselChevronBorderDisabledDark: ContainerFunction = (
+	containerPalette,
+) => transparentColour(cardHeadlineDark(containerPalette), 0.4);
+
 type ColourName = Parameters<typeof palette>[0];
 
 type ContainerFunction = (containerPalette: DCRContainerPalette) => string;
@@ -1162,6 +1184,22 @@ const containerColours = {
 	'--carousel-arrow-background-hover': {
 		light: carouselArrowBackgroundHover,
 		dark: carouselArrowBackgroundHover,
+	},
+	'--carousel-chevron': {
+		light: carouselChevronLight,
+		dark: carouselChevronDark,
+	},
+	'--carousel-chevron-border': {
+		light: carouselChevronBorderLight,
+		dark: carouselChevronBorderDark,
+	},
+	'--carousel-chevron-border-disabled': {
+		light: carouselChevronBorderDisabledLight,
+		dark: carouselChevronBorderDisabledDark,
+	},
+	'--carousel-chevron-disabled': {
+		light: carouselChevronDisabledLight,
+		dark: carouselChevronDisabledDark,
 	},
 	'--section-border': {
 		light: sectionBorderLight,

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -9,6 +9,7 @@ import {
 	Hide,
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
+	type ThemeButton,
 } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
 import { palette } from '../palette';
@@ -41,12 +42,12 @@ const titlePreset = headlineMedium24Object;
 const gridColumnWidth = '60px';
 const gridGap = '20px';
 
-const themeButton = {
+const themeButton: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border'),
 	textTertiary: palette('--carousel-chevron'),
 };
 
-const themeButtonDisabled = {
+const themeButtonDisabled: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border-disabled'),
 	textTertiary: palette('--carousel-chevron-disabled'),
 };

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/highlights-trails';
+import type { DCRContainerPalette } from '../types/front';
 import { FrontSection } from './FrontSection';
 import { ScrollableSmall } from './ScrollableSmall.importable';
 
@@ -31,5 +32,43 @@ export const WithFrontSection = {
 		>
 			<ScrollableSmall {...args} />
 		</FrontSection>
+	),
+} satisfies Story;
+
+const containerPalettes = [
+	'InvestigationPalette',
+	'LongRunningPalette',
+	'SombrePalette',
+	'BreakingPalette',
+	'EventPalette',
+	'EventAltPalette',
+	'LongRunningAltPalette',
+	'SombreAltPalette',
+	'SpecialReportAltPalette',
+	'Branded',
+] as const satisfies readonly Omit<
+	DCRContainerPalette,
+	'MediaPalette' | 'PodcastPalette'
+>[];
+
+export const WithSpecialPaletteVariations = {
+	render: (args) => (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<FrontSection
+					title="Scrollable small"
+					discussionApiUrl={discussionApiUrl}
+					editionId={'UK'}
+					showTopBorder={false}
+					key={containerPalette}
+					containerPalette={containerPalette}
+				>
+					<ScrollableSmall
+						{...args}
+						containerPalette={containerPalette}
+					/>
+				</FrontSection>
+			))}
+		</>
 	),
 } satisfies Story;


### PR DESCRIPTION
## What does this change?

Passes container palette through to scrollable small container and adds palette overrides for navigation buttons.

This will require some further refinement to update the button hover state and possibly bring the default colour scheme into line with the special palettes which would reduce the number of custom properties required. (The default colour scheme defines specific colours for the icon, border and disabled states. For special palettes these are all based on the container title colour with opacity applied.)

## Why?

So the carousel is styled correctly when a special palette is used.

## Screenshots

### Light
![light](https://github.com/user-attachments/assets/63386d7e-5beb-46a1-bff9-411ec47b9a7c)

### Dark

![dark](https://github.com/user-attachments/assets/97088e71-750a-42cb-9ea5-e72e0cdaff2f)
