### PR TITLE
Use mute icon for muting

### DIFF
--- a/dotcom-rendering/src/components/AudioPlayer/components/Volume.tsx
+++ b/dotcom-rendering/src/components/AudioPlayer/components/Volume.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, palette } from '@guardian/source/foundations';
-import { SvgAudio } from '@guardian/source/react-components';
+import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { buttonBaseCss } from '../styles';
 
 type ButtonProps = React.ComponentPropsWithoutRef<'button'>;
@@ -63,7 +63,7 @@ Volume.Mute = ({
 	...props
 }: { isMuted: boolean } & Omit<ButtonProps, 'children'>) => (
 	<Control aria-label="Mute" {...props}>
-		<SvgAudio
+		<SvgAudioMute
 			theme={{
 				fill: isMuted ? palette.brandAlt[400] : palette.neutral[46],
 			}}


### PR DESCRIPTION
## What does this change?

uses the mute icon, rather than unmute, for the mute button

## Why?

so it makes sense

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="76" alt="image" src="https://github.com/user-attachments/assets/36a52b14-a12c-42d3-a757-f1ce437422e3"> | <img width="79" alt="image" src="https://github.com/user-attachments/assets/9f6a5d41-38d0-4fbb-b0cd-ec936ac8a171"> |



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
