### PR TITLE
Tidy ad slot styles

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -96,30 +96,12 @@ const darkLabelStyles = css`
 	}
 `;
 
-/**
- * Usage according to DAP (Digital Ad Production)
- *
- * #### Desktop
- * - `fabric` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-custom` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-expandable` &rarr; `merchandising-high`
- * - `fabric-third-party` &rarr; `top-above-nav`,`merchandising-high`,`merchandising`
- * - `fabric-video` &rarr; `top-above-nav`,`merchandising-high`
- * - `fabric-video-expandable` &rarr; `merchandising-high`
- *
- * #### Mobile
- * - `interscroller` &rarr; `top-above-nav`
- * - `mobile-revealer` &rarr; `top-above-nav`
- */
-const fluidAdStyles = css`
-	&.ad-slot--fluid {
-		min-height: 250px;
-		line-height: 10px;
-		padding: 0;
-		margin: 0;
-		overflow: visible;
-		width: 100%;
-	}
+const topAboveNavContainerStyles = css`
+	padding-bottom: 18px;
+	position: relative;
+	margin: 0 auto;
+	text-align: left;
+	display: block;
 `;
 
 /**
@@ -527,19 +509,23 @@ export const AdSlot = ({
 		case 'top-above-nav': {
 			return (
 				<div
-					id="dfp-ad--top-above-nav"
-					className={[
-						'js-ad-slot',
-						'ad-slot',
-						'ad-slot--top-above-nav',
-						'ad-slot--mpu-banner-ad',
-						'ad-slot--rendered',
-					].join(' ')}
-					css={[fluidAdStyles]}
-					data-link-name="ad slot top-above-nav"
-					data-name="top-above-nav"
-					aria-hidden="true"
-				></div>
+					css={[topAboveNavContainerStyles]}
+					className="ad-slot-container"
+				>
+					<div
+						id="dfp-ad--top-above-nav"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--top-above-nav',
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+						].join(' ')}
+						data-link-name="ad slot top-above-nav"
+						data-name="top-above-nav"
+						aria-hidden="true"
+					></div>
+				</div>
 			);
 		}
 		case 'mostpop': {

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -1,16 +1,15 @@
 import { css } from '@emotion/react';
 import type { SlotName } from '@guardian/commercial';
-import { adSizes, constants } from '@guardian/commercial';
+import { adSizes } from '@guardian/commercial';
 import {
 	between,
 	breakpoints,
 	from,
 	palette,
-	space,
-	textSans12,
 	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
+import { labelBoxStyles, labelHeight, labelStyles } from '../lib/adStyles';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
@@ -68,82 +67,10 @@ type RemainingProps = {
  */
 type Props = DefaultProps & (RightProps | InlineProps | RemainingProps);
 
-const labelHeight = constants.AD_LABEL_HEIGHT;
 const halfPageAdHeight = adSizes.halfPage.height;
-
-const individualLabelCSS = css`
-	${textSans12};
-	height: ${labelHeight}px;
-	max-height: ${labelHeight}px;
-	background-color: ${schemedPalette('--ad-background')};
-	padding-top: 3px;
-	border-top: 1px solid ${schemedPalette('--ad-border')};
-	color: ${schemedPalette('--ad-labels-text')};
-	text-align: center;
-	box-sizing: border-box;
-`;
 
 const outOfPageStyles = css`
 	height: 0;
-`;
-
-export const labelStyles = css`
-	.ad-slot__scroll {
-		${individualLabelCSS}
-		position: relative;
-		&.visible {
-			visibility: initial;
-		}
-		&.hidden {
-			visibility: hidden;
-		}
-	}
-	.ad-slot__close-button {
-		display: none;
-	}
-
-	.ad-slot__scroll {
-		position: fixed;
-		bottom: 0;
-		width: 100%;
-		${individualLabelCSS}
-	}
-
-	.ad-slot:not[data-label-show='true']::before {
-		content: '';
-		display: block;
-		height: ${labelHeight}px;
-		visibility: hidden;
-	}
-
-	.ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before {
-		content: attr(ad-label-text);
-		display: block;
-		position: relative;
-		${individualLabelCSS}
-	}
-
-	.ad-slot__adtest-cookie-clear-link {
-		${textSans12};
-		text-align: left;
-		position: absolute;
-		left: 268px;
-		top: 1px;
-		z-index: 10;
-		padding: 0;
-		border: 0;
-	}
-
-	.ad-slot--interscroller[data-label-show='true']::before {
-		content: 'Advertisement';
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		border: 0;
-		display: block;
-		${individualLabelCSS}
-	}
 `;
 
 const darkLabelStyles = css`
@@ -151,25 +78,6 @@ const darkLabelStyles = css`
 		background-color: transparent;
 		border-top-color: ${palette.neutral[20]};
 		color: ${palette.neutral[86]};
-	}
-`;
-
-const adContainerCollapseStyles = css`
-	& .ad-slot.ad-slot--collapse {
-		display: none;
-	}
-`;
-
-const adContainerCentreSlotStyles = css`
-	&.ad-slot-container--centre-slot {
-		width: fit-content;
-		margin: 0 auto;
-	}
-`;
-
-const adSlotCollapseStyles = css`
-	&.ad-slot.ad-slot--collapse {
-		display: none;
 	}
 `;
 
@@ -243,15 +151,6 @@ const merchandisingAdStyles = css`
 		${between.phablet.and.desktop} {
 			display: none;
 		}
-	}
-`;
-
-const inlineAdStyles = css`
-	position: relative;
-	background-color: ${schemedPalette('--ad-background-article-inner')};
-
-	${until.tablet} {
-		display: none;
 	}
 `;
 
@@ -401,28 +300,6 @@ const liveBlogTopContainerStyles = css`
 	display: flex;
 	justify-content: center;
 `;
-/**
- * For implementation in Frontend, see mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
- * These styles come mostly from RichLink in DCR.
- */
-export const carrotAdStyles = css`
-	.ad-slot--carrot {
-		float: left;
-		clear: both;
-		width: 140px;
-		margin-right: 20px;
-		margin-bottom: ${space[1]}px;
-		${from.leftCol} {
-			position: relative;
-			margin-left: -160px;
-			width: 140px;
-		}
-		${from.wide} {
-			margin-left: -240px;
-			width: 220px;
-		}
-	}
-`;
 
 const mobileStickyAdStyles = css`
 	position: fixed;
@@ -476,7 +353,7 @@ const mobileStickyAdStyles = css`
 		content: 'Advertisement';
 		display: block;
 		position: relative;
