### PR TITLE
Feature card

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -138,7 +138,7 @@ const starWrapper = (cardHasImage: boolean) => css`
 	}
 `;
 
-const StarRatingComponent = ({
+export const StarRatingComponent = ({
 	rating,
 	cardHasImage,
 }: {
@@ -252,7 +252,7 @@ const getHeadlinePosition = ({
 	return 'inner';
 };
 
-const isWithinTwelveHours = (webPublicationDate: string): boolean => {
+export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	const timeDiffMs = Math.abs(
 		new Date().getTime() - new Date(webPublicationDate).getTime(),
 	);

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -498,7 +498,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					isFlexSplash={isFlexSplash}
+					fillBackground={isFlexSplash}
 				/>
 			);
 		}
@@ -509,7 +509,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					isFlexSplash={isFlexSplash}
+					fillBackground={isFlexSplash}
 				/>
 			</Hide>
 		);
@@ -526,7 +526,7 @@ export const Card = ({
 					alignment="vertical"
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
-					isFlexSplash={isFlexSplash}
+					fillBackground={isFlexSplash}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -18,7 +18,14 @@ export type ImageFixedSizeOptions = {
 };
 
 export type ImagePositionType = 'left' | 'top' | 'right' | 'bottom' | 'none';
-export type ImageSizeType = 'small' | 'medium' | 'large' | 'jumbo' | 'carousel';
+export type ImageSizeType =
+	| 'small'
+	| 'medium'
+	| 'large'
+	| 'jumbo'
+	| 'carousel'
+	| 'feature'
+	| 'feature-large';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -52,6 +52,8 @@ const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
 		case 'large':
 		case 'carousel':
 		case 'medium':
+		case 'feature':
+		case 'feature-large':
 			return 'large';
 		case 'small':
 			return 'small';

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -7,7 +7,7 @@ import type { ImageWidthType } from './Picture';
 import { generateSources, getFallbackSource } from './Picture';
 
 export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
-export type AspectRatio = '5:3' | '5:4';
+export type AspectRatio = '5:3' | '5:4' | '4:5';
 
 type Props = {
 	imageSize: ImageSizeType;
@@ -71,6 +71,20 @@ const decideImageWidths = (
 				{ breakpoint: breakpoints.tablet, width: 680 },
 				{ breakpoint: breakpoints.desktop, width: 940 },
 			];
+
+		case 'feature':
+			return [
+				{ breakpoint: breakpoints.mobile, width: 325 },
+
+				{ breakpoint: breakpoints.tablet, width: 220 },
+				{ breakpoint: breakpoints.desktop, width: 300 },
+			];
+		case 'feature-large':
+			return [
+				{ breakpoint: breakpoints.mobile, width: 325 },
+				{ breakpoint: breakpoints.tablet, width: 337 },
+				{ breakpoint: breakpoints.desktop, width: 460 },
+			];
 	}
 };
 
@@ -85,16 +99,26 @@ const block = css`
 	display: block;
 `;
 
+const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
+	switch (aspectRatio) {
+		case '5:4':
+			return '80%';
+		case '4:5':
+			return '125%';
+		case '5:3':
+		default:
+			return '60%';
+	}
+};
 /**
  * On fronts, Fairground cards have an image ration of 5:4.
  * This is due to replace the existing card ratio of 5:3
  * For now, we are keeping both ratios.
  */
 const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
+	const paddingRatio = getAspectRatioPadding(aspectRatio);
 	return css`
-		padding-top: ${aspectRatio === '5:4'
-			? `${(4 / 5) * 100}%`
-			: `${(3 / 5) * 100}%`};
+		padding-top: ${paddingRatio};
 		position: relative;
 		& > * {
 			position: absolute;

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -1,0 +1,123 @@
+import { css } from '@emotion/react';
+import { breakpoints, from } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { Props as CardProps, FeatureCard } from './FeatureCard';
+
+const cardProps: CardProps = {
+	linkTo: '',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	},
+	headlineText: 'Headline text',
+	trailText:
+		'The 29-year-old source behind the biggest intelligence leak in the NSA’s history explains his motives',
+	kickerText: 'Kicker',
+	webPublicationDate: new Date(Date.now() - 60 * 60 * 1000).toString(),
+	image: {
+		src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+		altText: 'alt text',
+	},
+	imagePositionOnDesktop: 'top',
+	isExternalLink: false,
+	isPlayableMediaCard: false,
+	imageLoading: 'eager',
+	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
+	absoluteServerTimes: true,
+	aspectRatio: '4:5',
+	byline: 'Byline text',
+	showByline: true,
+	headlineSizes: { desktop: 'medium' },
+	showPulsingDot: false,
+	showClock: false,
+	imageSize: 'feature',
+};
+
+const aBasicLink = {
+	headline: 'Headline',
+	url: 'https://www.theguardian.com',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	},
+};
+
+const CardWrapper = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<div
+			css={css`
+				max-width: 460px;
+				flex-basis: 100%;
+				${from.tablet} {
+					flex-basis: 1;
+				}
+				margin: 10px;
+			`}
+		>
+			{children}
+		</div>
+	);
+};
+
+const meta = {
+	component: FeatureCard,
+	title: 'Components/FeatureCard',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+	args: {},
+	render: (args) => (
+		<CardWrapper>
+			<FeatureCard {...args} />
+		</CardWrapper>
+	),
+} satisfies Meta<typeof FeatureCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Feature: Story = {
+	name: 'Feature story',
+	args: {
+		...cardProps,
+	},
+};
+
+export const FeatureSubs: Story = {
+	name: 'Feature story with sub links',
+	args: {
+		supportingContent: [
+			{
+				...aBasicLink,
+				headline: 'Headline 1',
+				kickerText: 'Kicker',
+			},
+			{
+				...aBasicLink,
+				headline: 'Headline 2',
+				kickerText: 'Kicker',
+				format: {
+					theme: Pillar.Sport,
+					design: ArticleDesign.Gallery,
+					display: ArticleDisplay.Standard,
+				},
+			},
+			{
+				...aBasicLink,
+				headline: 'Headline 3',
+				kickerText: 'Kicker',
+			},
+		],
+		...cardProps,
+	},
+};

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,0 +1,423 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import { Link } from '@guardian/source/react-components';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
+import { getZIndex } from '../lib/getZIndex';
+import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../lib/useCommentCount';
+import type { Branding } from '../types/branding';
+import type { StarRating as Rating } from '../types/content';
+import type {
+	DCRContainerPalette,
+	DCRContainerType,
+	DCRFrontImage,
+	DCRSnapType,
+	DCRSupportingContent,
+} from '../types/front';
+import type { MainMedia } from '../types/mainMedia';
+import { isWithinTwelveHours, StarRatingComponent } from './Card/Card';
+import { CardAge as AgeStamp } from './Card/components/CardAge';
+import { CardFooter } from './Card/components/CardFooter';
+import { CardLink } from './Card/components/CardLink';
+import type {
+	ImagePositionType,
+	ImageSizeType,
+} from './Card/components/ImageWrapper';
+import { CardCommentCount } from './CardCommentCount.importable';
+import { CardHeadline, type ResponsiveFontSize } from './CardHeadline';
+import type { AspectRatio, Loading } from './CardPicture';
+import { CardPicture } from './CardPicture';
+import { ContainerOverrides } from './ContainerOverrides';
+import { FormatBoundary } from './FormatBoundary';
+import { Island } from './Island';
+import { MediaDuration } from './MediaDuration';
+import { SupportingContent } from './SupportingContent';
+
+export type Position = 'inner' | 'outer' | 'none';
+
+export type Props = {
+	linkTo: string;
+	format: ArticleFormat;
+	absoluteServerTimes: boolean;
+	headlineText: string;
+	headlineSizes?: ResponsiveFontSize;
+	byline?: string;
+	showByline?: boolean;
+	webPublicationDate?: string;
+	image?: DCRFrontImage;
+	imagePositionOnDesktop?: ImagePositionType;
+	imagePositionOnMobile?: ImagePositionType;
+	/** Size is ignored when position = 'top' because in that case the image flows based on width */
+	imageSize?: ImageSizeType;
+	imageLoading: Loading;
+	isCrossword?: boolean;
+	isOnwardContent?: boolean;
+	trailText?: string;
+	avatarUrl?: string;
+	showClock?: boolean;
+	mainMedia?: MainMedia;
+
+	/** Note YouTube recommends a minimum width of 480px @see https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-youtube-player-size
+	 * At 300px or below, the player will begin to lose functionality e.g. volume controls being omitted.
+	 * Youtube requires a minimum width 200px.
+	 */
+	isPlayableMediaCard?: boolean;
+	kickerText?: string;
+	showPulsingDot?: boolean;
+	starRating?: Rating;
+	minWidthInPixels?: number;
+	/** Used for Ophan tracking */
+	dataLinkName?: string;
+	/** Only used on Labs cards */
+	branding?: Branding;
+	/** Supporting content refers to sublinks */
+	supportingContent?: DCRSupportingContent[];
+	snapData?: DCRSnapType;
+	containerPalette?: DCRContainerPalette;
+	containerType?: DCRContainerType;
+	discussionApiUrl: string;
+	discussionId?: string;
+	isExternalLink: boolean;
+	/** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
+	aspectRatio?: AspectRatio;
+	index?: number;
+};
+
+const baseCardStyles = css`
+	/* We absolutely position the faux link
+		so this is required here */
+	position: relative;
+
+	/* Target Safari 10.1 */
+	/* https://www.browserstack.com/guide/create-browser-specific-css */
+	@media not all and (min-resolution: 0.001dpcm) {
+		@supports (-webkit-appearance: none) and
+			(not (stroke-color: transparent)) {
+			display: grid;
+			grid-auto-rows: min-content;
+			align-content: start;
+		}
+	}
+
+	/* a tag specific styles */
+	color: inherit;
+	text-decoration: none;
+`;
+
+const overlayStyles = css`
+	position: absolute;
+	width: 100%;
+	bottom: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	flex-grow: 1;
+	padding: 8px;
+	backdrop-filter: blur(12px);
+	row-gap: 8px;
+`;
+
+const getMedia = ({
+	imageUrl,
+	imageAltText,
+	mainMedia,
+	isPlayableMediaCard,
+}: {
+	imageUrl?: string;
+	imageAltText?: string;
+	mainMedia?: MainMedia;
+	isPlayableMediaCard?: boolean;
+}) => {
+	if (mainMedia && mainMedia.type === 'Video' && isPlayableMediaCard) {
+		return {
+			type: 'video',
+			mainMedia,
+			...(imageUrl && { imageUrl }),
+		} as const;
+	}
+	if (imageUrl) {
+		return { type: 'picture', imageUrl, imageAltText } as const;
+	}
+	return undefined;
+};
+
+const CardAge = ({
+	showClock,
+	absoluteServerTimes,
+	webPublicationDate,
+}: {
+	showClock: boolean;
+	absoluteServerTimes: boolean;
+	webPublicationDate?: string;
+}) => {
+	if (!webPublicationDate) return undefined;
+	const withinTwelveHours = isWithinTwelveHours(webPublicationDate);
+
+	return (
+		<AgeStamp
+			webPublication={{
+				date: webPublicationDate,
+				isWithinTwelveHours: withinTwelveHours,
+			}}
+			showClock={showClock}
+			isOnwardContent={false}
+			absoluteServerTimes={absoluteServerTimes}
+			isTagPage={false}
+		/>
+	);
+};
+
+const CommentCount = ({
+	discussionId,
+	linkTo,
+	discussionApiUrl,
+}: {
+	linkTo: string;
+	discussionApiUrl?: string;
+	discussionId?: string;
+}) => {
+	if (!discussionId) return null;
+	if (!discussionApiUrl) return null;
+	return (
+		<Link
+			{...{
+				[DISCUSSION_ID_DATA_ATTRIBUTE]: discussionId,
+			}}
+			data-ignore="global-link-styling"
+			data-link-name="Comment count"
+			href={`${linkTo}#comments`}
+			cssOverrides={css`
+				/* See: https://css-tricks.com/nested-links/ */
+				${getZIndex('card-nested-link')}
+				/* The following styles turn off those provided by Link */
+				color: inherit;
+				/* stylelint-disable-next-line property-disallowed-list */
+				font-family: inherit;
+				font-size: inherit;
+				line-height: inherit;
+				text-decoration: none;
+				min-height: 10px;
+			`}
+		>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<CardCommentCount
+					discussionApiUrl={discussionApiUrl}
+					discussionId={discussionId}
+					isOnwardContent={false}
+				/>
+			</Island>
+		</Link>
+	);
+};
+
+export const FeatureCard = ({
+	linkTo,
+	format,
+	headlineText,
+	headlineSizes,
+	byline,
+	showByline,
+	webPublicationDate,
+	image,
+	imagePositionOnDesktop = 'top',
+	imagePositionOnMobile = 'left',
+	imageSize = 'small',
+	imageLoading,
+	showClock,
+	mainMedia,
+	isPlayableMediaCard,
+	kickerText,
+	showPulsingDot,
+	dataLinkName,
+	branding,
+	supportingContent,
+	containerPalette,
+	discussionApiUrl,
+	discussionId,
+	isExternalLink,
+	absoluteServerTimes,
+	aspectRatio,
+	starRating,
+}: Props) => {
+	const hasSublinks = supportingContent && supportingContent.length > 0;
+
+	/**TODO: Check if feaure cards should be playable */
+	// If the card isn't playable, we need to show a play icon.
+	// Otherwise, this is handled by the YoutubeAtom
+	const showPlayIcon = mainMedia?.type === 'Video' && !isPlayableMediaCard;
+
+	const media = getMedia({
+		imageUrl: image?.src,
+		imageAltText: image?.altText,
+		mainMedia,
+		isPlayableMediaCard,
+	});
+
+	return (
+		<FormatBoundary format={format}>
+			<ContainerOverrides containerPalette={containerPalette}>
+				<div css={[baseCardStyles]}>
+					<CardLink
+						linkTo={linkTo}
+						headlineText={headlineText}
+						dataLinkName={dataLinkName}
+						isExternalLink={isExternalLink}
+					/>
+
+					<div
+						css={[
+							css`
+								display: flex;
+								flex-direction: column;
+							`,
+						]}
+					>
+						{media && (
+							<div
+								css={css`
+									//** check if these styles are needed  */
+
+									/* position relative is required here to bound the image overlay */
+									position: relative;
+									img {
+										width: 100%;
+										display: block;
+									}
+								`}
+							>
+								{media.type === 'video' && (
+									<>
+										<div>
+											<CardPicture
+												mainImage={
+													media.imageUrl
+														? media.imageUrl
+														: media.mainMedia.images.reduce(
+																(
+																	prev,
+																	current,
+																) =>
+																	prev.width >
+																	current.width
+																		? prev
+																		: current,
+														  ).url
+												}
+												imageSize={imageSize}
+												alt={headlineText}
+												loading={imageLoading}
+												roundedCorners={false}
+												aspectRatio={aspectRatio}
+											/>
+										</div>
+									</>
+								)}
+								{media.type === 'picture' && (
+									<>
+										<CardPicture
+											mainImage={media.imageUrl}
+											imageSize={imageSize}
+											alt={media.imageAltText}
+											loading={imageLoading}
+											roundedCorners={false}
+											aspectRatio={aspectRatio}
+										/>
+										{showPlayIcon &&
+											mainMedia.duration > 0 && (
+												<MediaDuration
+													mediaDuration={
+														mainMedia.duration
+													}
+													imagePositionOnDesktop={
+														imagePositionOnDesktop
+													}
+													imagePositionOnMobile={
+														imagePositionOnMobile
+													}
+												/>
+											)}
+									</>
+								)}
+								<div css={overlayStyles}>
+									<CardHeadline
+										headlineText={headlineText}
+										format={format}
+										fontSizes={headlineSizes}
+										showQuotes={false}
+										kickerText={
+											format.design ===
+												ArticleDesign.LiveBlog &&
+											!kickerText
+												? 'Live'
+												: kickerText
+										}
+										showPulsingDot={
+											format.design ===
+												ArticleDesign.LiveBlog ||
+											showPulsingDot
+										}
+										byline={byline}
+										showByline={showByline}
+										isExternalLink={isExternalLink}
+									/>
+									{starRating !== undefined ? (
+										<StarRatingComponent
+											rating={starRating}
+											cardHasImage={!!image}
+										/>
+									) : null}
+									<CardFooter
+										format={format}
+										age={
+											<CardAge
+												webPublicationDate={
+													webPublicationDate
+												}
+												showClock={!!showClock}
+												absoluteServerTimes={
+													absoluteServerTimes
+												}
+											/>
+										}
+										commentCount={
+											<CommentCount
+												linkTo={linkTo}
+												discussionId={discussionId}
+												discussionApiUrl={
+													discussionApiUrl
+												}
+											/>
+										}
+										/**TODO: check if this is needed */
+										// cardBranding={
+										// 	branding ? (
+										// 		<CardBranding
+										// 			branding={branding}
+										// 			format={format}
+										// 			onwardsSource={
+										// 				onwardsSource
+										// 			}
+										// 			containerPalette={
+										// 				containerPalette
+										// 			}
+										// 		/>
+										// 	) : undefined
+										// }
+										showLivePlayable={false}
+									/>
+								</div>
+							</div>
+						)}
+					</div>
+
+					{hasSublinks && (
+						<SupportingContent
+							supportingContent={supportingContent}
+							containerPalette={containerPalette}
+							alignment={'vertical'}
+						/>
+					)}
+				</div>
+			</ContainerOverrides>
+		</FormatBoundary>
+	);
+};

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -414,6 +414,7 @@ export const FeatureCard = ({
 							supportingContent={supportingContent}
 							containerPalette={containerPalette}
 							alignment={'vertical'}
+							fillBackground={true}
 						/>
 					)}
 				</div>

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,7 +16,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
-	isFlexSplash?: boolean;
+	fillBackground?: boolean;
 };
 
 /**
@@ -134,7 +134,7 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
-	isFlexSplash = false,
+	fillBackground = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -144,7 +144,7 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				isFlexSplash && backgroundFill,
+				fillBackground && backgroundFill,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {


### PR DESCRIPTION
## What does this change?
Adds the beginning of the feature card component with stories. 

## Why?
This is a new card for the fairground redesign project.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
