### PR TITLE
Use card headline fonts for card byline

### DIFF
--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -3,7 +3,7 @@ import { palette } from '../palette';
 
 type Props = {
 	text: string;
-	fonts: SerializedStyles;
+	fontStyles: SerializedStyles;
 	/** Optional override of the standard text colour */
 	colour?: string;
 };
@@ -15,8 +15,8 @@ const baseStyles = (colour: string) => css`
 
 export const Byline = ({
 	text,
-	fonts,
+	fontStyles,
 	colour = palette('--byline'),
 }: Props) => {
-	return <span css={[baseStyles(colour), fonts]}>{text}</span>;
+	return <span css={[baseStyles(colour), fontStyles]}>{text}</span>;
 };

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,21 +1,9 @@
-import { css } from '@emotion/react';
-import {
-	headlineMedium17,
-	headlineMedium20,
-	headlineMedium24,
-	headlineMedium28,
-	textSans17,
-	textSans20,
-	textSans24,
-	until,
-} from '@guardian/source/foundations';
+import { css, SerializedStyles } from '@emotion/react';
 import { palette } from '../palette';
-import type { SmallHeadlineSize } from '../types/layout';
 
 type Props = {
 	text: string;
-	isLabs: boolean;
-	size: SmallHeadlineSize;
+	fonts: SerializedStyles;
 	/** Optional override of the standard text colour */
 	colour?: string;
 };
@@ -25,79 +13,10 @@ const baseStyles = (colour: string) => css`
 	color: ${colour};
 `;
 
-const bylineStyles = (size: SmallHeadlineSize, isLabs: boolean) => {
-	switch (size) {
-		case 'ginormous':
-		case 'huge':
-			if (isLabs) {
-				return css`
-					${textSans24};
-				`;
-			}
-			return css`
-				${headlineMedium28};
-				${until.desktop} {
-					${headlineMedium24};
-				}
-			`;
-		case 'large': {
-			if (isLabs) {
-				return css`
-					${textSans24};
-					${until.desktop} {
-						${textSans20};
-					}
-				`;
-			}
-			return css`
-				${headlineMedium24};
-				${until.desktop} {
-					${headlineMedium20};
-				}
-			`;
-		}
-		case 'medium': {
-			if (isLabs) {
-				return css`
-					${textSans20};
-					${until.desktop} {
-						${textSans17};
-					}
-				`;
-			}
-			return css`
-				${headlineMedium20};
-				${until.desktop} {
-					${headlineMedium17};
-				}
-			`;
-		}
-		case 'small': {
-			if (isLabs) {
-				return css`
-					${textSans17};
-				`;
-			}
-			return css`
-				${headlineMedium17};
-			`;
-		}
-		case 'tiny':
-			return css`
-				${headlineMedium17};
-			`;
-	}
-};
-
 export const Byline = ({
 	text,
-	isLabs,
-	size,
+	fonts,
 	colour = palette('--byline'),
 }: Props) => {
-	return (
-		<span css={[baseStyles(colour), bylineStyles(size, isLabs)]}>
-			{text}
-		</span>
-	);
+	return <span css={[baseStyles(colour), fonts]}>{text}</span>;
 };

--- a/dotcom-rendering/src/components/Byline.tsx
+++ b/dotcom-rendering/src/components/Byline.tsx
@@ -1,4 +1,4 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css, type SerializedStyles } from '@emotion/react';
 import { palette } from '../palette';
 
 type Props = {

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1475,8 +1475,8 @@ export const WithAFiveFourAspectRatio = () => {
 						}}
 						format={{
 							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Comment,
-							theme: Pillar.Opinion,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
 						}}
 						aspectRatio="5:4"
 					/>
@@ -1500,7 +1500,7 @@ export const WithNoGap = () => {
 						isOnwardContent={true}
 						format={{
 							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Comment,
+							design: ArticleDesign.Standard,
 							theme: Pillar.Opinion,
 						}}
 					/>
@@ -1548,7 +1548,7 @@ export const WithASmallGap = () => {
 						imagePositionOnDesktop="left"
 						format={{
 							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Comment,
+							design: ArticleDesign.Standard,
 							theme: Pillar.Opinion,
 						}}
 					/>
@@ -1573,7 +1573,7 @@ export const WithAMediumGap = () => {
 						imagePositionOnDesktop="left"
 						format={{
 							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Comment,
+							design: ArticleDesign.Standard,
 							theme: Pillar.Opinion,
 						}}
 					/>
@@ -1598,7 +1598,7 @@ export const WithALargeGap = () => {
 						imagePositionOnDesktop="left"
 						format={{
 							display: ArticleDisplay.Standard,
-							design: ArticleDesign.Comment,
+							design: ArticleDesign.Standard,
 							theme: Pillar.Opinion,
 						}}
 						showTopBarDesktop={false}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -60,6 +60,17 @@ import { TrailText, type TrailTextSize } from './components/TrailText';
 
 export type Position = 'inner' | 'outer' | 'none';
 
+export const BETA_CONTAINERS = [
+	'scrollable/highlights',
+	'flexible/special',
+	'flexible/general',
+	'scrollable/small',
+	'scrollable/medium',
+	'scrollable/feature',
+	'static/feature/2',
+	'static/medium/4',
+];
+
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
@@ -332,6 +343,8 @@ export const Card = ({
 		format.design === ArticleDesign.Editorial ||
 		format.design === ArticleDesign.Letter;
 
+	const isBetaContainer = BETA_CONTAINERS.includes(containerType ?? '');
+
 	const decideAge = () => {
 		if (!webPublicationDate) return undefined;
 		const withinTwelveHours = isWithinTwelveHours(webPublicationDate);
@@ -567,6 +580,7 @@ export const Card = ({
 						byline={byline}
 						showByline={showByline}
 						isExternalLink={isExternalLink}
+						isBetaContainer={isBetaContainer}
 					/>
 					{!isUndefined(starRating) ? (
 						<StarRatingComponent
@@ -808,6 +822,7 @@ export const Card = ({
 										byline={byline}
 										showByline={showByline}
 										isExternalLink={isExternalLink}
+										isBetaContainer={isBetaContainer}
 									/>
 									{!isUndefined(starRating) ? (
 										<StarRatingComponent

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -61,6 +61,7 @@ type Props = {
 	headlineColour?: string;
 	/** Optional override of the standard card kicker colour */
 	kickerColour?: string;
+	isBetaContainer?: boolean;
 };
 
 const sublinkStyles = css`
