### PR TITLE
Feature Cards: Add default background colour

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -80,9 +80,9 @@ const baseCardStyles = css`
 	flex-direction: column;
 	justify-content: space-between;
 	width: 100%;
-	/* We absolutely position the faux link
-		so this is required here */
+	/* We absolutely position the faux link so this is required here */
 	position: relative;
+	background-color: ${palette('--feature-card-background')};
 
 	/* Target Safari 10.1 */
 	/* https://www.browserstack.com/guide/create-browser-specific-css */

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -80,9 +80,9 @@ const baseCardStyles = css`
 	flex-direction: column;
 	justify-content: space-between;
 	width: 100%;
-	/* We absolutely position the faux link so this is required here */
+	/* We absolutely position the faux link
+		so this is required here */
 	position: relative;
-	background-color: ${palette('--feature-card-background')};
 
 	/* Target Safari 10.1 */
 	/* https://www.browserstack.com/guide/create-browser-specific-css */
@@ -334,6 +334,9 @@ export const FeatureCard = ({
 							<div
 								css={css`
 									position: relative;
+									background-color: ${palette(
+										'--feature-card-background',
+									)};
 									img {
 										width: 100%;
 										display: block;

--- a/dotcom-rendering/src/palette.ts
+++ b/dotcom-rendering/src/palette.ts
@@ -6456,6 +6456,10 @@ const paletteColours = {
 		light: explainerAtomBackgroundLight,
 		dark: explainerAtomBackgroundDark,
 	},
+	'--feature-card-background': {
+		light: () => sourcePalette.neutral[93],
+		dark: () => sourcePalette.neutral[38],
+	},
 	'--feature-card-footer-text': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],


### PR DESCRIPTION
## What does this change?

Adds default background colour to feature cards

## Why?

This ensures feature cards always have a solid background colour, even if the image fails to load

> [!note]
> Although this defines a dark mode background colour, feature cards do not yet fully render correctly in dark mode

## Screenshots

![localhost_4002_iframe html_globals=viewport%3Awide id=components-staticfeaturetwo--default viewMode=story](https://github.com/user-attachments/assets/f04f72f8-90cc-4906-a934-d6ce640eccbb)

![localhost_4002_iframe html_globals=viewport%3Awide id=components-staticfeaturetwo--default viewMode=story (1)](https://github.com/user-attachments/assets/f62a5641-1146-4076-886c-73fd90f568ba)
