### PR TITLE
[Fairground 🎡] Add the `static/medium/four` container to DCR

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -50,7 +50,6 @@ export const DecideContainer = ({
 	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
-	console.log('containerType:', containerType);
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
 		case 'dynamic/fast':

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -12,6 +12,7 @@ import { DynamicSlowMPU } from './DynamicSlowMPU';
 import { FixedLargeSlowXIV } from './FixedLargeSlowXIV';
 import { FixedMediumFastXI } from './FixedMediumFastXI';
 import { FixedMediumFastXII } from './FixedMediumFastXII';
+import { StaticMediumFour } from './StaticMediumFour';
 import { FixedMediumSlowVI } from './FixedMediumSlowVI';
 import { FixedMediumSlowVII } from './FixedMediumSlowVII';
 import { FixedMediumSlowXIIMPU } from './FixedMediumSlowXIIMPU';
@@ -49,6 +50,7 @@ export const DecideContainer = ({
 	absoluteServerTimes,
 	imageLoading,
 }: Props) => {
+	console.log('containerType:', containerType);
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -277,9 +279,18 @@ export const DecideContainer = ({
 					/>
 				</Island>
 			);
+		case 'static/medium/4':
+			return (
+				<StaticMediumFour
+					trails={trails}
+					containerPalette={containerPalette}
+					showAge={showAge}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+				/>
+			);
 		case 'scrollable/feature':
 		case 'static/feature/2':
-		case 'static/medium/4':
 		default:
 			return <p>{containerType} is not yet supported</p>;
 	}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -12,7 +12,6 @@ import { DynamicSlowMPU } from './DynamicSlowMPU';
 import { FixedLargeSlowXIV } from './FixedLargeSlowXIV';
 import { FixedMediumFastXI } from './FixedMediumFastXI';
 import { FixedMediumFastXII } from './FixedMediumFastXII';
-import { StaticMediumFour } from './StaticMediumFour';
 import { FixedMediumSlowVI } from './FixedMediumSlowVI';
 import { FixedMediumSlowVII } from './FixedMediumSlowVII';
 import { FixedMediumSlowXIIMPU } from './FixedMediumSlowXIIMPU';
@@ -30,6 +29,7 @@ import { NavList } from './NavList';
 import { ScrollableHighlights } from './ScrollableHighlights.importable';
 import { ScrollableMedium } from './ScrollableMedium.importable';
 import { ScrollableSmall } from './ScrollableSmall.importable';
+import { StaticMediumFour } from './StaticMediumFour';
 
 type Props = {
 	trails: DCRFrontCard[];

--- a/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
@@ -2,8 +2,8 @@ import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
-import { StaticMediumFour } from './StaticMediumFour';
 import { FrontSection } from './FrontSection';
+import { StaticMediumFour } from './StaticMediumFour';
 
 const meta = {
 	component: StaticMediumFour,
@@ -18,7 +18,7 @@ const meta = {
 		},
 	},
 	args: {
-		trails: trails,
+		trails,
 		showAge: true,
 		absoluteServerTimes: true,
 		imageLoading: 'eager',

--- a/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
@@ -1,0 +1,67 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { trails } from '../../fixtures/manual/trails';
+import { StaticMediumFour } from './StaticMediumFour';
+import { FrontSection } from './FrontSection';
+
+const meta = {
+	component: StaticMediumFour,
+	title: 'Components/StaticMediumFour',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+	args: {
+		trails: trails,
+		showAge: true,
+		absoluteServerTimes: true,
+		imageLoading: 'eager',
+	},
+	render: (args) => (
+		<FrontSection
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+			showTopBorder={true}
+		>
+			<StaticMediumFour {...args} />
+		</FrontSection>
+	),
+} satisfies Meta<typeof StaticMediumFour>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const One: Story = {
+	name: 'With one card',
+	args: {
+		trails: trails.slice(0, 1),
+	},
+};
+
+export const Two: Story = {
+	name: 'With two cards',
+	args: {
+		trails: trails.slice(0, 2),
+	},
+};
+
+export const Three: Story = {
+	name: 'With three cards',
+	args: {
+		trails: trails.slice(0, 3),
+	},
+};
+
+export const Four: Story = {
+	name: 'With four cards',
+	args: {
+		trails: trails.slice(0, 4),
+	},
+};

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -1,0 +1,65 @@
+import type { DCRContainerPalette, DCRFrontCard } from 'src/types/front';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { Loading } from './CardPicture';
+import { FrontCard } from './FrontCard';
+
+type Props = {
+	trails: DCRFrontCard[];
+	imageLoading: Loading;
+	containerPalette?: DCRContainerPalette;
+	showAge?: boolean;
+	absoluteServerTimes: boolean;
+	showImage?: boolean;
+};
+
+export const StaticMediumFour = ({
+	trails,
+	containerPalette,
+	showAge,
+	absoluteServerTimes,
+	imageLoading,
+	showImage = true,
+}: Props) => {
+	const cards = trails.splice(0, 4);
+
+	return (
+		<UL
+			direction="row"
+			padBottom={true}
+			showTopBar={true}
+			isFlexibleContainer={true}
+		>
+			{cards.map((card, cardIndex) => {
+				return (
+					<LI
+						stretch={false}
+						percentage={'25%'}
+						key={card.url}
+						padSides={true}
+						showDivider={cardIndex > 0}
+					>
+						<FrontCard
+							trail={card}
+							containerPalette={containerPalette}
+							containerType="flexible/special"
+							showAge={showAge}
+							absoluteServerTimes={absoluteServerTimes}
+							image={showImage ? card.image : undefined}
+							imageLoading={imageLoading}
+							imagePositionOnDesktop={'bottom'}
+							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
+							supportingContent={undefined}
+							imageSize={'medium'}
+							aspectRatio="5:4"
+							kickerText={card.kickerText}
+							showLivePlayable={false}
+							showTopBarDesktop={false}
+							showTopBarMobile={true}
+						/>
+					</LI>
+				);
+			})}
+		</UL>
+	);
+};

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -1,7 +1,7 @@
-import type { DCRContainerPalette, DCRFrontCard } from 'src/types/front';
+import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
-import { Loading } from './CardPicture';
+import type { Loading } from './CardPicture';
 import { FrontCard } from './FrontCard';
 
 type Props = {

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -13,11 +13,7 @@ const FORBIDDEN_CONTAINERS = [
 	'qatar treat',
 ];
 
-const UNSUPPORTED_CONTAINERS = [
-	'scrollable/feature',
-	'static/feature/2',
-	'static/medium/4',
-];
+const UNSUPPORTED_CONTAINERS = ['scrollable/feature', 'static/feature/2'];
 
 const PALETTE_STYLES_URI =
 	'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default';


### PR DESCRIPTION
## What does this change?
Adds the static/medium/four container rendering logic and stories and removes the container type from the list of unsupported containers. 

The requirements for this container (at time of writing) are as follows:

- 4 stories, fixed! 
- No carouselling
- No sublinks
- No boost
- No live playable updates
- No trail text (standfirst)
- Image can be removed (trail text will not replace image)
- Media cards can exist here, as well as Opinion.
- It can have primary or secondary styling 
- Labs is able to have a custom design
- Can have special container colour palettes.

## Why?
This is a new container for the fairground project. 

## Screenshots

| web      | mobile      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/324d116b-ceaf-4390-af4d-8aa066fc6410
[after]: https://github.com/user-attachments/assets/3650914b-7252-479a-8ddc-46819918f05c


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
