### PR TITLE
Carousels: Prevent vertical scrolling

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -129,6 +129,7 @@ const carouselStyles = css`
 	grid-auto-flow: column;
 	gap: 20px;
 	overflow-x: auto;
+	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 	overscroll-behavior: contain auto;

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -34,6 +34,7 @@ const themeButtonDisabled: Partial<ThemeButton> = {
 const carouselStyles = css`
 	display: flex;
 	overflow-x: auto;
+	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 	overscroll-behavior: contain auto;


### PR DESCRIPTION
## What does this change?

Sets overflow on the y axis to `hidden` to prevent vertical scrolling of carousel content

## Why?

It's possible to vertically scroll small carousels if one of the cards includes a comment count. The `CardFooter` component uses a negative margin to align the comment icon which pulls the element outside of the container by a couple of pixels. This adds extra space to the bottom of the carousel which can then be scrolled. This can block scrolling the page itself as if your cursor is on a carousel whilst scrolling the carousel will be scrolled rather than the page.

## Screenshots

<img width="1276" alt="Screenshot 2024-12-06 at 15 52 51" src="https://github.com/user-attachments/assets/ee5dad9e-865b-48e1-97e8-a55bd678ad58">
