### PR TITLE
us-news and us-elections-2024 should amplify

### DIFF
--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -102,8 +102,6 @@ export const isAmpSupported = ({
 	const excludedTagIds = new Set([
 		'type/video',
 		'thefilter/series/the-filter',
-		'us-news/us-news',
-		'us-news/us-elections-2024',
 	]);
 
 	if (tags.some((tag) => excludedTagIds.has(tag.id))) {


### PR DESCRIPTION
## What does this change?

Reverts #12776 and #12771

Not AMPlifying `us-news` and `us-elections-2024` was a 48 hour test, and now, the test is over.
