### PR TITLE
YoutubeAtom fullscreen support for iOS

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -38,7 +38,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/braze-components": "21.0.0",
-		"@guardian/bridget": "7.0.0",
+		"@guardian/bridget": "0.0.0-2024-10-10-snapshot-1",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "23.0.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -38,7 +38,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/braze-components": "21.0.0",
-		"@guardian/bridget": "0.0.0-2024-10-10-snapshot-1",
+		"@guardian/bridget": "8.0.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "23.0.0",

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 import type { Participations } from '@guardian/ab-core';
 import { buildImaAdTagUrl } from '@guardian/commercial';
 import type { ConsentState } from '@guardian/libs';
@@ -72,6 +72,19 @@ const imaPlayerStyles = css`
 	left: 0;
 	width: 100%;
 	height: 100%;
+`;
+
+const fullscreenStyles = (id: string) => css`
+	html {
+		overflow: hidden;
+	}
+	iframe#${id} {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100vw;
+		height: 100vh;
+	}
 `;
 
 /**
@@ -398,6 +411,7 @@ export const YoutubeAtomPlayer = ({
 	});
 
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
+	const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
 	const playerReadyCallback = useCallback(() => setPlayerReady(true), []);
 	const playerListeners = useRef<PlayerListeners>([]);
 	/**
@@ -472,8 +486,7 @@ export const YoutubeAtomPlayer = ({
 										from: 'YoutubeAtomPlayer fullscreen',
 										videoId,
 									});
-									// For Android only, iOS will stub the method
-									void getVideoClient().fullscreen();
+									setIsFullscreen((prev) => !prev);
 								}
 							},
 						},
@@ -644,17 +657,27 @@ export const YoutubeAtomPlayer = ({
 		};
 	}, []);
 
+	useEffect(() => {
+		if (renderingTarget === 'Apps') {
+			console.log('fullscreen', isFullscreen);
+			// For Android only, iOS will stub the method
+			// void getVideoClient().fullscreen(isFullscreen);
+		}
+	}, [isFullscreen, renderingTarget]);
+
 	/**
 	 * An element for the YouTube player to hook into the dom
 	 */
 	return (
-		<div
-			id={id}
-			data-atom-id={id}
-			data-testid={id}
-			data-atom-type="youtube"
-			title={title}
-			css={enableAds && imaPlayerStyles}
-		></div>
+		<>
+			{isFullscreen && <Global styles={fullscreenStyles(id)} />}
+			<div
+				id={id}
+				data-testid={id}
+				data-atom-type="youtube"
+				title={title}
+				css={enableAds && imaPlayerStyles}
+			></div>
+		</>
 	);
 };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -465,9 +465,6 @@ export const YoutubeAtomPlayer = ({
 						videoId,
 						playerVars: {
 							controls: 1,
-							// @ts-expect-error -- advised by YouTube for Android but does not exist in @types/youtube
-							external_fullscreen:
-								renderingTarget === 'Apps' ? 1 : 0,
 							fs: 1,
 							modestbranding: 1,
 							origin,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -662,9 +662,8 @@ export const YoutubeAtomPlayer = ({
 	}, []);
 
 	/**
-	 * For apps rendered articles that return true for `webFullscreen` the web layer
-	 * needs to handle the application of fullscreen styles and inform the native
-	 * layer of the fullscreen state.
+	 * For apps rendered articles that return true for `setFullscreen` the web layer
+	 * needs to handle the application of fullscreen styles
 	 *
 	 * This is only for the YouTube player in Android web views which does not support fullscreen
 	 */

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -24,6 +24,7 @@
 const indices = [
 	// Modals will go here at the top
 	'lightbox',
+	'youTubeFullscreen',
 
 	// Sticky video and button need to be above everything
 	'sticky-video-button',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,8 +329,8 @@ importers:
         specifier: 21.0.0
         version: 21.0.0(@emotion/react@11.11.3)(@guardian/libs@19.1.0)(@guardian/source@8.0.0)(react@18.3.1)
       '@guardian/bridget':
-        specifier: 0.0.0-2024-10-10-snapshot-1
-        version: 0.0.0-2024-10-10-snapshot-1
+        specifier: 8.0.0
+        version: 8.0.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.23.0)(tslib@2.6.2)
@@ -3999,12 +3999,12 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@guardian/bridget@0.0.0-2024-10-10-snapshot-1:
-    resolution: {integrity: sha512-y7iXxGiqAxxgNC2+xAuFjjYxkjmQwJ5kdWojNzpnrfbIiMyNoQTFHBC9tPs0sR1OQ2MkGUno/xb6RAwnTv+O1Q==}
-    dev: false
-
   /@guardian/bridget@7.0.0:
     resolution: {integrity: sha512-S0NmkyYd1hQRyOUj7l9Ddfr6FKEHJFLpS2jSMkGexCSscsZd7e8JBdFmlKSUljt4G6hrxcaaevsV4QfT9LnhUg==}
+    dev: false
+
+  /@guardian/bridget@8.0.0:
+    resolution: {integrity: sha512-ae+yENkvcEOZBDqFE8RkdjyLki/iczatDc+MBTZS2vipmrcTeP0lOkZcsq/QxlNMSvZ6HNOETV8MIcGK/Gx3Hw==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.23.0)(tslib@2.6.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,8 +329,8 @@ importers:
         specifier: 21.0.0
         version: 21.0.0(@emotion/react@11.11.3)(@guardian/libs@19.1.0)(@guardian/source@8.0.0)(react@18.3.1)
       '@guardian/bridget':
-        specifier: 7.0.0
-        version: 7.0.0
+        specifier: 0.0.0-2024-10-10-snapshot-1
+        version: 0.0.0-2024-10-10-snapshot-1
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.23.0)(tslib@2.6.2)
@@ -3999,6 +3999,10 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@guardian/bridget@0.0.0-2024-10-10-snapshot-1:
+    resolution: {integrity: sha512-y7iXxGiqAxxgNC2+xAuFjjYxkjmQwJ5kdWojNzpnrfbIiMyNoQTFHBC9tPs0sR1OQ2MkGUno/xb6RAwnTv+O1Q==}
+    dev: false
+
   /@guardian/bridget@7.0.0:
     resolution: {integrity: sha512-S0NmkyYd1hQRyOUj7l9Ddfr6FKEHJFLpS2jSMkGexCSscsZd7e8JBdFmlKSUljt4G6hrxcaaevsV4QfT9LnhUg==}
     dev: false
@@ -4247,7 +4251,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -6468,7 +6472,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8082,8 +8086,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.94.0)
     dev: false
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0):
@@ -8093,8 +8097,8 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.94.0)
     dev: false
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.0.4)(webpack@5.94.0):
@@ -8108,8 +8112,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.94.0)
       webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.94.0)
     dev: false
 
