### PR TITLE
Update text colour for items in `LatestLinks` component

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -61,7 +61,7 @@ const bold = css`
 		width: 0.75em;
 		margin-right: ${space[1]}px;
 		display: inline-block;
-		background-color: currentColor;
+		background-color: ${themePalette('--card-kicker-text')};
 		border-radius: 100%;
 	}
 `;
@@ -186,7 +186,7 @@ export const LatestLinks = ({
 									{index > 0 && (
 										<li
 											key={block.id + ' : divider'}
-											css={[dividerStyles]}
+											css={dividerStyles}
 										></li>
 									)}
 									<li
@@ -201,7 +201,7 @@ export const LatestLinks = ({
 												css={bold}
 												style={{
 													color: themePalette(
-														'--card-kicker-text',
+														'--card-trail-text',
 													),
 												}}
 											>


### PR DESCRIPTION
## What does this change?

Changes the text colour from the kicker colour to the trail text colour for items within the `LatestLinks` component used to represent live blog updates within cards.

The circle / bullet point on the left hand side of the items remains the same colour as the kicker

## Why?

As part of the Fairground designs.

[Trello ticket link](https://trello.com/c/nmKUKKLu/682-flexible-general-and-dynamics-liveblogs-colour-change)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/d81a7155-ad95-4191-acbc-8799e0bbe9ae
[after]: https://github.com/user-attachments/assets/6425dd24-5857-40c7-90a9-4bb6045a0972

