### PR TITLE
Feature Cards: Add gradient mask to background blur

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -116,6 +116,14 @@ const hoverStyles = css`
 	}
 `;
 
+/**
+ * Image mask gradient has additional colour stops to emulate a non-linear
+ * ease in / ease out curve to make the transition smoother. Values were
+ * generated with https://non-boring-gradients.netlify.app and manually
+ * optimised. (Opacity values have been rounded and the number of colour stops
+ * reduced.) The following article has more detail on non-linear gradients:
+ * https://css-tricks.com/easing-linear-gradients/
+ */
 const overlayStyles = css`
 	position: absolute;
 	bottom: 0;
@@ -126,9 +134,20 @@ const overlayStyles = css`
 	justify-content: flex-start;
 	flex-grow: 1;
 	gap: ${space[1]}px;
-	padding: 72px ${space[2]}px ${space[2]}px;
-	mask-image: linear-gradient(180deg, transparent 0, rgb(0, 0, 0) 64px);
-	backdrop-filter: blur(12px) brightness(0.7);
+	padding: 64px ${space[2]}px ${space[2]}px;
+	mask-image: linear-gradient(
+		180deg,
+		transparent 0px,
+		rgba(0, 0, 0, 0.0381) 8px,
+		rgba(0, 0, 0, 0.1464) 16px,
+		rgba(0, 0, 0, 0.3087) 24px,
+		rgba(0, 0, 0, 0.5) 32px,
+		rgba(0, 0, 0, 0.6913) 40px,
+		rgba(0, 0, 0, 0.8536) 48px,
+		rgba(0, 0, 0, 0.9619) 56px,
+		rgb(0, 0, 0) 64px
+	);
+	backdrop-filter: blur(12px) brightness(0.5);
 `;
 
 const starRatingWrapper = css`

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -125,8 +125,9 @@ const overlayStyles = css`
 	flex-direction: column;
 	justify-content: flex-start;
 	flex-grow: 1;
-	padding: ${space[2]}px;
 	gap: ${space[1]}px;
+	padding: 72px ${space[2]}px ${space[2]}px;
+	mask-image: linear-gradient(180deg, transparent 0, rgb(0, 0, 0) 64px);
 	backdrop-filter: blur(12px) brightness(0.7);
 `;
 


### PR DESCRIPTION
## What does this change?

Masks the background image with a linear gradient so the blur behind the text fades our rather than having a hard edge. A gradient with multiple colour stops is used to [approximate a non-linear gradient with an ease-in / ease-out curve](https://css-tricks.com/easing-linear-gradients/), making the transition smoother.

## Why?

This makes the effect on web more consistent with the native iOS and Android apps.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6ba06563-a0e9-44b7-a774-bfc1c095b22b
[after]: https://github.com/user-attachments/assets/1cbe38a5-1185-4699-bba9-d8258354ebac