### PR TITLE
Update the goal amount colour in Giving Tuesday thrasher

### DIFF
--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -218,8 +218,8 @@ const tickerSettingsGivingTuesday = {
 		filledProgressColour: '#016D67',
 		progressBarBackgroundColour: 'rgba(1, 109, 103, 0.3)',
 		headlineColour: '#000000',
-		totalColour: '#1A2835',
-		goalColour: '#016D67',
+		totalColour: '#016D67',
+		goalColour: '#1A2835',
 	},
 };
 


### PR DESCRIPTION
## What does this change?

This PR is to update the colour of goal amount and total amount under the ticker

## Screenshots

## Before 
![image](https://github.com/user-attachments/assets/7f238305-64bd-4a3b-90ce-d129ff1555e5)

## After 

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/647b8d2c-f82f-4515-b2b6-7fee5d1f2d8e">


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
