### PR TITLE
Fix types for podcast images

### DIFF
--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -56,6 +56,7 @@ export const FrontCard = (props: Props) => {
 		showLivePlayable: trail.showLivePlayable,
 		showMainVideo: trail.showMainVideo,
 		galleryCount: trail.galleryCount,
+		podcastImage: trail.podcastImage,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -11,7 +11,7 @@ import type { BoostLevel, Image, StarRating } from './content';
 import type { FooterType } from './footer';
 import type { FEFormat, FENavType } from './frontend';
 import type { MainMedia } from './mainMedia';
-import type { FETagType } from './tag';
+import type { FETagType, PodcastSeriesImage } from './tag';
 import type { Territory } from './territory';
 import type { FETrailType, TrailType } from './trails';
 
@@ -348,8 +348,8 @@ export type DCRFrontCard = {
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
 	showMainVideo?: boolean;
-	podcastImageSrc?: string;
 	galleryCount?: number;
+	podcastImage?: PodcastSeriesImage;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?
Adjusts the types in DCR so naming is consistent 

## Why?
The property was called two things meaning the data wasnt flowing through.
