### PR TITLE
Carousels: button hover states for special palette variations

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -1055,6 +1055,11 @@ const carouselChevronLight: ContainerFunction = (containerPalette) =>
 const carouselChevronDark: ContainerFunction = (containerPalette) =>
 	cardHeadlineDark(containerPalette);
 
+const carouselChevronHoverLight: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineLight(containerPalette), 0.1);
+const carouselChevronHoverDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.1);
+
 const carouselChevronBorderLight: ContainerFunction = (containerPalette) =>
 	transparentColour(cardHeadlineLight(containerPalette), 0.2);
 const carouselChevronBorderDark: ContainerFunction = (containerPalette) =>
@@ -1200,6 +1205,10 @@ const containerColours = {
 	'--carousel-chevron-disabled': {
 		light: carouselChevronDisabledLight,
 		dark: carouselChevronDisabledDark,
+	},
+	'--carousel-chevron-hover': {
+		light: carouselChevronHoverLight,
+		dark: carouselChevronHoverDark,
 	},
 	'--section-border': {
 		light: sectionBorderLight,

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -37,11 +37,13 @@ const gridGap = '20px';
 const themeButton: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border'),
 	textTertiary: palette('--carousel-chevron'),
+	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
 };
 
 const themeButtonDisabled: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border-disabled'),
 	textTertiary: palette('--carousel-chevron-disabled'),
+	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
 };
 
 const containerStyles = css`

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4375,8 +4375,10 @@ const carouselTitleHighlightDark: PaletteFunction = ({ theme, design }) => {
 
 const carouselChevronLight: PaletteFunction = () => sourcePalette.neutral[7];
 const carouselChevronDark: PaletteFunction = () => sourcePalette.neutral[86];
-const carouselChevronHoverLight: PaletteFunction = () => '#e5e5e5'; // Source tertiary button default hover colour - not in palette
-const carouselChevronHoverDark: PaletteFunction = () => '#e5e5e5';
+const carouselChevronHoverLight: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[73], 0.2);
+const carouselChevronHoverDark: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[73], 0.2);
 const carouselChevronBorderLight: PaletteFunction = () =>
 	sourcePalette.neutral[73];
 const carouselChevronBorderDark: PaletteFunction = () =>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4375,6 +4375,8 @@ const carouselTitleHighlightDark: PaletteFunction = ({ theme, design }) => {
 
 const carouselChevronLight: PaletteFunction = () => sourcePalette.neutral[7];
 const carouselChevronDark: PaletteFunction = () => sourcePalette.neutral[86];
+const carouselChevronHoverLight: PaletteFunction = () => '#e5e5e5'; // Source tertiary button default hover colour - not in palette
+const carouselChevronHoverDark: PaletteFunction = () => '#e5e5e5';
 const carouselChevronBorderLight: PaletteFunction = () =>
 	sourcePalette.neutral[73];
 const carouselChevronBorderDark: PaletteFunction = () =>
@@ -6146,6 +6148,10 @@ const paletteColours = {
 	'--carousel-chevron-disabled': {
 		light: carouselChevronDisabledLight,
 		dark: carouselChevronDisabledDark,
+	},
+	'--carousel-chevron-hover': {
+		light: carouselChevronHoverLight,
+		dark: carouselChevronHoverDark,
 	},
 	'--carousel-dot': {
 		light: carouselDotLight,


### PR DESCRIPTION
## What does this change?

Adds custom button hover states for special palette variations and updates default light and mode hover states

## Why?

Previously buttons were using the default Source tertiary button hover colour (`#E5E5E5`) which is designed to work on a white background and looks incorrect against a coloured background. The updated colours use the existing border colour with opacity applied.

## Screenshots

### Default light and dark mode

<img width="779" alt="Screenshot 2024-11-05 at 10 48 59" src="https://github.com/user-attachments/assets/0070eb3f-e56e-40de-84ac-a43181e1eabd">
<img width="778" alt="Screenshot 2024-11-05 at 10 49 27" src="https://github.com/user-attachments/assets/cd4c9b0b-1d43-4b9e-b7cb-ba3888a97b71">

### Special palette variations

<img width="776" alt="Screenshot 2024-11-04 at 19 58 39" src="https://github.com/user-attachments/assets/83664713-18c4-4c14-b1bc-96e2adb5fef2">