@@ -174,16 +175,21 @@ const getFontSize = (sizes: ResponsiveFontSize, family: FontFamily) => {
 	`;
 };
 
-const getFonts = (format: ArticleFormat, fontSizes: ResponsiveFontSize) => {
+const getFonts = (
+	format: ArticleFormat,
+	fontSizes: ResponsiveFontSize,
+	isBetaContainer: boolean,
+) => {
 	if (format.theme === ArticleSpecial.Labs) {
 		return getFontSize(fontSizes, FontFamily.TextSans);
 	}
 
 	if (
+		isBetaContainer &&
 		/** Any of these designs are considered an "opinion" */
-		format.design === ArticleDesign.Comment ||
-		format.design === ArticleDesign.Editorial ||
-		format.design === ArticleDesign.Letter
+		(format.design === ArticleDesign.Comment ||
+			format.design === ArticleDesign.Editorial ||
+			format.design === ArticleDesign.Letter)
 	) {
 		return getFontSize(fontSizes, FontFamily.HeadlineLight);
 	}
@@ -223,11 +229,12 @@ export const CardHeadline = ({
 	isExternalLink,
 	headlineColour = palette('--card-headline'),
 	kickerColour = palette('--card-kicker-text'),
+	isBetaContainer = false,
 }: Props) => {
 	// The link is only applied directly to the headline if it is a sublink
 	const isSublink = !!linkTo;
 
-	const fontStyles = getFonts(format, fontSizes);
+	const fontStyles = getFonts(format, fontSizes, isBetaContainer);
 
 	return (
 		<WithLink linkTo={linkTo}>

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -227,7 +227,7 @@ export const CardHeadline = ({
 	// The link is only applied directly to the headline if it is a sublink
 	const isSublink = !!linkTo;
 
-	const fonts = getFonts(format, fontSizes);
+	const fontStyles = getFonts(format, fontSizes);
 
 	return (
 		<WithLink linkTo={linkTo}>
@@ -240,7 +240,7 @@ export const CardHeadline = ({
 						? css`
 								${textSans14}
 						  `
-						: fonts,
+						: fontStyles,
 				]}
 			>
 				{!!kickerText && (
@@ -271,7 +271,11 @@ export const CardHeadline = ({
 				</span>
 			</h3>
 			{!!byline && showByline && (
-				<Byline text={byline} colour={kickerColour} fonts={fonts} />
+				<Byline
+					text={byline}
+					colour={kickerColour}
+					fontStyles={fontStyles}
+				/>
 			)}
 		</WithLink>
 	);

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -158,29 +158,6 @@ export const WithLink = ({
 	return <>{children}</>;
 };
 
-/**
- * The Byline component uses a different type to determine font sizes but infers the size from the desktop headline size.
- * This function converts the headline size to the appropriate byline size.
- */
-const getBylineFontSizes = (size: HeadlineSize): SmallHeadlineSize => {
-	switch (size) {
-		case 'xxlarge':
-			return 'ginormous';
-		case 'medium':
-			return 'huge';
-		case 'small':
-			return 'large';
-		case 'xsmall':
-			return 'medium';
-		case 'xxsmall':
-			return 'small';
-		case 'tiny':
-			return 'tiny';
-		default:
-			return 'medium';
-	}
-};
-
 export const CardHeadline = ({
 	headlineText,
 	format,
@@ -204,8 +181,6 @@ export const CardHeadline = ({
 		format.theme === ArticleSpecial.Labs
 			? getFontSize(fontSizes, 'textSans')
 			: getFontSize(fontSizes, 'headline');
-
-	const bylineSize = getBylineFontSizes(fontSizes.desktop);
 
 	return (
 		<WithLink linkTo={linkTo}>
@@ -249,12 +224,7 @@ export const CardHeadline = ({
 				</span>
 			</h3>
 			{!!byline && showByline && (
-				<Byline
-					text={byline}
-					isLabs={format.theme === ArticleSpecial.Labs}
-					size={bylineSize}
-					colour={kickerColour}
-				/>
+				<Byline text={byline} colour={kickerColour} fonts={fonts} />
 			)}
 		</WithLink>
 	);

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -23,7 +23,6 @@ import React from 'react';
 import { type ArticleFormat, ArticleSpecial } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
-import type { SmallHeadlineSize } from '../types/layout';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -174,23 +174,6 @@ const getFontSize = (sizes: ResponsiveFontSize, family: FontFamily) => {
 	`;
 };
 
