### PR TITLE
Slideshow: Add navigation controls

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -80,7 +80,7 @@ export const SlideshowCarousel = ({
 	images: readonly DCRSlideshowImage[];
 	imageSize: ImageSizeType;
 }) => {
-	const carouselRef = useRef<HTMLOListElement | null>(null);
+	const carouselRef = useRef<HTMLUListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
 	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
 
@@ -176,9 +176,8 @@ export const SlideshowCarousel = ({
 					}
 					size="small"
 					disabled={!previousButtonEnabled}
-					// TODO
-					// aria-label="Previous story"
-					// data-link-name="container left chevron"
+					aria-label="Move image carousel backwards"
+					// TODO: data-link-name="slideshow carousel left chevron"
 				/>
 
 				<Button
@@ -192,9 +191,8 @@ export const SlideshowCarousel = ({
 					}
 					size="small"
 					disabled={!nextButtonEnabled}
-					// TODO
-					// aria-label="Next story"
-					// data-link-name="container right chevron"
+					aria-label="Move image carousel forwards"
+					// TODO: data-link-name="slideshow carousel right chevron"
 				/>
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -1,9 +1,32 @@
 import { css } from '@emotion/react';
-import { palette, space, textSansBold12 } from '@guardian/source/foundations';
+import {
+	palette as sourcePalette,
+	space,
+	textSansBold12,
+} from '@guardian/source/foundations';
+import type { ThemeButton } from '@guardian/source/react-components';
+import {
+	Button,
+	SvgChevronLeftSingle,
+	SvgChevronRightSingle,
+} from '@guardian/source/react-components';
 import { takeFirst } from '../lib/tuple';
+import { palette } from '../palette';
 import type { DCRSlideshowImage } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
+
+const themeButton: Partial<ThemeButton> = {
+	borderTertiary: palette('--carousel-chevron-border'),
+	textTertiary: palette('--carousel-chevron'),
+	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
+};
+
+const themeButtonDisabled: Partial<ThemeButton> = {
+	borderTertiary: palette('--carousel-chevron-border-disabled'),
+	textTertiary: palette('--carousel-chevron-disabled'),
+	backgroundTertiaryHover: 'transparent',
+};
 
 const carouselStyles = css`
 	display: flex;
@@ -27,7 +50,7 @@ const carouselItemStyles = css`
 	scroll-snap-align: start;
 `;
 
-const caption = css`
+const captionStyles = css`
 	${textSansBold12}
 	position: absolute;
 	bottom: 0;
@@ -38,8 +61,15 @@ const caption = css`
 		rgba(0, 0, 0, 0) 0%,
 		rgba(0, 0, 0, 0.8) 100%
 	);
-	color: ${palette.neutral[100]};
+	color: ${sourcePalette.neutral[100]};
 	padding: 60px ${space[2]}px ${space[2]}px;
+`;
+
+const buttonStyles = css`
+	display: flex;
+	justify-content: flex-end;
+	gap: ${space[2]}px;
+	margin-top: ${space[2]}px;
 `;
 
 export const SlideshowCarousel = ({
@@ -49,27 +79,58 @@ export const SlideshowCarousel = ({
 	images: readonly DCRSlideshowImage[];
 	imageSize: ImageSizeType;
 }) => (
-	<ul css={carouselStyles}>
-		{takeFirst(images, 10).map((image, index) => {
-			const loading = index > 0 ? 'lazy' : 'eager';
-			return (
-				<li css={carouselItemStyles} key={image.imageSrc}>
-					<figure>
-						<CardPicture
-							mainImage={image.imageSrc}
-							imageSize={imageSize}
-							aspectRatio="5:4"
-							alt={image.imageCaption}
-							loading={loading}
-						/>
-						{!!image.imageCaption && (
-							<figcaption css={caption}>
-								{image.imageCaption}
-							</figcaption>
-						)}
-					</figure>
-				</li>
-			);
-		})}
-	</ul>
+	<div>
+		<ul css={carouselStyles}>
+			{takeFirst(images, 10).map((image, index) => {
+				const loading = index > 0 ? 'lazy' : 'eager';
+				return (
+					<li css={carouselItemStyles} key={image.imageSrc}>
+						<figure>
+							<CardPicture
+								mainImage={image.imageSrc}
+								imageSize={imageSize}
+								aspectRatio="5:4"
+								alt={image.imageCaption}
+								loading={loading}
+							/>
+							{!!image.imageCaption && (
+								<figcaption css={captionStyles}>
+									{image.imageCaption}
+								</figcaption>
+							)}
+						</figure>
+					</li>
+				);
+			})}
+		</ul>
+		<div css={buttonStyles}>
+			<Button
+				hideLabel={true}
+				iconSide="left"
+				icon={<SvgChevronLeftSingle />}
+				// onClick={() => scrollTo('left')}
+				priority="tertiary"
+				theme={themeButtonDisabled}
+				size="small"
+				// disabled={!previousButtonEnabled}
+				// TODO
+				// aria-label="Previous story"
+				// data-link-name="container left chevron"
+			/>
+
+			<Button
+				hideLabel={true}
+				iconSide="left"
+				icon={<SvgChevronRightSingle />}
+				// onClick={() => scrollTo('right')}
+				priority="tertiary"
+				theme={themeButton}
+				size="small"
+				// disabled={!nextButtonEnabled}
+				// TODO
+				// aria-label="Next story"
+				// data-link-name="container right chevron"
+			/>
+		</div>
+	</div>
 );


### PR DESCRIPTION
## What does this change?

Adds navigation controls and state management to slideshow carousel component.

## Why?

Part of the work to [support slideshow carousels in DCR](https://trello.com/c/53tELnFE/236-slideshow-carousel-on-web), bringing parity between web and app.

## Screenshots

<img width="953" alt="Screenshot 2024-11-13 at 16 11 23" src="https://github.com/user-attachments/assets/5cc27622-7b5b-45d8-8847-d87a0952a23b">

<img width="957" alt="Screenshot 2024-11-13 at 16 11 40" src="https://github.com/user-attachments/assets/eaad238a-1dc6-449b-a3fb-ccab8543e080">
