### PR TITLE
fix text colour for the audio articles dark mode

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -59,14 +59,7 @@ const textblockTextLight: PaletteFunction = (format: ArticleFormat) => {
 	}
 };
 
-const textblockTextDark: PaletteFunction = (format: ArticleFormat) => {
-	switch (format.design) {
-		case ArticleDesign.Audio:
-			return sourcePalette.neutral[7];
-		default:
-			return 'inherit';
-	}
-};
+const textblockTextDark: PaletteFunction = () => 'inherit';
 
 const headlineTextLight: PaletteFunction = ({ design, display, theme }) => {
 	switch (display) {


### PR DESCRIPTION
## What does this change?
Make the text for the textblock-dark "inherit" for all designs

## Why?
The text was set to dark  for dark-mode and light for light-mode.
The audio article background is dark in both light and dark modes. so the text must be light for both.
It is "inherit" like the other articles for dark mode 
and neutral[97] for "light" mode

## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/4668e03d-8093-4b12-a65d-85c7d594f294
[after]: https://github.com/user-attachments/assets/c5f2e791-e82c-45b7-8084-6a7c8ae7acc3