### PR TITLE
Extract carousel navigation buttons into separate component

### DIFF
--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source/foundations';
+import type { ThemeButton } from '@guardian/source/react-components';
+import {
+	Button,
+	SvgChevronLeftSingle,
+	SvgChevronRightSingle,
+} from '@guardian/source/react-components';
+import { palette } from '../palette';
+
+type Props = {
+	previousButtonEnabled: boolean;
+	nextButtonEnabled: boolean;
+	onClickPreviousButton: () => void;
+	onClickNextButton: () => void;
+	dataLinkNameNextButton: string;
+	dataLinkNamePreviousButton: string;
+};
+
+const themeButton: Partial<ThemeButton> = {
+	borderTertiary: palette('--carousel-chevron-border'),
+	textTertiary: palette('--carousel-chevron'),
+	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
+};
+
+const themeButtonDisabled: Partial<ThemeButton> = {
+	borderTertiary: palette('--carousel-chevron-border-disabled'),
+	textTertiary: palette('--carousel-chevron-disabled'),
+	backgroundTertiaryHover: 'transparent',
+};
+
+const buttonStyles = css`
+	display: none;
+	${from.tablet} {
+		display: flex;
+		gap: ${space[1]}px;
+		margin-left: auto;
+	}
+`;
+
+/**
+ * Navigation buttons for use in a carousel-like component
+ */
+export const CarouselNavigationButtons = ({
+	previousButtonEnabled,
+	nextButtonEnabled,
+	onClickPreviousButton,
+	onClickNextButton,
+	dataLinkNameNextButton,
+	dataLinkNamePreviousButton,
+}: Props) => {
+	return (
+		<div
+			aria-controls="carousel"
+			aria-label="carousel arrows"
+			css={buttonStyles}
+		>
+			<Button
+				hideLabel={true}
+				iconSide="left"
+				icon={<SvgChevronLeftSingle />}
+				onClick={onClickPreviousButton}
+				priority="tertiary"
+				theme={
+					previousButtonEnabled ? themeButton : themeButtonDisabled
+				}
+				size="small"
+				disabled={!previousButtonEnabled}
+				aria-label="previous"
+				value="previous"
+				data-link-name={dataLinkNamePreviousButton}
+			/>
+
+			<Button
+				hideLabel={true}
+				iconSide="left"
+				icon={<SvgChevronRightSingle />}
+				onClick={onClickNextButton}
+				priority="tertiary"
+				theme={nextButtonEnabled ? themeButton : themeButtonDisabled}
+				size="small"
+				disabled={!nextButtonEnabled}
+				aria-label="next"
+				value="next"
+				data-link-name={dataLinkNameNextButton}
+			/>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -6,14 +6,10 @@ import {
 	space,
 	textSansBold17Object,
 } from '@guardian/source/foundations';
-import type { ThemeButton } from '@guardian/source/react-components';
-import {
-	Button,
-	SvgChevronLeftSingle,
-	SvgChevronRightSingle,
-} from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
+import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { palette } from '../palette';
+import { CarouselNavigationButtons } from './CarouselNavigationButtons';
 
 type Props = {
 	children: React.ReactNode;
@@ -38,18 +34,6 @@ const secondaryTitlePreset = textSansBold17Object;
 const gridColumnWidth = 60;
 const gridGap = 20;
 const gridGapMobile = 10;
-
-const themeButton: Partial<ThemeButton> = {
-	borderTertiary: palette('--carousel-chevron-border'),
-	textTertiary: palette('--carousel-chevron'),
-	backgroundTertiaryHover: palette('--carousel-chevron-hover'),
-};
-
-const themeButtonDisabled: Partial<ThemeButton> = {
-	borderTertiary: palette('--carousel-chevron-border-disabled'),
-	textTertiary: palette('--carousel-chevron-disabled'),
-	backgroundTertiaryHover: 'transparent',
-};
 
 /**
  * On mobile the carousel extends into the outer margins to use the full width
@@ -158,15 +142,6 @@ const carouselStyles = css`
 	${from.leftCol} {
 		padding-left: ${gridGap / 2}px;
 		scroll-padding-left: ${gridGap / 2}px;
-	}
-`;
-
-const buttonStyles = css`
-	display: none;
-	${from.tablet} {
-		display: flex;
-		gap: ${space[1]}px;
-		margin-left: auto;
 	}
 `;
 
@@ -346,44 +321,22 @@ export const ScrollableCarousel = ({
 			>
 				{children}
 			</ol>
-			{showNavigation && (
-				<div css={buttonStyles}>
-					<Button
-						hideLabel={true}
-						iconSide="left"
-						icon={<SvgChevronLeftSingle />}
-						onClick={() => scrollTo('left')}
-						priority="tertiary"
-						theme={
-							previousButtonEnabled
-								? themeButton
-								: themeButtonDisabled
-						}
-						size="small"
-						disabled={!previousButtonEnabled}
-						// TODO
-						// aria-label="Move stories backwards"
-						// data-link-name="container left chevron"
-					/>
 
-					<Button
-						hideLabel={true}
-						iconSide="left"
-						icon={<SvgChevronRightSingle />}
-						onClick={() => scrollTo('right')}
-						priority="tertiary"
-						theme={
-							nextButtonEnabled
-								? themeButton
-								: themeButtonDisabled
-						}
-						size="small"
-						disabled={!nextButtonEnabled}
-						// TODO
-						// aria-label="Move stories forwards"
-						// data-link-name="container right chevron"
-					/>
-				</div>
+			{showNavigation && (
+				<CarouselNavigationButtons
+					previousButtonEnabled={previousButtonEnabled}
+					nextButtonEnabled={nextButtonEnabled}
+					onClickPreviousButton={() => scrollTo('left')}
+					onClickNextButton={() => scrollTo('right')}
+					dataLinkNamePreviousButton={nestedOphanComponents(
+						'carousel',
+						'previous-button',
+					)}
+					dataLinkNameNextButton={nestedOphanComponents(
+						'carousel',
+						'next-button',
+					)}
+				/>
 			)}
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Extracts the carousel navigation buttons into their own separate component.

Specifies `data-link-name` and `aria-label` for each `Button` component as well as adding additional `aria-label` and `aria-controls` attributes to the parent `div` of the buttons.

There should be no visual or behavioural differences apart from specifying data-link-name and ARIA information as this is just a refactoring change

## Why?

So that they can be used in various places consistently.

Also improves accessibility and tracking for this component

[Trello ticket](https://trello.com/c/zIfcXK0Y/772-web-componentise-carousel-arrow-buttons)