### PR TITLE
Move shared carousel styles into base component

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -132,6 +132,34 @@ const buttonLayoutStyles = css`
 	gap: ${space[1]}px;
 `;
 
+const itemStyles = css`
+	scroll-snap-align: start;
+	grid-area: span 1;
+	position: relative;
+	:not(:last-child)::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: -10px;
+		width: 1px;
+		background-color: ${palette('--card-border-top')};
+		transform: translateX(-50%);
+	}
+	${from.leftCol} {
+		:first-child::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: -10px;
+			width: 1px;
+			background-color: ${palette('--card-border-top')};
+			transform: translateX(-50%);
+		}
+	}
+`;
+
 /**
  * Generates CSS styles for a grid layout used in a carousel.
  *
@@ -267,3 +295,7 @@ export const ScrollableCarousel = ({ children, carouselLength }: Props) => {
 		</div>
 	);
 };
+
+ScrollableCarousel.Item = ({ children }: { children: React.ReactNode }) => (
+	<li css={itemStyles}>{children}</li>
+);

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -3,6 +3,7 @@ import {
 	from,
 	headlineMedium24Object,
 	space,
+	until,
 } from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
 import {
@@ -136,26 +137,19 @@ const itemStyles = css`
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
-	:not(:last-child)::after {
+	::before {
 		content: '';
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		right: -10px;
+		left: -10px;
 		width: 1px;
 		background-color: ${palette('--card-border-top')};
 		transform: translateX(-50%);
 	}
-	${from.leftCol} {
+	${until.leftCol} {
 		:first-child::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			bottom: 0;
-			left: -10px;
-			width: 1px;
-			background-color: ${palette('--card-border-top')};
-			transform: translateX(-50%);
+			background-color: transparent;
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -1,6 +1,3 @@
-import { css } from '@emotion/react';
-import { from } from '@guardian/source/foundations';
-import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
@@ -17,37 +14,6 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 };
-
-const itemStyles = css`
-	scroll-snap-align: start;
-	grid-area: span 1;
-	position: relative;
-`;
-
-const verticalLineStyles = css`
-	:not(:last-child)::after {
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		right: -10px;
-		width: 1px;
-		background-color: ${palette('--card-border-top')};
-		transform: translateX(-50%);
-	}
-	${from.leftCol} {
-		:first-child::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			bottom: 0;
-			left: -10px;
-			width: 1px;
-			background-color: ${palette('--card-border-top')};
-			transform: translateX(-50%);
-		}
-	}
-`;
 
 /**
  * A container used on fronts to display a carousel of small cards
@@ -68,7 +34,7 @@ export const ScrollableMedium = ({
 		<ScrollableCarousel carouselLength={trails.length}>
 			{trails.map((trail) => {
 				return (
-					<li key={trail.url} css={[itemStyles, verticalLineStyles]}>
+					<ScrollableCarousel.Item key={trail.url}>
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}
@@ -91,7 +57,7 @@ export const ScrollableMedium = ({
 							showTopBarDesktop={false}
 							showTopBarMobile={false}
 						/>
-					</li>
+					</ScrollableCarousel.Item>
 				);
 			})}
 		</ScrollableCarousel>

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,6 +1,3 @@
-import { css } from '@emotion/react';
-import { from } from '@guardian/source/foundations';
-import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
 	DCRContainerType,
@@ -17,37 +14,6 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 };
-
-const itemStyles = css`
-	scroll-snap-align: start;
-	grid-area: span 1;
-	position: relative;
-`;
-
-const verticalLineStyles = css`
-	:not(:last-child)::after {
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		right: -10px;
-		width: 1px;
-		background-color: ${palette('--card-border-top')};
-		transform: translateX(-50%);
-	}
-	${from.leftCol} {
-		:first-child::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			bottom: 0;
-			left: -10px;
-			width: 1px;
-			background-color: ${palette('--card-border-top')};
-			transform: translateX(-50%);
-		}
-	}
-`;
 
 /**
  * A container used on fronts to display a carousel of small cards
@@ -68,7 +34,7 @@ export const ScrollableSmall = ({
 		<ScrollableCarousel carouselLength={trails.length}>
 			{trails.map((trail) => {
 				return (
-					<li key={trail.url} css={[itemStyles, verticalLineStyles]}>
+					<ScrollableCarousel.Item key={trail.url}>
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}
@@ -91,7 +57,7 @@ export const ScrollableSmall = ({
 							showTopBarDesktop={false}
 							showTopBarMobile={false}
 						/>
-					</li>
+					</ScrollableCarousel.Item>
 				);
 			})}
 		</ScrollableCarousel>


### PR DESCRIPTION
## What does this change?

- Moves remaining shared carousel styles from individual components to the base `ScrollableCarousel` component
- Adds `ScrollableCarousel.Item` component to render carousel items and apply divider styles
- Simplifies divider styling to avoid duplication when divider is added to left of first item at `leftCol`

## Why?

Keeps all shared carousel logic and styling in a single place and simplifies `ScrollableSmall` and `ScrollableMedium` containers by removing code