### PR TITLE
Remove superfluous space from headlines container

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -253,12 +253,6 @@ const sectionHeadlineFromLeftCol = (borderColour: string) => css`
 	}
 `;
 
-const sectionHeadlineHeight = css`
-	${until.tablet} {
-		min-height: 58px;
-	}
-`;
-
 const topPadding = css`
 	padding-top: ${space[2]}px;
 `;
@@ -559,8 +553,6 @@ export const FrontSection = ({
 							sectionHeadlineFromLeftCol(
 								schemePalette('--section-border'),
 							),
-						title?.toLowerCase() === 'headlines' &&
-							sectionHeadlineHeight,
 					]}
 				>
 					<FrontSectionTitle


### PR DESCRIPTION
## What does this change?

Removes the extra space from the Headlines container.

## Why?

This space was [introduced](https://github.com/guardian/dotcom-rendering/pull/8287) to minimise CLS from the Weather widget. This weather widget is now turned off, and it not displaying is why we see the extra space.

We expect that we will not be turning the weather widget back on, so instead of encapsulating this minimum space in the Weather feature switch, it is removed.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f681b8ad-9e8f-4490-9588-ee099a52cb77
[after]: https://github.com/user-attachments/assets/c0b44031-4912-42f0-b59f-70325ce292d7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
