### PR TITLE
Fix pagination and key events app links

### DIFF
--- a/dotcom-rendering/src/components/KeyEventCard.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.stories.tsx
@@ -60,6 +60,7 @@ export const SummaryCard = () => (
 			filterKeyEvents={false}
 			isSummary={true}
 			absoluteServerTimes={true}
+			renderingTarget="Web"
 		/>
 	</ul>
 );
@@ -76,6 +77,7 @@ export const StandardCard = () => (
 			isSummary={events[0].isSummary}
 			filterKeyEvents={false}
 			absoluteServerTimes={true}
+			renderingTarget="Web"
 		/>
 	</ul>
 );
@@ -93,6 +95,7 @@ export const MultipleCards = () => (
 				isSummary={event.isSummary}
 				filterKeyEvents={false}
 				absoluteServerTimes={true}
+				renderingTarget="Web"
 			/>
 		))}
 	</ul>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -113,6 +113,25 @@ const timeStyles = css`
 	display: block;
 `;
 
+export const getUrl = ({
+	filterKeyEvents,
+	renderingTarget,
+	id,
+}: {
+	filterKeyEvents: boolean;
+	renderingTarget: RenderingTarget;
+	id: string;
+}) => {
+	const searchParams = new URLSearchParams();
+	searchParams.append('filterKeyEvents', String(filterKeyEvents));
+	searchParams.append('page', `with:block-${id}`);
+	if (renderingTarget === 'Apps') {
+		searchParams.append('dcr', 'apps');
+	}
+
+	return `?${searchParams.toString()}#block-${id}`;
+};
+
 export const KeyEventCard = ({
 	id,
 	blockFirstPublished,
@@ -123,14 +142,7 @@ export const KeyEventCard = ({
 	absoluteServerTimes,
 	renderingTarget,
 }: Props) => {
-	const searchParams = new URLSearchParams();
-	searchParams.append('filterKeyEvents', String(filterKeyEvents));
-	searchParams.append('page', `with:block-${id}`);
-	if (renderingTarget === 'Apps') {
-		searchParams.append('dcr', 'apps');
-	}
-
-	const url = `?${searchParams.toString()}#block-${id}`;
+	const url = getUrl({ filterKeyEvents, renderingTarget, id });
 
 	return (
 		<li css={listItemStyles}>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -7,7 +7,7 @@ import {
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { palette } from '../palette';
-import { useConfig } from './ConfigContext';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { DateTime } from './DateTime';
 
 interface Props {
@@ -18,6 +18,7 @@ interface Props {
 	filterKeyEvents: boolean;
 	absoluteServerTimes: boolean;
 	cardPosition?: string;
+	renderingTarget: RenderingTarget;
 }
 
 const linkStyles = css`
@@ -120,13 +121,16 @@ export const KeyEventCard = ({
 	filterKeyEvents,
 	cardPosition = 'unknown position',
 	absoluteServerTimes,
+	renderingTarget,
 }: Props) => {
-	const { renderingTarget } = useConfig();
-	const appsParam = renderingTarget === 'Apps' ? '&dcr=apps' : '';
+	const searchParams = new URLSearchParams();
+	searchParams.append('filterKeyEvents', String(filterKeyEvents));
+	searchParams.append('page', `with:block-${id}`);
+	if (renderingTarget === 'Apps') {
+		searchParams.append('dcr', 'apps');
+	}
 
-	const url = `?filterKeyEvents=${String(
-		filterKeyEvents,
-	)}&page=with:block-${id}${appsParam}#block-${id}`;
+	const url = `?${searchParams.toString()}#block-${id}`;
 
 	return (
 		<li css={listItemStyles}>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -8,6 +8,7 @@ import {
 import { Link } from '@guardian/source/react-components';
 import { palette } from '../palette';
 import { DateTime } from './DateTime';
+import { useConfig } from './ConfigContext';
 
 interface Props {
 	id: string;
@@ -120,15 +121,19 @@ export const KeyEventCard = ({
 	cardPosition = 'unknown position',
 	absoluteServerTimes,
 }: Props) => {
+	const { renderingTarget } = useConfig();
+	const appsParam = renderingTarget === 'Apps' ? '&dcr=apps' : '';
+
 	const url = `?filterKeyEvents=${String(
 		filterKeyEvents,
-	)}&page=with:block-${id}#block-${id}`;
+	)}&page=with:block-${id}${appsParam}#block-${id}`;
+
 	return (
 		<li css={listItemStyles}>
 			<Link
 				priority="secondary"
 				cssOverrides={css([linkStyles, isSummary && summaryStyles])}
-				href={url}
+				href={`${url}${appsParam}`}
 				data-link-name={`key event card | ${cardPosition}`}
 			>
 				<div css={timeStyles}>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -133,7 +133,7 @@ export const KeyEventCard = ({
 			<Link
 				priority="secondary"
 				cssOverrides={css([linkStyles, isSummary && summaryStyles])}
-				href={`${url}${appsParam}`}
+				href={url}
 				data-link-name={`key event card | ${cardPosition}`}
 			>
 				<div css={timeStyles}>

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -7,8 +7,8 @@ import {
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { palette } from '../palette';
-import { DateTime } from './DateTime';
 import { useConfig } from './ConfigContext';
+import { DateTime } from './DateTime';
 
 interface Props {
 	id: string;

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source/react-components';
 import { useRef } from 'react';
 import { palette } from '../palette';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { KeyEventCard } from './KeyEventCard';
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
 	filterKeyEvents: boolean;
 	id: 'key-events-carousel-desktop' | 'key-events-carousel-mobile';
 	absoluteServerTimes: boolean;
+	renderingTarget: RenderingTarget;
 }
 type ValidBlock = Block & {
 	title: string;
@@ -107,6 +109,7 @@ export const KeyEventsCarousel = ({
 	filterKeyEvents,
 	id,
 	absoluteServerTimes,
+	renderingTarget,
 }: Props) => {
 	const carousel = useRef<HTMLDivElement | null>(null);
 	const cardWidth = 200;
@@ -146,6 +149,7 @@ export const KeyEventsCarousel = ({
 								title={keyEvent.title}
 								cardPosition={`${index} of ${carouselLength}`}
 								absoluteServerTimes={absoluteServerTimes}
+								renderingTarget={renderingTarget}
 							/>
 						);
 					})}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.stories.tsx
@@ -67,6 +67,7 @@ export const SingleKeyEventCarousel = () => {
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
 				absoluteServerTimes={true}
+				renderingTarget="Web"
 			/>
 		</Wrapper>
 	);
@@ -81,6 +82,7 @@ export const ShortKeyEventCarousel = () => {
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
 				absoluteServerTimes={true}
+				renderingTarget="Web"
 			/>
 		</Wrapper>
 	);
@@ -95,6 +97,7 @@ export const LongKeyEventCarousel = () => {
 				filterKeyEvents={false}
 				id="key-events-carousel-desktop"
 				absoluteServerTimes={true}
+				renderingTarget="Web"
 			/>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -103,6 +103,7 @@ export const LiveBlogRenderer = ({
 							filterKeyEvents={filterKeyEvents}
 							id={'key-events-carousel-mobile'}
 							absoluteServerTimes={absoluteServerTimes}
+							renderingTarget={renderingTarget}
 						/>
 					</Island>
 					<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/components/Pagination.stories.tsx
+++ b/dotcom-rendering/src/components/Pagination.stories.tsx
@@ -32,6 +32,7 @@ export const notFirstPage = ({ format }: StoryProps) => (
 			older="older"
 			newer="newer"
 			newest="newest"
+			renderingTarget="Web"
 		/>
 	</>
 );
@@ -49,6 +50,7 @@ export const firstPageStory = ({ format }: StoryProps) => (
 			older="older"
 			newer="newer"
 			newest="newest"
+			renderingTarget="Web"
 		/>
 	</>
 );
@@ -66,6 +68,7 @@ export const lastPage = ({ format }: StoryProps) => (
 			older="older"
 			newer="newer"
 			newest="newest"
+			renderingTarget="Web"
 		/>
 	</>
 );

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -9,7 +9,7 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
-import { RenderingTarget } from 'src/types/renderingTarget';
+import type { RenderingTarget } from '../types/renderingTarget';
 
 type Props = {
 	currentPage: number;

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -57,6 +57,20 @@ const decidePaginationCss = css`
 	}
 `;
 
+const getPagePath = (
+	pagePath: string,
+	renderingTarget: RenderingTarget,
+	fragment: string,
+) => {
+	const searchParams = new URLSearchParams(pagePath);
+
+	if (renderingTarget === 'Apps') {
+		searchParams.append('dcr', 'apps');
+	}
+
+	return `${searchParams.toString()}#${fragment}`;
+};
+
 export const Pagination = ({
 	currentPage,
 	totalPages,
@@ -67,7 +81,6 @@ export const Pagination = ({
 	renderingTarget,
 }: Props) => {
 	const cssOverrides = decidePaginationCss;
-	const appsParam = renderingTarget === 'Apps' ? '&dcr=apps' : '';
 
 	return (
 		<nav id={id} css={grid}>
@@ -86,7 +99,11 @@ export const Pagination = ({
 									iconSide="left"
 									hideLabel={true}
 									// There’s no pagination at the top of the newest page
-									href={`${newest}${appsParam}#maincontent`}
+									href={getPagePath(
+										newest,
+										renderingTarget,
+										'maincontent',
+									)}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -99,7 +116,11 @@ export const Pagination = ({
 									icon={<SvgChevronLeftDouble />}
 									iconSide="left"
 									// There’s no pagination at the top of the newest page
-									href={`${newest}${appsParam}#maincontent`}
+									href={getPagePath(
+										newest,
+										renderingTarget,
+										'maincontent',
+									)}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -113,7 +134,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronLeftSingle />}
 							hideLabel={true}
-							href={`${newer}${appsParam}#${id}`}
+							href={getPagePath(newer, renderingTarget, id)}
 							cssOverrides={cssOverrides}
 						>
 							Previous
@@ -142,7 +163,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronRightSingle />}
 							hideLabel={true}
-							href={`${older}${appsParam}#${id}`}
+							href={getPagePath(older, renderingTarget, id)}
 							cssOverrides={cssOverrides}
 						>
 							Next
@@ -156,7 +177,11 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={`${oldest}${appsParam}#${id}`}
+									href={getPagePath(
+										oldest,
+										renderingTarget,
+										id,
+									)}
 									hideLabel={true}
 									cssOverrides={cssOverrides}
 								>
@@ -169,7 +194,11 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={`${oldest}${appsParam}#${id}`}
+									href={getPagePath(
+										oldest,
+										renderingTarget,
+										id,
+									)}
 									cssOverrides={cssOverrides}
 								>
 									Oldest

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -68,7 +68,7 @@ const getPagePath = (
 		searchParams.append('dcr', 'apps');
 	}
 
-	return `${searchParams.toString()}#${fragment}`;
+	return `?${searchParams.toString()}#${fragment}`;
 };
 
 export const Pagination = ({

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -9,6 +9,7 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
+import { RenderingTarget } from 'src/types/renderingTarget';
 
 type Props = {
 	currentPage: number;
@@ -17,6 +18,7 @@ type Props = {
 	newer?: string;
 	oldest?: string;
 	older?: string;
+	renderingTarget: RenderingTarget;
 };
 
 /** Used to scroll the page to this point when using permalinks */
@@ -62,8 +64,10 @@ export const Pagination = ({
 	older,
 	newest,
 	newer,
+	renderingTarget,
 }: Props) => {
 	const cssOverrides = decidePaginationCss;
+	const appsParam = renderingTarget === 'Apps' ? '&dcr=apps' : '';
 
 	return (
 		<nav id={id} css={grid}>
@@ -82,7 +86,7 @@ export const Pagination = ({
 									iconSide="left"
 									hideLabel={true}
 									// There’s no pagination at the top of the newest page
-									href={`${newest}#maincontent`}
+									href={`${newest}${appsParam}#maincontent`}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -95,7 +99,7 @@ export const Pagination = ({
 									icon={<SvgChevronLeftDouble />}
 									iconSide="left"
 									// There’s no pagination at the top of the newest page
-									href={`${newest}#maincontent`}
+									href={`${newest}${appsParam}#maincontent`}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -109,7 +113,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronLeftSingle />}
 							hideLabel={true}
-							href={`${newer}#${id}`}
+							href={`${newer}${appsParam}#${id}`}
 							cssOverrides={cssOverrides}
 						>
 							Previous
@@ -138,7 +142,7 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronRightSingle />}
 							hideLabel={true}
-							href={`${older}#${id}`}
+							href={`${older}${appsParam}#${id}`}
 							cssOverrides={cssOverrides}
 						>
 							Next
@@ -152,7 +156,7 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={`${oldest}#${id}`}
+									href={`${oldest}${appsParam}#${id}`}
 									hideLabel={true}
 									cssOverrides={cssOverrides}
 								>
@@ -165,7 +169,7 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={`${oldest}#${id}`}
+									href={`${oldest}${appsParam}#${id}`}
 									cssOverrides={cssOverrides}
 								>
 									Oldest

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -57,12 +57,16 @@ const decidePaginationCss = css`
 	}
 `;
 
-const getPagePath = (
-	pagePath: string,
-	renderingTarget: RenderingTarget,
-	fragment: string,
-) => {
-	const searchParams = new URLSearchParams(pagePath);
+const getPagePath = ({
+	pageParams,
+	renderingTarget,
+	fragment,
+}: {
+	pageParams: string;
+	renderingTarget: RenderingTarget;
+	fragment: string;
+}) => {
+	const searchParams = new URLSearchParams(pageParams);
 
 	if (renderingTarget === 'Apps') {
 		searchParams.append('dcr', 'apps');
@@ -99,11 +103,11 @@ export const Pagination = ({
 									iconSide="left"
 									hideLabel={true}
 									// There’s no pagination at the top of the newest page
-									href={getPagePath(
-										newest,
+									href={getPagePath({
+										pageParams: newest,
 										renderingTarget,
-										'maincontent',
-									)}
+										fragment: 'maincontent',
+									})}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -116,11 +120,11 @@ export const Pagination = ({
 									icon={<SvgChevronLeftDouble />}
 									iconSide="left"
 									// There’s no pagination at the top of the newest page
-									href={getPagePath(
-										newest,
+									href={getPagePath({
+										pageParams: newest,
 										renderingTarget,
-										'maincontent',
-									)}
+										fragment: 'maincontent',
+									})}
 									cssOverrides={cssOverrides}
 								>
 									Newest
@@ -134,7 +138,11 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronLeftSingle />}
 							hideLabel={true}
-							href={getPagePath(newer, renderingTarget, id)}
+							href={getPagePath({
+								pageParams: newer,
+								renderingTarget,
+								fragment: id,
+							})}
 							cssOverrides={cssOverrides}
 						>
 							Previous
@@ -163,7 +171,11 @@ export const Pagination = ({
 							priority="tertiary"
 							icon={<SvgChevronRightSingle />}
 							hideLabel={true}
-							href={getPagePath(older, renderingTarget, id)}
+							href={getPagePath({
+								pageParams: older,
+								renderingTarget,
+								fragment: id,
+							})}
 							cssOverrides={cssOverrides}
 						>
 							Next
@@ -177,11 +189,11 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={getPagePath(
-										oldest,
+									href={getPagePath({
+										pageParams: oldest,
 										renderingTarget,
-										id,
-									)}
+										fragment: id,
+									})}
 									hideLabel={true}
 									cssOverrides={cssOverrides}
 								>
@@ -194,11 +206,11 @@ export const Pagination = ({
 									priority="tertiary"
 									icon={<SvgChevronRightDouble />}
 									iconSide="right"
-									href={getPagePath(
-										oldest,
+									href={getPagePath({
+										pageParams: oldest,
 										renderingTarget,
-										id,
-									)}
+										fragment: id,
+									})}
 									cssOverrides={cssOverrides}
 								>
 									Oldest

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -777,6 +777,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													oldest={pagination.oldest}
 													newer={pagination.newer}
 													older={pagination.older}
+													renderingTarget={
+														renderingTarget
+													}
 												/>
 											)}
 											<ArticleBody
@@ -849,6 +852,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													oldest={pagination.oldest}
 													newer={pagination.newer}
 													older={pagination.older}
+													renderingTarget={
+														renderingTarget
+													}
 												/>
 											)}
 											<StraightLines

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -569,6 +569,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									filterKeyEvents={article.filterKeyEvents}
 									id={'key-events-carousel-desktop'}
 									absoluteServerTimes={absoluteServerTimes}
+									renderingTarget={renderingTarget}
 								/>
 							</Island>
 						</Hide>


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

## What does this change?
While testing the key events in the apps we noticed that when a key event link or a pagination link is clicked, the web version of the page is loaded. This PR adds the `dcr=apps` query parameter to these links if the rendering target is `Apps`. 

The reason that we hadn't noticed this issue before could be because, we were always testing liveblog in apps with local dcr rather than code/prod. When using local dcr, the native apps replace the host with `AppsArticle` path. ios replaces it with `http://localhost:3030/AppsArticle/` and android with `http://$localServerAddress:$localPortNumber/AppsArticle/`. This url path forces dcr to render the apps version. 

### How to reproduce the issue:
- point CODE MAPI to PROD fronts & capi
- open ios/android debug app
- go to the liveblog page
- go to one of the key events or pagination links

## Why?
This resolves one of the last remaining DCR liveblog issues in the app, paving the way to enable DCR liveblogs
 
## Screenshots

| ios before      | ios after      |
| ----------- | ---------- |
| <video src="https://github.com/user-attachments/assets/6282c02d-5b54-401c-bf4c-7056325ad072"> | <video src="https://github.com/user-attachments/assets/a15670c6-9e86-473c-840b-59f3d7d467a7"> |


| Android before      | Android after      |
| ----------- | ---------- |
| <video src="https://github.com/user-attachments/assets/ece12ab6-5c63-4c72-b558-5cd425b4a2d2"> | <video src="https://github.com/user-attachments/assets/ddf27f2e-b34d-4c06-a1c1-36229850588c"> |






<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |




You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
