### PR TITLE
Remove Ad free  as a benefit on epic  and live blog epic choice cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -39,7 +39,6 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 		benefits: () => [
 			'Unlimited access to the Guardian app',
 			'Unlimited access to our new Feast App',
-			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 			'Far fewer asks for support',
 		],
@@ -73,7 +72,6 @@ export const ChoiceCardTestData_US: ChoiceInfo[] = [
 		benefits: () => [
 			'Unlimited access to the Guardian app',
 			'Unlimited access to our new Feast App',
-			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 			'Far fewer asks for support',
 		],
@@ -118,7 +116,6 @@ export const ChoiceCardTestData_TwoTier_REGULAR: ChoiceInfo[] = [
 		benefitsLabel: 'All-access digital',
 		benefits: () => [
 			'Unlimited access to the Guardian app',
-			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters',
 			'And much more!',
 		],


### PR DESCRIPTION
## What does this change?

This PR is to remove ad free as a benefit on epic  and live blog epic choice cards
## Why?

Portfolio team are running a test to remove ad free as a benefit on all marketing channels and landing page on the 6th of Jan.

[Trello card](https://trello.com/c/s8EiyWLt/867-remove-ad-free-as-a-benefit-on-epic-and-live-blog-epic-choice-cards)

## Screenshots : 

## Before Change

## Epic

<img width="565" alt="image" src="https://github.com/user-attachments/assets/d49e0f4e-0bc2-4426-bf10-8cfa9201318c" />


## Liveblog Epic

<img width="565" alt="image" src="https://github.com/user-attachments/assets/1d1f9f9e-4f5d-4efb-9d5c-b4fcfb1ae8a6" />


## After Change

## Epic

<img width="565" alt="image" src="https://github.com/user-attachments/assets/4bafec42-51b7-4c5a-8493-81c47cc6efda" />


## Liveblog Epic

<img width="565" alt="image" src="https://github.com/user-attachments/assets/f1341501-4f46-4303-a066-ec191c78b41b" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