-		${individualLabelCSS}
+		${labelBoxStyles}
 	}
 `;
 
@@ -490,12 +367,6 @@ const mobileStickyAdStylesFullWidth = css`
 		padding-right: calc((100% - ${adSizes.mobilesticky.width}px) / 2);
 	}
 `;
-
-export const adContainerStyles = [
-	adContainerCollapseStyles,
-	labelStyles,
-	adContainerCentreSlotStyles,
-];
 
 export const AdSlot = ({
 	position,
@@ -511,10 +382,7 @@ export const AdSlot = ({
 			switch (display) {
 				case ArticleDisplay.Immersive: {
 					return (
-						<div
-							className="ad-slot-container"
-							css={adContainerStyles}
-						>
+						<div className="ad-slot-container">
 							<div
 								id="dfp-ad--right"
 								css={rightAdStyles}
@@ -538,10 +406,7 @@ export const AdSlot = ({
 					return (
 						<div
 							className="ad-slot-container"
-							css={[
-								adContainerStyles,
-								showcaseRightColumnContainerStyles,
-							]}
+							css={[showcaseRightColumnContainerStyles]}
 						>
 							<div
 								id="dfp-ad--right"
@@ -625,7 +490,7 @@ export const AdSlot = ({
 			}
 		case 'comments': {
 			return (
-				<div className="ad-slot-container" css={adContainerStyles}>
+				<div className="ad-slot-container">
 					<div
 						id="dfp-ad--comments"
 						className={[
@@ -666,7 +531,7 @@ export const AdSlot = ({
 				<Hide until="tablet">
 					<div
 						className="ad-slot-container"
-						css={[adContainerStyles, mostPopContainerStyles]}
+						css={[mostPopContainerStyles]}
 					>
 						<div
 							id="dfp-ad--mostpop"
@@ -694,7 +559,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[merchandisingAdContainerStyles, adContainerStyles]}
+					css={[merchandisingAdContainerStyles]}
 				>
 					<div
 						id="dfp-ad--merchandising-high"
@@ -707,7 +572,6 @@ export const AdSlot = ({
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
 							merchandisingAdStyles,
-							adSlotCollapseStyles,
 						]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
@@ -721,7 +585,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[merchandisingAdContainerStyles, adContainerStyles]}
+					css={[merchandisingAdContainerStyles]}
 				>
 					<div
 						id="dfp-ad--merchandising"
@@ -734,7 +598,6 @@ export const AdSlot = ({
 							fluidAdStyles,
 							fluidFullWidthAdStyles,
 							merchandisingAdStyles,
-							adSlotCollapseStyles,
 						]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
@@ -755,7 +618,6 @@ export const AdSlot = ({
 						css={[
 							frontsBannerAdContainerStyles,
 							hasPageskin && frontsBannerCollapseStyles,
-							adContainerStyles,
 						]}
 					>
 						<div
@@ -789,7 +651,7 @@ export const AdSlot = ({
 						'ad-slot',
 						'ad-slot--survey',
 					].join(' ')}
-					css={[outOfPageStyles, adSlotCollapseStyles]}
+					css={[outOfPageStyles]}
 					data-link-name="ad slot survey"
 					data-name="survey"
 					data-label="false"
@@ -799,34 +661,31 @@ export const AdSlot = ({
 				/>
 			);
 		}
-		case 'inline': {
-			const advertId = `inline${index + 1}`;
-			return (
-				<div className="ad-slot-container" css={adContainerStyles}>
-					<div
-						id={`dfp-ad--${advertId}`}
-						className={[
-							'js-ad-slot',
-							'ad-slot',
-							`ad-slot--${advertId}`,
-							'ad-slot--container-inline',
-							'ad-slot--rendered',
-						].join(' ')}
-						css={inlineAdStyles}
-						data-link-name={`ad slot ${advertId}`}
-						data-name={advertId}
-						aria-hidden="true"
-					/>
-				</div>
-			);
-		}
+		// case 'inline': {
+		// 	const advertId = `inline${index + 1}`;
+		// 	return (
+		// 		<div className="ad-slot-container" css={adContainerStyles}>
+		// 			<div
+		// 				id={`dfp-ad--${advertId}`}
+		// 				className={[
+		// 					'js-ad-slot',
+		// 					'ad-slot',
+		// 					`ad-slot--${advertId}`,
+		// 					'ad-slot--container-inline',
+		// 					'ad-slot--rendered',
+		// 				].join(' ')}
+		// 				css={inlineAdStyles}
+		// 				data-link-name={`ad slot ${advertId}`}
+		// 				data-name={advertId}
+		// 				aria-hidden="true"
+		// 			/>
+		// 		</div>
+		// 	);
+		// }
 		case 'liveblog-inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div
-					className="ad-slot-container ad-slot-desktop"
-					css={adContainerStyles}
-				>
+				<div className="ad-slot-container ad-slot-desktop">
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -848,10 +707,7 @@ export const AdSlot = ({
 		case 'liveblog-inline-mobile': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div
-					className="ad-slot-container ad-slot-mobile"
-					css={adContainerStyles}
-				>
+				<div className="ad-slot-container ad-slot-mobile">
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -874,7 +730,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="ad-slot-container"
-					css={[adContainerStyles, liveBlogTopContainerStyles]}
+					css={[liveBlogTopContainerStyles]}
 				>
 					<div
 						id="dfp-ad--liveblog-top"
@@ -899,7 +755,7 @@ export const AdSlot = ({
 		case 'mobile-front': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div className="ad-slot-container" css={adContainerStyles}>
+				<div className="ad-slot-container">
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -921,7 +777,7 @@ export const AdSlot = ({
 		}
 		case 'pageskin': {
 			return (
-				<div className="ad-slot-container" css={adContainerStyles}>
+				<div className="ad-slot-container">
 					<div
 						id="dfp-ad--pageskin-inread"
 						className={[
@@ -944,7 +800,7 @@ export const AdSlot = ({
 		}
 		case 'article-end': {
 			return (
-				<div className="ad-slot-container" css={adContainerStyles}>
+				<div className="ad-slot-container">
 					<div
 						id="dfp-ad--article-end"
 						className={[

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -18,8 +18,12 @@ import type { FEArticleType } from '../types/frontend';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { Island } from './Island';
 
-// When requesting from Ad Manager these are all "inline" slots
-type InlineSlot = 'liveblog-inline' | 'liveblog-inline-mobile' | 'mobile-front';
+// There are multiple of these ad slots on the page
+type IndexedSlot =
+	| 'fronts-banner'
+	| 'liveblog-inline'
+	| 'liveblog-inline-mobile'
+	| 'mobile-front';
 
 // TODO move to commercial
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
@@ -48,8 +52,8 @@ type DefaultProps = {
 // for dark ad labels
 type ColourScheme = 'light' | 'dark';
 
-type InlineProps = {
-	position: InlineSlot;
+type IndexedSlotProps = {
+	position: IndexedSlot;
 	colourScheme?: ColourScheme;
 	index: number;
 	shouldHideReaderRevenue?: never;
@@ -63,7 +67,7 @@ type RightProps = {
 };
 
 type RemainingProps = {
-	position: Exclude<ServerRenderedSlot, InlineSlot>;
+	position: Exclude<ServerRenderedSlot, IndexedSlot>;
 	colourScheme?: ColourScheme;
 	index?: never;
 	shouldHideReaderRevenue?: never;
@@ -76,7 +80,7 @@ type RemainingProps = {
  * - If `position` is `right` then we expect the `shouldHideReaderRevenue` prop
  * - If not, then we explicitly refuse these properties
  */
-type Props = DefaultProps & (RightProps | InlineProps | RemainingProps);
+type Props = DefaultProps & (RightProps | IndexedSlotProps | RemainingProps);
 
 const halfPageAdHeight = adSizes.halfPage.height;
 

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -661,27 +661,6 @@ export const AdSlot = ({
 				/>
 			);
 		}
-		// case 'inline': {
-		// 	const advertId = `inline${index + 1}`;
-		// 	return (
-		// 		<div className="ad-slot-container" css={adContainerStyles}>
-		// 			<div
-		// 				id={`dfp-ad--${advertId}`}
-		// 				className={[
-		// 					'js-ad-slot',
-		// 					'ad-slot',
-		// 					`ad-slot--${advertId}`,
-		// 					'ad-slot--container-inline',
-		// 					'ad-slot--rendered',
-		// 				].join(' ')}
-		// 				css={inlineAdStyles}
-		// 				data-link-name={`ad slot ${advertId}`}
-		// 				data-name={advertId}
-		// 				aria-hidden="true"
-		// 			/>
-		// 		</div>
-		// 	);
-		// }
 		case 'liveblog-inline': {
 			const advertId = `inline${index + 1}`;
 			return (

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -544,7 +544,7 @@ export const AdSlot = ({
 								'ad-slot--mpu-banner-ad',
 								'ad-slot--rendered',
 							].join(' ')}
-							css={[fluidAdStyles, mostPopAdStyles]}
+							css={[mostPopAdStyles]}
 							data-link-name="ad slot mostpop"
 							data-name="mostpop"
 							aria-hidden="true"
@@ -566,7 +566,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising-high',
 						].join(' ')}
-						css={[fluidAdStyles, merchandisingAdStyles]}
+						css={[merchandisingAdStyles]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						data-refresh="false"
@@ -588,7 +588,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising',
 						].join(' ')}
-						css={[fluidAdStyles, merchandisingAdStyles]}
+						css={[merchandisingAdStyles]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
 						aria-hidden="true"
@@ -619,7 +619,7 @@ export const AdSlot = ({
 								'ad-slot--rendered',
 								hasPageskin && 'ad-slot--collapse',
 							].join(' ')}
-							css={[fluidAdStyles, frontsBannerAdStyles]}
+							css={[frontsBannerAdStyles]}
 							data-link-name={`ad slot ${advertId}`}
 							data-name={`${advertId}`}
 							aria-hidden="true"
@@ -711,7 +711,7 @@ export const AdSlot = ({
 							'ad-slot--liveblog-top',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[fluidAdStyles, liveBlogTopAdStyles]}
+						css={[liveBlogTopAdStyles]}
 						data-link-name="ad slot liveblog-top"
 						data-name="liveblog-top"
 						aria-hidden="true"
@@ -776,7 +776,7 @@ export const AdSlot = ({
 							'ad-slot--article-end',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[fluidAdStyles, articleEndAdStyles]}
+						css={[articleEndAdStyles]}
 						data-link-name="ad slot article-end"
 						data-name="article-end"
 						aria-hidden="true"

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -18,12 +18,26 @@ import type { FEArticleType } from '../types/frontend';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { Island } from './Island';
 
-type InlinePosition =
-	| 'fronts-banner'
+// When requesting from Ad Manager these are all "inline" slots
+type InlineSlot = 'liveblog-inline' | 'liveblog-inline-mobile' | 'mobile-front';
+
+// TODO move to commercial
+type SlotNamesWithPageSkin = SlotName | 'pageskin';
+
+type ServerRenderedSlot = Exclude<
+	SlotNamesWithPageSkin,
+	| 'carrot'
+	| 'comments-expanded'
+	| 'crossword-banner'
+	| 'crossword-banner-mobile'
+	| 'exclusion'
+	| 'external'
 	| 'inline'
-	| 'liveblog-inline'
-	| 'liveblog-inline-mobile'
-	| 'mobile-front';
+	| 'mobile-sticky'
+	| 'football-right'
+	| 'sponsor-logo'
+	| 'interactive'
+>;
 
 type DefaultProps = {
 	display?: ArticleDisplay;
@@ -31,14 +45,11 @@ type DefaultProps = {
 	hasPageskin?: boolean;
 };
 
-// TODO move to commercial
-type SlotNamesWithPageSkin = SlotName | 'pageskin';
-
 // for dark ad labels
 type ColourScheme = 'light' | 'dark';
 
 type InlineProps = {
-	position: InlinePosition;
+	position: InlineSlot;
 	colourScheme?: ColourScheme;
 	index: number;
 	shouldHideReaderRevenue?: never;
@@ -52,7 +63,7 @@ type RightProps = {
 };
 
 type RemainingProps = {
-	position: Exclude<SlotNamesWithPageSkin, InlinePosition | 'right'>;
+	position: Exclude<ServerRenderedSlot, InlineSlot>;
 	colourScheme?: ColourScheme;
 	index?: never;
 	shouldHideReaderRevenue?: never;
@@ -82,19 +93,6 @@ const darkLabelStyles = css`
 `;
 
 /**
- * For CSS in Frontend, see mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
- */
-const fluidAdStyles = css`
-	&.ad-slot--fluid {
-		min-height: 250px;
-		line-height: 10px;
-		padding: 0;
-		margin: 0;
-		overflow: visible;
-	}
-`;
-
-/**
  * Usage according to DAP (Digital Ad Production)
  *
  * #### Desktop
@@ -109,8 +107,13 @@ const fluidAdStyles = css`
  * - `interscroller` &rarr; `top-above-nav`
  * - `mobile-revealer` &rarr; `top-above-nav`
  */
