### PR TITLE
Reader Revenue message on US front

### DIFF
--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -167,7 +167,6 @@ const whatAmI = 'sticky-liveblog-ask';
 export const StickyLiveblogAskWrapper: ReactComponent<
 	StickyLiveblogAskWrapperProps
 > = ({ referrerUrl, shouldHideReaderRevenueOnArticle }) => {
-	console.log('StickyLiveblogAskWrapper');
 	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode(whatAmI);
 	const pageViewId = usePageViewId(renderingTarget);
@@ -178,7 +177,6 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 	const isSignedIn = useIsSignedIn();
 
 	useEffect(() => {
-		console.log('effect');
 		if (isSignedIn !== 'Pending') {
 			setShowSupportMessaging(
 				shouldHideSupportMessaging(isSignedIn) === false,

--- a/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/StickyLiveblogAskWrapper.importable.tsx
@@ -167,6 +167,7 @@ const whatAmI = 'sticky-liveblog-ask';
 export const StickyLiveblogAskWrapper: ReactComponent<
 	StickyLiveblogAskWrapperProps
 > = ({ referrerUrl, shouldHideReaderRevenueOnArticle }) => {
+	console.log('StickyLiveblogAskWrapper');
 	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode(whatAmI);
 	const pageViewId = usePageViewId(renderingTarget);
@@ -177,6 +178,7 @@ export const StickyLiveblogAskWrapper: ReactComponent<
 	const isSignedIn = useIsSignedIn();
 
 	useEffect(() => {
+		console.log('effect');
 		if (isSignedIn !== 'Pending') {
 			setShowSupportMessaging(
 				shouldHideSupportMessaging(isSignedIn) === false,

--- a/dotcom-rendering/src/components/UsEoy2024.stories.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UsEoy2024 } from './UsEoy2024Wrapper.importable';
+
+const meta = {
+	title: 'Components/UsEoy2024',
+	component: UsEoy2024,
+} satisfies Meta<typeof UsEoy2024>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		tickerData: {
+			total: 1000000,
+			goal: 2000000,
+		},
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/UsEoy2024.stories.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024.stories.tsx
@@ -16,5 +16,7 @@ export const Default = {
 			total: 1000000,
 			goal: 2000000,
 		},
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		submitTrackingEvent: () => {},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { isObject } from '@guardian/libs';
+import type { ComponentEvent } from '@guardian/ophan-tracker-js';
 import {
 	from,
 	headlineMedium24,
@@ -17,8 +18,10 @@ import type {
 	TickerData,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import { shouldHideSupportMessaging } from '../lib/contributions';
 import { useIsSignedIn } from '../lib/useAuthStatus';
+import { useConfig } from './ConfigContext';
 import type { ChoiceCardSettings } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
 import { ChoiceCards } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
 import { buttonStyles } from './marketing/banners/designableBanner/styles/buttonStyles';
@@ -170,17 +173,20 @@ const choiceCardSettings: ChoiceCardSettings = {
 	buttonSelectTextColour: '#000000',
 	buttonSelectBorderColour: '#0077B6',
 };
+const componentId = 'USEOY24_LAUNCH_UPDATED_THRASHER';
 const cta = {
-	ctaUrl: 'https://support.theguardian.com/us/contribute?acquisitionData={"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_THRASHER","componentId":"USEOY24_LAUNCH_UPDATED_THRASHER","campaignCode":"USEOY24"}&INTCMP=USEOY24',
+	ctaUrl: `https://support.theguardian.com/us/contribute?acquisitionData={"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_THRASHER","componentId":"${componentId}","campaignCode":"USEOY24"}&INTCMP=USEOY24`,
 	ctaText: 'Support us',
 };
 
 interface Props {
 	tickerData: TickerData;
+	submitTrackingEvent: (event: ComponentEvent) => void;
 }
 
 export const UsEoy2024: ReactComponent<Props> = ({
 	tickerData,
+	submitTrackingEvent,
 }: Props): JSX.Element => {
 	const {
 		choiceCardSelection,
@@ -223,9 +229,9 @@ export const UsEoy2024: ReactComponent<Props> = ({
 					<ChoiceCards
 						setSelectionsCallback={setChoiceCardSelection}
 						selection={choiceCardSelection}
-						submitComponentEvent={() => {}}
+						submitComponentEvent={submitTrackingEvent}
 						currencySymbol={currencySymbol}
-						componentId={'contributions-banner-choice-cards'}
+						componentId={'thrasher-choice-cards'}
 						amountsTest={choiceCardAmounts}
 						design={choiceCardSettings}
 						getCtaText={getCtaText}
@@ -240,7 +246,18 @@ export const UsEoy2024: ReactComponent<Props> = ({
 								textColour: '#FFFFFF',
 							},
 						})}
-						onCtaClick={() => {}}
+						onCtaClick={() => {
+							void submitComponentEvent(
+								{
+									component: {
+										componentType: 'ACQUISITIONS_THRASHER',
+										id: componentId,
+									},
+									action: 'CLICK',
+								},
+								'Web',
+							);
+						}}
 					/>
 				</div>
 			</div>
@@ -267,10 +284,18 @@ export const UsEoy2024Wrapper = (): JSX.Element => {
 		void getTickerData().then(setTickerData);
 	}, []);
 
+	const { renderingTarget } = useConfig();
+	const submitTrackingEvent = (event: ComponentEvent) => {
+		void submitComponentEvent(event, renderingTarget);
+	};
+
 	return (
 		<>
 			{showSupportMessagingForUser && tickerData && (
-				<UsEoy2024 tickerData={tickerData} />
+				<UsEoy2024
+					tickerData={tickerData}
+					submitTrackingEvent={submitTrackingEvent}
+				/>
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -247,16 +247,13 @@ export const UsEoy2024: ReactComponent<Props> = ({
 							},
 						})}
 						onCtaClick={() => {
-							void submitComponentEvent(
-								{
-									component: {
-										componentType: 'ACQUISITIONS_THRASHER',
-										id: componentId,
-									},
-									action: 'CLICK',
+							submitTrackingEvent({
+								component: {
+									componentType: 'ACQUISITIONS_THRASHER',
+									id: componentId,
 								},
-								'Web',
-							);
+								action: 'CLICK',
+							});
 						}}
 					/>
 				</div>

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -122,7 +122,7 @@ const tickerSettings = {
 
 const getTickerData = async (): Promise<TickerData | undefined> => {
 	const data = await fetch(
-		'https://support.code.dev-theguardian.com/ticker/US.json',
+		'https://support.theguardian.com/ticker/US.json',
 	).then((response) => response.json());
 
 	if (isObject(data)) {

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -27,13 +27,6 @@ const styles = {
 	container: css`
 		background: #051d32;
 		color: #ffffff;
-
-		display: flex;
-		justify-content: space-between;
-		overflow: hidden;
-		${from.desktop} {
-			padding-right: 40px;
-		}
 	`,
 	grid: css`
 		display: grid;
@@ -43,10 +36,6 @@ const styles = {
 		${from.tablet} {
 			display: grid;
 			grid-template-columns: 350px 350px;
-			grid-template-rows: auto 1fr auto;
-			width: 100%;
-			max-width: 1300px;
-			margin: 0 auto;
 			padding: 0 ${space[5]}px 30px ${space[5]}px;
 		}
 		${from.desktop} {
@@ -71,8 +60,6 @@ const styles = {
 		}
 	`,
 	heading: css`
-		order: 2;
-
 		${from.tablet} {
 			grid-column: 1;
 			grid-row: 1;
@@ -96,11 +83,6 @@ const styles = {
 		}
 	`,
 	body: css`
-		order: 2;
-		${from.tablet} {
-			grid-column: 1;
-			grid-row: 2 / span 2;
-		}
 		${textEgyptian17};
 		strong {
 			${textEgyptianBold17};
@@ -110,7 +92,6 @@ const styles = {
 		margin-bottom: ${space[4]}px;
 	`,
 	choiceCards: css`
-		order: 3;
 		margin-top: ${space[6]}px;
 		${from.tablet} {
 			grid-column: 2;
@@ -183,6 +164,7 @@ const choiceCardSettings: ChoiceCardSettings = {
 	buttonSelectBorderColour: '#0077B6',
 };
 const cta = {
+	// TODO - tracking
 	ctaUrl: 'https://support.theguardian.com/contribute',
 	ctaText: 'Support us',
 };

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -1,0 +1,268 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineMedium24,
+	headlineMedium28,
+	headlineMedium34,
+	space,
+	textEgyptian17,
+	textEgyptianBold17,
+} from '@guardian/source/foundations';
+import { Ticker } from '@guardian/source-development-kitchen/react-components';
+import type {
+	SelectedAmountsVariant,
+	TickerData,
+} from '@guardian/support-dotcom-components/dist/shared/src/types';
+import { useEffect, useState } from 'react';
+import { shouldHideSupportMessaging } from '../lib/contributions';
+import { useIsSignedIn } from '../lib/useAuthStatus';
+import type { ChoiceCardSettings } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
+import { ChoiceCards } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
+import { useChoiceCards } from './marketing/hooks/useChoiceCards';
+import type { ReactComponent } from './marketing/lib/ReactComponent';
+import { buttonStyles } from './marketing/banners/designableBanner/styles/buttonStyles';
+import { SvgGuardianLogo } from '@guardian/source/react-components';
+
+const styles = {
+	container: css`
+		background: #051d32;
+		color: #ffffff;
+	`,
+	grid: css`
+		display: flex;
+		flex-direction: column;
+		position: relative;
+		padding: 0 10px 30px 10px;
+		${from.tablet} {
+			display: grid;
+			grid-template-columns: 220px 1fr 280px;
+			grid-template-rows: auto 1fr auto;
+			column-gap: ${space[1]}px;
+			width: 100%;
+			max-width: 1300px;
+			margin: 0 auto;
+			padding: 0 ${space[5]}px 30px ${space[5]}px;
+		}
+		${from.desktop} {
+			grid-template-columns: 145px 480px 480px;
+		}
+		${from.wide} {
+			grid-template-columns: 226px 480px 480px;
+		}
+	`,
+	logo: css`
+		grid-column: 1;
+		grid-row: 1;
+		margin-top: ${space[2]}px;
+	`,
+	heading: css`
+		order: 2;
+
+		${from.tablet} {
+			grid-column: 2;
+			grid-row: 1;
+		}
+		h2 {
+			margin: ${space[2]}px 0 ${space[3]}px;
+			color: #ffffff;
+
+			${headlineMedium24}
+			${from.tablet} {
+				${headlineMedium28}
+			}
+			${from.leftCol} {
+				${headlineMedium34}
+			}
+		}
+		border-left: 1px solid rgba(255, 255, 255, 0.2);
+		padding-left: ${space[2]}px;
+	`,
+	body: css`
+		order: 2;
+		${from.tablet} {
+			grid-column: 1;
+			grid-row: 2 / span 2;
+		}
+		${textEgyptian17};
+		strong {
+			${textEgyptianBold17};
+		}
+	`,
+	ticker: css`
+		margin-bottom: ${space[4]}px;
+	`,
+	choiceCards: css`
+		order: 3;
+		margin-top: ${space[6]}px;
+		${from.tablet} {
+			grid-column: 3;
+			grid-row: 1;
+			align-self: flex-start;
+			display: flex;
+			justify-content: flex-end;
+			margin-right: ${space[3]}px;
+		}
+	`,
+};
+
+const tickerSettings = {
+	currencySymbol: '$',
+	copy: {},
+	tickerStylingSettings: {
+		filledProgressColour: '#64B7C4',
+		progressBarBackgroundColour: 'rgba(34, 75, 95, 1)',
+		headlineColour: '#000000',
+		totalColour: '#64B7C4',
+		goalColour: '#FFFFFF',
+	},
+};
+
+const getTickerData = async () => {
+	const data = await fetch(
+		'https://support.code.dev-theguardian.com/ticker/US.json',
+	).then((response) => response.json());
+	const total = Math.floor(data.total);
+	const goal = Math.floor(data.goal);
+	return {
+		total,
+		goal,
+	};
+};
+
+// TODO - correct amounts?
+const choiceCardAmounts: SelectedAmountsVariant = {
+	testName: 'us-eoy-front-amounts',
+	variantName: 'CONTROL',
+	defaultContributionType: 'MONTHLY',
+	displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
+	amountsCardData: {
+		ONE_OFF: {
+			amounts: [75, 125],
+			defaultAmount: 75,
+			hideChooseYourAmount: false,
+		},
+		MONTHLY: {
+			amounts: [5, 15],
+			defaultAmount: 15,
+			hideChooseYourAmount: false,
+		},
+		ANNUAL: {
+			amounts: [60, 150],
+			defaultAmount: 150,
+			hideChooseYourAmount: false,
+		},
+	},
+};
+const choiceCardSettings: ChoiceCardSettings = {
+	buttonColour: '#FFFFFF',
+	buttonTextColour: '#000000',
+	buttonBorderColour: '#000000',
+	buttonSelectColour: '#E3F6FF',
+	buttonSelectTextColour: '#000000',
+	buttonSelectBorderColour: '#0077B6',
+};
+const cta = {
+	ctaUrl: 'https://support.theguardian.com/contribute',
+	ctaText: 'Support us',
+};
+
+interface Props {
+	tickerData: TickerData;
+}
+
+export const UsEoy2024: ReactComponent<Props> = ({
+	tickerData,
+}: Props): JSX.Element => {
+	const {
+		choiceCardSelection,
+		setChoiceCardSelection,
+		getCtaText,
+		getCtaUrl,
+		currencySymbol,
+	} = useChoiceCards(choiceCardAmounts, 'US', cta, cta);
+
+	return (
+		<div css={styles.container}>
+			<div css={styles.grid}>
+				<div css={styles.logo}>
+					<SvgGuardianLogo textColor={'#FFFFFF'} width={100} />
+				</div>
+				<div css={styles.heading}>
+					<h2>Can you help us hit our goal?</h2>
+					<div css={styles.body}>
+						<div css={styles.ticker}>
+							<Ticker
+								currencySymbol={tickerSettings.currencySymbol}
+								copy={{}}
+								tickerData={tickerData}
+								tickerStylingSettings={
+									tickerSettings.tickerStylingSettings
+								}
+								size={'medium'}
+							/>
+						</div>
+						With no billionaire owner or shareholders pulling our
+						strings, reader support keeps us fiercely independent.
+						<strong>
+							{' '}
+							Help us hit our most important annual fundraising
+							goal so we can keep going.
+						</strong>
+					</div>
+				</div>
+				<div css={styles.choiceCards}>
+					<ChoiceCards
+						setSelectionsCallback={setChoiceCardSelection}
+						selection={choiceCardSelection}
+						submitComponentEvent={() => {}}
+						currencySymbol={currencySymbol}
+						componentId={'contributions-banner-choice-cards'}
+						amountsTest={choiceCardAmounts}
+						design={choiceCardSettings}
+						getCtaText={getCtaText}
+						getCtaUrl={getCtaUrl}
+						cssCtaOverides={buttonStyles({
+							default: {
+								backgroundColour: '#C41C1C',
+								textColour: '#FFFFFF',
+							},
+							hover: {
+								backgroundColour: '#C41C1C',
+								textColour: '#FFFFFF',
+							},
+						})}
+						onCtaClick={() => {}}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const UsEoy2024Wrapper = (): JSX.Element => {
+	const [tickerData, setTickerData] = useState<TickerData | undefined>();
+
+	const [showSupportMessagingForUser, setShowSupportMessaging] =
+		useState<boolean>(false);
+	const isSignedIn = useIsSignedIn();
+
+	useEffect(() => {
+		if (isSignedIn !== 'Pending') {
+			setShowSupportMessaging(
+				shouldHideSupportMessaging(isSignedIn) === false,
+			);
+		}
+	}, [isSignedIn]);
+
+	useEffect(() => {
+		void getTickerData().then(setTickerData);
+	}, []);
+
+	return (
+		<>
+			{showSupportMessagingForUser && tickerData && (
+				<UsEoy2024 tickerData={tickerData} />
+			)}
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -27,39 +27,54 @@ const styles = {
 	container: css`
 		background: #051d32;
 		color: #ffffff;
+
+		display: flex;
+		justify-content: space-between;
+		overflow: hidden;
+		${from.desktop} {
+			padding-right: 40px;
+		}
 	`,
 	grid: css`
-		display: flex;
+		display: grid;
 		flex-direction: column;
 		position: relative;
 		padding: 0 10px 30px 10px;
 		${from.tablet} {
 			display: grid;
-			grid-template-columns: 220px 1fr 280px;
+			grid-template-columns: 350px 350px;
 			grid-template-rows: auto 1fr auto;
-			column-gap: ${space[1]}px;
 			width: 100%;
 			max-width: 1300px;
 			margin: 0 auto;
 			padding: 0 ${space[5]}px 30px ${space[5]}px;
 		}
 		${from.desktop} {
-			grid-template-columns: 145px 480px 480px;
+			grid-template-columns: 462px 462px;
+			column-gap: ${space[4]}px;
+		}
+		${from.leftCol} {
+			grid-template-columns: 148px 482px 482px;
+			column-gap: 0;
 		}
 		${from.wide} {
-			grid-template-columns: 226px 480px 480px;
+			grid-template-columns: 228px 482px 482px;
 		}
 	`,
 	logo: css`
-		grid-column: 1;
-		grid-row: 1;
-		margin-top: ${space[2]}px;
+		display: none;
+		${from.leftCol} {
+			display: block;
+			grid-column: 1;
+			grid-row: 1;
+			margin-top: ${space[2]}px;
+		}
 	`,
 	heading: css`
 		order: 2;
 
 		${from.tablet} {
-			grid-column: 2;
+			grid-column: 1;
 			grid-row: 1;
 		}
 		h2 {
@@ -74,8 +89,11 @@ const styles = {
 				${headlineMedium34}
 			}
 		}
-		border-left: 1px solid rgba(255, 255, 255, 0.2);
-		padding-left: ${space[2]}px;
+		${from.leftCol} {
+			grid-column: 2;
+			border-left: 1px solid rgba(255, 255, 255, 0.2);
+			padding-left: ${space[2]}px;
+		}
 	`,
 	body: css`
 		order: 2;
@@ -95,11 +113,14 @@ const styles = {
 		order: 3;
 		margin-top: ${space[6]}px;
 		${from.tablet} {
-			grid-column: 3;
+			grid-column: 2;
 			grid-row: 1;
 			align-self: flex-start;
 			display: flex;
 			justify-content: flex-end;
+		}
+		${from.leftCol} {
+			grid-column: 3;
 			margin-right: ${space[3]}px;
 		}
 	`,

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isObject } from '@guardian/libs';
 import {
 	from,
 	headlineMedium24,
@@ -8,6 +9,7 @@ import {
 	textEgyptian17,
 	textEgyptianBold17,
 } from '@guardian/source/foundations';
+import { SvgGuardianLogo } from '@guardian/source/react-components';
 import { Ticker } from '@guardian/source-development-kitchen/react-components';
 import type {
 	SelectedAmountsVariant,
@@ -18,10 +20,9 @@ import { shouldHideSupportMessaging } from '../lib/contributions';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import type { ChoiceCardSettings } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
 import { ChoiceCards } from './marketing/banners/designableBanner/components/choiceCards/ChoiceCards';
+import { buttonStyles } from './marketing/banners/designableBanner/styles/buttonStyles';
 import { useChoiceCards } from './marketing/hooks/useChoiceCards';
 import type { ReactComponent } from './marketing/lib/ReactComponent';
-import { buttonStyles } from './marketing/banners/designableBanner/styles/buttonStyles';
-import { SvgGuardianLogo } from '@guardian/source/react-components';
 
 const styles = {
 	container: css`
@@ -119,16 +120,18 @@ const tickerSettings = {
 	},
 };
 
-const getTickerData = async () => {
+const getTickerData = async (): Promise<TickerData | undefined> => {
 	const data = await fetch(
 		'https://support.code.dev-theguardian.com/ticker/US.json',
 	).then((response) => response.json());
-	const total = Math.floor(data.total);
-	const goal = Math.floor(data.goal);
-	return {
-		total,
-		goal,
-	};
+	if (isObject(data) && data.total && data.goal) {
+		const total = Math.floor(data.total);
+		const goal = Math.floor(data.goal);
+		return {
+			total,
+			goal,
+		};
+	}
 };
 
 // TODO - correct amounts?

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -5,6 +5,7 @@ import {
 	headlineMedium24,
 	headlineMedium28,
 	headlineMedium34,
+	palette,
 	space,
 	textEgyptian17,
 	textEgyptianBold17,
@@ -26,8 +27,9 @@ import type { ReactComponent } from './marketing/lib/ReactComponent';
 
 const styles = {
 	container: css`
+		/* stylelint-disable-next-line color-no-hex */
 		background: #051d32;
-		color: #ffffff;
+		color: ${palette.neutral[100]};
 	`,
 	grid: css`
 		display: grid;
@@ -67,7 +69,7 @@ const styles = {
 		}
 		h2 {
 			margin: ${space[2]}px 0 ${space[3]}px;
-			color: #ffffff;
+			color: ${palette.neutral[100]};
 
 			${headlineMedium24}
 			${from.tablet} {

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -137,7 +137,6 @@ const getTickerData = async (): Promise<TickerData | undefined> => {
 	return;
 };
 
-// TODO - correct amounts?
 const choiceCardAmounts: SelectedAmountsVariant = {
 	testName: 'us-eoy-front-amounts',
 	variantName: 'CONTROL',

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -169,8 +169,7 @@ const choiceCardSettings: ChoiceCardSettings = {
 	buttonSelectBorderColour: '#0077B6',
 };
 const cta = {
-	// TODO - tracking
-	ctaUrl: 'https://support.theguardian.com/contribute',
+	ctaUrl: 'https://support.theguardian.com/us/contribute?acquisitionData={"source":"GUARDIAN_WEB","componentType":"ACQUISITIONS_THRASHER","componentId":"USEOY24_LAUNCH_UPDATED_THRASHER","campaignCode":"USEOY24"}&INTCMP=USEOY24',
 	ctaText: 'Support us',
 };
 

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -35,11 +35,11 @@ const styles = {
 		display: grid;
 		flex-direction: column;
 		position: relative;
-		padding: 0 10px 30px 10px;
+		padding: 0 ${space[3]}px ${space[4]}px ${space[3]}px;
 		${from.tablet} {
 			display: grid;
 			grid-template-columns: 350px 350px;
-			padding: 0 ${space[5]}px 30px ${space[5]}px;
+			padding: 0 ${space[5]}px ${space[4]}px ${space[5]}px;
 		}
 		${from.desktop} {
 			grid-template-columns: 462px 462px;
@@ -68,7 +68,7 @@ const styles = {
 			grid-row: 1;
 		}
 		h2 {
-			margin: ${space[2]}px 0 ${space[3]}px;
+			margin: ${space[2]}px 0 ${space[4]}px;
 			color: ${palette.neutral[100]};
 
 			${headlineMedium24}

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -124,14 +124,17 @@ const getTickerData = async (): Promise<TickerData | undefined> => {
 	const data = await fetch(
 		'https://support.code.dev-theguardian.com/ticker/US.json',
 	).then((response) => response.json());
-	if (isObject(data) && data.total && data.goal) {
-		const total = Math.floor(data.total);
-		const goal = Math.floor(data.goal);
-		return {
-			total,
-			goal,
-		};
+
+	if (isObject(data)) {
+		const { total, goal } = data;
+		if (typeof total === 'number' && typeof goal === 'number') {
+			return {
+				total: Math.floor(total),
+				goal: Math.floor(goal),
+			};
+		}
 	}
+	return;
 };
 
 // TODO - correct amounts?

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -166,7 +166,12 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 		getCtaText,
 		getCtaUrl,
 		currencySymbol,
-	} = useChoiceCards(choiceCardAmounts, countryCode, content);
+	} = useChoiceCards(
+		choiceCardAmounts,
+		countryCode,
+		content.mainContent.primaryCta,
+		content.mobileContent.primaryCta,
+	);
 
 	// We can't render anything without a design
 	if (!design) {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCardInteractive.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCardInteractive.tsx
@@ -170,7 +170,7 @@ export const ChoiceCardInteractive: ReactComponent<
 					label={`${currencySymbol}${amount} ${
 						contributionType[selection.frequency].suffix
 					}`}
-					id={`contributions-banner-${amount}`}
+					id={`${componentId}-${amount}`}
 					checked={selection.amount === amount}
 					onChange={() => updateAmount(amount)}
 					cssOverrides={style.buttonOverride}
@@ -190,7 +190,7 @@ export const ChoiceCardInteractive: ReactComponent<
 				<ChoiceCard
 					value="third"
 					label="Other"
-					id="contributions-banner-third"
+					id={`${componentId}-third`}
 					checked={true}
 					cssOverrides={style.buttonOverride}
 				/>
@@ -208,7 +208,7 @@ export const ChoiceCardInteractive: ReactComponent<
 					key={2}
 					value="other"
 					label="Other"
-					id="contributions-banner-other"
+					id={`${componentId}-other`}
 					checked={selection.amount === 'other'}
 					onChange={() => updateAmount('other')}
 					cssOverrides={style.buttonOverride}
@@ -226,7 +226,7 @@ export const ChoiceCardInteractive: ReactComponent<
 				key={label}
 				label={label}
 				value={frequency}
-				id={`contributions-banner-${frequency}`}
+				id={`${componentId}-${frequency}`}
 				checked={selection.frequency === frequency}
 				onChange={() => updateFrequency(frequency)}
 				cssOverrides={style.buttonOverride}
@@ -237,7 +237,7 @@ export const ChoiceCardInteractive: ReactComponent<
 	return (
 		<>
 			<ChoiceCardGroup
-				name="contribution-frequency"
+				name={`${componentId}-contribution-frequency`}
 				label="Contribution frequency"
 				columns={noOfContributionTabs}
 				hideLabel={true}
@@ -255,7 +255,7 @@ export const ChoiceCardInteractive: ReactComponent<
 				)}
 			</ChoiceCardGroup>
 			<ChoiceCardGroup
-				name="contribution-amount"
+				name={`${componentId}-contribution-amount`}
 				label="Contribution amount"
 				columns={2}
 				hideLabel={true}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
@@ -118,7 +118,7 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
 				submitComponentEvent({
 					component: {
 						componentType: 'ACQUISITIONS_OTHER',
-						id: 'contributions-banner-choice-cards',
+						id: componentId,
 					},
 					action: 'VIEW',
 					abTest: {
@@ -128,7 +128,7 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
 				});
 			}
 		}
-	}, [hasBeenSeen, submitComponentEvent, testName, variantName]);
+	}, [componentId, hasBeenSeen, submitComponentEvent, testName, variantName]);
 
 	if (!selection) {
 		return <></>;

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
@@ -104,7 +104,6 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
 	cssCtaOverides,
 	onCtaClick,
 }: ChoiceCardProps) => {
-	console.log('cssCtaOverides', cssCtaOverides);
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
 		threshold: 0,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/choiceCards/ChoiceCards.tsx
@@ -104,6 +104,7 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
 	cssCtaOverides,
 	onCtaClick,
 }: ChoiceCardProps) => {
+	console.log('cssCtaOverides', cssCtaOverides);
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
 		threshold: 0,

--- a/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
+++ b/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
@@ -12,11 +12,11 @@ import type {
 	SelectedAmountsVariant,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
+import type { BannerEnrichedCta } from '../banners/common/types';
 import type { SupportTier } from '../epics/utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from '../epics/utils/threeTierChoiceCardAmounts';
 import type { ChoiceCardSelection } from '../lib/choiceCards';
 import { addChoiceCardsProductParams } from '../lib/tracking';
-import { BannerEnrichedCta } from '../banners/common/types';
 
 export type ContentType = 'mainContent' | 'mobileContent';
 

--- a/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
+++ b/dotcom-rendering/src/components/marketing/hooks/useChoiceCards.ts
@@ -12,11 +12,11 @@ import type {
 	SelectedAmountsVariant,
 } from '@guardian/support-dotcom-components/dist/shared/src/types';
 import { useEffect, useState } from 'react';
-import type { BannerTextContent } from '../banners/common/types';
 import type { SupportTier } from '../epics/utils/threeTierChoiceCardAmounts';
 import { threeTierChoiceCardAmounts } from '../epics/utils/threeTierChoiceCardAmounts';
 import type { ChoiceCardSelection } from '../lib/choiceCards';
 import { addChoiceCardsProductParams } from '../lib/tracking';
+import { BannerEnrichedCta } from '../banners/common/types';
 
 export type ContentType = 'mainContent' | 'mobileContent';
 
@@ -45,7 +45,8 @@ function transformChoiceCardsAmountsToProduct(
 const useChoiceCards = (
 	choiceCardAmounts: SelectedAmountsVariant | undefined,
 	countryCode: string | undefined,
-	content: BannerTextContent,
+	primaryCtaMain: BannerEnrichedCta | null,
+	primaryCtaMobile: BannerEnrichedCta | null,
 ): {
 	choiceCardSelection: ChoiceCardSelection | undefined;
 	setChoiceCardSelection: (choiceCardSelection: ChoiceCardSelection) => void;
@@ -74,16 +75,15 @@ const useChoiceCards = (
 	}, [choiceCardAmounts]);
 
 	const getCtaText = (contentType: ContentType): string => {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the types and data fetched from the API are out of sync
-		const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
-
-		return primaryCtaText ? primaryCtaText : 'Contribute';
+		const cta =
+			contentType === 'mobileContent' ? primaryCtaMobile : primaryCtaMain;
+		return cta?.ctaText ?? 'Contribute';
 	};
 	const getCtaUrl = (contentType: ContentType): string => {
+		const cta =
+			contentType === 'mobileContent' ? primaryCtaMobile : primaryCtaMain;
 		const primaryCtaUrl =
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the types and data fetched from the API are out of sync
-			content?.[contentType]?.primaryCta?.ctaUrl ??
-			'https://support.theguardian.com/contribute';
+			cta?.ctaUrl ?? 'https://support.theguardian.com/contribute';
 
 		if (choiceCardSelection && choiceCardSelection.amount !== 'other') {
 			const { product, ratePlan } = transformChoiceCardsAmountsToProduct(

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -46,6 +46,8 @@ import { palette as schemePalette } from '../palette';
 import { type DCRCollectionType, type DCRFrontType } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
+import { StickyLiveblogAskWrapper } from '../components/StickyLiveblogAskWrapper.importable';
+import { UsEoy2024Wrapper } from '../components/UsEoy2024Wrapper.importable';
 
 interface Props {
 	front: DCRFrontType;
@@ -304,6 +306,40 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					if (collection.collectionType === 'scrollable/highlights') {
 						// Highlights are rendered in the Masthead component
 						return null;
+					}
+
+					if (collection.displayName === 'highlights') {
+						return (
+							<ContainerOverrides
+								key={ophanName}
+								containerPalette={collection.containerPalette}
+							>
+								<Section
+									fullWidth={true}
+									padSides={false}
+									showTopBorder={false}
+									showSideBorders={false}
+									ophanComponentLink={ophanComponentLink}
+									ophanComponentName={ophanName}
+									containerName={collection.collectionType}
+									hasPageSkin={hasPageSkin}
+									shouldCenter={false}
+								>
+									<Island
+										priority="feature"
+										defer={{ until: 'visible' }}
+									>
+										<UsEoy2024Wrapper />
+										{/*<StickyLiveblogAskWrapper*/}
+										{/*	referrerUrl={'url'}*/}
+										{/*	shouldHideReaderRevenueOnArticle={*/}
+										{/*		false*/}
+										{/*	}*/}
+										{/*/>*/}
+									</Island>
+								</Section>
+							</ContainerOverrides>
+						);
 					}
 
 					if (collection.collectionType === 'fixed/thrasher') {

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -307,7 +307,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						return null;
 					}
 
-					if (collection.displayName === 'US end-of-year 2024') {
+					if (
+						collection.displayName === 'US end-of-year 2024' &&
+						pageId.toLowerCase() === 'us'
+					) {
 						return (
 							<ContainerOverrides
 								key={ophanName}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -318,7 +318,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							>
 								<Section
 									fullWidth={true}
-									padBottom={true}
+									padBottom={false}
 									showSideBorders={false}
 									padSides={false}
 									showTopBorder={false}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -307,8 +307,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						return null;
 					}
 
-					// TODO - proper name
-					if (collection.displayName === 'highlights') {
+					if (collection.displayName === 'US end-of-year 2024') {
 						return (
 							<ContainerOverrides
 								key={ophanName}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -30,6 +30,7 @@ import { SnapCssSandbox } from '../components/SnapCssSandbox';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
+import { UsEoy2024Wrapper } from '../components/UsEoy2024Wrapper.importable';
 import { WeatherWrapper } from '../components/WeatherWrapper.importable';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { badgeFromBranding, isPaidContentSameBranding } from '../lib/branding';
@@ -46,9 +47,6 @@ import { palette as schemePalette } from '../palette';
 import { type DCRCollectionType, type DCRFrontType } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
-import { StickyLiveblogAskWrapper } from '../components/StickyLiveblogAskWrapper.importable';
-import { UsEoy2024Wrapper } from '../components/UsEoy2024Wrapper.importable';
-import { css } from '@emotion/react';
 
 interface Props {
 	front: DCRFrontType;

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -48,6 +48,7 @@ import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 import { StickyLiveblogAskWrapper } from '../components/StickyLiveblogAskWrapper.importable';
 import { UsEoy2024Wrapper } from '../components/UsEoy2024Wrapper.importable';
+import { css } from '@emotion/react';
 
 interface Props {
 	front: DCRFrontType;
@@ -308,6 +309,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						return null;
 					}
 
+					// TODO - proper name
 					if (collection.displayName === 'highlights') {
 						return (
 							<ContainerOverrides
@@ -316,26 +318,24 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							>
 								<Section
 									fullWidth={true}
+									padBottom={true}
+									showSideBorders={
+										collection.collectionType !==
+										'fixed/video'
+									}
 									padSides={false}
 									showTopBorder={false}
-									showSideBorders={false}
 									ophanComponentLink={ophanComponentLink}
 									ophanComponentName={ophanName}
-									containerName={collection.collectionType}
+									containerName={'fixed/medium/slow-VII'}
 									hasPageSkin={hasPageSkin}
-									shouldCenter={false}
+									// shouldCenter={false}
 								>
 									<Island
 										priority="feature"
 										defer={{ until: 'visible' }}
 									>
 										<UsEoy2024Wrapper />
-										{/*<StickyLiveblogAskWrapper*/}
-										{/*	referrerUrl={'url'}*/}
-										{/*	shouldHideReaderRevenueOnArticle={*/}
-										{/*		false*/}
-										{/*	}*/}
-										{/*/>*/}
 									</Island>
 								</Section>
 							</ContainerOverrides>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -319,17 +319,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								<Section
 									fullWidth={true}
 									padBottom={true}
-									showSideBorders={
-										collection.collectionType !==
-										'fixed/video'
-									}
+									showSideBorders={false}
 									padSides={false}
 									showTopBorder={false}
 									ophanComponentLink={ophanComponentLink}
 									ophanComponentName={ophanName}
-									containerName={'fixed/medium/slow-VII'}
 									hasPageSkin={hasPageSkin}
-									// shouldCenter={false}
 								>
 									<Island
 										priority="feature"


### PR DESCRIPTION
## What does this change?
Adds a new component for the upcoming US end-of-year "Moment". This component is rendered in a Front container. We use the name of the container ("US end-of-year 2024") to decide when to render it. This means a container will need to be created in the fronts tool with the correct name.

## Why?
In the past we've used "Thrashers" to deploy this type of message to the fronts. However, thrashers are not suitable for rich/interactive components like this. This component needs to render a ticker (based on a fetch) and interactive choice cards.
It's now much easier to build this type of thing in DCR as islands, where the relevant source components etc exist. It's also easier to line it up with the columns of the fronts.


## Screenshots

Wide:
<img width="1299" alt="Screenshot 2024-10-21 at 12 20 20" src="https://github.com/user-attachments/assets/6580042e-c53b-4cb2-8799-1a40e2c41e62">

Leftcol:
<img width="1141" alt="Screenshot 2024-10-21 at 12 20 40" src="https://github.com/user-attachments/assets/a0e9d571-8ad7-49f4-a848-22edef09a13f">

Desktop:
<img width="981" alt="Screenshot 2024-10-21 at 12 20 59" src="https://github.com/user-attachments/assets/9ee5af4d-d7f7-47fa-83a7-32cda132e8eb">

Tablet:
<img width="740" alt="Screenshot 2024-10-21 at 12 21 30" src="https://github.com/user-attachments/assets/1b258f33-cd73-4ba3-83ae-ef6900ea3646">

Mobile:
<img width="321" alt="Screenshot 2024-10-21 at 12 21 54" src="https://github.com/user-attachments/assets/958c563d-02c8-4961-98fd-e56dd14d22f3">

