### PR TITLE
Carousels: Update disabled button styles

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -43,7 +43,7 @@ const themeButton: Partial<ThemeButton> = {
 const themeButtonDisabled: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border-disabled'),
 	textTertiary: palette('--carousel-chevron-disabled'),
-	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
+	backgroundTertiaryHover: 'transparent',
 };
 
 const containerStyles = css`

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4388,9 +4388,9 @@ const carouselChevronDisabledLight: PaletteFunction = () =>
 const carouselChevronDisabledDark: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[86], 0.32);
 const carouselChevronBorderDisabledLight: PaletteFunction = () =>
-	transparentColour(sourcePalette.neutral[73], 0.32);
+	transparentColour(sourcePalette.neutral[73], 0.2);
 const carouselChevronBorderDisabledDark: PaletteFunction = () =>
-	transparentColour(sourcePalette.neutral[73], 0.32);
+	transparentColour(sourcePalette.neutral[73], 0.2);
 
 const mostViewedFooterHoverLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];


### PR DESCRIPTION
## What does this change?

- Reduces opacity of border on disabled buttons for default light and dark themes. (Special palette buttons are unchanged.)
- Suppresses background colour change on hover when button is disabled

## Why?

These changes were requested following design review of the `scrollable/small` and `scrollable/medium` containers.

## Screenshots

<img width="186" alt="Screenshot 2024-11-06 at 17 10 35" src="https://github.com/user-attachments/assets/fbb46fb1-6aab-442f-907c-6c377194ba2d">
