### PR TITLE
Handle nested images in TimelineBlockElement

### DIFF
--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -115,11 +115,11 @@ const getImages = (
 				item.elements.flatMap(getImages),
 			);
 		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
-			return element.sections.flatMap((section) =>
-				section.events.flatMap((event) =>
-					event.body.flatMap((body) => getImages(body)),
-				),
-			);
+			return element.sections.flatMap(section =>
+					section.events.flatMap(event =>
+						event.body.flatMap(getImages)
+					)
+				);
 
 		default:
 			return [];

--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -114,6 +114,13 @@ const getImages = (
 			return element.items.flatMap((item) =>
 				item.elements.flatMap(getImages),
 			);
+		case 'model.dotcomrendering.pageElements.TimelineBlockElement':
+			return element.sections.flatMap((section) =>
+				section.events.flatMap((event) =>
+					event.body.flatMap((body) => getImages(body)),
+				),
+			);
+
 		default:
 			return [];
 	}


### PR DESCRIPTION
## What does this change?

Closes #[#27570](https://github.com/guardian/frontend/issues/27570)

Lightbox is broken in the Timeline story format as the `TimelineBlockElement` isn't handled when building Lightbox images. 

Example of broken article:
https://www.theguardian.com/us-news/2024/oct/25/trump-sexual-misconduct-allegations-timeline

TimelineBlockElement json:
![Screenshot 2024-11-12 at 02 36 50](https://github.com/user-attachments/assets/7738c16c-2b04-4fc8-bbc4-553652b0cb66)

This change handles extracting the nested images from TimelineBlockElements.

## Screenshots

[before] (1 image lightboxed): 

<img width="1723" alt="Screenshot 2024-11-12 at 02 39 52" src="https://github.com/user-attachments/assets/2cf6d047-f08c-4565-974f-3eb92d973496">


[after] (22 images lightboxed): 
<img width="1728" alt="Screenshot 2024-11-12 at 02 35 37" src="https://github.com/user-attachments/assets/96fb1533-cb54-4264-b2c0-31a591a86ea1">



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
