### PR TITLE
Switch To "fe-articles" Fixtures In `canRenderAds` Tests

### DIFF
--- a/dotcom-rendering/src/lib/canRenderAds.test.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.test.ts
@@ -1,5 +1,8 @@
-import { Standard as standardPage } from '../../fixtures/generated/dcr-articles/Standard';
+import { Standard } from '../../fixtures/generated/fe-articles/Standard';
+import { enhanceArticleType } from '../types/article';
 import { canRenderAds } from './canRenderAds';
+
+const standardPage = enhanceArticleType(Standard, 'Web');
 
 describe('canRenderAds', () => {
 	it('shows ads by default', () => {


### PR DESCRIPTION
We'd like to remove the "dcr-articles" fixtures and this is one of the few places they are used.

The article is instead generated from the "fe-articles" fixtures.
