### PR TITLE
pass new heading size to the banner header to enable smaller size

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -325,6 +325,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						heading={content.mainContent.heading}
 						mobileHeading={content.mobileContent.heading}
 						headerSettings={templateSettings.headerSettings}
+						headingSize={design.fonts?.heading.size ?? 'medium'}
 					/>
 				</div>
 				<div css={styles.contentContainer(showReminder)}>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -9,10 +9,14 @@ import {
 	headlineBold24,
 	headlineBold28,
 	headlineBold34,
+	headlineMedium17,
 	neutral,
 	space,
 } from '@guardian/source/foundations';
-import type { Image } from '@guardian/support-dotcom-components/dist/shared/src/types';
+import type {
+	FontSize,
+	Image,
+} from '@guardian/support-dotcom-components/dist/shared/src/types';
 import {
 	removeMediaRulePrefix,
 	useMatchMedia,
@@ -24,15 +28,17 @@ interface DesignableBannerHeaderProps {
 	heading: JSX.Element | JSX.Element[] | null;
 	mobileHeading: JSX.Element | JSX.Element[] | null;
 	headerSettings: HeaderSettings | undefined;
+	headingSize: FontSize;
 }
 
 export function DesignableBannerHeader({
 	heading,
 	mobileHeading,
 	headerSettings,
+	headingSize,
 }: DesignableBannerHeaderProps): JSX.Element {
 	const isTabletOrAbove = useMatchMedia(removeMediaRulePrefix(from.tablet));
-	const styles = getStyles(headerSettings);
+	const styles = getStyles(headerSettings, headingSize);
 
 	const resolveImage = (settings: Image) => {
 		return (
@@ -55,7 +61,10 @@ export function DesignableBannerHeader({
 	);
 }
 
-const getStyles = (headerSettings: HeaderSettings | undefined) => {
+const getStyles = (
+	headerSettings: HeaderSettings | undefined,
+	headingSize: FontSize,
+) => {
 	const color = headerSettings?.textColour ?? neutral[0];
 	const copyTopMargin = headerSettings?.headerImage ? space[6] : space[3];
 	const containerMargin = headerSettings?.headerImage ? `${space[6]}px` : '0';
@@ -70,7 +79,7 @@ const getStyles = (headerSettings: HeaderSettings | undefined) => {
 				margin: ${copyTopMargin}px 0 ${space[3]}px;
 				color: ${color};
 
-				${headlineBold24}
+				${headingSize === 'small' ? headlineMedium17 : headlineBold24};
 				${from.tablet} {
 					${headlineBold28}
 					margin-bottom: ${space[6]}px;


### PR DESCRIPTION
## What does this change?

Enables the ability to change the size of the designable banner heading from medium (current default) to small.

This PR requires [SDC PR1245](https://github.com/guardian/support-dotcom-components/pull/1245) to be merged first and the version of SDC updated in here.

[Trello ticket](https://trello.com/c/RKgNkcgw).

## Why?

This is intended to work with tiny banners such as for abandoned basket and app download with no copy and will be configurable in the RRCP tool.

## Screenshots

### Before

<img width="316" alt="Screenshot 2024-11-04 at 17 51 09" src="https://github.com/user-attachments/assets/50723b12-df53-4f35-8f21-4244342c9328">

### After: 

<img width="316" alt="Screenshot 2024-11-04 at 17 50 38" src="https://github.com/user-attachments/assets/85e3d509-716b-4710-86b9-5c7f97155b8b">


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
