### PR TITLE
Carousels: Optimise updating button state

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -305,19 +305,30 @@ export const ScrollableCarousel = ({
 		setNextButtonEnabled(scrollLeft < maxScrollLeft - cardWidth / 2);
 	};
 
+	const throttle = (callback: () => void) => {
+		let isThrottled: boolean = false;
+		return function () {
+			if (!isThrottled) {
+				callback();
+				isThrottled = true;
+				setTimeout(() => (isThrottled = false), 200);
+			}
+		};
+	};
+
 	useEffect(() => {
 		const carouselElement = carouselRef.current;
 		if (!carouselElement) return;
 
 		carouselElement.addEventListener(
 			'scroll',
-			updateButtonVisibilityOnScroll,
+			throttle(updateButtonVisibilityOnScroll),
 		);
 
 		return () => {
 			carouselElement.removeEventListener(
 				'scroll',
-				updateButtonVisibilityOnScroll,
+				throttle(updateButtonVisibilityOnScroll),
 			);
 		};
 	}, []);

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -288,9 +288,9 @@ export const ScrollableCarousel = ({
 	 * Updates state of navigation buttons based on carousel's scroll position.
 	 *
 	 * This function checks the current scroll position of the carousel and sets
-	 * the styles of the previous and next buttons accordingly. The previous
-	 * button is disabled if the carousel is at the start, and the next button
-	 * is disabled if the carousel is at the end.
+	 * the styles of the previous and next buttons accordingly. The button state
+	 * is toggled when the midpoint of the first or last card has been scrolled
+	 * in or out of view.
 	 */
 	const updateButtonVisibilityOnScroll = () => {
 		const carouselElement = carouselRef.current;
@@ -305,7 +305,13 @@ export const ScrollableCarousel = ({
 		setNextButtonEnabled(scrollLeft < maxScrollLeft - cardWidth / 2);
 	};
 
-	const throttle = (callback: () => void) => {
+	/**
+	 * Throttle scroll events to optimise performance. As we're only using this
+	 * to toggle button state as the carousel is scrolled we don't need to
+	 * handle every event. This function ensures the callback is only called
+	 * once every 200ms, no matter how many scroll events are fired.
+	 */
+	const throttleEvent = (callback: () => void) => {
 		let isThrottled: boolean = false;
 		return function () {
 			if (!isThrottled) {
@@ -322,13 +328,13 @@ export const ScrollableCarousel = ({
 
 		carouselElement.addEventListener(
 			'scroll',
-			throttle(updateButtonVisibilityOnScroll),
+			throttleEvent(updateButtonVisibilityOnScroll),
 		);
 
 		return () => {
 			carouselElement.removeEventListener(
 				'scroll',
-				throttle(updateButtonVisibilityOnScroll),
+				throttleEvent(updateButtonVisibilityOnScroll),
 			);
 		};
 	}, []);

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -299,9 +299,10 @@ export const ScrollableCarousel = ({
 		const scrollLeft = carouselElement.scrollLeft;
 		const maxScrollLeft =
 			carouselElement.scrollWidth - carouselElement.clientWidth;
+		const cardWidth = carouselElement.querySelector('li')?.offsetWidth ?? 0;
 
-		setPreviousButtonEnabled(scrollLeft > 0);
-		setNextButtonEnabled(scrollLeft < maxScrollLeft);
+		setPreviousButtonEnabled(scrollLeft > cardWidth / 2);
+		setNextButtonEnabled(scrollLeft < maxScrollLeft - cardWidth / 2);
 	};
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -124,9 +124,9 @@ export const SlideshowCarousel = ({
 	 * Updates state of navigation buttons based on carousel's scroll position.
 	 *
 	 * This function checks the current scroll position of the carousel and sets
-	 * the styles of the previous and next buttons accordingly. The previous
-	 * button is disabled if the carousel is at the start, and the next button
-	 * is disabled if the carousel is at the end.
+	 * the styles of the previous and next buttons accordingly. The button state
+	 * is toggled when the midpoint of the first or last card has been scrolled
+	 * in or out of view.
 	 */
 	const updatePaginationStateOnScroll = () => {
 		const carouselElement = carouselRef.current;
@@ -142,7 +142,13 @@ export const SlideshowCarousel = ({
 		setCurrentPage(Math.round(scrollLeft / cardWidth));
 	};
 
-	const throttle = (callback: () => void) => {
+	/**
+	 * Throttle scroll events to optimise performance. As the scroll events are
+	 * used to trigger the pagination dot animation we're using
+	 * `requestAnimationFrame` rather than `setTimeout` to ensure this animates
+	 * smoothly in sync with the carousel being scrolled.
+	 */
+	const throttleEvent = (callback: () => void) => {
 		let requestId: number;
 		return function () {
 			cancelAnimationFrame(requestId);
@@ -156,13 +162,13 @@ export const SlideshowCarousel = ({
 
 		carouselElement.addEventListener(
 			'scroll',
-			throttle(updatePaginationStateOnScroll),
+			throttleEvent(updatePaginationStateOnScroll),
 		);
 
 		return () => {
 			carouselElement.removeEventListener(
 				'scroll',
-				throttle(updatePaginationStateOnScroll),
+				throttleEvent(updatePaginationStateOnScroll),
 			);
 		};
 	}, []);

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -142,19 +142,27 @@ export const SlideshowCarousel = ({
 		setCurrentPage(Math.round(scrollLeft / cardWidth));
 	};
 
+	const throttle = (callback: () => void) => {
+		let requestId: number;
+		return function () {
+			cancelAnimationFrame(requestId);
+			requestId = requestAnimationFrame(callback);
+		};
+	};
+
 	useEffect(() => {
 		const carouselElement = carouselRef.current;
 		if (!carouselElement) return;
 
 		carouselElement.addEventListener(
 			'scroll',
-			updatePaginationStateOnScroll,
+			throttle(updatePaginationStateOnScroll),
 		);
 
 		return () => {
 			carouselElement.removeEventListener(
 				'scroll',
-				updatePaginationStateOnScroll,
+				throttle(updatePaginationStateOnScroll),
 			);
 		};
 	}, []);

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -133,17 +133,13 @@ export const SlideshowCarousel = ({
 		if (!carouselElement) return;
 
 		const scrollLeft = carouselElement.scrollLeft;
-
 		const maxScrollLeft =
 			carouselElement.scrollWidth - carouselElement.clientWidth;
-
-		setPreviousButtonEnabled(scrollLeft > 0);
-		setNextButtonEnabled(scrollLeft < maxScrollLeft);
-
 		const cardWidth = carouselElement.querySelector('li')?.offsetWidth ?? 0;
-		const page = Math.round(scrollLeft / cardWidth);
 
-		setCurrentPage(page);
+		setPreviousButtonEnabled(scrollLeft > cardWidth / 2);
+		setNextButtonEnabled(scrollLeft < maxScrollLeft - cardWidth / 2);
+		setCurrentPage(Math.round(scrollLeft / cardWidth));
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
## What does this change?

- Fixes a bug where the 'next' button is sometimes not disabled when on the last image and the page has been zoomed
  - Previously the carousel had to be scrolled to the very start or end before the button state was toggled. The midpoint of the first and last cards is now used instead, which feels more natural and matches the existing behaviour of the pagination dots. (The active dot changes when the image is half in view.) This change has been applied to `ScrollableCarousel` and `SlideshowCarousel`.
- Scroll events are now throttled to optimise performance.

## Why?

This ensures the button state correctly reflects the carousel's scroll position, and we're not unnecessarily processing events as the carousel is scrolled.

## Screenshots

<img width="954" alt="Screenshot 2024-11-28 at 11 37 46" src="https://github.com/user-attachments/assets/65a73b57-05aa-413b-b3ad-21245d9a5437">
