### PR TITLE
Update `CalloutEmbedBlockComponent` Stories To CSF v3

### DIFF
--- a/dotcom-rendering/src/components/CalloutEmbed/Form.stories.tsx
+++ b/dotcom-rendering/src/components/CalloutEmbed/Form.stories.tsx
@@ -7,7 +7,7 @@ import { Form } from './Form';
 
 export default {
 	component: Form,
-	title: 'Components/CalloutEmbedBlockComponent/Form',
+	title: 'Components/Callout Embed Block Component/Form',
 };
 
 export const Default = () => {

--- a/dotcom-rendering/src/components/CalloutEmbedBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/CalloutEmbedBlockComponent.stories.tsx
@@ -1,42 +1,49 @@
-import { css } from '@emotion/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
 import { calloutCampaign } from '../../fixtures/manual/calloutCampaign';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { customMockFetch } from '../lib/mockRESTCalls';
-import { CalloutEmbedBlockComponent } from './CalloutEmbedBlockComponent.importable';
+import { CalloutEmbedBlockComponent as CalloutEmbedBlock } from './CalloutEmbedBlockComponent.importable';
 
-export default {
-	component: CalloutEmbedBlockComponent,
-	title: 'Components/CalloutEmbedBlockComponent',
-};
-
-const mockGoodRequestFetch = customMockFetch([
-	{
-		mockedMethod: 'POST',
-		mockedUrl:
-			'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
-		mockedStatus: 201,
+const meta = {
+	component: CalloutEmbedBlock,
+	title: 'Components/Callout Embed Block Component',
+	decorators: [centreColumnDecorator],
+	parameters: {
+		chromatic: {
+			modes: {
+				'light mobileMedium': allModes['light mobileMedium'],
+			},
+		},
 	},
-]);
+} satisfies Meta<typeof CalloutEmbedBlock>;
 
-export const Default = () => {
-	global.fetch = mockGoodRequestFetch;
+export default meta;
 
-	return (
-		<div
-			css={css`
-				width: 630px;
-				padding: 15px;
-			`}
-		>
-			<CalloutEmbedBlockComponent
-				callout={calloutCampaign}
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.News,
-				}}
-			/>
-		</div>
-	);
+type Story = StoryObj<typeof meta>;
+
+const goodRequest: Decorator<Story['args']> = (Story) => {
+	global.fetch = customMockFetch([
+		{
+			mockedMethod: 'POST',
+			mockedUrl:
+				'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
+			mockedStatus: 201,
+		},
+	]);
+
+	return <Story />;
 };
-Default.storyName = 'default';
+
+export const CalloutEmbedBlockComponent = {
+	args: {
+		callout: calloutCampaign,
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+	},
+	decorators: [goodRequest],
+} satisfies Story;


### PR DESCRIPTION
Component Story Format v3 is the default for Storybook 7+, and integrates better with some of its features[^1].

Using `satisfies` gives better type safety for args[^2]. Applied the "mobileMedium" breakpoint for Chromatic snapshots, as this component doesn't use up the space on the default "wide" breakpoint. Added the `centreColumnDecorator`, so the stories better reflect the layout commonly used in articles. Refactored the "good request" feature into a decorator. As there's only one story, renamed the story to have the same name as the component, which allows storybook to hoist the story in the UI[^3]. Also updated the `title` for the related form stories, so that they appear together in the UI.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
[^3]: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting