### PR TITLE
Support multi-bylines in `apps-rendering`

### DIFF
--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -498,28 +498,47 @@ const parse =
 
 				const parser = parse(context, campaigns, atoms);
 
-				const isMiniProfile =
-					listTypeData.type === ListType.MINI_PROFILES;
-				if (isMiniProfile) {
-					return listTypeData.items.flatMap((item) => {
-						return (
-							item.title ? parseSubheading(item.title) : []
-						).concat(
-							item.bio
-								? flattenTextElement(
-										context.docParser(item.bio),
-								  ).map((elem) => Result.ok(elem))
-								: [],
-							item.elements.flatMap(parser),
-							item.endNote ? parseEmphasis(item.endNote) : [],
-						);
-					});
-				} else {
-					return listTypeData.items.flatMap((item) => {
-						return (
-							item.title ? parseTitle(item.title) : []
-						).concat(item.elements.flatMap(parser));
-					});
+				switch (listTypeData.type) {
+					case ListType.MINI_PROFILES:
+						return listTypeData.items.flatMap((item) => {
+							return (
+								item.title ? parseSubheading(item.title) : []
+							).concat(
+								item.bio
+									? flattenTextElement(
+											context.docParser(item.bio),
+									  ).map((elem) => Result.ok(elem))
+									: [],
+								item.elements.flatMap(parser),
+								item.endNote ? parseEmphasis(item.endNote) : [],
+							);
+						});
+					case ListType.MULTI_BYLINE:
+						return listTypeData.items.flatMap((item) => {
+							return (
+								item.title ? parseSubheading(item.title) : []
+							).concat(
+								item.bylineHtml
+									? flattenTextElement(
+											context.docParser(
+												`<p>${item.bylineHtml}</p>`,
+											),
+									  ).map((elem) => Result.ok(elem))
+									: [],
+								item.bio
+									? flattenTextElement(
+											context.docParser(item.bio),
+									  ).map((elem) => Result.ok(elem))
+									: [],
+								item.elements.flatMap(parser),
+							);
+						});
+					default:
+						return listTypeData.items.flatMap((item) => {
+							return (
+								item.title ? parseTitle(item.title) : []
+							).concat(item.elements.flatMap(parser));
+						});
 				}
 			}
 

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -519,17 +519,9 @@ const parse =
 								item.title ? parseSubheading(item.title) : []
 							).concat(
 								item.bylineHtml
-									? flattenTextElement(
-											context.docParser(
-												`<p>${item.bylineHtml}</p>`,
-											),
-									  ).map((elem) => Result.ok(elem))
+									? parseWithTags(['p'])(item.bylineHtml)
 									: [],
-								item.bio
-									? flattenTextElement(
-											context.docParser(item.bio),
-									  ).map((elem) => Result.ok(elem))
-									: [],
+								item.bio ? parseWithTags([])(item.bio) : [],
 								item.elements.flatMap(parser),
 							);
 						});

--- a/apps-rendering/src/bodyElement.ts
+++ b/apps-rendering/src/bodyElement.ts
@@ -500,12 +500,8 @@ const parse =
 
 				const isMiniProfile =
 					listTypeData.type === ListType.MINI_PROFILES;
