### PR TITLE
Remove the top border for the first row of beta containers

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -267,6 +267,7 @@ export const BoostedCardLayout = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	isFirstRow,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -274,6 +275,7 @@ export const BoostedCardLayout = ({
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	isFirstRow: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -285,7 +287,7 @@ export const BoostedCardLayout = ({
 		liveUpdatesPosition,
 	} = decideCardProperties(card.boostLevel);
 	return (
-		<UL padBottom={true} hasLargeSpacing={true} showTopBar={true}>
+		<UL padBottom={true} hasLargeSpacing={true} showTopBar={!isFirstRow}>
 			<LI
 				padSides={true}
 				verticalDividerColour={palette('--card-border-supporting')}
@@ -329,11 +331,13 @@ export const StandardCardLayout = ({
 	showImage = true,
 	imageLoading,
 	isFirstRow,
+	isFirstStandardRow,
 	aspectRatio,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
-	isFirstRow: boolean;
+	isFirstRow?: boolean;
+	isFirstStandardRow?: boolean;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
@@ -347,8 +351,9 @@ export const StandardCardLayout = ({
 			direction="row"
 			padBottom={true}
 			hasLargeSpacing={true}
-			showTopBar={true}
-			splitTopBar={!isFirstRow}
+			showTopBar={!isFirstRow}
+			/** We use one full top bar for the first row and use a split one for subsequent rows */
+			splitTopBar={!isFirstStandardRow}
 		>
 			{cards.map((card, cardIndex) => {
 				return (
@@ -438,6 +443,7 @@ export const FlexibleGeneral = ({
 								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
 								aspectRatio={aspectRatio}
+								isFirstRow={!splash.length && i === 0}
 							/>
 						);
 
@@ -451,7 +457,8 @@ export const FlexibleGeneral = ({
 								showAge={showAge}
 								absoluteServerTimes={absoluteServerTimes}
 								imageLoading={imageLoading}
-								isFirstRow={i === 0}
+								isFirstRow={!splash.length && i === 0}
+								isFirstStandardRow={i === 0}
 								aspectRatio={aspectRatio}
 							/>
 						);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -26,12 +26,7 @@ export const StaticFeatureTwo = ({
 	const cards = trails.slice(0, 2);
 
 	return (
-		<UL
-			direction="row"
-			padBottom={true}
-			showTopBar={true}
-			hasLargeSpacing={true}
-		>
+		<UL direction="row" padBottom={true} hasLargeSpacing={true}>
 			{cards.map((card) => {
 				return (
 					<LI

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -30,12 +30,7 @@ export const StaticMediumFour = ({
 	const cards = trails.slice(0, 4);
 
 	return (
-		<UL
-			direction="row"
-			padBottom={true}
-			showTopBar={true}
-			hasLargeSpacing={true}
-		>
+		<UL direction="row" padBottom={true} hasLargeSpacing={true}>
 			{cards.map((card, cardIndex) => {
 				return (
 					<LI


### PR DESCRIPTION
## What does this change?

- Removes the top border on the first row of cards on flexible general containers
- Removes the top border from static containers

## Why?

Deduplicates the container top borders since we already have a top border on the container itself

[Trello ticket](https://trello.com/c/QyK89DkZ/774-web-review-row-border-top-for-all-containers)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before]: https://github.com/user-attachments/assets/31e6e471-a56f-4be3-ab97-1d4aae6c4fad
[after]: https://github.com/user-attachments/assets/8bdf6279-0dbc-4dba-998c-ab8833cda149
[before2]: https://github.com/user-attachments/assets/216cff7c-78f7-454c-a416-71f10a25584a
[after2]: https://github.com/user-attachments/assets/fbf8e3b8-d253-46bd-9a42-3f7d258b97e7
[before3]: https://github.com/user-attachments/assets/4437f422-3b82-4c33-9ac6-2b518b3bfc5e
[after3]: https://github.com/user-attachments/assets/8fbb978f-527d-4c82-8d98-5ccac6eba2c5
[before4]: https://github.com/user-attachments/assets/7b8adb99-dfa1-4207-a05f-c79cafc17ce3
[after4]: https://github.com/user-attachments/assets/64c98269-2bf8-471c-a52f-22a57e7efb8e
