### PR TITLE
Spike feature card (specifically for the blur effect)

### DIFF
--- a/dotcom-rendering/src/components/Card/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/Card/FeatureCard.stories.tsx
@@ -1,0 +1,54 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
+import type { Meta } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
+import { FeatureCard } from './FeatureCard';
+
+const meta = {
+	component: FeatureCard,
+	title: 'Components/FeatureCard',
+	render: (args) => (
+		<CardWrapper>
+			<FeatureCard {...args} />
+		</CardWrapper>
+	),
+	args: {
+		linkTo: '',
+		headlineText: 'Underground cave found on moon could be ideal base',
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Sport,
+		},
+		kickerText: 'News',
+		byline: 'Georges Monbiot',
+		image: {
+			src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+			altText: 'alt text',
+		},
+		imageLoading: 'eager',
+	},
+} satisfies Meta<typeof FeatureCard>;
+
+export default meta;
+
+const CardWrapper = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<div
+			css={css`
+				width: 150px;
+				flex-basis: 100%;
+				${from.tablet} {
+					width: 300px;
+					flex-basis: 1;
+				}
+				margin: 10px;
+				position: relative;
+			`}
+		>
+			{children}
+		</div>
+	);
+};
+
+export const Default = {};

--- a/dotcom-rendering/src/components/Card/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/Card/FeatureCard.stories.tsx
@@ -14,16 +14,16 @@ const meta = {
 	),
 	args: {
 		linkTo: '',
-		headlineText: 'Underground cave found on moon could be ideal base',
+		headlineText: 'Running a takeaway kitchen in an Iraqi border town',
 		format: {
 			display: ArticleDisplay.Standard,
 			design: ArticleDesign.Standard,
-			theme: Pillar.Sport,
+			theme: Pillar.News,
 		},
 		kickerText: 'News',
-		byline: 'Georges Monbiot',
+		byline: '',
 		image: {
-			src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+			src: 'https://media.guim.co.uk/569f45834d7be5211a6c0e4ccb9acc9ed562ffa5/0_256_3840_2304/master/3840.jpg',
 			altText: 'alt text',
 		},
 		imageLoading: 'eager',

--- a/dotcom-rendering/src/components/Card/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/Card/FeatureCard.tsx
@@ -41,16 +41,17 @@ const hoverStyles = css`
 
 const headline = css`
 	position: absolute;
-	bottom: 0; /* Align to the bottom of the image area */
+	bottom: 10%;
 	left: 0;
 	width: 100%;
-	z-index: 10000; /* Make sure headline is above the overlay */
+	z-index: 10000;
+	margin-left: 5px;
 `;
 
 const imageArea = css`
 	height: 396px;
 	width: 300px;
-	position: relative; /* Changed to relative so child elements can be absolutely positioned */
+	position: relative;
 	display: flex;
 	justify-content: center;
 `;
@@ -59,7 +60,7 @@ const imageWrapper = css`
 	position: relative;
 	height: 396px;
 	width: 300px;
-	overflow: hidden; /* Hide any overflow */
+	overflow: hidden;
 `;
 
 const blurredOverlay = css`
@@ -68,7 +69,7 @@ const blurredOverlay = css`
 	width: 100%;
 	height: 33%;
 	backdrop-filter: blur(1rem); /* Apply blur effect */
-	z-index: 9999; /* Ensure the overlay is above the image but below the headline */
+	z-index: 9999;
 `;
 
 const imageStyle = css`

--- a/dotcom-rendering/src/components/Card/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/Card/FeatureCard.tsx
@@ -1,0 +1,137 @@
+import { css } from '@emotion/react';
+import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
+import { palette } from '../../palette';
+import type { DCRFrontImage } from '../../types/front';
+import { CardHeadline } from '../CardHeadline';
+import type { Loading } from '../CardPicture';
+import { CardPicture } from '../CardPicture';
+import { FormatBoundary } from '../FormatBoundary';
+
+export type FeatureCardProps = {
+	linkTo: string;
+	format: ArticleFormat;
+	headlineText: string;
+	showQuotedHeadline: boolean;
+	image?: DCRFrontImage;
+	imageLoading?: Loading;
+	avatarUrl?: string;
+	kickerText?: string;
+	dataLinkName: string;
+	byline?: string;
+	isExternalLink: boolean;
+};
+
+const hoverStyles = css`
+	:hover .image-overlay {
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		height: 100%;
+		width: 100%;
+		border-radius: 100%;
+		background-color: ${palette('--highlights-card-headline')};
+		opacity: 0.1;
+	}
+
+	/* Only underline the headline element we want to target (not kickers/sublink headlines) */
+	:hover .card-headline .show-underline {
+		text-decoration: underline;
+	}
+`;
+
+const headline = css`
+	position: absolute;
+	bottom: 0; /* Align to the bottom of the image area */
+	left: 0;
+	width: 100%;
+	z-index: 10000; /* Make sure headline is above the overlay */
+`;
+
+const imageArea = css`
+	height: 396px;
+	width: 300px;
+	position: relative; /* Changed to relative so child elements can be absolutely positioned */
+	display: flex;
+	justify-content: center;
+`;
+
+const imageWrapper = css`
+	position: relative;
+	height: 396px;
+	width: 300px;
+	overflow: hidden; /* Hide any overflow */
+`;
+
+const blurredOverlay = css`
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	height: 33%;
+	backdrop-filter: blur(1rem); /* Apply blur effect */
+	z-index: 9999; /* Ensure the overlay is above the image but below the headline */
+`;
+
+const imageStyle = css`
+	height: 100%;
+	width: 100%;
+	object-fit: cover;
+	object-position: center;
+`;
+
+export const FeatureCard = ({
+	linkTo,
+	format,
+	headlineText,
+	showQuotedHeadline,
+	image,
+	imageLoading = 'lazy',
+	avatarUrl,
+	kickerText,
+	dataLinkName,
+	byline,
+	isExternalLink,
+}: FeatureCardProps) => {
+	return (
+		// <div className="image-overlay"> </div> {/* This image overlay is styled when the CardLink is hovered */} 			{/* <CardPicture
+		// 	imageSize="jumbo"
+		// 	mainImage={image.src}
+		// 	alt={image.altText}
+		// 	loading={imageLoading}
+		// 	aspectRatio='5:4'
+		// /> */}
+
+		<FormatBoundary format={format}>
+			{/* <div css={[hoverStyles]}> */}
+			<div>
+				<div css={imageArea}>
+					{image && (
+						<>
+							<div id="imagewrapper" css={imageWrapper}>
+								<img
+									src={image.src}
+									alt={image.altText}
+									css={imageStyle}
+								/>
+								<div css={blurredOverlay}></div>
+							</div>
+						</>
+					)}
+				</div>
+				<div css={headline}>
+					<CardHeadline
+						headlineText={headlineText}
+						format={format}
+						size="medium"
+						sizeOnMobile="small"
+						showPulsingDot={
+							format.design === ArticleDesign.LiveBlog
+						}
+						kickerText={kickerText}
+						isExternalLink={isExternalLink}
+						showQuotes={showQuotedHeadline}
+					/>
+				</div>
+			</div>
+		</FormatBoundary>
+	);
+};

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,0 +1,265 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineMedium24Object,
+	space,
+} from '@guardian/source/foundations';
+import {
+	Button,
+	Hide,
+	SvgChevronLeftSingle,
+	SvgChevronRightSingle,
+} from '@guardian/source/react-components';
+import { useEffect, useRef, useState } from 'react';
+import { palette } from '../palette';
+
+type Props = {
+	children: React.ReactNode;
+	carouselLength: number;
+};
+
+/**
+ * This needs to match the `FrontSection` title font and is used to calculate
+ * the negative margin that aligns the navigation buttons with the title.
+ */
+const titlePreset = headlineMedium24Object;
+
+/**
+ * Grid sizing to calculate negative margin used to pull navigation buttons
+ * out side of `FrontSection` container at `wide` breakpoint.
+ */
+const gridColumnWidth = '60px';
+const gridGap = '20px';
+
+const themeButton = {
+	borderTertiary: palette('--carousel-chevron-border'),
+	textTertiary: palette('--carousel-chevron'),
+};
+
+const themeButtonDisabled = {
+	borderTertiary: palette('--carousel-chevron-border-disabled'),
+	textTertiary: palette('--carousel-chevron-disabled'),
+};
+
+const carouselContainerStyles = css`
+	display: flex;
+	flex-direction: column-reverse;
+	${from.wide} {
+		flex-direction: row;
+	}
+
+	/* Extend carousel into outer margins on mobile */
+	margin-left: -10px;
+	margin-right: -10px;
+	${from.mobileLandscape} {
+		margin-left: -20px;
+		margin-right: -20px;
+	}
+
+	/**
+	 * From tablet, pull container up so navigation buttons align with title.
+	 * The margin is calculated from the front section title font size and line
+	 * height, and the default container spacing.
+	 *
+	 * From wide, the navigation buttons are pulled out of the main content area
+	 * into the right-hand column.
+	 */
+	${from.tablet} {
+		margin-left: 10px;
+		margin-right: 10px;
+		margin-top: calc(
+			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
+				${space[3]}px
+		);
+	}
+	${from.leftCol} {
+		margin-top: 0;
+		margin-left: -10px;
+	}
+	${from.wide} {
+		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
+	}
+`;
+
+const carouselStyles = css`
+	display: grid;
+	grid-auto-columns: 1fr;
+	grid-auto-flow: column;
+	gap: 20px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	overscroll-behavior-x: contain;
+	overscroll-behavior-y: auto;
+	/**
+	 * Hide scrollbars
+	 * See: https://stackoverflow.com/a/38994837
+	 */
+	::-webkit-scrollbar {
+		display: none; /* Safari and Chrome */
+	}
+	scrollbar-width: none; /* Firefox */
+	position: relative;
+
+	padding-left: 10px;
+	scroll-padding-left: 10px;
+	${from.mobileLandscape} {
+		padding-left: 20px;
+		scroll-padding-left: 20px;
+	}
+	${from.tablet} {
+		padding-left: 0px;
+		scroll-padding-left: 0px;
+	}
+	${from.leftCol} {
+		padding-left: 20px;
+		scroll-padding-left: 20px;
+	}
+`;
+
+const buttonContainerStyles = css`
+	margin-left: auto;
+	${from.wide} {
+		margin-left: ${space[1]}px;
+	}
+`;
+
+const buttonLayoutStyles = css`
+	display: flex;
+	gap: ${space[1]}px;
+`;
+
+/**
+ * Generates CSS styles for a grid layout used in a carousel.
+ *
+ * @param {number} totalCards - The total number of cards in the carousel.
+ * @returns {string} - The CSS styles for the grid layout.
+ */
+const generateCarouselColumnStyles = (totalCards: number) => {
+	const peepingCardWidth = space[8];
+
+	return css`
+		grid-template-columns: repeat(
+			${totalCards},
+			calc((100% - ${peepingCardWidth}px - 20px))
+		);
+		${from.tablet} {
+			grid-template-columns: repeat(${totalCards}, calc(50% - 10px));
+		}
+	`;
+};
+
+/**
+ * A component used in the carousel fronts containers (e.g. small/medium/feature)
+ *
+ */
+
+export const ScrollableCarousel = ({ children, carouselLength }: Props) => {
+	const carouselRef = useRef<HTMLOListElement | null>(null);
+	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
+	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
+
+	const scrollTo = (direction: 'left' | 'right') => {
+		if (!carouselRef.current) return;
+
+		const cardWidth =
+			carouselRef.current.querySelector('li')?.offsetWidth ?? 0;
+		const offset = direction === 'left' ? -cardWidth : cardWidth;
+		carouselRef.current.scrollBy({
+			left: offset,
+			behavior: 'smooth',
+		});
+	};
+
+	/**
+	 * Updates state of navigation buttons based on carousel's scroll position.
+	 *
+	 * This function checks the current scroll position of the carousel and sets
+	 * the styles of the previous and next buttons accordingly. The previous
+	 * button is disabled if the carousel is at the start, and the next button
+	 * is disabled if the carousel is at the end.
+	 */
+	const updateButtonVisibilityOnScroll = () => {
+		const carouselElement = carouselRef.current;
+		if (!carouselElement) return;
+
+		const scrollLeft = carouselElement.scrollLeft;
+		const maxScrollLeft =
+			carouselElement.scrollWidth - carouselElement.clientWidth;
+
+		setPreviousButtonEnabled(scrollLeft > 0);
+		setNextButtonEnabled(scrollLeft < maxScrollLeft);
+	};
+
+	useEffect(() => {
+		const carouselElement = carouselRef.current;
+		if (!carouselElement) return;
+
+		carouselElement.addEventListener(
+			'scroll',
+			updateButtonVisibilityOnScroll,
+		);
+
+		return () => {
+			carouselElement.removeEventListener(
+				'scroll',
+				updateButtonVisibilityOnScroll,
+			);
+		};
+	}, []);
+
+	return (
+		<>
+			<div css={carouselContainerStyles}>
+				<ol
+					ref={carouselRef}
+					css={[
+						carouselStyles,
+						generateCarouselColumnStyles(carouselLength),
+					]}
+					data-heatphan-type="carousel"
+				>
+					{children}
+				</ol>
+				<div css={buttonContainerStyles}>
+					<Hide until={'tablet'}>
+						{carouselLength > 2 && (
+							<div css={buttonLayoutStyles}>
+								<Button
+									hideLabel={true}
+									iconSide="left"
+									icon={<SvgChevronLeftSingle />}
+									onClick={() => scrollTo('left')}
+									priority="tertiary"
+									theme={
+										previousButtonEnabled
+											? themeButton
+											: themeButtonDisabled
+									}
+									size="small"
+									disabled={!previousButtonEnabled}
+								/>
+
+								<Button
+									hideLabel={true}
+									iconSide="left"
+									icon={<SvgChevronRightSingle />}
+									onClick={() => scrollTo('right')}
+									priority="tertiary"
+									theme={
+										nextButtonEnabled
+											? themeButton
+											: themeButtonDisabled
+									}
+									size="small"
+									disabled={!nextButtonEnabled}
+								/>
+							</div>
+						)}
+					</Hide>
+				</div>{' '}
+			</div>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -1,21 +1,13 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
 import { palette } from '../palette';
-import type {
-	DCRContainerPalette,
-	DCRContainerType,
-	DCRFrontCard,
-} from '../types/front';
-import { FrontCard } from './FrontCard';
+import type { DCRFrontCard } from '../types/front';
+import { FeatureCard } from './Card/FeatureCard';
 import { ScrollableCarousel } from './ScrollableCarousel';
 
 type Props = {
 	trails: DCRFrontCard[];
-	containerPalette?: DCRContainerPalette;
-	showAge?: boolean;
-	absoluteServerTimes?: boolean;
 	imageLoading: 'lazy' | 'eager';
-	containerType: DCRContainerType;
 };
 
 const itemStyles = css`
@@ -56,39 +48,24 @@ const verticalLineStyles = css`
  *
  * The carouselling arrow buttons need to run javascript.
  */
-export const ScrollableFeature = ({
-	trails,
-	containerPalette,
-	containerType,
-	absoluteServerTimes,
-	imageLoading,
-	showAge,
-}: Props) => {
+export const ScrollableFeature = ({ trails, imageLoading }: Props) => {
 	return (
 		<ScrollableCarousel carouselLength={trails.length}>
 			{trails.map((trail) => {
 				return (
 					<li key={trail.url} css={[itemStyles, verticalLineStyles]}>
-						<FrontCard
-							trail={trail}
-							imageLoading={imageLoading}
-							absoluteServerTimes={!!absoluteServerTimes}
-							containerPalette={containerPalette}
-							containerType={containerType}
-							showAge={!!showAge}
-							headlineSize="small"
-							headlineSizeOnMobile="small"
-							headlineSizeOnTablet="small"
-							imagePositionOnDesktop="left"
-							imagePositionOnMobile="left"
-							imageSize="small" // TODO - needs fixed width images
-							trailText={undefined} // unsupported
-							supportingContent={undefined} // unsupported
-							aspectRatio="5:4"
+						<FeatureCard
+							format={trail.format}
+							headlineText={trail.headline}
 							kickerText={trail.kickerText}
-							showLivePlayable={trail.showLivePlayable}
-							showTopBarDesktop={false}
-							showTopBarMobile={false}
+							avatarUrl={trail.avatarUrl}
+							byline={trail.byline}
+							image={trail.image}
+							imageLoading={imageLoading}
+							linkTo={trail.url}
+							dataLinkName={trail.dataLinkName}
+							isExternalLink={trail.isExternalLink}
+							showQuotedHeadline={trail.showQuotedHeadline}
 						/>
 					</li>
 				);

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -1,0 +1,98 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
+import { palette } from '../palette';
+import type {
+	DCRContainerPalette,
+	DCRContainerType,
+	DCRFrontCard,
+} from '../types/front';
+import { FrontCard } from './FrontCard';
+import { ScrollableCarousel } from './ScrollableCarousel';
+
+type Props = {
+	trails: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes?: boolean;
+	imageLoading: 'lazy' | 'eager';
+	containerType: DCRContainerType;
+};
+
+const itemStyles = css`
+	scroll-snap-align: start;
+	grid-area: span 1;
+	position: relative;
+`;
+
+const verticalLineStyles = css`
+	:not(:last-child)::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: -10px;
+		width: 1px;
+		background-color: ${palette('--card-border-top')};
+		transform: translateX(-50%);
+	}
+	${from.leftCol} {
+		:first-child::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: -10px;
+			width: 1px;
+			background-color: ${palette('--card-border-top')};
+			transform: translateX(-50%);
+		}
+	}
+`;
+
+/**
+ * A container used on fronts to display a carousel of feature cards
+ *
+ * ## Why does this need to be an Island?
+ *
+ * The carouselling arrow buttons need to run javascript.
+ */
+export const ScrollableFeature = ({
+	trails,
+	containerPalette,
+	containerType,
+	absoluteServerTimes,
+	imageLoading,
+	showAge,
+}: Props) => {
+	return (
+		<ScrollableCarousel carouselLength={trails.length}>
+			{trails.map((trail) => {
+				return (
+					<li key={trail.url} css={[itemStyles, verticalLineStyles]}>
+						<FrontCard
+							trail={trail}
+							imageLoading={imageLoading}
+							absoluteServerTimes={!!absoluteServerTimes}
+							containerPalette={containerPalette}
+							containerType={containerType}
+							showAge={!!showAge}
+							headlineSize="small"
+							headlineSizeOnMobile="small"
+							headlineSizeOnTablet="small"
+							imagePositionOnDesktop="left"
+							imagePositionOnMobile="left"
+							imageSize="small" // TODO - needs fixed width images
+							trailText={undefined} // unsupported
+							supportingContent={undefined} // unsupported
+							aspectRatio="5:4"
+							kickerText={trail.kickerText}
+							showLivePlayable={trail.showLivePlayable}
+							showTopBarDesktop={false}
+							showTopBarMobile={false}
+						/>
+					</li>
+				);
+			})}
+		</ScrollableCarousel>
+	);
+};

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -24,7 +24,7 @@ export const Default = {};
 export const WithFrontSection = {
 	render: (args) => (
 		<FrontSection
-			title="Scrollable small"
+			title="Scrollable feature"
 			discussionApiUrl={discussionApiUrl}
 			editionId={'UK'}
 			showTopBorder={false}

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { trails } from '../../fixtures/manual/highlights-trails';
+import { FrontSection } from './FrontSection';
+import { ScrollableFeature } from './ScrollableFeature.importable';
+
+export default {
+	title: 'Components/ScrollableFeature',
+	component: ScrollableFeature,
+	args: {
+		trails,
+		containerPalette: undefined,
+		showAge: true,
+		absoluteServerTimes: true,
+		imageLoading: 'eager',
+		containerType: 'scrollable/feature',
+	},
+} as Meta;
+
+type Story = StoryObj<typeof ScrollableFeature>;
+
+export const Default = {};
+
+export const WithFrontSection = {
+	render: (args) => (
+		<FrontSection
+			title="Scrollable small"
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+			showTopBorder={false}
+		>
+			<ScrollableFeature {...args} />
+		</FrontSection>
+	),
+} satisfies Story;

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,16 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	headlineMedium24Object,
-	space,
-} from '@guardian/source/foundations';
-import {
-	Button,
-	Hide,
-	SvgChevronLeftSingle,
-	SvgChevronRightSingle,
-} from '@guardian/source/react-components';
-import { useEffect, useRef, useState } from 'react';
+import { from } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
@@ -18,6 +7,7 @@ import type {
 	DCRFrontCard,
 } from '../types/front';
 import { FrontCard } from './FrontCard';
+import { ScrollableCarousel } from './ScrollableCarousel';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -27,106 +17,6 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 };
-
-/**
- * This needs to match the `FrontSection` title font and is used to calculate
- * the negative margin that aligns the navigation buttons with the title.
- */
-const titlePreset = headlineMedium24Object;
-
-/**
- * Grid sizing to calculate negative margin used to pull navigation buttons
- * out side of `FrontSection` container at `wide` breakpoint.
- */
-const gridColumnWidth = '60px';
-const gridGap = '20px';
-
-const themeButton = {
-	borderTertiary: palette('--carousel-chevron-border'),
-	textTertiary: palette('--carousel-chevron'),
-};
-
-const themeButtonDisabled = {
-	borderTertiary: palette('--carousel-chevron-border-disabled'),
-	textTertiary: palette('--carousel-chevron-disabled'),
-};
-
-const carouselContainerStyles = css`
-	display: flex;
-	flex-direction: column-reverse;
-	${from.wide} {
-		flex-direction: row;
-	}
-
-	/* Extend carousel into outer margins on mobile */
-	margin-left: -10px;
-	margin-right: -10px;
-	${from.mobileLandscape} {
-		margin-left: -20px;
-		margin-right: -20px;
-	}
-
-	/**
-	 * From tablet, pull container up so navigation buttons align with title.
-	 * The margin is calculated from the front section title font size and line
-	 * height, and the default container spacing.
-	 *
-	 * From wide, the navigation buttons are pulled out of the main content area
-	 * into the right-hand column.
-	 */
-	${from.tablet} {
-		margin-left: 10px;
-		margin-right: 10px;
-		margin-top: calc(
-			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
-				${space[3]}px
-		);
-	}
-	${from.leftCol} {
-		margin-top: 0;
-		margin-left: -10px;
-	}
-	${from.wide} {
-		margin-right: calc(${space[2]}px - ${gridColumnWidth} - ${gridGap});
-	}
-`;
-
-const carouselStyles = css`
-	display: grid;
-	grid-auto-columns: 1fr;
-	grid-auto-flow: column;
-	gap: 20px;
-	overflow-x: auto;
-	overflow-y: hidden;
-	scroll-snap-type: x mandatory;
-	scroll-behavior: smooth;
-	overscroll-behavior-x: contain;
-	overscroll-behavior-y: auto;
-	/**
-	 * Hide scrollbars
-	 * See: https://stackoverflow.com/a/38994837
-	 */
-	::-webkit-scrollbar {
-		display: none; /* Safari and Chrome */
-	}
-	scrollbar-width: none; /* Firefox */
-	position: relative;
-
-	padding-left: 10px;
-	scroll-padding-left: 10px;
-	${from.mobileLandscape} {
-		padding-left: 20px;
-		scroll-padding-left: 20px;
-	}
-	${from.tablet} {
-		padding-left: 0px;
-		scroll-padding-left: 0px;
-	}
-	${from.leftCol} {
-		padding-left: 20px;
-		scroll-padding-left: 20px;
-	}
-`;
 
 const itemStyles = css`
 	scroll-snap-align: start;
