### PR TITLE
5:4 video images 

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -674,11 +674,7 @@ export const Card = ({
 														: imageSize
 												}
 												enableAds={false}
-												aspectRatio={
-													isFlexibleContainer
-														? '5/4'
-														: ''
-												}
+												aspectRatio={aspectRatio}
 											/>
 										</Island>
 									</div>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -674,6 +674,11 @@ export const Card = ({
 														: imageSize
 												}
 												enableAds={false}
+												aspectRatio={
+													isFlexibleContainer
+														? '5/4'
+														: ''
+												}
 											/>
 										</Island>
 									</div>

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -3,17 +3,24 @@ import { css } from '@emotion/react';
 type Props = {
 	height: number;
 	width: number;
+	aspectRatio?: string;
 	children: React.ReactNode;
 };
 
-export const MaintainAspectRatio = ({ height, width, children }: Props) => (
+export const MaintainAspectRatio = ({
+	height,
+	width,
+	aspectRatio,
+	children,
+}: Props) => (
 	/* https://css-tricks.com/aspect-ratio-boxes/ */
 	<div
 		css={css`
 			/* position relative to contain the absolutely positioned iframe plus any Overlay image */
 			position: relative;
-			padding-bottom: ${(height / width) * 100}%;
-
+			${aspectRatio
+				? `aspect-ratio: ${aspectRatio};`
+				: `padding-bottom: ${(height / width) * 100}% `}
 			& > iframe,
 			& > video {
 				width: 100%;

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { AspectRatio } from './CardPicture';
+import type { AspectRatio } from './CardPicture';
 
 type Props = {
 	height: number;

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
+import { AspectRatio } from './CardPicture';
 
 type Props = {
 	height: number;
 	width: number;
-	aspectRatio?: string;
+	aspectRatio?: AspectRatio;
 	children: React.ReactNode;
 };
 
@@ -12,25 +13,30 @@ export const MaintainAspectRatio = ({
 	width,
 	aspectRatio,
 	children,
-}: Props) => (
+}: Props) => {
 	/* https://css-tricks.com/aspect-ratio-boxes/ */
-	<div
-		css={css`
-			/* position relative to contain the absolutely positioned iframe plus any Overlay image */
-			position: relative;
-			${aspectRatio
-				? `aspect-ratio: ${aspectRatio};`
-				: `padding-bottom: ${(height / width) * 100}% `}
-			& > iframe,
-			& > video {
-				width: 100%;
-				height: 100%;
-				position: absolute;
-				top: 0;
-				left: 0;
-			}
-		`}
-	>
-		{children}
-	</div>
-);
+	const paddingBottom =
+		aspectRatio === '5:4'
+			? `${(4 / 5) * 100}%`
+			: `${(height / width) * 100}%`;
+
+	return (
+		<div
+			css={css`
+				/* position relative to contain the absolutely positioned iframe plus any Overlay image */
+				position: relative;
+				padding-bottom: ${paddingBottom};
+				& > iframe,
+				& > video {
+					width: 100%;
+					height: 100%;
+					position: absolute;
+					top: 0;
+					left: 0;
+				}
+			`}
+		>
+			{children}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -7,6 +7,7 @@ import type {
 	ImagePositionType,
 	ImageSizeType,
 } from '../Card/components/ImageWrapper';
+import { AspectRatio } from '../CardPicture';
 import { MaintainAspectRatio } from '../MaintainAspectRatio';
 import type { VideoCategory } from './YoutubeAtomOverlay';
 import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';
@@ -51,7 +52,7 @@ export type Props = {
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
 	renderingTarget: RenderingTarget;
-	aspectRatio?: string;
+	aspectRatio?: AspectRatio;
 };
 
 export const YoutubeAtom = ({

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -253,6 +253,7 @@ export const YoutubeAtom = ({
 							showTextOverlay={showTextOverlay}
 							imageSize={imageSize}
 							imagePositionOnMobile={imagePositionOnMobile}
+							aspectRatio={aspectRatio}
 						/>
 					)}
 					{showPlaceholder && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -7,7 +7,7 @@ import type {
 	ImagePositionType,
 	ImageSizeType,
 } from '../Card/components/ImageWrapper';
-import { AspectRatio } from '../CardPicture';
+import type { AspectRatio } from '../CardPicture';
 import { MaintainAspectRatio } from '../MaintainAspectRatio';
 import type { VideoCategory } from './YoutubeAtomOverlay';
 import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -51,6 +51,7 @@ export type Props = {
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
 	renderingTarget: RenderingTarget;
+	aspectRatio?: string;
 };
 
 export const YoutubeAtom = ({
@@ -79,6 +80,7 @@ export const YoutubeAtom = ({
 	imageSize,
 	imagePositionOnMobile,
 	renderingTarget,
+	aspectRatio,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -196,7 +198,11 @@ export const YoutubeAtom = ({
 				setIsClosed={setIsClosed}
 				shouldPauseOutOfView={shouldPauseOutOfView}
 			>
-				<MaintainAspectRatio height={height} width={width}>
+				<MaintainAspectRatio
+					height={height}
+					width={width}
+					aspectRatio={aspectRatio}
+				>
 					{
 						/**
 						 * Consent and ad targeting are initially undefined and set by subsequent re-renders

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -19,6 +19,7 @@ import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { secondsToDuration } from '../MediaDuration';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
+import { AspectRatio } from '../CardPicture';
 
 export type VideoCategory = 'live' | 'documentary' | 'explainer';
 
@@ -38,6 +39,7 @@ type Props = {
 	showTextOverlay?: boolean;
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
+	aspectRatio: AspectRatio;
 };
 
 const overlayStyles = css`
@@ -149,6 +151,7 @@ export const YoutubeAtomOverlay = ({
 	showTextOverlay,
 	imageSize,
 	imagePositionOnMobile,
+	aspectRatio,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -173,6 +176,7 @@ export const YoutubeAtomOverlay = ({
 						alt={alt}
 						height={height}
 						width={width}
+						aspectRatio={aspectRatio}
 					/>
 				)}
 				{showPill && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -15,11 +15,11 @@ import type {
 	ImageSizeType,
 } from '../Card/components/ImageWrapper';
 import { PlayIcon } from '../Card/components/PlayIcon';
+import type { AspectRatio } from '../CardPicture';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { secondsToDuration } from '../MediaDuration';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
-import { AspectRatio } from '../CardPicture';
 
 export type VideoCategory = 'live' | 'documentary' | 'explainer';
 
@@ -39,7 +39,7 @@ type Props = {
 	showTextOverlay?: boolean;
 	imageSize: ImageSizeType;
 	imagePositionOnMobile: ImagePositionType;
-	aspectRatio: AspectRatio;
+	aspectRatio?: AspectRatio;
 };
 
 const overlayStyles = css`

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -16,7 +16,7 @@ export const YoutubeAtomPicture = ({
 	alt,
 	height,
 	width,
-	aspectRatio = '5:4',
+	aspectRatio,
 }: Props) => {
 	const sources = generateSources(
 		getSourceImageUrl(image),

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -8,16 +8,27 @@ type Props = {
 	alt: string;
 	height: number;
 	width: number;
+	aspectRatio?: string;
 };
 
-export const YoutubeAtomPicture = ({ image, alt, height, width }: Props) => {
-	const sources = generateSources(getSourceImageUrl(image), [
-		{ breakpoint: breakpoints.mobile, width: 465 },
-		{ breakpoint: breakpoints.mobileLandscape, width: 645 },
-		{ breakpoint: breakpoints.phablet, width: 620 },
-		{ breakpoint: breakpoints.tablet, width: 700 },
-		{ breakpoint: breakpoints.desktop, width: 620 },
-	]);
+export const YoutubeAtomPicture = ({
+	image,
+	alt,
+	height,
+	width,
+	aspectRatio = '5:4',
+}: Props) => {
+	const sources = generateSources(
+		getSourceImageUrl(image),
+		[
+			{ breakpoint: breakpoints.mobile, width: 465 },
+			{ breakpoint: breakpoints.mobileLandscape, width: 645 },
+			{ breakpoint: breakpoints.phablet, width: 620 },
+			{ breakpoint: breakpoints.tablet, width: 700 },
+			{ breakpoint: breakpoints.desktop, width: 620 },
+		],
+		aspectRatio,
+	);
 	const fallbackSource = getFallbackSource(sources);
 
 	return (

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -40,6 +40,7 @@ type Props = {
 	imageSize?: ImageSizeType;
 	imagePositionOnMobile?: ImagePositionType;
 	enableAds: boolean;
+	aspectRatio?: string;
 };
 
 /**
@@ -81,6 +82,7 @@ export const YoutubeBlockComponent = ({
 	imageSize = 'large',
 	imagePositionOnMobile = 'none',
 	enableAds,
+	aspectRatio,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -173,6 +175,7 @@ export const YoutubeBlockComponent = ({
 				imageSize={imageSize}
 				imagePositionOnMobile={imagePositionOnMobile}
 				renderingTarget={renderingTarget}
+				aspectRatio={aspectRatio}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -8,7 +8,7 @@ import type {
 	ImagePositionType,
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
-import { AspectRatio } from './CardPicture';
+import type { AspectRatio } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -8,6 +8,7 @@ import type {
 	ImagePositionType,
 	ImageSizeType,
 } from './Card/components/ImageWrapper';
+import { AspectRatio } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
@@ -40,7 +41,7 @@ type Props = {
 	imageSize?: ImageSizeType;
 	imagePositionOnMobile?: ImagePositionType;
 	enableAds: boolean;
-	aspectRatio?: string;
+	aspectRatio?: AspectRatio;
 };
 
 /**


### PR DESCRIPTION
## What does this change?
Allows an override of the youtube aspect ratio so that video image overlays appear in 5:4. It also requests this crop from fastly. 

NB - whilst the image for the video will be 5:4, the aspect ratio of the video will remain 16:9, leading to a letterbox effect on play.

## Why?
This is required as part of the fairground redesign. 
## Screenshots

###  Overlay

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/2a4382e1-da29-4c32-be06-e89ece929d81
[after]: https://github.com/user-attachments/assets/4efe28c2-c72b-4282-ab30-5456d8fa8fb7

###  Playing


| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

[before1]: https://github.com/user-attachments/assets/442fd1d1-2a5a-4094-9ea7-322a9ab2313c
[after1]: https://github.com/user-attachments/assets/e9e6ee57-584c-4175-a044-e7ab9c9d11e0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
