### PR TITLE
Fix trail text rendering

### DIFF
--- a/dotcom-rendering/src/components/Card/components/TrailText.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailText.tsx
@@ -58,10 +58,13 @@ export const TrailText = ({
 				fontStyles(trailTextSize),
 				padTop && topPadding,
 			]}
-			dangerouslySetInnerHTML={{
-				__html: text,
-			}}
-		/>
+		>
+			<div
+				dangerouslySetInnerHTML={{
+					__html: text,
+				}}
+			/>
+		</div>
 	);
 	return hideUntil ? (
 		<Hide until={hideUntil}>{trailText}</Hide>


### PR DESCRIPTION
## What does this change?

The trail text logic was [recently reworked](https://github.com/guardian/dotcom-rendering/pull/12584), but following that change, we spotted it looks broken (notably visible on https://www.theguardian.com/tone/letters/all)

It seems this is because of a recent change which "unnested" the div which uses `dangerouslySetInnerHTML` to render the trailtext. This PR reintroduces the nesting, which should fix the rendering of the component.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/8a35a4f7-3416-4140-9f04-9ba345506a70
[after]: https://github.com/user-attachments/assets/6a060c4c-2195-4e6f-a869-f84734cf4d81

| Before2      | After2      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before2]: https://github.com/user-attachments/assets/cb4dad55-838f-41a1-94c9-355e53ffe655
[after2]: https://github.com/user-attachments/assets/a7025bac-6d79-48b9-ad43-738f72cc7874



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
