### PR TITLE
Add container level property to DCR types

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -659,7 +659,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								collectionBranding={
 									collection.collectionBranding
 								}
-								containerLevel={collection.containerLevel}
+								containerLevel={
+									collection.config.containerLevel
+								}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -125,10 +125,10 @@ export const enhanceCollections = ({
 			),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
+				containerLevel: collection.config.collectionLevel,
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,
-			containerLevel: collection.containerLevel,
 		};
 	});
 };

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2697,9 +2697,6 @@
                             "collectionType": {
                                 "$ref": "#/definitions/FEContainerType"
                             },
-                            "containerLevel": {
-                                "$ref": "#/definitions/FEContainerLevel"
-                            },
                             "uneditable": {
                                 "type": "boolean"
                             },
@@ -2740,6 +2737,9 @@
                                     },
                                     "collectionType": {
                                         "$ref": "#/definitions/FEContainerType"
+                                    },
+                                    "collectionLevel": {
+                                        "$ref": "#/definitions/FEContainerLevel"
                                     },
                                     "href": {
                                         "type": "string"
@@ -3233,13 +3233,6 @@
             ],
             "type": "string"
         },
-        "FEContainerLevel": {
-            "enum": [
-                "Primary",
-                "Secondary"
-            ],
-            "type": "string"
-        },
         "FEContainerPalette": {
             "enum": [
                 "Branded",
@@ -3260,6 +3253,13 @@
                 "SombrePalette",
                 "Special",
                 "SpecialReportAltPalette"
+            ],
+            "type": "string"
+        },
+        "FEContainerLevel": {
+            "enum": [
+                "Primary",
+                "Secondary"
             ],
             "type": "string"
         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -370,6 +370,7 @@ type FECollectionConfigType = {
 	displayName: string;
 	metadata?: { type: FEContainerPalette }[];
 	collectionType: FEContainerType;
+	collectionLevel?: FEContainerLevel;
 	href?: string;
 	groups?: string[];
 	uneditable: boolean;
@@ -395,7 +396,6 @@ export type FECollectionType = {
 	href?: string;
 	groups?: string[];
 	collectionType: FEContainerType;
-	containerLevel?: FEContainerLevel;
 	uneditable: boolean;
 	showTags: boolean;
 	showSections: boolean;
@@ -413,7 +413,6 @@ export type DCRCollectionType = {
 	description?: string;
 	collectionType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
-	containerLevel?: DCRContainerLevel;
 	grouped: DCRGroupedTrails;
 	curated: DCRFrontCard[];
 	backfill: DCRFrontCard[];
@@ -421,6 +420,7 @@ export type DCRCollectionType = {
 	href?: string;
 	config: {
 		showDateHeader: boolean;
+		containerLevel?: DCRContainerLevel;
 	};
 	/**
 	 * @property {?boolean} canShowMore - Whether the 'show more' button should be shown.


### PR DESCRIPTION
## What does this change?

Adds `containerLevel` property to FE and DCR collection types and feeds through to collection level data

## Why?

Re-implements https://github.com/guardian/dotcom-rendering/pull/12710 now that we are planning to feed container level through from frontend rather than determining its value in DCR


_Below is a screenshot showing how, when combined with work in https://github.com/guardian/frontend/pull/27574 and https://github.com/guardian/facia-tool/pull/1719 we can pull the container level data all the way through to the container, where the first container has a secondary level and the second has a primary level :_ 

<img width="1315" alt="Screenshot 2024-11-14 at 10 02 08" src="https://github.com/user-attachments/assets/0d771950-7796-4767-93ef-3b18bee0eedb">

