### PR TITLE
Use square podcast image

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -218,6 +218,7 @@ const getMedia = ({
 	if (slideshowImages) return { type: 'slideshow', slideshowImages } as const;
 	if (avatarUrl) return { type: 'avatar', avatarUrl } as const;
 	if (podcastImage && isBetaContainer) {
+		console.log({ podcastImage });
 		return {
 			type: 'podcast',
 			podcastImage,
@@ -291,11 +292,6 @@ export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	const timeDiffHours = timeDiffMs / (1000 * 60 * 60);
 	return timeDiffHours <= 12;
 };
-
-const podcastMarginStyles = css`
-	margin-left: 8px;
-	margin-top: 8px;
-`;
 
 const podcastImageStyles = (imageSize: ImageSizeType) => {
 	switch (imageSize) {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -288,6 +288,34 @@ export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	return timeDiffHours <= 12;
 };
 
+const podcastImageStyles = (imageSize: ImageSizeType) => {
+	switch (imageSize) {
+		case 'small':
+			return css`
+				width: 69px;
+				height: 69px;
+				${from.tablet} {
+					width: 98px;
+					height: 98px;
+				}
+			`;
+
+		case 'medium':
+			return css`
+				width: 98px;
+				height: 98px;
+				${from.tablet} {
+					width: 120px;
+					height: 120px;
+				}
+			`;
+		default:
+			return css`
+				width: 120px;
+				height: 120px;
+			`;
+	}
+};
 export const Card = ({
 	linkTo,
 	format,
@@ -803,6 +831,25 @@ export const Card = ({
 						)}
 						{media.type === 'crossword' && (
 							<img src={media.imageUrl} alt="" />
+						)}
+						{media.type === 'podcast' && media.podcastImage.src && (
+							<div
+								css={[
+									css`
+										margin: 8px;
+									`,
+									podcastImageStyles(imageSize),
+								]}
+							>
+								<CardPicture
+									mainImage={media.podcastImage.src}
+									imageSize={imageSize}
+									alt={media.imageAltText}
+									loading={imageLoading}
+									roundedCorners={isOnwardContent}
+									aspectRatio={'1:1'}
+								/>
+							</div>
 						)}
 					</ImageWrapper>
 				)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -380,7 +380,6 @@ export const Card = ({
 	galleryCount,
 	showAccentImage = false,
 }: Props) => {
-	console.log({ headlineText, showAccentImage });
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
 		supportingContent,

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -681,6 +681,7 @@ export const Card = ({
 						hideImageOverlay={
 							media.type === 'slideshow' && isFlexibleContainer
 						}
+						padImage={isMediaCard(format)}
 					>
 						{media.type === 'slideshow' &&
 							(isFlexibleContainer ? (
@@ -847,12 +848,7 @@ export const Card = ({
 						{media.type === 'podcast' && (
 							<>
 								{media.podcastImage.src && !showAccentImage ? (
-									<div
-										css={[
-											podcastMarginStyles,
-											podcastImageStyles(imageSize),
-										]}
-									>
+									<div css={[podcastImageStyles(imageSize)]}>
 										<CardPicture
 											mainImage={media.podcastImage.src}
 											imageSize={'small'}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -221,7 +221,7 @@ const getMedia = ({
 		return {
 			type: 'podcast',
 			podcastImage,
-			...(imageUrl && { imageUrl }),
+			trailImage: { src: imageUrl, altText: imageAltText },
 		} as const;
 	}
 	if (imageUrl) {
@@ -261,14 +261,14 @@ const getHeadlinePosition = ({
 	isFlexSplash,
 	containerType,
 	showLivePlayable,
-	isMediaCard,
+	isAMediaCard,
 }: {
 	containerType?: DCRContainerType;
 	isFlexSplash?: boolean;
 	showLivePlayable: boolean;
-	isMediaCard: boolean;
+	isAMediaCard: boolean;
 }) => {
-	if (isMediaCard) return 'inner';
+	if (isAMediaCard) return 'inner';
 	if (containerType === 'flexible/special' && isFlexSplash) {
 		return 'outer';
 	}
@@ -291,6 +291,11 @@ export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
 	const timeDiffHours = timeDiffMs / (1000 * 60 * 60);
 	return timeDiffHours <= 12;
 };
+
+const podcastMarginStyles = css`
+	margin-left: 8px;
+	margin-top: 8px;
+`;
 
 const podcastImageStyles = (imageSize: ImageSizeType) => {
 	switch (imageSize) {
@@ -475,8 +480,6 @@ export const Card = ({
 		isBetaContainer,
 	});
 
-	console.log({ headlineText, media });
-
 	// For opinion type cards with avatars (which aren't onwards content)
 	// we render the footer in a different location
 	const showCommentFooter =
@@ -515,7 +518,7 @@ export const Card = ({
 		containerType,
 		isFlexSplash,
 		showLivePlayable,
-		isMediaCard: isMediaCard(format),
+		isAMediaCard: isMediaCard(format),
 	});
 
 	const hideTrailTextUntil = () => {
@@ -846,9 +849,7 @@ export const Card = ({
 								{media.podcastImage.src && !showAccentImage ? (
 									<div
 										css={[
-											css`
-												margin: 8px;
-											`,
+											podcastMarginStyles,
 											podcastImageStyles(imageSize),
 										]}
 									>
@@ -863,9 +864,9 @@ export const Card = ({
 									</div>
 								) : (
 									<CardPicture
-										mainImage={media.imageUrl ?? ''}
+										mainImage={media.trailImage.src ?? ''}
 										imageSize={imageSize}
-										alt={media.imageAltText}
+										alt={media.trailImage.altText}
 										loading={imageLoading}
 										aspectRatio={aspectRatio}
 									/>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -919,8 +919,8 @@ export const Card = ({
 										accentImage={
 											showAccentImage &&
 											media?.type === 'podcast'
-												? media?.podcastImage?.src
-												: ''
+												? media?.podcastImage
+												: undefined
 										}
 									/>
 									{!isUndefined(starRating) ? (

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -64,6 +64,7 @@ const flexBasisStyles = ({
 const paddingStyles = (
 	imagePosition: ImagePositionType,
 	isFlexibleContainer: boolean,
+	paddingSize: '4' | '8',
 ) => {
 	/**
 	 * If we're in a flexible container there is a 20px gap between the image
@@ -72,18 +73,18 @@ const paddingStyles = (
 	 */
 	if (isFlexibleContainer && imagePosition === 'left') {
 		return css`
-			padding: ${space[1]}px ${space[1]}px ${space[1]}px 0;
+			padding: ${paddingSize}px ${paddingSize}px ${paddingSize}px 0;
 		`;
 	}
 
 	if (isFlexibleContainer && imagePosition === 'right') {
 		return css`
-			padding: ${space[1]}px 0 ${space[1]}px ${space[1]}px;
+			padding: ${paddingSize}px 0 ${paddingSize}px ${paddingSize}px;
 		`;
 	}
 
 	return css`
-		padding: ${space[1]}px;
+		padding: ${paddingSize}px;
 	`;
 };
 
@@ -95,6 +96,7 @@ type Props = {
 	hasBackgroundColour?: boolean;
 	isOnwardContent?: boolean;
 	isFlexibleContainer?: boolean;
+	largePadding?: boolean;
 };
 
 export const ContentWrapper = ({
@@ -108,6 +110,7 @@ export const ContentWrapper = ({
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
+	const paddingWidth = hasBackgroundColour ? '8' : '4';
 
 	return (
 		<div
@@ -116,7 +119,11 @@ export const ContentWrapper = ({
 				isHorizontalOnDesktop &&
 					flexBasisStyles({ imageSize, imageType }),
 				(!!hasBackgroundColour || !!isOnwardContent) &&
-					paddingStyles(imagePositionOnDesktop, isFlexibleContainer),
+					paddingStyles(
+						imagePositionOnDesktop,
+						isFlexibleContainer,
+						paddingWidth,
+					),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { between, from, space } from '@guardian/source/foundations';
+import { between, from } from '@guardian/source/foundations';
 import type { CardImageType } from '../../../types/layout';
 import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -137,7 +137,9 @@ export const ImageWrapper = ({
 					flexBasisStyles({
 						imageSize,
 					}),
-				(imageType === 'picture' || imageType === 'video') &&
+				(imageType === 'picture' ||
+					imageType === 'video' ||
+					'podcast') &&
 					isHorizontalOnDesktop &&
 					flexBasisStyles({
 						imageSize,

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -42,6 +42,7 @@ type Props = {
 	 * want it to be shown whilst retaining it for existing slideshows.
 	 */
 	hideImageOverlay?: boolean;
+	padImage?: boolean;
 };
 
 /**
@@ -124,6 +125,7 @@ export const ImageWrapper = ({
 	imagePositionOnMobile,
 	showPlayIcon,
 	hideImageOverlay,
+	padImage,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -172,6 +174,10 @@ export const ImageWrapper = ({
 						display: block;
 					}
 				`,
+				padImage &&
+					css`
+						padding: 8px;
+					`,
 			]}
 		>
 			<>

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -37,7 +37,7 @@ import {
 } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
-import { PodcastSeriesImage } from '../types/tag';
+import type { PodcastSeriesImage } from '../types/tag';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -37,6 +37,7 @@ import {
 } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
+import { PodcastSeriesImage } from '../types/tag';
 import { Byline } from './Byline';
 import { Kicker } from './Kicker';
 import { QuoteIcon } from './QuoteIcon';
@@ -62,7 +63,7 @@ type Props = {
 	/** Optional override of the standard card kicker colour */
 	kickerColour?: string;
 	isBetaContainer?: boolean;
-	accentImage?: string;
+	accentImage?: PodcastSeriesImage;
 };
 
 const sublinkStyles = css`

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -62,6 +62,7 @@ type Props = {
 	/** Optional override of the standard card kicker colour */
 	kickerColour?: string;
 	isBetaContainer?: boolean;
+	accentImage?: string;
 };
 
 const sublinkStyles = css`
@@ -230,6 +231,7 @@ export const CardHeadline = ({
 	headlineColour = palette('--card-headline'),
 	kickerColour = palette('--card-kicker-text'),
 	isBetaContainer = false,
+	accentImage,
 }: Props) => {
 	// The link is only applied directly to the headline if it is a sublink
 	const isSublink = !!linkTo;
@@ -256,6 +258,7 @@ export const CardHeadline = ({
 						color={kickerColour}
 						showPulsingDot={showPulsingDot}
 						isInline={hasInlineKicker}
+						accentImage={accentImage}
 					/>
 				)}
 				{showQuotes && <QuoteIcon colour={kickerColour} />}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -104,6 +104,8 @@ const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 			return '80%';
 		case '4:5':
 			return '125%';
+		case '1:1':
+			return '100%';
 		case '5:3':
 		default:
 			return '60%';

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -1,3 +1,4 @@
+import { isMediaCard } from '../lib/cardHelpers';
 import { palette } from '../palette';
 import type { BoostLevel } from '../types/content';
 import type {
@@ -86,6 +87,7 @@ type BoostedSplashProperties = {
 const decideSplashCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
+	isMediaCard: boolean,
 ): BoostedSplashProperties => {
 	switch (boostLevel) {
 		// boostedfont sizing
@@ -98,7 +100,7 @@ const decideSplashCardProperties = (
 					mobile: 'medium',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
@@ -113,7 +115,7 @@ const decideSplashCardProperties = (
 					mobile: 'large',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
@@ -127,8 +129,8 @@ const decideSplashCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
-				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -141,8 +143,8 @@ const decideSplashCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xxlarge',
 				},
-				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -182,6 +184,7 @@ export const SplashCardLayout = ({
 	} = decideSplashCardProperties(
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
+		isMediaCard(card.format),
 	);
 
 	return (
@@ -221,6 +224,7 @@ export const SplashCardLayout = ({
 					showTopBarMobile={true}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
+					showAccentImage={true}
 				/>
 			</LI>
 		</UL>
@@ -313,7 +317,9 @@ export const BoostedCardLayout = ({
 					absoluteServerTimes={absoluteServerTimes}
 					headlineSizes={headlineSizes}
 					imagePositionOnDesktop={'right'}
-					imagePositionOnMobile={'bottom'}
+					imagePositionOnMobile={
+						isMediaCard(card.format) ? 'top' : 'bottom'
+					}
 					imageSize={imageSize}
 					trailText={card.trailText}
 					supportingContent={card.supportingContent}
@@ -331,6 +337,7 @@ export const BoostedCardLayout = ({
 					showTopBarMobile={true}
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
+					showAccentImage={true}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign } from '../lib/articleFormat';
 import { isMediaCard } from '../lib/cardHelpers';
 import { palette } from '../palette';
 import type { BoostLevel } from '../types/content';
@@ -224,7 +225,7 @@ export const SplashCardLayout = ({
 					showTopBarMobile={true}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
-					showAccentImage={true}
+					showAccentImage={card.format.design === ArticleDesign.Audio}
 				/>
 			</LI>
 		</UL>
@@ -337,7 +338,7 @@ export const BoostedCardLayout = ({
 					showTopBarMobile={true}
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
-					showAccentImage={true}
+					showAccentImage={card.format.design === ArticleDesign.Audio}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -88,7 +88,7 @@ type BoostedSplashProperties = {
 const decideSplashCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
-	isMediaCard: boolean,
+	isAMediaCard: boolean,
 ): BoostedSplashProperties => {
 	switch (boostLevel) {
 		// boostedfont sizing
@@ -101,7 +101,7 @@ const decideSplashCardProperties = (
 					mobile: 'medium',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
@@ -116,7 +116,7 @@ const decideSplashCardProperties = (
 					mobile: 'large',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 4 ? 'horizontal' : 'vertical',
@@ -130,8 +130,8 @@ const decideSplashCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
-				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnDesktop: isAMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -144,8 +144,8 @@ const decideSplashCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xxlarge',
 				},
-				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnDesktop: isAMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign } from '../lib/articleFormat';
 import { isMediaCard } from '../lib/cardHelpers';
 import type { BoostLevel } from '../types/content';
 import type {
@@ -167,7 +168,7 @@ export const OneCardLayout = ({
 					showTopBarMobile={true}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
-					showAccentImage={true}
+					showAccentImage={card.format.design === ArticleDesign.Audio}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,3 +1,4 @@
+import { isMediaCard } from '../lib/cardHelpers';
 import type { BoostLevel } from '../types/content';
 import type {
 	AspectRatio,
@@ -170,6 +171,15 @@ export const OneCardLayout = ({
 	);
 };
 
+const getImagePosition = (
+	hasTwoOrFewerCards: boolean,
+	isMediaCard: boolean,
+) => {
+	if (isMediaCard && !hasTwoOrFewerCards) return 'top';
+	if (hasTwoOrFewerCards) return 'left';
+	return 'bottom';
+};
+
 const TwoCardOrFourCardLayout = ({
 	cards,
 	containerPalette,
@@ -208,9 +218,10 @@ const TwoCardOrFourCardLayout = ({
 							absoluteServerTimes={absoluteServerTimes}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
-							imagePositionOnDesktop={
-								hasTwoOrFewerCards ? 'left' : 'bottom'
-							}
+							imagePositionOnDesktop={getImagePosition(
+								hasTwoOrFewerCards,
+								isMediaCard(card.format),
+							)}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
 							imageSize={'medium'}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -44,7 +44,7 @@ type BoostProperties = {
 const determineCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
-	isMediaCard: boolean,
+	isAMediaCard: boolean,
 ): BoostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
@@ -56,7 +56,7 @@ const determineCardProperties = (
 					mobile: 'medium',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
@@ -72,7 +72,7 @@ const determineCardProperties = (
 					mobile: 'large',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
@@ -86,8 +86,8 @@ const determineCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
-				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnDesktop: isAMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -100,8 +100,8 @@ const determineCardProperties = (
 					tablet: 'xxlarge',
 					mobile: 'xxlarge',
 				},
-				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
-				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnDesktop: isAMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isAMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -177,9 +177,9 @@ export const OneCardLayout = ({
 
 const getImagePosition = (
 	hasTwoOrFewerCards: boolean,
-	isMediaCard: boolean,
+	isAMediaCard: boolean,
 ) => {
-	if (isMediaCard && !hasTwoOrFewerCards) return 'top';
+	if (isAMediaCard && !hasTwoOrFewerCards) return 'top';
 	if (hasTwoOrFewerCards) return 'left';
 	return 'bottom';
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -43,6 +43,7 @@ type BoostProperties = {
 const determineCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
+	isMediaCard: boolean,
 ): BoostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
@@ -54,7 +55,7 @@ const determineCardProperties = (
 					mobile: 'medium',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'large',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
@@ -70,7 +71,7 @@ const determineCardProperties = (
 					mobile: 'large',
 				},
 				imagePositionOnDesktop: 'right',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment:
 					supportingContentLength >= 3 ? 'horizontal' : 'vertical',
@@ -84,8 +85,8 @@ const determineCardProperties = (
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
-				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -98,8 +99,8 @@ const determineCardProperties = (
 					tablet: 'xxlarge',
 					mobile: 'xxlarge',
 				},
-				imagePositionOnDesktop: 'bottom',
-				imagePositionOnMobile: 'bottom',
+				imagePositionOnDesktop: isMediaCard ? 'top' : 'bottom',
+				imagePositionOnMobile: isMediaCard ? 'top' : 'bottom',
 				imageSize: 'jumbo',
 				supportingContentAlignment: 'horizontal',
 				liveUpdatesAlignment: 'horizontal',
@@ -138,6 +139,7 @@ export const OneCardLayout = ({
 	} = determineCardProperties(
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
+		isMediaCard(card.format),
 	);
 	return (
 		<UL padBottom={!isLastRow} hasLargeSpacing={!isLastRow}>
@@ -165,6 +167,7 @@ export const OneCardLayout = ({
 					showTopBarMobile={true}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
+					showAccentImage={true}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/Kicker.stories.tsx
+++ b/dotcom-rendering/src/components/Kicker.stories.tsx
@@ -110,3 +110,17 @@ export const CardKickerWithContainerOverrides = {
 		</>
 	),
 };
+
+export const CardKickerWithAccentImage = () => {
+	<Kicker
+		text="Standard kicker"
+		color={palette('--card-kicker-text')}
+		showPulsingDot={false}
+		isInline={false}
+		accentImage={{
+			src: 'https://uploads.guim.co.uk/2022/02/10/TiF_FINAL_3000x3000.jpg',
+			altText: 'Today in Focus',
+		}}
+	/>;
+};
+CardKickerWithAccentImage.storyName = 'Card kicker with accent image';

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -9,6 +9,7 @@ import { palette } from '../palette';
 import { CardPicture } from './CardPicture';
 import { Island } from './Island';
 import { PulsingDot } from './PulsingDot.importable';
+import { PodcastSeriesImage } from '../types/tag';
 
 type Props = {
 	text: string;
@@ -18,7 +19,7 @@ type Props = {
 	isInline?: boolean;
 	/** Controls the weight of the standard, non-live kicker. Defaults to regular */
 	fontWeight?: 'regular' | 'bold';
-	accentImage?: string;
+	accentImage?: PodcastSeriesImage;
 };
 
 const standardTextStyles = css`
@@ -91,7 +92,7 @@ export const Kicker = ({
 					: 'transparent',
 			}}
 		>
-			{accentImage && (
+			{accentImage?.src && (
 				<div
 					css={[
 						css`
@@ -101,9 +102,9 @@ export const Kicker = ({
 					]}
 				>
 					<CardPicture
-						mainImage={accentImage}
+						mainImage={accentImage.src}
 						imageSize={'small'}
-						alt={'media.imageAltText'} // TODO : pass through
+						alt={accentImage.altText}
 						loading={'lazy'}
 						aspectRatio={'1:1'}
 					/>

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -6,6 +6,7 @@ import {
 	textSansBold15,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import { CardPicture } from './CardPicture';
 import { Island } from './Island';
 import { PulsingDot } from './PulsingDot.importable';
 
@@ -17,6 +18,7 @@ type Props = {
 	isInline?: boolean;
 	/** Controls the weight of the standard, non-live kicker. Defaults to regular */
 	fontWeight?: 'regular' | 'bold';
+	accentImage?: string;
 };
 
 const standardTextStyles = css`
@@ -62,6 +64,7 @@ export const Kicker = ({
 	showPulsingDot,
 	isInline,
 	fontWeight = 'regular',
+	accentImage,
 }: Props) => {
 	/**
 	 * @todo
@@ -88,6 +91,24 @@ export const Kicker = ({
 					: 'transparent',
 			}}
 		>
+			{accentImage && (
+				<div
+					css={[
+						css`
+							height: 88px;
+							width: 88px;
+						`,
+					]}
+				>
+					<CardPicture
+						mainImage={accentImage}
+						imageSize={'small'}
+						alt={'media.imageAltText'} // TODO : pass through
+						loading={'lazy'}
+						aspectRatio={'1:1'}
+					/>
+				</div>
+			)}
 			{showPulsingDot && (
 				<Island priority="enhancement" defer={{ until: 'visible' }}>
 					<PulsingDot colour={palette('--kicker-pulsing-dot-live')} />

--- a/dotcom-rendering/src/components/Kicker.tsx
+++ b/dotcom-rendering/src/components/Kicker.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import {
 	space,
 	textSans15,
@@ -6,10 +7,10 @@ import {
 	textSansBold15,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import type { PodcastSeriesImage } from '../types/tag';
 import { CardPicture } from './CardPicture';
 import { Island } from './Island';
 import { PulsingDot } from './PulsingDot.importable';
-import { PodcastSeriesImage } from '../types/tag';
 
 type Props = {
 	text: string;
@@ -92,7 +93,7 @@ export const Kicker = ({
 					: 'transparent',
 			}}
 		>
-			{accentImage?.src && (
+			{!isUndefined(accentImage?.src) && (
 				<div
 					css={[
 						css`

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -1,3 +1,4 @@
+import { isMediaCard } from '../lib/cardHelpers';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -40,6 +41,10 @@ export const ScrollableMedium = ({
 			visibleCardsOnTablet={4}
 		>
 			{trails.map((trail) => {
+				const imagePosition = isMediaCard(trail.format)
+					? 'top'
+					: 'bottom';
+
 				return (
 					<ScrollableCarousel.Item key={trail.url}>
 						<FrontCard
@@ -53,8 +58,8 @@ export const ScrollableMedium = ({
 								desktop: 'xsmall',
 								tablet: 'xxsmall',
 							}}
-							imagePositionOnDesktop="bottom"
-							imagePositionOnMobile="bottom"
+							imagePositionOnDesktop={imagePosition}
+							imagePositionOnMobile={imagePosition}
 							imageSize="medium"
 							trailText={undefined} // unsupported
 							supportingContent={undefined} // unsupported

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -1,3 +1,4 @@
+import { isMediaCard } from '../lib/cardHelpers';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -48,7 +49,9 @@ export const StaticMediumFour = ({
 							absoluteServerTimes={absoluteServerTimes}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
-							imagePositionOnDesktop={'bottom'}
+							imagePositionOnDesktop={
+								isMediaCard(card.format) ? 'top' : 'bottom'
+							}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
 							imageSize={'medium'}


### PR DESCRIPTION
## What does this change?

Updates podcasts cards to use the series image. Depending on the layout of the card, the podcast image appears either instead of the trail image or alongside the trail image as an accent series image above the kicker.

It also checks is the card is a media card and sets the image layout to 'top' if so, as new designs specify media card images are always top.

This currently only affects beta containers.

## Why?
This is part of the redesign of media cards as part of the fairground project. 

## Screenshots

| Horizontal      | Vertical      | With Trail      |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/d92200ea-8ab2-4eed-8329-e8097b8c2ed3
[after]: https://github.com/user-attachments/assets/099d75d1-014f-4dd6-8101-ef89e5831695
[after2]: https://github.com/user-attachments/assets/f0dc4525-22f4-438e-af81-43b7058071b2


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
