### PR TITLE
Slideshow: Reduce gradient height and hide buttons on mobile

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -75,8 +75,11 @@ const navigationStyles = css`
 `;
 
 const buttonStyles = css`
-	display: flex;
-	gap: ${space[2]}px;
+	display: none;
+	${from.tablet} {
+		display: flex;
+		gap: ${space[2]}px;
+	}
 `;
 
 /**

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { space, textSansBold12, width } from '@guardian/source/foundations';
+import {
+	from,
+	space,
+	textSansBold12,
+	width,
+} from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
 import {
 	Button,
@@ -49,18 +54,18 @@ const carouselItemStyles = css`
 `;
 
 const captionStyles = css`
-	${textSansBold12}
 	position: absolute;
 	bottom: 0;
 	left: 0;
 	right: 0;
+	${textSansBold12}
+	color: ${palette('--slideshow-caption')};
 	background: linear-gradient(
 		to bottom,
 		rgba(0, 0, 0, 0) 0%,
 		rgba(0, 0, 0, 0.8) 100%
 	);
-	color: ${palette('--slideshow-caption')};
-	padding: 60px ${space[2]}px ${space[2]}px;
+	padding: 40px ${space[2]}px ${space[2]}px;
 `;
 
 const navigationStyles = css`
@@ -76,14 +81,16 @@ const buttonStyles = css`
 
 /**
  * Padding is added to the left of the scrolling navigation dots to match the
- * width of the navigation buttons on the right. This allows them to be centred
- * below the slideshow image.
+ * width of the navigation buttons on the right at tablet and above. This allows
+ * them to be centred below the slideshow image.
  */
 const scrollingDotStyles = css`
 	display: flex;
 	justify-content: center;
 	flex: 1 0 0;
-	padding-left: ${width.ctaSmall * 2 + space[2]}px;
+	${from.tablet} {
+		padding-left: ${width.ctaSmall * 2 + space[2]}px;
+	}
 `;
 
 export const SlideshowCarousel = ({

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -65,7 +65,7 @@ const captionStyles = css`
 		rgba(0, 0, 0, 0) 0%,
 		rgba(0, 0, 0, 0.8) 100%
 	);
-	padding: 40px ${space[2]}px ${space[2]}px;
+	padding: ${space[10]}px ${space[2]}px ${space[2]}px;
 `;
 
 const navigationStyles = css`


### PR DESCRIPTION
## What does this change?

- Reduces height of gradient behind caption to 64px (this will increase in height if the text wraps)
- Hides navigation buttons on mobile

## Why?

Part of the work to [support slideshow carousels in DCR](https://trello.com/c/53tELnFE/236-slideshow-carousel-on-web)

## Screenshots

| Mobile      | Tablet      |
| ----------- | ---------- |
| ![mobile][] | ![tablet][] |

[mobile]: https://github.com/user-attachments/assets/146ca30d-9801-43ee-bab3-d616d9c861c0
[tablet]: https://github.com/user-attachments/assets/9d222fad-9988-42fd-8a35-9d8220684053
