### PR TITLE
Onwards content gallery-style AB test

### DIFF
--- a/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
+++ b/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
@@ -102,6 +102,8 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 	const firstSlice25 = trails.slice(1, 2);
 	const secondSlice25 = trails.slice(2, 6);
 
+	const heading = data.heading || data.displayname;
+
 	return (
 		<div
 			data-component="onwards-content-gallery-style"
@@ -109,11 +111,11 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 		>
 			<LeftColumn>
 				<h2 css={headerStyles}>
-					<span>{data.heading}</span>
+					<span>{heading}</span>
 				</h2>
 			</LeftColumn>
 			<h2 css={mobileHeaderStyles}>
-				<span>{data.heading}</span>
+				<span>{heading}</span>
 			</h2>
 			<div>
 				<UL direction="row" padBottom={true}>

--- a/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
+++ b/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
@@ -1,0 +1,194 @@
+import { css } from '@emotion/react';
+import { from, headlineBold24, space } from '@guardian/source/foundations';
+import { decideFormat } from '../lib/articleFormat';
+import { useApi } from '../lib/useApi';
+import { palette } from '../palette';
+import type { DCRFrontCard } from '../types/front';
+import type { FETrailType } from '../types/trails';
+import { Card } from './Card/Card';
+import { LI } from './Card/components/LI';
+import { UL } from './Card/components/UL';
+import { LeftColumn } from './LeftColumn';
+import { Placeholder } from './Placeholder';
+
+type Props = { url: string; discussionApiUrl: string };
+
+type OnwardsResponse = {
+	trails: FETrailType[];
+	heading: string;
+	displayname: string;
+	description: string;
+};
+
+const containerStyles = css`
+	display: flex;
+	flex-direction: column;
+	padding-bottom: ${space[6]}px;
+
+	${from.leftCol} {
+		flex-direction: row;
+		padding-right: 80px;
+	}
+`;
+
+const headerStyles = css`
+	${headlineBold24};
+	color: ${palette('--carousel-text')};
+	padding-bottom: ${space[2]}px;
+	padding-top: ${space[1]}px;
+	margin-left: 0;
+`;
+const mobileHeaderStyles = css`
+	${headerStyles};
+	${from.tablet} {
+		padding-left: 10px;
+	}
+	${from.leftCol} {
+		display: none;
+	}
+`;
+
+const convertFETrailToDcrTrail = (
+	trails: FETrailType[],
+	discussionApiUrl: string,
+): DCRFrontCard[] =>
+	trails.map((trail) => ({
+		dataLinkName: 'onwards-content-card',
+		discussionId: trail.discussion?.discussionId,
+		discussionApiUrl,
+		format: decideFormat(trail.format),
+		headline: trail.headline,
+		image: {
+			src: trail.masterImage ?? '',
+			altText: trail.linkText ?? '',
+		},
+		isExternalLink: false,
+		onwardsSource: 'related-content',
+		showLivePlayable: false,
+		showQuotedHeadline: false,
+		url: trail.url,
+		webPublicationDate: trail.webPublicationDate,
+	}));
+
+export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
+	const { data, error } = useApi<OnwardsResponse>(url);
+
+	if (error) {
+		// Send the error to Sentry and then prevent the element from rendering
+		window.guardian.modules.sentry.reportError(error, 'onwards-lower');
+		return null;
+	}
+
+	if (!data?.trails) {
+		return (
+			<Placeholder
+				height={580} // best guess at typical height
+				shouldShimmer={false}
+				backgroundColor={palette('--article-background')}
+			/>
+		);
+	}
+
+	const trails: DCRFrontCard[] = convertFETrailToDcrTrail(
+		data.trails,
+		discussionApiUrl,
+	);
+
+	const firstSlice75 = trails.slice(0, 1);
+	const firstSlice25 = trails.slice(1, 2);
+	const secondSlice25 = trails.slice(2, 6);
+
+	return (
+		<div css={containerStyles}>
+			<LeftColumn>
+				<h2 css={headerStyles}>
+					<span>{data.heading}</span>
+				</h2>
+			</LeftColumn>
+			<h2 css={mobileHeaderStyles}>
+				<span>{data.heading}</span>
+			</h2>
+			<div>
+				<UL direction="row" padBottom={true}>
+					{firstSlice75.map((trail) => (
+						<LI key={trail.url} padSides={true} percentage="75%">
+							<Card
+								absoluteServerTimes={false}
+								imagePositionOnDesktop="right"
+								imagePositionOnMobile="top"
+								imageSize="large"
+								imageLoading="lazy"
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								image={trail.image}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+								discussionApiUrl={trail.discussionApiUrl}
+								isExternalLink={trail.isExternalLink}
+								showAge={true}
+								webPublicationDate={trail.webPublicationDate}
+								onwardsSource="related-content"
+							/>
+						</LI>
+					))}
+					{firstSlice25.map((trail) => (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={true}
+							percentage="25%"
+						>
+							<Card
+								absoluteServerTimes={false}
+								imagePositionOnDesktop="top"
+								imagePositionOnMobile="left"
+								imageSize="small"
+								imageLoading="lazy"
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								image={trail.image}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+								discussionApiUrl={trail.discussionApiUrl}
+								isExternalLink={trail.isExternalLink}
+								showAge={true}
+								webPublicationDate={trail.webPublicationDate}
+								onwardsSource="related-content"
+							/>
+						</LI>
+					))}
+				</UL>
+				<UL direction="row">
+					{secondSlice25.map((trail, index) => (
+						<LI
+							key={trail.url}
+							padSides={true}
+							showDivider={index > 0}
+						>
+							<Card
+								absoluteServerTimes={false}
+								imagePositionOnDesktop="top"
+								imagePositionOnMobile="left"
+								imageSize="small"
+								imageLoading="lazy"
+								linkTo={trail.url}
+								format={trail.format}
+								headlineText={trail.headline}
+								image={trail.image}
+								dataLinkName={trail.dataLinkName}
+								discussionId={trail.discussionId}
+								discussionApiUrl={trail.discussionApiUrl}
+								isExternalLink={trail.isExternalLink}
+								showAge={true}
+								webPublicationDate={trail.webPublicationDate}
+								onwardsSource="related-content"
+							/>
+						</LI>
+					))}
+				</UL>
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
+++ b/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
@@ -11,8 +11,6 @@ import { UL } from './Card/components/UL';
 import { LeftColumn } from './LeftColumn';
 import { Placeholder } from './Placeholder';
 
-type Props = { url: string; discussionApiUrl: string };
-
 type OnwardsResponse = {
 	trails: FETrailType[];
 	heading: string;
@@ -70,6 +68,12 @@ const convertFETrailToDcrTrail = (
 		webPublicationDate: trail.webPublicationDate,
 	}));
 
+type Props = { url: string; discussionApiUrl: string };
+
+/**
+ * Big Six refers to the style of the onwards content container. It displays six article
+ * cards in a gallery-style container, as opposed to a carousel.
+ */
 export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 	const { data, error } = useApi<OnwardsResponse>(url);
 
@@ -99,7 +103,10 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 	const secondSlice25 = trails.slice(2, 6);
 
 	return (
-		<div css={containerStyles}>
+		<div
+			data-component="onwards-content-gallery-style"
+			css={containerStyles}
+		>
 			<LeftColumn>
 				<h2 css={headerStyles}>
 					<span>{data.heading}</span>
@@ -122,7 +129,7 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 								format={trail.format}
 								headlineText={trail.headline}
 								image={trail.image}
-								dataLinkName={trail.dataLinkName}
+								dataLinkName={`onwards-content-gallery-style ${trail.dataLinkName}`}
 								discussionId={trail.discussionId}
 								discussionApiUrl={trail.discussionApiUrl}
 								isExternalLink={trail.isExternalLink}
@@ -149,7 +156,7 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 								format={trail.format}
 								headlineText={trail.headline}
 								image={trail.image}
-								dataLinkName={trail.dataLinkName}
+								dataLinkName={`onwards-content-gallery-style ${trail.dataLinkName}`}
 								discussionId={trail.discussionId}
 								discussionApiUrl={trail.discussionApiUrl}
 								isExternalLink={trail.isExternalLink}
@@ -177,7 +184,7 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 								format={trail.format}
 								headlineText={trail.headline}
 								image={trail.image}
-								dataLinkName={trail.dataLinkName}
+								dataLinkName={`onwards-content-gallery-style ${trail.dataLinkName}`}
 								discussionId={trail.discussionId}
 								discussionApiUrl={trail.discussionApiUrl}
 								isExternalLink={trail.isExternalLink}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -453,6 +453,7 @@ const Title = ({
 			<span css={titleStyle(isCuratedContent)}>{title}</span>
 		</h2>
 	);
+
 type CarouselCardProps = {
 	isFirst: boolean;
 	index: number;
@@ -500,6 +501,7 @@ const CarouselCard = ({
 }: CarouselCardProps) => {
 	const isVideoContainer = containerType === 'fixed/video';
 	const cardImagePosition = isOnwardContent ? 'bottom' : 'top';
+
 	return (
 		<LI
 			percentage="25%"

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -332,7 +332,7 @@ export const OnwardsUpper = ({
 					/>
 				</Section>
 			)}
-			{!isPaidContent && curatedDataUrl !== undefined && (
+			{!!curatedDataUrl && !isPaidContent && (
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-border')}

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -6,10 +6,12 @@ import {
 	Pillar,
 } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
+import { useAB } from '../lib/useAB';
 import { useIsAndroid } from '../lib/useIsAndroid';
 import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { TagType } from '../types/tag';
+import { BigSixOnwardsContent } from './BigSixOnwardsContent';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
 import { Section } from './Section';
 
@@ -214,6 +216,12 @@ export const OnwardsUpper = ({
 	discussionApiUrl,
 	absoluteServerTimes,
 }: Props) => {
+	const abTestAPI = useAB()?.api;
+	const isInOnwardsAbTestVariant = abTestAPI?.isUserInVariant(
+		'OnwardsContentArticle',
+		'variant',
+	);
+
 	const isAndroid = useIsAndroid();
 
 	if (isAndroid) return null;
@@ -260,10 +268,12 @@ export const OnwardsUpper = ({
 
 		// --- Tag excludes --- //
 		const tagsToExclude = [];
+
 		// Exclude ad features from non-ad feature content
 		if (!isPaidContent) {
 			tagsToExclude.push('tone/advertisement-features');
 		}
+
 		// We don't want to show professional network content on videos or interactives
 		if (
 			contentType.toLowerCase() === 'video' ||
@@ -296,7 +306,18 @@ export const OnwardsUpper = ({
 
 	return (
 		<div css={onwardsWrapper}>
-			{!!url && (
+			{!!url && isInOnwardsAbTestVariant && (
+				<Section
+					fullWidth={true}
+					borderColour={palette('--article-border')}
+				>
+					<BigSixOnwardsContent
+						url={url}
+						discussionApiUrl={discussionApiUrl}
+					/>
+				</Section>
+			)}
+			{!!url && !isInOnwardsAbTestVariant && (
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-border')}
@@ -311,7 +332,7 @@ export const OnwardsUpper = ({
 					/>
 				</Section>
 			)}
-			{!!(!isPaidContent && curatedDataUrl) && (
+			{!isPaidContent && curatedDataUrl !== undefined && (
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-border')}

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { adBlockAsk } from './tests/ad-block-ask';
 import { consentlessAds } from './tests/consentless-ads';
 import { integrateIma } from './tests/integrate-ima';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { onwardsContentArticle } from './tests/onwards-content-article';
 import { optimiseSpacefinderInline } from './tests/optimise-spacefinder-inline';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -21,4 +22,5 @@ export const tests: ABTest[] = [
 	adBlockAsk,
 	optimiseSpacefinderInline,
 	UsaExpandableMarketingCard,
+	onwardsContentArticle,
 ];

--- a/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
+++ b/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
@@ -1,0 +1,30 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const onwardsContentArticle: ABTest = {
+	id: 'onwardsContentArticle',
+	start: '2024-11-25',
+	expiry: '2024-01-29',
+	author: 'dotcom.platform@guardian.co.uk',
+	description:
+		'Test the impact of showing the galleries onwards content component on article pages.',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Article pages',
+	successMeasure:
+		'Users are more likely to click a link in the onward content component.',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};

--- a/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
+++ b/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
@@ -1,9 +1,9 @@
 import type { ABTest } from '@guardian/ab-core';
 
 export const onwardsContentArticle: ABTest = {
-	id: 'onwardsContentArticle',
-	start: '2024-11-25',
-	expiry: '2024-01-29',
+	id: 'OnwardsContentArticle',
+	start: '2024-12-05',
+	expiry: '2025-01-29',
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the galleries onwards content component on article pages.',

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -323,6 +323,11 @@ export type DCRFrontCard = {
 	url: string;
 	headline: string;
 	showQuotedHeadline: boolean;
+	/** @see JSX.IntrinsicAttributes["data-link-name"] */
+	dataLinkName: string;
+	discussionApiUrl: string;
+	isExternalLink: boolean;
+	showLivePlayable: boolean;
 	trailText?: string;
 	starRating?: StarRating;
 	webPublicationDate?: string;
@@ -333,19 +338,14 @@ export type DCRFrontCard = {
 	isBoosted?: boolean;
 	boostLevel?: BoostLevel;
 	isCrossword?: boolean;
-	/** @see JSX.IntrinsicAttributes["data-link-name"] */
-	dataLinkName: string;
-	discussionApiUrl: string;
 	discussionId?: string;
 	byline?: string;
 	showByline?: boolean;
 	avatarUrl?: string;
 	mainMedia?: MainMedia;
-	isExternalLink: boolean;
 	embedUri?: string;
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
-	showLivePlayable: boolean;
 	showMainVideo?: boolean;
 };
 


### PR DESCRIPTION
Closes #12867

## What does this change?

Introduces an AB test that provides a different onwards content experience for those in the variant of the test. The variant uses a gallery-style container for the upper section of onwards content.

## Why?

To test whether onwards journey's increase when in the variant of the test.

## Screenshots

| <img width=300/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| tablet | ![tablet-before] | ![tablet-after] |
| desktop | ![desktop-before] | ![desktop-after] |
| wide | ![wide-before] | ![wide-after] |

[mobile-before]: https://github.com/user-attachments/assets/b31d1a0b-2d2a-4f7c-a306-c513d0b053af
[tablet-before]: https://github.com/user-attachments/assets/49ae92e9-04b1-4016-b006-ddd03e7e5f05
[desktop-before]: https://github.com/user-attachments/assets/ed5b1ed2-e57c-4f42-84b9-a2fdd0f16cd2
[wide-before]: https://github.com/user-attachments/assets/42844292-f5fd-4a01-b5ea-6ed2da10178b

[mobile-after]: https://github.com/user-attachments/assets/f1274865-3867-4fa9-b556-48f86cba9e24
[tablet-after]: https://github.com/user-attachments/assets/8c054f07-86c6-4cd3-8e65-33bc7381f047
[desktop-after]: https://github.com/user-attachments/assets/58c1d9f3-11b8-43cb-b313-ddfab44f946e
[wide-after]: https://github.com/user-attachments/assets/f285d7f2-2082-401a-8212-77a77a790ad2
