### PR TITLE
Turning discount pill back on 

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -487,7 +487,7 @@ export const WithThreeTierDiscountChoiceCards: Story = {
 			cta: {
 				text: 'Support the Guardian',
 				baseUrl:
-					'https://support.theguardian.com/uk/contribute?promoCode=OCT_DISCOUNT_50_3_MONTHS',
+					'https://support.theguardian.com/uk/contribute?promoCode=BLACK_FRIDAY_DISCOUNT_2024',
 			},
 		},
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -58,7 +58,7 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 		showChoiceCards && variant.name.includes('US_CHECKOUT_PAGE');
 
 	const hasSupporterPlusPromoCode =
-		variant.cta?.baseUrl.includes('OCT_DISCOUNT_50_3_MONTHS') ?? false;
+		variant.cta?.baseUrl.includes('BLACK_FRIDAY_DISCOUNT_2024') ?? false;
 
 	const variantOfChoiceCard =
 		countryCode === 'US' && showUSSupportCheckout


### PR DESCRIPTION
## What does this change?
Turns the red discount pill back on for the Black Friday promotion. It checks for the promo code `BLACK_FRIDAY_DISCOUNT_2024` in the url to know whether to render the discount.

## Screenshots
<img width="653" alt="image" src="https://github.com/user-attachments/assets/5f108716-1780-4571-8a35-dd91a8f9105d">


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
