### PR TITLE
Unnest the `containerLevel` field in DCR front collection

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -742,9 +742,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								collectionBranding={
 									collection.collectionBranding
 								}
-								containerLevel={
-									collection.config.containerLevel
-								}
+								containerLevel={collection.containerLevel}
 								containerSpacing={collection.containerSpacing}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -108,6 +108,7 @@ export const enhanceCollections = ({
 			collectionType,
 			href,
 			containerPalette,
+			containerLevel: collection.config.collectionLevel,
 			containerSpacing,
 			collectionBranding,
 			grouped: groupCards(
@@ -135,7 +136,6 @@ export const enhanceCollections = ({
 			),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
-				containerLevel: collection.config.collectionLevel,
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -419,6 +419,7 @@ export type DCRCollectionType = {
 	description?: string;
 	collectionType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
+	containerLevel?: DCRContainerLevel;
 	containerSpacing?: 'large' | 'small';
 	grouped: DCRGroupedTrails;
 	curated: DCRFrontCard[];
@@ -427,7 +428,6 @@ export type DCRCollectionType = {
 	href?: string;
 	config: {
 		showDateHeader: boolean;
-		containerLevel?: DCRContainerLevel;
 	};
 	/**
 	 * @property {?boolean} canShowMore - Whether the 'show more' button should be shown.


### PR DESCRIPTION
## What does this change?

Moves the `containerLevel` field to the top level of the collection object rather than nesting it within collection config.

## Why?

Refactoring to make working with `containerLevel` easier
