### PR TITLE
Media Cards: Update palette

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -448,7 +448,7 @@ export const Card = ({
 
 	const hasMedia = isMediaCard(format);
 	const backgroundColour = hasMedia
-		? palette('--card-background-media')
+		? palette('--card-media-background')
 		: palette('--card-background');
 
 	/**

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -446,11 +446,18 @@ export const Card = ({
 	const showCommentFooter =
 		isOpinion && !isOnwardContent && media?.type === 'avatar';
 
+	const hasMedia = isMediaCard(format);
+	const backgroundColour = hasMedia
+		? palette('--card-background-media')
+		: palette('--card-background');
+
 	/**
 	 * Some cards in standard containers have contrasting background colours.
 	 * We need to add additional padding to these cards to keep the text readable.
 	 */
-	const hasBackgroundColour = !containerPalette && isMediaCard(format);
+	const hasBackgroundColour = !containerPalette && hasMedia;
+
+	/* Set background colour depending
 
 	/* Whilst we migrate to the new container types, we need to check which container we are in. */
 	const isFlexibleContainer =
@@ -580,7 +587,7 @@ export const Card = ({
 					css={css`
 						padding-bottom: ${space[5]}px;
 					`}
-					style={{ backgroundColor: palette('--card-background') }}
+					style={{ backgroundColor: backgroundColour }}
 				>
 					<CardHeadline
 						headlineText={headlineText}
@@ -618,7 +625,7 @@ export const Card = ({
 			)}
 
 			<CardLayout
-				cardBackgroundColour={palette('--card-background')}
+				cardBackgroundColour={backgroundColour}
 				imagePositionOnDesktop={imagePositionOnDesktop}
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -498,7 +498,7 @@ export const Card = ({
 	/** Determines the gap of between card components based on card properties */
 	const getGapSize = (): GapSize => {
 		if (isOnwardContent) return 'none';
-		if (hasBackgroundColour) return 'tiny';
+		if (hasBackgroundColour && !isFlexibleContainer) return 'tiny';
 		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
 			return 'small';
 		}
@@ -814,6 +814,7 @@ export const Card = ({
 						imagePositionOnDesktop={imagePositionOnDesktop}
 						hasBackgroundColour={hasBackgroundColour}
 						isOnwardContent={isOnwardContent}
+						isFlexibleContainer={isFlexibleContainer}
 					>
 						{/* This div is needed to keep the headline and trail text justified at the start */}
 						<div

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -446,18 +446,15 @@ export const Card = ({
 	const showCommentFooter =
 		isOpinion && !isOnwardContent && media?.type === 'avatar';
 
-	const hasMedia = isMediaCard(format);
-	const backgroundColour = hasMedia
+	/**
+-	 * Media cards have contrasting background colours. We add additional
+	 * padding to these cards to keep the text readable.
+-	 */
+	const hasBackgroundColour = isMediaCard(format);
+
+	const backgroundColour = hasBackgroundColour
 		? palette('--card-media-background')
 		: palette('--card-background');
-
-	/**
-	 * Some cards in standard containers have contrasting background colours.
-	 * We need to add additional padding to these cards to keep the text readable.
-	 */
-	const hasBackgroundColour = !containerPalette && hasMedia;
-
-	/* Set background colour depending
 
 	/* Whilst we migrate to the new container types, we need to check which container we are in. */
 	const isFlexibleContainer =

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -61,6 +61,32 @@ const flexBasisStyles = ({
 	}
 };
 
+const paddingStyles = (
+	imagePosition: ImagePositionType,
+	isFlexibleContainer: boolean,
+) => {
+	/**
+	 * If we're in a flexible container there is a 20px gap between the image
+	 * and content. We don't apply padding to the content on the same edge as
+	 * the image so the content is aligned with the grid.
+	 */
+	if (isFlexibleContainer && imagePosition === 'left') {
+		return css`
+			padding: ${space[1]}px ${space[1]}px ${space[1]}px 0;
+		`;
+	}
+
+	if (isFlexibleContainer && imagePosition === 'right') {
+		return css`
+			padding: ${space[1]}px 0 ${space[1]}px ${space[1]}px;
+		`;
+	}
+
+	return css`
+		padding: ${space[1]}px;
+	`;
+};
+
 type Props = {
 	children: React.ReactNode;
 	imageType?: CardImageType;
@@ -68,6 +94,7 @@ type Props = {
 	imagePositionOnDesktop: ImagePositionType;
 	hasBackgroundColour?: boolean;
 	isOnwardContent?: boolean;
+	isFlexibleContainer?: boolean;
 };
 
 export const ContentWrapper = ({
@@ -77,6 +104,7 @@ export const ContentWrapper = ({
 	imagePositionOnDesktop,
 	hasBackgroundColour,
 	isOnwardContent,
+	isFlexibleContainer = false,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -85,14 +113,10 @@ export const ContentWrapper = ({
 		<div
 			css={[
 				sizingStyles,
-				isHorizontalOnDesktop && [
+				isHorizontalOnDesktop &&
 					flexBasisStyles({ imageSize, imageType }),
-				],
-				css`
-					padding: ${!!hasBackgroundColour || !!isOnwardContent
-						? space[1]
-						: 0}px;
-				`,
+				(!!hasBackgroundColour || !!isOnwardContent) &&
+					paddingStyles(imagePositionOnDesktop, isFlexibleContainer),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -580,6 +580,16 @@ const cardBackgroundDark: ContainerFunction = (containerPalette) => {
 	}
 };
 
+const cardMediaBackgroundLight: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineLight(containerPalette), 0.1);
+const cardMediaBackgroundDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.1);
+
+const cardMediaIconLight: ContainerFunction = (containerPalette) =>
+	cardBackgroundLight(containerPalette);
+const cardMediaIconDark: ContainerFunction = (containerPalette) =>
+	cardBackgroundDark(containerPalette);
+
 const sectionBackgroundLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
 		case 'InvestigationPalette':
@@ -1068,6 +1078,14 @@ const containerColours = {
 	'--card-kicker-text': {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
+	},
+	'--card-media-background': {
+		light: cardMediaBackgroundLight,
+		dark: cardMediaBackgroundDark,
+	},
+	'--card-media-icon': {
+		light: cardMediaIconLight,
+		dark: cardMediaIconDark,
 	},
 	'--card-sublinks-background': {
 		light: cardSublinksBackgroundLight,

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -29,7 +29,7 @@ const iconWrapperStyles = (hasKicker: boolean) => css`
 		margin-right: auto;
 		margin-top: 2px;
 		display: block;
-		fill: ${themePalette('--card-background-media')};
+		fill: ${themePalette('--card-media-icon')};
 	}
 `;
 

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -29,7 +29,7 @@ const iconWrapperStyles = (hasKicker: boolean) => css`
 		margin-right: auto;
 		margin-top: 2px;
 		display: block;
-		fill: ${themePalette('--card-background')};
+		fill: ${themePalette('--card-background-media')};
 	}
 `;
 

--- a/dotcom-rendering/src/lib/cardHelpers.test.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.test.ts
@@ -33,7 +33,7 @@ describe('cardHasDarkBackground', () => {
 		{
 			format: galleryFormat,
 			containerPalette: undefined,
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			format: pictureFormat,

--- a/dotcom-rendering/src/lib/cardHelpers.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.ts
@@ -40,7 +40,7 @@ export const cardHasDarkBackground = (
 		case 'PodcastPalette':
 		// If no containerPalette provided, card is in a standard container
 		case undefined: {
-			return isMediaCard(format);
+			return false;
 		}
 	}
 };

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2485,10 +2485,15 @@ const cardMetaTextDark: PaletteFunction = () => sourcePalette.neutral[60];
 const cardBackgroundLight: PaletteFunction = () => 'transparent';
 const cardBackgroundDark: PaletteFunction = () => 'transparent';
 
-const cardBackgroundMediaLight: PaletteFunction = () =>
+const cardMediaBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
-const cardBackgroundMediaDark: PaletteFunction = () =>
+const cardMediaBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[20];
+
+const cardMediaIconLight: PaletteFunction = (format) =>
+	cardMediaBackgroundLight(format);
+const cardMediaIconDark: PaletteFunction = (format) =>
+	cardMediaBackgroundDark(format);
 
 const cardHeadlineTextLight: PaletteFunction = () => sourcePalette.neutral[7];
 
@@ -6069,10 +6074,6 @@ const paletteColours = {
 		light: cardBackgroundHover,
 		dark: cardBackgroundHover,
 	},
-	'--card-background-media': {
-		light: cardBackgroundMediaLight,
-		dark: cardBackgroundMediaDark,
-	},
 	'--card-border-supporting': {
 		light: cardBorderSupportingLight,
 		dark: cardBorderSupportingDark,
@@ -6092,6 +6093,14 @@ const paletteColours = {
 	'--card-kicker-text': {
 		light: cardKickerTextLight,
 		dark: cardKickerTextDark,
+	},
+	'--card-media-background': {
+		light: cardMediaBackgroundLight,
+		dark: cardMediaBackgroundDark,
+	},
+	'--card-media-icon': {
+		light: cardMediaIconLight,
+		dark: cardMediaIconDark,
 	},
 	'--card-sublinks-background': {
 		light: cardSublinksBackgroundLight,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2479,21 +2479,21 @@ const cardBorderSupportingLight: PaletteFunction = () =>
 const cardBorderSupportingDark: PaletteFunction = () =>
 	sourcePalette.neutral[46];
 
-const cardMetaTextLight: PaletteFunction = (format) =>
-	isMediaCard(format) ? sourcePalette.neutral[86] : sourcePalette.neutral[46];
+const cardMetaTextLight: PaletteFunction = () => sourcePalette.neutral[46];
 
 const cardMetaTextDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const cardBackground: PaletteFunction = (format) =>
+const cardBackgroundLight: PaletteFunction = (format) =>
+	isMediaCard(format) ? sourcePalette.neutral[97] : 'transparent';
+
+const cardBackgroundDark: PaletteFunction = (format) =>
 	isMediaCard(format) ? sourcePalette.neutral[20] : 'transparent';
 
-const cardHeadlineTextLight: PaletteFunction = (format) =>
-	isMediaCard(format) ? sourcePalette.neutral[100] : sourcePalette.neutral[7];
+const cardHeadlineTextLight: PaletteFunction = () => sourcePalette.neutral[7];
 
 const cardTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const cardTrailTextLight: PaletteFunction = (format) =>
-	isMediaCard(format) ? sourcePalette.neutral[86] : sourcePalette.neutral[38];
+const cardTrailTextLight: PaletteFunction = () => sourcePalette.neutral[38];
 const cardTrailTextDark: PaletteFunction = () => sourcePalette.neutral[73];
 
 const liveKickerBackgroundLight: PaletteFunction = (format) => {
@@ -6061,8 +6061,8 @@ const paletteColours = {
 		dark: captionTextDark,
 	},
 	'--card-background': {
-		light: cardBackground,
-		dark: cardBackground,
+		light: cardBackgroundLight,
+		dark: cardBackgroundDark,
 	},
 	'--card-background-hover': {
 		light: cardBackgroundHover,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2545,44 +2545,20 @@ const liveKickerPulsingDot: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[97], 0.75);
 
 const cardKickerTextLight: PaletteFunction = (format) => {
-	switch (format.design) {
-		case ArticleDesign.Gallery:
-		case ArticleDesign.Audio:
-		case ArticleDesign.Video:
-			switch (format.theme) {
-				case Pillar.News:
-					return sourcePalette.news[550];
-				case Pillar.Sport:
-					return sourcePalette.sport[600];
-				case Pillar.Opinion:
-					return sourcePalette.opinion[550];
-				case Pillar.Lifestyle:
-					return sourcePalette.lifestyle[500];
-				case Pillar.Culture:
-					return sourcePalette.culture[500];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[400];
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.news[400];
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.specialReportAlt[200];
-			}
-		default:
-			switch (format.theme) {
-				case Pillar.Opinion:
-					return pillarPalette(format.theme, 300);
-				case Pillar.Sport:
-				case Pillar.Culture:
-				case Pillar.Lifestyle:
-				case Pillar.News:
-					return pillarPalette(format.theme, 400);
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[200];
-				case ArticleSpecial.SpecialReport:
-					return sourcePalette.news[400];
-				case ArticleSpecial.SpecialReportAlt:
-					return sourcePalette.specialReportAlt[200];
-			}
+	switch (format.theme) {
+		case Pillar.Opinion:
+			return pillarPalette(format.theme, 300);
+		case Pillar.Sport:
+		case Pillar.Culture:
+		case Pillar.Lifestyle:
+		case Pillar.News:
+			return pillarPalette(format.theme, 400);
+		case ArticleSpecial.Labs:
+			return sourcePalette.labs[200];
+		case ArticleSpecial.SpecialReport:
+			return sourcePalette.news[400];
+		case ArticleSpecial.SpecialReportAlt:
+			return sourcePalette.specialReportAlt[200];
 	}
 };
 

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -22,7 +22,6 @@ import {
 	type ArticleTheme,
 	Pillar,
 } from './lib/articleFormat';
-import { isMediaCard } from './lib/cardHelpers';
 import { transparentColour } from './lib/transparentColour';
 
 // ----- Palette Functions ----- //
@@ -2483,11 +2482,13 @@ const cardMetaTextLight: PaletteFunction = () => sourcePalette.neutral[46];
 
 const cardMetaTextDark: PaletteFunction = () => sourcePalette.neutral[60];
 
-const cardBackgroundLight: PaletteFunction = (format) =>
-	isMediaCard(format) ? sourcePalette.neutral[97] : 'transparent';
+const cardBackgroundLight: PaletteFunction = () => 'transparent';
+const cardBackgroundDark: PaletteFunction = () => 'transparent';
 
-const cardBackgroundDark: PaletteFunction = (format) =>
-	isMediaCard(format) ? sourcePalette.neutral[20] : 'transparent';
+const cardBackgroundMediaLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const cardBackgroundMediaDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
 
 const cardHeadlineTextLight: PaletteFunction = () => sourcePalette.neutral[7];
 
@@ -6067,6 +6068,10 @@ const paletteColours = {
 	'--card-background-hover': {
 		light: cardBackgroundHover,
 		dark: cardBackgroundHover,
+	},
+	'--card-background-media': {
+		light: cardBackgroundMediaLight,
+		dark: cardBackgroundMediaDark,
 	},
 	'--card-border-supporting': {
 		light: cardBorderSupportingLight,


### PR DESCRIPTION
## What does this change?

- Updates media card background and text colours
- Adds special palette background colours for media cards
- Applies padding to _all_ media cards as they now always have a background colour, even when in a container with special palette

## Why?

This is an incremental change which forms part of a larger body of work to [update the design of media cards](https://trello.com/c/M98Xbjwd/756-web-media-cards-xs-s-m)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before1]: https://github.com/user-attachments/assets/668fba31-1ff4-434a-9ebe-0a13442df126
[after1]: https://github.com/user-attachments/assets/9b64a27b-2d21-4802-aab7-4cc2215bae06
[before2]: https://github.com/user-attachments/assets/b9a21fce-4e53-4d7b-9f8b-84f07db5535c
[after2]: https://github.com/user-attachments/assets/e5f260a1-51f0-45cb-96a4-268895f048d1
[before3]: https://github.com/user-attachments/assets/c2f79811-9c98-4738-8baa-810e3a80e141
[after3]: https://github.com/user-attachments/assets/0710b443-9f86-492e-998b-ef6dfa94f4d4
[before4]: https://github.com/user-attachments/assets/5b1b94a9-debf-43df-869f-cfd62860111d
[after4]: https://github.com/user-attachments/assets/fa38412d-6fe7-4b54-9a55-5eebce8a8e39

<img width="1293" alt="Screenshot 2024-12-11 at 15 25 00" src="https://github.com/user-attachments/assets/e784e12d-ae6b-4124-9268-58aa7f2463fc" />
