### PR TITLE
Rework container level spacing for beta containers

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -443,7 +443,7 @@ export const FlexibleGeneral = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
-					isLastRow={!cards}
+					isLastRow={cards.length === 0}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -158,6 +158,7 @@ export const SplashCardLayout = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	isLastRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -165,6 +166,7 @@ export const SplashCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	isLastRow: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -183,7 +185,11 @@ export const SplashCardLayout = ({
 	);
 
 	return (
-		<UL padBottom={true} hasLargeSpacing={true} showTopBar={false}>
+		<UL
+			padBottom={!isLastRow}
+			hasLargeSpacing={!isLastRow}
+			showTopBar={false}
+		>
 			<LI
 				padSides={true}
 				verticalDividerColour={palette('--card-border-supporting')}
@@ -268,6 +274,7 @@ export const BoostedCardLayout = ({
 	imageLoading,
 	aspectRatio,
 	isFirstRow,
+	isLastRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -276,6 +283,7 @@ export const BoostedCardLayout = ({
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
+	isLastRow: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -287,7 +295,11 @@ export const BoostedCardLayout = ({
 		liveUpdatesPosition,
 	} = decideCardProperties(card.boostLevel);
 	return (
-		<UL padBottom={true} hasLargeSpacing={true} showTopBar={!isFirstRow}>
+		<UL
+			showTopBar={!isFirstRow}
+			padBottom={!isLastRow}
+			hasLargeSpacing={!isLastRow}
+		>
 			<LI
 				padSides={true}
 				verticalDividerColour={palette('--card-border-supporting')}
@@ -333,6 +345,7 @@ export const StandardCardLayout = ({
 	isFirstRow,
 	isFirstStandardRow,
 	aspectRatio,
+	isLastRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -343,14 +356,15 @@ export const StandardCardLayout = ({
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
+	isLastRow: boolean;
 }) => {
 	if (cards.length === 0) return null;
 
 	return (
 		<UL
 			direction="row"
-			padBottom={true}
-			hasLargeSpacing={true}
+			padBottom={!isLastRow}
+			hasLargeSpacing={!isLastRow}
 			showTopBar={!isFirstRow}
 			/** We use one full top bar for the first row and use a split one for subsequent rows */
 			splitTopBar={!isFirstStandardRow}
@@ -429,6 +443,7 @@ export const FlexibleGeneral = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
+					isLastRow={!cards}
 				/>
 			)}
 
@@ -444,6 +459,7 @@ export const FlexibleGeneral = ({
 								imageLoading={imageLoading}
 								aspectRatio={aspectRatio}
 								isFirstRow={!splash.length && i === 0}
+								isLastRow={i === groupedCards.length - 1}
 							/>
 						);
 
@@ -460,6 +476,7 @@ export const FlexibleGeneral = ({
 								isFirstRow={!splash.length && i === 0}
 								isFirstStandardRow={i === 0}
 								aspectRatio={aspectRatio}
+								isLastRow={i === groupedCards.length - 1}
 							/>
 						);
 				}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -247,7 +247,7 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
-				isLastRow={!splash && !cards}
+				isLastRow={splash.length === 0 && cards.length === 0}
 			/>
 			<OneCardLayout
 				cards={splash}
@@ -256,7 +256,7 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
-				isLastRow={!cards}
+				isLastRow={cards.length === 0}
 			/>
 			<TwoCardOrFourCardLayout
 				cards={cards}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -113,6 +113,7 @@ export const OneCardLayout = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	isLastRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -120,6 +121,7 @@ export const OneCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	isLastRow: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -137,7 +139,7 @@ export const OneCardLayout = ({
 		card.supportingContent?.length ?? 0,
 	);
 	return (
-		<UL padBottom={true} hasLargeSpacing={true}>
+		<UL padBottom={!isLastRow} hasLargeSpacing={!isLastRow}>
 			<LI padSides={true}>
 				<FrontCard
 					trail={card}
@@ -187,12 +189,7 @@ const TwoCardOrFourCardLayout = ({
 	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
 	return (
-		<UL
-			direction="row"
-			padBottom={true}
-			showTopBar={true}
-			hasLargeSpacing={true}
-		>
+		<UL direction="row" showTopBar={true}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI
@@ -250,6 +247,7 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
+				isLastRow={!splash && !cards}
 			/>
 			<OneCardLayout
 				cards={splash}
@@ -258,6 +256,7 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
+				isLastRow={!cards}
 			/>
 			<TwoCardOrFourCardLayout
 				cards={cards}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -297,7 +297,7 @@ const sectionContentBorderFromLeftCol = css`
 			content: '';
 			position: absolute;
 			top: ${space[2]}px;
-			bottom: ${space[6]}px;
+			bottom: 0px;
 			border-left: 1px solid ${schemePalette('--section-border')};
 			transform: translateX(-50%);
 			/** Keeps the vertical divider ontop of carousel item dividers */
@@ -357,9 +357,14 @@ const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-const extraBottomPadding = css`
-	padding-bottom: ${space[4]}px;
+const smallBottomPadding = css`
+	padding-bottom: ${space[6]}px;
 `;
+
+const largeBottomPadding = css`
+	padding-bottom: ${space[10]}px;
+`;
+
 const primaryLevelTopBorder = css`
 	grid-row: 1;
 	grid-column: 1 / -1;
@@ -606,7 +611,8 @@ export const FrontSection = ({
 						sectionContentPadded,
 						sectionBottomContent,
 						!containerLevel && bottomPadding,
-						containerSpacing === 'large' && extraBottomPadding,
+						containerSpacing === 'small' && smallBottomPadding,
+						containerSpacing === 'large' && largeBottomPadding,
 					]}
 				>
 					{isString(targetedTerritory) &&

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -297,7 +297,7 @@ const sectionContentBorderFromLeftCol = css`
 			content: '';
 			position: absolute;
 			top: ${space[2]}px;
-			bottom: 0px;
+			bottom: 0;
 			border-left: 1px solid ${schemePalette('--section-border')};
 			transform: translateX(-50%);
 			/** Keeps the vertical divider ontop of carousel item dividers */

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -55,7 +55,8 @@ type Props = {
 	/** Fronts containers can have their styling overridden using a `containerLevel`.
 	 * If used, this can be either "Primary" or "Secondary", both of which have different styles */
 	containerLevel?: DCRContainerLevel;
-
+	/** Fronts containers spacing rules vary depending on the size of their container spacing which is derived from if the next container is a primary or secondary. */
+	containerSpacing?: 'large' | 'small';
 	/** Defaults to `false`. If true a Hide button is show top right allowing this section
 	 * to be collapsed
 	 */
@@ -356,48 +357,9 @@ const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-/** Adds space above the border of primary level containers without
- * causing gaps in the vertical side borders from tablet upwards
- */
-const primaryLevelTopSpacer = css`
-	height: ${space[4]}px;
-	background-color: ${schemePalette('--front-page-background')};
-	${from.tablet} {
-		display: grid;
-		column-gap: 20px;
-		grid-template-columns:
-			minmax(0, 1fr)
-			[decoration-start]
-			repeat(12, 40px)
-			[decoration-end]
-			minmax(0, 1fr);
-	}
-	${from.desktop} {
-		grid-template-columns:
-			minmax(0, 1fr)
-			[decoration-start]
-			repeat(12, 60px)
-			[decoration-end]
-			minmax(0, 1fr);
-	}
-	${from.leftCol} {
-		grid-template-columns:
-			minmax(0, 1fr)
-			[decoration-start]
-			repeat(14, 60px)
-			[decoration-end]
-			minmax(0, 1fr);
-	}
-	${from.wide} {
-		grid-template-columns:
-			minmax(0, 1fr)
-			[decoration-start]
-			repeat(16, 60px)
-			[decoration-end]
-			minmax(0, 1fr);
-	}
+const extraBottomPadding = css`
+	padding-bottom: ${space[4]}px;
 `;
-
 const primaryLevelTopBorder = css`
 	grid-row: 1;
 	grid-column: 1 / -1;
@@ -503,6 +465,7 @@ export const FrontSection = ({
 	containerName,
 	containerPalette,
 	containerLevel,
+	containerSpacing,
 	description,
 	editionId,
 	leftContent,
@@ -536,174 +499,161 @@ export const FrontSection = ({
 		!!ajaxUrl &&
 		!containerLevel;
 	const showVerticalRule = !hasPageSkin;
-
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
 	 * this id pre-existed showMore so is probably also being used for something else.
 	 */
 	return (
-		<>
-			{/** Primary level containers have additional spacing above the horizontal rule */}
-			{containerLevel === 'Primary' && (
-				<div css={primaryLevelTopSpacer}>
-					<div css={[decoration, sideBorders]} />
-				</div>
-			)}
-			<ContainerOverrides containerPalette={containerPalette}>
-				<section
-					id={sectionId}
-					data-link-name={ophanComponentLink}
-					data-component={ophanComponentName}
-					data-container-name={containerName}
-					data-container-level={containerLevel}
-					css={[
-						fallbackStyles,
-						containerStylesUntilLeftCol,
-						!hasPageSkin && containerStylesFromLeftCol,
-						hasPageSkin && pageSkinContainer,
-					]}
-					style={{
-						backgroundColor: schemePalette(
-							'--front-container-background',
-						),
-					}}
-				>
-					{!!containerLevel && showTopBorder && (
-						<div
-							css={[
-								containerLevel === 'Secondary'
-									? secondaryLevelTopBorder
-									: primaryLevelTopBorder,
-							]}
-						/>
-					)}
-
+		<ContainerOverrides containerPalette={containerPalette}>
+			<section
+				id={sectionId}
+				data-link-name={ophanComponentLink}
+				data-component={ophanComponentName}
+				data-container-name={containerName}
+				data-container-level={containerLevel}
+				css={[
+					fallbackStyles,
+					containerStylesUntilLeftCol,
+					!hasPageSkin && containerStylesFromLeftCol,
+					hasPageSkin && pageSkinContainer,
+				]}
+				style={{
+					backgroundColor: schemePalette(
+						'--front-container-background',
+					),
+				}}
+			>
+				{!!containerLevel && showTopBorder && (
 					<div
 						css={[
-							decoration,
-							sideBorders,
-							showTopBorder && !containerLevel && topBorder,
+							containerLevel === 'Secondary'
+								? secondaryLevelTopBorder
+								: primaryLevelTopBorder,
 						]}
 					/>
+				)}
 
-					<div
-						css={[
-							sectionHeadlineUntilLeftCol(
-								// TODO FIXME:
-								// This relies on sections called "opinion"
-								// only ever having <CPScott> as the leftContent
-								title?.toLowerCase() === 'opinion',
+				<div
+					css={[
+						decoration,
+						sideBorders,
+						showTopBorder && !containerLevel && topBorder,
+					]}
+				/>
+
+				<div
+					css={[
+						sectionHeadlineUntilLeftCol(
+							// TODO FIXME:
+							// This relies on sections called "opinion"
+							// only ever having <CPScott> as the leftContent
+							title?.toLowerCase() === 'opinion',
+						),
+						showVerticalRule &&
+							!containerLevel &&
+							sectionHeadlineFromLeftCol(
+								schemePalette('--section-border'),
 							),
-							showVerticalRule &&
-								!containerLevel &&
-								sectionHeadlineFromLeftCol(
-									schemePalette('--section-border'),
-								),
-							title?.toLowerCase() === 'headlines' &&
-								sectionHeadlineHeight,
-						]}
-					>
-						<FrontSectionTitle
-							title={
-								<ContainerTitle
-									title={title}
-									lightweightHeader={isTagPage}
-									description={description}
-									fontColour={schemePalette(
-										'--article-section-title',
-									)}
-									// On paid fronts the title is not treated as a link
-									url={
-										!isOnPaidContentFront ? url : undefined
-									}
-									showDateHeader={showDateHeader}
-									editionId={editionId}
-									containerLevel={containerLevel}
-								/>
-							}
-							collectionBranding={collectionBranding}
+						title?.toLowerCase() === 'headlines' &&
+							sectionHeadlineHeight,
+					]}
+				>
+					<FrontSectionTitle
+						title={
+							<ContainerTitle
+								title={title}
+								lightweightHeader={isTagPage}
+								description={description}
+								fontColour={schemePalette(
+									'--article-section-title',
+								)}
+								// On paid fronts the title is not treated as a link
+								url={!isOnPaidContentFront ? url : undefined}
+								showDateHeader={showDateHeader}
+								editionId={editionId}
+								containerLevel={containerLevel}
+							/>
+						}
+						collectionBranding={collectionBranding}
+					/>
+
+					{leftContent}
+				</div>
+
+				{isToggleable && (
+					<div css={sectionShowHide}>
+						<ShowHideButton sectionId={sectionId} />
+					</div>
+				)}
+
+				<div
+					css={[
+						sectionContent,
+						sectionContentPadded,
+						sectionContentRow(toggleable),
+						topPadding,
+						showVerticalRule &&
+							!!containerLevel &&
+							sectionContentBorderFromLeftCol,
+					]}
+					id={`container-${sectionId}`}
+				>
+					{children}
+				</div>
+
+				<div
+					css={[
+						sectionContentPadded,
+						sectionBottomContent,
+						!containerLevel && bottomPadding,
+						containerSpacing === 'large' && extraBottomPadding,
+					]}
+				>
+					{isString(targetedTerritory) &&
+					isAustralianTerritory(targetedTerritory) ? (
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<AustralianTerritorySwitcher
+								targetedTerritory={targetedTerritory}
+							/>
+						</Island>
+					) : showMore ? (
+						<Island
+							priority="feature"
+							defer={{ until: 'interaction' }}
+						>
+							<ShowMore
+								title={title}
+								sectionId={sectionId}
+								collectionId={collectionId}
+								pageId={pageId}
+								ajaxUrl={ajaxUrl}
+								editionId={editionId}
+								containerPalette={containerPalette}
+								showAge={!hideAge.includes(title)}
+								discussionApiUrl={discussionApiUrl}
+							/>
+						</Island>
+					) : null}
+					{pagination && (
+						<FrontPagination
+							sectionName={pagination.sectionName}
+							totalContent={pagination.totalContent}
+							currentPage={pagination.currentPage}
+							lastPage={pagination.lastPage}
+							pageId={pagination.pageId}
 						/>
-
-						{leftContent}
-					</div>
-
-					{isToggleable && (
-						<div css={sectionShowHide}>
-							<ShowHideButton sectionId={sectionId} />
-						</div>
 					)}
+				</div>
 
-					<div
-						css={[
-							sectionContent,
-							sectionContentPadded,
-							sectionContentRow(toggleable),
-							topPadding,
-							showVerticalRule &&
-								!!containerLevel &&
-								sectionContentBorderFromLeftCol,
-						]}
-						id={`container-${sectionId}`}
-					>
-						{children}
+				{treats && !hasPageSkin && (
+					<div css={[sectionTreats, topPadding]}>
+						<Treats
+							treats={treats}
+							borderColour={palette('--section-border')}
+						/>
 					</div>
-
-					<div
-						css={[
-							sectionContentPadded,
-							sectionBottomContent,
-							!containerLevel && bottomPadding,
-						]}
-					>
-						{isString(targetedTerritory) &&
-						isAustralianTerritory(targetedTerritory) ? (
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<AustralianTerritorySwitcher
-									targetedTerritory={targetedTerritory}
-								/>
-							</Island>
-						) : showMore ? (
-							<Island
-								priority="feature"
-								defer={{ until: 'interaction' }}
-							>
-								<ShowMore
-									title={title}
-									sectionId={sectionId}
-									collectionId={collectionId}
-									pageId={pageId}
-									ajaxUrl={ajaxUrl}
-									editionId={editionId}
-									containerPalette={containerPalette}
-									showAge={!hideAge.includes(title)}
-									discussionApiUrl={discussionApiUrl}
-								/>
-							</Island>
-						) : null}
-						{pagination && (
-							<FrontPagination
-								sectionName={pagination.sectionName}
-								totalContent={pagination.totalContent}
-								currentPage={pagination.currentPage}
-								lastPage={pagination.lastPage}
-								pageId={pagination.pageId}
-							/>
-						)}
-					</div>
-
-					{treats && !hasPageSkin && (
-						<div css={[sectionTreats, topPadding]}>
-							<Treats
-								treats={treats}
-								borderColour={palette('--section-border')}
-							/>
-						</div>
-					)}
-				</section>
-			</ContainerOverrides>
-		</>
+				)}
+			</section>
+		</ContainerOverrides>
 	);
 };

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -47,7 +47,6 @@ const gridGapMobile = 10;
  */
 const containerStyles = css`
 	position: relative;
-	margin-bottom: ${space[6]}px;
 	margin-left: -${gridGapMobile}px;
 	margin-right: -${gridGapMobile}px;
 	${from.mobileLandscape} {

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -26,7 +26,7 @@ export const StaticFeatureTwo = ({
 	const cards = trails.slice(0, 2);
 
 	return (
-		<UL direction="row" padBottom={true} hasLargeSpacing={true}>
+		<UL direction="row">
 			{cards.map((card) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -30,7 +30,7 @@ export const StaticMediumFour = ({
 	const cards = trails.slice(0, 4);
 
 	return (
-		<UL direction="row" padBottom={true} hasLargeSpacing={true}>
+		<UL direction="row">
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -745,6 +745,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								containerLevel={
 									collection.config.containerLevel
 								}
+								containerSpacing={collection.containerSpacing}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -42,6 +42,13 @@ const findCollectionSuitableForFrontBranding = (
 	return index;
 };
 
+/** Depending on the next sibling of the container, we assign either large or small spacing rules during render */
+const getContainerSpacing = (nextSiblingCollection?: FECollectionType) => {
+	const nextCollectionIsPrimary =
+		nextSiblingCollection?.config.collectionLevel === 'Primary';
+	return nextCollectionIsPrimary ? 'large' : 'small';
+};
+
 export const enhanceCollections = ({
 	collections,
 	editionId,
@@ -89,6 +96,8 @@ export const enhanceCollections = ({
 			},
 		);
 
+		const containerSpacing = getContainerSpacing(collections[index + 1]);
+
 		return {
 			id,
 			displayName,
@@ -99,6 +108,7 @@ export const enhanceCollections = ({
 			collectionType,
 			href,
 			containerPalette,
+			containerSpacing,
 			collectionBranding,
 			grouped: groupCards(
 				collectionType,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -417,6 +417,7 @@ export type DCRCollectionType = {
 	description?: string;
 	collectionType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
+	containerSpacing?: 'large' | 'small';
 	grouped: DCRGroupedTrails;
 	curated: DCRFrontCard[];
 	backfill: DCRFrontCard[];


### PR DESCRIPTION
## What does this change?
Reworks how container spacing is calculated and adds it to the model so that beta containers have either 24px or 40px bottom padding.

This is calculated at the enhancer layer by checking if the next sibling container has `primary` container styling. If this is true, we assign "large" container spacing, else we assign "small" container spacing. 

There is no extra padding adding after thrashers or ads. These continue to sit flush with the top of the container that follows them. 

Previously, container spacing was handled in a mixture of places. This PR reconciles this soft contract so that bottom container spacing is only set in one place: in the front section. 

## Why?
We want to add additional spacing to the bottom of beta containers that are followed by container with primary styling. It doesn't matter what styling the current container has. 

**Container spacing rules**
small === is not followed by a primary container === 24px bottom padding
large === is followed by a primary container === 40px bottom padding


## Screenshots

![Screenshot 2024-12-11 at 16 27 22](https://github.com/user-attachments/assets/8d89ac23-781c-42b0-abaf-6b872d668b95)

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
