### PR TITLE
Non-thrasher - update copy now that the goal has been achieved

### DIFF
--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -235,7 +235,7 @@ const tickerSettingsSubCampaign = {
 const heading = (isSubCampaign: boolean) => {
 	return isSubCampaign
 		? 'Last chance to support us this year'
-		: 'Can you help us hit our goal?';
+		: 'Can you help us beat our goal?';
 };
 const bodyCopy = (isSubCampaign: boolean) => {
 	const SubCampaignCopy =
@@ -248,7 +248,7 @@ const bodyCopy = (isSubCampaign: boolean) => {
 const bodyCopyHighlightedText = (isSubCampaign: boolean) => {
 	const SubCampaignCopy = 'Help us keep going in 2025.';
 	const normalCopy =
-		'Help us hit our most important annual fundraising goal so we can keep going.';
+		'Help us raise as much as we can to power our journalism in 2025.';
 	return isSubCampaign ? SubCampaignCopy : normalCopy;
 };
 


### PR DESCRIPTION
## What does this change?

Now that we have met the $4M goal, we need to tweak the copy to be consistent with the ticker.

[Trello card](https://trello.com/c/ouUXiH46)

## Why?

To continue to ask our readers to support our journalism as much as possible for the next year.

## Screenshots

### From
<img width="1250" alt="Screenshot 2024-12-11 at 16 21 28" src="https://github.com/user-attachments/assets/fda4d484-be5b-4633-a550-5aaa95f9fc60" />

### To
<img width="1250
" alt="Screenshot 2024-12-16 at 11 17 02" src="https://github.com/user-attachments/assets/a7770496-1261-495a-85f3-4e0bea347153" />

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
