### PR TITLE
Scrollable Small: apply smaller headline size on mobile

### DIFF
--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -76,7 +76,10 @@ export const ScrollableSmall = ({
 							containerPalette={containerPalette}
 							containerType={containerType}
 							showAge={!!showAge}
-							headlineSizes={{ desktop: 'xxsmall' }}
+							headlineSizes={{
+								desktop: 'xxsmall',
+								mobile: 'xxxsmall',
+							}}
 							imagePositionOnDesktop="left"
 							imagePositionOnMobile="left"
 							imageSize="small" // TODO - needs fixed width images


### PR DESCRIPTION
## What does this change?

Applies 15px headline size between mobile and tablet breakpoints, defaulting to 17px on larger screens.

This was previously awkward to achieve due to the `CardHeadline` component lacking a 15px size and its existing type scale and logic not having a suitable place to insert a new size. @abeddow91's work to refactor card headlines (#12571) has now made this trivially simple 🙏 

## Why?

Part of the ongoing work to support the new `scrollable/small` container in DCR.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![mobileLandscape][] | ![desktop][] |

[mobileLandscape]: https://github.com/user-attachments/assets/8da895f4-5a19-47c3-990f-57f075ca9bd6
[desktop]: https://github.com/user-attachments/assets/1750a448-8149-440a-b4c6-fe2bfd09b930