### PR TITLE
Add story for scrollable feature

### DIFF
--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign } from '../lib/articleFormat';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { FeatureCard } from './FeatureCard';
 import { ScrollableCarousel } from './ScrollableCarousel';
@@ -39,6 +40,11 @@ export const ScrollableFeature = ({
 							showByline={card.showByline}
 							webPublicationDate={card.webPublicationDate}
 							kickerText={card.kickerText}
+							/** TODO check if the pulsing dot should be be supported */
+							showPulsingDot={
+								card.format.design === ArticleDesign.LiveBlog
+							}
+							/** TODO - implement show age */
 							showClock={false}
 							image={card.image}
 							isPlayableMediaCard={true}
@@ -53,7 +59,7 @@ export const ScrollableFeature = ({
 							absoluteServerTimes={absoluteServerTimes}
 							imageLoading={imageLoading}
 							aspectRatio="4:5"
-							imageSize={'feature'}
+							imageSize="feature"
 							headlineSizes={{
 								desktop: 'xsmall',
 								tablet: 'xxsmall',

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -1,0 +1,130 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
+import { FrontSection } from './FrontSection';
+import { ScrollableFeature } from './ScrollableFeature.importable';
+
+const imageUrls = [
+	'https://media.guim.co.uk/2d214bdf3ed8e014360e8fde41b471973e4bad44/948_2222_2703_3378/800.jpg',
+	'https://media.guim.co.uk/ebdbdcf43ae69f4e8e85cd94f8cb67faeaef5d4a/1087_735_988_1235/800.jpg',
+	'https://media.guim.co.uk/9bd0b0432950315837ba204e5d5b2250b3e75744/204_838_4422_5524/801.jpg',
+	'https://media.guim.co.uk/f30ec00394386361d3b4b278984f27b32dab4d42/328_2337_5032_6290/800.jpg',
+	'https://media.guim.co.uk/1a99dd52b89bc67ee384b337d8793f1303080010/154_958_2405_3006/800.jpg',
+	'https://media.guim.co.uk/49e438dd362c146523d6006b4054e8b5a9ffb44b/2077_322_3325_4157/800.jpg',
+];
+
+const frontCard = {
+	url: '',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: Pillar.News,
+	},
+	headline: 'HeadlineText',
+	kickerText: 'Kicker',
+	webPublicationDate: new Date(Date.now() - 60 * 60 * 1000).toString(),
+	image: {
+		src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+		altText: 'alt text',
+	},
+	showQuotedHeadline: false,
+	showLivePlayable: false,
+	isExternalLink: false,
+	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
+	byline: 'Byline text',
+	showByline: true,
+	dataLinkName: 'data-link-name',
+} satisfies DCRFrontCard;
+
+const trails = new Array(6)
+	.fill(frontCard)
+	.map((trail: DCRFrontCard, idx: number) => ({
+		...trail,
+		image: {
+			src: imageUrls[idx] as string,
+			altText: '',
+		},
+		format: {
+			...frontCard.format,
+			theme: idx, // Uses index to cycle through each theme enum value
+		},
+	}));
+
+const meta = {
+	title: 'Components/ScrollableFeature',
+	component: ScrollableFeature,
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+	args: {
+		trails,
+		containerPalette: undefined,
+		absoluteServerTimes: true,
+		imageLoading: 'eager',
+	},
+	render: (args) => (
+		<FrontSection
+			title="Scrollable feature"
+			discussionApiUrl={discussionApiUrl}
+			editionId="UK"
+			showTopBorder={false}
+		>
+			<ScrollableFeature {...args} />
+		</FrontSection>
+	),
+} satisfies Meta<typeof ScrollableFeature>;
+
+export default meta;
+
+type Story = StoryObj<typeof ScrollableFeature>;
+
+export const Default = {} satisfies Story;
+
+const containerPalettes = [
+	'InvestigationPalette',
+	'LongRunningPalette',
+	'SombrePalette',
+	'BreakingPalette',
+	'EventPalette',
+	'EventAltPalette',
+	'LongRunningAltPalette',
+	'SombreAltPalette',
+	'SpecialReportAltPalette',
+	'Branded',
+] as const satisfies readonly Omit<
+	DCRContainerPalette,
+	'MediaPalette' | 'PodcastPalette'
+>[];
+
+export const WithSpecialPaletteVariations = {
+	parameters: {
+		chromatic: { viewports: [breakpoints.desktop] },
+	},
+	render: (args) => (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<FrontSection
+					title="Scrollable feature"
+					discussionApiUrl={discussionApiUrl}
+					editionId="UK"
+					showTopBorder={false}
+					key={containerPalette}
+					containerPalette={containerPalette}
+				>
+					<ScrollableFeature
+						{...args}
+						containerPalette={containerPalette}
+					/>
+				</FrontSection>
+			))}
+		</>
+	),
+} satisfies Story;

--- a/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
@@ -1,7 +1,7 @@
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
-import { trails } from '../../fixtures/manual/trails';
+import { trails as trailsFixture } from '../../fixtures/manual/trails';
 import { FrontSection } from './FrontSection';
 import { StaticFeatureTwo } from './StaticFeatureTwo';
 
@@ -18,7 +18,7 @@ const meta = {
 		},
 	},
 	args: {
-		trails,
+		trails: trailsFixture.slice(0, 2),
 		absoluteServerTimes: true,
 		imageLoading: 'eager',
 	},
@@ -37,9 +37,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-	name: 'Default Story',
-	args: {
-		trails: trails.slice(0, 2),
-	},
-};
+export const Default: Story = {};

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign } from '../lib/articleFormat';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
@@ -43,7 +44,11 @@ export const StaticFeatureTwo = ({
 								webPublicationDate={card.webPublicationDate}
 								kickerText={card.kickerText}
 								/** TODO check if the pulsing dot should be be supported */
-								showPulsingDot={false}
+								showPulsingDot={
+									card.format.design ===
+									ArticleDesign.LiveBlog
+								}
+								/** TODO - implement show age */
 								showClock={false}
 								image={card.image}
 								isPlayableMediaCard={true}
@@ -59,7 +64,7 @@ export const StaticFeatureTwo = ({
 								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
 								aspectRatio="4:5"
-								imageSize={'feature-large'}
+								imageSize="feature-large"
 								headlineSizes={{
 									desktop: 'medium',
 									tablet: 'small',


### PR DESCRIPTION
## What does this change?

- Adds Storybook story for `ScrollableFeature` container, with six image variations to test the blur overlay with
- Adds `TODO` comments for props in `ScrollableFeature` and `StaticFeatureTwo` containers

## Why?

We need to better visualise the blur overlay in various scenarios so that we can decide on an approach and ensure the text is readable and accessible

Part of [this Trello ticket](https://trello.com/c/59LL8eCr/627-web-feature-card-carousel-and-static)

## Screenshots

<img width="1313" alt="Screenshot 2024-11-06 at 16 55 09" src="https://github.com/user-attachments/assets/0f095272-ffe4-4a0a-b0a2-226f3b870011">
<img width="1303" alt="Screenshot 2024-11-06 at 16 55 18" src="https://github.com/user-attachments/assets/eeedd119-9584-4e87-8ab3-8570e58c71b4">


