### PR TITLE
Hide Match Tab when no data

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -109,7 +109,7 @@ const StandardGrid = ({
 								grid-template-areas:
 									'title  border  matchNav   . right-column'
 									'title  border  matchtabs  . right-column'
-									'.      border  headline   . right-column'
+									'title  border  headline   . right-column'
 									'.      border  standfirst . right-column'
 									'meta   border  media      . right-column'
 									'meta   border  body       . right-column'
@@ -152,7 +152,7 @@ const StandardGrid = ({
 							grid-template-areas:
 								'title  border  matchNav     right-column'
 								'title  border  matchtabs    right-column'
-								'.      border  headline     right-column'
+								'title  border  headline     right-column'
 								'.      border  standfirst   right-column'
 								'meta   border  media        right-column'
 								'meta   border  body         right-column'


### PR DESCRIPTION
Closes #12308

## What does this change?

Hides the match tab when we don't have the match data

## Why?

We currently show a blank match tab when we don't have the data. This affects all matches that are older than we currently have the data for (>2 seasons ago).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fc42b0a6-e718-44cd-bf5e-5d241d9b43bc
[after]: https://github.com/user-attachments/assets/d64354d1-7c88-49ea-9c99-c7450735fb99

