### PR TITLE
Mini profiles tweaks

### DIFF
--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -5,6 +5,7 @@ import type { ArticleFormat } from '../lib/articleFormat';
 import { slugify } from '../model/enhance-H2s';
 import { palette } from '../palette';
 import type { MiniProfile as MiniProfileModel } from '../types/content';
+import { Heading } from './Heading';
 import { headingLineStyles } from './KeyTakeaway';
 import { subheadingStyles } from './Subheading';
 
@@ -75,27 +76,36 @@ const headingMarginStyle = css`
 	margin-bottom: ${space[2]}px;
 `;
 
+const sectionedTitleStyle = css`
+	font-size: 1.5rem;
+`;
+
 interface MiniProfileProps {
 	miniProfile: MiniProfileModel;
 	format: ArticleFormat;
 	children: React.ReactNode;
+	sectioned: boolean;
 }
 
 export const MiniProfile = ({
 	miniProfile,
 	format,
 	children,
+	sectioned,
 }: MiniProfileProps) => {
 	return (
 		<>
 			<li css={miniProfileStyles} data-spacefinder-role="nested">
 				<hr css={headingLineStyles} />
-				<h3
+				<Heading
 					id={slugify(miniProfile.title)}
 					css={[subheadingStyles(format), headingMarginStyle]}
+					level={sectioned ? 3 : 2}
 				>
-					{miniProfile.title}
-				</h3>
+					<span css={sectioned && sectionedTitleStyle}>
+						{miniProfile.title}
+					</span>
+				</Heading>
 				<Bio html={miniProfile.bio} />
 				{children}
 				{miniProfile.endNote ? (

--- a/dotcom-rendering/src/components/MiniProfile.tsx
+++ b/dotcom-rendering/src/components/MiniProfile.tsx
@@ -116,8 +116,16 @@ export const MiniProfile = ({
 	);
 };
 
+const containsText = (html: string) => {
+	const htmlWithoutTags = sanitise(html, {
+		allowedTags: [],
+		allowedAttributes: {},
+	});
+	return htmlWithoutTags.length > 0;
+};
+
 const Bio = ({ html }: { html?: string }) => {
-	if (!html) return null;
+	if (!html || !containsText(html)) return null;
 	const sanitizedHtml = sanitise(html, {});
 	return (
 		<>

--- a/dotcom-rendering/src/components/MiniProfiles.stories.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.stories.tsx
@@ -75,6 +75,7 @@ export const ThemeVariations = {
 		pageId: 'testID',
 		switches: {},
 		RenderArticleElement,
+		sectioned: false,
 	},
 	decorators: [centreColumnDecorator],
 	parameters: {
@@ -196,6 +197,19 @@ export const WithSeparatorLine = {
 	args: {
 		...ThemeVariations.args,
 		isLastElement: false,
+		format: {
+			design: ArticleDesign.Standard,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.Culture,
+		},
+	},
+	decorators: [centreColumnDecorator],
+} satisfies Story;
+
+export const Sectioned = {
+	args: {
+		...ThemeVariations.args,
+		sectioned: true,
 		format: {
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -51,6 +51,8 @@ export const MiniProfiles = ({
 	isLastElement,
 	sectioned,
 }: MiniProfilesProps) => {
+	const displaySeparator = !isLastElement && !sectioned;
+
 	return (
 		<ol data-ignore="global-ol-styling">
 			{miniProfiles.map((miniProfile, index) => (
@@ -85,7 +87,7 @@ export const MiniProfiles = ({
 					))}
 				</MiniProfileComponent>
 			))}
-			{!isLastElement && <hr css={separatorStyles} />}
+			{displaySeparator && <hr css={separatorStyles} />}
 		</ol>
 	);
 };

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -25,6 +25,7 @@ interface MiniProfilesProps {
 	 * Whether this is the last element in the article. If true, no separator will be rendered.
 	 */
 	isLastElement: boolean;
+	sectioned: boolean;
 }
 
 const separatorStyles = css`
@@ -48,6 +49,7 @@ export const MiniProfiles = ({
 	starRating,
 	RenderArticleElement,
 	isLastElement,
+	sectioned,
 }: MiniProfilesProps) => {
 	return (
 		<ol data-ignore="global-ol-styling">
@@ -57,6 +59,7 @@ export const MiniProfiles = ({
 					miniProfile={miniProfile}
 					format={format}
 					key={`${miniProfile.title}-${index}`}
+					sectioned={sectioned}
 				>
 					{miniProfile.body.map((element) => (
 						// eslint-disable-next-line react/jsx-key -- The element array should remain consistent as it's derived from the order of elements in CAPI

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -56,6 +56,13 @@ export const ArticleRenderer = ({
 	abTests,
 	editionId,
 }: Props) => {
+	const isSectionedMiniProfilesArticle =
+		elements.filter(
+			(element) =>
+				element._type ===
+				'model.dotcomrendering.pageElements.MiniProfilesBlockElement',
+		).length > 1;
+
 	const renderedElements = elements.map((element, index, { length }) => {
 		return (
 			<RenderArticleElement
@@ -75,6 +82,7 @@ export const ArticleRenderer = ({
 				abTests={abTests}
 				editionId={editionId}
 				totalElements={length}
+				isSectionedMiniProfilesArticle={isSectionedMiniProfilesArticle}
 			/>
 		);
 	});

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -91,6 +91,7 @@ type Props = {
 	isTimeline?: boolean;
 	totalElements?: number;
 	isListElement?: boolean;
+	isSectionedMiniProfilesArticle?: boolean;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -150,6 +151,7 @@ export const renderElement = ({
 	isTimeline = false,
 	totalElements = 0,
 	isListElement = false,
+	isSectionedMiniProfilesArticle = false,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -490,6 +492,7 @@ export const renderElement = ({
 					editionId={editionId}
 					RenderArticleElement={RenderArticleElement}
 					isLastElement={index === totalElements - 1}
+					sectioned={!!isSectionedMiniProfilesArticle}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MultiImageBlockElement':
@@ -891,6 +894,7 @@ export const RenderArticleElement = ({
 	isTimeline,
 	totalElements,
 	isListElement,
+	isSectionedMiniProfilesArticle,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -915,6 +919,7 @@ export const RenderArticleElement = ({
 		isTimeline,
 		totalElements,
 		isListElement,
+		isSectionedMiniProfilesArticle,
 	});
 
 	const needsFigure = !bareElements.has(element._type);


### PR DESCRIPTION
## What does this change?

Three separate tweaks to the mini profiles format:

1) Render titles as `h3`s (with font size `24px`) for mini profiles articles which include sections. Continue to render titles as `h2`s for mini profiles articles which don't include sections. This should help distinguish titles from section headers. More info [here](https://www.figma.com/design/TK4X89VBAIZ65zmIqApOkI/Formats-%E2%80%94-Structured-elements?node-id=525-18042&node-type=section&t=Uh5UcQdE4amPpVWy-0) (see "Option 2").
2) Don't display the bottom separator for mini profiles articles with sections. The bottom separator, borrowed from previous list elements, was intended to separate list elements from anything below them in the document (e.g. closing remarks), but was being mistakenly inserted between sections of mini profiles articles. This was happening because mini profiles articles with sections are actually multiple mini profiles elements with text elements between them.
3) Don't display empty bios. The logic for hiding empty bios was broken because `<p></p>` was considered non-empty.

## Why?

This was in response to feedback from Rich and Theresa

## Screenshots

| before | after |
|--------|--------|
| ![Screenshot 2024-11-27 at 15 00 54](https://github.com/user-attachments/assets/218ea1e5-3e26-47ba-9a45-ddf4615fbf0f) | ![Screenshot 2024-11-27 at 15 09 18](https://github.com/user-attachments/assets/1df4cf33-5306-49b0-aee3-018df3ba2f45) | 
