### PR TITLE
WIP

### DIFF
--- a/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.stories.tsx
+++ b/apps-rendering/src/components/EmbedWrapper/EmbedWrapper.stories.tsx
@@ -49,11 +49,6 @@ const Generic = () => (
 		/>
 	</div>
 );
-Generic.story = {
-	parameters: {
-		chromatic: { disable: true },
-	},
-};
 
 // I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
@@ -92,11 +87,6 @@ const Youtube = () => (
 		/>
 	</div>
 );
-Youtube.story = {
-	parameters: {
-		chromatic: { disable: true },
-	},
-};
 
 // I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
@@ -135,11 +125,6 @@ const Spotify = () => (
 		/>
 	</div>
 );
-Spotify.story = {
-	parameters: {
-		chromatic: { disable: true },
-	},
-};
 
 // I'm disabling the requirement for a return type because that doesnt make sense here 🤷. It
 // popped up after I removed the FC type which was causing problems when I tried to set parameters
@@ -176,11 +161,6 @@ const Instagram = () => (
 		/>
 	</div>
 );
-Instagram.story = {
-	parameters: {
-		chromatic: { disable: true },
-	},
-};
 
 // ----- Exports ----- //
 

--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.stories.tsx
@@ -21,10 +21,6 @@ export const AudioAtom = {
 		title: 'Q&A and Detective Wilson',
 		duration: 849,
 	},
-	parameters: {
-		// We only want to snapshot the `multipleFormats` version below.
-		chromatic: { disable: true },
-	},
 } satisfies Story;
 
 export const MultipleFormats = {

--- a/dotcom-rendering/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/dotcom-rendering/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -19,10 +19,6 @@ export const AudioPlayer = {
 		src: 'https://audio.guim.co.uk/2024/10/18-57753-USEE_181024.mp3',
 		mediaId: 'mediaId',
 	},
-	parameters: {
-		// We only want to snapshot the `multipleFormats` version below.
-		chromatic: { disable: true },
-	},
 } satisfies Story;
 
 export const MultipleFormats = {

--- a/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.stories.tsx
@@ -535,6 +535,5 @@ HalfWidthWide.storyName = 'with role halfWidth';
 HalfWidthWide.story = {
 	parameters: {
 		viewport: { defaultViewport: 'wide' },
-		chromatic: { disable: true },
 	},
 };

--- a/dotcom-rendering/src/components/InteractiveAtom.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.stories.tsx
@@ -33,10 +33,6 @@ export const Default = {
 			<StoryComponent />
 		</div>
 	),
-	parameters: {
-		// This interactive uses animation which is causing false negatives for Chromatic
-		chromatic: { disable: true },
-	},
 } satisfies Story;
 
 export const ImmersiveMainMedia = {
@@ -58,8 +54,4 @@ export const ImmersiveMainMedia = {
 			<StoryComponent />
 		</div>
 	),
-	parameters: {
-		// This interactive uses animation which is causing false negatives for Chromatic
-		chromatic: { disable: true },
-	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/InteractiveLayoutAtom.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveLayoutAtom.stories.tsx
@@ -29,8 +29,4 @@ export const InteractiveLayoutAtom = {
 			<StoryComponent />
 		</div>
 	),
-	parameters: {
-		// This interactive uses animation which is causing false negatives for Chromatic
-		chromatic: { disable: true },
-	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.stories.tsx
@@ -7,9 +7,6 @@ const meta = {
 	parameters: {
 		backgrounds: { default: 'dark' },
 		layout: 'centered',
-		chromatic: {
-			disable: true,
-		},
 	},
 	render: (args) => <EditionDropdown {...args} />,
 	args: {

--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -5,11 +5,6 @@ import { VideoAtom } from './VideoAtom';
 const meta = {
 	title: 'Components/VideoAtom',
 	component: VideoAtom,
-	parameters: {
-		// Chromatic ignores video elements by design so there's no point trying to snapshot here
-		// https://www.chromatic.com/docs/ignoring-elements
-		chromatic: { disable: true },
-	},
 } satisfies Meta<typeof VideoAtom>;
 
 export default meta;

--- a/dotcom-rendering/src/components/VideoFacebookBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/VideoFacebookBlockComponent.stories.tsx
@@ -42,9 +42,6 @@ export const largeAspectRatio = () => {
 	);
 };
 largeAspectRatio.storyName = 'with large aspect ratio';
-largeAspectRatio.story = {
-	chromatic: { disable: true },
-};
 
 export const verticalAspectRatio = () => {
 	return (

--- a/dotcom-rendering/src/components/WitnessBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/WitnessBlockComponent.stories.tsx
@@ -10,11 +10,6 @@ import {
 
 export default {
 	title: 'Components/WitnessBlockComponent',
-	parameters: {
-		chromatic: {
-			disable: true,
-		},
-	},
 };
 
 const sportFormat = {

--- a/dotcom-rendering/src/components/YoutubeEmbedBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeEmbedBlockComponent.stories.tsx
@@ -5,11 +5,6 @@ import { YoutubeEmbedBlockComponent } from './YoutubeEmbedBlockComponent';
 export default {
 	component: YoutubeEmbedBlockComponent,
 	title: 'Components/YoutubeEmbedComponent',
-	parameters: {
-		chromatic: {
-			disable: true,
-		},
-	},
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
