### PR TITLE
Move Validation Out Of `enhanceArticleType`

### DIFF
--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -7,6 +7,7 @@ const execa = require('execa');
 const { config } = require('../../fixtures/config');
 const { configOverrides } = require('../../fixtures/config-overrides');
 const { switchOverrides } = require('../../fixtures/switch-overrides');
+const { validateAsArticleType } = require('../../src/model/validate');
 const { enhanceArticleType } = require('../../src/types/article');
 
 const root = resolve(__dirname, '..', '..');
@@ -172,7 +173,8 @@ const requests = articles.map((article) => {
 				frontendJson.format.design = 'LiveBlogDesign';
 			}
 
-			const dcrArticle = enhanceArticleType(frontendJson);
+			const frontendData = validateAsArticleType(frontendJson);
+			const dcrArticle = enhanceArticleType(frontendData);
 
 			// manual hack for Video articles
 			if (article.name === 'Video') {

--- a/dotcom-rendering/src/server/handler.article.apps.ts
+++ b/dotcom-rendering/src/server/handler.article.apps.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express';
 import { decideFormat } from '../lib/articleFormat';
 import { enhanceBlocks } from '../model/enhanceBlocks';
-import { validateAsBlock } from '../model/validate';
+import { validateAsArticleType, validateAsBlock } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
@@ -11,7 +11,8 @@ import { renderAppsBlocks, renderArticle } from './render.article.apps';
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'apps');
 
-	const article = enhanceArticleType(body, 'Apps');
+	const frontendData = validateAsArticleType(body);
+	const article = enhanceArticleType(frontendData, 'Apps');
 	const { html, prefetchScripts } = renderArticle(article);
 
 	// The Android app will cache these assets to enable offline reading
@@ -21,7 +22,8 @@ export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 export const handleAppsInteractive: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('interactive', 'app');
 
-	const article = enhanceArticleType(body, 'Apps');
+	const frontendData = validateAsArticleType(body);
+	const article = enhanceArticleType(frontendData, 'Apps');
 	const { html, prefetchScripts } = renderArticle(article);
 
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from 'express';
 import { Standard as ExampleArticle } from '../../fixtures/generated/fe-articles/Standard';
 import { decideFormat } from '../lib/articleFormat';
 import { enhanceBlocks } from '../model/enhanceBlocks';
-import { validateAsBlock } from '../model/validate';
+import { validateAsArticleType, validateAsBlock } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
@@ -11,7 +11,9 @@ import { renderBlocks, renderHtml } from './render.article.web';
 
 export const handleArticle: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'web');
-	const article = enhanceArticleType(body, 'Web');
+
+	const frontendData = validateAsArticleType(body);
+	const article = enhanceArticleType(frontendData, 'Web');
 	const { html, prefetchScripts } = renderHtml({
 		article,
 	});
@@ -21,7 +23,9 @@ export const handleArticle: RequestHandler = ({ body }, res) => {
 
 export const handleArticleJson: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('article', 'json');
-	const article = enhanceArticleType(body, 'Web');
+
+	const frontendData = validateAsArticleType(body);
+	const article = enhanceArticleType(frontendData, 'Web');
 	const resp = {
 		data: {
 			// TODO: We should rename this to 'article' or 'FEArticle', but first we need to investigate
@@ -40,7 +44,9 @@ export const handleArticlePerfTest: RequestHandler = (req, res, next) => {
 
 export const handleInteractive: RequestHandler = ({ body }, res) => {
 	recordTypeAndPlatform('interactive', 'web');
-	const article = enhanceArticleType(body, 'Web');
+
+	const frontendData = validateAsArticleType(body);
+	const article = enhanceArticleType(frontendData, 'Web');
 	const { html, prefetchScripts } = renderHtml({
 		article,
 	});

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -6,7 +6,6 @@ import { enhanceBlocks, enhanceMainMedia } from '../model/enhanceBlocks';
 import { enhanceCommercialProperties } from '../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../model/enhanceStandfirst';
 import { enhanceTableOfContents } from '../model/enhanceTableOfContents';
-import { validateAsArticleType } from '../model/validate';
 import type { ImageForLightbox } from './content';
 import type { FEArticleType } from './frontend';
 import { type RenderingTarget } from './renderingTarget';
@@ -52,10 +51,9 @@ const enhancePinnedPost = (
 };
 
 export const enhanceArticleType = (
-	body: unknown,
+	data: FEArticleType,
 	renderingTarget: RenderingTarget,
 ): Article => {
-	const data = validateAsArticleType(body);
 	const format = decideFormat(data.format);
 
 	const imagesForLightbox = data.config.switches.lightbox


### PR DESCRIPTION
This simplifies the function, as it now just transforms from `FEArticleType` to `Article`. It also means that the article and blocks handlers follow a similar pattern: validate, then enhance.

In addition, it means that it can be used on the "fe-articles" fixtures in tests and stories without having to include the validation step. This will make it easier to rely on the "fe-articles" fixtures only, allowing us to remove the "dcr-articles" fixtures.
