### PR TITLE
FeatureCard: Update spacing between text elements

### DIFF
--- a/dotcom-rendering/src/components/Card/components/TrailText.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailText.tsx
@@ -17,6 +17,8 @@ type Props = {
 	trailTextColour?: string;
 	/** Controls visibility of trail text on various breakpoints */
 	hideUntil?: 'tablet' | 'desktop';
+	/** Defaults to `true`. Adds padding to the bottom of the trail text */
+	padBottom?: boolean;
 	/** Adds padding to the top of the trail text */
 	padTop?: boolean;
 };
@@ -24,6 +26,9 @@ type Props = {
 const trailTextStyles = css`
 	display: flex;
 	flex-direction: column;
+`;
+
+const bottomPadding = css`
 	padding-bottom: ${space[2]}px;
 `;
 
@@ -46,6 +51,7 @@ export const TrailText = ({
 	trailTextSize = 'regular',
 	trailTextColour = palette('--card-trail-text'),
 	hideUntil,
+	padBottom = true,
 	padTop = false,
 }: Props) => {
 	const trailText = (
@@ -56,6 +62,7 @@ export const TrailText = ({
 					color: ${trailTextColour};
 				`,
 				fontStyles(trailTextSize),
+				padBottom && bottomPadding,
 				padTop && topPadding,
 			]}
 		>

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -118,6 +118,21 @@ export const Opinion: Story = {
 	},
 };
 
+export const WithTrailText: Story = {
+	args: {
+		kickerText: undefined,
+		headlineText: 'Nigel Slater’s recipe for coffee cream liqueur trifle',
+		image: {
+			src: 'https://media.guim.co.uk/9194170f3170be3f48f1924a7434f0b69c7adb77/205_0_5825_3496/master/5825.jpg',
+			altText: 'Hazelnut Tiramisu',
+		},
+		format: { ...cardProps.format, theme: Pillar.Lifestyle },
+		byline: undefined,
+		trailText:
+			'Part trifle, part tiramisu… this midweek treat ticks all the right boxes',
+	},
+};
+
 export const WithSublinks: Story = {
 	args: {
 		supportingContent: [

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -27,7 +27,7 @@ const cardProps: CardProps = {
 	aspectRatio: '4:5',
 	byline: 'Byline text',
 	showByline: true,
-	headlineSizes: { desktop: 'medium' },
+	headlineSizes: { desktop: 'small' },
 	showPulsingDot: false,
 	showClock: false,
 	imageSize: 'feature',

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -126,7 +126,7 @@ const overlayStyles = css`
 	justify-content: flex-start;
 	flex-grow: 1;
 	padding: ${space[2]}px;
-	row-gap: ${space[2]}px;
+	gap: ${space[1]}px;
 	backdrop-filter: blur(12px) brightness(0.7);
 `;
 
@@ -136,6 +136,10 @@ const starRatingWrapper = css`
 	margin-top: ${space[1]}px;
 	display: inline-block;
 	width: fit-content;
+`;
+
+const trailTextWrapper = css`
+	margin-top: ${space[3]}px;
 `;
 
 const getMedia = ({
@@ -377,33 +381,35 @@ export const FeatureCard = ({
 								<div className="image-overlay" />
 
 								<div css={overlayStyles}>
-									<CardHeadline
-										headlineText={headlineText}
-										format={format}
-										fontSizes={headlineSizes}
-										showQuotes={showQuotes}
-										kickerText={
-											format.design ===
-												ArticleDesign.LiveBlog &&
-											!kickerText
-												? 'Live'
-												: kickerText
-										}
-										showPulsingDot={
-											format.design ===
-												ArticleDesign.LiveBlog ||
-											showPulsingDot
-										}
-										byline={byline}
-										showByline={showByline}
-										isExternalLink={isExternalLink}
-										headlineColour={palette(
-											'--feature-card-headline',
-										)}
-										kickerColour={palette(
-											'--feature-card-kicker-text',
-										)}
-									/>
+									<div>
+										<CardHeadline
+											headlineText={headlineText}
+											format={format}
+											fontSizes={headlineSizes}
+											showQuotes={showQuotes}
+											kickerText={
+												format.design ===
+													ArticleDesign.LiveBlog &&
+												!kickerText
+													? 'Live'
+													: kickerText
+											}
+											showPulsingDot={
+												format.design ===
+													ArticleDesign.LiveBlog ||
+												showPulsingDot
+											}
+											byline={byline}
+											showByline={showByline}
+											isExternalLink={isExternalLink}
+											headlineColour={palette(
+												'--feature-card-headline',
+											)}
+											kickerColour={palette(
+												'--feature-card-kicker-text',
+											)}
+										/>
+									</div>
 
 									{starRating !== undefined ? (
 										<div css={starRatingWrapper}>
@@ -415,13 +421,16 @@ export const FeatureCard = ({
 									) : null}
 
 									{!!trailText && (
-										<TrailText
-											trailText={trailText}
-											trailTextColour={palette(
-												'--feature-card-trail-text',
-											)}
-											trailTextSize={'regular'}
-										/>
+										<div css={trailTextWrapper}>
+											<TrailText
+												trailText={trailText}
+												trailTextColour={palette(
+													'--feature-card-trail-text',
+												)}
+												trailTextSize={'regular'}
+												padBottom={false}
+											/>
+										</div>
 									)}
 
 									<CardFooter

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -381,6 +381,12 @@ export const FeatureCard = ({
 								<div className="image-overlay" />
 
 								<div css={overlayStyles}>
+									{/**
+									 * Without the wrapping div the headline and
+									 * byline would have space inserted between
+									 * them due to being direct children of the
+									 * flex container
+									 */}
 									<div>
 										<CardHeadline
 											headlineText={headlineText}

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -63,10 +63,7 @@ export const StaticFeatureTwo = ({
 							imageLoading={imageLoading}
 							aspectRatio="4:5"
 							imageSize="feature-large"
-							headlineSizes={{
-								desktop: 'medium',
-								tablet: 'small',
-							}}
+							headlineSizes={{ desktop: 'small' }}
 							supportingContent={card.supportingContent}
 						/>
 					</LI>


### PR DESCRIPTION
## What does this change?

- Reduces default spacing between text elements to 4px
  - Headline text and byline are grouped so no space is inserted in between
  - Bottom padding on `TrailText` has been made optional so we can apply correct spacing in `FeatureCard` layout
- Headline size for static cards has been reduced to `small` (24px) for all breakpoints

## Why?

Part of the work to implement the `FeatureCard` component

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |

[before1]: https://github.com/user-attachments/assets/afebdb0f-fc5e-4aa0-8be5-5ecc67d47bab
[after1]: https://github.com/user-attachments/assets/bf3c27e1-feef-4e7c-ab00-445325f429f0
[before2]: https://github.com/user-attachments/assets/7c9b07b8-ec56-4a6d-a31d-87dc215f672c
[after2]: https://github.com/user-attachments/assets/db52e30c-6a4b-4b1a-a0e2-603831c2fac8
[before3]: https://github.com/user-attachments/assets/1a80c4af-9227-4430-866a-35518910fb74
[after3]: https://github.com/user-attachments/assets/c2830472-18e3-410c-97a0-88519fdca755
[before4]: https://github.com/user-attachments/assets/dad67013-e40b-4d59-a492-306b271fb410
[after4]: https://github.com/user-attachments/assets/242c778b-eabe-47d5-9d1a-fda16702ddab
[before5]: https://github.com/user-attachments/assets/bd92a395-4ebd-42f4-9817-96dd636f1344
[after5]: https://github.com/user-attachments/assets/4fdcd8a9-9647-4e12-946b-1973ba148db1