### PR TITLE
Pad content based on card properties

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -570,12 +570,12 @@ export const Card = ({
 	};
 
 	const determinePadContent = (
-		isMediaCard: boolean,
-		isBetaContainer: boolean,
-		isOnwardContent: boolean,
+		mediaCard: boolean,
+		betaContainer: boolean,
+		onwardContent: boolean,
 	): 'large' | 'small' | undefined => {
-		if (isMediaCard && isBetaContainer) return 'large';
-		if (isMediaCard || isOnwardContent) return 'small';
+		if (mediaCard && betaContainer) return 'large';
+		if (mediaCard || onwardContent) return 'small';
 		return undefined;
 	};
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -569,6 +569,16 @@ export const Card = ({
 		);
 	};
 
+	const determinePadContent = (
+		isMediaCard: boolean,
+		isBetaContainer: boolean,
+		isOnwardContent: boolean,
+	): 'large' | 'small' | undefined => {
+		if (isMediaCard && isBetaContainer) return 'large';
+		if (isMediaCard || isOnwardContent) return 'small';
+		return undefined;
+	};
+
 	return (
 		<CardWrapper
 			format={format}
@@ -817,8 +827,11 @@ export const Card = ({
 						imageType={media?.type}
 						imageSize={imageSize}
 						imagePositionOnDesktop={imagePositionOnDesktop}
-						hasBackgroundColour={isMediaCard}
-						isOnwardContent={isOnwardContent}
+						padContent={determinePadContent(
+							isMediaCard,
+							isBetaContainer,
+							isOnwardContent,
+						)}
 						isFlexibleContainer={isFlexibleContainer}
 					>
 						{/* This div is needed to keep the headline and trail text justified at the start */}

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -64,7 +64,10 @@ const flexBasisStyles = ({
 const paddingStyles = (
 	imagePosition: ImagePositionType,
 	isFlexibleContainer: boolean,
+	paddingWidth: 'small' | 'large',
 ) => {
+	const paddingSize =
+		paddingWidth === 'small' ? `${space[1]}` : `${space[2]}`;
 	/**
 	 * If we're in a flexible container there is a 20px gap between the image
 	 * and content. We don't apply padding to the content on the same edge as
@@ -72,18 +75,18 @@ const paddingStyles = (
 	 */
 	if (isFlexibleContainer && imagePosition === 'left') {
 		return css`
-			padding: ${space[1]}px ${space[1]}px ${space[1]}px 0;
+			padding: ${paddingSize}px ${paddingSize}px ${paddingSize}px 0;
 		`;
 	}
 
 	if (isFlexibleContainer && imagePosition === 'right') {
 		return css`
-			padding: ${space[1]}px 0 ${space[1]}px ${space[1]}px;
+			padding: ${paddingSize}px 0 ${paddingSize}px ${paddingSize}px;
 		`;
 	}
 
 	return css`
-		padding: ${space[1]}px;
+		padding: ${paddingSize}px;
 	`;
 };
 
@@ -92,8 +95,7 @@ type Props = {
 	imageType?: CardImageType;
 	imageSize: ImageSizeType;
 	imagePositionOnDesktop: ImagePositionType;
-	hasBackgroundColour?: boolean;
-	isOnwardContent?: boolean;
+	padContent?: 'small' | 'large';
 	isFlexibleContainer?: boolean;
 };
 
@@ -102,8 +104,7 @@ export const ContentWrapper = ({
 	imageType,
 	imageSize,
 	imagePositionOnDesktop,
-	hasBackgroundColour,
-	isOnwardContent,
+	padContent,
 	isFlexibleContainer = false,
 }: Props) => {
 	const isHorizontalOnDesktop =
@@ -115,8 +116,12 @@ export const ContentWrapper = ({
 				sizingStyles,
 				isHorizontalOnDesktop &&
 					flexBasisStyles({ imageSize, imageType }),
-				(!!hasBackgroundColour || !!isOnwardContent) &&
-					paddingStyles(imagePositionOnDesktop, isFlexibleContainer),
+				padContent &&
+					paddingStyles(
+						imagePositionOnDesktop,
+						isFlexibleContainer,
+						padContent,
+					),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -64,10 +64,8 @@ const flexBasisStyles = ({
 const paddingStyles = (
 	imagePosition: ImagePositionType,
 	isFlexibleContainer: boolean,
-	paddingWidth: 'small' | 'large',
+	paddingWidth: 1 | 2,
 ) => {
-	const paddingSize =
-		paddingWidth === 'small' ? `${space[1]}` : `${space[2]}`;
 	/**
 	 * If we're in a flexible container there is a 20px gap between the image
 	 * and content. We don't apply padding to the content on the same edge as
@@ -75,18 +73,20 @@ const paddingStyles = (
 	 */
 	if (isFlexibleContainer && imagePosition === 'left') {
 		return css`
-			padding: ${paddingSize}px ${paddingSize}px ${paddingSize}px 0;
+			padding: ${space[paddingWidth]}px ${space[paddingWidth]}px
+				${space[paddingWidth]}px 0;
 		`;
 	}
 
 	if (isFlexibleContainer && imagePosition === 'right') {
 		return css`
-			padding: ${paddingSize}px 0 ${paddingSize}px ${paddingSize}px;
+			padding: ${space[paddingWidth]}px 0 ${space[paddingWidth]}px
+				${space[paddingWidth]}px;
 		`;
 	}
 
 	return css`
-		padding: ${paddingSize}px;
+		padding: ${space[paddingWidth]}px;
 	`;
 };
 
@@ -120,7 +120,7 @@ export const ContentWrapper = ({
 					paddingStyles(
 						imagePositionOnDesktop,
 						isFlexibleContainer,
-						padContent,
+						padContent === 'small' ? 1 : 2,
 					),
 			]}
 		>


### PR DESCRIPTION
## What does this change?
Adds padding option to the content wrapper, allowing the user to choose between small, large or no padding. 

This allows us to remove some card context from the content wrapper, with this now being handled at the card level.

## Why?
We need to extend the padding offering to allow for "large" (8px) padding on media cards in beta containers. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/85968144-1b7a-4a32-a3dc-d09c5077d8a5
[after]: https://github.com/user-attachments/assets/0b5e23fc-d6de-4b6a-8b39-417c85a0088a


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
