### PR TITLE
Reinstate additional spacing for media cards

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -45,8 +45,12 @@ const themeButtonDisabled: Partial<ThemeButton> = {
 const carouselContainerStyles = css`
 	display: flex;
 	flex-direction: column-reverse;
+	${from.tablet} {
+		gap: ${space[2]}px;
+	}
 	${from.wide} {
 		flex-direction: row;
+		gap: ${space[1]}px;
 	}
 
 	/* Extend carousel into outer margins on mobile */
@@ -121,9 +125,6 @@ const carouselStyles = css`
 
 const buttonContainerStyles = css`
 	margin-left: auto;
-	${from.wide} {
-		margin-left: ${space[1]}px;
-	}
 `;
 
 const buttonLayoutStyles = css`


### PR DESCRIPTION
## What does this change?

Reinstates the 8px spacing applied to the top of the carousel between tablet and wide breakpoints added in #12576. This was lost when the carousel logic and styling was split out into a separate component.

## Why?

The top edge of the carousel is currently flush with the bottom of the navigation buttons. This isn't immediately apparent when the carousel is static or the cards have a transparent background, but it becomes obvious when the carousel is in motion (as the images and buttons touch) or a card has a solid background colour such as a media card.

## Screenshots

| Tablet      | leftCol      |
| ----------- | ---------- |
| ![tablet][] | ![leftcol][] |

[tablet]: https://github.com/user-attachments/assets/750e85e1-1994-4964-a886-0d8e14dc5c1f
[leftcol]: https://github.com/user-attachments/assets/85edbb22-844e-4578-a1e3-c7acf5099592
