### PR TITLE
Carousels: Align navigation with container title and grid

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -477,6 +477,7 @@ export const FrontSection = ({
 				data-link-name={ophanComponentLink}
 				data-component={ophanComponentName}
 				data-container-name={containerName}
+				data-container-level={containerLevel}
 				css={[
 					fallbackStyles,
 					containerStylesUntilLeftCol,

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	between,
 	from,
 	headlineBold28Object,
 	height,
@@ -112,7 +113,7 @@ const containerWithNavigationStyles = css`
 	 * down so it starts below the navigation buttons and gap, and aligns with
 	 * the top of the carousel.
 	 */
-	${from.tablet} {
+	${between.tablet.and.leftCol} {
 		[data-container-level='Primary'] & {
 			margin-top: calc(
 				-${primaryTitlePreset.fontSize} * ${primaryTitlePreset.lineHeight} -
@@ -126,17 +127,13 @@ const containerWithNavigationStyles = css`
 			);
 		}
 	}
-	${from.leftCol} {
-		margin-top: 0;
+	${between.leftCol.and.wide} {
 		::before {
 			top: ${height.ctaSmall + space[2]}px;
 		}
 	}
 	${from.wide} {
 		margin-right: -${gridColumnWidth + gridGap / 2}px;
-		::before {
-			top: 0;
-		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	from,
+	headlineBold28Object,
 	height,
 	space,
 	textSansBold17Object,
@@ -22,17 +23,21 @@ type Props = {
 };
 
 /**
- * This needs to match the `FrontSection` title font and is used to calculate
- * the negative margin that aligns the navigation buttons with the title.
+ * Primary and Secondary containers have different typographic styles for the
+ * titles. We get the font size and line height values for these from the
+ * typography presets so we can calculate the offset needed to align the
+ * navigation buttons with the title on tablet and desktop.
  */
-const titlePreset = textSansBold17Object;
+const primaryTitlePreset = headlineBold28Object;
+const secondaryTitlePreset = textSansBold17Object;
 
 /**
- * Grid sizing to calculate negative margin used to pull navigation buttons
- * out side of `FrontSection` container at `wide` breakpoint.
+ * Grid sizing values to calculate negative margin used to pull navigation
+ * buttons outside of container into the outer grid column at wide breakpoint.
  */
 const gridColumnWidth = 60;
 const gridGap = 20;
+const gridGapMobile = 10;
 
 const themeButton: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border'),
@@ -58,15 +63,15 @@ const themeButtonDisabled: Partial<ThemeButton> = {
  */
 const containerStyles = css`
 	position: relative;
-	margin-left: -10px;
-	margin-right: -10px;
+	margin-left: -${gridGapMobile}px;
+	margin-right: -${gridGapMobile}px;
 	${from.mobileLandscape} {
-		margin-left: -20px;
-		margin-right: -20px;
+		margin-left: -${gridGap}px;
+		margin-right: -${gridGap}px;
 	}
 	${from.tablet} {
-		margin-left: 10px;
-		margin-right: 10px;
+		margin-left: ${gridGap / 2}px;
+		margin-right: ${gridGap / 2}px;
 	}
 	${from.leftCol} {
 		margin-left: 0;
@@ -108,10 +113,18 @@ const containerWithNavigationStyles = css`
 	 * the top of the carousel.
 	 */
 	${from.tablet} {
-		margin-top: calc(
-			(-${titlePreset.fontSize} * ${titlePreset.lineHeight}) -
-				${space[3]}px
-		);
+		[data-container-level='Primary'] & {
+			margin-top: calc(
+				-${primaryTitlePreset.fontSize} * ${primaryTitlePreset.lineHeight} -
+					${space[3]}px
+			);
+		}
+		[data-container-level='Secondary'] & {
+			margin-top: calc(
+				-${secondaryTitlePreset.fontSize} * ${secondaryTitlePreset.lineHeight} -
+					${space[3]}px
+			);
+		}
 	}
 	${from.leftCol} {
 		margin-top: 0;
@@ -120,7 +133,7 @@ const containerWithNavigationStyles = css`
 		}
 	}
 	${from.wide} {
-		margin-right: calc(${space[2]}px - ${gridColumnWidth}px - ${gridGap}px);
+		margin-right: -${gridColumnWidth + gridGap / 2}px;
 		::before {
 			top: 0;
 		}
@@ -146,13 +159,13 @@ const carouselStyles = css`
 	}
 	scrollbar-width: none; /* Firefox */
 
-	padding-left: 10px;
-	padding-right: 10px;
-	scroll-padding-left: 10px;
+	padding-left: ${gridGapMobile}px;
+	padding-right: ${gridGapMobile}px;
+	scroll-padding-left: ${gridGapMobile}px;
 	${from.mobileLandscape} {
-		padding-left: 20px;
-		padding-right: 20px;
-		scroll-padding-left: 20px;
+		padding-left: ${gridGap}px;
+		padding-right: ${gridGap}px;
+		scroll-padding-left: ${gridGap}px;
 	}
 	${from.tablet} {
 		padding-left: 0;
@@ -160,8 +173,8 @@ const carouselStyles = css`
 		scroll-padding-left: 0;
 	}
 	${from.leftCol} {
-		padding-left: 10px;
-		scroll-padding-left: 10px;
+		padding-left: ${gridGap / 2}px;
+		scroll-padding-left: ${gridGap / 2}px;
 	}
 `;
 
@@ -225,7 +238,7 @@ const generateCarouselColumnStyles = (
 			${totalCards},
 			calc(
 				(100% / ${visibleCardsOnMobile}) - ${offsetPeepingCardWidth}px +
-					${10 / visibleCardsOnMobile}px
+					${gridGapMobile / visibleCardsOnMobile}px
 			)
 		);
 		${from.mobileLandscape} {
@@ -234,7 +247,7 @@ const generateCarouselColumnStyles = (
 				calc(
 					(100% / ${visibleCardsOnMobile}) -
 						${offsetPeepingCardWidth}px +
-						${20 / visibleCardsOnMobile}px
+						${gridGap / visibleCardsOnMobile}px
 				)
 			);
 		}

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -89,6 +89,20 @@ type Story = StoryObj<typeof ScrollableFeature>;
 
 export const Default = {};
 
+export const WithPrimaryContainer = {
+	render: (args) => (
+		<FrontSection
+			title="Scrollable feature"
+			discussionApiUrl={discussionApiUrl}
+			editionId="UK"
+			showTopBorder={false}
+			containerLevel="Primary"
+		>
+			<ScrollableFeature {...args} />
+		</FrontSection>
+	),
+} satisfies Story;
+
 const containerPalettes = [
 	'InvestigationPalette',
 	'LongRunningPalette',

--- a/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
@@ -69,6 +69,20 @@ export const WithFourCards = {
 	},
 } satisfies Story;
 
+export const WithPrimaryContainer = {
+	render: (args) => (
+		<FrontSection
+			title="Scrollable medium"
+			discussionApiUrl={discussionApiUrl}
+			editionId="UK"
+			showTopBorder={false}
+			containerLevel="Primary"
+		>
+			<ScrollableMedium {...args} />
+		</FrontSection>
+	),
+} satisfies Story;
+
 const containerPalettes = [
 	'InvestigationPalette',
 	'LongRunningPalette',

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -69,6 +69,20 @@ export const WithTwoCards = {
 	},
 };
 
+export const WithPrimaryContainer = {
+	render: (args) => (
+		<FrontSection
+			title="Scrollable small"
+			discussionApiUrl={discussionApiUrl}
+			editionId={'UK'}
+			showTopBorder={false}
+			containerLevel="Primary"
+		>
+			<ScrollableSmall {...args} />
+		</FrontSection>
+	),
+} satisfies Story;
+
 const containerPalettes = [
 	'InvestigationPalette',
 	'LongRunningPalette',


### PR DESCRIPTION
## What does this change?

- Exposes `containerLevel` as data attribute on `FrontSection` container
- Adjusts carousel offset so navigation aligns with top of Primary and Secondary titles
- Fixes offset calculation at `leftCol` so navigation and cards align exactly with grid columns
- Adds Primary container examples to `scrollable/small`, `scrollable/medium` and `scrollable/feature` stories

## Why?

Part of the work to implement scrollable containers and support Primary and Secondary container styling

## Screenshots

| Primary      | Secondary      |
| ----------- | ---------- |
| ![primary][] | ![secondary][] |

[primary]: https://github.com/user-attachments/assets/3f20b822-7edf-4e99-bd59-d02d1faf5f81
[secondary]: https://github.com/user-attachments/assets/a4209f2c-fcbf-45a5-83d7-989d190502d2

<img width="1347" alt="Screenshot 2024-11-08 at 13 19 52" src="https://github.com/user-attachments/assets/ad88a6c4-395a-47bf-a51a-370899ddb26c">
