### PR TITLE
Allow trail text on `StaticFeatureTwo` container

### DIFF
--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -55,6 +55,7 @@ export const StaticFeatureTwo = ({
 								isExternalLink={card.isExternalLink}
 								// branding={card.branding}
 								containerPalette={containerPalette}
+								trailText={card.trailText}
 								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
 								aspectRatio="4:5"


### PR DESCRIPTION
## What does this change?

Enables trail text to be shown on cards within the `static/feature/2` container

## Why?

Has been decided these cards are generally large enough to display trail text without obscuring much of the background image.

Trail text can be omitted in the fronts tool for cases where the headline is particularly long

Resolves [this Trello ticket](https://trello.com/c/RqcXYeXR/683-allow-trail-text-in-cards-within-static-feature-container)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/376c42e1-4530-40bf-87d3-b87fbe64577e
[after]: https://github.com/user-attachments/assets/024ec4da-a701-46cd-bbde-8048d0609ddf

