### PR TITLE
Big Six AB test: Adds padding above top row

### DIFF
--- a/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
+++ b/dotcom-rendering/src/components/BigSixOnwardsContent.tsx
@@ -32,6 +32,10 @@ const containerStyles = css`
 	}
 `;
 
+const cardsContainer = css`
+	padding-top: ${space[2]}px;
+`;
+
 const headerStyles = css`
 	${headlineBold24};
 	color: ${palette('--carousel-text')};
@@ -124,7 +128,7 @@ export const BigSixOnwardsContent = ({ url, discussionApiUrl }: Props) => {
 			<h2 css={mobileHeaderStyles}>
 				<span>{heading}</span>
 			</h2>
-			<div>
+			<div css={cardsContainer}>
 				<UL direction="row" padBottom={true}>
 					{firstSlice75.map((trail) => (
 						<LI key={trail.url} padSides={true} percentage="75%">


### PR DESCRIPTION
## What does this change?

Add a bit of padding above the top row.

## Why?

to avoid the lines above the cards in the top row clashing with the container line.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b971e763-6006-4bee-84d9-d399afd6503f
[after]: https://github.com/user-attachments/assets/f3bec9c0-c195-4e28-8302-a6fcb9a2cb06



