### PR TITLE
Opinion card design updates

### DIFF
--- a/dotcom-rendering/src/components/Avatar.stories.tsx
+++ b/dotcom-rendering/src/components/Avatar.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-
 import { Avatar } from './Avatar';
 
 const meta = {

--- a/dotcom-rendering/src/components/Avatar.stories.tsx
+++ b/dotcom-rendering/src/components/Avatar.stories.tsx
@@ -1,13 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { allModes } from '../../.storybook/modes';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	type ArticleFormat,
-	ArticleSpecial,
-	type ArticleTheme,
-	Pillar,
-} from '../lib/articleFormat';
+
 import { Avatar } from './Avatar';
 
 const meta = {
@@ -25,103 +17,20 @@ const meta = {
 			</div>
 		),
 	],
-	parameters: {
-		chromatic: {
-			modes: {
-				horizontal: allModes['vertical mobileMedium'],
-			},
-		},
-	},
 } satisfies Meta<typeof Avatar>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const standardStandardWithTheme = (theme: ArticleTheme): ArticleFormat => ({
-	design: ArticleDesign.Standard,
-	display: ArticleDisplay.Standard,
-	theme,
-});
-
-export const RoundMediumOpinionTheme = {
+export const RoundAvatar = {
 	args: {
 		src: 'https://uploads.guim.co.uk/2017/10/06/George-Monbiot,-L.png',
 		alt: 'The alt of the image',
 		shape: 'round',
 	},
 	parameters: {
-		formats: [standardStandardWithTheme(Pillar.Opinion)],
 		size: '136px',
 	},
-	name: 'Round Medium, Opinion Theme (Rich Links)',
-} satisfies Story;
-
-export const CutoutMediumOpinionTheme = {
-	...RoundMediumOpinionTheme,
-	args: {
-		...RoundMediumOpinionTheme.args,
-		shape: 'cutout',
-	},
-	name: 'Cutout Medium, Opinion Theme (Rich Links)',
-} satisfies Story;
-
-export const RoundLargeLifestyleTheme = {
-	args: {
-		src: 'https://uploads.guim.co.uk/2017/10/06/Leah-Harper,-L.png',
-		alt: 'The alt of the image',
-	},
-	parameters: {
-		formats: [standardStandardWithTheme(Pillar.Lifestyle)],
-		size: '140px',
-	},
-	name: 'Round Large, Lifestyle Theme (Byline image - Desktop)',
-} satisfies Story;
-
-export const RoundLargeNewsTheme: Story = {
-	...RoundLargeLifestyleTheme,
-	parameters: {
-		...RoundLargeLifestyleTheme.parameters,
-		formats: [standardStandardWithTheme(Pillar.News)],
-	},
-	name: 'Round Large, News Theme (Byline image - Desktop)',
-} satisfies Story;
-
-export const RoundLargeCultureTheme: Story = {
-	...RoundLargeLifestyleTheme,
-	parameters: {
-		...RoundLargeLifestyleTheme.parameters,
-		formats: [standardStandardWithTheme(Pillar.Culture)],
-	},
-	name: 'Round Large, Culture Theme (Byline image - Desktop)',
-} satisfies Story;
-
-export const RoundLargeSpecialReportTheme: Story = {
-	...RoundLargeLifestyleTheme,
-	parameters: {
-		...RoundLargeLifestyleTheme.parameters,
-		formats: [standardStandardWithTheme(ArticleSpecial.SpecialReport)],
-	},
-	name: 'Round Large, SpecialReport Theme (Byline image - Desktop)',
-} satisfies Story;
-
-export const RoundLargeSpecialReportAltTheme: Story = {
-	...RoundLargeLifestyleTheme,
-	parameters: {
-		...RoundLargeLifestyleTheme.parameters,
-		formats: [standardStandardWithTheme(ArticleSpecial.SpecialReportAlt)],
-	},
-	name: 'Round Large, SpecialReportAlt Theme (Byline image - Desktop)',
-} satisfies Story;
-
-export const RoundSmallSportTheme = {
-	args: {
-		src: 'https://uploads.guim.co.uk/2018/05/25/Sid_Lowe,_L.png',
-		alt: 'The alt of the image',
-	},
-	parameters: {
-		formats: [standardStandardWithTheme(Pillar.Sport)],
-		size: '60px',
-	},
-	name: 'Round Small, Sport Theme (Byline image - Mobile)',
+	name: 'Round Avatar Cutout With Coloured Background',
 } satisfies Story;

--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { Fragment } from 'react';
 import { getSourceImageUrl } from '../lib/getSourceImageUrl_temp_fix';
 import { palette } from '../palette';
+import { useConfig } from './ConfigContext';
 import { generateSources, getFallbackSource } from './Picture';
 
 const picture = css`
@@ -68,10 +69,22 @@ export const Avatar = ({ src, alt, shape = 'round' }: Props) => {
 	 */
 	const fallbackSource = getFallbackSource(sources);
 
+	const { renderingTarget } = useConfig();
+	const isApps = renderingTarget === 'Apps';
 	return (
 		<picture
 			// data-size={imageSize}
-			css={[block, picture, shape === 'round' && round]}
+			css={[
+				block,
+				picture,
+				shape === 'round' && round,
+				isApps &&
+					css`
+						background-color: ${palette(
+							'--avatar-background-colour',
+						)};
+					`,
+			]}
 		>
 			{sources.map((source) => {
 				return (

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import {
-	headlineMediumItalic17,
-	headlineMediumItalic20,
-	headlineMediumItalic24,
-	headlineMediumItalic28,
+	headlineMedium17,
+	headlineMedium20,
+	headlineMedium24,
+	headlineMedium28,
 	textSansItalic17,
 	textSansItalic20,
 	textSansItalic24,
@@ -40,9 +40,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 				`;
 			}
 			return css`
-				${headlineMediumItalic28};
+				${headlineMedium28};
 				${until.desktop} {
-					${headlineMediumItalic24};
+					${headlineMedium24};
 				}
 			`;
 		case 'large': {
@@ -58,9 +58,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 				`;
 			}
 			return css`
-				${headlineMediumItalic24};
+				${headlineMedium24};
 				${until.desktop} {
-					${headlineMediumItalic20};
+					${headlineMedium20};
 				}
 			`;
 		}
@@ -76,9 +76,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 				`;
 			}
 			return css`
-				${headlineMediumItalic20};
+				${headlineMedium20};
 				${until.desktop} {
-					${headlineMediumItalic17};
+					${headlineMedium17};
 				}
 			`;
 		}
