### PR TITLE
Change links to use dark mode colors for audio articles

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3130,8 +3130,10 @@ const articleSectionTitleLight: PaletteFunction = () =>
 const articleSectionTitleDark: PaletteFunction = () =>
 	sourcePalette.neutral[86];
 
-const articleLinkTextLight: PaletteFunction = ({ design, theme }) => {
+const articleLinkTextLight: PaletteFunction = ({ display, design, theme }) => {
 	if (design === ArticleDesign.Analysis) return sourcePalette.news[300];
+	if (design === ArticleDesign.Audio)
+		return articleLinkTextDark({ display, design, theme });
 	switch (theme) {
 		case Pillar.Lifestyle:
 			return sourcePalette.lifestyle[300];
@@ -3204,7 +3206,9 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 	}
 };
 
-const articleLinkHoverLight: PaletteFunction = ({ design, theme }) => {
+const articleLinkHoverLight: PaletteFunction = ({ display, design, theme }) => {
+	if (design === ArticleDesign.Audio)
+		return articleLinkHoverDark({ display, design, theme });
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			switch (theme) {
@@ -3275,6 +3279,7 @@ const articleLinkHoverDark: PaletteFunction = (f) => articleLinkTextDark(f);
 
 const articleLinkBorderHoverLight: PaletteFunction = ({ design, theme }) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[7];
+	if (design === ArticleDesign.Audio) return sourcePalette.neutral[86];
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[100];
 	}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3132,8 +3132,9 @@ const articleSectionTitleDark: PaletteFunction = () =>
 
 const articleLinkTextLight: PaletteFunction = ({ display, design, theme }) => {
 	if (design === ArticleDesign.Analysis) return sourcePalette.news[300];
-	if (design === ArticleDesign.Audio)
+	if (design === ArticleDesign.Audio) {
 		return articleLinkTextDark({ display, design, theme });
+	}
 	switch (theme) {
 		case Pillar.Lifestyle:
 			return sourcePalette.lifestyle[300];
@@ -3207,8 +3208,9 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 };
 
 const articleLinkHoverLight: PaletteFunction = ({ display, design, theme }) => {
-	if (design === ArticleDesign.Audio)
+	if (design === ArticleDesign.Audio) {
 		return articleLinkHoverDark({ display, design, theme });
+	}
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			switch (theme) {
@@ -3277,9 +3279,17 @@ const articleLinkHoverLight: PaletteFunction = ({ display, design, theme }) => {
 
 const articleLinkHoverDark: PaletteFunction = (f) => articleLinkTextDark(f);
 
-const articleLinkBorderHoverLight: PaletteFunction = ({ design, theme }) => {
-	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[7];
-	if (design === ArticleDesign.Audio) return sourcePalette.neutral[86];
+const articleLinkBorderHoverLight: PaletteFunction = ({
+	display,
+	design,
+	theme,
+}) => {
+	if (theme === ArticleSpecial.Labs) {
+		return sourcePalette.neutral[7];
+	}
+	if (design === ArticleDesign.Audio) {
+		return articleLinkBorderHoverDark({ display, design, theme });
+	}
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[100];
 	}

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -3172,9 +3172,15 @@ const articleLinkTextDark: PaletteFunction = ({ display, theme }) => {
 	}
 };
 
-const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
+const articleLinkBorderLight: PaletteFunction = ({
+	display,
+	design,
+	theme,
+}) => {
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
-
+	if (design === ArticleDesign.Audio) {
+		return articleLinkBorderDark({ display, design, theme });
+	}
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
 	}


### PR DESCRIPTION
## What does this change?

## Why?
The Audio Articles have a dark background so the text needs to be light. This PR redirects the call to get the dark font even if the light font is requested (for audio articles). As there is no light/dark version of the audio articles.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[after]: https://github.com/user-attachments/assets/13e35bb0-5150-4eca-919c-2fd37de2b887
[before]: https://github.com/user-attachments/assets/827e1501-400f-4a4d-a70b-a99c51a93b6b

