### PR TITLE
Slideshow: Reduce button gap to match other carousels

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -78,7 +78,7 @@ const buttonStyles = css`
 	display: none;
 	${from.tablet} {
 		display: flex;
-		gap: ${space[2]}px;
+		gap: ${space[1]}px;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Reduces gap between navigation buttons on slideshows to match other carousels

## Why?

The designs for slideshows are older and hadn't been updated to match the spacing of the other carousel components.

## Screenshots

<img width="751" alt="Screenshot 2024-12-03 at 11 38 54" src="https://github.com/user-attachments/assets/83e34866-a310-43bb-b660-173a7ddcbdec">
