### PR TITLE
datawrapper: Use dark background in dark mode

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -113,7 +113,11 @@ const wrapperStyle = ({
 	isDatawrapperGraphic: boolean;
 }) => css`
 	${format.theme === ArticleSpecial.Labs ? textSans17 : article17}
-	background-color: ${themePalette('--interactive-block-background')};
+	background-color: ${themePalette(
+		isDatawrapperGraphic
+			? '--interactive-block-background-datawrapper'
+			: '--interactive-block-background',
+	)};
 	min-height: ${getMinHeight(role, loaded)};
 	position: relative;
 	display: flex;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4109,12 +4109,12 @@ const interactiveBlockBackgroundDatawrapperDark: PaletteFunction = ({
 		case ArticleDesign.Editorial:
 			switch (theme) {
 				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.specialReportAlt[100];
+					return sourcePalette.specialReportAlt[100]; // same as articleBackgroundDark
 				default:
-					return sourcePalette.neutral[10];
+					return sourcePalette.neutral[10]; // same as articleBackgroundDark
 			}
 		default:
-			return sourcePalette.neutral[10];
+			return sourcePalette.neutral[10]; // same as articleBackgroundDark
 	}
 };
 

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6551,6 +6551,10 @@ const paletteColours = {
 		light: interactiveBlockBackgroundLight,
 		dark: interactiveBlockBackgroundDark,
 	},
+	'--interactive-block-background-datawrapper': {
+		light: interactiveBlockBackgroundLight,
+		dark: articleBackgroundDark,
+	},
 	'--interactive-contents-hover': {
 		light: interactiveContentsHoverLight,
 		dark: interactiveContentsHoverDark,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4087,6 +4087,38 @@ const interactiveBlockBackgroundLight: PaletteFunction = ({
 
 const interactiveBlockBackgroundDark = () => sourcePalette.neutral[100];
 
+const interactiveBlockBackgroundDatawrapperDark: PaletteFunction = ({
+	design,
+	theme,
+}) => {
+	switch (design) {
+		case ArticleDesign.DeadBlog:
+			return sourcePalette.neutral[7];
+		case ArticleDesign.LiveBlog:
+			return sourcePalette.neutral[10];
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[100];
+				default:
+					return sourcePalette.neutral[10];
+			}
+		default:
+			return sourcePalette.neutral[10];
+	}
+};
+
 const mostViewedHeadlineLight = (): string => sourcePalette.neutral[7];
 const mostViewedHeadlineDark = (): string => sourcePalette.neutral[86];
 
@@ -6553,7 +6585,7 @@ const paletteColours = {
 	},
 	'--interactive-block-background-datawrapper': {
 		light: interactiveBlockBackgroundLight,
-		dark: articleBackgroundDark,
+		dark: interactiveBlockBackgroundDatawrapperDark,
 	},
 	'--interactive-contents-hover': {
 		light: interactiveContentsHoverLight,

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4093,9 +4093,8 @@ const interactiveBlockBackgroundDatawrapperDark: PaletteFunction = ({
 }) => {
 	switch (design) {
 		case ArticleDesign.DeadBlog:
-			return sourcePalette.neutral[7];
 		case ArticleDesign.LiveBlog:
-			return sourcePalette.neutral[10];
+			return sourcePalette.neutral[10]; // same as liveBlockContainerBackgroundDark
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
 		case ArticleDesign.Explainer:


### PR DESCRIPTION
## What does this change?

This PR changes (only) datawrapper interactive block components to set a dark background in dark mode, instead of the white background currently set.

## Why?

At the moment, interactive block components set a white background in dark mode because interactive embeds are assumed not to handle dark mode.

This was done in https://github.com/guardian/dotcom-rendering/pull/10578, later modified in https://github.com/guardian/dotcom-rendering/pull/10580 to remove transparency.

This blocks the use of datawrapper’s automatic dark mode, because it causes it to display dark mode colours on a white background. This PR lets us use the automatic dark mode.

## Implementation Notes

I wasn’t entirely sure which colours to use: articleBackgroundDark seems the obvious choice (and is what I’ve gone with), but then why doesn’t interactiveBlockBackgroundList use articleBackgroundLight?

## Screenshots

| Before (auto dark mode on)      | After (auto dark mode on)      |
| ----------- | ---------- |
| ![before-auto-dark-on][] | ![after-auto-dark-on][] |

| Before (auto dark mode off)      | After (auto dark mode off)      |
| ----------- | ---------- |
| ![before-auto-dark-off][] | ![after-auto-dark-off][] |

[before-auto-dark-on]: https://github.com/user-attachments/assets/26209ec3-91aa-4690-afd6-7c312fcd933c
[after-auto-dark-on]: https://github.com/user-attachments/assets/b02f3d6a-8322-4eef-bc80-eca0f6dffebb
[after-auto-dark-off]: https://github.com/user-attachments/assets/2db55f87-b4fb-4699-8469-28694f915f3b
[before-auto-dark-off]: https://github.com/user-attachments/assets/8f87c72b-4d65-48e9-a083-0fa5f701ca0b

| Before (auto dark mode off; live blog)      | After (auto dark mode off; live blog)      |
| ----------- | ---------- |
| ![before-auto-dark-off-live-blog][] | ![after-auto-dark-off-live-blog][] |

| Before (auto dark mode on; live blog)      | After (auto dark mode on; live blog)      |
| ----------- | ---------- |
| ![before-auto-dark-on-live-blog][] | ![after-auto-dark-on-live-blog][] |

[before-auto-dark-off-live-blog]: https://github.com/user-attachments/assets/5ea88c0e-83ac-47e2-84ce-cce7ade7666f
[after-auto-dark-off-live-blog]: https://github.com/user-attachments/assets/8b7536f5-ed01-417d-b8d1-31289802c73c
[before-auto-dark-on-live-blog]: https://github.com/user-attachments/assets/446f10dc-5d4e-4326-9cdc-c46e035a9756
[after-auto-dark-on-live-blog]: https://github.com/user-attachments/assets/d46a0aa3-67f0-4ad6-855b-f69d1d7a4407

| Before (auto dark mode off; dead blog)      | After (auto dark mode off; dead blog)      |
| ----------- | ---------- |
|  | ![after-auto-dark-off-dead-blog][] |

| Before (auto dark mode on; dead blog)      | After (auto dark mode on; dead blog)      |
| ----------- | ---------- |
|  | ![after-auto-dark-on-dead-blog][] |

[after-auto-dark-off-dead-blog]: https://github.com/user-attachments/assets/5e7cca6d-cd99-4ab0-9943-4bd9bbb96f8b
[after-auto-dark-on-dead-blog]: https://github.com/user-attachments/assets/4f3f4329-b2de-4783-acc0-887169ae3621

Note: the “after” is using a local instance of DCR with frontend-CODE, which seems to cause the overlap error with the sidebar behind.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
