### PR TITLE
Use headline colour for latest links title text

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -29,6 +29,7 @@ type Props = {
 const header = css`
 	padding: ${space[2]}px 0;
 	${textSansBold17};
+	color: ${themePalette('--card-headline')};
 `;
 
 const horizontal = css`


### PR DESCRIPTION
## What does this change?

Explicitly uses the card headline colour (`neutral[7]` for non special palettes) for the latest links title text, rather than using the inherited `neutral[0]`.

This has the benefit of already being an existing colour that adapts to special palettes.

## Why?

There was a visual bug when viewing a card with latest links within a "Breaking" special palette

Resolves [this Trello ticket](https://trello.com/c/BclBTcZx/661-fix-latest-links-text-colour-for-special-container-palettes)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/31080e8c-4d8a-419d-ad63-0aeb0c6daf57
[after]: https://github.com/user-attachments/assets/7a96e98b-df5d-4d85-b257-ee876d2b264e
