### PR TITLE
Slideshow: add pagination dots

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	palette as sourcePalette,
-	space,
-	textSansBold12,
-	width,
-} from '@guardian/source/foundations';
+import { space, textSansBold12, width } from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
 import {
 	Button,
@@ -63,7 +58,7 @@ const captionStyles = css`
 		rgba(0, 0, 0, 0) 0%,
 		rgba(0, 0, 0, 0.8) 100%
 	);
-	color: ${sourcePalette.neutral[100]};
+	color: ${palette('--slideshow-caption')};
 	padding: 60px ${space[2]}px ${space[2]}px;
 `;
 
@@ -76,6 +71,7 @@ const navigationStyles = css`
 const paginationStyles = css`
 	display: flex;
 	justify-content: center;
+	align-items: center;
 	gap: ${space[1]}px;
 	flex: 1 0 0;
 	padding-left: ${space[2] + width.ctaSmall * 2}px;
@@ -85,14 +81,13 @@ const dotStyles = css`
 	width: 7px;
 	height: 7px;
 	border-radius: 100%;
-	background-color: ${sourcePalette.neutral[7]};
-	opacity: 0.2;
+	background-color: ${palette('--slideshow-pagination-dot')};
 `;
 
-const selectedDotStyles = css`
+const activeDotStyles = css`
 	width: 8px;
 	height: 8px;
-	opacity: 1;
+	background-color: ${palette('--slideshow-pagination-dot-active')};
 `;
 
 const buttonStyles = css`
@@ -202,7 +197,7 @@ export const SlideshowCarousel = ({
 						<span
 							css={[
 								dotStyles,
-								currentPage === index && selectedDotStyles,
+								currentPage === index && activeDotStyles,
 							]}
 							key={image.imageSrc}
 						/>

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -68,13 +68,17 @@ const navigationStyles = css`
 	margin-top: ${space[2]}px;
 `;
 
+/**
+ * Padding is added to the left of the navigation dots to match the width of the
+ * navigation buttons on the right so they are centred below the image.
+ */
 const paginationStyles = css`
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	gap: ${space[1]}px;
 	flex: 1 0 0;
-	padding-left: ${space[2] + width.ctaSmall * 2}px;
+	padding-left: ${width.ctaSmall * 2 + space[2]}px;
 `;
 
 const dotStyles = css`

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -82,17 +82,18 @@ const paginationStyles = css`
 `;
 
 const dotStyles = css`
-	width: 6px;
-	height: 6px;
+	width: 7px;
+	height: 7px;
 	border-radius: 100%;
-	background-color: ${sourcePalette.neutral[86]};
+	background-color: ${sourcePalette.neutral[7]};
+	opacity: 0.2;
 `;
 
-// const selectedDotStyles = css`
-// 	width: 8px;
-// 	height: 8px;
-// 	background-color: ${sourcePalette.neutral[0]};
-// `;
+const selectedDotStyles = css`
+	width: 8px;
+	height: 8px;
+	opacity: 1;
+`;
 
 const buttonStyles = css`
 	display: flex;
@@ -109,6 +110,7 @@ export const SlideshowCarousel = ({
 	const carouselRef = useRef<HTMLUListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
 	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
+	const [currentPage, setCurrentPage] = useState(0);
 
 	const scrollTo = (direction: 'left' | 'right') => {
 		if (!carouselRef.current) return;
@@ -130,16 +132,22 @@ export const SlideshowCarousel = ({
 	 * button is disabled if the carousel is at the start, and the next button
 	 * is disabled if the carousel is at the end.
 	 */
-	const updateButtonVisibilityOnScroll = () => {
+	const updatePaginationStateOnScroll = () => {
 		const carouselElement = carouselRef.current;
 		if (!carouselElement) return;
 
 		const scrollLeft = carouselElement.scrollLeft;
+
 		const maxScrollLeft =
 			carouselElement.scrollWidth - carouselElement.clientWidth;
 
 		setPreviousButtonEnabled(scrollLeft > 0);
 		setNextButtonEnabled(scrollLeft < maxScrollLeft);
+
+		const cardWidth = carouselElement.querySelector('li')?.offsetWidth ?? 0;
+		const page = Math.round(scrollLeft / cardWidth);
+
+		setCurrentPage(page);
 	};
 
 	useEffect(() => {
@@ -148,13 +156,13 @@ export const SlideshowCarousel = ({
 
 		carouselElement.addEventListener(
 			'scroll',
-			updateButtonVisibilityOnScroll,
+			updatePaginationStateOnScroll,
 		);
 
 		return () => {
 			carouselElement.removeEventListener(
 				'scroll',
-				updateButtonVisibilityOnScroll,
+				updatePaginationStateOnScroll,
 			);
 		};
 	}, []);
@@ -190,8 +198,14 @@ export const SlideshowCarousel = ({
 			</ul>
 			<div css={navigationStyles}>
 				<div css={paginationStyles}>
-					{takeFirst(images, 10).map((image) => (
-						<span css={dotStyles} key={image.imageSrc} />
+					{takeFirst(images, 10).map((image, index) => (
+						<span
+							css={[
+								dotStyles,
+								currentPage === index && selectedDotStyles,
+							]}
+							key={image.imageSrc}
+						/>
 					))}
 				</div>
 				<div css={buttonStyles}>

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -221,7 +221,7 @@ export const SlideshowCarousel = ({
 						}
 						size="small"
 						disabled={!previousButtonEnabled}
-						aria-label="Move image carousel backwards"
+						aria-label="View next image in slideshow"
 						// TODO: data-link-name="slideshow carousel left chevron"
 					/>
 
@@ -238,7 +238,7 @@ export const SlideshowCarousel = ({
 						}
 						size="small"
 						disabled={!nextButtonEnabled}
-						aria-label="Move image carousel forwards"
+						aria-label="View previous image in slideshow"
 						// TODO: data-link-name="slideshow carousel right chevron"
 					/>
 				</div>

--- a/dotcom-rendering/src/components/SlideshowCarousel.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.tsx
@@ -3,6 +3,7 @@ import {
 	palette as sourcePalette,
 	space,
 	textSansBold12,
+	width,
 } from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
 import {
@@ -66,11 +67,36 @@ const captionStyles = css`
 	padding: 60px ${space[2]}px ${space[2]}px;
 `;
 
+const navigationStyles = css`
+	display: flex;
+	align-items: center;
+	margin-top: ${space[2]}px;
+`;
+
+const paginationStyles = css`
+	display: flex;
+	justify-content: center;
+	gap: ${space[1]}px;
+	flex: 1 0 0;
+	padding-left: ${space[2] + width.ctaSmall * 2}px;
+`;
+
+const dotStyles = css`
+	width: 6px;
+	height: 6px;
+	border-radius: 100%;
+	background-color: ${sourcePalette.neutral[86]};
+`;
+
+// const selectedDotStyles = css`
+// 	width: 8px;
+// 	height: 8px;
+// 	background-color: ${sourcePalette.neutral[0]};
+// `;
+
 const buttonStyles = css`
 	display: flex;
-	justify-content: flex-end;
 	gap: ${space[2]}px;
-	margin-top: ${space[2]}px;
 `;
 
 export const SlideshowCarousel = ({
@@ -162,38 +188,47 @@ export const SlideshowCarousel = ({
 					);
 				})}
 			</ul>
-			<div css={buttonStyles}>
-				<Button
-					hideLabel={true}
-					iconSide="left"
-					icon={<SvgChevronLeftSingle />}
-					onClick={() => scrollTo('left')}
-					priority="tertiary"
-					theme={
-						previousButtonEnabled
-							? themeButton
-							: themeButtonDisabled
-					}
-					size="small"
-					disabled={!previousButtonEnabled}
-					aria-label="Move image carousel backwards"
-					// TODO: data-link-name="slideshow carousel left chevron"
-				/>
+			<div css={navigationStyles}>
+				<div css={paginationStyles}>
+					{takeFirst(images, 10).map((image) => (
+						<span css={dotStyles} key={image.imageSrc} />
+					))}
+				</div>
+				<div css={buttonStyles}>
+					<Button
+						hideLabel={true}
+						iconSide="left"
+						icon={<SvgChevronLeftSingle />}
+						onClick={() => scrollTo('left')}
+						priority="tertiary"
+						theme={
+							previousButtonEnabled
+								? themeButton
+								: themeButtonDisabled
+						}
+						size="small"
+						disabled={!previousButtonEnabled}
+						aria-label="Move image carousel backwards"
+						// TODO: data-link-name="slideshow carousel left chevron"
+					/>
 
-				<Button
-					hideLabel={true}
-					iconSide="left"
-					icon={<SvgChevronRightSingle />}
-					onClick={() => scrollTo('right')}
-					priority="tertiary"
-					theme={
-						nextButtonEnabled ? themeButton : themeButtonDisabled
-					}
-					size="small"
-					disabled={!nextButtonEnabled}
-					aria-label="Move image carousel forwards"
-					// TODO: data-link-name="slideshow carousel right chevron"
-				/>
+					<Button
+						hideLabel={true}
+						iconSide="left"
+						icon={<SvgChevronRightSingle />}
+						onClick={() => scrollTo('right')}
+						priority="tertiary"
+						theme={
+							nextButtonEnabled
+								? themeButton
+								: themeButtonDisabled
+						}
+						size="small"
+						disabled={!nextButtonEnabled}
+						aria-label="Move image carousel forwards"
+						// TODO: data-link-name="slideshow carousel right chevron"
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -4392,6 +4392,17 @@ const carouselChevronBorderDisabledLight: PaletteFunction = () =>
 const carouselChevronBorderDisabledDark: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[73], 0.32);
 
+const slideshowCaptionLight: PaletteFunction = () => sourcePalette.neutral[100];
+const slideshowCaptionDark: PaletteFunction = () => sourcePalette.neutral[100];
+const slideshowPaginationDotLight: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[7], 0.2);
+const slideshowPaginationDotDark: PaletteFunction = () =>
+	transparentColour(sourcePalette.neutral[86], 0.2);
+const slideshowPaginationDotActiveLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const slideshowPaginationDotActiveDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
 const mostViewedFooterHoverLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
 const mostViewedFooterHoverDark: PaletteFunction = () =>
@@ -6982,6 +6993,18 @@ const paletteColours = {
 	'--sign-in-link-underline': {
 		light: signInLinkLineLight,
 		dark: signInLinkLineDark,
+	},
+	'--slideshow-caption': {
+		light: slideshowCaptionLight,
+		dark: slideshowCaptionDark,
+	},
+	'--slideshow-pagination-dot': {
+		light: slideshowPaginationDotLight,
+		dark: slideshowPaginationDotDark,
+	},
+	'--slideshow-pagination-dot-active': {
+		light: slideshowPaginationDotActiveLight,
+		dark: slideshowPaginationDotActiveDark,
 	},
 	'--staff-contributor-badge': {
 		light: staffBadgeLight,


### PR DESCRIPTION
## What does this change?

- Adds basic pagination dot styling and layout to slideshows
- Adds slideshow colours to `palette`

## Why?

Part of the work to [support slideshow carousels in DCR](https://trello.com/c/53tELnFE/236-slideshow-carousel-on-web), bringing parity between web and app.

## Screenshots

<img width="476" alt="Screenshot 2024-11-14 at 14 13 01" src="https://github.com/user-attachments/assets/71e64152-0c47-46f8-803d-590df552a7b9">
<img width="954" alt="Screenshot 2024-11-14 at 14 12 20" src="https://github.com/user-attachments/assets/6d7497f5-7564-41d1-96ee-2856e60a50c1">
e3-be9d3b06cb4e">
<img width="955" alt="Screenshot 2024-11-14 at 14 12 37" src="https://github.com/user-attachments/assets/e4d4b4a2-f9b3-48b6-bddb-0b71aa6c9aff">


