### PR TITLE
Change the highlight text colour and CTA hover colour

### DIFF
--- a/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
+++ b/dotcom-rendering/src/components/UsEoy2024Wrapper.importable.tsx
@@ -185,7 +185,7 @@ const stylesSubCampaign = {
 		color: ${'#1A2835'};
 	`,
 	highlight: css`
-		background-color: ${'#670055'};
+		background-color: ${'#016D67'};
 		color: ${'#F6F6F6'};
 		padding-left: 2px;
 	`,
@@ -413,7 +413,7 @@ export const UsEoy2024: ReactComponent<Props> = ({
 							},
 							hover: {
 								backgroundColour: isSubCampaign
-									? '#891414'
+									? '#01544F'
 									: '#C41C1C',
 								textColour: '#FFFFFF',
 							},


### PR DESCRIPTION
## What does this change?

## Why?

This PR is to change the colour of the highlighted text and the CTA hover colour in the EOY NYE thrasher/Not thrasher 
## Screenshots

## Before 
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/4adf7eee-e20c-4282-b76c-75a06191c92a" />

## CTA Hover colour
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/abebb75e-edbd-4783-ac33-c37d4625c050" />

## After 

<img width="1173" alt="image" src="https://github.com/user-attachments/assets/1359fc8e-3398-4b90-87c3-2d2e798f05c1" />


## CTA After Hover colour

<img width="1173" alt="image" src="https://github.com/user-attachments/assets/8a042641-2075-4aa3-8561-e07d26d7b34a" />

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

