### PR TITLE
Fix Picture Layout Onwards Content section colour

### DIFF
--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -587,7 +587,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 				{article.storyPackage && (
 					<Section
 						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						borderColour={themePalette('--article-border')}
 					>
 						<Island priority="feature" defer={{ until: 'visible' }}>


### PR DESCRIPTION
## What does this change?

Uses the Article section background instead of the article background for the "more on this story" onwards content section.

## Why?

Fixes #12253 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/dabb5785-603e-4e88-8239-25c545bdb332
[after]: https://github.com/user-attachments/assets/7c88b11e-f33f-439c-b3e2-6865e459afa7
