### PR TITLE
Slideshows: Special palette overrides

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -1077,6 +1077,28 @@ const carouselChevronBorderDisabledDark: ContainerFunction = (
 	containerPalette,
 ) => transparentColour(cardHeadlineDark(containerPalette), 0.4);
 
+const slideshowPaginationDotLight: ContainerFunction = (containerPalette) => {
+	switch (containerPalette) {
+		case 'BreakingPalette':
+		case 'InvestigationPalette':
+		case 'SombrePalette':
+		case 'SombreAltPalette':
+			return transparentColour(cardHeadlineLight(containerPalette), 0.4);
+		default:
+			return transparentColour(cardHeadlineLight(containerPalette), 0.2);
+	}
+};
+
+const slideshowPaginationDotDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.4);
+
+const slideshowPaginationDotActiveLight: ContainerFunction = (
+	containerPalette,
+) => cardHeadlineLight(containerPalette);
+const slideshowPaginationDotActiveDark: ContainerFunction = (
+	containerPalette,
+) => cardHeadlineDark(containerPalette);
+
 type ColourName = Parameters<typeof palette>[0];
 
 type ContainerFunction = (containerPalette: DCRContainerPalette) => string;
@@ -1209,6 +1231,14 @@ const containerColours = {
 	'--carousel-chevron-hover': {
 		light: carouselChevronHoverLight,
 		dark: carouselChevronHoverDark,
+	},
+	'--slideshow-pagination-dot': {
+		light: slideshowPaginationDotLight,
+		dark: slideshowPaginationDotDark,
+	},
+	'--slideshow-pagination-dot-active': {
+		light: slideshowPaginationDotActiveLight,
+		dark: slideshowPaginationDotActiveDark,
 	},
 	'--section-border': {
 		light: sectionBorderLight,

--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -1,40 +1,11 @@
 import { css } from '@emotion/react';
-import { breakpoints, space } from '@guardian/source/foundations';
+import { breakpoints, space, textSans17 } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ReactNode } from 'react';
-import type { DCRSlideshowImage } from '../types/front';
+import { palette } from '../palette';
+import type { DCRContainerPalette, DCRSlideshowImage } from '../types/front';
+import { ContainerOverrides } from './ContainerOverrides';
 import { SlideshowCarousel } from './SlideshowCarousel.importable';
-
-const Wrapper = ({ children }: { children: ReactNode }) => {
-	const styles = css`
-		margin: ${space[2]}px;
-		max-width: 460px;
-	`;
-	return <div css={styles}>{children}</div>;
-};
-
-const meta = {
-	component: SlideshowCarousel,
-	title: 'Components/SlideshowCarousel',
-	render: (args) => (
-		<Wrapper>
-			<SlideshowCarousel {...args} />
-		</Wrapper>
-	),
-	parameters: {
-		chromatic: {
-			viewports: [
-				breakpoints.mobile,
-				breakpoints.tablet,
-				breakpoints.leftCol,
-			],
-		},
-	},
-} satisfies Meta<typeof SlideshowCarousel>;
-
-export default meta;
-
-type Story = StoryObj<typeof meta>;
 
 const images = [
 	{
@@ -75,23 +46,109 @@ const images = [
 	},
 ] as const satisfies readonly DCRSlideshowImage[];
 
-export const WithMultipleImages = {
+const Wrapper = ({
+	children,
+	heading,
+}: {
+	children: ReactNode;
+	heading?: string;
+}) => {
+	const sectionStyles = css`
+		padding: ${space[4]}px;
+		background: ${palette('--card-background')};
+	`;
+	const containerStyles = css`
+		max-width: 460px;
+	`;
+	const headingStyles = css`
+		${textSans17};
+		color: ${palette('--card-headline')};
+		margin-bottom: ${space[2]}px;
+	`;
+	return (
+		<section css={sectionStyles}>
+			<div css={containerStyles}>
+				{!!heading && <h2 css={headingStyles}>{heading}</h2>}
+				{children}
+			</div>
+		</section>
+	);
+};
+
+const meta = {
+	component: SlideshowCarousel,
+	title: 'Components/SlideshowCarousel',
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.leftCol,
+			],
+		},
+	},
 	args: {
 		images,
 		imageSize: 'medium',
 	},
-} satisfies Story;
+	render: (args) => (
+		<Wrapper>
+			<SlideshowCarousel {...args} />
+		</Wrapper>
+	),
+} satisfies Meta<typeof SlideshowCarousel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithMultipleImages = {} satisfies Story;
 
 export const WithThreeImages = {
 	args: {
 		images: images.slice(0, 3),
-		imageSize: 'medium',
 	},
 } satisfies Story;
 
 export const WithOneImage = {
 	args: {
 		images: images.slice(0, 1),
-		imageSize: 'medium',
 	},
+} satisfies Story;
+
+const containerPalettes = [
+	'InvestigationPalette',
+	'LongRunningPalette',
+	'SombrePalette',
+	'BreakingPalette',
+	'EventPalette',
+	'EventAltPalette',
+	'LongRunningAltPalette',
+	'SombreAltPalette',
+	'SpecialReportAltPalette',
+	'Branded',
+] as const satisfies readonly Omit<
+	DCRContainerPalette,
+	'MediaPalette' | 'PodcastPalette'
+>[];
+
+export const WithSpecialPaletteVariations = {
+	parameters: {
+		/** We only want one breakpoint snapshotted for special palette variations */
+		chromatic: { viewports: [breakpoints.desktop] },
+	},
+	render: (args) => (
+		<>
+			{containerPalettes.map((containerPalette) => (
+				<ContainerOverrides
+					containerPalette={containerPalette}
+					key={containerPalette}
+				>
+					<Wrapper heading={containerPalette}>
+						<SlideshowCarousel {...args} />
+					</Wrapper>
+				</ContainerOverrides>
+			))}
+		</>
+	),
 } satisfies Story;


### PR DESCRIPTION
## What does this change?

Adds special palette overrides for slideshows

## Why?

To ensure slideshows render correctly when placed in a card with a special palette

## Screenshots

![localhost_4002_iframe html_globals=viewport%3Awide args= id=components-slideshowcarousel--with-special-palette-variations viewMode=story (1)](https://github.com/user-attachments/assets/b67b73d8-9c5f-45d7-9835-57c5d8a74aca)

![localhost_4002_iframe html_globals=viewport%3Awide args= id=components-slideshowcarousel--with-special-palette-variations viewMode=story](https://github.com/user-attachments/assets/ff567546-f7ba-410c-b823-61603456984d)
