### PR TITLE
Fix avatar compressing on small screens

### DIFF
--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -8,6 +8,7 @@ const picture = css`
 	height: 100%;
 	width: 100%;
 	overflow: hidden;
+	min-width: 60px;
 `;
 
 const round = css`


### PR DESCRIPTION
## What does this change?
Fix avatar compressing on small screens
## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0bb1e0ff-dfc4-4113-bab8-7b830e1b1fdb
[after]: https://github.com/user-attachments/assets/48b92ed1-c830-4477-be37-603034cb10cb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
