### PR TITLE
Introduce `containerLevel` prop to `FrontSection`

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -37,19 +37,12 @@ const headerStyles = css`
 	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
 `;
 
-const containerLevelStyling = (level: DCRContainerLevel) => {
-	if (level === 'Primary') {
-		return css`
-			${headlineBold28};
-		`;
-	}
-	if (level === 'Secondary') {
-		return css`
-			${textSansBold17};
-		`;
-	}
-	return null;
-};
+const primaryTitleStyles = css`
+	${headlineBold28};
+`;
+const secondaryTitleStyles = css`
+	${textSansBold17};
+`;
 
 const headerStylesWithUrl = css`
 	:hover {
@@ -134,8 +127,9 @@ export const ContainerTitle = ({
 							headerStylesWithUrl,
 							headerStyles,
 							lightweightHeader && article17,
-							containerLevel &&
-								containerLevelStyling(containerLevel),
+							containerLevel === 'Primary' && primaryTitleStyles,
+							containerLevel === 'Secondary' &&
+								secondaryTitleStyles,
 						]}
 					>
 						{localisedTitle(title, editionId)}
@@ -147,7 +141,8 @@ export const ContainerTitle = ({
 					css={[
 						headerStyles,
 						lightweightHeader && article17,
-						containerLevel && containerLevelStyling(containerLevel),
+						containerLevel === 'Primary' && primaryTitleStyles,
+						containerLevel === 'Secondary' && secondaryTitleStyles,
 					]}
 				>
 					{localisedTitle(title, editionId)}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -52,7 +52,8 @@ type Props = {
 	containerName?: string;
 	/** Fronts containers can have their styling overridden using a `containerPalette` */
 	containerPalette?: DCRContainerPalette;
-	/** Fronts containers can have their styling overridden using a `containerLevel`. If used, this can be either "Primary" or "Secondary", both of which have different styles*/
+	/** Fronts containers can have their styling overridden using a `containerLevel`.
+	 * If used, this can be either "Primary" or "Secondary", both of which have different styles */
 	containerLevel?: DCRContainerLevel;
 
 	/** Defaults to `false`. If true a Hide button is show top right allowing this section

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -659,7 +659,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								collectionBranding={
 									collection.collectionBranding
 								}
-								containerLevel={collection.containerLevel}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -153,6 +153,8 @@ export type DCRContainerPalette =
 // TODO: These may need to be declared differently than the front types in the future
 export type DCRContainerType = FEContainerType;
 
+export type DCRContainerLevel = 'Primary' | 'Secondary';
+
 /** @see https://github.com/guardian/frontend/blob/0bf69f55a/common/app/model/content/Atom.scala#L191-L196 */
 interface MediaAsset {
 	id: string;


### PR DESCRIPTION
## What does this change?

Adds optional `containerLevel` prop to `FrontSection` component so that we can begin styling these sections differently

## Why?

Breaking down https://github.com/guardian/dotcom-rendering/pull/12710 (cherry picked c4fd4005558d7e7e23ed7ce03e908a3c39da3dd0) into smaller PRs so that we can safely work on adapting the styles in Storybook without affecting existing container styling on the site.

As part of the Fairground project. [Trello ticket here](https://trello.com/c/pACWIDNy)


## Screenshots

| Primary     | Secondary  |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c81c8813-5f8e-4afd-af47-ce316c040620
[after]: https://github.com/user-attachments/assets/3e3ed5ee-97e6-4464-8a14-13b79914450a
