### PR TITLE
Fix labs card branding for dynamic containers

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -49,6 +49,7 @@ import type {
 	DCRCollectionType,
 	DCRContainerType,
 	DCRFrontType,
+	DCRGroupedTrails,
 } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
 import { BannerWrapper, Stuck } from './lib/stickiness';
@@ -329,46 +330,34 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					// We also need to remove the branding for the cards in grouped
 					// trails for dynamic containers
-					const groupedWithoutBranding = isPaidContentSameBranding(
-						collection.collectionBranding,
-					)
-						? {
-								snap: collection.grouped.snap.map(
-									(labTrail) => ({
+					const groupedWithoutBranding: DCRGroupedTrails = (() => {
+						if (
+							isPaidContentSameBranding(
+								collection.collectionBranding,
+							)
+						) {
+							const groupedTrailsWithoutBranding: DCRGroupedTrails =
+								{
+									snap: [],
+									huge: [],
+									veryBig: [],
+									big: [],
+									standard: [],
+									splash: [],
+								};
+							for (const key of Object.keys(
+								collection.grouped,
+							) as (keyof DCRGroupedTrails)[]) {
+								groupedTrailsWithoutBranding[key] =
+									collection.grouped[key].map((labTrail) => ({
 										...labTrail,
 										branding: undefined,
-									}),
-								),
-								huge: collection.grouped.huge.map(
-									(labTrail) => ({
-										...labTrail,
-										branding: undefined,
-									}),
-								),
-								veryBig: collection.grouped.veryBig.map(
-									(labTrail) => ({
-										...labTrail,
-										branding: undefined,
-									}),
-								),
-								big: collection.grouped.big.map((labTrail) => ({
-									...labTrail,
-									branding: undefined,
-								})),
-								standard: collection.grouped.standard.map(
-									(labTrail) => ({
-										...labTrail,
-										branding: undefined,
-									}),
-								),
-								splash: collection.grouped.splash.map(
-									(labTrail) => ({
-										...labTrail,
-										branding: undefined,
-									}),
-								),
-						  }
-						: collection.grouped;
+									}));
+							}
+							return groupedTrailsWithoutBranding;
+						}
+						return collection.grouped;
+					})();
 
 					if (collection.collectionType === 'scrollable/highlights') {
 						// Highlights are rendered in the Masthead component

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -327,6 +327,49 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						  }))
 						: trails;
 
+					// We also need to remove the branding for the cards in grouped
+					// trails for dynamic containers
+					const groupedWithoutBranding = isPaidContentSameBranding(
+						collection.collectionBranding,
+					)
+						? {
+								snap: collection.grouped.snap.map(
+									(labTrail) => ({
+										...labTrail,
+										branding: undefined,
+									}),
+								),
+								huge: collection.grouped.huge.map(
+									(labTrail) => ({
+										...labTrail,
+										branding: undefined,
+									}),
+								),
+								veryBig: collection.grouped.veryBig.map(
+									(labTrail) => ({
+										...labTrail,
+										branding: undefined,
+									}),
+								),
+								big: collection.grouped.big.map((labTrail) => ({
+									...labTrail,
+									branding: undefined,
+								})),
+								standard: collection.grouped.standard.map(
+									(labTrail) => ({
+										...labTrail,
+										branding: undefined,
+									}),
+								),
+								splash: collection.grouped.splash.map(
+									(labTrail) => ({
+										...labTrail,
+										branding: undefined,
+									}),
+								),
+						  }
+						: collection.grouped;
+
 					if (collection.collectionType === 'scrollable/highlights') {
 						// Highlights are rendered in the Masthead component
 						return null;
@@ -716,7 +759,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}
-									groupedTrails={collection.grouped}
+									groupedTrails={groupedWithoutBranding}
 									containerType={collection.collectionType}
 									containerPalette={
 										collection.containerPalette


### PR DESCRIPTION
## What does this change?
Adds a function to remove branding from cards in collection.grouped when branding doesn't need to be shown.

`Object.keys` doesn't preserve type information, so I've manually specified the object keys as a workaround to keep Typescript happy, to avoid any heavy type assertion.

## Why?
At the moment, for labs pages which use a dynamic container type (eg [here](https://www.theguardian.com/wear-more-wash-less)), branding is appearing on cards when it shouldn't be. Because the branding is shown on the side, it doesn't need to be shown on every card. There is currently a function to remove branding for trails, but dynamic containers use grouped trails instead, so the current fix doesn't apply to them. This PR adds logic based on that for fixed containers, but adapted to map over the different object structure for grouped trails.

## Screenshots
### Before:

<img width="829" alt="Screenshot 2024-12-04 at 14 13 36" src="https://github.com/user-attachments/assets/4ab3cd5a-de04-4e7b-8f61-3cee702eb2b7">

### After:
<img width="829" alt="Screenshot 2024-12-04 at 14 13 24" src="https://github.com/user-attachments/assets/658c2f94-943d-4a8d-85ed-69fe2481185d">

