### PR TITLE
Improve tracking of expands in AB test

### DIFF
--- a/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardSwipeable.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/react';
 import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
-import { getOphan } from '../client/ophan/ophan';
+import { getOphan, submitComponentEvent } from '../client/ophan/ophan';
 import { getZIndex } from '../lib/getZIndex';
 import { ExpandableMarketingCard } from './ExpandableMarketingCard';
+import type { UsBannerTestVariantName } from './ExpandableMarketingCardWrapper.importable';
 
 // The minimum length of the left swipe on the x-axis to close the banner
 const LEFT_SWIPE_THRESHOLD_PX = 20;
@@ -25,6 +26,7 @@ interface Props {
 	isExpanded: boolean;
 	setIsExpanded: Dispatch<SetStateAction<boolean>>;
 	setIsClosed: Dispatch<SetStateAction<boolean>>;
+	abTestVariant: UsBannerTestVariantName;
 }
 
 const hideBannerStyles = css`
@@ -86,6 +88,7 @@ export const ExpandableMarketingCardSwipeable = ({
 	isExpanded,
 	setIsExpanded,
 	setIsClosed,
+	abTestVariant,
 }: Props) => {
 	const [lastDownXCoord, setLastDownXCoord] = useState<number | null>(null);
 	const [lastDownYCoord, setLastDownYCoord] = useState<number | null>(null);
@@ -153,6 +156,25 @@ export const ExpandableMarketingCardSwipeable = ({
 		}
 	}, [shouldDisplayCard]);
 
+	useEffect(() => {
+		if (isExpanded) {
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: 'CONTAINER',
+						id: 'us-expandable-marketing-card',
+					},
+					action: 'EXPAND',
+					abTest: {
+						name: 'UsaExpandableMarketingCard',
+						variant: abTestVariant,
+					},
+				},
+				'Web',
+			);
+		}
+	}, [abTestVariant, isExpanded]);
+
 	if (!shouldDisplayCard) {
 		return null;
 	}
@@ -164,7 +186,6 @@ export const ExpandableMarketingCardSwipeable = ({
 				css={[stickyContainerStyles]}
 			>
 				<div
-					data-link-name="us-expandable-marketing-card expand"
 					css={[
 						absoluteContainerStyles,
 						isDown &&

--- a/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/ExpandableMarketingCardWrapper.importable.tsx
@@ -9,11 +9,16 @@ import { ExpandableMarketingCard } from './ExpandableMarketingCard';
 import { ExpandableMarketingCardSwipeable } from './ExpandableMarketingCardSwipeable';
 import { Hide } from './Hide';
 
-type VariantName = 'variant-free' | 'variant-bubble' | 'variant-billionaire';
+export type UsBannerTestVariantName =
+	| 'variant-free'
+	| 'variant-bubble'
+	| 'variant-billionaire';
+
 type Variant = {
 	heading: string;
 	kicker: string;
 };
+
 const variantFree: Variant = {
 	heading: 'Yes, this story is free',
 	kicker: 'Why the Guardian has no paywall',
@@ -27,7 +32,9 @@ const variantBillionaire: Variant = {
 	kicker: 'How the Guardian is different',
 };
 
-const getVariant = (abTestAPI: ABTestAPI | undefined): VariantName | null => {
+const getVariant = (
+	abTestAPI: ABTestAPI | undefined,
+): UsBannerTestVariantName | null => {
 	if (!abTestAPI) {
 		return null;
 	}
@@ -60,7 +67,7 @@ const getVariant = (abTestAPI: ABTestAPI | undefined): VariantName | null => {
 	return null;
 };
 
-const getVariantCopy = (variant: VariantName): Variant => {
+const getVariantCopy = (variant: UsBannerTestVariantName): Variant => {
 	if (variant === 'variant-free') {
 		return variantFree;
 	}
@@ -138,11 +145,6 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 					onClick={() => {
 						!isExpanded && setIsExpanded(true);
 					}}
-					data-link-name={
-						!isExpanded
-							? 'us-expandable-marketing-card expand'
-							: undefined
-					}
 				>
 					<ExpandableMarketingCard
 						guardianBaseURL={guardianBaseURL}
@@ -161,6 +163,7 @@ export const ExpandableMarketingCardWrapper = ({ guardianBaseURL }: Props) => {
 					isExpanded={isExpanded}
 					setIsExpanded={setIsExpanded}
 					setIsClosed={setIsClosed}
+					abTestVariant={abTestVariant}
 				/>
 			</Hide>
 		</>


### PR DESCRIPTION
Closes #12945 

## What does this change?

Submit an Ophan event whenever the user has expanded the Expandable Marketing banner, instead of using `data-link-name` to track clicks.

## Why?

We had not been collecting accurate numbers of expand events, probably due to the element that receives click not being a link element. With this change, we should more accurately be able to collect events that cause the banner to expand.

## Videos

#### These videos show that the correct events are sent to Ophan

### Mobile

https://github.com/user-attachments/assets/ff286821-46cd-46cf-98f6-59b5313d5c48

### Desktop

https://github.com/user-attachments/assets/356ba7d4-e362-42b4-834b-ff9b770e2169