-				console.log(isMiniProfile);
 				if (isMiniProfile) {
 					return listTypeData.items.flatMap((item) => {
-						console.log(
-							item.title ? parseSubheading(item.title) : [],
-						);
 						return (
 							item.title ? parseSubheading(item.title) : []
 						).concat(

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -571,7 +571,7 @@ describe('embed elements', () => {
 });
 
 describe('list elements', () => {
-	test('parses non-mini profiles list elements', () => {
+	test('parses key takeaways list elements', () => {
 		const embedElement = {
 			type: ElementType.EMBED,
 			assets: [],
@@ -598,8 +598,6 @@ describe('list elements', () => {
 					{
 						title: 'Some title 1',
 						elements: [embedElement, textElement, textElement],
-						bio: 'Some bio 1',
-						endNote: 'Some end note 1',
 					},
 					{
 						title: 'Some title 2',
@@ -696,6 +694,52 @@ describe('list elements', () => {
 		expect(
 			item.body[8].kind === ElementKind.Text &&
 				item.body[8].doc.firstChild?.textContent == 'Some title 3',
+		).toBe(true);
+	});
+
+	test('parses multi-byline list elements', () => {
+		const textElement = {
+			type: ElementType.TEXT,
+			assets: [],
+			textTypeData: {
+				html: '<p>paragraph</p>',
+			},
+		};
+
+		const listElement = {
+			type: ElementType.LIST,
+			assets: [],
+			listTypeData: {
+				items: [
+					{
+						title: 'Some title 1',
+						elements: [textElement],
+						bio: '<p>Some bio 1</p>',
+						bylineHtml: '<a href="/123">Some byline 1</a>',
+					},
+					{
+						title: 'Some title 2',
+						elements: [textElement],
+						bio: '<p>Some bio 2</p>',
+						bylineHtml: '<a href="/456">Some byline 2</a>',
+					},
+				],
+				type: ListType.MULTI_BYLINE,
+			},
+		};
+		const item = f(articleContentWith(listElement)) as Standard;
+
+		expect(
+			item.body[0].kind === ElementKind.Text &&
+				item.body[0].doc.firstChild?.textContent == 'Some title 1',
+		).toBe(true);
+		expect(
+			item.body[1].kind === ElementKind.Text &&
+				item.body[1].doc.textContent == 'Some byline 1',
+		).toBe(true);
+		expect(
+			item.body[2].kind === ElementKind.Text &&
+				item.body[2].doc.textContent === 'Some bio 1',
 		).toBe(true);
 	});
 

--- a/apps-rendering/src/item.test.ts
+++ b/apps-rendering/src/item.test.ts
@@ -615,17 +615,17 @@ describe('list elements', () => {
 
 		expect(
 			item.body[0].kind === ElementKind.HeadingTwo &&
-				item.body[0].doc.firstChild?.textContent == 'Some title 1',
+				item.body[0].doc.firstChild?.textContent === 'Some title 1',
 		).toBe(true);
 		expect(item.body[1].kind).toBe(ElementKind.Embed);
 		expect(
 			item.body[4].kind === ElementKind.HeadingTwo &&
-				item.body[4].doc.firstChild?.textContent == 'Some title 2',
+				item.body[4].doc.firstChild?.textContent === 'Some title 2',
 		).toBe(true);
 		expect(item.body[5].kind).toBe(ElementKind.Text);
 		expect(
 			item.body[6].kind === ElementKind.HeadingTwo &&
-				item.body[6].doc.firstChild?.textContent == 'Some title 3',
+				item.body[6].doc.firstChild?.textContent === 'Some title 3',
 		).toBe(true);
 	});
 
@@ -675,7 +675,7 @@ describe('list elements', () => {
 
 		expect(
 			item.body[0].kind === ElementKind.Text &&
-				item.body[0].doc.firstChild?.textContent == 'Some title 1',
+				item.body[0].doc.firstChild?.textContent === 'Some title 1',
 		).toBe(true);
 		expect(
 			item.body[1].kind === ElementKind.Text &&
@@ -688,12 +688,12 @@ describe('list elements', () => {
 		).toBe(true);
 		expect(
 			item.body[6].kind === ElementKind.Text &&
-				item.body[6].doc.firstChild?.textContent == 'Some title 2',
+				item.body[6].doc.firstChild?.textContent === 'Some title 2',
 		).toBe(true);
 		expect(item.body[7].kind).toBe(ElementKind.Text);
 		expect(
 			item.body[8].kind === ElementKind.Text &&
-				item.body[8].doc.firstChild?.textContent == 'Some title 3',
+				item.body[8].doc.firstChild?.textContent === 'Some title 3',
 		).toBe(true);
 	});
 
@@ -731,11 +731,11 @@ describe('list elements', () => {
 
 		expect(
 			item.body[0].kind === ElementKind.Text &&
-				item.body[0].doc.firstChild?.textContent == 'Some title 1',
+				item.body[0].doc.firstChild?.textContent === 'Some title 1',
 		).toBe(true);
 		expect(
 			item.body[1].kind === ElementKind.Text &&
-				item.body[1].doc.textContent == 'Some byline 1',
+				item.body[1].doc.textContent === 'Some byline 1',
 		).toBe(true);
 		expect(
 			item.body[2].kind === ElementKind.Text &&


### PR DESCRIPTION
## What does this change?

Adds support for the multi-byline element in `apps-rendering`

## Why?

If we don't make this change, multi-byline articles will not correctly render in AR and therefore editions

## Screenshots

| Before | After |
|--------|--------|
|     ![Screenshot 2024-11-11 at 16 52 04](https://github.com/user-attachments/assets/7e0aaa88-a592-4c73-b42f-53716c3fd912) |      ![Screenshot 2024-11-11 at 16 51 54](https://github.com/user-attachments/assets/ac112e1a-002e-405a-a556-9adf0d75f421) | 

## How to test

To test this change, we'll need to:

- update configuration to point CODE MAPI to CODE Fronts and CODE CAPI. This can be done by running [this script](https://github.com/guardian/mobile-platform/blob/main/scripts/mapi-code-config.sh) with MAPI Janus credentials, or by asking someone nicely in the apps team to do it
- redeploy `mobile-fronts` and `mobile-item` to CODE so the config changes took effect
- publish a multi-byline article on CODE
- verify the article doesn't appear correctly here: 
https://mobile.code.dev-guardianapis.com/uk/rendered-items/commentisfree/2024/nov/07/multi-byline-end-to-end-test
(in particular, the `bio` and `byline` fields will be missing)
- deploy *this branch* (`apps-rendering-multi-bylines`) to CODE (project name: `Mobile::mobile-apps-rendering`)
- verify the multi-byline article _does_ render correctly here:
https://mobile.code.dev-guardianapis.com/uk/rendered-items/commentisfree/2024/nov/07/multi-byline-end-to-end-test
it should include the new fields `bio` and `byline`
