### PR TITLE
Media Cards: Replace media icons with pills

### DIFF
--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -923,6 +923,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mhe94',
 			group: '0',
 			isLive: false,
+			galleryCount: 11,
 		},
 		discussion: {
 			isCommentable: false,
@@ -1450,6 +1451,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mgmvx',
 			group: '0',
 			isLive: false,
+			galleryCount: 19,
 		},
 		discussion: {
 			isCommentable: false,

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -45,6 +45,7 @@ const basicCardProps: CardProps = {
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
 	showMainVideo: true,
 	absoluteServerTimes: true,
+	galleryCount: 8,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -6,7 +6,11 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
-import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
@@ -898,18 +902,20 @@ export const Card = ({
 									{showPill ? (
 										<>
 											<MediaPill />
-											{branding && (
-												<CardBranding
-													branding={branding}
-													format={format}
-													onwardsSource={
-														onwardsSource
-													}
-													containerPalette={
-														containerPalette
-													}
-												/>
-											)}
+											{format.theme ===
+												ArticleSpecial.Labs &&
+												branding && (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												)}
 										</>
 									) : (
 										<CardFooter

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
-import { Hide, Link } from '@guardian/source/react-components';
+import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
@@ -34,6 +34,7 @@ import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
 import { MediaMeta } from '../MediaMeta';
+import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
 import { Snap } from '../Snap';
@@ -432,6 +433,9 @@ export const Card = ({
 	const showPlayIcon =
 		mainMedia?.type === 'Video' && !canPlayInline && showMainVideo;
 
+	// Check media type to determine if we should show a pill or media icon
+	const showPill = mainMedia?.type === 'Gallery';
+
 	const media = getMedia({
 		imageUrl: image?.src,
 		imageAltText: image?.altText,
@@ -616,7 +620,7 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && (
+					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
 						<MediaMeta
 							mediaType={mainMedia.type}
 							hasKicker={!!kickerText}
@@ -860,7 +864,8 @@ export const Card = ({
 										/>
 									) : null}
 									{!!mainMedia &&
-										mainMedia.type !== 'Video' && (
+										mainMedia.type !== 'Video' &&
+										!showPill && (
 											<MediaMeta
 												mediaType={mainMedia.type}
 												hasKicker={!!kickerText}
@@ -879,7 +884,28 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && (
+							{!showCommentFooter && showPill ? (
+								<div
+									css={css`
+										margin-top: auto;
+									`}
+								>
+									{branding && (
+										<CardBranding
+											branding={branding}
+											format={format}
+											onwardsSource={onwardsSource}
+											containerPalette={containerPalette}
+										/>
+									)}
+									<Pill
+										prefix="Gallery"
+										content={(galleryCount ?? 0).toString()}
+										icon={<SvgCamera />}
+										iconSide="right"
+									/>
+								</div>
+							) : (
 								<CardFooter
 									format={format}
 									age={decideAge()}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -33,7 +33,6 @@ import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
-import { MediaMeta } from '../MediaMeta';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
@@ -42,6 +41,7 @@ import { SnapCssSandbox } from '../SnapCssSandbox';
 import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -425,12 +425,20 @@ export const Card = ({
 				margin-top: auto;
 			`}
 		>
-			<Pill
-				prefix="Gallery"
-				content={galleryCount?.toString() ?? ''}
-				icon={<SvgCamera />}
-				iconSide="right"
-			/>
+			{mainMedia?.type === 'Audio' && (
+				<Pill
+					content="0:00" // TODO: get podcast duration
+					icon={<SvgMediaControlsPlay />}
+				/>
+			)}
+			{mainMedia?.type === 'Gallery' && (
+				<Pill
+					prefix="Gallery"
+					content={galleryCount?.toString() ?? ''}
+					icon={<SvgCamera />}
+					iconSide="right"
+				/>
+			)}
 		</div>
 	);
 
@@ -448,7 +456,8 @@ export const Card = ({
 		mainMedia?.type === 'Video' && !canPlayInline && showMainVideo;
 
 	// Check media type to determine if we should show a pill or media icon
-	const showPill = mainMedia?.type === 'Gallery';
+	const showPill =
+		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -634,12 +643,6 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
-						<MediaMeta
-							mediaType={mainMedia.type}
-							hasKicker={!!kickerText}
-						/>
-					)}
 				</div>
 			)}
 
@@ -877,14 +880,6 @@ export const Card = ({
 											cardHasImage={!!image}
 										/>
 									) : null}
-									{!!mainMedia &&
-										mainMedia.type !== 'Video' &&
-										!showPill && (
-											<MediaMeta
-												mediaType={mainMedia.type}
-												hasKicker={!!kickerText}
-											/>
-										)}
 								</HeadlineWrapper>
 							)}
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -347,7 +347,6 @@ export const Card = ({
 	trailTextSize,
 	trailTextColour,
 	podcastImage,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Added in preparation for UI changes to display gallery count
 	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -419,6 +418,21 @@ export const Card = ({
 				</Island>
 			</Link>
 		);
+
+	const MediaPill = () => (
+		<div
+			css={css`
+				margin-top: auto;
+			`}
+		>
+			<Pill
+				prefix="Gallery"
+				content={galleryCount?.toString() ?? ''}
+				icon={<SvgCamera />}
+				iconSide="right"
+			/>
+		</div>
+	);
 
 	if (snapData?.embedHtml) {
 		return (
@@ -885,11 +899,8 @@ export const Card = ({
 							)}
 
 							{!showCommentFooter && showPill ? (
-								<div
-									css={css`
-										margin-top: auto;
-									`}
-								>
+								<>
+									<MediaPill />
 									{branding && (
 										<CardBranding
 											branding={branding}
@@ -898,13 +909,7 @@ export const Card = ({
 											containerPalette={containerPalette}
 										/>
 									)}
-									<Pill
-										prefix="Gallery"
-										content={(galleryCount ?? 0).toString()}
-										icon={<SvgCamera />}
-										iconSide="right"
-									/>
-								</div>
+								</>
 							) : (
 								<CardFooter
 									format={format}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -455,7 +455,7 @@ export const Card = ({
 	const showPlayIcon =
 		mainMedia?.type === 'Video' && !canPlayInline && showMainVideo;
 
-	// Check media type to determine if we should show a pill or media icon
+	// Check media type to determine if we show a pill or article metadata
 	const showPill =
 		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -898,37 +898,47 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && showPill ? (
+							{!showCommentFooter && (
 								<>
-									<MediaPill />
-									{branding && (
-										<CardBranding
-											branding={branding}
+									{showPill ? (
+										<>
+											<MediaPill />
+											{branding && (
+												<CardBranding
+													branding={branding}
+													format={format}
+													onwardsSource={
+														onwardsSource
+													}
+													containerPalette={
+														containerPalette
+													}
+												/>
+											)}
+										</>
+									) : (
+										<CardFooter
 											format={format}
-											onwardsSource={onwardsSource}
-											containerPalette={containerPalette}
+											age={decideAge()}
+											commentCount={<CommentCount />}
+											cardBranding={
+												branding ? (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												) : undefined
+											}
+											showLivePlayable={showLivePlayable}
 										/>
 									)}
 								</>
-							) : (
-								<CardFooter
-									format={format}
-									age={decideAge()}
-									commentCount={<CommentCount />}
-									cardBranding={
-										branding ? (
-											<CardBranding
-												branding={branding}
-												format={format}
-												onwardsSource={onwardsSource}
-												containerPalette={
-													containerPalette
-												}
-											/>
-										) : undefined
-									}
-									showLivePlayable={showLivePlayable}
-								/>
 							)}
 							{showLivePlayable &&
 								liveUpdatesPosition === 'inner' && (

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -1,43 +1,9 @@
-import { css } from '@emotion/react';
 import {
 	SvgAudio,
 	SvgCamera,
 	SvgVideo,
 } from '@guardian/source/react-components';
-import { palette as themePalette } from '../palette';
 import type { MediaType } from '../types/layout';
-
-type Props = {
-	mediaType: MediaType;
-	hasKicker: boolean;
-};
-
-const iconWrapperStyles = (hasKicker: boolean) => css`
-	width: 24px;
-	height: 24px;
-	/* We’re using the text colour for the icon badge */
-	background-color: ${hasKicker
-		? themePalette('--card-kicker-text')
-		: themePalette('--card-footer-text')};
-	border-radius: 50%;
-	display: inline-block;
-
-	> svg {
-		width: 20px;
-		height: 20px;
-		margin-left: auto;
-		margin-right: auto;
-		margin-top: 2px;
-		display: block;
-		fill: ${themePalette('--card-media-icon')};
-	}
-`;
-
-const wrapperStyles = css`
-	display: flex;
-	align-items: center;
-	margin-top: 4px;
-`;
 
 export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 	switch (mediaType) {
@@ -48,26 +14,4 @@ export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 		case 'Audio':
 			return <SvgAudio />;
 	}
-};
-
-const MediaIcon = ({
-	mediaType,
-	hasKicker,
-}: {
-	mediaType: MediaType;
-	hasKicker: boolean;
-}) => {
-	return (
-		<span css={iconWrapperStyles(hasKicker)}>
-			<Icon mediaType={mediaType} />
-		</span>
-	);
-};
-
-export const MediaMeta = ({ mediaType, hasKicker }: Props) => {
-	return (
-		<div css={wrapperStyles}>
-			<MediaIcon mediaType={mediaType} hasKicker={hasKicker} />
-		</div>
-	);
 };


### PR DESCRIPTION
## What does this change?

Updates media cards to replace the media icons for with a pill showing the number of items in a gallery or podcast duration The pill appears below the headline and trail text in place of the existing card metadata.

This is dependent upon #12980 which updates the media card colour palette.

> [!note]
> Podcast duration is not currently populated pending an update to `frontend`. This will be updated in a subsequent PR. (These changes are being merged to an intermediate feature branch rather than `main` so the changes can be broken down into smaller chunks and more easily reviewed.)

## Why?

This is an incremental change which forms part of a larger body of work to [update the design of media cards](https://trello.com/c/M98Xbjwd/756-web-media-cards-xs-s-m)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before1]: https://github.com/user-attachments/assets/adb49ea6-6215-4f64-88e4-80adb1c515da
[after1]: https://github.com/user-attachments/assets/7a3f0a0e-b585-4aa6-97b9-7fee0bd0f8d5
[before2]: https://github.com/user-attachments/assets/27c8b4e8-a4f1-4e17-956f-0caba59d13ea
[after2]: https://github.com/user-attachments/assets/98951b4b-03d2-48b8-b359-7d4e90116a44
[before3]: https://github.com/user-attachments/assets/be5ba8bb-1f8e-491f-ba96-26a1de7b6db4
[after3]: https://github.com/user-attachments/assets/4245c6c3-408a-425e-86de-c6df17ed0db1
[before4]: https://github.com/user-attachments/assets/04a72a4b-4de6-4559-b9aa-f5cdd55b5073
[after4]: https://github.com/user-attachments/assets/2ceb7586-f08c-4dfe-beba-60e41826ce82