### PR TITLE
Support vertical card layout with avatar on mobile

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -24,22 +24,6 @@ const containerStyles = css`
 	flex-basis: 100%;
 `;
 
-const decideDirection = (imagePosition: ImagePositionType) => {
-	switch (imagePosition) {
-		case 'top':
-			return 'column';
-		case 'bottom':
-			return 'column-reverse';
-		case 'left':
-			return 'row';
-		case 'right':
-			return 'row-reverse';
-		// If there's no image (so no imagePosition) default to top down
-		case 'none':
-			return 'column';
-	}
-};
-
 // Until mobile landscape, show 1 card on small screens
 // Above mobile landscape, show 1 full card and min 20vw of second card
 const videoWidth = css`
@@ -64,36 +48,71 @@ const minWidth = (minWidthInPixels?: number) => {
 	`;
 };
 
+/**
+ * Cards with an avatar are a special case as these are rendered horizontally
+ * on mobile and vertically on desktop by default, with the avatar on the right
+ * or bottom of the card respectively.
+ *
+ * A boosted card in a `dynamic/slow` container is an exception to this as it is
+ * rendered horizontally on desktop by overriding `imagePositionOnDesktop`
+ *
+ * `scrollable/medium` is another exception as the medium cards require a
+ * vertical layout at all breakpoints so we explicitly check that the image
+ * position for desktop and mobile are both set to `bottom` to avoid affecting
+ * existing layouts where the default position values are relied upon.
+ */
+const decideDirection = (
+	imagePositionOnDesktop: ImagePositionType,
+	imagePositionOnMobile: ImagePositionType,
+	hasAvatar?: boolean,
+) => {
+	const imagePosition = {
+		top: 'column',
+		bottom: 'column-reverse',
+		left: 'row',
+		right: 'row-reverse',
+		none: 'column',
+	};
+
+	if (hasAvatar) {
+		if (
+			imagePositionOnMobile === 'bottom' &&
+			imagePositionOnDesktop === 'bottom'
+		) {
+			return [imagePosition['bottom'], imagePosition['bottom']];
+		}
+
+		if (
+			imagePositionOnDesktop === 'left' ||
+			imagePositionOnDesktop === 'right'
+		) {
+			return [imagePosition['right'], imagePosition['right']];
+		}
+
+		return [imagePosition['bottom'], imagePosition['right']];
+	}
+
+	return [
+		imagePosition[imagePositionOnDesktop],
+		imagePosition[imagePositionOnMobile],
+	];
+};
+
 const decidePosition = (
 	imagePositionOnDesktop: ImagePositionType,
 	imagePositionOnMobile: ImagePositionType,
-	imageType?: CardImageType,
+	hasAvatar?: boolean,
 ) => {
-	if (imageType === 'avatar') {
-		switch (imagePositionOnDesktop) {
-			case 'left':
-			case 'right': {
-				return css`
-					flex-direction: row-reverse;
-					${from.tablet} {
-						flex-direction: row-reverse;
-					}
-				`;
-			}
-			default: {
-				return css`
-					flex-direction: row-reverse;
-					${from.tablet} {
-						flex-direction: column-reverse;
-					}
-				`;
-			}
-		}
-	}
+	const [directionOnDesktop, directionOnMobile] = decideDirection(
+		imagePositionOnDesktop,
+		imagePositionOnMobile,
+		hasAvatar,
+	);
+
 	return css`
-		flex-direction: ${decideDirection(imagePositionOnMobile)};
+		flex-direction: ${directionOnMobile};
 		${from.tablet} {
-			flex-direction: ${decideDirection(imagePositionOnDesktop)};
+			flex-direction: ${directionOnDesktop};
 		}
 	`;
 };
@@ -133,7 +152,7 @@ export const CardLayout = ({
 			decidePosition(
 				imagePositionOnDesktop,
 				imagePositionOnMobile,
-				imageType,
+				imageType === 'avatar',
 			),
 		]}
 		style={{

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -62,8 +62,8 @@ const minWidth = (minWidthInPixels?: number) => {
  * existing layouts where the default position values are relied upon.
  */
 const decideDirection = (
-	imagePositionOnDesktop: ImagePositionType,
 	imagePositionOnMobile: ImagePositionType,
+	imagePositionOnDesktop: ImagePositionType,
 	hasAvatar?: boolean,
 ) => {
 	const imagePosition = {
@@ -79,40 +79,49 @@ const decideDirection = (
 			imagePositionOnMobile === 'bottom' &&
 			imagePositionOnDesktop === 'bottom'
 		) {
-			return [imagePosition['bottom'], imagePosition['bottom']];
+			return {
+				mobile: imagePosition['bottom'],
+				desktop: imagePosition['bottom'],
+			};
 		}
 
 		if (
 			imagePositionOnDesktop === 'left' ||
 			imagePositionOnDesktop === 'right'
 		) {
-			return [imagePosition['right'], imagePosition['right']];
+			return {
+				mobile: imagePosition['right'],
+				desktop: imagePosition['right'],
+			};
 		}
 
-		return [imagePosition['bottom'], imagePosition['right']];
+		return {
+			mobile: imagePosition['right'],
+			desktop: imagePosition['bottom'],
+		};
 	}
 
-	return [
-		imagePosition[imagePositionOnDesktop],
-		imagePosition[imagePositionOnMobile],
-	];
+	return {
+		mobile: imagePosition[imagePositionOnMobile],
+		desktop: imagePosition[imagePositionOnDesktop],
+	};
 };
 
 const decidePosition = (
-	imagePositionOnDesktop: ImagePositionType,
 	imagePositionOnMobile: ImagePositionType,
+	imagePositionOnDesktop: ImagePositionType,
 	hasAvatar?: boolean,
 ) => {
-	const [directionOnDesktop, directionOnMobile] = decideDirection(
-		imagePositionOnDesktop,
+	const { mobile, desktop } = decideDirection(
 		imagePositionOnMobile,
+		imagePositionOnDesktop,
 		hasAvatar,
 	);
 
 	return css`
-		flex-direction: ${directionOnMobile};
+		flex-direction: ${mobile};
 		${from.tablet} {
-			flex-direction: ${directionOnDesktop};
+			flex-direction: ${desktop};
 		}
 	`;
 };
@@ -150,8 +159,8 @@ export const CardLayout = ({
 				? videoWidth
 				: minWidth(minWidthInPixels),
 			decidePosition(
-				imagePositionOnDesktop,
 				imagePositionOnMobile,
+				imagePositionOnDesktop,
 				imageType === 'avatar',
 			),
 		]}


### PR DESCRIPTION
## What does this change?

Updates cards to support vertical layout on mobile when an avatar is included. Currently cards with avatars are an exception to the card layout logic and are always rendered horizontally on mobile. `imagePositionOnMobile` and `imagePositionOnDesktop` both have to be explicitly set to `bottom` to allow this to avoid affecting existing layouts where containers have set `imagePositionOnMobile` to `top`, but can include avatars which ignore this and continue to have a horizontal layout.

## Why?

This is to support the new `scrollable/medium` container where cards have a vertical layout across all breakpoints.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a614433a-14c6-4989-a919-431e9babbb9a
[after]: https://github.com/user-attachments/assets/4e50ff34-5d3e-4c6c-bafb-6ef7a8694977
