### PR TITLE
Remove duplicated `ContainerOverrides` wrapper around `FrontSection` and `LabsSection` components

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -430,10 +430,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							: undefined;
 
 						return (
-							<ContainerOverrides
-								key={ophanName}
-								containerPalette={collection.containerPalette}
-							>
+							<div key={ophanName}>
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
@@ -493,16 +490,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									mobileAdPositions,
 									hasPageSkin,
 								)}
-							</ContainerOverrides>
+							</div>
 						);
 					}
 
 					if (collection.containerPalette === 'Branded') {
 						return (
-							<ContainerOverrides
-								key={ophanName}
-								containerPalette={collection.containerPalette}
-							>
+							<div key={ophanName}>
 								<LabsSection
 									title={collection.displayName}
 									collectionId={collection.id}
@@ -548,7 +542,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									mobileAdPositions,
 									hasPageSkin,
 								)}
-							</ContainerOverrides>
+							</div>
 						);
 					}
 
@@ -560,10 +554,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							collection.containerPalette ?? 'MediaPalette';
 
 						return (
-							<ContainerOverrides
-								key={ophanName}
-								containerPalette={containerPalette}
-							>
+							<div key={ophanName}>
 								{decideFrontsBannerAdSlot(
 									renderAds,
 									hasPageSkin,
@@ -635,15 +626,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										mobileAdPositions,
 										hasPageSkin,
 									)}
-							</ContainerOverrides>
+							</div>
 						);
 					}
 
 					return (
-						<ContainerOverrides
-							key={ophanName}
-							containerPalette={collection.containerPalette}
-						>
+						<div key={ophanName}>
 							{decideFrontsBannerAdSlot(
 								renderAds,
 								hasPageSkin,
@@ -718,7 +706,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								mobileAdPositions,
 								hasPageSkin,
 							)}
-						</ContainerOverrides>
+						</div>
 					);
 				})}
 			</main>


### PR DESCRIPTION
## What does this change?

Removes `ContainerOverrides` wrappers from the `FrontSection` and `LabsSection` components in `FrontLayout` because these components already use `ContainerOverrides` at the top level with them.

## Why?

Resolves small, palette inheritance bug in side border colours extending above the horizontal rule

Also tidies up the rendering tree, removing unnecessary duplication and bulk

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5c2049d5-78da-4553-bef5-47c2ac3ab7e3
[after]: https://github.com/user-attachments/assets/c3e50ef7-9bcd-410e-9a43-6f6f71ca435f
