### PR TITLE
adds interactive content type to mobileStickyContainer

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -981,7 +981,9 @@ export const MobileStickyContainer = ({
 			className="mobilesticky-container"
 			css={[
 				mobileStickyAdStyles,
-				(contentType === 'Article' || pageId.startsWith('football/')) &&
+				(contentType === 'Article' ||
+					contentType === 'Interactive' ||
+					pageId.startsWith('football/')) &&
 					mobileStickyAdStylesFullWidth,
 			]}
 		/>


### PR DESCRIPTION
## What does this change?

This is a small change to include the `Interactive` contentType 
As a result of the related PR in commercial: https://github.com/guardian/commercial/pull/1640
## Why?

We would like to display `mobile-sticky-banners` to Interactive articles outside of the UK (currently only on "Article" types).

The styling for applying the mobile-sticky-banner lies here in DCR, and the relevant CSS currently only applies to Article types, so this has been updated.

I updated the MobileStickyContainer component logic to include a new condition: contentType === 'Interactive'. This addition allows the mobileStickyAdStylesFullWidth style to be applied when the contentType is 'Interactive', in addition to when it's 'Article' or if pageId starts with 'football/'.


## Testing
Run `commercial` locally and using `COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js PORT=3030 make dev` to test locally:
http://localhost:3030/Article/https://www.theguardian.com/us-news/ng-interactive/2024/oct/30/election-harris-trump-myths-lies-fact-checkfalse-claims-include-that-noncitizens-are-voting-in-broad-numbers-and-attacks-on-the-voting-and-counting-process?adtest=mobile_sticky_test?adtest=mobile_sticky_test


## Screenshots

https://github.com/user-attachments/assets/fcbec2e5-96fa-4fd1-b50c-056c68220dfb



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
