### PR TITLE
Fix targeting by signed in status in Liveblog

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -129,6 +129,7 @@ const usePayload = ({
 			weeklyArticleHistory: articleCounts?.weeklyArticleHistory,
 			hasOptedOutOfArticleCount,
 			url: window.location.origin + window.location.pathname,
+			isSignedIn,
 		},
 	};
 };


### PR DESCRIPTION
## What does this change?

This is to  include the isSignedIn flag in the targeting data sent to SDC for liveblog epics
[Trello card](https://trello.com/c/BqNBUbgV/848-liveblog-epic-targeting-by-signed-in-status)

## Before Change
<img width="618" alt="image" src="https://github.com/user-attachments/assets/524f931e-cf79-4470-bf6a-0f48883c7f81" />

## After Change

<img width="618" alt="Screenshot 2025-01-02 at 13 31 26" src="https://github.com/user-attachments/assets/6f926f14-c7fd-4a5c-920e-85c0db11e425" />

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
