### PR TITLE
Skip flaky Chromatic tests

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.stories.tsx
@@ -253,6 +253,14 @@ export const EditorialDesign = {
 	},
 } satisfies Story;
 
+/**
+ * Skipped (flaky).
+ *
+ * This story fails intermittently. It is unclear to whether it is the icon, the
+ * image, the font, or something else that is causing the issue.
+ *
+ * Example: https://www.chromatic.com/test?appId=637e406971a9af18ddba0505&id=665eecc338adeba89d31f92b
+ */
 export const MatchReportDesignSportTheme = {
 	args: {
 		...StandardDesign.args,
@@ -263,6 +271,9 @@ export const MatchReportDesignSportTheme = {
 		},
 	},
 	name: 'MatchReport Design, Sport Theme',
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const LiveBlogDesign = {

--- a/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.stories.tsx
@@ -143,6 +143,14 @@ export const InitialPage = {
 	],
 } satisfies Story;
 
+/**
+ * Skipped (flaky).
+ *
+ * This story fails intermittently. The monospaced
+ * text: "code" is often different in the snapshot.
+ *
+ * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=6659d8e7fde909fdd4dbf8b9
+ */
 export const LoggedInHiddenNoPicks = {
 	...LoggedOutHiddenPicks,
 	name: 'When logged in, with no picks and not expanded',
@@ -152,6 +160,9 @@ export const LoggedInHiddenNoPicks = {
 		user: aUser,
 	},
 	decorators: [splitTheme([format])],
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
 } satisfies Story;
 
 export const LoggedIn = {

--- a/dotcom-rendering/src/components/DocumentBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/DocumentBlockComponent.stories.tsx
@@ -34,6 +34,15 @@ export const ScribdDocument: Story = {
 	},
 };
 
+/**
+ * Skipped (flaky).
+ *
+ * This story fails intermittently. The text: "fit width" in
+ * the button in the bottom-right sometimes causes a difference.
+ * often different in the snapshot.
+ *
+ * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=676405bf6014bfa8ccddc7be
+ */
 export const DocumentCloudDocument: Story = {
 	args: {
 		embedUrl: 'https://embed.documentcloud.org/documents/20417938-test-pdf',
@@ -43,5 +52,8 @@ export const DocumentCloudDocument: Story = {
 		source: 'DocumentCloud',
 		isTracking: false,
 		isMainMedia: false,
+	},
+	parameters: {
+		chromatic: { disableSnapshot: true },
 	},
 };

--- a/dotcom-rendering/src/components/VimeoBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/VimeoBlockComponent.stories.tsx
@@ -69,6 +69,14 @@ largeAspectRatio.story = {
 	chromatic: { disable: true },
 };
 
+/**
+ * Skipped (flaky).
+ *
+ * This story fails intermittently. Sometimes the video doesn't load
+ * with the error message: "We couldn't verify the security of your connection."
+ *
+ * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=6762b11e0dbf28eb24702ff1
+ */
 export const verticalAspectRatio = () => {
 	return (
 		<Wrapper>
@@ -92,3 +100,6 @@ export const verticalAspectRatio = () => {
 	);
 };
 verticalAspectRatio.storyName = 'with vertical aspect ratio';
+verticalAspectRatio.story = {
+	chromatic: { disableSnapshot: true },
+};

--- a/dotcom-rendering/src/components/VimeoBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/VimeoBlockComponent.stories.tsx
@@ -1,105 +1,73 @@
 import { css } from '@emotion/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { VimeoBlockComponent } from './VimeoBlockComponent';
 
-export default {
+const meta = {
 	component: VimeoBlockComponent,
-	title: 'Components/VimeoComponent',
-};
+	title: 'Components/Vimeo Component',
+	decorators: [
+		(Story) => (
+			<div
+				css={css`
+					max-width: 620px;
+					padding: 20px;
+				`}
+			>
+				<p>abc</p>
+				<Story />
+				<p>abc</p>
+			</div>
+		),
+	],
+	/**
+	 * Skipped (flaky).
+	 *
+	 * This story fails intermittently. Sometimes the video doesn't load
+	 * with the error message: "We couldn't verify the security of your connection."
+	 *
+	 * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=6762b11e0dbf28eb24702ff1
+	 */
+	parameters: {
+		chromatic: { disableSnapshot: true },
+	},
+} satisfies Meta<typeof VimeoBlockComponent>;
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-	<div
-		css={css`
-			max-width: 620px;
-			padding: 20px;
-		`}
-	>
-		{children}
-	</div>
-);
+export default meta;
 
-export const smallAspectRatio = () => {
-	return (
-		<Wrapper>
-			<p>abc</p>
-			<VimeoBlockComponent
-				embedUrl="https://player.vimeo.com/video/327310297?app_id=122963"
-				height={250}
-				width={250}
-				caption="blah"
-				credit=""
-				title=""
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.News,
-				}}
-				isMainMedia={false}
-			/>
-			<p>abc</p>
-		</Wrapper>
-	);
-};
-smallAspectRatio.storyName = 'with small aspect ratio';
+type Story = StoryObj<typeof meta>;
 
