### PR TITLE
Remove italic byline on web

### DIFF
--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -24,10 +24,10 @@ import type { ContentType, StarRating as Rating } from '../types/content';
 import type { RichLinkCardType } from '../types/layout';
 import type { TagType } from '../types/tag';
 import { Avatar } from './Avatar';
+import { useConfig } from './ConfigContext';
 import { FormatBoundary } from './FormatBoundary';
 import { QuoteIcon } from './QuoteIcon';
 import { StarRating } from './StarRating/StarRating';
-import { useConfig } from './ConfigContext';
 
 interface Props {
 	richLinkIndex: number;

--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -27,6 +27,7 @@ import { Avatar } from './Avatar';
 import { FormatBoundary } from './FormatBoundary';
 import { QuoteIcon } from './QuoteIcon';
 import { StarRating } from './StarRating/StarRating';
+import { useConfig } from './ConfigContext';
 
 interface Props {
 	richLinkIndex: number;
@@ -107,6 +108,14 @@ const labsTitleStyles = css`
 
 const bylineStyles = css`
 	color: ${themePalette('--rich-link-text')};
+	${headlineMedium14};
+
+	${from.wide} {
+		${headlineMedium20};
+	}
+`;
+
+const italicBylineStyles = css`
 	${headlineMediumItalic14};
 
 	${from.wide} {
@@ -201,6 +210,7 @@ export const RichLink = ({
 	contributorImage,
 	isPlaceholder,
 }: Props) => {
+	const { renderingTarget } = useConfig();
 	const linkText =
 		cardStyle === 'letters' ? `${headlineText} | Letters ` : headlineText;
 
@@ -267,7 +277,15 @@ export const RichLink = ({
 							</div>
 
 							{isOpinion && byline !== '' && (
-								<div css={bylineStyles}>{byline}</div>
+								<div
+									css={[
+										bylineStyles,
+										renderingTarget === 'Apps' &&
+											italicBylineStyles,
+									]}
+								>
+									{byline}
+								</div>
 							)}
 
 							{!isUndefined(starRating) ? (


### PR DESCRIPTION
## What does this change?
Removes the italic byline in favour of roman. As we are coordinting release with apps, this change is to be made on web only for now. This is achieved using the rendering target to determine styles.

## Why?
Part of the fairground redesign project

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a42b3d2c-7f69-462d-8901-d473e1793428
[after]: https://github.com/user-attachments/assets/339fc329-0051-4fcb-a0bb-fc28d6dc4492

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