@@ -90,12 +90,12 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 				`;
 			}
 			return css`
-				${headlineMediumItalic17};
+				${headlineMedium17};
 			`;
 		}
 		case 'tiny':
 			return css`
-				${headlineMediumItalic17};
+				${headlineMedium17};
 			`;
 	}
 };

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -4,9 +4,9 @@ import {
 	headlineMedium20,
 	headlineMedium24,
 	headlineMedium28,
-	textSansItalic17,
-	textSansItalic20,
-	textSansItalic24,
+	textSans17,
+	textSans20,
+	textSans24,
 	until,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
@@ -31,12 +31,7 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 		case 'huge':
 			if (isLabs) {
 				return css`
-					${textSansItalic24};
-					line-height: 24px;
-					${until.desktop} {
-						${textSansItalic24};
-						line-height: 20px;
-					}
+					${textSans24};
 				`;
 			}
 			return css`
@@ -48,12 +43,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 		case 'large': {
 			if (isLabs) {
 				return css`
-					${textSansItalic20};
-					font-size: 24px;
-					line-height: 24px;
+					${textSans24};
 					${until.desktop} {
-						${textSansItalic20};
-						line-height: 20px;
+						${textSans20};
 					}
 				`;
 			}
@@ -67,11 +59,9 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 		case 'medium': {
 			if (isLabs) {
 				return css`
-					${textSansItalic20};
-					line-height: 20px;
+					${textSans20};
 					${until.desktop} {
-						${textSansItalic17};
-						line-height: 18px;
+						${textSans17};
 					}
 				`;
 			}
@@ -85,8 +75,7 @@ const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
 		case 'small': {
 			if (isLabs) {
 				return css`
-					${textSansItalic17};
-					line-height: 18px;
+					${textSans17};
 				`;
 			}
 			return css`

--- a/dotcom-rendering/src/components/BylineLink.tsx
+++ b/dotcom-rendering/src/components/BylineLink.tsx
@@ -184,6 +184,7 @@ export const BylineLink = ({
 
 	const { renderingTarget } = useConfig();
 	const isApps = renderingTarget === 'Apps';
+
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
 
 	return (

--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 import {
 	from,
+	headlineLight28,
+	headlineLight34,
 	headlineLightItalic28,
 	headlineLightItalic34,
 	headlineMedium20,
@@ -10,6 +12,7 @@ import {
 	space,
 	textSans20,
 	textSans24,
+	textSans34,
 	textSansItalic20,
 	textSansItalic34,
 	until,
@@ -24,6 +27,7 @@ import { getSoleContributor } from '../lib/byline';
 import { palette as schemedPalette } from '../palette';
 import type { TagType } from '../types/tag';
 import { BylineLink } from './BylineLink';
+import { useConfig } from './ConfigContext';
 
 const wrapperStyles = css`
 	margin-left: 6px;
@@ -58,17 +62,21 @@ const opinionWrapperStyles = css`
 	display: inline-block;
 `;
 
-const opinionStyles = (format: ArticleFormat) => css`
-	${format.theme === ArticleSpecial.Labs
-		? textSansItalic34
-		: headlineLightItalic34}
+const opinionStyles = (format: ArticleFormat, isApps: boolean) => css`
+	${isApps
+		? format.theme === ArticleSpecial.Labs
+			? textSansItalic34
+			: headlineLightItalic34
+		: format.theme === ArticleSpecial.Labs
+		? textSans34
+		: headlineLight34}
 	line-height: 38px;
 	/* Used to prevent the byline stretching full width */
 	display: inline;
 	color: ${schemedPalette('--byline')};
 
 	${until.tablet} {
-		${headlineLightItalic28}
+		${isApps ? headlineLightItalic28 : headlineLight28}
 	}
 
 	a {
@@ -148,6 +156,9 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 	if (byline === '') {
 		return null;
 	}
+	/** This is required for a staggered design release between web and app. This will be removed changes are ready for release on ios/android   */
+	const { renderingTarget } = useConfig();
+	const isApps = renderingTarget === 'Apps';
 
 	const hasSingleContributor = !!getSoleContributor(tags, byline);
 
@@ -194,7 +205,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 								hasSingleContributor && authorBylineWithImage,
 							]}
 						>
-							<div css={opinionStyles(format)}>
+							<div css={opinionStyles(format, isApps)}>
 								<BylineLink
 									byline={byline}
 									tags={tags}

--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -160,11 +160,11 @@ type Props = {
 };
 
 export const HeadlineByline = ({ format, byline, tags }: Props) => {
+	const { renderingTarget } = useConfig();
 	if (byline === '') {
 		return null;
 	}
 	/** This is required for a staggered design release between web and app. This will be removed changes are ready for release on ios/android   */
-	const { renderingTarget } = useConfig();
 	const isApps = renderingTarget === 'Apps';
 
 	const hasSingleContributor = !!getSoleContributor(tags, byline);

--- a/dotcom-rendering/src/components/HeadlineByline.tsx
+++ b/dotcom-rendering/src/components/HeadlineByline.tsx
@@ -36,10 +36,17 @@ const wrapperStyles = css`
 	z-index: 1;
 `;
 
-const interviewBylineBoxStyles = (format: ArticleFormat) => css`
-	${format.theme === ArticleSpecial.Labs
-		? textSansItalic20
-		: headlineMediumItalic20}
+const interviewBylineBoxStyles = (
+	format: ArticleFormat,
+	isApps: boolean,
+) => css`
+	${isApps
+		? format.theme === ArticleSpecial.Labs
+			? textSansItalic20
+			: headlineMediumItalic20
+		: format.theme === ArticleSpecial.Labs
+		? textSans20
+		: headlineMedium20}
 	${format.theme !== ArticleSpecial.Labs && 'line-height: 1.4;'}
 	background-color: ${schemedPalette('--byline-background')};
 	box-shadow:
@@ -88,13 +95,13 @@ const opinionStyles = (format: ArticleFormat, isApps: boolean) => css`
 	}
 `;
 
-const analysisStyles = css`
-	${headlineLightItalic34};
+const analysisStyles = (isApps: boolean) => css`
+	${isApps ? headlineLightItalic34 : headlineLight34};
 	line-height: 38px;
 	color: ${schemedPalette('--byline-anchor')};
 
 	${until.tablet} {
-		${headlineLightItalic28}
+		${isApps ? headlineLightItalic28 : headlineLight28}
 	}
 
 	a {
@@ -185,7 +192,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 				case ArticleDesign.Interview:
 					return (
 						<div css={wrapperStyles}>
-							<div css={interviewBylineBoxStyles(format)}>
+							<div css={interviewBylineBoxStyles(format, isApps)}>
 								<BylineLink
 									byline={byline}
 									tags={tags}
@@ -220,7 +227,7 @@ export const HeadlineByline = ({ format, byline, tags }: Props) => {
 						<div css={opinionWrapperStyles}>
 							<div
 								css={[
-									analysisStyles,
+									analysisStyles(isApps),
 									hasSingleContributor &&
 										analysisSingleContributorStyles,
 								]}

--- a/dotcom-rendering/src/components/LiveBlockContainer.tsx
+++ b/dotcom-rendering/src/components/LiveBlockContainer.tsx
@@ -7,6 +7,7 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import { useConfig } from './ConfigContext';
 import { FirstPublished } from './FirstPublished';
 
 type BlockContributor = {
@@ -67,6 +68,8 @@ const BlockByline = ({
 	name: string;
 	imageUrl?: string;
 }) => {
+	const { renderingTarget } = useConfig();
+	const isApps = renderingTarget === 'Apps';
 	return (
 		<div
 			css={css`
@@ -91,7 +94,9 @@ const BlockByline = ({
 							width: 100%;
 							height: 100%;
 							object-fit: cover;
-							background-color: ${palette('--avatar-background')};
+							background-color: ${isApps
+								? palette('--avatar-background-colour')
+								: palette('--avatar-background')};
 						`}
 					/>
 				</div>

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1173,86 +1173,9 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 			return sourcePalette.neutral[86];
 	}
 };
-const avatarLight: PaletteFunction = ({ design, theme }) => {
-	switch (design) {
-		case ArticleDesign.Standard:
-		case ArticleDesign.Review:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Feature:
-		case ArticleDesign.Interview:
-		case ArticleDesign.Interactive:
-		case ArticleDesign.PhotoEssay:
-		case ArticleDesign.FullPageInteractive:
-		case ArticleDesign.NewsletterSignup:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Analysis:
-			switch (theme) {
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[800];
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.specialReportAlt[300];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[400];
-				case Pillar.Opinion:
-					return sourcePalette.opinion[300];
-				case Pillar.Culture:
-					return sourcePalette.culture[500];
-				case Pillar.Lifestyle:
-					return sourcePalette.lifestyle[500];
-				case Pillar.Sport:
-					return sourcePalette.sport[500];
-				case Pillar.News:
-					return sourcePalette.news[500];
-			}
-		default:
-			switch (theme) {
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.specialReport[800];
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.news[500];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[400];
-				case Pillar.Opinion:
-					return sourcePalette.opinion[300];
-				case Pillar.Culture:
-					return sourcePalette.culture[500];
-				case Pillar.Lifestyle:
-					return sourcePalette.lifestyle[500];
-				case Pillar.Sport:
-					return sourcePalette.sport[500];
-				case Pillar.News:
-					return sourcePalette.news[500];
-			}
-	}
-};
+const avatarLight: PaletteFunction = () => sourcePalette.neutral[97];
 
-const avatarDark: PaletteFunction = ({ design, theme }) => {
-	switch (design) {
-		case ArticleDesign.Standard:
-		case ArticleDesign.Review:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Feature:
-		case ArticleDesign.Interview:
-		case ArticleDesign.Interactive:
-		case ArticleDesign.PhotoEssay:
-		case ArticleDesign.FullPageInteractive:
-		case ArticleDesign.NewsletterSignup:
-		case ArticleDesign.Comment:
-		case ArticleDesign.Letter:
-		case ArticleDesign.Editorial:
-		case ArticleDesign.Analysis:
-			switch (theme) {
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.neutral[46];
-				default:
-					return sourcePalette.neutral[20];
-			}
-		default:
-			return sourcePalette.neutral[20];
-	}
-};
+const avatarDark: PaletteFunction = () => sourcePalette.neutral[97];
 
 const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1173,9 +1173,9 @@ const subheadingTextDark = ({ design, theme }: ArticleFormat) => {
 			return sourcePalette.neutral[86];
 	}
 };
-const avatarLight: PaletteFunction = () => sourcePalette.neutral[97];
+const avatarLight: PaletteFunction = () => sourcePalette.neutral[93];
 
-const avatarDark: PaletteFunction = () => sourcePalette.neutral[97];
+const avatarDark: PaletteFunction = () => sourcePalette.neutral[93];
 
 const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -1177,6 +1177,87 @@ const avatarLight: PaletteFunction = () => sourcePalette.neutral[93];
 
 const avatarDark: PaletteFunction = () => sourcePalette.neutral[93];
 
+const avatarColourLight: PaletteFunction = ({ design, theme }) => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[300];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[500];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[500];
+				case Pillar.Sport:
+					return sourcePalette.sport[500];
+				case Pillar.News:
+					return sourcePalette.news[500];
+			}
+		default:
+			switch (theme) {
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[800];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.news[500];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[500];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[500];
+				case Pillar.Sport:
+					return sourcePalette.sport[500];
+				case Pillar.News:
+					return sourcePalette.news[500];
+			}
+	}
+};
+
+const avatarColourDark: PaletteFunction = ({ design, theme }) => {
+	switch (design) {
+		case ArticleDesign.Standard:
+		case ArticleDesign.Review:
+		case ArticleDesign.Explainer:
+		case ArticleDesign.Feature:
+		case ArticleDesign.Interview:
+		case ArticleDesign.Interactive:
+		case ArticleDesign.PhotoEssay:
+		case ArticleDesign.FullPageInteractive:
+		case ArticleDesign.NewsletterSignup:
+		case ArticleDesign.Comment:
+		case ArticleDesign.Letter:
+		case ArticleDesign.Editorial:
+		case ArticleDesign.Analysis:
+			switch (theme) {
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.neutral[46];
+				default:
+					return sourcePalette.neutral[20];
+			}
+		default:
+			return sourcePalette.neutral[20];
+	}
+};
+
 const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
@@ -5943,6 +6024,10 @@ const paletteColours = {
 	'--avatar-background': {
 		light: avatarLight,
 		dark: avatarDark,
+	},
+	'--avatar-background-colour': {
+		light: avatarColourLight,
+		dark: avatarColourDark,
 	},
 	'--block-quote-fill': {
 		light: blockQuoteFillLight,


### PR DESCRIPTION
## What does this change?
- Removes the italic font styling from bylines on cards. 
- Replaces pillar and custom background colours from the avatar cutouts with neutral.93 across the site.
- Removes the italic font styling from bylines on opinion articles. 


These changes affect web only., 

## Why?
This is part of the fairground redesign project. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |

[before]: https://github.com/user-attachments/assets/07dd0a66-4ccf-4035-bb58-58dd75a60253
[after]: https://github.com/user-attachments/assets/6cde18ef-3179-4175-80e4-69db08f918c8
[before2]: https://github.com/user-attachments/assets/ed7a430a-5b38-4a4a-b42c-b1ca9580ccde
[after2]: https://github.com/user-attachments/assets/491e9771-7183-49e4-adae-e4a94e34d4c7
[before3]: https://github.com/user-attachments/assets/6f3b53e7-e31d-4b15-8a53-6e233c51a4dd
[after3]: https://github.com/user-attachments/assets/550adbbf-b8bd-4c65-afbf-7710ea11d553
[before4]: https://github.com/user-attachments/assets/348c23c1-e521-468b-924b-69cef3a4ce2a
[after4]: https://github.com/user-attachments/assets/6838def0-ac3b-4aeb-a64f-7b0713a99c0f
[before5]: https://github.com/user-attachments/assets/3f03d802-e28f-4b08-89dd-340daeabab4c
[after5]: https://github.com/user-attachments/assets/8c3fbdf0-dacb-4f64-b8c4-16b5d71a388c



<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
