### PR TITLE
Scaffold slideshow carousel component

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -1,0 +1,73 @@
+import { css } from '@emotion/react';
+import { breakpoints, space } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
+import type { DCRSlideshowImage } from '../types/front';
+import { SlideshowCarousel } from './SlideshowCarousel';
+
+const meta = {
+	component: SlideshowCarousel,
+	title: 'Components/SlideshowCarousel',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.leftCol,
+			],
+		},
+	},
+} satisfies Meta<typeof SlideshowCarousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const images = [
+	{
+		imageSrc:
+			'https://media.guim.co.uk/4199670a084d3179778332af3ee6297486332e91/0_0_4000_3000/master/4000.jpg',
+		imageCaption: 'First image in slideshow',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/fe27aabf35683caa6b89f2781ee5d0ad9042e209/0_0_4800_3197/master/4800.jpg',
+		imageCaption: 'Second image',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/326773ef9d4e78e14be0cb6f6123bfec773ddf03/0_229_5500_3300/5500.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/2b14981ddc59bce686c07fe356eb09cae48fde87/0_76_5832_3499/5832.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/cc9dc53d0eff3b047c6d045fa49cb48846a860b3/0_36_2048_1500/2048.jpg',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/ed66e9dc6a84de6bc0afe1965833f0fa4047c22d/0_324_3500_2100/3500.jpg',
+	},
+] as const satisfies readonly DCRSlideshowImage[];
+
+const Wrapper = ({ children }: { children: ReactNode }) => {
+	const styles = css`
+		margin: ${space[2]}px;
+		max-width: 460px;
+	`;
+	return <div css={styles}>{children}</div>;
+};
+
+export const Default = {
+	render: (args) => (
+		<Wrapper>
+			<SlideshowCarousel {...args} />
+		</Wrapper>
+	),
+	args: {
+		images,
+		imageSize: 'medium',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -1,0 +1,75 @@
+import { css } from '@emotion/react';
+import { palette, space, textSansBold12 } from '@guardian/source/foundations';
+import { takeFirst } from '../lib/tuple';
+import type { DCRSlideshowImage } from '../types/front';
+import type { ImageSizeType } from './Card/components/ImageWrapper';
+import { CardPicture } from './CardPicture';
+
+const carouselStyles = css`
+	display: flex;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	overscroll-behavior: contain auto;
+	/**
+	 * Hide scrollbars
+	 * See: https://stackoverflow.com/a/38994837
+	 */
+	::-webkit-scrollbar {
+		display: none; /* Safari and Chrome */
+	}
+	scrollbar-width: none; /* Firefox */
+`;
+
+const carouselItemStyles = css`
+	position: relative;
+	flex: 1 0 100%;
+	scroll-snap-align: start;
+`;
+
+const caption = css`
+	${textSansBold12}
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: linear-gradient(
+		to bottom,
+		rgba(0, 0, 0, 0) 0%,
+		rgba(0, 0, 0, 0.8) 100%
+	);
+	color: ${palette.neutral[100]};
+	padding: 60px ${space[2]}px ${space[2]}px;
+`;
+
+export const SlideshowCarousel = ({
+	images,
+	imageSize,
+}: {
+	images: readonly DCRSlideshowImage[];
+	imageSize: ImageSizeType;
+}) => (
+	<ul css={carouselStyles}>
+		{takeFirst(images, 10).map((image, index) => {
+			const loading = index > 0 ? 'lazy' : 'eager';
+			return (
+				<li css={carouselItemStyles} key={image.imageSrc}>
+					<figure>
+						<CardPicture
+							mainImage={image.imageSrc}
+							imageSize={imageSize}
+							aspectRatio="5:4"
+							alt={image.imageCaption}
+							loading={loading}
+						/>
+						{!!image.imageCaption && (
+							<figcaption css={caption}>
+								{image.imageCaption}
+							</figcaption>
+						)}
+					</figure>
+				</li>
+			);
+		})}
+	</ul>
+);


### PR DESCRIPTION
## What does this change?

Adds scaffolding for basic slideshow carousel component and example Storybook story.

## Why?

Initial work to support slideshow carousels in DCR, bringing parity between web and app.

Part of [this Trello ticket](https://trello.com/c/53tELnFE/236-slideshow-carousel-on-web)

## Screenshots

<img width="959" alt="Screenshot 2024-11-12 at 11 34 57" src="https://github.com/user-attachments/assets/caa1733c-4597-4656-a83b-9aa0950c5b99">

<img width="963" alt="Screenshot 2024-11-12 at 11 35 25" src="https://github.com/user-attachments/assets/70a73bec-157a-471b-be63-c35e324dd122">
