### PR TITLE
Disable show more on front container if `containerLevel` is defined

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -517,7 +517,8 @@ export const FrontSection = ({
 		!!sectionId &&
 		!!collectionId &&
 		!!pageId &&
-		!!ajaxUrl;
+		!!ajaxUrl &&
+		!containerLevel;
 	const showVerticalRule = !hasPageSkin && !containerLevel;
 
 	/**


### PR DESCRIPTION
## What does this change?

Prevents `Primary` and `Secondary` levels from rendering the "Show more" button at the bottom of front containers

## Why?

There are no designs to accommodate this behaviour in the new Primary and Secondary level containers.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e6bd17f1-3d05-4bac-b517-fb0989e656cc
[after]: https://github.com/user-attachments/assets/544e4aa2-34b3-402e-9756-0837f5f9e865
