### PR TITLE
Fix Submeta Scaling

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -62,34 +62,34 @@ const listStyleNone = css`
 	background-image: repeating-linear-gradient(
 			to bottom,
 			${palette('--sub-meta-background')} 0px,
-			${palette('--sub-meta-background')} 36px,
-			transparent 36px,
-			transparent 37px,
-			${palette('--sub-meta-background')} 37px,
-			${palette('--sub-meta-background')} 48px
+			${palette('--sub-meta-background')} 2.25rem,
+			transparent 2.25rem,
+			transparent 2.3125rem,
+			${palette('--sub-meta-background')} 2.3125rem,
+			${palette('--sub-meta-background')} 3rem
 		),
 		repeating-linear-gradient(
 			to right,
 			${palette('--article-border')} 0px,
-			${palette('--article-border')} 3px,
-			transparent 3px,
-			transparent 5px
+			${palette('--article-border')} 0.1875rem,
+			transparent 0.1875rem,
+			transparent 0.3125rem
 		);
 	background-position: top;
 	background-repeat: no-repeat;
 `;
 
 const listWrapper = css`
-	padding-bottom: 12px;
+	padding-bottom: 0.75rem;
 	margin-bottom: 6px;
 	border-bottom: 1px solid ${palette('--article-border')};
 `;
 
 const listItemStyles = css`
 	${textSans14};
-	border: 1px solid ${palette('--sub-meta-text')};
-	border-radius: 12px;
-	padding: 2px 9px;
+	border: 0.0625rem solid ${palette('--sub-meta-text')};
+	border-radius: 0.75rem;
+	padding: 0.125rem 0.5625rem;
 	:hover {
 		background-color: ${palette('--sub-meta-text')};
 		a {


### PR DESCRIPTION
The apps include a feature for scaling text and other aspects of the UI by changing the root font size of the page. When this feature is used it causes the fonts in the submeta to scale up and down.

However, the dotted lines that appear between the tag links are created using a background image[^1] that relies on precise alignment, calculated in pixels. When the fonts scale this alignment is lost, and the lines start to overlap the text in the tag links.

To fix this, this change migrates several pixel values to their `rem`[^2] equivalents. This allows the lengths in the background image, and other aspects of the submeta design, to scale proportionately with the change in root font size.

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/background-image
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem

## Screenshots

| | Before | After |
|--------|--------|--------|
| Default | ![default-font-size-before] | ![default-font-size-after] |
| Scaled | ![scaled-font-size-before] | ![scaled-font-size-after] | 

[scaled-font-size-before]: https://github.com/user-attachments/assets/e2f047bf-55af-4d88-87ac-7c8f3a8f45da
[default-font-size-before]: https://github.com/user-attachments/assets/7caec98c-6ff8-4409-9a5b-b4f632a4393a
[scaled-font-size-after]: https://github.com/user-attachments/assets/a736cb3c-284b-43c4-85bf-e31dda93f710
[default-font-size-after]: https://github.com/user-attachments/assets/6e5956a7-8a86-4411-b4b3-e182218f864c
