### PR TITLE
Remove vertical rule from Primary and Secondary containers

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -461,6 +461,10 @@ export const FrontSection = ({
 		!!collectionId &&
 		!!pageId &&
 		!!ajaxUrl;
+	const showVerticalRule =
+		!hasPageSkin &&
+		containerLevel !== 'Primary' &&
+		containerLevel !== 'Secondary';
 
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
@@ -501,7 +505,7 @@ export const FrontSection = ({
 							// only ever having <CPScott> as the leftContent
 							title?.toLowerCase() === 'opinion',
 						),
-						!hasPageSkin &&
+						showVerticalRule &&
 							sectionHeadlineFromLeftCol(
 								schemePalette('--section-border'),
 							),

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import {
 	from,
-	headlineMedium24Object,
 	space,
+	textSansBold17Object,
 	until,
 } from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
@@ -25,7 +25,7 @@ type Props = {
  * This needs to match the `FrontSection` title font and is used to calculate
  * the negative margin that aligns the navigation buttons with the title.
  */
-const titlePreset = headlineMedium24Object;
+const titlePreset = textSansBold17Object;
 
 /**
  * Grid sizing to calculate negative margin used to pull navigation buttons


### PR DESCRIPTION
## What does this change?

- The small vertical rule between the container title and content is not shown for Primary and Secondary containers
- Spacing in carousels has been adjusted to account for the Storybook examples using Secondary containers which have a smaller container title

> [!note]
> The spacing changes are to ensure the examples in Storybook look correct, but do not account for making the carousels work in both Primary and Secondary containers where they need to account for the different title styling and spacing. This will be done in a separate PR.

## Why?

Part of the work to update Primary and Secondary container styling and to ensure examples in Storybook more closely represent how new containers will look when used on the site.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://github.com/user-attachments/assets/7250ec9c-4d20-45b3-b583-a9ed390c12a9
[after1]: https://github.com/user-attachments/assets/950c9472-961e-4748-b92a-5bfd6c16066f
[before2]: https://github.com/user-attachments/assets/f6d9d466-7aad-4e04-a901-1b96fdce75cd
[after2]: https://github.com/user-attachments/assets/4ed19679-4175-486c-95dc-7abef13927aa

