### PR TITLE
Move commercial and reader revenue types out of `index.d.ts`

### DIFF
--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -8,22 +8,6 @@ type SharePlatform =
 
 // shared type declarations
 
-type CustomParams = {
-	sens: 't' | 'f';
-	urlkw: string[];
-	[key: string]: string | string[] | number | number[] | boolean | boolean[];
-};
-
-type AdTargeting =
-	| {
-			adUnit: string;
-			customParams: CustomParams;
-			disableAds?: false;
-	  }
-	| {
-			disableAds: true;
-	  };
-
 interface SectionNielsenAPI {
 	name: string;
 	apiID: string;

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -8,11 +8,6 @@ type SharePlatform =
 
 // shared type declarations
 
-interface AdTargetParam {
-	name: string;
-	value: string | string[];
-}
-
 type CustomParams = {
 	sens: 't' | 'f';
 	urlkw: string[];

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -13,24 +13,6 @@ interface SectionNielsenAPI {
 	apiID: string;
 }
 
-interface ReaderRevenueCategories {
-	contribute: string;
-	subscribe: string;
-	support: string;
-	supporter: string;
-	gifting?: string;
-}
-
-interface ReaderRevenuePositions {
-	header: ReaderRevenueCategories;
-	footer: ReaderRevenueCategories;
-	sideMenu: ReaderRevenueCategories;
-	ampHeader: ReaderRevenueCategories;
-	ampFooter: ReaderRevenueCategories;
-}
-
-type ReaderRevenuePosition = keyof ReaderRevenuePositions;
-
 interface MembershipPlaceholder {
 	campaignCode?: string;
 }

--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -2,7 +2,11 @@ import { adJson, stringify } from '../lib/ad-json.amp';
 import type { EditionId } from '../lib/edition';
 import type { AdType } from '../lib/real-time-config.amp';
 import { realTimeConfig } from '../lib/real-time-config.amp';
-import type { AdTargetParam, CommercialProperties } from '../types/commercial';
+import type {
+	AdTargeting,
+	AdTargetParam,
+	CommercialProperties,
+} from '../types/commercial';
 
 // Largest size first
 const inlineSizes = [

--- a/dotcom-rendering/src/components/Ad.amp.tsx
+++ b/dotcom-rendering/src/components/Ad.amp.tsx
@@ -2,7 +2,7 @@ import { adJson, stringify } from '../lib/ad-json.amp';
 import type { EditionId } from '../lib/edition';
 import type { AdType } from '../lib/real-time-config.amp';
 import { realTimeConfig } from '../lib/real-time-config.amp';
-import type { CommercialProperties } from '../types/commercial';
+import type { AdTargetParam, CommercialProperties } from '../types/commercial';
 
 // Largest size first
 const inlineSizes = [

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -5,7 +5,7 @@ import { blockLink } from '../lib/block-link.amp';
 import type { EditionId } from '../lib/edition';
 import { findBlockAdSlots } from '../lib/find-adslots.amp';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
-import type { CommercialProperties } from '../types/commercial';
+import type { AdTargeting, CommercialProperties } from '../types/commercial';
 import type { Switches } from '../types/config';
 import { Elements } from './Elements.amp';
 import { InlineAd } from './InlineAd.amp';

--- a/dotcom-rendering/src/components/BodyArticle.amp.tsx
+++ b/dotcom-rendering/src/components/BodyArticle.amp.tsx
@@ -15,6 +15,7 @@ import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import { insertDisclaimerElement } from '../model/enhance-disclaimer';
 import type { AMPArticleModel } from '../types/article.amp';
+import type { AdTargeting } from '../types/commercial';
 import type { ConfigType } from '../types/config';
 import { Elements } from './Elements.amp';
 import { Epic } from './Epic.amp';

--- a/dotcom-rendering/src/components/BodyLiveblog.amp.tsx
+++ b/dotcom-rendering/src/components/BodyLiveblog.amp.tsx
@@ -9,6 +9,7 @@ import { decideTheme } from '../lib/articleFormat';
 import { getSharingUrls } from '../lib/sharing-urls';
 import RefreshIcon from '../static/icons/refresh.svg';
 import type { AMPArticleModel } from '../types/article.amp';
+import type { AdTargeting } from '../types/commercial';
 import type { ConfigType } from '../types/config';
 import { Blocks } from './Blocks.amp';
 import { KeyEvents } from './KeyEvents.amp';

--- a/dotcom-rendering/src/components/Elements.amp.tsx
+++ b/dotcom-rendering/src/components/Elements.amp.tsx
@@ -5,6 +5,7 @@ import {
 	type ArticleTheme,
 } from '../lib/articleFormat';
 import { NotRenderableInDCR } from '../lib/errors/not-renderable-in-dcr';
+import type { AdTargeting } from '../types/commercial';
 import type { Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { TagType } from '../types/tag';

--- a/dotcom-rendering/src/components/Footer.tsx
+++ b/dotcom-rendering/src/components/Footer.tsx
@@ -20,6 +20,7 @@ import type { EditionId } from '../lib/edition';
 import { clearFix } from '../lib/mixins';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import type { PillarLinkType } from '../model/extract-nav';
+import type { ReaderRevenueCategories } from '../types/commercial';
 import type { FooterType } from '../types/footer';
 import { BackToTop } from './BackToTop';
 import { FooterLabel } from './FooterLabel.importable';

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
@@ -11,6 +11,7 @@ import { nestedOphanComponents } from '../../../../lib/ophan-helpers';
 import { usePageViewId } from '../../../../lib/usePageViewId';
 import type { LinkType } from '../../../../model/extract-nav';
 import { palette as themePalette } from '../../../../palette';
+import type { ReaderRevenuePositions } from '../../../../types/commercial';
 import { useConfig } from '../../../ConfigContext';
 import { expandedNavLinkStyles, hideFromDesktop } from '../commonStyles';
 

--- a/dotcom-rendering/src/components/ReaderRevenueButton.amp.tsx
+++ b/dotcom-rendering/src/components/ReaderRevenueButton.amp.tsx
@@ -7,6 +7,7 @@ import {
 } from '@guardian/source/foundations';
 import type { NavType } from '../model/extract-nav';
 import ArrowRight from '../static/icons/arrow-right.svg';
+import type { ReaderRevenuePosition } from '../types/commercial';
 
 const supportStyles = css`
 	align-self: flex-start;

--- a/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
+++ b/dotcom-rendering/src/components/SetAdTargeting.importable.tsx
@@ -1,5 +1,6 @@
 import { log } from '@guardian/libs';
 import { setAdTargeting } from '../lib/useAdTargeting';
+import type { AdTargeting } from '../types/commercial';
 
 type Props = {
 	adTargeting: AdTargeting;

--- a/dotcom-rendering/src/components/TopMeta.amp.tsx
+++ b/dotcom-rendering/src/components/TopMeta.amp.tsx
@@ -4,6 +4,7 @@ import {
 	type ArticleTheme,
 } from '../lib/articleFormat';
 import type { AMPArticleModel } from '../types/article.amp';
+import type { AdTargeting } from '../types/commercial';
 import { TopMetaAnalysis } from './TopMetaAnalysis.amp';
 import { TopMetaNews } from './TopMetaNews.amp';
 import { TopMetaOpinion } from './TopMetaOpinion.amp';

--- a/dotcom-rendering/src/components/TopMetaAnalysis.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaAnalysis.amp.tsx
@@ -12,6 +12,7 @@ import type { ArticleTheme } from '../lib/articleFormat';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
+import type { AdTargeting } from '../types/commercial';
 import { Branding, BrandingRegionContainer } from './Branding.amp';
 import { Byline } from './Byline.amp';
 import { MainMedia } from './MainMedia.amp';

--- a/dotcom-rendering/src/components/TopMetaNews.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaNews.amp.tsx
@@ -11,6 +11,7 @@ import type { ArticleTheme } from '../lib/articleFormat';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
 import { getSharingUrls } from '../lib/sharing-urls';
 import type { AMPArticleModel } from '../types/article.amp';
+import type { AdTargeting } from '../types/commercial';
 import { Branding, BrandingRegionContainer } from './Branding.amp';
 import { Byline } from './Byline.amp';
 import { MainMedia } from './MainMedia.amp';

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -3,6 +3,7 @@ import type { ConsentState } from '@guardian/libs';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
+import type { AdTargeting } from '../../types/commercial';
 import type {
 	ImagePositionType,
 	ImageSizeType,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -2,6 +2,7 @@ import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/libs';
 import { useCallback, useState } from 'react';
 import type { ArticleFormat } from '../../lib/articleFormat';
+import type { AdTargeting } from '../../types/commercial';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import type {
 	ImagePositionType,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -13,6 +13,7 @@ import {
 import { getVideoClient } from '../../lib/bridgetApi';
 import { getZIndex } from '../../lib/getZIndex';
 import { getAuthStatus } from '../../lib/identity';
+import type { AdTargeting } from '../../types/commercial';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import type { google } from './ima';
 import type { VideoEventKey } from './YoutubeAtom';

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.amp.tsx
@@ -1,5 +1,6 @@
 import type { ArticleTheme } from '../lib/articleFormat';
 import { constructQuery } from '../lib/querystring';
+import type { AdTargeting } from '../types/commercial';
 import type { YoutubeBlockElement } from '../types/content';
 import { Caption } from './Caption.amp';
 

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
+import type { AdTargeting } from '../types/commercial';
 import { Caption } from './Caption';
 import type {
 	ImagePositionType,

--- a/dotcom-rendering/src/lib/ad-json.amp.test.ts
+++ b/dotcom-rendering/src/lib/ad-json.amp.test.ts
@@ -1,4 +1,5 @@
 import { isUndefined } from '@guardian/libs';
+import type { AdTargetParam } from '../types/commercial';
 import { adJson, stringify } from './ad-json.amp';
 
 const paramSet: AdTargetParam[] = [

--- a/dotcom-rendering/src/lib/ad-json.amp.ts
+++ b/dotcom-rendering/src/lib/ad-json.amp.ts
@@ -1,3 +1,5 @@
+import type { AdTargetParam } from '../types/commercial';
+
 // Passed raw as configuration to the ad
 interface KV {
 	name: string;

--- a/dotcom-rendering/src/lib/ad-targeting.ts
+++ b/dotcom-rendering/src/lib/ad-targeting.ts
@@ -1,4 +1,5 @@
 import { isString } from '@guardian/libs';
+import type { AdTargeting } from '../types/commercial';
 
 export type SharedAdTargeting = Record<string, unknown>;
 

--- a/dotcom-rendering/src/lib/useAdTargeting.ts
+++ b/dotcom-rendering/src/lib/useAdTargeting.ts
@@ -1,6 +1,7 @@
 import { log } from '@guardian/libs';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
+import type { AdTargeting } from '../types/commercial';
 
 const key = 'ad-targeting';
 const apiPromise = new Promise<AdTargeting>(() => {

--- a/dotcom-rendering/src/model/extract-nav.ts
+++ b/dotcom-rendering/src/model/extract-nav.ts
@@ -1,5 +1,10 @@
 import { type ArticleTheme, Pillar } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
+import type {
+	ReaderRevenueCategories,
+	ReaderRevenuePosition,
+	ReaderRevenuePositions,
+} from '../types/commercial';
 import type { FELinkType, FENavType } from '../types/frontend';
 import { findPillar } from './find-pillar';
 

--- a/dotcom-rendering/src/types/commercial.ts
+++ b/dotcom-rendering/src/types/commercial.ts
@@ -17,3 +17,8 @@ export type CommercialProperties = {
 export type FrontsBannerAdCollections = {
 	[key: string]: string[];
 };
+
+export interface AdTargetParam {
+	name: string;
+	value: string | string[];
+}

--- a/dotcom-rendering/src/types/commercial.ts
+++ b/dotcom-rendering/src/types/commercial.ts
@@ -22,3 +22,19 @@ export interface AdTargetParam {
 	name: string;
 	value: string | string[];
 }
+
+type CustomParams = {
+	sens: 't' | 'f';
+	urlkw: string[];
+	[key: string]: string | string[] | number | number[] | boolean | boolean[];
+};
+
+export type AdTargeting =
+	| {
+			adUnit: string;
+			customParams: CustomParams;
+			disableAds?: false;
+	  }
+	| {
+			disableAds: true;
+	  };

--- a/dotcom-rendering/src/types/commercial.ts
+++ b/dotcom-rendering/src/types/commercial.ts
@@ -38,3 +38,21 @@ export type AdTargeting =
 	| {
 			disableAds: true;
 	  };
+
+export interface ReaderRevenueCategories {
+	contribute: string;
+	subscribe: string;
+	support: string;
+	supporter: string;
+	gifting?: string;
+}
+
+export interface ReaderRevenuePositions {
+	header: ReaderRevenueCategories;
+	footer: ReaderRevenueCategories;
+	sideMenu: ReaderRevenueCategories;
+	ampHeader: ReaderRevenueCategories;
+	ampFooter: ReaderRevenueCategories;
+}
+
+export type ReaderRevenuePosition = keyof ReaderRevenuePositions;

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,7 +1,10 @@
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { FEArticleBadgeType } from './badge';
-import type { CommercialProperties } from './commercial';
+import type {
+	CommercialProperties,
+	ReaderRevenuePositions,
+} from './commercial';
 import type { ConfigType, ServerSideTests } from './config';
 import type {
 	FEElement,


### PR DESCRIPTION
Another step towards addressing https://github.com/guardian/dotcom-rendering/issues/7638, this moves advertising and reader revenue types out of `index.d.ts` and imports them explicitly where appropriate.
