### PR TITLE
Remove background for sublinks on cards when within a container with a special palette override

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -464,63 +464,12 @@ const cardBorderTopDark: ContainerFunction = (containerPalette) => {
 };
 
 const cardSublinksBackgroundLight: ContainerFunction = (containerPalette) => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return sourcePalette.neutral[93];
-		case 'LongRunningAltPalette':
-			return sourcePalette.neutral[86];
-		case 'SombrePalette':
-			return sourcePalette.neutral[38];
-		case 'SombreAltPalette':
-			return sourcePalette.neutral[20];
-		case 'InvestigationPalette':
-			return sourcePalette.neutral[46];
-		case 'BreakingPalette':
-			return sourcePalette.news[100];
-		case 'EventPalette':
-			return sourcePalette.neutral[86];
-		case 'EventAltPalette':
-			return sourcePalette.neutral[93];
-		case 'SpecialReportAltPalette':
-			return sourcePalette.neutral[86];
-		case 'Branded':
-			return sourcePalette.neutral[86];
-		case 'MediaPalette':
-			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
-	}
+	return cardBackgroundLight(containerPalette);
 };
 
 const cardSublinksBackgroundDark: ContainerFunction = (containerPalette) => {
-	switch (containerPalette) {
-		case 'LongRunningPalette':
-			return sourcePalette.brand[100];
-		case 'LongRunningAltPalette':
-			return sourcePalette.neutral[10];
-		case 'SombrePalette':
-			return sourcePalette.neutral[20];
-		case 'SombreAltPalette':
-			return sourcePalette.neutral[10];
-		case 'BreakingPalette':
-			return sourcePalette.news[100];
-		case 'InvestigationPalette':
-			return sourcePalette.neutral[38];
-		case 'EventPalette':
-			return sourcePalette.neutral[10];
-		case 'EventAltPalette':
-			return sourcePalette.neutral[10];
-		case 'SpecialReportAltPalette':
-			return sourcePalette.neutral[20];
-		case 'Branded':
-			return sourcePalette.neutral[10];
-		case 'MediaPalette':
-			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
-	}
+	return cardBackgroundDark(containerPalette);
 };
-
 const articleBorderLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
 		case 'LongRunningPalette':


### PR DESCRIPTION
## What does this change?

Sets the sublinks background to the same as the card background when within a container with a special palette applied

## Why?

We noticed a discrepancy between the way web and apps treat this scenario and prefer the way apps does it

[Trello link](https://trello.com/c/wvfpzyJj/776-web-remove-sublinks-background-colour-for-special-palettes)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3c54ab70-569a-49dd-82c2-1ac0a3aa57e0
[after]: https://github.com/user-attachments/assets/2e5b9ccb-593c-46bb-b678-5cfafdc4d6cf

