### PR TITLE
One time messaging

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -51,8 +51,6 @@ const validateResponse = (
 		isObject(response) &&
 		isBoolean(response.showSupportMessaging) &&
 		isObject(response.contentAccess) &&
-		isBoolean(response.contentAccess.paidMember) &&
-		isBoolean(response.contentAccess.recurringContributor) &&
 		isBoolean(response.contentAccess.digitalPack)
 	);
 };

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -1,14 +1,10 @@
 import { setCookie, storage } from '@guardian/libs';
-import MockDate from 'mockdate';
 import {
-	getLastOneOffContributionTimestamp,
-	hasSupporterCookie,
 	HIDE_SUPPORT_MESSAGING_COOKIE,
-	isRecentOneOffContributor,
 	NO_RR_BANNER_KEY,
 	recentlyClosedBanner,
 	setLocalNoBannerCachePeriod,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+	shouldHideSupportMessaging,
 	withinLocalNoBannerCachePeriod,
 } from './contributions';
 
@@ -20,75 +16,6 @@ const clearAllCookies = () => {
 		document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 	}
 };
-
-describe('getLastOneOffContributionTimestamp', () => {
-	beforeEach(clearAllCookies);
-
-	it('returns a support cookie date if found', () => {
-		const somePastDate = 1582567969093;
-		setCookie({
-			name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-			value: String(somePastDate),
-		});
-		const lastOneOffContributionDate = getLastOneOffContributionTimestamp();
-		expect(lastOneOffContributionDate).toBe(somePastDate);
-	});
-
-	it('returns undefined if the date cannot be parsed correctly', () => {
-		setCookie({
-			name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-			value: 'NOT_A_DATE',
-		});
-
-		const lastOneOffContributionDate = getLastOneOffContributionTimestamp();
-		expect(lastOneOffContributionDate).toBeUndefined();
-	});
-
-	it('returns an empty string if no one-off contribution found', () => {
-		const lastOneOffContributionDate = getLastOneOffContributionTimestamp();
-		expect(lastOneOffContributionDate).toBeUndefined();
-	});
-});
-
-describe('isRecentOneOffContributor', () => {
-	beforeEach(clearAllCookies);
-	afterEach(() => {
-		MockDate.reset();
-	});
-
-	it('returns false if there is no one-off contribution cookie', () => {
-		expect(isRecentOneOffContributor()).toBe(false);
-	});
-
-	it('returns true if there are 5 days between the last contribution date and now', () => {
-		setCookie({
-			name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-			value: Date.parse('2018-08-01').toString(),
-		});
-
-		MockDate.set(Date.parse('2018-08-07T10:50:34'));
-		expect(isRecentOneOffContributor()).toBe(true);
-	});
-
-	it('returns true if there are 0 days between the last contribution date and now', () => {
-		const theDate = Date.parse('2018-08-01T13:00:30');
-		setCookie({
-			name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-			value: theDate.toString(),
-		});
-		MockDate.set(theDate);
-		expect(isRecentOneOffContributor()).toBe(true);
-	});
-
-	it('returns false if the one-off contribution was more than 3 months ago', () => {
-		setCookie({
-			name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-			value: Date.parse('2018-08-01').toString(),
-		});
-		MockDate.set(Date.parse('2019-08-01T13:00:30'));
-		expect(isRecentOneOffContributor()).toBe(false);
-	});
-});
 
 describe('getPurchaseInfo', () => {
 	let getPurchaseInfo: () => any;
@@ -176,7 +103,7 @@ describe('withinLocalNoBannerCachePeriod', () => {
 	});
 });
 
-describe('hasSupporterCookie', () => {
+describe('shouldHideSupportMessaging', () => {
 	beforeEach(clearAllCookies);
 
 	it('returns false if cookie exists and is set to false', () => {
@@ -184,7 +111,7 @@ describe('hasSupporterCookie', () => {
 			name: HIDE_SUPPORT_MESSAGING_COOKIE,
 			value: 'false',
 		});
-		expect(hasSupporterCookie(true)).toEqual(false);
+		expect(shouldHideSupportMessaging(true)).toEqual(false);
 	});
 
 	it('returns true if cookie exists and is set to true', () => {
@@ -192,14 +119,14 @@ describe('hasSupporterCookie', () => {
 			name: HIDE_SUPPORT_MESSAGING_COOKIE,
 			value: 'true',
 		});
-		expect(hasSupporterCookie(true)).toEqual(true);
+		expect(shouldHideSupportMessaging(true)).toEqual(true);
 	});
 
 	it('returns false if cookie does not exist and user is signed out', () => {
-		expect(hasSupporterCookie(false)).toEqual(false);
+		expect(shouldHideSupportMessaging(false)).toEqual(false);
 	});
 
 	it('returns Pending if cookie does not exist and user is signed in', () => {
-		expect(hasSupporterCookie(true)).toEqual('Pending');
+		expect(shouldHideSupportMessaging(true)).toEqual('Pending');
 	});
 });

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -6,9 +6,9 @@ import type { DCRFrontType } from '../types/front';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
 import type { DCRTagPageType } from '../types/tagPage';
 
-// User Attributes API cookies (created on sign-in)
+// User Attributes API cookie (created on sign-in)
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
-export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
+
 export const OPT_OUT_OF_ARTICLE_COUNT_COOKIE = 'gu_article_count_opt_out';
 
 //  Local storage keys

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -1,16 +1,8 @@
 import { getCookie, removeCookie, setCookie, storage } from '@guardian/libs';
-import {
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-} from './contributions';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from './contributions';
 import { getLocaleCode } from './getCountryCode';
 
-const readerRevenueCookies = [
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-];
+const readerRevenueCookies = [HIDE_SUPPORT_MESSAGING_COOKIE];
 
 const clearEpicViewLog = (): void =>
 	storage.local.remove('gu.contributions.views');
@@ -21,12 +13,6 @@ const clearBannerLastClosedAt = (): void => {
 	storage.local.remove('gu.prefs.abandonedBasketLastClosedAt');
 	storage.local.remove('gu.noRRBannerTimestamp');
 };
-
-const fakeOneOffContributor = (): void =>
-	setCookie({
-		name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-		value: Date.now().toString(),
-	});
 
 const MULTIVARIATE_ID_COOKIE = 'GU_mvt_id';
 const MAX_CLIENT_MVT_ID = 1000000;
@@ -75,10 +61,6 @@ const clearCommonReaderRevenueStateAndReload = (
 
 	for (const cookie of readerRevenueCookies) removeCookie({ name: cookie });
 	clearEpicViewLog();
-
-	if (asExistingSupporter) {
-		fakeOneOffContributor();
-	}
 
 	window.location.reload();
 };


### PR DESCRIPTION
## What does this change?
Stop using the one time contributor cookie which is set by support-frontend on the thank you page to work out whether a user should see support messaging or not. From now on we will only use the 'hide support messaging' cookie, and support-frontend will be updated to set this instead of the other.

I have also removed the 90 day age check which was carried out on the previous cookie and will just set the hide support messaging cookie to expire after 90 days when creating it.