### PR TITLE
Remove X / Twitter from AMP footer

### DIFF
--- a/dotcom-rendering/src/components/Footer.amp.tsx
+++ b/dotcom-rendering/src/components/Footer.amp.tsx
@@ -79,10 +79,6 @@ export const footerLinks: Link[][] = [
 			title: 'Facebook',
 			url: 'https://www.facebook.com/theguardian',
 		},
-		{
-			title: 'X',
-			url: 'https://x.com/guardian',
-		},
 	],
 	[
 		{


### PR DESCRIPTION
## What does this change?

Removing the link to X (Twitter) in the AMP footer.

## Why?

💩
