### PR TITLE
Start Onwards Content AB test

### DIFF
--- a/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
+++ b/dotcom-rendering/src/experiments/tests/onwards-content-article.ts
@@ -7,8 +7,8 @@ export const onwardsContentArticle: ABTest = {
 	author: 'dotcom.platform@guardian.co.uk',
 	description:
 		'Test the impact of showing the galleries onwards content component on article pages.',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 50 / 100,
+	audienceOffset: 50 / 100,
 	audienceCriteria: 'Article pages',
 	successMeasure:
 		'Users are more likely to click a link in the onward content component.',


### PR DESCRIPTION
## What does this change?

Starts the Onwards Content [AB test](https://github.com/guardian/frontend/pull/27632).

The control and the variant will each use 25% of the eligible population.