### PR TITLE
Remove digital subscription cookie

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -4,7 +4,7 @@ import {
 	getAuthStatus as getAuthStatus_,
 	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
 } from '../../lib/identity';
-import { isDigitalSubscriber, refresh } from './user-features';
+import { refresh } from './user-features';
 import { fetchJson } from './user-features-lib';
 
 jest.mock('./user-features-lib', () => {
@@ -37,7 +37,6 @@ const PERSISTENCE_KEYS = {
 	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
 	AD_FREE_USER_COOKIE: 'GU_AF1',
 	ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
-	DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
 	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
 	HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
 };
@@ -51,10 +50,6 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 	const adFreeExpiryDate = opts.isExpired
 		? new Date(currentTime - msInOneDay * 2)
 		: new Date(currentTime + msInOneDay * 2);
-	setCookie({
-		name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
-		value: 'true',
-	});
 	setCookie({
 		name: PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE,
 		value: 'true',
@@ -74,7 +69,6 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 };
 
 const deleteAllFeaturesData = () => {
-	removeCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE });
 	removeCookie({ name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE });
 	removeCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE });
 	removeCookie({ name: PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE });
@@ -148,49 +142,10 @@ describe('If user signed out', () => {
 			getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
 		).toBeNull();
 		expect(
-			getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-		).toBeNull();
-		expect(
 			getCookie({
 				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
 			}),
 		).toBeNull();
-	});
-});
-
-describe('The isDigitalSubscriber getter', () => {
-	it('Is false when the user is logged out', () => {
-		jest.resetAllMocks();
-		isUserLoggedInOktaRefactor.mockResolvedValue(false);
-		expect(isDigitalSubscriber()).toBe(false);
-	});
-
-	describe('When the user is logged in', () => {
-		beforeEach(() => {
-			jest.resetAllMocks();
-			isUserLoggedInOktaRefactor.mockResolvedValue(true);
-		});
-
-		it('Is true when the user has a `true` digital subscriber cookie', () => {
-			setCookie({
-				name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
-				value: 'true',
-			});
-			expect(isDigitalSubscriber()).toBe(true);
-		});
-
-		it('Is false when the user has a `false` digital subscriber cookie', () => {
-			setCookie({
-				name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE,
-				value: 'false',
-			});
-			expect(isDigitalSubscriber()).toBe(false);
-		});
-
-		it('Is false when the user has no digital subscriber cookie', () => {
-			removeCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE });
-			expect(isDigitalSubscriber()).toBe(false);
-		});
 	});
 });
 
@@ -232,9 +187,6 @@ describe('Storing new feature data', () => {
 		);
 		return refresh().then(() => {
 			expect(
-				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-			).toBe('false');
-			expect(
 				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
 			).toBeNull();
 		});
@@ -253,9 +205,6 @@ describe('Storing new feature data', () => {
 			}),
 		);
 		return refresh().then(() => {
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-			).toBe('true');
 			expect(
 				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
 			).toBeTruthy();

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -123,13 +123,11 @@ const requestNewData = () => {
 const featuresDataIsOld = () =>
 	cookieIsExpiredOrMissing(USER_FEATURES_EXPIRY_COOKIE);
 
-const userNeedsNewFeatureData = (): boolean => featuresDataIsOld();
-
 const userHasDataAfterSignout = async (): Promise<boolean> =>
 	!(await isUserLoggedInOktaRefactor()) && userHasData();
 
 const refresh = async (): Promise<void> => {
-	if ((await isUserLoggedInOktaRefactor()) && userNeedsNewFeatureData()) {
+	if ((await isUserLoggedInOktaRefactor()) && featuresDataIsOld()) {
 		return requestNewData();
 	} else if ((await userHasDataAfterSignout()) && !forcedAdFreeMode) {
 		deleteOldData();

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -28,7 +28,6 @@ import type { UserFeaturesResponse } from './user-features-lib';
 
 const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
 const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
-const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
 const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 
@@ -39,7 +38,6 @@ const userHasData = () => {
 		getAdFreeCookie() ??
 		getCookie({ name: ACTION_REQUIRED_FOR_COOKIE }) ??
 		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
-		getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) ??
 		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 	return !!cookie;
 };
@@ -61,10 +59,6 @@ const persistResponse = (JsonResponse: UserFeaturesResponse) => {
 	setCookie({
 		name: USER_FEATURES_EXPIRY_COOKIE,
 		value: timeInDaysFromNow(1),
-	});
-	setCookie({
-		name: DIGITAL_SUBSCRIBER_COOKIE,
-		value: String(JsonResponse.contentAccess.digitalPack),
 	});
 	setCookie({
 		name: HIDE_SUPPORT_MESSAGING_COOKIE,
@@ -90,7 +84,6 @@ const deleteOldData = (): void => {
 	removeCookie({ name: AD_FREE_USER_COOKIE });
 	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
 	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
-	removeCookie({ name: DIGITAL_SUBSCRIBER_COOKIE });
 	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 };
 
@@ -130,11 +123,7 @@ const requestNewData = () => {
 const featuresDataIsOld = () =>
 	cookieIsExpiredOrMissing(USER_FEATURES_EXPIRY_COOKIE);
 
-const isDigitalSubscriber = (): boolean =>
-	getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) === 'true';
-
-const userNeedsNewFeatureData = (): boolean =>
-	featuresDataIsOld() || (isDigitalSubscriber() && !adFreeDataIsPresent());
+const userNeedsNewFeatureData = (): boolean => featuresDataIsOld();
 
 const userHasDataAfterSignout = async (): Promise<boolean> =>
 	!(await isUserLoggedInOktaRefactor()) && userHasData();
@@ -148,4 +137,4 @@ const refresh = async (): Promise<void> => {
 	return Promise.resolve();
 };
 
-export { refresh, isDigitalSubscriber };
+export { refresh };


### PR DESCRIPTION
## What does this change?
This PR removes the digital subscription user features cookie. 
## Why?
Previously we used this cookie to store information about whether a user had a digital subscription and then made the decision about whether they were entitled to ad-free reading as a result of that. However this is problematic because there are other products which give ad-free reading as a benefit and we don't want to duplicate this logic for each of them.  

In future we want to just give ad-free reading to those users who already have the ad-free cookie (which is set by support-frontend post purchase), or when the response from the user-benefits api tells us that they are entitled to ad-free reading.

Currently we are not using the user-benefits api in DCR so this PR still looks at the `digitalPack` flag in the members-data-api response but then persists the user's entitlement in the ad-free cookie rather than the digital subscription one.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
