### PR TITLE
Slideshow: Scrolling dot animation

### DIFF
--- a/dotcom-rendering/src/components/ScrollingDots.tsx
+++ b/dotcom-rendering/src/components/ScrollingDots.tsx
@@ -32,6 +32,14 @@ const activeDotStyles = css`
 	background-color: ${palette('--slideshow-pagination-dot-active')};
 `;
 
+const moreDotStyles = css`
+	transform: scale(0.85);
+`;
+
+const hiddenDotStyles = css`
+	transform: scale(0);
+`;
+
 export const ScrollingDots = ({
 	total,
 	current,
@@ -63,12 +71,63 @@ export const ScrollingDots = ({
 		};
 	};
 
+	const dotScale = (index: number) => {
+		if (index === dotsVisible - 1 && current < scrollThreshold) {
+			return moreDotStyles;
+		}
+
+		if (
+			index === total - dotsVisible &&
+			current >= total - scrollThreshold - 1
+		) {
+			return moreDotStyles;
+		}
+
+		if (
+			index === current + scrollThreshold &&
+			current >= scrollThreshold &&
+			current < total - scrollThreshold - 1
+		) {
+			return moreDotStyles;
+		}
+
+		if (
+			index === current - scrollThreshold &&
+			current > scrollThreshold &&
+			current <= total - scrollThreshold - 1
+		) {
+			return moreDotStyles;
+		}
+
+		if (
+			index === current + scrollThreshold + 1 &&
+			current >= scrollThreshold &&
+			current < total - scrollThreshold - 1
+		) {
+			return hiddenDotStyles;
+		}
+
+		if (
+			index === current - scrollThreshold - 1 &&
+			current > scrollThreshold &&
+			current <= total - scrollThreshold - 1
+		) {
+			return hiddenDotStyles;
+		}
+
+		return;
+	};
+
 	return (
 		<div css={scrollingDotContainerStyles}>
 			<div css={scrollingDotStyles(total)} style={scrollingDotOffset()}>
 				{Array.from({ length: total }, (_, index) => (
 					<span
-						css={[dotStyles, current === index && activeDotStyles]}
+						css={[
+							dotStyles,
+							current === index && activeDotStyles,
+							dotScale(index),
+						]}
 						key={index}
 					/>
 				))}

--- a/dotcom-rendering/src/components/ScrollingDots.tsx
+++ b/dotcom-rendering/src/components/ScrollingDots.tsx
@@ -72,6 +72,8 @@ export const ScrollingDots = ({
 	};
 
 	const dotScale = (index: number) => {
+		if (total <= dotsVisible) return;
+
 		if (index === dotsVisible - 1 && current < scrollThreshold) {
 			return moreDotStyles;
 		}

--- a/dotcom-rendering/src/components/ScrollingDots.tsx
+++ b/dotcom-rendering/src/components/ScrollingDots.tsx
@@ -32,11 +32,11 @@ const activeDotStyles = css`
 	background-color: ${palette('--slideshow-pagination-dot-active')};
 `;
 
-const moreDotStyles = css`
+const trailingDotStyles = css`
 	transform: scale(0.85);
 `;
 
-const hiddenDotStyles = css`
+const offscreenDotStyles = css`
 	transform: scale(0);
 `;
 
@@ -47,7 +47,7 @@ export const ScrollingDots = ({
 	total: number;
 	current: number;
 }) => {
-	const scrollingDotOffset = () => {
+	const scrollDots = () => {
 		const offsetPerDot = -(dotSize + dotGap);
 
 		if (total <= dotsVisible) return;
@@ -71,50 +71,80 @@ export const ScrollingDots = ({
 		};
 	};
 
-	const dotScale = (index: number) => {
+	const scaleDot = (index: number) => {
 		if (total <= dotsVisible) return;
 
+		/**
+		 * If we haven't reached the scroll threshold and the current dot is the
+		 * last visible dot apply trailing style to indicate additional pages
+		 * to the right
+		 */
 		if (index === dotsVisible - 1 && current < scrollThreshold) {
-			return moreDotStyles;
+			return trailingDotStyles;
 		}
 
+		/**
+		 * If we're past the scroll threshold at the end and the current dot is
+		 * the first visible dot apply trailing style to indicate additional
+		 * pages to the left
+		 */
 		if (
 			index === total - dotsVisible &&
 			current >= total - scrollThreshold - 1
 		) {
-			return moreDotStyles;
+			return trailingDotStyles;
 		}
 
+		/**
+		 * If we've hit the scroll threshold and the current dot is the last
+		 * visible dot and there are more dots to the right apply the trailing
+		 * style to indicate additional pages to the right
+		 */
 		if (
 			index === current + scrollThreshold &&
 			current >= scrollThreshold &&
 			current < total - scrollThreshold - 1
 		) {
-			return moreDotStyles;
+			return trailingDotStyles;
 		}
 
+		/**
+		 * If we've hit the scroll threshold and the current dot is the first
+		 * visible dot and there are more dots to the left apply the trailing
+		 * style to indicate additional pages to the left
+		 */
 		if (
 			index === current - scrollThreshold &&
 			current > scrollThreshold &&
 			current <= total - scrollThreshold - 1
 		) {
-			return moreDotStyles;
+			return trailingDotStyles;
 		}
 
+		/**
+		 * If we've hit the scroll threshold and the current dot is just
+		 * offscreen to the right apply the offscreen style so the dot size
+		 * scales as it scrolls into or out of view
+		 */
 		if (
 			index === current + scrollThreshold + 1 &&
 			current >= scrollThreshold &&
 			current < total - scrollThreshold - 1
 		) {
-			return hiddenDotStyles;
+			return offscreenDotStyles;
 		}
 
+		/**
+		 * If we've hit the scroll threshold and the current dot is just
+		 * offscreen to the left apply the offscreen style so the dor size
+		 * scales as it scrolls into or out of view
+		 */
 		if (
 			index === current - scrollThreshold - 1 &&
 			current > scrollThreshold &&
 			current <= total - scrollThreshold - 1
 		) {
-			return hiddenDotStyles;
+			return offscreenDotStyles;
 		}
 
 		return;
@@ -122,13 +152,13 @@ export const ScrollingDots = ({
 
 	return (
 		<div css={scrollingDotContainerStyles}>
-			<div css={scrollingDotStyles(total)} style={scrollingDotOffset()}>
+			<div css={scrollingDotStyles(total)} style={scrollDots()}>
 				{Array.from({ length: total }, (_, index) => (
 					<span
 						css={[
 							dotStyles,
 							current === index && activeDotStyles,
-							dotScale(index),
+							scaleDot(index),
 						]}
 						key={index}
 					/>

--- a/dotcom-rendering/src/components/ScrollingDots.tsx
+++ b/dotcom-rendering/src/components/ScrollingDots.tsx
@@ -1,0 +1,78 @@
+import { css } from '@emotion/react';
+import { palette } from '../palette';
+
+const dotSize = 7;
+const dotGap = 4;
+const dotsVisible = 5;
+const scrollThreshold = Math.floor(dotsVisible / 2);
+
+const scrollingDotContainerStyles = css`
+	overflow: hidden;
+	max-width: ${dotSize * dotsVisible + dotGap * (dotsVisible - 1) + 8}px;
+`;
+
+const scrollingDotStyles = (total: number) => css`
+	display: grid;
+	gap: ${dotGap}px;
+	grid-template-columns: repeat(${total}, ${dotSize}px);
+	padding: 4px;
+	transition: transform 0.25s ease;
+`;
+
+const dotStyles = css`
+	width: ${dotSize}px;
+	height: ${dotSize}px;
+	border-radius: 100%;
+	background-color: ${palette('--slideshow-pagination-dot')};
+	transition: all 0.25s ease;
+`;
+
+const activeDotStyles = css`
+	transform: scale(1.15);
+	background-color: ${palette('--slideshow-pagination-dot-active')};
+`;
+
+export const ScrollingDots = ({
+	total,
+	current,
+}: {
+	total: number;
+	current: number;
+}) => {
+	const scrollingDotOffset = () => {
+		const offsetPerDot = -(dotSize + dotGap);
+
+		if (total <= dotsVisible) return;
+
+		if (current < scrollThreshold) {
+			return { transform: 'translateX(0)' };
+		}
+
+		if (current >= total - scrollThreshold) {
+			return {
+				transform: `translateX(${
+					(total - dotsVisible) * offsetPerDot
+				}px)`,
+			};
+		}
+
+		return {
+			transform: `translateX(${
+				(current - scrollThreshold) * offsetPerDot
+			}px)`,
+		};
+	};
+
+	return (
+		<div css={scrollingDotContainerStyles}>
+			<div css={scrollingDotStyles(total)} style={scrollingDotOffset()}>
+				{Array.from({ length: total }, (_, index) => (
+					<span
+						css={[dotStyles, current === index && activeDotStyles]}
+						key={index}
+					/>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -12,7 +12,7 @@ import { palette } from '../palette';
 import type { DCRSlideshowImage } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
-import { ScrollingDots } from './ScrollingDots';
+import { SlideshowCarouselScrollingDots } from './SlideshowCarouselScrollingDots';
 
 const themeButton: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border'),
@@ -192,7 +192,7 @@ export const SlideshowCarousel = ({
 			{slideshowImageCount > 1 && (
 				<div css={navigationStyles}>
 					<div css={scrollingDotStyles}>
-						<ScrollingDots
+						<SlideshowCarouselScrollingDots
 							total={slideshowImageCount}
 							current={currentPage}
 						/>

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -12,6 +12,7 @@ import { palette } from '../palette';
 import type { DCRSlideshowImage } from '../types/front';
 import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { CardPicture } from './CardPicture';
+import { ScrollingDots } from './ScrollingDots';
 
 const themeButton: Partial<ThemeButton> = {
 	borderTertiary: palette('--carousel-chevron-border'),
@@ -68,35 +69,21 @@ const navigationStyles = css`
 	margin-top: ${space[2]}px;
 `;
 
-/**
- * Padding is added to the left of the navigation dots to match the width of the
- * navigation buttons on the right so they are centred below the image.
- */
-const paginationStyles = css`
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	gap: ${space[1]}px;
-	flex: 1 0 0;
-	padding-left: ${width.ctaSmall * 2 + space[2]}px;
-`;
-
-const dotStyles = css`
-	width: 7px;
-	height: 7px;
-	border-radius: 100%;
-	background-color: ${palette('--slideshow-pagination-dot')};
-`;
-
-const activeDotStyles = css`
-	width: 8px;
-	height: 8px;
-	background-color: ${palette('--slideshow-pagination-dot-active')};
-`;
-
 const buttonStyles = css`
 	display: flex;
 	gap: ${space[2]}px;
+`;
+
+/**
+ * Padding is added to the left of the scrolling navigation dots to match the
+ * width of the navigation buttons on the right. This allows them to be centred
+ * below the slideshow image.
+ */
+const scrollingDotStyles = css`
+	display: flex;
+	justify-content: center;
+	flex: 1 0 0;
+	padding-left: ${width.ctaSmall * 2 + space[2]}px;
 `;
 
 export const SlideshowCarousel = ({
@@ -166,6 +153,9 @@ export const SlideshowCarousel = ({
 		};
 	}, []);
 
+	const slideshowImages = takeFirst(images, 10);
+	const slideshowImageCount = slideshowImages.length;
+
 	return (
 		<div>
 			<ul
@@ -173,7 +163,7 @@ export const SlideshowCarousel = ({
 				css={carouselStyles}
 				data-heatphan-type="carousel"
 			>
-				{takeFirst(images, 10).map((image, index) => {
+				{slideshowImages.map((image, index) => {
 					const loading = index > 0 ? 'lazy' : 'eager';
 					return (
 						<li css={carouselItemStyles} key={image.imageSrc}>
@@ -195,17 +185,13 @@ export const SlideshowCarousel = ({
 					);
 				})}
 			</ul>
+
 			<div css={navigationStyles}>
-				<div css={paginationStyles}>
-					{takeFirst(images, 10).map((image, index) => (
-						<span
-							css={[
-								dotStyles,
-								currentPage === index && activeDotStyles,
-							]}
-							key={image.imageSrc}
-						/>
-					))}
+				<div css={scrollingDotStyles}>
+					<ScrollingDots
+						total={slideshowImageCount}
+						current={currentPage}
+					/>
 				</div>
 				<div css={buttonStyles}>
 					<Button

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -153,6 +153,9 @@ export const SlideshowCarousel = ({
 		};
 	}, []);
 
+	/**
+	 * Restrict slideshow to a maximum of 10 images
+	 */
 	const slideshowImages = takeFirst(images, 10);
 	const slideshowImageCount = slideshowImages.length;
 
@@ -186,49 +189,51 @@ export const SlideshowCarousel = ({
 				})}
 			</ul>
 
-			<div css={navigationStyles}>
-				<div css={scrollingDotStyles}>
-					<ScrollingDots
-						total={slideshowImageCount}
-						current={currentPage}
-					/>
-				</div>
-				<div css={buttonStyles}>
-					<Button
-						hideLabel={true}
-						iconSide="left"
-						icon={<SvgChevronLeftSingle />}
-						onClick={() => scrollTo('left')}
-						priority="tertiary"
-						theme={
-							previousButtonEnabled
-								? themeButton
-								: themeButtonDisabled
-						}
-						size="small"
-						disabled={!previousButtonEnabled}
-						aria-label="View next image in slideshow"
-						// TODO: data-link-name="slideshow carousel left chevron"
-					/>
+			{slideshowImageCount > 1 && (
+				<div css={navigationStyles}>
+					<div css={scrollingDotStyles}>
+						<ScrollingDots
+							total={slideshowImageCount}
+							current={currentPage}
+						/>
+					</div>
+					<div css={buttonStyles}>
+						<Button
+							hideLabel={true}
+							iconSide="left"
+							icon={<SvgChevronLeftSingle />}
+							onClick={() => scrollTo('left')}
+							priority="tertiary"
+							theme={
+								previousButtonEnabled
+									? themeButton
+									: themeButtonDisabled
+							}
+							size="small"
+							disabled={!previousButtonEnabled}
+							aria-label="View next image in slideshow"
+							// TODO: data-link-name="slideshow carousel left chevron"
+						/>
 
-					<Button
-						hideLabel={true}
-						iconSide="left"
-						icon={<SvgChevronRightSingle />}
-						onClick={() => scrollTo('right')}
-						priority="tertiary"
-						theme={
-							nextButtonEnabled
-								? themeButton
-								: themeButtonDisabled
-						}
-						size="small"
-						disabled={!nextButtonEnabled}
-						aria-label="View previous image in slideshow"
-						// TODO: data-link-name="slideshow carousel right chevron"
-					/>
+						<Button
+							hideLabel={true}
+							iconSide="left"
+							icon={<SvgChevronRightSingle />}
+							onClick={() => scrollTo('right')}
+							priority="tertiary"
+							theme={
+								nextButtonEnabled
+									? themeButton
+									: themeButtonDisabled
+							}
+							size="small"
+							disabled={!nextButtonEnabled}
+							aria-label="View previous image in slideshow"
+							// TODO: data-link-name="slideshow carousel right chevron"
+						/>
+					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -5,9 +5,22 @@ import type { ReactNode } from 'react';
 import type { DCRSlideshowImage } from '../types/front';
 import { SlideshowCarousel } from './SlideshowCarousel.importable';
 
+const Wrapper = ({ children }: { children: ReactNode }) => {
+	const styles = css`
+		margin: ${space[2]}px;
+		max-width: 460px;
+	`;
+	return <div css={styles}>{children}</div>;
+};
+
 const meta = {
 	component: SlideshowCarousel,
 	title: 'Components/SlideshowCarousel',
+	render: (args) => (
+		<Wrapper>
+			<SlideshowCarousel {...args} />
+		</Wrapper>
+	),
 	parameters: {
 		chromatic: {
 			viewports: [
@@ -62,22 +75,23 @@ const images = [
 	},
 ] as const satisfies readonly DCRSlideshowImage[];
 
-const Wrapper = ({ children }: { children: ReactNode }) => {
-	const styles = css`
-		margin: ${space[2]}px;
-		max-width: 460px;
-	`;
-	return <div css={styles}>{children}</div>;
-};
-
-export const Default = {
-	render: (args) => (
-		<Wrapper>
-			<SlideshowCarousel {...args} />
-		</Wrapper>
-	),
+export const WithMultipleImages = {
 	args: {
 		images,
+		imageSize: 'medium',
+	},
+} satisfies Story;
+
+export const WithThreeImages = {
+	args: {
+		images: images.slice(0, 3),
+		imageSize: 'medium',
+	},
+} satisfies Story;
+
+export const WithOneImage = {
+	args: {
+		images: images.slice(0, 1),
 		imageSize: 'medium',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -26,13 +26,23 @@ type Story = StoryObj<typeof meta>;
 const images = [
 	{
 		imageSrc:
+			'https://media.guim.co.uk/7cffd9d6809318a9d92c719c473d193caf95d601/0_0_3110_2074/3110.jpg',
+		imageCaption:
+			'Land Rover parked somewhere on the Roseland Heritage Coast, Cornwall.',
+	},
+	{
+		imageSrc:
+			'https://media.guim.co.uk/c36af9ca4c805e161ec991df550277db32637f32/0_0_3110_2074/3110.jpg',
+		imageCaption:
+			'Kudhva, architectural hideouts on the north Cornish coast',
+	},
+	{
+		imageSrc:
 			'https://media.guim.co.uk/4199670a084d3179778332af3ee6297486332e91/0_0_4000_3000/master/4000.jpg',
-		imageCaption: 'First image in slideshow',
 	},
 	{
 		imageSrc:
 			'https://media.guim.co.uk/fe27aabf35683caa6b89f2781ee5d0ad9042e209/0_0_4800_3197/master/4800.jpg',
-		imageCaption: 'Second image',
 	},
 	{
 		imageSrc:

--- a/dotcom-rendering/src/components/SlideshowCarouselScrollingDots.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarouselScrollingDots.tsx
@@ -40,7 +40,7 @@ const offscreenDotStyles = css`
 	transform: scale(0);
 `;
 
-export const ScrollingDots = ({
+export const SlideshowCarouselScrollingDots = ({
 	total,
 	current,
 }: {

--- a/dotcom-rendering/src/components/SlideshowCarouselScrollingDots.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarouselScrollingDots.tsx
@@ -136,7 +136,7 @@ export const SlideshowCarouselScrollingDots = ({
 
 		/**
 		 * If we've hit the scroll threshold and the current dot is just
-		 * offscreen to the left apply the offscreen style so the dor size
+		 * offscreen to the left apply the offscreen style so the dot size
 		 * scales as it scrolls into or out of view
 		 */
 		if (


### PR DESCRIPTION
## What does this change?

Animates the slideshow's pagination dots so they scroll (and scale) as you move through the images. A maximum of 5 dots are shown at a time with smaller trailing dots used to indicate additional pages.

## Why?

To match the animation in the native apps.

## Screenshots

![dots](https://github.com/user-attachments/assets/ca37326a-fdac-4768-92a8-e5d56d3c2743)

<img width="475" alt="Screenshot 2024-11-20 at 10 52 25" src="https://github.com/user-attachments/assets/8b083616-029b-4122-a45a-73f9cc9b4930">
