### PR TITLE
Fix Table Element Dark Mode Text

### DIFF
--- a/dotcom-rendering/src/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TableBlockComponent.tsx
@@ -8,6 +8,7 @@ const tableEmbed = css`
 		width: 100%;
 		background: ${palette.neutral[97]};
 		border-top: 0.0625rem solid ${palette.focus[400]};
+		color: ${palette.neutral[7]};
 		border-collapse: inherit;
 		tr:nth-child(odd) > td {
 			background-color: ${palette.neutral[93]};


### PR DESCRIPTION
The table font colour is switching to an (inherited) light grey in dark mode, but the background colours aren't changing so it clashes. This sets a specific font colour on the table, so that it remains a dark grey on the light table background in both light and dark mode.

| Before | After |
|--------|--------|
| ![table-before] | ![table-after] | 

[table-before]: https://github.com/user-attachments/assets/676ce06d-ac55-49a5-ac99-a12d91fe8bb6
[table-after]: https://github.com/user-attachments/assets/fdb5e221-f218-4c4c-aa8c-7a1fc1c69b0b
