### PR TITLE
Add data-link-name to `ExpandableMarketingCardSwipeable`

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
@@ -144,6 +144,7 @@ export const ExpandableMarketingCardSwipeable = ({
 		return (
 			<div css={[stickyContainerStyles]}>
 				<div
+					data-link-name="us-expandable-marketing-card expand"
 					css={[
 						absoluteContainerStyles,
 						isDown &&


### PR DESCRIPTION
## What does this change?
Adds the data link name `"us-expandable-marketing-card expand"` to `ExpandableMarketingCardSwipeable`
## Why?
This was not tracking correctly as was not being called on the swipeable component.
