### PR TITLE
Check if user is signed in before stripping the show/hide buttons

### DIFF
--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -1,5 +1,6 @@
 import { isObject, isString, storage } from '@guardian/libs';
 import { useEffect } from 'react';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 
 type ContainerStates = { [id: string]: string };
 
@@ -19,14 +20,16 @@ const getContainerStates = (): ContainerStates => {
 };
 
 type Props = {
-	/** When in the ON position, we remove the show/hide functionality for all
-	 * containers on the page if the user does not have any hidden containers */
+	/** When in the ON position, we remove the show/hide functionality for all containers
+	 * on the page if the user is not signed in and does not have any hidden containers */
 	disableFrontContainerToggleSwitch: boolean;
 };
 
 export const ShowHideContainers = ({
 	disableFrontContainerToggleSwitch,
 }: Props) => {
+	const isSignedIn = useIsSignedIn();
+
 	useEffect(() => {
 		const containerStates = getContainerStates();
 
@@ -67,9 +70,16 @@ export const ShowHideContainers = ({
 			.every((state) => state !== 'closed');
 
 		for (const e of allShowHideButtons) {
-			// We want to remove the ability to toggle front containers between expanded and collapsed states.
-			// The first part of doing this is removing the feature for those who do not currently use it.
-			if (disableFrontContainerToggleSwitch && allContainersAreExpanded) {
+			// Users are not able to hide containers if the following three conditions are met:
+			// - They are not signed in
+			// - The disableFrontContainerToggleSwitch is on
+			// - All containers are expanded
+			// Otherwise, they should be able to hide containers
+			if (
+				!(isSignedIn === 'Pending' ? false : isSignedIn) &&
+				disableFrontContainerToggleSwitch &&
+				allContainersAreExpanded
+			) {
 				e.remove();
 			}
 
@@ -82,7 +92,7 @@ export const ShowHideContainers = ({
 				toggleContainer(sectionId, e);
 			}
 		}
-	}, [disableFrontContainerToggleSwitch]);
+	}, [isSignedIn, disableFrontContainerToggleSwitch]);
 
 	return <></>;
 };


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
