### PR TITLE
Use max-width to prevent containers expanding

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -51,9 +51,6 @@ export const rootStyles = (
 
 	.ad-slot-container {
 		/* prevent third-party code from breaking our layout */
-		/* using hidden as a fallback for browsers that don't support clip */
-		overflow-x: hidden;
-		/* clip is our preferred choice as it allows sticky ads in the right column */
-		overflow-x: clip;
+		max-width: 100%;
 	}
 `;


### PR DESCRIPTION
## What does this change?
Switches to using max-width instead of overflow to prevent containers expanding beyond 100% and breaking the layout. Follows on from this PR: https://github.com/guardian/dotcom-rendering/pull/11552

## Why?
We're investigating whether or not hiding overflow on ad containers has caused a drop in teads viewability, and we will be closely monitoring to see if this change affects teads viewability.