### PR TITLE
Compress the fake audio data

### DIFF
--- a/dotcom-rendering/src/components/AudioPlayer/components/WaveForm.tsx
+++ b/dotcom-rendering/src/components/AudioPlayer/components/WaveForm.tsx
@@ -43,6 +43,21 @@ const normalizeAmplitude = (data: number[]) => {
 	return data.map((n) => n * multiplier * 100);
 };
 
+/**
+ * Compresses an of values to a range between the threshold and the existing
+ * maximum.
+ */
+const compress = (array: number[], threshold: number) => {
+	const minValue = Math.min(...array);
+	const maxValue = Math.max(...array);
+
+	return array.map(
+		(x) =>
+			((x - minValue) / (maxValue - minValue)) * (maxValue - threshold) +
+			threshold,
+	);
+};
+
 /** Returns a string of the specified length, repeating the input string as necessary. */
 function padString(str: string, length: number) {
 	// Repeat the string until it is longer than the desired length
@@ -74,8 +89,11 @@ function generateWaveform(url: string, bars: number) {
 	// Normalize the amplitude of the fake audio data
 	const normalized = normalizeAmplitude(shuffled);
 
+	// Compress the amplitude of the fake audio data, like a podcast would
+	const compressed = compress(normalized, 60);
+
 	// Return the normalized the amplitude of the fake audio data
-	return normalized;
+	return compressed;
 }
 
 type Theme = {

--- a/dotcom-rendering/src/components/AudioPlayer/components/WaveForm.tsx
+++ b/dotcom-rendering/src/components/AudioPlayer/components/WaveForm.tsx
@@ -168,11 +168,11 @@ export const WaveForm = ({
 					})}
 				</g>
 
-				<clipPath id="buffer-clip-path">
+				<clipPath id={`buffer-clip-path-${id}`}>
 					<rect height="100" width={(buffer / 100) * totalWidth} />
 				</clipPath>
 
-				<clipPath id="progress-clip-path">
+				<clipPath id={`progress-clip-path-${id}`}>
 					<rect height="100" width={(progress / 100) * totalWidth} />
 				</clipPath>
 			</defs>
@@ -183,14 +183,14 @@ export const WaveForm = ({
 			{/* buffer wave */}
 			<use
 				href={`#bars-${id}`}
-				clipPath="url(#buffer-clip-path)"
+				clipPath={`url(#buffer-clip-path-${id})`}
 				fill={theme.buffer}
 			/>
 
 			{/* progress wave */}
 			<use
 				href={`#bars-${id}`}
-				clipPath="url(#progress-clip-path)"
+				clipPath={`url(#progress-clip-path-${id})`}
 				fill={theme.progress}
 			/>
 		</svg>


### PR DESCRIPTION
## What does this change?

- compresses the fake audio data to make it more realistic
- uses `id` on the `clipPath` ids too

## Why?

this is the real waveform for a guardian podcast:

<img width="729" alt="image" src="https://github.com/user-attachments/assets/9efa82f0-176c-4b4f-ac23-ce962a93e660">


this is the current fake one:

<img width="727" alt="Screenshot 2024-10-24 at 18 41 32" src="https://github.com/user-attachments/assets/07ab9f93-4dc8-4231-9554-17b64d19b22b">

this is the compressed one:

<img width="728" alt="Screenshot 2024-10-24 at 18 41 51" src="https://github.com/user-attachments/assets/9a0c1d43-ed0d-4ca5-a3ab-49cfac61ce4b">

it looks more realistic to me (since we do compress the audio)