### PR TITLE
Move Block types out of `index.d.ts`

### DIFF
--- a/dotcom-rendering/fixtures/manual/live-blog-key-events.ts
+++ b/dotcom-rendering/fixtures/manual/live-blog-key-events.ts
@@ -1,3 +1,5 @@
+import type { Block } from '../../src/types/blocks';
+
 export const SingleKeyEvent: Block[] = [
 	{
 		id: '60300f5f8f08ad21ea60071e',

--- a/dotcom-rendering/fixtures/manual/liveBlock.ts
+++ b/dotcom-rendering/fixtures/manual/liveBlock.ts
@@ -1,3 +1,5 @@
+import type { Block } from '../../src/types/blocks';
+
 export const liveBlock: Block = {
 	secondaryDateLine: 'First published on Fri 19 Feb 2021 17.20 GMT',
 	blockFirstPublishedDisplay: '19.30 GMT',

--- a/dotcom-rendering/index.d.ts
+++ b/dotcom-rendering/index.d.ts
@@ -13,46 +13,6 @@ interface SectionNielsenAPI {
 	apiID: string;
 }
 
-interface MembershipPlaceholder {
-	campaignCode?: string;
-}
-
-interface Attributes {
-	pinned: boolean;
-	summary: boolean;
-	keyEvent: boolean;
-	membershipPlaceholder?: MembershipPlaceholder;
-}
-
-interface BlockContributor {
-	name: string;
-	imageUrl?: string;
-	largeImageUrl?: string;
-}
-
-interface Block {
-	id: string;
-	elements: import('./src/types/content').FEElement[];
-	attributes: Attributes;
-	blockCreatedOn?: number;
-	blockCreatedOnDisplay?: string;
-	blockLastUpdated?: number;
-	blockLastUpdatedDisplay?: string;
-	title?: string;
-	blockFirstPublished?: number;
-	blockFirstPublishedDisplay?: string;
-	blockFirstPublishedDisplayNoTimezone?: string;
-	primaryDateLine: string;
-	secondaryDateLine: string;
-	createdOn?: number;
-	createdOnDisplay?: string;
-	lastUpdated?: number;
-	lastUpdatedDisplay?: string;
-	firstPublished?: number;
-	firstPublishedDisplay?: string;
-	contributors?: BlockContributor[];
-}
-
 interface Pagination {
 	currentPage: number;
 	totalPages: number;

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -16,6 +16,7 @@ import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { revealStyles } from '../lib/revealStyles';
 import { palette as themePalette } from '../palette';
 import type { TableOfContentsItem } from '../types/article';
+import type { Block } from '../types/blocks';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { TagType } from '../types/tag';
 import { Island } from './Island';

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -5,6 +5,7 @@ import { blockLink } from '../lib/block-link.amp';
 import type { EditionId } from '../lib/edition';
 import { findBlockAdSlots } from '../lib/find-adslots.amp';
 import { pillarPalette_DO_NOT_USE } from '../lib/pillars';
+import type { Block } from '../types/blocks';
 import type { AdTargeting, CommercialProperties } from '../types/commercial';
 import type { Switches } from '../types/config';
 import { Elements } from './Elements.amp';

--- a/dotcom-rendering/src/components/KeyEvents.amp.tsx
+++ b/dotcom-rendering/src/components/KeyEvents.amp.tsx
@@ -6,6 +6,7 @@ import {
 } from '@guardian/source/foundations';
 import { blockLink } from '../lib/block-link.amp';
 import DownArrow from '../static/icons/down-arrow.svg';
+import type { Block } from '../types/blocks';
 
 const headingStyle = css`
 	${headlineMedium20};

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@guardian/source/react-components';
 import { useRef } from 'react';
 import { palette } from '../palette';
+import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { KeyEventCard } from './KeyEventCard';
 

--- a/dotcom-rendering/src/components/LiveBlock.stories.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.stories.tsx
@@ -4,6 +4,7 @@ import { lightDecorator } from '../../.storybook/decorators/themeDecorator';
 import { images } from '../../fixtures/generated/images';
 import { liveBlock } from '../../fixtures/manual/liveBlock';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import type { Block } from '../types/blocks';
 import { LiveBlock } from './LiveBlock';
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import type { ArticleFormat } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
 import { RenderArticleElement } from '../lib/renderElement';
+import type { Block } from '../types/blocks';
 import type { ServerSideTests, Switches } from '../types/config';
 import { Island } from './Island';
 import { LastUpdated } from './LastUpdated';

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
 import { getLiveblogAdPositions } from '../lib/getLiveblogAdPositions';
+import type { Block } from '../types/blocks';
 import type { ServerSideTests, Switches } from '../types/config';
 import { AdPlaceholder } from './AdPlaceholder.apps';
 import { AdSlot } from './AdSlot.web';

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -1,6 +1,7 @@
 import { Hide } from '@guardian/source/react-components';
 import type { ArticleFormat } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
+import type { Block } from '../types/blocks';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';

--- a/dotcom-rendering/src/components/PinnedPost.stories.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.stories.tsx
@@ -9,6 +9,7 @@ import {
 	ArticleSpecial,
 	Pillar,
 } from '../lib/articleFormat';
+import type { Block } from '../types/blocks';
 import { FormatBoundary } from './FormatBoundary';
 import { LiveBlock } from './LiveBlock';
 import { PinnedPost } from './PinnedPost';

--- a/dotcom-rendering/src/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.tsx
@@ -17,6 +17,7 @@ import {
 	SvgPlus,
 } from '@guardian/source/react-components';
 import { palette } from '../palette';
+import type { Block } from '../types/blocks';
 import { DateTime } from './DateTime';
 
 const pinnedPostContainer = css`

--- a/dotcom-rendering/src/lib/getLiveblogAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getLiveblogAdPositions.test.ts
@@ -1,4 +1,5 @@
 import { liveBlock as mockBlock } from '../../fixtures/manual/liveBlock';
+import type { Block } from '../types/blocks';
 import { getLiveblogAdPositions } from './getLiveblogAdPositions';
 
 describe('get liveblog ad positions', () => {

--- a/dotcom-rendering/src/lib/getLiveblogAdPositions.ts
+++ b/dotcom-rendering/src/lib/getLiveblogAdPositions.ts
@@ -1,3 +1,4 @@
+import type { Block } from '../types/blocks';
 import {
 	calculateApproximateBlockHeight,
 	shouldDisplayAd,

--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { isUndefined } from '@guardian/libs';
 import { getLargest, getMaster } from '../lib/image';
+import type { Block } from '../types/blocks';
 import type {
 	CartoonBlockElement,
 	FEElement,

--- a/dotcom-rendering/src/model/enhanceBlocks.ts
+++ b/dotcom-rendering/src/model/enhanceBlocks.ts
@@ -1,5 +1,6 @@
 import { isUndefined } from '@guardian/libs';
 import { type ArticleFormat } from '../lib/articleFormat';
+import type { Block } from '../types/blocks';
 import type {
 	FEElement,
 	ImageBlockElement,

--- a/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
@@ -1,4 +1,5 @@
 import { blockMetaData } from '../../fixtures/manual/block-meta-data';
+import type { Block } from '../types/blocks';
 import { enhanceTableOfContents } from './enhanceTableOfContents';
 
 describe('Enhance Table of Contents', () => {

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import type { TableOfContentsItem } from '../types/article';
+import type { Block } from '../types/blocks';
 import type {
 	NumberedTitleBlockElement,
 	SubheadingBlockElement,

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -3,6 +3,7 @@ import type { Options } from 'ajv';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import type { FEFrontType } from '../../src/types/front';
+import type { Block } from '../types/blocks';
 import type { FEArticleType } from '../types/frontend';
 import type { FENewslettersPageType } from '../types/newslettersPage';
 import type { FETagPageType } from '../types/tagPage';

--- a/dotcom-rendering/src/types/article.amp.tsx
+++ b/dotcom-rendering/src/types/article.amp.tsx
@@ -1,4 +1,5 @@
 import type { EditionId } from '../lib/edition';
+import type { Block } from './blocks';
 import type { CommercialProperties } from './commercial';
 import type { FEElement } from './content';
 import type { FEFormat, FELinkType, LegacyPillar } from './frontend';

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -6,6 +6,7 @@ import { enhanceBlocks, enhanceMainMedia } from '../model/enhanceBlocks';
 import { enhanceCommercialProperties } from '../model/enhanceCommercialProperties';
 import { enhanceStandfirst } from '../model/enhanceStandfirst';
 import { enhanceTableOfContents } from '../model/enhanceTableOfContents';
+import type { Block } from './blocks';
 import type { ImageForLightbox } from './content';
 import type { FEArticleType } from './frontend';
 import { type RenderingTarget } from './renderingTarget';

--- a/dotcom-rendering/src/types/blocks.ts
+++ b/dotcom-rendering/src/types/blocks.ts
@@ -1,0 +1,41 @@
+import type { FEElement } from './content';
+
+interface MembershipPlaceholder {
+	campaignCode?: string;
+}
+
+interface Attributes {
+	pinned: boolean;
+	summary: boolean;
+	keyEvent: boolean;
+	membershipPlaceholder?: MembershipPlaceholder;
+}
+
+interface BlockContributor {
+	name: string;
+	imageUrl?: string;
+	largeImageUrl?: string;
+}
+
+export interface Block {
+	id: string;
+	elements: FEElement[];
+	attributes: Attributes;
+	blockCreatedOn?: number;
+	blockCreatedOnDisplay?: string;
+	blockLastUpdated?: number;
+	blockLastUpdatedDisplay?: string;
+	title?: string;
+	blockFirstPublished?: number;
+	blockFirstPublishedDisplay?: string;
+	blockFirstPublishedDisplayNoTimezone?: string;
+	primaryDateLine: string;
+	secondaryDateLine: string;
+	createdOn?: number;
+	createdOnDisplay?: string;
+	lastUpdated?: number;
+	lastUpdatedDisplay?: string;
+	firstPublished?: number;
+	firstPublishedDisplay?: string;
+	contributors?: BlockContributor[];
+}

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -1,6 +1,7 @@
 import type { SharedAdTargeting } from '../lib/ad-targeting';
 import type { EditionId } from '../lib/edition';
 import type { FEArticleBadgeType } from './badge';
+import type { Block } from './blocks';
 import type {
 	CommercialProperties,
 	ReaderRevenuePositions,


### PR DESCRIPTION
Another piece addressing https://github.com/guardian/dotcom-rendering/issues/7638. Case to be made that these could/should sit along content-related types but that should be easier to do once they're out of global types land.

Branched off of https://github.com/guardian/dotcom-rendering/pull/12816 so that needs to be approved and merged before this.