### PR TITLE
Don't render empty flexible rows 

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -332,6 +332,8 @@ export const StandardCardLayout = ({
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
 }) => {
+	if (cards.length === 0) return null;
+
 	return (
 		<UL
 			direction="row"

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -178,6 +178,7 @@ const TwoCardOrFourCardLayout = ({
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
 }) => {
+	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
 		<UL
@@ -242,7 +243,6 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 			/>
-
 			<OneCardLayout
 				cards={splash}
 				containerPalette={containerPalette}
@@ -250,7 +250,6 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 			/>
-
 			<TwoCardOrFourCardLayout
 				cards={cards}
 				containerPalette={containerPalette}


### PR DESCRIPTION
## What does this change?
Adds an early return into flexible splash and general row layouts so that if there are no cards to render, the row is null. This pattern exists already in single card layouts.

## Why?
We don't want to render a row if there aren't any cards to fill it as we are applying styles (such as a top border) when we don't want them there. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/b31b4079-88ac-45f2-bcef-3221d655d1c4
[after]: https://github.com/user-attachments/assets/f5124282-e2d3-4fbc-a496-622c9aa9e59a


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
