### PR TITLE
[Fairground 🎡] Reduce gap size if the image is jumbo

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -466,9 +466,11 @@ export const Card = ({
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
 		if (hasBackgroundColour) return 'tiny';
-		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo'))
+		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
 			return 'small';
+		}
 		if (isSmallCard) return 'medium';
+
 		if (
 			isFlexibleContainer &&
 			(imagePositionOnDesktop === 'left' ||

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -466,7 +466,7 @@ export const Card = ({
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
 		if (hasBackgroundColour) return 'tiny';
-		if (isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo'))
+		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo'))
 			return 'small';
 		if (isSmallCard) return 'medium';
 		if (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -466,7 +466,8 @@ export const Card = ({
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
 		if (hasBackgroundColour) return 'tiny';
-		if (isFlexSplash) return 'small';
+		if (isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo'))
+			return 'small';
 		if (isSmallCard) return 'medium';
 		if (
 			isFlexibleContainer &&


### PR DESCRIPTION
## What does this change?
Reduce the gap size between the image and the content to 8px if the image is jumbo. This imitates the styling of a flex splash.

## Why?
A bug had been introduced that was causing a megaboost card to take up too big a gap which was breaking the grid alignment of the front.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/aa4be52f-9d27-49aa-a70d-4917f175c549
[after]: https://github.com/user-attachments/assets/661cd153-7489-4e62-a798-a149c9f51c5a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