-const fluidFullWidthAdStyles = css`
+const fluidAdStyles = css`
 	&.ad-slot--fluid {
+		min-height: 250px;
+		line-height: 10px;
+		padding: 0;
+		margin: 0;
+		overflow: visible;
 		width: 100%;
 	}
 `;
@@ -133,6 +136,11 @@ const showcaseRightColumnStyles = css`
 const merchandisingAdContainerStyles = css`
 	display: flex;
 	justify-content: center;
+
+	&.ad-slot-container--centre-slot {
+		width: fit-content;
+		margin: 0 auto;
+	}
 `;
 
 const merchandisingAdStyles = css`
@@ -519,7 +527,7 @@ export const AdSlot = ({
 						'ad-slot--mpu-banner-ad',
 						'ad-slot--rendered',
 					].join(' ')}
-					css={[fluidAdStyles, fluidFullWidthAdStyles]}
+					css={[fluidAdStyles]}
 					data-link-name="ad slot top-above-nav"
 					data-name="top-above-nav"
 					aria-hidden="true"
@@ -542,11 +550,7 @@ export const AdSlot = ({
 								'ad-slot--mpu-banner-ad',
 								'ad-slot--rendered',
 							].join(' ')}
-							css={[
-								fluidAdStyles,
-								fluidFullWidthAdStyles,
-								mostPopAdStyles,
-							]}
+							css={[fluidAdStyles, mostPopAdStyles]}
 							data-link-name="ad slot mostpop"
 							data-name="mostpop"
 							aria-hidden="true"
@@ -568,11 +572,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising-high',
 						].join(' ')}
-						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							merchandisingAdStyles,
-						]}
+						css={[fluidAdStyles, merchandisingAdStyles]}
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						data-refresh="false"
@@ -594,11 +594,7 @@ export const AdSlot = ({
 							'ad-slot',
 							'ad-slot--merchandising',
 						].join(' ')}
-						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							merchandisingAdStyles,
-						]}
+						css={[fluidAdStyles, merchandisingAdStyles]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
 						aria-hidden="true"
@@ -629,11 +625,7 @@ export const AdSlot = ({
 								'ad-slot--rendered',
 								hasPageskin && 'ad-slot--collapse',
 							].join(' ')}
-							css={[
-								fluidAdStyles,
-								fluidFullWidthAdStyles,
-								frontsBannerAdStyles,
-							]}
+							css={[fluidAdStyles, frontsBannerAdStyles]}
 							data-link-name={`ad slot ${advertId}`}
 							data-name={`${advertId}`}
 							aria-hidden="true"
@@ -719,11 +711,7 @@ export const AdSlot = ({
 							'ad-slot--liveblog-top',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							liveBlogTopAdStyles,
-						]}
+						css={[fluidAdStyles, liveBlogTopAdStyles]}
 						data-link-name="ad slot liveblog-top"
 						data-name="liveblog-top"
 						aria-hidden="true"
@@ -746,7 +734,7 @@ export const AdSlot = ({
 							'mobile-only',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[mobileFrontAdStyles, fluidFullWidthAdStyles]}
+						css={[mobileFrontAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
 						aria-hidden="true"
@@ -788,11 +776,7 @@ export const AdSlot = ({
 							'ad-slot--article-end',
 							'ad-slot--rendered',
 						].join(' ')}
-						css={[
-							fluidAdStyles,
-							fluidFullWidthAdStyles,
-							articleEndAdStyles,
-						]}
+						css={[fluidAdStyles, articleEndAdStyles]}
 						data-link-name="ad slot article-end"
 						data-name="article-end"
 						aria-hidden="true"
@@ -800,8 +784,6 @@ export const AdSlot = ({
 				</div>
 			);
 		}
-		default:
-			return null;
 	}
 };
 

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -171,6 +171,10 @@ const rightAdStyles = css`
 	max-width: 300px;
 `;
 
+const liveblogInlineContainerStyles = css`
+	margin: 12px auto;
+`;
+
 const liveblogInlineAdStyles = css`
 	position: relative;
 	min-height: ${adSizes.mpu.height + labelHeight}px;