-export const WithLink = ({
-	linkTo,
-	children,
-}: {
-	linkTo?: string;
-	children: React.ReactNode;
-}) => {
-	if (linkTo) {
-		return (
-			<Link href={linkTo} cssOverrides={sublinkStyles}>
-				{children}
-			</Link>
-		);
-	}
-	return <>{children}</>;
-};
-
 const getFonts = (format: ArticleFormat, fontSizes: ResponsiveFontSize) => {
 	if (format.theme === ArticleSpecial.Labs) {
 		return getFontSize(fontSizes, FontFamily.TextSans);
@@ -206,6 +189,23 @@ const getFonts = (format: ArticleFormat, fontSizes: ResponsiveFontSize) => {
 	}
 
 	return getFontSize(fontSizes, FontFamily.HeadlineMedium);
+};
+
+export const WithLink = ({
+	linkTo,
+	children,
+}: {
+	linkTo?: string;
+	children: React.ReactNode;
+}) => {
+	if (linkTo) {
+		return (
+			<Link href={linkTo} cssOverrides={sublinkStyles}>
+				{children}
+			</Link>
+		);
+	}
+	return <>{children}</>;
 };
 
 export const CardHeadline = ({

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -1,6 +1,16 @@
 import { css } from '@emotion/react';
 import {
 	between,
+	headlineLight14,
+	headlineLight15,
+	headlineLight17,
+	headlineLight20,
+	headlineLight24,
+	headlineLight28,
+	headlineLight34,
+	headlineLight42,
+	headlineLight50,
+	headlineLight64,
 	headlineMedium14,
 	headlineMedium15,
 	headlineMedium17,
@@ -20,7 +30,11 @@ import {
 } from '@guardian/source/foundations';
 import { Link, SvgExternal } from '@guardian/source/react-components';
 import React from 'react';
-import { type ArticleFormat, ArticleSpecial } from '../lib/articleFormat';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
 import { Byline } from './Byline';
@@ -28,91 +42,25 @@ import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
 
 type Props = {
-	headlineText: string; // The text shown
-	format: ArticleFormat; // Used to decide when to add type specific styles
+	/** The text shown */
+	headlineText: string;
+	/** Used to decide when to add type specific styles */
+	format: ArticleFormat;
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	hasInlineKicker?: boolean;
-	showQuotes?: boolean; // Even with design !== Comment, a piece can be opinion
+	/** Even with design !== Comment, a piece can be opinion */
+	showQuotes?: boolean;
 	fontSizes?: ResponsiveFontSize;
 	byline?: string;
 	showByline?: boolean;
-	linkTo?: string; // If provided, the headline is wrapped in a link
+	/** If provided, the headline is wrapped in a link */
+	linkTo?: string;
 	isExternalLink?: boolean;
 	/** Optional override of the standard card headline colour */
 	headlineColour?: string;
 	/** Optional override of the standard card kicker colour */
 	kickerColour?: string;
-};
-
-const headlineSize = {
-	xxxlarge: headlineMedium64,
-	xxlarge: headlineMedium50,
-	xlarge: headlineMedium42,
-	large: headlineMedium34,
-	medium: headlineMedium28,
-	small: headlineMedium24,
-	xsmall: headlineMedium20,
-	xxsmall: headlineMedium17,
-	xxxsmall: headlineMedium15,
-	tiny: headlineMedium14,
-};
-
-const textSansSize = {
-	xxxlarge: textSans20,
-	xxlarge: textSans20,
-	xlarge: textSans20,
-	large: textSans20,
-	medium: textSans20,
-	small: textSans20,
-	xsmall: textSans20,
-	xxsmall: textSans17,
-	xxxsmall: textSans15,
-	tiny: textSans12,
-};
-
-export type HeadlineSize = keyof typeof headlineSize;
-export type TextSansSize = keyof typeof textSansSize;
-
-export type ResponsiveFontSize = {
-	desktop: HeadlineSize;
-	tablet?: HeadlineSize;
-	mobile?: HeadlineSize;
-	mobileMedium?: HeadlineSize;
-};
-
-const getFontSize = (
-	sizes: ResponsiveFontSize,
-	family: 'headline' | 'textSans',
-) => {
-	const { desktop, tablet, mobileMedium, mobile } = sizes;
-
-	const fontSize = family === 'headline' ? headlineSize : textSansSize;
-
-	return css`
-		${fontSize[desktop]};
-
-		${tablet &&
-		css`
-			${until.desktop} {
-				${fontSize[tablet]};
-			}
-		`}
-
-		${mobile &&
-		css`
-			${until.tablet} {
-				${fontSize[mobile]};
-			}
-		`}
-
-		${mobileMedium &&
-		css`
-			${between.mobileMedium.and.tablet} {
-				${fontSize[mobileMedium]};
-			}
-		`}
-	`;
 };
 
 const sublinkStyles = css`
@@ -140,6 +88,92 @@ const sublinkStyles = css`
 	}
 `;
 
+/** These represent the font groups used by card headline */
+const fontFamilies = {
+	headlineMedium: {
+		xxxlarge: headlineMedium64,
+		xxlarge: headlineMedium50,
+		xlarge: headlineMedium42,
+		large: headlineMedium34,
+		medium: headlineMedium28,
+		small: headlineMedium24,
+		xsmall: headlineMedium20,
+		xxsmall: headlineMedium17,
+		xxxsmall: headlineMedium15,
+		tiny: headlineMedium14,
+	},
+	headlineLight: {
+		xxxlarge: headlineLight64,
+		xxlarge: headlineLight50,
+		xlarge: headlineLight42,
+		large: headlineLight34,
+		medium: headlineLight28,
+		small: headlineLight24,
+		xsmall: headlineLight20,
+		xxsmall: headlineLight17,
+		xxxsmall: headlineLight15,
+		tiny: headlineLight14,
+	},
+	textSans: {
+		xxxlarge: textSans20,
+		xxlarge: textSans20,
+		xlarge: textSans20,
+		large: textSans20,
+		medium: textSans20,
+		small: textSans20,
+		xsmall: textSans20,
+		xxsmall: textSans17,
+		xxxsmall: textSans15,
+		tiny: textSans12,
+	},
+} as const;
+
+export enum FontFamily {
+	HeadlineMedium = 'headlineMedium',
+	HeadlineLight = 'headlineLight',
+	TextSans = 'textSans',
+}
+
+export type HeadlineSize = keyof typeof fontFamilies.headlineMedium;
+
+export type ResponsiveFontSize = {
+	desktop: HeadlineSize;
+	tablet?: HeadlineSize;
+	mobile?: HeadlineSize;
+	mobileMedium?: HeadlineSize;
+};
+
+const getFontSize = (sizes: ResponsiveFontSize, family: FontFamily) => {
+	const font = fontFamilies[family];
+
+	const { desktop, tablet, mobileMedium, mobile } = sizes;
+
+	return css`
+		${font[desktop]};
+
+		${tablet &&
+		css`
+			${until.desktop} {
+				${font[tablet]};
+			}
+		`}
+
+		${mobile &&
+		css`
+			${until.tablet} {
+				${font[mobile]};
+			}
+		`}
+
+		${mobileMedium &&
+		css`
+			${between.mobileMedium.and.tablet} {
+				${font[mobileMedium]};
+			}
+		`}
+	`;
+};
+
 export const WithLink = ({
 	linkTo,
 	children,
@@ -155,6 +189,23 @@ export const WithLink = ({
 		);
 	}
 	return <>{children}</>;
+};
+
+const getFonts = (format: ArticleFormat, fontSizes: ResponsiveFontSize) => {
+	if (format.theme === ArticleSpecial.Labs) {
+		return getFontSize(fontSizes, FontFamily.TextSans);
+	}
+
+	if (
+		/** Any of these designs are considered an "opinion" */
+		format.design === ArticleDesign.Comment ||
+		format.design === ArticleDesign.Editorial ||
+		format.design === ArticleDesign.Letter
+	) {
+		return getFontSize(fontSizes, FontFamily.HeadlineLight);
+	}
+
+	return getFontSize(fontSizes, FontFamily.HeadlineMedium);
 };
 
 export const CardHeadline = ({
@@ -176,10 +227,7 @@ export const CardHeadline = ({
 	// The link is only applied directly to the headline if it is a sublink
 	const isSublink = !!linkTo;
 
-	const fonts =
-		format.theme === ArticleSpecial.Labs
-			? getFontSize(fontSizes, 'textSans')
-			: getFontSize(fontSizes, 'headline');
+	const fonts = getFonts(format, fontSizes);
 
 	return (
 		<WithLink linkTo={linkTo}>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -435,6 +435,7 @@ export const FeatureCard = ({
 											kickerColour={palette(
 												'--feature-card-kicker-text',
 											)}
+											isBetaContainer={true}
 										/>
 									</div>
 

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -12,9 +12,9 @@ import {
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import type { SmallHeadlineSize } from '../types/layout';
+import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
-import { Byline } from './Byline';
 
 type HeadlineLink = {
 	to: string; // the href for the anchor tag

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -157,7 +157,7 @@ export const LinkHeadline = ({
 					</a>
 					{!!byline && (
 						<Byline
-							fonts={
+							fontStyles={
 								isLabs
 									? bylineLabsStyles(size)
 									: fontStyles(size)
@@ -172,7 +172,7 @@ export const LinkHeadline = ({
 					<span>{headlineText}</span>
 					{!!byline && (
 						<Byline
-							fonts={
+							fontStyles={
 								isLabs
 									? bylineLabsStyles(size)
 									: fontStyles(size)

--- a/dotcom-rendering/src/components/LinkHeadline.tsx
+++ b/dotcom-rendering/src/components/LinkHeadline.tsx
@@ -1,15 +1,20 @@
 import { css } from '@emotion/react';
 import {
+	headlineMedium14,
 	headlineMedium17,
 	headlineMedium20,
 	headlineMedium24,
 	headlineMedium28,
+	textSans17,
+	textSans20,
+	textSans24,
+	until,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import type { SmallHeadlineSize } from '../types/layout';
-import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
+import { Byline } from './Byline';
 
 type HeadlineLink = {
 	to: string; // the href for the anchor tag
@@ -51,8 +56,40 @@ const fontStyles = (size: SmallHeadlineSize) => {
 			`;
 		case 'tiny':
 			return css`
-				${headlineMedium17};
-				font-size: 14px;
+				${headlineMedium14};
+			`;
+	}
+};
+
+const bylineLabsStyles = (size: SmallHeadlineSize) => {
+	switch (size) {
+		case 'ginormous':
+		case 'huge':
+			return css`
+				${textSans24};
+			`;
+
+		case 'large': {
+			return css`
+				${textSans24};
+				${until.desktop} {
+					${textSans20};
+				}
+			`;
+		}
+		case 'medium': {
+			return css`
+				${textSans20};
+				${until.desktop} {
+					${textSans17};
+				}
+			`;
+		}
+		case 'small':
+		case 'tiny':
+		default:
+			return css`
+				${textSans17};
 			`;
 	}
 };
@@ -119,7 +156,14 @@ export const LinkHeadline = ({
 						{headlineText}
 					</a>
 					{!!byline && (
-						<Byline text={byline} size={size} isLabs={isLabs} />
+						<Byline
+							fonts={
+								isLabs
+									? bylineLabsStyles(size)
+									: fontStyles(size)
+							}
+							text={byline}
+						/>
 					)}
 				</>
 			) : (
@@ -127,7 +171,14 @@ export const LinkHeadline = ({
 				<>
 					<span>{headlineText}</span>
 					{!!byline && (
-						<Byline text={byline} size={size} isLabs={isLabs} />
+						<Byline
+							fonts={
+								isLabs
+									? bylineLabsStyles(size)
+									: fontStyles(size)
+							}
+							text={byline}
+						/>
 					)}
 				</>
 			)}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -165,6 +165,7 @@ export const HighlightsCard = ({
 						showQuotes={showQuotedHeadline}
 						headlineColour={palette('--highlights-card-headline')}
 						kickerColour={palette('--highlights-card-kicker-text')}
+						isBetaContainer={true}
 					/>
 				</div>
 


### PR DESCRIPTION
## What does this change?
Allows the byline to use the same font styles as the headline by passing through the font styles as a prop. 

It also extends the font offering in card headline to include headline light as this is used by opinion cards. A card is considered an opinion card if it matches one of the following format criteria:

```
format.design === ArticleDesign.Comment ||
format.design === ArticleDesign.Editorial ||
format.design === ArticleDesign.Letter

```

It also refactors the card headline component with the intent of tightening the types to make it easier to select the correct font family and size. 

## Why?
Recent redesigns determine that card bylines should inherit the card headline styles (except colour). As the byline is not always a child of the headline, we cannot simply inherit the styles so we pass them through instead. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/66c1a333-6c51-4401-927b-211bdb316634
[after]: https://github.com/user-attachments/assets/35a328b7-dece-4f1b-a0df-e6ccf376f159
[before2]: https://github.com/user-attachments/assets/2b164f7c-7e85-4a24-b9a7-646c6fa45c58
[after2]: https://github.com/user-attachments/assets/2dd32506-6aa2-4f9a-9485-ea4ae9db6e90
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |



[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
