### PR TITLE
Add 1:1 padding option for card picture

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -104,6 +104,8 @@ const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 			return '80%';
 		case '4:5':
 			return '125%';
+		case '1:1':
+			return '100%';
 		case '5:3':
 		default:
 			return '60%';


### PR DESCRIPTION
## What does this change?
Adds the option to choose padding for an image in a 1:1 aspect ratio.

## Why?
Currently, padding for 1:1s aren't specified so they default to 60% that skews the image.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cefeb328-5a45-4164-aa8d-2908c7fdf502
[after]: https://github.com/user-attachments/assets/93935972-57cb-48bd-be1c-104408eb9c77


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |


You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
