### PR TITLE
Pass gallery count to card 

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -341,6 +341,7 @@ export const Card = ({
 	trailTextSize,
 	trailTextColour,
 	podcastImage,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Added in preparation for UI changes to display gallery count
 	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -556,9 +557,6 @@ export const Card = ({
 			</Hide>
 		);
 	};
-
-	/** This log has been deliberatley left in to satisfy the lint check of gallery count not being used */
-	console.log({ galleryCount });
 
 	return (
 		<CardWrapper

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -557,6 +557,9 @@ export const Card = ({
 		);
 	};
 
+	/** This log has been deliberatley left in to satisfy the lint check of gallery count not being used */
+	console.log({ galleryCount });
+
 	return (
 		<CardWrapper
 			format={format}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -141,6 +141,7 @@ export type Props = {
 	trailTextColour?: string;
 	/** The square podcast series image, if it exists for a card */
 	podcastImage?: PodcastSeriesImage;
+	galleryCount?: number;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -340,6 +341,7 @@ export const Card = ({
 	trailTextSize,
 	trailTextColour,
 	podcastImage,
+	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -55,6 +55,7 @@ export const FrontCard = (props: Props) => {
 		slideshowImages: trail.slideshowImages,
 		showLivePlayable: trail.showLivePlayable,
 		showMainVideo: trail.showMainVideo,
+		galleryCount: trail.galleryCount,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -269,7 +269,6 @@ export const enhanceCards = (
 		const podcastImage = getPodcastSeriesImage(faciaCard);
 
 		const isContributorTagPage = !!pageId && pageId.startsWith('profile/');
-
 		return {
 			format,
 			dataLinkName,
@@ -329,5 +328,6 @@ export const enhanceCards = (
 				},
 			}),
 			podcastImage,
+			galleryCount: faciaCard.card.galleryCount,
 		};
 	});

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1031,6 +1031,9 @@
                                                 },
                                                 "isLive": {
                                                     "type": "boolean"
+                                                },
+                                                "galleryCount": {
+                                                    "type": "number"
                                                 }
                                             },
                                             "required": [
@@ -1779,6 +1782,9 @@
                                                 },
                                                 "isLive": {
                                                     "type": "boolean"
+                                                },
+                                                "galleryCount": {
+                                                    "type": "number"
                                                 }
                                             },
                                             "required": [
@@ -2527,6 +2533,9 @@
                                                 },
                                                 "isLive": {
                                                     "type": "boolean"
+                                                },
+                                                "galleryCount": {
+                                                    "type": "number"
                                                 }
                                             },
                                             "required": [

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -552,6 +552,9 @@
                             },
                             "isLive": {
                                 "type": "boolean"
+                            },
+                            "galleryCount": {
+                                "type": "number"
                             }
                         },
                         "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -290,6 +290,7 @@ export type FEFrontCard = {
 		shortUrl: string;
 		group: string;
 		isLive: boolean;
+		galleryCount?: number;
 	};
 	discussion: {
 		isCommentable: boolean;
@@ -348,6 +349,7 @@ export type DCRFrontCard = {
 	slideshowImages?: DCRSlideshowImage[];
 	showMainVideo?: boolean;
 	podcastImageSrc?: string;
+	galleryCount?: number;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?
Passes the gallery count from frontend to the card component, updating the fe model and dcr model to expect the new prop. 

The gallery count is being calculated in frontend and added to the pressedCard model [here](https://github.com/guardian/frontend/pull/27664). 

## Why?
Design want to be able to display the gallery count at card level. The rendering portion of this work will be dealt with in an upcoming PR

## Screenshots

![Screenshot 2024-12-12 at 10 22 35](https://github.com/user-attachments/assets/7adf7066-4027-44b6-825a-3229d996ba59)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
