### PR TITLE
Update US election banner header and kicker for both variants

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
@@ -62,9 +62,7 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 		return null;
 	}
 
-	const heading = isInVariantBubble
-		? 'Pop your US news bubble'
-		: 'Yes, this story is free';
+	const heading = 'No billionaire approved this';
 
 	const kicker = isInVariantBubble
 		? 'How the Guardian is different'

--- a/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
@@ -63,10 +63,7 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 	}
 
 	const heading = 'No billionaire approved this';
-
-	const kicker = isInVariantBubble
-		? 'How the Guardian is different'
-		: 'Why the Guardian has no paywall';
+	const kicker = 'How the Guardian is different';
 
 	return (
 		<>


### PR DESCRIPTION
## What does this change?

Update US election banner heading and kicker for both variants as per request from US teams

## Screenshots

| Before      | After      |
| :---------: | :--------: |
| mobile | mobile |
| ![beforem][] | ![afterm][] |
| desktop | desktop |
| ![befored][] | ![afterd][] |

[befored]: https://github.com/user-attachments/assets/c4ffcb43-fac4-444a-a3df-9fa729ae38b6
[afterd]: https://github.com/user-attachments/assets/70db38c2-d700-44c1-867d-7673538ee639

[beforem]: https://github.com/user-attachments/assets/b7012d77-d88c-450a-a318-0a2cab962290
[afterm]: https://github.com/user-attachments/assets/4046ce74-a666-4272-8f4c-d36fe595ebd5

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
