### PR TITLE
Giving Tuesday: Update Thrasher colour/copy

### DIFF
--- a/dotcom-rendering/src/components/UsEoy2024.stories.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024.stories.tsx
@@ -18,5 +18,6 @@ export const Default = {
 		},
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		submitTrackingEvent: () => {},
+		date: new Date('2024-11-26T00:00:00Z'),
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -317,7 +317,7 @@ export const UsEoy2024: ReactComponent<Props> = ({
 	} = useChoiceCards(choiceCardAmounts, 'US', cta, cta);
 
 	const isGivingTuesday =
-		date >= new Date('2024-11-27T00:00:00Z') &&
+		date >= new Date('2024-11-27T00:00:01Z') &&
 		date < new Date('2024-12-04T23:59:59Z');
 
 	return (

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -317,8 +317,8 @@ export const UsEoy2024: ReactComponent<Props> = ({
 	} = useChoiceCards(choiceCardAmounts, 'US', cta, cta);
 
 	const isGivingTuesday =
-		date >= new Date('2024-11-27T00:00:01Z') &&
-		date < new Date('2024-12-04T23:59:59Z');
+		date >= new Date('2024-11-27T00:00:01') &&
+		date < new Date('2024-12-03T23:59:59');
 
 	return (
 		<div

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -31,7 +31,7 @@ import type { ReactComponent } from './marketing/lib/ReactComponent';
 const styles = {
 	container: css`
 		/* stylelint-disable-next-line color-no-hex */
-		background: #051d32;
+		background: #f3afd9;
 		color: ${palette.neutral[100]};
 	`,
 	grid: css`
@@ -72,7 +72,7 @@ const styles = {
 		}
 		h2 {
 			margin: ${space[2]}px 0 ${space[4]}px;
-			color: ${palette.neutral[100]};
+			color: ${'#670055'};
 
 			${headlineMedium24}
 			${from.tablet} {
@@ -84,7 +84,7 @@ const styles = {
 		}
 		${from.leftCol} {
 			grid-column: 2;
-			border-left: 1px solid rgba(255, 255, 255, 0.2);
+			border-left: 1px solid rgba(0, 0, 0, 0.2);
 			padding-left: ${space[2]}px;
 		}
 	`,
@@ -93,6 +93,7 @@ const styles = {
 		strong {
 			${textEgyptianBold17};
 		}
+		color: ${'#1A2835'};
 	`,
 	ticker: css`
 		margin-bottom: ${space[4]}px;
@@ -117,11 +118,11 @@ const tickerSettings = {
 	currencySymbol: '$',
 	copy: {},
 	tickerStylingSettings: {
-		filledProgressColour: '#64B7C4',
-		progressBarBackgroundColour: 'rgba(34, 75, 95, 1)',
+		filledProgressColour: '#016D67',
+		progressBarBackgroundColour: 'rgba(1, 109, 103, 0.3)',
 		headlineColour: '#000000',
-		totalColour: '#64B7C4',
-		goalColour: '#FFFFFF',
+		totalColour: '#1A2835',
+		goalColour: '#016D67',
 	},
 };
 
@@ -200,10 +201,10 @@ export const UsEoy2024: ReactComponent<Props> = ({
 		<div css={styles.container}>
 			<div css={styles.grid}>
 				<div css={styles.logo}>
-					<SvgGuardianLogo textColor={'#FFFFFF'} width={100} />
+					<SvgGuardianLogo textColor={'#000000'} width={100} />
 				</div>
 				<div css={styles.heading}>
-					<h2>Can you help us hit our goal?</h2>
+					<h2>This Giving Tuesday, give to the Guardian.</h2>
 					<div css={styles.body}>
 						<div css={styles.ticker}>
 							<Ticker
@@ -216,12 +217,12 @@ export const UsEoy2024: ReactComponent<Props> = ({
 								size={'medium'}
 							/>
 						</div>
-						With no billionaire owner or shareholders pulling our
-						strings, reader support keeps us fiercely independent.
+						We’re funded by readers, not billionaires - which means
+						we can publish factual journalism with no outside
+						influence.
 						<strong>
 							{' '}
-							Help us hit our most important annual fundraising
-							goal so we can keep going.
+							Help us raise $4m to keep going in 2025.
 						</strong>
 					</div>
 				</div>
@@ -238,11 +239,11 @@ export const UsEoy2024: ReactComponent<Props> = ({
 						getCtaUrl={getCtaUrl}
 						cssCtaOverides={buttonStyles({
 							default: {
-								backgroundColour: '#C41C1C',
+								backgroundColour: '#016D67',
 								textColour: '#FFFFFF',
 							},
 							hover: {
-								backgroundColour: '#C41C1C',
+								backgroundColour: '#891414',
 								textColour: '#FFFFFF',
 							},
 						})}

--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -31,6 +31,91 @@ import type { ReactComponent } from './marketing/lib/ReactComponent';
 const styles = {
 	container: css`
 		/* stylelint-disable-next-line color-no-hex */
+		background: #051d32;
+		color: ${palette.neutral[100]};
+	`,
+	grid: css`
+		display: grid;
+		flex-direction: column;
+		position: relative;
+		padding: 0 ${space[3]}px ${space[4]}px ${space[3]}px;
+		${from.tablet} {
+			display: grid;
+			grid-template-columns: 350px 350px;
+			padding: 0 ${space[5]}px ${space[4]}px ${space[5]}px;
+		}
+		${from.desktop} {
+			grid-template-columns: 462px 462px;
+			column-gap: ${space[4]}px;
+		}
+		${from.leftCol} {
+			grid-template-columns: 148px 482px 482px;
+			column-gap: 0;
+		}
+		${from.wide} {
+			grid-template-columns: 228px 482px 482px;
+		}
+	`,
+	logo: css`
+		display: none;
+		${from.leftCol} {
+			display: block;
+			grid-column: 1;
+			grid-row: 1;
+			margin-top: ${space[2]}px;
+		}
+	`,
+	heading: css`
+		${from.tablet} {
+			grid-column: 1;
+			grid-row: 1;
+		}
+		h2 {
+			margin: ${space[2]}px 0 ${space[4]}px;
+			color: ${palette.neutral[100]};
+
+			${headlineMedium24}
+			${from.tablet} {
+				${headlineMedium28}
+			}
+			${from.leftCol} {
+				${headlineMedium34}
+			}
+		}
+		${from.leftCol} {
+			grid-column: 2;
+			border-left: 1px solid rgba(255, 255, 255, 0.2);
+			padding-left: ${space[2]}px;
+		}
+	`,
+	body: css`
+		${textEgyptian17};
+		strong {
+			${textEgyptianBold17};
+		}
+	`,
+	ticker: css`
+		margin-bottom: ${space[4]}px;
+	`,
+	choiceCards: css`
+		margin-top: ${space[6]}px;
+		${from.tablet} {
+			grid-column: 2;
+			grid-row: 1;
+			align-self: flex-start;
+			display: flex;
+			justify-content: flex-end;
+		}
+		${from.leftCol} {
+			grid-column: 3;
+			margin-right: ${space[3]}px;
+		}
+	`,
+};
+
+const stylesGivingTuesday = {
+	container: css`
+		/* stylelint-disable-next-line color-no-hex */
 		background: #f3afd9;
 		color: ${palette.neutral[100]};
 	`,
@@ -118,12 +203,44 @@ const tickerSettings = {
 	currencySymbol: '$',
 	copy: {},
 	tickerStylingSettings: {
+		filledProgressColour: '#64B7C4',
+		progressBarBackgroundColour: 'rgba(34, 75, 95, 1)',
+		headlineColour: '#000000',
+		totalColour: '#64B7C4',
+		goalColour: '#FFFFFF',
+	},
+};
+
+const tickerSettingsGivingTuesday = {
+	currencySymbol: '$',
+	copy: {},
+	tickerStylingSettings: {
 		filledProgressColour: '#016D67',
 		progressBarBackgroundColour: 'rgba(1, 109, 103, 0.3)',
 		headlineColour: '#000000',
 		totalColour: '#1A2835',
 		goalColour: '#016D67',
 	},
+};
+
+const heading = (isGivingTuesday: boolean) => {
+	return isGivingTuesday
+		? 'This Giving Tuesday, give to the Guardian.'
+		: 'Can you help us hit our goal?';
+};
+const bodyCopy = (isGivingTuesday: boolean) => {
+	const givingTuesdayCopy =
+		'We’re funded by readers, not billionaires - which means we can publish factual journalism with no outside influence.';
+	const normalCopy =
+		'With no billionaire owner or shareholders pulling our strings, reader support keeps us fiercely independent.';
+	return isGivingTuesday ? givingTuesdayCopy : normalCopy;
+};
+
+const bodyCopyHighlightedText = (isGivingTuesday: boolean) => {
+	const givingTuesdayCopy = 'Help us raise $4m to keep going in 2025.';
+	const normalCopy =
+		'Help us hit our most important annual fundraising goal so we can keep going.';
+	return isGivingTuesday ? givingTuesdayCopy : normalCopy;
 };
 
 const getTickerData = async (): Promise<TickerData | undefined> => {
@@ -183,11 +300,13 @@ const cta = {
 interface Props {
 	tickerData: TickerData;
 	submitTrackingEvent: (event: ComponentEvent) => void;
+	date: Date;
 }
 
 export const UsEoy2024: ReactComponent<Props> = ({
 	tickerData,
 	submitTrackingEvent,
+	date,
 }: Props): JSX.Element => {
 	const {
 		choiceCardSelection,
@@ -197,36 +316,77 @@ export const UsEoy2024: ReactComponent<Props> = ({
 		currencySymbol,
 	} = useChoiceCards(choiceCardAmounts, 'US', cta, cta);
 
+	const isGivingTuesday =
+		date >= new Date('2024-11-27T00:00:00Z') &&
+		date < new Date('2024-12-04T23:59:59Z');
+
 	return (
-		<div css={styles.container}>
-			<div css={styles.grid}>
-				<div css={styles.logo}>
-					<SvgGuardianLogo textColor={'#000000'} width={100} />
+		<div
+			css={
+				isGivingTuesday
+					? stylesGivingTuesday.container
+					: styles.container
+			}
+		>
+			<div css={isGivingTuesday ? stylesGivingTuesday.grid : styles.grid}>
+				<div
+					css={
+						isGivingTuesday ? stylesGivingTuesday.logo : styles.logo
+					}
+				>
+					<SvgGuardianLogo
+						textColor={isGivingTuesday ? '#000000' : '#FFFFFF'}
+						width={100}
+					/>
 				</div>
-				<div css={styles.heading}>
-					<h2>This Giving Tuesday, give to the Guardian.</h2>
-					<div css={styles.body}>
-						<div css={styles.ticker}>
+				<div
+					css={
+						isGivingTuesday
+							? stylesGivingTuesday.heading
+							: styles.heading
+					}
+				>
+					<h2>{heading(isGivingTuesday)}</h2>
+					<div
+						css={
+							isGivingTuesday
+								? stylesGivingTuesday.body
+								: styles.body
+						}
+					>
+						<div
+							css={
+								isGivingTuesday
+									? stylesGivingTuesday.ticker
+									: styles.ticker
+							}
+						>
 							<Ticker
 								currencySymbol={tickerSettings.currencySymbol}
 								copy={{}}
 								tickerData={tickerData}
 								tickerStylingSettings={
-									tickerSettings.tickerStylingSettings
+									isGivingTuesday
+										? tickerSettingsGivingTuesday.tickerStylingSettings
+										: tickerSettings.tickerStylingSettings
 								}
 								size={'medium'}
 							/>
 						</div>
-						We’re funded by readers, not billionaires - which means
-						we can publish factual journalism with no outside
-						influence.
+						{bodyCopy(isGivingTuesday)}
 						<strong>
 							{' '}
-							Help us raise $4m to keep going in 2025.
+							{bodyCopyHighlightedText(isGivingTuesday)}
 						</strong>
 					</div>
 				</div>
-				<div css={styles.choiceCards}>
+				<div
+					css={
+						isGivingTuesday
+							? stylesGivingTuesday.choiceCards
+							: styles.choiceCards
+					}
+				>
 					<ChoiceCards
 						setSelectionsCallback={setChoiceCardSelection}
 						selection={choiceCardSelection}
@@ -239,11 +399,15 @@ export const UsEoy2024: ReactComponent<Props> = ({
 						getCtaUrl={getCtaUrl}
 						cssCtaOverides={buttonStyles({
 							default: {
-								backgroundColour: '#016D67',
+								backgroundColour: isGivingTuesday
+									? '#016D67'
+									: '#C41C1C',
 								textColour: '#FFFFFF',
 							},
 							hover: {
-								backgroundColour: '#891414',
+								backgroundColour: isGivingTuesday
+									? '#891414'
+									: '#C41C1C',
 								textColour: '#FFFFFF',
 							},
 						})}
@@ -286,6 +450,7 @@ export const UsEoy2024Wrapper = (): JSX.Element => {
 	const submitTrackingEvent = (event: ComponentEvent) => {
 		void submitComponentEvent(event, renderingTarget);
 	};
+	const now = new Date();
 
 	return (
 		<>
@@ -293,6 +458,7 @@ export const UsEoy2024Wrapper = (): JSX.Element => {
 				<UsEoy2024
 					tickerData={tickerData}
 					submitTrackingEvent={submitTrackingEvent}
+					date={now}
 				/>
 			)}
 		</>


### PR DESCRIPTION
## What does this change?

This PR is to  Update Thrasher/non-Thrasher with Choice cards  colour/copy for Giving Tuesday

This changes would be toggled from  27th Nov 12:01am till  11:59pm on 4th Dec

## Screenshots


## Thrasher/Non Thrasher till 27th Nov 12.01 am would be 

<img width="1172" alt="image" src="https://github.com/user-attachments/assets/8ef55c6d-61ba-4fbf-8dff-eed18861dd6d">

## Thrasher/Non Thrasher from  '2024-11-27T00:00:01Z' till '2024-12-04T23:59:59Z' , ie from  27th Nov 12:01am till  11:59pm on 4th Dec  would be 

<img width="1172" alt="image" src="https://github.com/user-attachments/assets/558f2b64-fb1a-486f-8b31-cdaad580cefc">



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
