### PR TITLE
YoutubeAtom implement fullscreen for Android

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -107,15 +107,15 @@ const setAppsConfiguration = async (
 	renderingTarget: RenderingTarget,
 ) => {
 	if (renderingTarget === 'Apps') {
-		const videoClient = getVideoClient();
-		const requiresWebFullscreen = await videoClient.setFullscreen(false);
+		const requiresWebFullscreen =
+			await getVideoClient().setFullscreen(false);
 		const updatedConfiguration = {
 			...basePlayerConfiguration,
 			external_fullscreen: requiresWebFullscreen ? 1 : 0,
 		};
 		return updatedConfiguration;
 	}
-	return Promise.resolve(basePlayerConfiguration);
+	return basePlayerConfiguration;
 };
 
 /**
@@ -406,7 +406,7 @@ const isSignedIn = async (): Promise<boolean> => {
 			);
 		}
 	}
-	return Promise.resolve(false);
+	return false;
 };
 
 export const YoutubeAtomPlayer = ({

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -83,8 +83,8 @@ const fullscreenStyles = (id: string) => css`
 		position: fixed;
 		top: 0;
 		left: 0;
-		width: 100vw;
-		height: 100vh;
+		width: 100svw;
+		height: 100svh;
 		z-index: ${getZIndex('youTubeFullscreen')};
 	}
 `;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -82,8 +82,12 @@ const fullscreenStyles = (id: string) => css`
 	iframe#${id} {
 		position: fixed;
 		top: 0;
-		left: 0;
+		/* override vw and vh with vsw and vsh if supported */
+		width: 100vw;
+		height: 100vh;
+		/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 		width: 100svw;
+		/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
 		height: 100svh;
 		${getZIndex('youTubeFullscreen')};
 	}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -111,7 +111,7 @@ const setAppsConfiguration = async (
 		const requiresWebFullscreen = await videoClient.setFullscreen(false);
 		const updatedConfiguration = {
 			...basePlayerConfiguration,
-			external_fullscreen: requiresWebFullscreen,
+			external_fullscreen: requiresWebFullscreen ? 1 : 0,
 		};
 		return updatedConfiguration;
 	}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -85,7 +85,7 @@ const fullscreenStyles = (id: string) => css`
 		left: 0;
 		width: 100svw;
 		height: 100svh;
-		z-index: ${getZIndex('youTubeFullscreen')};
+		${getZIndex('youTubeFullscreen')};
 	}
 `;
 

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -465,6 +465,9 @@ export const YoutubeAtomPlayer = ({
 						videoId,
 						playerVars: {
 							controls: 1,
+							// @ts-expect-error -- advised by YouTube for Android but does not exist in @types/youtube
+							external_fullscreen:
+								renderingTarget === 'Apps' ? 1 : 0,
 							fs: 1,
 							modestbranding: 1,
 							origin,


### PR DESCRIPTION
Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>

## What does this change?

On Android webviews YouTube fullscreen is not an implemented feature.

The custom fullscreen flow is:

### 1. Initialisation
Before initialising the player if rendering for apps and we receive a value of `true` from the Bridget method [`setFullscreen(false)`](https://github.com/guardian/bridget/blob/087cf74e5c20294d83c5f6c4d57196e73f0d6dc1/thrift/native.thrift#L144-L154) we enable the configuration setting `external_fullscreen`

### 2. Set fullscreen listeners
If `external_fullscreen` is enabled and the page is on an allow-listed domain, `external_fullscreen` enables fullscreen toggle listeners to be passed to the YouTube player

### 3. Set fullscreen styling
If the fullscreen listener is called and we receive a value of `true` from the Bridget method [`setFullscreen(isFullscreen)`](https://github.com/guardian/bridget/blob/087cf74e5c20294d83c5f6c4d57196e73f0d6dc1/thrift/native.thrift#L144-L154) we apply custom styling to the YouTube iframe to expand to fullscreen

   The custom styling expands the available width and height to fullscreen using [small](https://developer.mozilla.org/en-US/docs/Web/CSS/length#small) viewport units to account for user elements added by mobile browsers.

### Testing

Currently Android has stubbed the `setFullscreen` method to return false. To test this we forced `setFullscreen` to return true and removed any UI inserted by app. These elements will be removed by the Android app once `setFullscreen` is implemented natively.

We have tested this change does not affect web or iOS.

### Production

Currently this feature will not be activated in production as both apps return false for `setFullscreen` but we can still merge in preparation for the Android team to implement the work on their side.

## Screenshots

###  Mobile portrait
https://github.com/user-attachments/assets/33f2e1ed-864f-41ba-95d6-3d49b66c7c7a

###  Mobile landscape
https://github.com/user-attachments/assets/55688409-1864-4f56-9e8f-2cade25acd1e

###  Tablet portrait
https://github.com/user-attachments/assets/66859b6c-d93b-4291-a043-cb9f7123d459

###  Tablet landscape
https://github.com/user-attachments/assets/571d6c70-ea7d-48af-b2dc-6ef12cba420d

