### PR TITLE
Exclude us-news/us-elections-2024 tagged articles from amp

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -103,6 +103,7 @@ export const isAmpSupported = ({
 		'type/video',
 		'thefilter/series/the-filter',
 		'us-news/us-news',
+		'us-news/us-elections-2024',
 	]);
 
 	if (tags.some((tag) => excludedTagIds.has(tag.id))) {


### PR DESCRIPTION
## What does this change?

Excludes us-news/us-elections-2024 tagged articles from AMP

Follow on from #12771

## Why?

We want to turn off AMP for these articles as a test for 48 hours
