### PR TITLE
Create A `Lightbox` Component

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -14,8 +14,7 @@ import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
 import { Island } from './Island';
-import { LightboxHash } from './LightboxHash.importable';
-import { LightboxLayout } from './LightboxLayout.importable';
+import { Lightbox } from './Lightbox';
 import { Metrics } from './Metrics.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
 import { SendTargetingParams } from './SendTargetingParams.importable';
@@ -57,7 +56,6 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 	});
 
 	const isWeb = renderingTarget === 'Web';
-	const webLightbox = isWeb && !!frontendData.config.switches.lightbox;
 	const { darkModeAvailable } = useConfig();
 
 	return (
@@ -69,20 +67,19 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					<SkipTo id="navigation" label="Skip to navigation" />
 				</>
 			)}
-			{webLightbox && frontendData.imagesForLightbox.length > 0 && (
-				<>
-					<Island priority="feature" defer={{ until: 'hash' }}>
-						<LightboxLayout
-							format={format}
-							images={frontendData.imagesForLightbox}
-						/>
-					</Island>
-					<Island priority="feature" defer={{ until: 'idle' }}>
-						<LightboxHash />
-					</Island>
-				</>
-			)}
-
+			<Lightbox
+				format={format}
+				switches={frontendData.config.switches}
+				{...(renderingTarget === 'Web'
+					? {
+							lightboxImages: frontendData.imagesForLightbox,
+							renderingTarget,
+					  }
+					: {
+							lightboxImages: frontendData.imagesForAppsLightbox,
+							renderingTarget,
+					  })}
+			/>
 			<Island priority="enhancement" defer={{ until: 'idle' }}>
 				<FocusStyles />
 			</Island>

--- a/dotcom-rendering/src/components/Lightbox.tsx
+++ b/dotcom-rendering/src/components/Lightbox.tsx
@@ -1,0 +1,63 @@
+import type { ArticleFormat } from '../lib/articleFormat';
+import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
+import type { Switches } from '../types/config';
+import type { ImageForLightbox } from '../types/content';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { AppsLightboxImageStore } from './AppsLightboxImageStore.importable';
+import { Island } from './Island';
+import { LightboxHash } from './LightboxHash.importable';
+import { LightboxLayout } from './LightboxLayout.importable';
+
+interface BaseProps {
+	format: ArticleFormat;
+	renderingTarget: RenderingTarget;
+	switches: Switches;
+}
+
+interface WebProps extends BaseProps {
+	renderingTarget: 'Web';
+	lightboxImages: ImageForLightbox[];
+}
+
+interface AppProps extends BaseProps {
+	renderingTarget: 'Apps';
+	lightboxImages: ImageForAppsLightbox[];
+}
+
+export const Lightbox = ({
+	format,
+	lightboxImages,
+	renderingTarget,
+	switches,
+}: WebProps | AppProps) => {
+	switch (renderingTarget) {
+		case 'Web':
+			if (
+				switches.lightbox === undefined ||
+				!switches.lightbox ||
+				lightboxImages.length === 0
+			) {
+				return null;
+			}
+
+			return (
+				<>
+					<Island priority="feature" defer={{ until: 'hash' }}>
+						<LightboxLayout
+							format={format}
+							images={lightboxImages}
+						/>
+					</Island>
+					<Island priority="feature" defer={{ until: 'idle' }}>
+						<LightboxHash />
+					</Island>
+				</>
+			);
+		case 'Apps':
+			return (
+				<Island priority="feature" defer={{ until: 'idle' }}>
+					<AppsLightboxImageStore images={lightboxImages} />
+				</Island>
+			);
+	}
+};

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -10,7 +10,6 @@ import { StraightLines } from '@guardian/source-development-kitchen/react-compon
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -374,11 +373,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -11,7 +11,6 @@ import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AffiliateDisclaimer } from '../components/AffiliateDisclaimer';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -459,11 +458,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -310,11 +309,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -13,7 +13,6 @@ import { RightAdsPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -360,11 +359,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals rightAlignFrom="wide" />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -10,7 +10,6 @@ import { StraightLines } from '@guardian/source-development-kitchen/react-compon
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMetaApps } from '../components/ArticleMeta.apps';
@@ -337,11 +336,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -12,7 +12,6 @@ import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AffiliateDisclaimer } from '../components/AffiliateDisclaimer';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -394,11 +393,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -13,7 +13,6 @@ import { AdSlot, MobileStickyContainer } from '../components/AdSlot.web';
 import { AffiliateDisclaimer } from '../components/AffiliateDisclaimer';
 import { AppsEpic } from '../components/AppsEpic.importable';
 import { AppsFooter } from '../components/AppsFooter.importable';
-import { AppsLightboxImageStore } from '../components/AppsLightboxImageStore.importable';
 import { ArticleBody } from '../components/ArticleBody';
 import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
@@ -481,11 +480,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<>
 						<Island priority="critical">
 							<AdPortals />
-						</Island>
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<AppsLightboxImageStore
-								images={article.imagesForAppsLightbox}
-							/>
 						</Island>
 					</>
 				)}


### PR DESCRIPTION
Combines the web and apps lightbox setup into a single component. This puts the logic in a single place, hopefully making it easier to find and understand.

For apps, this also means the component is now referenced once at the `ArticlePage` level, rather than separately in each layout file. This reduces repetition and matches the way it's handled for web.
