### PR TITLE
Fix US Marketing Card `expand` analytics event

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCard.tsx
@@ -230,10 +230,7 @@ export const ExpandableMarketingCard = ({
 								type="faded"
 								styles={imageTopStyles}
 							/>
-							<section
-								data-link-name="us-expandable-marketing-card expand"
-								css={contractedSummaryStyles}
-							>
+							<section css={contractedSummaryStyles}>
 								<div css={headingStyles}>
 									<h2>{heading}</h2>
 									<div css={arrowStyles}>

--- a/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
@@ -69,10 +69,10 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 		<>
 			<Hide when="below" breakpoint="leftCol">
 				<div
-					role="button"
+					role={!isExpanded ? 'button' : 'none'}
 					tabIndex={0}
 					onKeyDown={(event) => {
-						if (event.key === 'Enter') {
+						if (event.key === 'Enter' && !isExpanded) {
 							setIsExpanded(true);
 						}
 						if (event.key === 'Escape') {
@@ -80,8 +80,13 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 						}
 					}}
 					onClick={() => {
-						setIsExpanded(true);
+						!isExpanded && setIsExpanded(true);
 					}}
+					data-link-name={
+						!isExpanded
+							? 'us-expandable-marketing-card expand'
+							: undefined
+					}
 				>
 					<ExpandableMarketingCard
 						guardianBaseURL={guardianBaseURL}


### PR DESCRIPTION
Closes #12819

## What does this change?

- Move the `expand` data-link-name up the tree on large screen, to the clickable element.
- Remove the duplicated `us-expandable-marketing-card expand` on mobile.

## Why?

- We were not receiving as many `expand` events in the data lake as we were expecting. It may be because it was on the wrong element on large screens and duplicated on small screens.

