### PR TITLE
Use `fe-articles` Fixtures In More Places

### DIFF
--- a/dotcom-rendering/src/components/Footer.stories.tsx
+++ b/dotcom-rendering/src/components/Footer.stories.tsx
@@ -5,7 +5,7 @@ import {
 	space,
 	textSans34,
 } from '@guardian/source/foundations';
-import { Standard } from '../../fixtures/generated/dcr-articles/Standard';
+import { Standard } from '../../fixtures/generated/fe-articles/Standard';
 import { Pillar } from '../lib/articleFormat';
 import { editionList } from '../lib/edition';
 import { extractNAV } from '../model/extract-nav';
@@ -45,12 +45,10 @@ export const Footers = () => (
 				</h1>
 				<Wrapper>
 					<Footer
-						pageFooter={Standard.frontendData.pageFooter}
+						pageFooter={Standard.pageFooter}
 						selectedPillar={Pillar.News}
-						pillars={extractNAV(Standard.frontendData.nav).pillars}
-						urls={
-							Standard.frontendData.nav.readerRevenueLinks.header
-						}
+						pillars={extractNAV(Standard.nav).pillars}
+						urls={Standard.nav.readerRevenueLinks.header}
 						editionId={editionId}
 					/>
 				</Wrapper>

--- a/dotcom-rendering/src/components/InteractiveContentsBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveContentsBlockComponent.stories.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
-import { NumberedList } from '../../fixtures/generated/dcr-articles/NumberedList';
+import { NumberedList } from '../../fixtures/generated/fe-articles/NumberedList';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { enhanceInteractiveContentsElements } from '../model/enhance-interactive-contents-elements';
 import type { InteractiveContentsBlockElement } from '../types/content';
 import { InteractiveContentsBlockComponent } from './InteractiveContentsBlockComponent.importable';
 
 const interactiveContentsBlock = enhanceInteractiveContentsElements(
-	NumberedList.frontendData.blocks[0]?.elements ?? [],
+	NumberedList.blocks[0]?.elements ?? [],
 ).find(
 	(element): element is InteractiveContentsBlockElement =>
 		element._type ===


### PR DESCRIPTION
These usages don't rely on enhanced data from the `dcr-articles` fixtures.
