### PR TITLE
Exclude the filter articles from amp

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -99,7 +99,13 @@ export const isAmpSupported = ({
 		if (!hasAmpInteractiveTag) return false;
 	}
 
-	if (tags.some((tag) => tag.id === 'type/video')) {
+	if (
+		tags.some(
+			(tag) =>
+				tag.id === 'type/video' ||
+				tag.id === 'thefilter/series/the-filter',
+		)
+	) {
 		return false;
 	}
 


### PR DESCRIPTION
## What does this change?
Reintroduces https://github.com/guardian/dotcom-rendering/pull/12624 following https://github.com/guardian/fastly-edge-cache/pull/1069
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/12633
