### PR TITLE
simplify inner scrolling behaviour, use overflow auto to hide scrollbars

### DIFF
--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -83,7 +83,7 @@ const stickyStyles = css`
 		background: ${palette('--article-background')};
 	}
 	ul {
-		max-height: 100vh;
+		max-height: 90vh;
 		overflow-y: auto;
 	}
 `;

--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -3,7 +3,7 @@ import {
 	headlineBold17,
 	headlineLight17,
 	space,
-	textSans14,
+	textSansBold14,
 } from '@guardian/source/foundations';
 import {
 	SvgChevronDownSingle,
@@ -78,13 +78,13 @@ const stickyStyles = css`
 	top: 0;
 	background: ${palette('--article-background')};
 	z-index: ${getZIndex('tableOfContents')};
-	max-height: 100vh;
-	overflow: scroll;
 	summary {
-		position: sticky;
-		top: 0;
 		z-index: 1;
 		background: ${palette('--article-background')};
+	}
+	ul {
+		max-height: 100vh;
+		overflow-y: auto;
 	}
 `;
 
@@ -108,7 +108,7 @@ const summaryStyles = css`
 `;
 
 const titleStyle = css`
-	${textSans14}
+	${textSansBold14}
 	color:${palette('--table-of-contents')};
 `;
 


### PR DESCRIPTION
## What does this change?
Apply scroll height to the list within the details and use overflow auto instead of scroll so that users with scrollbars always on don't see empty scrollbars
Also made the Jump to... bold weight as it gets a little lost in the page
## Why?
Better experience