### PR TITLE
Carousels: Revert change to disabled button border opacity

### DIFF
--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4388,9 +4388,9 @@ const carouselChevronDisabledLight: PaletteFunction = () =>
 const carouselChevronDisabledDark: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[86], 0.32);
 const carouselChevronBorderDisabledLight: PaletteFunction = () =>
-	transparentColour(sourcePalette.neutral[73], 0.2);
+	transparentColour(sourcePalette.neutral[73], 0.32);
 const carouselChevronBorderDisabledDark: PaletteFunction = () =>
-	transparentColour(sourcePalette.neutral[73], 0.2);
+	transparentColour(sourcePalette.neutral[73], 0.32);
 
 const mostViewedFooterHoverLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];


### PR DESCRIPTION
## What does this change?

Changes the opacity of the border on disabled buttons back to 32%

## Why?

Akemi noticed a discrepancy with the colours in Figma and requested we revert the change in opacity until she can review with Alex.