### PR TITLE
Hide most viewed in right column on the AudioLayout.tsx

### DIFF
--- a/dotcom-rendering/src/components/MostViewedRightWithAd.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedRightWithAd.importable.tsx
@@ -14,6 +14,7 @@ type Props = {
 	isPaidContent: boolean;
 	renderAds: boolean;
 	shouldHideReaderRevenue: boolean;
+	shouldHideMostViewed?: boolean;
 };
 
 /**
@@ -41,6 +42,7 @@ export const MostViewedRightWithAd = ({
 	isPaidContent,
 	renderAds,
 	shouldHideReaderRevenue,
+	shouldHideMostViewed = false,
 }: Props) => {
 	const componentDataAttribute = 'most-viewed-right-container';
 	const { renderingTarget } = useConfig();
@@ -75,7 +77,7 @@ export const MostViewedRightWithAd = ({
 				/>
 			) : null}
 
-			{!isPaidContent ? (
+			{!isPaidContent && !shouldHideMostViewed ? (
 				<MostViewedRightWrapper
 					maxHeightPx={MAX_HEIGHT_PX}
 					componentDataAttribute={componentDataAttribute}

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -504,6 +504,7 @@ export const AudioLayout = (props: WebProps) => {
 												!!article.config
 													.shouldHideReaderRevenue
 											}
+											shouldHideMostViewed={true}
 										/>
 									</Island>
 								</RightColumn>


### PR DESCRIPTION
## What does this change?
Hides the "most viewed" part of the `MostViewedRightWithAd` for audio layout

## Why?
This section was not rendering in the correct colours. It was deemed not needed for this layout. 

Closes #12677 
