### PR TITLE
Disable VideoFacebookBlockComponent `largeAspectRatio` Chromatic test

### DIFF
--- a/dotcom-rendering/src/components/VideoFacebookBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/VideoFacebookBlockComponent.stories.tsx
@@ -43,7 +43,9 @@ export const largeAspectRatio = () => {
 };
 largeAspectRatio.storyName = 'with large aspect ratio';
 largeAspectRatio.story = {
-	chromatic: { disable: true },
+	parameters: {
+		chromatic: { disable: true },
+	},
 };
 
 export const verticalAspectRatio = () => {


### PR DESCRIPTION
## What does this change?

`chromatic` object needs to be inside `parameters`

## Why?

This test is running on Chromatic, but is probably not supposed to be.