@@ -660,7 +664,10 @@ export const AdSlot = ({
 		case 'liveblog-inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div className="ad-slot-container ad-slot-desktop">
+				<div
+					className="ad-slot-container ad-slot-desktop"
+					css={liveblogInlineContainerStyles}
+				>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -682,7 +689,10 @@ export const AdSlot = ({
 		case 'liveblog-inline-mobile': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div className="ad-slot-container ad-slot-mobile">
+				<div
+					className="ad-slot-container ad-slot-mobile"
+					css={liveblogInlineContainerStyles}
+				>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
-import { adSizes, constants } from '@guardian/commercial';
-import { from, space, until } from '@guardian/source/foundations';
+import { from, until } from '@guardian/source/foundations';
+import { articleAdSlotStyles } from '../lib/adStyles';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
-import { palette } from '../palette';
-import { carrotAdStyles, labelStyles } from './AdSlot.web';
 
 type Props = {
 	format: ArticleFormat;
@@ -62,142 +60,9 @@ const articleWrapper = css`
 	z-index: 1;
 `;
 
-const adStyles = css`
-	.ad-slot {
-		@media print {
-			/* stylelint-disable-next-line declaration-no-important */
-			display: none !important;
-		}
-		&.ad-slot--collapse {
-			display: none;
-		}
-	}
-	.ad-slot--mostpop {
-		${from.desktop} {
-			margin: 0;
-			width: auto;
-		}
-	}
-	.ad-slot--fluid {
-		width: 100%;
-	}
-
-	.ad-slot-container {
-		margin: ${space[3]}px auto;
-		:not(:has(.ad-slot)) {
-			margin: 0;
-		}
-
-		/* this is centring the ad iframe as they are display: inline; elements by default */
-		text-align: center;
-		display: flex;
-		justify-content: center;
-
-		${from.tablet} {
-			background-color: ${palette('--ad-background')};
-		}
-
-		/* Prevent merger with any nearby float left elements e.g. rich-links */
-		${until.desktop} {
-			clear: left;
-		}
-
-		.ad-slot {
-			${from.tablet} {
-				/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
-				flex: 1;
-				/* Ensures slots do not take on 100% of the container height, allowing them to be sticky in containers */
-				align-self: flex-start;
-			}
-
-			/*
-			   Ensure that the ad slot is centred,
-			   the element with this class name is inserted by GAM into the ad slot
-			*/
-			.ad-slot__content {
-				margin-left: auto;
-				margin-right: auto;
-			}
-		}
-
-		.ad-slot--interscroller {
-			/* this fixes inter-scrollers stealing mouse events */
-			overflow: hidden;
-			position: relative;
-
-			/* position the iframe absolutely (relative to the slot) so that it is in the correct position to detect viewability */
-			.ad-slot__content {
-				position: absolute;
-				height: 100%;
-				left: 0;
-				top: 0;
-				right: 0;
-
-				/* must be behind as the actual ad is on top of the iframe */
-				z-index: -1;
-			}
-		}
-	}
-
-	.ad-slot-container--offset-right {
-		${from.desktop} {
-			float: right;
-			max-width: 300px;
-			margin-right: -330px;
-			background-color: transparent;
-		}
-
-		${from.leftCol} {
-			margin-right: -310px;
-		}
-
-		${from.wide} {
-			margin-right: -400px;
-		}
-	}
-
-	/* Give ad slots inserted on the client side a placeholder height.
-	   Let the ad slot take control of its height once rendered. */
-	.ad-slot--inline:not(.ad-slot--rendered) {
-		min-height: ${adSizes.outstreamMobile.height +
-		constants.AD_LABEL_HEIGHT}px;
-
-		${from.desktop} {
-			min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
-		}
-	}
-
-	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
-	   Let the ad slot take control of its height once rendered.
-	   IMPORTANT NOTE: We currently do not serve OPT-OUT for inline1 but we will need to change this value before we do. */
-	.ad-slot--inline1:not(.ad-slot--rendered) {
-		${from.desktop} {
-			min-height: ${adSizes.outstreamDesktop.height +
-			constants.AD_LABEL_HEIGHT}px;
-		}
-	}
-
-	/* This refers to the inline top-above-nav slot used on mobile pages, NOT the
-	   top-above-nav that is inserted above the navigation. */
-	.ad-slot--top-above-nav:not(.ad-slot--rendered) {
-		${until.tablet} {
-			min-height: ${adSizes.outstreamMobile.height +
-			constants.AD_LABEL_HEIGHT}px;
-		}
-	}
-`;
-
 export const ArticleContainer = ({ children, format }: Props) => {
 	return (
-		<div
-			css={[
-				articleWrapper,
-				articleWidth(format),
-				adStyles,
-				carrotAdStyles,
-				labelStyles,
-			]}
-		>
+		<div css={[articleWrapper, articleWidth(format), articleAdSlotStyles]}>
 			{children}
 		</div>
 	);

--- a/dotcom-rendering/src/components/ArticleContainer.tsx
+++ b/dotcom-rendering/src/components/ArticleContainer.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { from, until } from '@guardian/source/foundations';
-import { articleAdSlotStyles } from '../lib/adStyles';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 
 type Props = {
@@ -61,9 +60,5 @@ const articleWrapper = css`
 `;
 
 export const ArticleContainer = ({ children, format }: Props) => {
-	return (
-		<div css={[articleWrapper, articleWidth(format), articleAdSlotStyles]}>
-			{children}
-		</div>
-	);
+	return <div css={[articleWrapper, articleWidth(format)]}>{children}</div>;
 };

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -13,7 +13,6 @@ import type {
 import type { preview, reportAbuse } from '../../lib/discussionApi';
 import { getPicks, initialiseApi } from '../../lib/discussionApi';
 import { palette as schemedPalette } from '../../palette';
-import { labelStyles } from '../AdSlot.web';
 import { useConfig } from '../ConfigContext';
 import { useDispatch } from '../DispatchContext';
 import { CommentContainer } from './CommentContainer';
@@ -440,7 +439,7 @@ export const Comments = ({
 				<NoComments />
 			) : (
 				<ul
-					css={[commentContainerStyles, labelStyles]}
+					css={[commentContainerStyles]}
 					data-commercial-id="comments-column"
 				>
 					{comments.map((comment) => (

--- a/dotcom-rendering/src/components/DiscussionLayout.tsx
+++ b/dotcom-rendering/src/components/DiscussionLayout.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
 import { ArticleDisplay, type ArticleFormat } from '../lib/articleFormat';
 import type { RenderingTarget } from '../types/renderingTarget';
-import { AdSlot, labelStyles } from './AdSlot.web';
+import { AdSlot } from './AdSlot.web';
 import { useConfig } from './ConfigContext';
 import { DiscussionApps } from './DiscussionApps.importable';
 import { DiscussionMeta } from './DiscussionMeta.importable';
@@ -123,7 +123,6 @@ export const DiscussionLayout = ({
 										gap: 100vh;
 										height: 100%;
 									`,
-									labelStyles,
 								]}
 							>
 								<AdSlot

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -41,13 +41,6 @@ const headerMinSizeStyles = css`
 	min-width: ${adSizes.leaderboard.width}px;
 `;
 
-const topAboveNavStyles = css`
-	position: relative;
-	margin: 0 auto;
-	text-align: left;
-	display: block;
-`;
-
 export const HeaderAdSlot = ({
 	shouldHideReaderRevenue,
 	isPaidContent,
@@ -80,12 +73,7 @@ export const HeaderAdSlot = ({
 							isPaidContent={isPaidContent}
 						/>
 					</Island>
-					<div
-						css={[topAboveNavStyles]}
-						className="ad-slot-container"
-					>
-						<AdSlot position="top-above-nav" />
-					</div>
+					<AdSlot position="top-above-nav" />
 				</div>
 			</div>
 		</Hide>

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -3,7 +3,7 @@ import { adSizes, constants } from '@guardian/commercial';
 import { space } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import { AdBlockAsk } from './AdBlockAsk.importable';
-import { adContainerStyles, AdSlot } from './AdSlot.web';
+import { AdSlot } from './AdSlot.web';
 import { Hide } from './Hide';
 import { Island } from './Island';
 
@@ -31,14 +31,6 @@ const headerAdWrapper = css`
 
 	position: sticky;
 	top: 0;
-`;
-
-// Remove this once new `ad-slot-container--centre-slot` class is in place
-const topAboveNavContainer = css`
-	&[top-above-nav-ad-rendered] {
-		margin: auto;
-	}
-	padding-bottom: ${padding}px;
 `;
 
 /**
@@ -89,11 +81,7 @@ export const HeaderAdSlot = ({
 						/>
 					</Island>
 					<div
-						css={[
-							adContainerStyles,
-							topAboveNavContainer,
-							topAboveNavStyles,
-						]}
+						css={[topAboveNavStyles]}
 						className="ad-slot-container"
 					>
 						<AdSlot position="top-above-nav" />

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -4,10 +4,7 @@ import {
 	palette as sourcePalette,
 	until,
 } from '@guardian/source/foundations';
-import {
-	adContainerStyles,
-	MobileStickyContainer,
-} from '../components/AdSlot.web';
+import { MobileStickyContainer } from '../components/AdSlot.web';
 import { Footer } from '../components/Footer';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
@@ -108,8 +105,6 @@ const Renderer = ({
 	});
 
 	const adStyles = css`
-		${adContainerStyles}
-
 		${from.tablet} {
 			.mobile-only .ad-slot {
 				display: none;

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { adContainerStyles } from '../components/AdSlot.web';
 import { useConfig } from '../components/ConfigContext';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { TagType } from '../types/tag';
+// import { adContainerStyles } from './adStyles';
 import { ArticleDesign, type ArticleFormat } from './articleFormat';
 import type { EditionId } from './edition';
 import { RenderArticleElement } from './renderElement';
@@ -20,9 +20,9 @@ const commercialPosition = css`
 //
 // spacefinder is scoped to placing elements in spaces within the .article-body-commercial-selector
 // hence we scope the styles at the same level
-const adStylesDynamic = css`
-	${adContainerStyles}
-`;
+// const adStylesDynamic = css`
+// 	${adContainerStyles}
+// `;
 
 type Props = {
 	format: ArticleFormat;
@@ -111,7 +111,7 @@ export const ArticleRenderer = ({
 					? interactiveLegacyClasses.contentMainColumn
 					: '',
 			].join(' ')}
-			css={[adStylesDynamic, commercialPosition]}
+			css={[commercialPosition]}
 		>
 			{renderingTarget === 'Apps'
 				? renderedElements

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -4,7 +4,7 @@ import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStylin
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { TagType } from '../types/tag';
-// import { adContainerStyles } from './adStyles';
+import { spacefinderAdSlotStyles } from './adStyles';
 import { ArticleDesign, type ArticleFormat } from './articleFormat';
 import type { EditionId } from './edition';
 import { RenderArticleElement } from './renderElement';
@@ -14,15 +14,6 @@ import { withSignInGateSlot } from './withSignInGateSlot';
 const commercialPosition = css`
 	position: relative;
 `;
-
-// These styles are applied to dynamic ad slots (i.e. slots that are not fixed), e.g. ads inserted
-// by spacefinder across all layout types (articles, comments, etc)
-//
-// spacefinder is scoped to placing elements in spaces within the .article-body-commercial-selector
-// hence we scope the styles at the same level
-// const adStylesDynamic = css`
-// 	${adContainerStyles}
-// `;
 
 type Props = {
 	format: ArticleFormat;
@@ -111,7 +102,7 @@ export const ArticleRenderer = ({
 					? interactiveLegacyClasses.contentMainColumn
 					: '',
 			].join(' ')}
-			css={[commercialPosition]}
+			css={[commercialPosition, spacefinderAdSlotStyles]}
 		>
 			{renderingTarget === 'Apps'
 				? renderedElements

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -4,7 +4,7 @@ import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStylin
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { TagType } from '../types/tag';
-import { spacefinderAdSlotStyles } from './adStyles';
+import { spacefinderAdStyles } from './adStyles';
 import { ArticleDesign, type ArticleFormat } from './articleFormat';
 import type { EditionId } from './edition';
 import { RenderArticleElement } from './renderElement';
@@ -102,7 +102,7 @@ export const ArticleRenderer = ({
 					? interactiveLegacyClasses.contentMainColumn
 					: '',
 			].join(' ')}
-			css={[commercialPosition, spacefinderAdSlotStyles]}
+			css={[commercialPosition, spacefinderAdStyles]}
 		>
 			{renderingTarget === 'Apps'
 				? renderedElements

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -1,0 +1,239 @@
+import { css } from '@emotion/react';
+import { adSizes, constants } from '@guardian/commercial';
+import { from, space, textSans12, until } from '@guardian/source/foundations';
+import { palette } from '../palette';
+
+const labelHeight = constants.AD_LABEL_HEIGHT;
+
+export const labelBoxStyles = css`
+	${textSans12};
+	height: ${labelHeight}px;
+	max-height: ${labelHeight}px;
+	background-color: ${palette('--ad-background')};
+	padding-top: 3px;
+	border-top: 1px solid ${palette('--ad-border')};
+	color: ${palette('--ad-labels-text')};
+	text-align: center;
+	box-sizing: border-box;
+`;
+
+const labelStyles = css`
+	.ad-slot[data-label-show='true']::before {
+		content: attr(ad-label-text);
+		display: block;
+		position: relative;
+		${labelBoxStyles}
+	}
+
+	.ad-slot[data-label-show='true'].ad-slot--interscroller::before {
+		display: none;
+	}
+
+	.ad-slot__adtest-cookie-clear-link {
+		${textSans12};
+		text-align: left;
+		position: absolute;
+		left: 268px;
+		top: 1px;
+		z-index: 10;
+		padding: 0;
+		border: 0;
+	}
+`;
+
+const adContainerCentreSlotStyles = css`
+	&.ad-slot-container--centre-slot {
+		width: fit-content;
+		margin: 0 auto;
+	}
+`;
+
+// const adContainerStyles = [labelStyles, adContainerCentreSlotStyles];
+
+const adSlotContainerStyles = css`
+	.ad-slot-container {
+		max-width: 100vw;
+		position: relative;
+	}
+`;
+
+const inlineAdSlotContainerStyles = css`
+	.ad-slot-container {
+		margin: 12px auto;
+		text-align: center;
+		display: flex;
+		justify-content: center;
+
+		${from.tablet} {
+			background-color: ${palette('--ad-background')};
+		}
+
+		/* Prevent merger with any nearby float left elements e.g. rich-links */
+		${until.desktop} {
+			clear: left;
+		}
+
+		.ad-slot--interscroller {
+			/* this fixes inter-scrollers stealing mouse events */
+			overflow: hidden;
+			position: relative;
+
+			/* position the iframe absolutely (relative to the slot) so that it is in the correct position to detect viewability */
+			.ad-slot__content {
+				position: absolute;
+				height: 100%;
+				left: 0;
+				top: 0;
+				right: 0;
+
+				/* must be behind as the actual ad is on top of the iframe */
+				z-index: -1;
+			}
+		}
+	}
+
+	/*
+	Some ads are in the right column, inline2+ for example.
+*/
+	.ad-slot-container--offset-right {
+		${from.desktop} {
+			float: right;
+			max-width: 300px;
+			margin-right: -330px;
+			background-color: transparent;
+		}
+
+		${from.leftCol} {
+			margin-right: -310px;
+		}
+
+		${from.wide} {
+			margin-right: -400px;
+		}
+	}
+`;
+
+const adSlotStyles = css`
+	.ad-slot {
+		/* this is centring the ad iframe as they are display: inline; elements by default */
+		text-align: center;
+
+		${from.tablet} {
+			/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
+			flex: 1;
+			/* Ensures slots do not take on 100% of the container height, allowing them to be sticky in containers */
+			align-self: flex-start;
+		}
+
+		/*
+			Ensure that the ad slot is centred,
+			the element with this class name is inserted by GAM into the ad slot
+		*/
+		.ad-slot__content {
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		@media print {
+			/* stylelint-disable-next-line declaration-no-important */
+			display: none !important;
+		}
+
+		&.ad-slot--collapse {
+			display: none;
+		}
+	}
+`;
+
+/* Styles applied only to ads within an article inserted by spacefinder */
+const articleAdSlotStyles = css`
+	${inlineAdSlotContainerStyles}
+
+	/* Give ad slots inserted on the client side a placeholder height.
+   Let the ad slot take control of its height once rendered. */
+	.ad-slot--inline:not(.ad-slot--rendered) {
+		min-height: ${adSizes.outstreamMobile.height +
+		constants.AD_LABEL_HEIGHT}px;
+
+		${from.desktop} {
+			min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+		}
+	}
+
+	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
+   Let the ad slot take control of its height once rendered.
+   IMPORTANT NOTE: We currently do not serve OPT-OUT for inline1 but we will need to change this value before we do. */
+	.ad-slot--inline1:not(.ad-slot--rendered) {
+		${from.desktop} {
+			min-height: ${adSizes.outstreamDesktop.height +
+			constants.AD_LABEL_HEIGHT}px;
+		}
+	}
+
+	/* This refers to the inline top-above-nav slot used on mobile pages, NOT the
+   top-above-nav that is inserted above the navigation. */
+	.ad-slot--top-above-nav:not(.ad-slot--rendered) {
+		${until.tablet} {
+			min-height: ${adSizes.outstreamMobile.height +
+			constants.AD_LABEL_HEIGHT}px;
+		}
+	}
+
+	.ad-slot--carrot {
+		float: left;
+		clear: both;
+		width: 140px;
+		margin-right: 20px;
+		margin-bottom: ${space[1]}px;
+		${from.leftCol} {
+			position: relative;
+			margin-left: -160px;
+			width: 140px;
+		}
+		${from.wide} {
+			margin-left: -240px;
+			width: 220px;
+		}
+	}
+
+	/* Scroll for more label on interscrollers */
+	.ad-slot__scroll {
+		position: fixed;
+		bottom: 0;
+		width: 100%;
+
+		${labelBoxStyles}
+
+		&.visible {
+			visibility: initial;
+		}
+		&.hidden {
+			visibility: hidden;
+		}
+	}
+
+	.ad-slot--interscroller[data-label-show='true']::before {
+		content: 'Advertisement';
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		border: 0;
+		display: block;
+		${labelBoxStyles}
+	}
+`;
+
+/* Styles applied to all ads regardless of their position */
+const rootAdStyles = [labelStyles, adSlotStyles, adSlotContainerStyles];
+
+export {
+	labelHeight,
+	// adSlotContainerStyles,
+	adSlotStyles,
+	articleAdSlotStyles,
+	labelStyles,
+	adContainerCentreSlotStyles,
+	// adContainerStyles,
+	rootAdStyles,
+};

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -91,7 +91,7 @@ const adSlotStyles = css`
 	}
 `;
 
-const inlineAdSlotContainerStyles = css`
+const spacefinderAdSlotContainerStyles = css`
 	.ad-slot-container {
 		margin: 12px auto;
 		text-align: center;
@@ -152,7 +152,7 @@ const inlineAdSlotContainerStyles = css`
 	}
 `;
 
-const inlineAdSlotStyles = css`
+const spacefinderAdSlotStyles = css`
 	${from.tablet} {
 		.ad-slot {
 			/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
@@ -248,9 +248,9 @@ const rootAdStyles = [labelStyles, adSlotStyles, adSlotContainerStyles];
 	applied to the ArticleRenderer component which spacefinder is scoped
 	to via the `.article-body-commercial-selector` class
 */
-const spacefinderAdSlotStyles = [
-	inlineAdSlotContainerStyles,
-	inlineAdSlotStyles,
+const spacefinderAdStyles = [
+	spacefinderAdSlotContainerStyles,
+	spacefinderAdSlotStyles,
 ];
 
 export {
@@ -258,5 +258,5 @@ export {
 	labelBoxStyles,
 	labelStyles,
 	rootAdStyles,
-	spacefinderAdSlotStyles,
+	spacefinderAdStyles,
 };

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -5,7 +5,7 @@ import { palette } from '../palette';
 
 const labelHeight = constants.AD_LABEL_HEIGHT;
 
-export const labelBoxStyles = css`
+const labelBoxStyles = css`
 	${textSans12};
 	height: ${labelHeight}px;
 	max-height: ${labelHeight}px;
@@ -214,16 +214,26 @@ const inlineAdSlotStyles = css`
 	}
 `;
 
-/* Styles applied to all ads regardless of their position, or method of insertion */
+/*
+	Styles applied to all ads regardless of their position, or method of insertion,
+	These are applied as part of `rootStyles`
+ */
 const rootAdStyles = [labelStyles, adSlotStyles, adSlotContainerStyles];
 
-/* Styles applied only to ads within an article inserted by spacefinder added to the ArticleContainer component */
-const articleAdSlotStyles = [inlineAdSlotContainerStyles, inlineAdSlotStyles];
+/*
+	Styles applied only to ads within an article inserted by spacefinder
+	applied to the ArticleRenderer component which spacefinder is scoped
+	to via the `.article-body-commercial-selector` class
+*/
+const spacefinderAdSlotStyles = [
+	inlineAdSlotContainerStyles,
+	inlineAdSlotStyles,
+];
 
 export {
 	labelHeight,
-	adSlotStyles,
-	articleAdSlotStyles,
+	labelBoxStyles,
 	labelStyles,
 	rootAdStyles,
+	spacefinderAdSlotStyles,
 };

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -65,6 +65,29 @@ const adSlotStyles = css`
 		&.ad-slot--collapse {
 			display: none;
 		}
+
+		/**
+		* Usage according to DAP (Digital Ad Production)
+		*
+		* #### Desktop
+		* - 'fabric' > 'top-above-nav','merchandising-high','merchandising'
+		* - 'fabric-custom' > 'top-above-nav','merchandising-high','merchandising'
+		* - 'fabric-expandable' > 'merchandising-high'
+		* - 'fabric-third-party' > 'top-above-nav','merchandising-high','merchandising'
+		* - 'fabric-video' > 'top-above-nav','merchandising-high'
+		* - 'fabric-video-expandable' > 'merchandising-high'
+		*
+		* #### Mobile
+		* - 'interscroller' > 'top-above-nav'
+		* - 'mobile-revealer' > 'top-above-nav'
+		*/
+		&.ad-slot--fluid {
+			min-height: 250px;
+			padding: 0;
+			margin: 0;
+			overflow: visible;
+			width: 100%;
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -21,12 +21,7 @@ const labelStyles = css`
 	.ad-slot[data-label-show='true']::before {
 		content: attr(ad-label-text);
 		display: block;
-		position: relative;
 		${labelBoxStyles}
-	}
-
-	.ad-slot[data-label-show='true'].ad-slot--interscroller::before {
-		display: none;
 	}
 
 	.ad-slot__adtest-cookie-clear-link {
@@ -41,19 +36,35 @@ const labelStyles = css`
 	}
 `;
 
-const adContainerCentreSlotStyles = css`
-	&.ad-slot-container--centre-slot {
-		width: fit-content;
-		margin: 0 auto;
-	}
-`;
-
-// const adContainerStyles = [labelStyles, adContainerCentreSlotStyles];
-
 const adSlotContainerStyles = css`
 	.ad-slot-container {
 		max-width: 100vw;
 		position: relative;
+	}
+`;
+
+const adSlotStyles = css`
+	.ad-slot {
+		/* this is centring the ad iframe as they are display: inline; elements by default */
+		text-align: center;
+
+		/*
+			Ensure that the ad slot is centred,
+			the element with this class name is inserted by GAM into the ad slot
+		*/
+		.ad-slot__content {
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		@media print {
+			/* stylelint-disable-next-line declaration-no-important */
+			display: none !important;
+		}
+
+		&.ad-slot--collapse {
+			display: none;
+		}
 	}
 `;
 
@@ -89,12 +100,17 @@ const inlineAdSlotContainerStyles = css`
 				/* must be behind as the actual ad is on top of the iframe */
 				z-index: -1;
 			}
+
+			/* Hide default label, interscrollers have a special label */
+			&::before {
+				display: none;
+			}
 		}
 	}
 
 	/*
-	Some ads are in the right column, inline2+ for example.
-*/
+		To push inline2+ on desktop to the right column
+	*/
 	.ad-slot-container--offset-right {
 		${from.desktop} {
 			float: right;
@@ -113,41 +129,15 @@ const inlineAdSlotContainerStyles = css`
 	}
 `;
 
-const adSlotStyles = css`
-	.ad-slot {
-		/* this is centring the ad iframe as they are display: inline; elements by default */
-		text-align: center;
-
-		${from.tablet} {
+const inlineAdSlotStyles = css`
+	${from.tablet} {
+		.ad-slot {
 			/* from tablet the ad slot will stretch to the full width of the container and the iframe will be centred by the text-align: center; on the container */
 			flex: 1;
 			/* Ensures slots do not take on 100% of the container height, allowing them to be sticky in containers */
 			align-self: flex-start;
 		}
-
-		/*
-			Ensure that the ad slot is centred,
-			the element with this class name is inserted by GAM into the ad slot
-		*/
-		.ad-slot__content {
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-		@media print {
-			/* stylelint-disable-next-line declaration-no-important */
-			display: none !important;
-		}
-
-		&.ad-slot--collapse {
-			display: none;
-		}
 	}
-`;
-
-/* Styles applied only to ads within an article inserted by spacefinder */
-const articleAdSlotStyles = css`
-	${inlineAdSlotContainerStyles}
 
 	/* Give ad slots inserted on the client side a placeholder height.
    Let the ad slot take control of its height once rendered. */
@@ -224,16 +214,16 @@ const articleAdSlotStyles = css`
 	}
 `;
 
-/* Styles applied to all ads regardless of their position */
+/* Styles applied to all ads regardless of their position, or method of insertion */
 const rootAdStyles = [labelStyles, adSlotStyles, adSlotContainerStyles];
+
+/* Styles applied only to ads within an article inserted by spacefinder added to the ArticleContainer component */
+const articleAdSlotStyles = [inlineAdSlotContainerStyles, inlineAdSlotStyles];
 
 export {
 	labelHeight,
-	// adSlotContainerStyles,
 	adSlotStyles,
 	articleAdSlotStyles,
 	labelStyles,
-	adContainerCentreSlotStyles,
-	// adContainerStyles,
 	rootAdStyles,
 };

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -4,6 +4,7 @@ import {
 	palette as sourcePalette,
 } from '@guardian/source/foundations';
 import { paletteDeclarations } from '../palette';
+import { rootAdStyles } from './adStyles';
 import type { ArticleFormat } from './articleFormat';
 
 /**
@@ -49,8 +50,5 @@ export const rootStyles = (
 		color: ${sourcePalette.neutral[7]};
 	}
 
-	.ad-slot-container {
-		/* prevent third-party code from breaking our layout */
-		max-width: 100vw;
-	}
+	${rootAdStyles}
 `;


### PR DESCRIPTION
## What does this change?
As well as a best effort to dedupe and remove redundant css as much as possible, I've organised them into the following areas/files:

`AdSlot.web.ts` now contains styles relating only to the the slots rendered by this component, AKA server rendered slots.

I've created a new file `adStyles.ts` which exports:
- `rootAdStyles` - styles applicable to all ad slots regardless of where they are or how they're inserted, included in `rootStyles.ts`, previously these styles were duplicated for article slots and SSR slots.
- `spacefinderAdSlotStyles` - styles specific to spacefinder slots in articles and are included in `ArticleRenderer`, previously these where strewn across the component itself,  `AdSlot.web.ts`, `ArticleContainer`.

I've tested in CODE, looking for as many kinds of ads as I can find.

## Why?
Less, hopefully clearer code in fewer places.