### PR TITLE
Dark mode for table block

### DIFF
--- a/dotcom-rendering/src/components/TableBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/TableBlockComponent.stories.tsx
@@ -1,0 +1,215 @@
+import type { Meta } from '@storybook/react';
+import { TableBlockComponent } from './TableBlockComponent';
+
+const tableHtml = `<table data-embed-type="table" class="table table--football table--striped">
+        <thead>
+            <tr>
+                <th class="football-stat--postition table-column--sub"><abbr title="Position">Pos</abbr></th>
+                <th class="football-stat--team table-column--main">Team</th>
+                <th class="football-stat--played"><abbr title="Played">P</abbr></th>
+                <th class="football-stat--difference"><abbr title="Goal difference">GD</abbr></th>
+                <th class="football-stat--points"><abbr title="Points">Pts</abbr></th>
+            </tr>
+        </thead>
+        <tbody>
+
+            <tr class="
+            ">
+                <td class="football-stat--postition table-column--sub">1</td>
+                <td class="football-stat--team table-column--main">Liverpool</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">15</td>
+                <td class="football-stat--points">28</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">2</td>
+                <td class="football-stat--team table-column--main">Man City</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">9</td>
+                <td class="football-stat--points">23</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">3</td>
+                <td class="football-stat--team table-column--main">Nottm Forest</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">5</td>
+                <td class="football-stat--points">19</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">4</td>
+                <td class="football-stat--team table-column--main">Brighton</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">4</td>
+                <td class="football-stat--points">19</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">5</td>
+                <td class="football-stat--team table-column--main">Chelsea</td>
+                <td class="football-stat--played">10</td>
+                <td class="football-stat--difference">8</td>
+                <td class="football-stat--points">18</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">6</td>
+                <td class="football-stat--team table-column--main">Arsenal</td>
+                <td class="football-stat--played">10</td>
+                <td class="football-stat--difference">6</td>
+                <td class="football-stat--points">18</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">7</td>
+                <td class="football-stat--team table-column--main">Fulham</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">3</td>
+                <td class="football-stat--points">18</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">8</td>
+                <td class="football-stat--team table-column--main">Newcastle</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">2</td>
+                <td class="football-stat--points">18</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">9</td>
+                <td class="football-stat--team table-column--main">Aston Villa</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">0</td>
+                <td class="football-stat--points">18</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">10</td>
+                <td class="football-stat--team table-column--main">Tottenham Hotspur</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">10</td>
+                <td class="football-stat--points">16</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">11</td>
+                <td class="football-stat--team table-column--main">Brentford</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">0</td>
+                <td class="football-stat--points">16</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">12</td>
+                <td class="football-stat--team table-column--main">AFC Bournemouth</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">0</td>
+                <td class="football-stat--points">15</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">13</td>
+                <td class="football-stat--team table-column--main">Man Utd</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">0</td>
+                <td class="football-stat--points">15</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">14</td>
+                <td class="football-stat--team table-column--main">West Ham</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-6</td>
+                <td class="football-stat--points">12</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">15</td>
+                <td class="football-stat--team table-column--main">Leicester</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-7</td>
+                <td class="football-stat--points">10</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">16</td>
+                <td class="football-stat--team table-column--main">Everton</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-7</td>
+                <td class="football-stat--points">10</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">17</td>
+                <td class="football-stat--team table-column--main">Ipswich</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-10</td>
+                <td class="football-stat--points">8</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">18</td>
+                <td class="football-stat--team table-column--main">Crystal Palace</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-7</td>
+                <td class="football-stat--points">7</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">19</td>
+                <td class="football-stat--team table-column--main">Wolverhampton</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-11</td>
+                <td class="football-stat--points">6</td>
+            </tr>
+
+            <tr class="
+             ">
+                <td class="football-stat--postition table-column--sub">20</td>
+                <td class="football-stat--team table-column--main">Southampton</td>
+                <td class="football-stat--played">11</td>
+                <td class="football-stat--difference">-14</td>
+                <td class="football-stat--points">4</td>
+            </tr>
+
+        </tbody>
+    </table>`;
+
+const meta = {
+	title: 'Components/TableBlockComponent',
+	component: TableBlockComponent,
+	render: (args) => <TableBlockComponent {...args} />,
+	args: {
+		element: {
+			isMandatory: true,
+			elementId: 'table',
+			_type: 'model.dotcomrendering.pageElements.TableBlockElement',
+			html: tableHtml,
+		},
+	},
+} satisfies Meta<typeof TableBlockComponent>;
+
+export default meta;
+
+export const Default = {};

