### PR TITLE
Allow highlights container on any front

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -172,9 +172,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const Highlights = () => {
 		const showHighlights =
 			// Must be opted into the Europe beta test or in preview
-			(abTests.europeBetaFrontVariant === 'variant' || isPreview) &&
-			// Must either be a network front or the Europe beta front (or training version of it) in order to see Highlights
-			(front.isNetworkFront || front.pageId.startsWith('europe-beta'));
+			abTests.europeBetaFrontVariant === 'variant' || isPreview;
 
 		const highlightsCollection =
 			front.pressedPage.collections.find(isHighlights);


### PR DESCRIPTION
## What does this change?

Removes the restriction previously put in place to only allow rendering the `Highlights` container on network fronts (or special cases like `europe-beta`)

## Why?

Prefer to leave this restriction to the fronts tool users rather than strictly in the platforms

Resolves [this Trello ticket](https://trello.com/c/xUuaooAA/688-web-allow-highlights-container-on-any-front)