### PR TITLE
make table of contents sticky if it has more than 5 items

### DIFF
--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -71,6 +71,21 @@ const detailsStyles = css`
 	summary::-webkit-details-marker {
 		display: none;
 	}
+
+	&.make-sticky {
+		position: sticky;
+		top: 0;
+		background: white;
+		z-index: 4;
+		max-height: 100vh;
+		overflow: scroll;
+		summary {
+			position: sticky;
+			top: 0;
+			z-index: 5;
+			background: white;
+		}
+	}
 `;
 
 const summaryStyles = css`
@@ -127,6 +142,7 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 		<details
 			open={open}
 			css={detailsStyles}
+			className={tableOfContents.length > 5 ? 'make-sticky' : ''}
 			data-component="table-of-contents"
 		>
 			<summary

--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -11,9 +11,9 @@ import {
 } from '@guardian/source/react-components';
 import { useState } from 'react';
 import { ArticleDisplay, type ArticleFormat } from '../lib/articleFormat';
+import { getZIndex } from '../lib/getZIndex';
 import type { TableOfContentsItem } from '../model/enhanceTableOfContents';
 import { palette } from '../palette';
-import { getZIndex } from '../lib/getZIndex';
 
 interface Props {
 	tableOfContents: TableOfContentsItem[];
@@ -191,7 +191,7 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 						<a
 							href={`#${item.id}`}
 							css={[anchorStyles, paddingStyles]}
