### PR TITLE
Add view tracking to `ExpandableMarketingCardSwipeable`

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+import { getOphan } from '../client/ophan/ophan';
 import { getZIndex } from '../lib/getZIndex';
 import { ExpandableMarketingCard } from './ExpandableMarketingCard';
 
@@ -135,6 +136,22 @@ export const ExpandableMarketingCardSwipeable = ({
 			observer.disconnect();
 		};
 	}, [topOfBody]);
+
+	useEffect(() => {
+		const reportView = () => {
+			void getOphan('Web').then((ophan) => {
+				ophan.record({
+					interaction: {
+						component: 'us-expandable-marketing-card',
+						value: 'us-expandable-marketing-card visible',
+					},
+				});
+			});
+		};
+		if (shouldDisplayCard) {
+			reportView();
+		}
+	}, [shouldDisplayCard]);
 
 	if (!shouldDisplayCard) {
 		return null;


### PR DESCRIPTION
## What does this change?
Report to ophan when the `ExpandableMarketingCardSwipeable` is visible to the user
## Why?
The component only appears when the user scrolls into the article body. We want to check if the component has been scrolled into view.