@@ -159,38 +49,6 @@ const verticalLineStyles = css`
 	}
 `;
 
-const buttonContainerStyles = css`
-	margin-left: auto;
-	${from.wide} {
-		margin-left: ${space[1]}px;
-	}
-`;
-
-const buttonLayoutStyles = css`
-	display: flex;
-	gap: ${space[1]}px;
-`;
-
-/**
- * Generates CSS styles for a grid layout used in a carousel.
- *
- * @param {number} totalCards - The total number of cards in the carousel.
- * @returns {string} - The CSS styles for the grid layout.
- */
-const generateCarouselColumnStyles = (totalCards: number) => {
-	const peepingCardWidth = space[8];
-
-	return css`
-		grid-template-columns: repeat(
-			${totalCards},
-			calc((100% - ${peepingCardWidth}px - 20px))
-		);
-		${from.tablet} {
-			grid-template-columns: repeat(${totalCards}, calc(50% - 10px));
-		}
-	`;
-};
-
 /**
  * A container used on fronts to display a carousel of small cards
  *
@@ -206,145 +64,35 @@ export const ScrollableSmall = ({
 	imageLoading,
 	showAge,
 }: Props) => {
-	const carouselRef = useRef<HTMLOListElement | null>(null);
-	const carouselLength = trails.length;
-	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
-	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
-
-	const scrollTo = (direction: 'left' | 'right') => {
-		if (!carouselRef.current) return;
-
-		const cardWidth =
-			carouselRef.current.querySelector('li')?.offsetWidth ?? 0;
-		const offset = direction === 'left' ? -cardWidth : cardWidth;
-		carouselRef.current.scrollBy({
-			left: offset,
-			behavior: 'smooth',
-		});
-	};
-
-	/**
-	 * Updates state of navigation buttons based on carousel's scroll position.
-	 *
-	 * This function checks the current scroll position of the carousel and sets
-	 * the styles of the previous and next buttons accordingly. The previous
-	 * button is disabled if the carousel is at the start, and the next button
-	 * is disabled if the carousel is at the end.
-	 */
-	const updateButtonVisibilityOnScroll = () => {
-		const carouselElement = carouselRef.current;
-		if (!carouselElement) return;
-
-		const scrollLeft = carouselElement.scrollLeft;
-		const maxScrollLeft =
-			carouselElement.scrollWidth - carouselElement.clientWidth;
-
-		setPreviousButtonEnabled(scrollLeft > 0);
-		setNextButtonEnabled(scrollLeft < maxScrollLeft);
-	};
-
-	useEffect(() => {
-		const carouselElement = carouselRef.current;
-		if (!carouselElement) return;
-
-		carouselElement.addEventListener(
-			'scroll',
-			updateButtonVisibilityOnScroll,
-		);
-
-		return () => {
-			carouselElement.removeEventListener(
-				'scroll',
-				updateButtonVisibilityOnScroll,
-			);
-		};
-	}, []);
-
 	return (
-		<div css={carouselContainerStyles}>
-			<ol
-				ref={carouselRef}
-				css={[
-					carouselStyles,
-					generateCarouselColumnStyles(carouselLength),
-				]}
-				data-heatphan-type="carousel"
-			>
-				{trails.map((trail) => {
-					return (
-						<li
-							key={trail.url}
-							css={[itemStyles, verticalLineStyles]}
-						>
-							<FrontCard
-								trail={trail}
-								imageLoading={imageLoading}
-								absoluteServerTimes={!!absoluteServerTimes}
-								containerPalette={containerPalette}
-								containerType={containerType}
-								showAge={!!showAge}
-								headlineSize="small"
-								headlineSizeOnMobile="small"
-								headlineSizeOnTablet="small"
-								imagePositionOnDesktop="left"
-								imagePositionOnMobile="left"
-								imageSize="small" // TODO - needs fixed width images
-								trailText={undefined} // unsupported
-								supportingContent={undefined} // unsupported
-								aspectRatio="5:4"
-								kickerText={trail.kickerText}
-								showLivePlayable={trail.showLivePlayable}
-								showTopBarDesktop={false}
-								showTopBarMobile={false}
-							/>
-						</li>
-					);
-				})}
-			</ol>
-
-			<div css={buttonContainerStyles}>
-				<Hide until={'tablet'}>
-					{carouselLength > 2 && (
-						<div css={buttonLayoutStyles}>
-							<Button
-								hideLabel={true}
-								iconSide="left"
-								icon={<SvgChevronLeftSingle />}
-								onClick={() => scrollTo('left')}
-								priority="tertiary"
-								theme={
-									previousButtonEnabled
-										? themeButton
-										: themeButtonDisabled
-								}
-								size="small"
-								disabled={!previousButtonEnabled}
-								// TODO
-								// aria-label="Move stories backwards"
-								// data-link-name="container left chevron"
-							/>
-
-							<Button
-								hideLabel={true}
-								iconSide="left"
-								icon={<SvgChevronRightSingle />}
-								onClick={() => scrollTo('right')}
-								priority="tertiary"
-								theme={
-									nextButtonEnabled
-										? themeButton
-										: themeButtonDisabled
-								}
-								size="small"
-								disabled={!nextButtonEnabled}
-								// TODO
-								// aria-label="Move stories forwards"
-								// data-link-name="container right chevron"
-							/>
-						</div>
-					)}
-				</Hide>
-			</div>
-		</div>
+		<ScrollableCarousel carouselLength={trails.length}>
+			{trails.map((trail) => {
+				return (
+					<li key={trail.url} css={[itemStyles, verticalLineStyles]}>
+						<FrontCard
+							trail={trail}
+							imageLoading={imageLoading}
+							absoluteServerTimes={!!absoluteServerTimes}
+							containerPalette={containerPalette}
+							containerType={containerType}
+							showAge={!!showAge}
+							headlineSize="small"
+							headlineSizeOnMobile="small"
+							headlineSizeOnTablet="small"
+							imagePositionOnDesktop="left"
+							imagePositionOnMobile="left"
+							imageSize="small" // TODO - needs fixed width images
+							trailText={undefined} // unsupported
+							supportingContent={undefined} // unsupported
+							aspectRatio="5:4"
+							kickerText={trail.kickerText}
+							showLivePlayable={trail.showLivePlayable}
+							showTopBarDesktop={false}
+							showTopBarMobile={false}
+						/>
+					</li>
+				);
+			})}
+		</ScrollableCarousel>
 	);
 };


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
