### PR TITLE
Use headline size from SDC model for mobile banner

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -325,6 +325,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						heading={content.mainContent.heading}
 						mobileHeading={content.mobileContent.heading}
 						headerSettings={templateSettings.headerSettings}
+						headlineSize={design.fonts?.heading.size ?? 'medium'}
 					/>
 				</div>
 				<div css={styles.contentContainer(showReminder)}>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -9,6 +9,7 @@ import {
 	headlineBold24,
 	headlineBold28,
 	headlineBold34,
+	headlineMedium17,
 	neutral,
 	space,
 } from '@guardian/source/foundations';
@@ -24,15 +25,17 @@ interface DesignableBannerHeaderProps {
 	heading: JSX.Element | JSX.Element[] | null;
 	mobileHeading: JSX.Element | JSX.Element[] | null;
 	headerSettings: HeaderSettings | undefined;
+	headlineSize: 'small' | 'medium' | 'large';
 }
 
 export function DesignableBannerHeader({
 	heading,
 	mobileHeading,
 	headerSettings,
+	headlineSize,
 }: DesignableBannerHeaderProps): JSX.Element {
 	const isTabletOrAbove = useMatchMedia(removeMediaRulePrefix(from.tablet));
-	const styles = getStyles(headerSettings);
+	const styles = getStyles(headerSettings, headlineSize);
 
 	const resolveImage = (settings: Image) => {
 		return (
@@ -55,7 +58,10 @@ export function DesignableBannerHeader({
 	);
 }
 
-const getStyles = (headerSettings: HeaderSettings | undefined) => {
+const getStyles = (
+	headerSettings: HeaderSettings | undefined,
+	headlineSize: 'small' | 'medium' | 'large',
+) => {
 	const color = headerSettings?.textColour ?? neutral[0];
 	const copyTopMargin = headerSettings?.headerImage ? space[6] : space[3];
 	const containerMargin = headerSettings?.headerImage ? `${space[6]}px` : '0';
@@ -70,7 +76,7 @@ const getStyles = (headerSettings: HeaderSettings | undefined) => {
 				margin: ${copyTopMargin}px 0 ${space[3]}px;
 				color: ${color};
 
-				${headlineBold24}
+				${headlineSize === 'small' ? headlineMedium17 : headlineBold24}
 				${from.tablet} {
 					${headlineBold28}
 					margin-bottom: ${space[6]}px;


### PR DESCRIPTION
## What does this change?

Enables the ability to change the size of the designable banner headline from medium (current default) to small for the mobile breakpoint when the small size is selected in the RRCP design.

This PR required: 
- [support-dotcom-components PR1245](https://github.com/guardian/support-dotcom-components/pull/1245) to add the font to the model.
- [dotcom-rendering PR12834](https://github.com/guardian/dotcom-rendering/pull/12834) - to bump support-dotcom-components (and fix breaking changes)

[Trello ticket](https://trello.com/c/RKgNkcgw)

## Why?

This is intended to be used with tiny banners such as the abandoned basket and app download banners with no copy and will be configurable in the RRCP banner design tool.

## Screenshots of stories

### Before

<img width="316" alt="Screenshot 2024-11-04 at 17 51 09" src="https://github.com/user-attachments/assets/50723b12-df53-4f35-8f21-4244342c9328">

### After: 

<img width="316" alt="Screenshot 2024-11-04 at 17 50 38" src="https://github.com/user-attachments/assets/85e3d509-716b-4710-86b9-5c7f97155b8b">


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