@@ -8662,7 +8666,7 @@ packages:
       '@babel/core': 7.25.8
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -9873,7 +9877,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.41)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /css-loader@7.1.2(webpack@5.94.0):
@@ -10824,7 +10828,7 @@ packages:
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.15.1
@@ -11832,7 +11836,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /form-data@3.0.1:
@@ -17313,7 +17317,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -17840,7 +17844,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.7.26)(@types/node@16.18.68)(typescript@5.1.6):
@@ -18621,7 +18625,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.2.1(webpack@5.94.0):
@@ -18639,7 +18643,7 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: false
 
   /webpack-dev-middleware@7.4.2(webpack@5.94.0):
@@ -18701,8 +18705,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.0.4)(webpack@5.94.0)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.94.0)
       webpack-dev-middleware: 7.2.1(webpack@5.94.0)
       ws: 8.17.1
     transitivePeerDependencies:
@@ -18747,7 +18751,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.94.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.94.0(@swc/core@1.7.26)(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

### iOS fullscreen

Fix iOS fullscreen handling by removing the `external_fullscreen` configuration.

This configuration setting declares whether the player should delegate fullscreen handling to a custom implementation which is required for Android. When testing locally on the iOS simulator fullscreen worked perfectly which led us to believe this setting was ignored by iOS allowing us to use the same setting for both apps.

However the setting is itself enabled via an allow-list of domains which meant it was not activated on iOS when testing locally and only activated on versions of the app using production DCAR requests. The result being fullscreen did not work on iOS when testing against production builds of the app.

We will reenable this configuration when we implement support for Android fullscreen and ensure we sit it appropriately for iOS.

### Bridget v8.0.0

Adds [Bridget v8.0.0](https://github.com/guardian/bridget/releases/tag/v8.0.0) to bring in the new fullscreen methods for the YouTube player in apps. Bridget v8 is used by the apps in BETA and hence expects DCAR to also use Bridget v8.

### Fullscreen event listeners

Adds `onFullscreenToggled` event listener in preparation for supporting fullscreen on Android. By removing `external_fullscreen` the `onFullscreenToggled` listener will not be called in production however we are adding this method to facilitate testing.

## Screenshots

### Before

https://github.com/user-attachments/assets/97ab92a9-8f2d-4904-a2f5-3da739eba751

### After

https://github.com/user-attachments/assets/40e5fc18-f1c0-4158-afde-630bb64b8fb4