-export const largeAspectRatio = () => {
-	return (
-		<Wrapper>
-			<p>abc</p>
-			<VimeoBlockComponent
-				embedUrl="https://player.vimeo.com/video/327310297?app_id=122963"
-				height={259}
-				width={460}
-				caption="blah"
-				credit=""
-				title=""
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.News,
-				}}
-				isMainMedia={false}
-			/>
-			<p>abc</p>
-		</Wrapper>
-	);
-};
-largeAspectRatio.storyName = 'with large aspect ratio';
-largeAspectRatio.story = {
-	chromatic: { disable: true },
-};
+export const SmallAspectRatio = {
+	args: {
+		embedUrl: 'https://player.vimeo.com/video/327310297?app_id=122963',
+		height: 250,
+		width: 250,
+		caption: 'blah',
+		credit: '',
+		title: '',
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+		isMainMedia: false,
+	},
+} satisfies Story;
 
-/**
- * Skipped (flaky).
- *
- * This story fails intermittently. Sometimes the video doesn't load
- * with the error message: "We couldn't verify the security of your connection."
- *
- * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=6762b11e0dbf28eb24702ff1
- */
-export const verticalAspectRatio = () => {
-	return (
-		<Wrapper>
-			<p>abc</p>
-			<VimeoBlockComponent
-				embedUrl="https://player.vimeo.com/video/265111898?app_id=122963"
-				height={818}
-				width={460}
-				caption="blah"
-				credit=""
-				title=""
-				format={{
-					display: ArticleDisplay.Standard,
-					design: ArticleDesign.Standard,
-					theme: Pillar.News,
-				}}
-				isMainMedia={false}
-			/>
-			<p>abc</p>
-		</Wrapper>
-	);
-};
-verticalAspectRatio.storyName = 'with vertical aspect ratio';
-verticalAspectRatio.story = {
-	chromatic: { disableSnapshot: true },
-};
+export const LargeAspectRatio = {
+	...SmallAspectRatio,
+	args: {
+		...SmallAspectRatio.args,
+		height: 259,
+		width: 460,
+	},
+} satisfies Story;
+
+export const VerticalAspectRatio = {
+	...SmallAspectRatio,
+	args: {
+		...SmallAspectRatio.args,
+		height: 818,
+		width: 460,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -222,12 +222,23 @@ export const AppsPictureShowcaseOpinionDark: Story = {
 	parameters: appsParameters,
 };
 
+/**
+ * Skipped (flaky).
+ *
+ * This story fails intermittently as an iframe is inserted into the page
+ * which is sometimes registered by the snapshot.
+ *
+ * Example: https://www.chromatic.com/test?appId=63e251470cfbe61776b0ef19&id=675aaa4f3aa384bd64bde3a1
+ */
 export const WebPhotoEssayImmersiveLabsLight: Story = {
 	args: {
 		article: enhanceArticleType(PhotoEssayImmersiveLabsFixture, 'Web')
 			.frontendData,
 	},
-	parameters: webParameters,
+	parameters: {
+		...webParameters,
+		chromatic: { disableSnapshot: true },
+	},
 };
 
 const standardStandardLabsWebFixture: ArticleDeprecated = {


### PR DESCRIPTION
Closes #13015

## What does this change?

Skips five flaky Chromatic tests. These tests often record false positives in Chromatic runs.

## Why?

These slow down the development workflow of many teams. However, there is a risk that we will miss unexpected changes because of this, so we should look to fix these as soon as possible.