### PR TITLE
Add two mobile only reader revenue links for the US edition

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/ReaderRevenueLinks.tsx
@@ -70,6 +70,22 @@ export const ReaderRevenueLinks = ({
 		referrerUrl,
 	});
 
+	/** Additional links configured to only appear on the US edition */
+	const usEditionLinks = [
+		{
+			longTitle: 'Newsletters',
+			title: 'Newsletters',
+			mobileOnly: true,
+			url: '/email-newsletters',
+		},
+		{
+			longTitle: 'Download the app',
+			title: 'Download the app',
+			mobileOnly: true,
+			url: 'https://app.adjust.com/1hskf6nd?adgroup=USHeader',
+		},
+	];
+
 	const links: LinkType[] = [
 		{
 			longTitle: 'Support us',
@@ -83,6 +99,7 @@ export const ReaderRevenueLinks = ({
 			mobileOnly: true,
 			url: printSubUrl,
 		},
+		...(editionId === 'US' ? usEditionLinks : []),
 	];
 
 	return (


### PR DESCRIPTION
## What does this change?

Add two links to the reader revenue links section of the mobile nav on the US edition only:

- Newsletters
- Download the app

## Why?

Requested by the team in the US

## Screenshots

| Edition | Before      | After      |
| ----- | ----------- | ---------- |
| US | ![before][] | ![after][] |
| UK | ![before2][] | ![after2][] |
 
[before]: https://github.com/user-attachments/assets/9d424610-86bd-4e40-82a0-48f100c5b5dc
[after]:https://github.com/user-attachments/assets/26a0ee47-11e4-4e45-887e-149ae51298bc
[before2]: https://github.com/user-attachments/assets/2919b061-77fc-4f86-a396-53e53b1da90f
[after2]: https://github.com/user-attachments/assets/9b1cea4f-a199-49e1-910d-e0fd3bd519e7

