### PR TITLE
Remove `randomUUID` From Lightbox

### DIFF
--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { isUndefined } from '@guardian/libs';
 import { getLargest, getMaster } from '../lib/image';
 import type {
@@ -176,8 +175,8 @@ export const buildLightboxImages = (
 	// we deduplicate the array here
 	return [
 		...new Map(
-			lightboxImages.map<[string, ImageForLightbox]>((image) => [
-				decideImageId(image) ?? randomUUID(),
+			lightboxImages.map<[string, ImageForLightbox]>((image, index) => [
+				decideImageId(image) ?? `lightbox-image-id-${index}`,
 				image,
 			]),
 		).values(),


### PR DESCRIPTION
This key is only being used to de-duplicate the list of images, and is dropped immediately when the `values` method is called. Therefore, for this purpose, a key based upon the array index is unique enough, and we don't need to involve `node:crypto`.