--- a/dotcom-rendering/src/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TableBlockComponent.tsx
@@ -1,17 +1,18 @@
 import { css } from '@emotion/react';
-import { palette, text, textSans12 } from '@guardian/source/foundations';
+import { textSans12 } from '@guardian/source/foundations';
 import { unescapeData } from '../lib/escapeData';
+import { palette } from '../palette';
 import type { TableBlockElement } from '../types/content';
 
 const tableEmbed = css`
 	.table--football {
 		width: 100%;
-		background: ${palette.neutral[97]};
-		border-top: 0.0625rem solid ${palette.focus[400]};
-		color: ${palette.neutral[7]};
+		background: ${palette('--table-block-background')};
+		border-top: 0.0625rem solid ${palette('--table-block-border-top')};
+		color: ${palette('--table-block-text')};
 		border-collapse: inherit;
 		tr:nth-child(odd) > td {
-			background-color: ${palette.neutral[93]};
+			background-color: ${palette('--table-block-stripe')};
 		}
 		th {
 			padding: 0.5rem;
@@ -30,7 +31,7 @@ const tableEmbed = css`
 		}
 		tr > th:first-child,
 		td:first-child {
-			color: ${text.supporting};
+			color: ${palette('--table-block-text-first-column')};
 		}
 		.table-column--main {
 			width: 100%;

--- a/dotcom-rendering/src/components/TableBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TableBlockComponent.tsx
@@ -5,37 +5,37 @@ import { palette } from '../palette';
 import { logger } from '../server/lib/logging';
 import type { TableBlockElement } from '../types/content';
 
-const tableEmbed = css`
-	.table--football {
-		width: 100%;
-		background: ${palette('--table-block-background')};
-		border-top: 0.0625rem solid ${palette('--table-block-border-top')};
-		color: ${palette('--table-block-text')};
-		border-collapse: inherit;
-		tr:nth-child(odd) > td {
-			background-color: ${palette('--table-block-stripe')};
-		}
-		th {
-			padding: 0.5rem;
-		}
-		td {
-			padding: 0.5rem;
-		}
-		tr {
-			${textSans12};
-		}
-		thead {
-			tr {
-				font-weight: 800;
-				text-align: left;
-			}
-		}
-		tr > th:first-child,
-		td:first-child {
-			color: ${palette('--table-block-text-first-column')};
-		}
+const tableStyles = css`
+	width: 100%;
+	background: ${palette('--table-block-background')};
+	border-top: 0.0625rem solid ${palette('--table-block-border-top')};
+	color: ${palette('--table-block-text')};
+	border-collapse: inherit;
+`;
+
+const headStyles = css`
+	tr {
+		font-weight: 800;
+		text-align: left;
 	}
-	margin-bottom: 16px;
+`;
+
+const rowStyles = css`
+	${textSans12};
+	:nth-child(odd) > td {
+		background-color: ${palette('--table-block-stripe')};
+	}
+`;
+
+const cellPadding = css`
+	padding: 0.5rem;
+`;
+
+const tableEmbed = css`
+	tr > th:first-child,
+	td:first-child {
+		color: ${palette('--table-block-text-first-column')};
+	}
 `;
 
 type Props = {
@@ -46,10 +46,14 @@ const buildElementTree = (node: Node) => {
 	const children = Array.from(node.childNodes).map(buildElementTree);
 	switch (node.nodeName) {
 		case 'TABLE': {
-			return <table className="table--football">{children}</table>;
+			return (
+				<table className="table--football" css={tableStyles}>
+					{children}
+				</table>
+			);
 		}
 		case 'THEAD': {
-			return <thead>{children}</thead>;
+			return <thead css={headStyles}>{children}</thead>;
 		}
 		case 'TBODY': {
 			return <tbody>{children}</tbody>;
@@ -62,17 +66,20 @@ const buildElementTree = (node: Node) => {
 			);
 		}
 		case 'TR': {
-			return <tr>{children}</tr>;
+			return <tr css={rowStyles}>{children}</tr>;
 		}
 		case 'TH': {
-			return <th>{children}</th>;
+			return <th css={cellPadding}>{children}</th>;
 		}
 		case 'TD': {
 			const isMainColumn = (node as HTMLElement).className.includes(
 				'table-column--main',
 			);
 			return (
-				<td style={isMainColumn ? { width: '100%' } : undefined}>
+				<td
+					style={isMainColumn ? { width: '100%' } : undefined}
+					css={cellPadding}
+				>
 					{children}
 				</td>
 			);
@@ -95,7 +102,11 @@ const buildElementTree = (node: Node) => {
 export const TableBlockComponent = ({ element }: Props) => {
 	const fragment = parseHtml(element.html);
 	return (
-		<div css={tableEmbed} data-testid="football-table-embed">
+		<div
+			css={tableEmbed}
+			style={{ marginBottom: '16px' }}
+			data-testid="football-table-embed"
+		>
 			{Array.from(fragment.childNodes).map(buildElementTree)}
 		</div>
 	);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1823,6 +1823,23 @@ const accordionBackgroundDark: PaletteFunction = () =>
 const accordionBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
 
+const tableBlockTextLight: PaletteFunction = () => sourcePalette.neutral[7];
+const tableBlockTextDark: PaletteFunction = () => sourcePalette.neutral[86];
+const tableBlockBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const tableBlockBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[38];
+const tableBlockStripeLight: PaletteFunction = () => sourcePalette.neutral[93];
+const tableBlockStripeDark: PaletteFunction = () => sourcePalette.neutral[20];
+const tableBlockTextFirstColumnLight: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+const tableBlockTextFirstColumnDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const tableBlockBorderTopLight: PaletteFunction = () =>
+	sourcePalette.brand[500];
+const tableBlockBorderTopDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+
 const tableOfContentsLight: PaletteFunction = () => sourcePalette.neutral[7];
 const tableOfContentsDark: PaletteFunction = () => sourcePalette.neutral[86];
 const tableOfContentsBorderLight: PaletteFunction = () =>
@@ -7085,6 +7102,26 @@ const paletteColours = {
 	'--syndication-button-text': {
 		light: syndicationButtonTextLight,
 		dark: syndicationButtonTextDark,
+	},
+	'--table-block-background': {
+		light: tableBlockBackgroundLight,
+		dark: tableBlockBackgroundDark,
+	},
+	'--table-block-border-top': {
+		light: tableBlockBorderTopLight,
+		dark: tableBlockBorderTopDark,
+	},
+	'--table-block-stripe': {
+		light: tableBlockStripeLight,
+		dark: tableBlockStripeDark,
+	},
+	'--table-block-text': {
+		light: tableBlockTextLight,
+		dark: tableBlockTextDark,
+	},
+	'--table-block-text-first-column': {
+		light: tableBlockTextFirstColumnLight,
+		dark: tableBlockTextFirstColumnDark,
 	},
 	'--table-of-contents': {
 		light: tableOfContentsLight,


### PR DESCRIPTION
This implements @richcousins's dark mode designs to table elements, addressing https://github.com/guardian/dotcom-rendering/issues/9775.

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/f3c8bf70-cc66-4082-a7b8-a30ff7ebd9c5">

Also adds a story for smoother local development.
