### PR TITLE
Add 8px padding to beta media card images

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -645,6 +645,7 @@ export const Card = ({
 						hideImageOverlay={
 							media.type === 'slideshow' && isFlexibleContainer
 						}
+						padImage={isMediaCard && isBetaContainer}
 					>
 						{media.type === 'slideshow' &&
 							(isFlexibleContainer ? (

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { between, from, until } from '@guardian/source/foundations';
+import { between, from, space, until } from '@guardian/source/foundations';
 import type { CardImageType } from '../../../types/layout';
 import { PlayIcon } from './PlayIcon';
 
@@ -42,6 +42,7 @@ type Props = {
 	 * want it to be shown whilst retaining it for existing slideshows.
 	 */
 	hideImageOverlay?: boolean;
+	padImage?: boolean;
 };
 
 /**
@@ -115,6 +116,10 @@ const fixImageWidth = ({
 	`}
 `;
 
+const imagePadding = css`
+	padding: ${space[2]}px;
+`;
+
 export const ImageWrapper = ({
 	children,
 	imageSize,
@@ -124,6 +129,7 @@ export const ImageWrapper = ({
 	imagePositionOnMobile,
 	showPlayIcon,
 	hideImageOverlay,
+	padImage,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -170,6 +176,7 @@ export const ImageWrapper = ({
 						display: block;
 					}
 				`,
+				padImage && imagePadding,
 			]}
 		>
 			<>


### PR DESCRIPTION
## What does this change?
Updates image wrapper to have a pad option. This allows us to add 8px padding around images for media card images. 
For now, this is limited to beta containers. 


## Why?
This is as per designs.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/47b35fdd-82ee-44cb-816d-2633e6330baf
[after]: https://github.com/user-attachments/assets/0bd351a0-79e4-4303-ad14-4515693a5fe1



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
