### PR TITLE
Support sublinks on feature cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -498,7 +498,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexSplash}
+					fillBackgroundOnMobile={isFlexSplash}
 				/>
 			);
 		}
@@ -509,7 +509,7 @@ export const Card = ({
 					containerPalette={containerPalette}
 					alignment={supportingContentAlignment}
 					isDynamo={isDynamo}
-					fillBackground={isFlexSplash}
+					fillBackgroundOnMobile={isFlexSplash}
 				/>
 			</Hide>
 		);
@@ -526,7 +526,7 @@ export const Card = ({
 					alignment="vertical"
 					containerPalette={containerPalette}
 					isDynamo={isDynamo}
-					fillBackground={isFlexSplash}
+					fillBackgroundOnMobile={isFlexSplash}
 				/>
 			</Hide>
 		);

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -471,7 +471,9 @@ export const FeatureCard = ({
 						<SupportingContent
 							supportingContent={supportingContent}
 							containerPalette={containerPalette}
-							alignment={'vertical'}
+							alignment="vertical"
+							fillBackgroundOnDesktop={true}
+							fillBackgroundOnMobile={true}
 						/>
 					)}
 				</div>

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -67,6 +67,7 @@ export const StaticFeatureTwo = ({
 								desktop: 'medium',
 								tablet: 'small',
 							}}
+							supportingContent={card.supportingContent}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,7 +16,10 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
-	fillBackground?: boolean;
+	/** Allows sublinks container to have a background colour on mobile screen sizes */
+	fillBackgroundOnMobile?: boolean;
+	/** Allows sublinks container to have a background colour on desktop screen sizes */
+	fillBackgroundOnDesktop?: boolean;
 };
 
 /**
@@ -121,20 +124,29 @@ const wrapperStyles = css`
 	}
 `;
 
-const backgroundFill = css`
-	/** background fill should only apply to sublinks on mobile breakpoints */
+const backgroundFillMobile = css`
 	${until.tablet} {
 		padding: ${space[2]}px;
 		padding-bottom: ${space[3]}px;
 		background-color: ${palette('--card-sublinks-background')};
 	}
 `;
+
+const backgroundFillDesktop = css`
+	${from.tablet} {
+		padding: ${space[2]}px;
+		padding-bottom: ${space[3]}px;
+		background-color: ${palette('--card-sublinks-background')};
+	}
+`;
+
 export const SupportingContent = ({
 	supportingContent,
 	alignment,
 	containerPalette,
 	isDynamo,
-	fillBackground = false,
+	fillBackgroundOnMobile = false,
+	fillBackgroundOnDesktop = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
 	return (
@@ -144,7 +156,8 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				fillBackground && backgroundFill,
+				fillBackgroundOnMobile && backgroundFillMobile,
+				fillBackgroundOnDesktop && backgroundFillDesktop,
 			]}
 		>
 			{supportingContent.map((subLink, index) => {


### PR DESCRIPTION
## What does this change?

Adds support for sublinks to feature cards. This is only used in practice in `StaticFeatureTwo` as we do not allow sublinks on `ScrollableFeature` containers

## Why?

Part of work to implement feature cards

Resolves [this Trello ticket](https://trello.com/c/KsKNOCsd/704-featurecard-support-sublinks)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4b17f71b-bdec-4602-8f4b-cff5596ef70b
[after]: https://github.com/user-attachments/assets/e4453053-3a47-4583-979f-9084518001eb