-							onClick={(e): void => {
+							onClick={(): void => {
 								setOpen((state) => !state);
 							}}
 						>

--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -75,7 +75,7 @@ const detailsStyles = css`
 	&.make-sticky {
 		position: sticky;
 		top: 0;
-		background: white;
+		background: ${palette('--article-background')};
 		z-index: 4;
 		max-height: 100vh;
 		overflow: scroll;
@@ -83,7 +83,7 @@ const detailsStyles = css`
 			position: sticky;
 			top: 0;
 			z-index: 5;
-			background: white;
+			background: ${palette('--article-background')};
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import { ArticleDisplay, type ArticleFormat } from '../lib/articleFormat';
 import type { TableOfContentsItem } from '../model/enhanceTableOfContents';
 import { palette } from '../palette';
+import { getZIndex } from '../lib/getZIndex';
 
 interface Props {
 	tableOfContents: TableOfContentsItem[];
@@ -71,20 +72,19 @@ const detailsStyles = css`
 	summary::-webkit-details-marker {
 		display: none;
 	}
-
-	&.make-sticky {
+`;
+const stickyStyles = css`
+	position: sticky;
+	top: 0;
+	background: ${palette('--article-background')};
+	${getZIndex('tableOfContents')}
+	max-height: 100vh;
+	overflow: scroll;
+	summary {
 		position: sticky;
 		top: 0;
+		z-index: 1;
 		background: ${palette('--article-background')};
-		z-index: 4;
-		max-height: 100vh;
-		overflow: scroll;
-		summary {
-			position: sticky;
-			top: 0;
-			z-index: 5;
-			background: ${palette('--article-background')};
-		}
 	}
 `;
 
@@ -141,8 +141,10 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	return (
 		<details
 			open={open}
-			css={detailsStyles}
-			className={tableOfContents.length > 5 ? 'make-sticky' : ''}
+			css={[
+				detailsStyles,
+				tableOfContents.length > 5 ? stickyStyles : undefined,
+			]}
 			data-component="table-of-contents"
 		>
 			<summary
@@ -189,6 +191,9 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 						<a
 							href={`#${item.id}`}
 							css={[anchorStyles, paddingStyles]}
+							onClick={(e): void => {
+								setOpen((state) => !state);
+							}}
 						>
 							{item.title}
 						</a>

--- a/dotcom-rendering/src/lib/getZIndex.test.ts
+++ b/dotcom-rendering/src/lib/getZIndex.test.ts
@@ -2,34 +2,35 @@ import { getZIndex } from './getZIndex';
 
 describe('getZIndex', () => {
 	it('gets the correct zindex for group and sibling', () => {
-		expect(getZIndex('sticky-video-button')).toBe('z-index: 31;');
-		expect(getZIndex('sticky-video')).toBe('z-index: 30;');
-		expect(getZIndex('banner')).toBe('z-index: 29;');
-		expect(getZIndex('dropdown')).toBe('z-index: 28;');
-		expect(getZIndex('burger')).toBe('z-index: 27;');
+		expect(getZIndex('sticky-video-button')).toBe('z-index: 32;');
+		expect(getZIndex('sticky-video')).toBe('z-index: 31;');
+		expect(getZIndex('banner')).toBe('z-index: 30;');
+		expect(getZIndex('dropdown')).toBe('z-index: 29;');
+		expect(getZIndex('burger')).toBe('z-index: 28;');
 		expect(getZIndex('mastheadVeggieBurgerExpandedMobile')).toBe(
-			'z-index: 26;',
+			'z-index: 27;',
 		);
-		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 25;');
-		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 24;');
+		expect(getZIndex('expanded-veggie-menu-wrapper')).toBe('z-index: 26;');
+		expect(getZIndex('expanded-veggie-menu')).toBe('z-index: 25;');
 		expect(getZIndex('fullPageInteractiveHeaderWrapper')).toBe(
-			'z-index: 23;',
+			'z-index: 24;',
 		);
-		expect(getZIndex('mobileSticky')).toBe('z-index: 22;');
-		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 21;');
-		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 20;');
-		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 19;');
-		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 18;');
-		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 17;');
-		expect(getZIndex('editionDropdown')).toBe('z-index: 16;');
-		expect(getZIndex('summaryDetails')).toBe('z-index: 15;');
-		expect(getZIndex('toast')).toBe('z-index: 14;');
-		expect(getZIndex('onwardsCarousel')).toBe('z-index: 13;');
-		expect(getZIndex('myAccountDropdown')).toBe('z-index: 12;');
-		expect(getZIndex('searchHeaderLink')).toBe('z-index: 11;');
-		expect(getZIndex('TheGuardian')).toBe('z-index: 10;');
-		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 9;');
-		expect(getZIndex('expandableMarketingCardOverlay')).toBe('z-index: 8;');
+		expect(getZIndex('mobileSticky')).toBe('z-index: 23;');
+		expect(getZIndex('stickyAdWrapperLabsHeader')).toBe('z-index: 22;');
+		expect(getZIndex('stickyAdWrapper')).toBe('z-index: 21;');
+		expect(getZIndex('stickyAdWrapperNav')).toBe('z-index: 20;');
+		expect(getZIndex('mastheadMyAccountDropdown')).toBe('z-index: 19;');
+		expect(getZIndex('mastheadEditionDropdown')).toBe('z-index: 18;');
+		expect(getZIndex('editionDropdown')).toBe('z-index: 17;');
+		expect(getZIndex('summaryDetails')).toBe('z-index: 16;');
+		expect(getZIndex('toast')).toBe('z-index: 15;');
+		expect(getZIndex('onwardsCarousel')).toBe('z-index: 14;');
+		expect(getZIndex('myAccountDropdown')).toBe('z-index: 13;');
+		expect(getZIndex('searchHeaderLink')).toBe('z-index: 12;');
+		expect(getZIndex('TheGuardian')).toBe('z-index: 11;');
+		expect(getZIndex('editionSwitcherBanner')).toBe('z-index: 10;');
+		expect(getZIndex('expandableMarketingCardOverlay')).toBe('z-index: 9;');
+		expect(getZIndex('tableOfContents')).toBe('z-index: 8;');
 		expect(getZIndex('articleHeadline')).toBe('z-index: 7;');
 		expect(getZIndex('immersiveBlackBox')).toBe('z-index: 6;');
 		expect(getZIndex('bodyArea')).toBe('z-index: 5;');

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -77,6 +77,9 @@ const indices = [
 	// Overlay for expandable marketing card (currently US only)
 	'expandableMarketingCardOverlay',
 
+	// Sticky table of contents element
+	'tableOfContents',
+
 	// Article headline (should be above main media)
 	'articleHeadline',
 	'immersiveBlackBox',


### PR DESCRIPTION
## What does this change?
This weekend the Christmas List affiliates content goes live. This ToC element is a bit redundant if it doesn't stick to the top of the browser as you scroll. There is some logic to default open vs close if there are more than 5 items. If the list is open then the whole thing sticks to the top of the browser and hides all the content hence I'm just applying this additional css if > 5 
## Why?
Allows users to jump around long articles. This has more than 200 items in


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
