### PR TITLE
US election 2024 scaling

### DIFF
--- a/apps-rendering/cdk/bin/cdk.ts
+++ b/apps-rendering/cdk/bin/cdk.ts
@@ -25,8 +25,8 @@ new MobileAppsRendering(app, 'MobileAppsRendering-PROD', {
 	stage: 'PROD',
 	recordPrefix: 'mobile-rendering',
 	asgCapacity: {
-		minimumInstances: 3,
-		maximumInstances: 12,
+		minimumInstances: 6,
+		maximumInstances: 24,
 	},
 	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',
@@ -55,8 +55,8 @@ new MobileAppsRendering(app, 'MobileAppsRenderingPreview-PROD', {
 	stage: 'PROD',
 	recordPrefix: 'mobile-preview-rendering',
 	asgCapacity: {
-		minimumInstances: 1,
-		maximumInstances: 2,
+		minimumInstances: 2,
+		maximumInstances: 4,
 	},
 	instanceSize: InstanceSize.MICRO,
 	appsRenderingDomain: 'mobile-aws.guardianapis.com',

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,9 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 36,
-		maximumInstances: 180,
+		minimumInstances: 72,
+		// DevX recommend max instances are 10x of min in PROD
+		maximumInstances: 720,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -68,8 +69,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 18,
-		maximumInstances: 180,
+		minimumInstances: 36,
+		maximumInstances: 360,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -108,8 +109,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 15,
-		maximumInstances: 150,
+		minimumInstances: 30,
+		maximumInstances: 300,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -148,8 +149,8 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'interactive-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 3,
-		maximumInstances: 30,
+		minimumInstances: 12,
+		maximumInstances: 120,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,

--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,9 +28,9 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 72,
+		minimumInstances: 48,
 		// DevX recommend max instances are 10x of min in PROD
-		maximumInstances: 720,
+		maximumInstances: 480,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
## What does this change?

Scale up the ASG min and max in preparation for the US election 2024

### DCR 

The article stack has been increased by 1.33x following the reasoning [here](https://chat.google.com/room/AAAAPTsU18A/Cp7R0NsMi6I/yTArbwCQ_QE?cls=10)

The interactive stack has been quadrupled as it is under-resourced when compared to the other stacks

All other stacks have been doubled

| stack | scaling |
|:-- |:-- |
|article  | 1.33x |
|facia, tag-page, legacy-rendering | 2x |
| interactive | 4x |

Corresponding platform PR: https://github.com/guardian/platform/pull/1637

#### Prior scaling

UK election 2024:
https://github.com/guardian/dotcom-rendering/pull/11781

Bump of articles to 36 minimum instances:
https://github.com/guardian/dotcom-rendering/pull/11947

### AR 

All stacks have been doubled



