### PR TITLE
Add touch start and end events for key events carousel

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -86,6 +86,10 @@ export const getDiscussionClient: BridgetApi<'getDiscussionClient'> = () => ({
 	recommend: async () => discussionErrorResponse,
 });
 
+export const getInteractionClient: BridgetApi<
+	'getInteractionClient'
+> = () => ({});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -100,6 +104,7 @@ export const ensure_all_exports_are_present = {
 	getNewslettersClient,
 	getDiscussionClient,
 	getTagClient,
+	getInteractionClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -38,7 +38,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/braze-components": "21.0.0",
-		"@guardian/bridget": "8.0.0",
+		"@guardian/bridget": "8.1.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "50.13.0",
 		"@guardian/commercial": "23.7.4",

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -116,6 +116,7 @@ export const KeyEventsCarousel = ({
 }: Props) => {
 	const carousel = useRef<HTMLDivElement | null>(null);
 	const cardWidth = 200;
+	const isApps = renderingTarget === 'Apps';
 
 	const goPrevious = () => {
 		if (carousel.current) carousel.current.scrollLeft -= cardWidth;
@@ -152,8 +153,8 @@ export const KeyEventsCarousel = ({
 				<div css={titleStyles}>Key events</div>
 			</Hide>
 			<div
-				onTouchStart={onTouchStart}
-				onTouchEnd={debouncedOnTouchEnd}
+				onTouchStart={isApps ? onTouchStart : undefined}
+				onTouchEnd={isApps ? debouncedOnTouchEnd : undefined}
 				ref={carousel}
 				id="key-events-carousel"
 				css={[carouselStyles, shortCarousel && leftMarginStyles]}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -7,7 +7,7 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { useRef } from 'react';
-import { getVideoClient } from '../lib/bridgetApi';
+import { getInteractionClient } from '../lib/bridgetApi';
 import { palette } from '../palette';
 import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -125,11 +125,11 @@ export const KeyEventsCarousel = ({
 	};
 
 	const onTouchStart = async () => {
-		await getVideoClient().setFullscreen(true);
+		await getInteractionClient().disableArticleSwipe(true);
 	};
 
 	const onTouchEnd = async () => {
-		await getVideoClient().setFullscreen(false);
+		await getInteractionClient().disableArticleSwipe(false);
 	};
 
 	const filteredKeyEvents = keyEvents.filter(isValidKeyEvent);

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -7,11 +7,11 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { useRef } from 'react';
+import { getVideoClient } from '../lib/bridgetApi';
 import { palette } from '../palette';
 import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { KeyEventCard } from './KeyEventCard';
-import { getVideoClient } from '../lib/bridgetApi';
 
 interface Props {
 	keyEvents: Block[];

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -11,6 +11,7 @@ import { palette } from '../palette';
 import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { KeyEventCard } from './KeyEventCard';
+import { getVideoClient } from '../lib/bridgetApi';
 
 interface Props {
 	keyEvents: Block[];
@@ -121,6 +122,17 @@ export const KeyEventsCarousel = ({
 	const goNext = () => {
 		if (carousel.current) carousel.current.scrollLeft += cardWidth;
 	};
+
+	const onTouchStart = async () => {
+		console.log('User started scrolling');
+		await getVideoClient().setFullscreen(true);
+	};
+
+	const onTouchEnd = async () => {
+		console.log('User stopped scrolling');
+		await getVideoClient().setFullscreen(false);
+	};
+
 	const filteredKeyEvents = keyEvents.filter(isValidKeyEvent);
 	const carouselLength = filteredKeyEvents.length;
 	const shortCarousel = carouselLength <= 4;
@@ -132,6 +144,9 @@ export const KeyEventsCarousel = ({
 				<div css={titleStyles}>Key events</div>
 			</Hide>
 			<div
+				// onScroll={onScrollCarousel}
+				onTouchStart={onTouchStart}
+				onTouchEnd={onTouchEnd}
 				ref={carousel}
 				id="key-events-carousel"
 				css={[carouselStyles, shortCarousel && leftMarginStyles]}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -6,8 +6,7 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import debounce from 'lodash.debounce';
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 import { getVideoClient } from '../lib/bridgetApi';
 import { palette } from '../palette';
 import type { Block } from '../types/blocks';
@@ -126,21 +125,12 @@ export const KeyEventsCarousel = ({
 	};
 
 	const onTouchStart = async () => {
-		console.log('User started scrolling');
 		await getVideoClient().setFullscreen(true);
-
-		// Cancel the debounced onTouchEnd if it's pending
-		debouncedOnTouchEnd.cancel();
 	};
 
-	const debouncedOnTouchEnd = useMemo(
-		() =>
-			debounce(() => {
-				console.log('User stopped scrolling');
-				getVideoClient().setFullscreen(false).catch(console.error);
-			}, 500),
-		[],
-	);
+	const onTouchEnd = async () => {
+		await getVideoClient().setFullscreen(false);
+	};
 
 	const filteredKeyEvents = keyEvents.filter(isValidKeyEvent);
 	const carouselLength = filteredKeyEvents.length;
@@ -154,7 +144,7 @@ export const KeyEventsCarousel = ({
 			</Hide>
 			<div
 				onTouchStart={isApps ? onTouchStart : undefined}
-				onTouchEnd={isApps ? debouncedOnTouchEnd : undefined}
+				onTouchEnd={isApps ? onTouchEnd : undefined}
 				ref={carousel}
 				id="key-events-carousel"
 				css={[carouselStyles, shortCarousel && leftMarginStyles]}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -6,13 +6,13 @@ import {
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
-import { useCallback, useRef } from 'react';
+import debounce from 'lodash.debounce';
+import { useMemo, useRef } from 'react';
 import { getVideoClient } from '../lib/bridgetApi';
 import { palette } from '../palette';
 import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { KeyEventCard } from './KeyEventCard';
-import debounce from 'lodash.debounce';
 
 interface Props {
 	keyEvents: Block[];
@@ -132,11 +132,12 @@ export const KeyEventsCarousel = ({
 		debouncedOnTouchEnd.cancel();
 	};
 
-	const debouncedOnTouchEnd = useCallback(
-		debounce(() => {
-			console.log('User stopped scrolling');
-			getVideoClient().setFullscreen(false).catch(console.error);
-		}, 500),
+	const debouncedOnTouchEnd = useMemo(
+		() =>
+			debounce(() => {
+				console.log('User stopped scrolling');
+				getVideoClient().setFullscreen(false).catch(console.error);
+			}, 500),
 		[],
 	);
 

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -4,6 +4,7 @@ import * as Commercial from '@guardian/bridget/Commercial';
 import * as Discussion from '@guardian/bridget/Discussion';
 import * as Environment from '@guardian/bridget/Environment';
 import * as Gallery from '@guardian/bridget/Gallery';
+import * as Interaction from '@guardian/bridget/Interaction';
 import * as Metrics from '@guardian/bridget/Metrics';
 import * as Navigation from '@guardian/bridget/Navigation';
 import * as Newsletters from '@guardian/bridget/Newsletters';
@@ -164,4 +165,16 @@ export const getDiscussionClient = (): Discussion.Client<void> => {
 		);
 	}
 	return discussionClient;
+};
+
+let interactionClient: Interaction.Client<void> | undefined = undefined;
+export const getInteractionClient = (): Interaction.Client<void> => {
+	if (!interactionClient) {
+		interactionClient = createAppClient<Interaction.Client<void>>(
+			Interaction.Client,
+			'buffered',
+			'compact',
+		);
+	}
+	return interactionClient;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,8 +329,8 @@ importers:
         specifier: 21.0.0
         version: 21.0.0(@emotion/react@11.11.3)(@guardian/libs@19.2.1)(@guardian/source@8.0.0)(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 8.1.0
+        version: 8.1.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.23.0)(tslib@2.6.2)
@@ -3774,8 +3774,8 @@ packages:
     resolution: {integrity: sha512-S0NmkyYd1hQRyOUj7l9Ddfr6FKEHJFLpS2jSMkGexCSscsZd7e8JBdFmlKSUljt4G6hrxcaaevsV4QfT9LnhUg==}
     dev: false
 
-  /@guardian/bridget@8.0.0:
-    resolution: {integrity: sha512-ae+yENkvcEOZBDqFE8RkdjyLki/iczatDc+MBTZS2vipmrcTeP0lOkZcsq/QxlNMSvZ6HNOETV8MIcGK/Gx3Hw==}
+  /@guardian/bridget@8.1.0:
+    resolution: {integrity: sha512-Sr2bvoUprOwuYVI4K1fpvDlOj5/5AMfTMZ/kx7gc8q/AUggIoejU3uvF00nFq9/AAe1EpLQcNU/mOfih8+oDGg==}
     dev: false
 
   /@guardian/browserslist-config@6.1.0(browserslist@4.23.0)(tslib@2.6.2):


### PR DESCRIPTION
## What does this change?
This PR is adding `onTouchStart` & `onTouchEnd` event handlers for the liveblog carousel. These event handlers call the new bridget function `disableArticleSwipe` to inform the native layer (android) if the user is touching/untouching the carousel. 

## Why?
Android has a feature for article swiping where user can swipe between article by scrolling left & right. This feature contradicts with the horizontal scrolling of components within the dcr rendered articles (e.g. carousel). 

Using the new bridget function, DCR informs the native layer that user wants to do horizontal scrolling, and android will disable the article swiping feature. Disabling article swiping, allows the user to do horizontal scrolling within the article. 

**Note 1:** This change doesn't affect ios. 

**Note 2:** This change was tested with MAPI change in https://github.com/guardian/mobile-apps-api/pull/3370 and with android change in https://github.com/guardian/android-news-app/pull/10947

**Note 3:** We are not dependant on android pull request to merge. MAPI and DCR change can be released though they won't have any impact until android change is released. 

## Screenshots
### Android
| Before      | After      |
| ----------- | ---------- |
| <video src="https://github.com/user-attachments/assets/cf84c24e-9fda-4e83-b707-1f1bf82832a0">Before sending touch events</video> | <video src="https://github.com/user-attachments/assets/0ab3ff2e-da52-4583-8089-0982fe7b7679">After sending touch events</video> |

### ios (No difference between before and after)
| Before      | After      |
| ----------- | ---------- |
| <video src="https://github.com/user-attachments/assets/7d3154a3-2252-43a4-8d9b-3f64b21f76ff">Before sending touch events</video> | <video src="https://github.com/user-attachments/assets/bfde704b-afa9-4f9b-9f89-1a41fa3ab70f">After sending touch events</video> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
