### PR TITLE
Use base url when on localhost for assets

### DIFF
--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -45,5 +45,8 @@ export default defineConfig({
 		reuseExistingServer: true,
 		stdout: 'pipe',
 		stderr: 'pipe',
+		env: {
+			PLAYWRIGHT: 'true',
+		},
 	},
 });

--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -44,7 +44,7 @@ describe('decidePublicPath', () => {
 	it('with production flag and localhost', () => {
 		process.env.NODE_ENV = 'production';
 		mockHostname('localhost');
-		expect(decidePublicPath()).toEqual('/assets/');
+		expect(decidePublicPath()).toEqual('http://localhost:3030/assets/');
 	});
 
 	it('with no flag', () => {

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -8,7 +8,7 @@ export const decidePublicPath = (): string => {
 	const isLocalHost = window.location.hostname === 'localhost';
 	const isPlaywright = process.env.PLAYWRIGHT === 'true';
 
-	if (isPlaywright) {
+	if (isPlaywright && isDev) {
 		return `/assets/`;
 	}
 

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -8,6 +8,6 @@ export const decidePublicPath = (): string => {
 	const isLocalHost = window.location.hostname === 'localhost';
 	// Use relative path if running locally or in CI
 	return isDev || isLocalHost
-		? '/assets/'
+		? 'http://localhost:3030/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -6,8 +6,14 @@
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
 	const isLocalHost = window.location.hostname === 'localhost';
-	// Use relative path if running locally or in CI
-	return isDev || isLocalHost
-		? 'http://localhost:3030/assets/'
-		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
+
+	if (isLocalHost) {
+		return 'http://localhost:3030/assets/';
+	}
+
+	if (isDev) {
+		return '/assets/';
+	}
+
+	return `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -6,13 +6,14 @@
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
 	const isLocalHost = window.location.hostname === 'localhost';
+	const isPlaywright = process.env.PLAYWRIGHT === 'true';
 
-	if (isLocalHost) {
-		return 'http://localhost:3030/assets/';
+	if (isPlaywright) {
+		return `/assets/`;
 	}
 
-	if (isDev) {
-		return '/assets/';
+	if (isDev || isLocalHost) {
+		return `http://localhost:3030/assets/`;
 	}
 
 	return `${window.guardian.config.frontendAssetsFullURL}assets/`;


### PR DESCRIPTION
## What does this change?
This adds some logic if we are on localhost to use the full 'http://localhost:3030/assets/' so that when running frontend we can load assets correctly 

Resolves https://github.com/guardian/dotcom-rendering/issues/13052


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7d59e1a8-1970-4726-9c13-2705edd8bae3
[after]: https://github.com/user-attachments/assets/b1bb6711-d13f-434f-9ecb-29144fb963fc

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
