### PR TITLE
Fix the labs header text colour

### DIFF
--- a/dotcom-rendering/src/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.tsx
@@ -24,6 +24,8 @@ const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 			height: ${LABS_HEADER_HEIGHT}px;
 			display: flex;
 			justify-content: space-between;
+
+			color: ${palette.neutral[7]};
 		`}
 	>
 		{children}


### PR DESCRIPTION
## What does this change?
Fix the labs header text colour to be the same whether on dark or light mode

## Why?
The background colour doesn't change, so the text colour doesn't need to change either.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/78fce26b-c742-4350-884f-cca11030b583

[after]: https://github.com/user-attachments/assets/c1dc4557-a02e-4431-b825-53bccf2db005


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
