### PR TITLE
Reduce article stack size from 36 to 30

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 36,
-		maximumInstances: 360,
+		minimumInstances: 30,
+		maximumInstances: 300,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
## What does this change?

Reduce article stack size from 36 to 30

More information [here](https://github.com/guardian/dotcom-rendering/issues/12793)

## Why?

Reduce unnecessary costs where possible

