### PR TITLE
Amp validation removal

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -82,9 +82,12 @@ playwright-open: clear clean-dist install build
 	$(call log, "starting DEV server and opening Playwright UI")
 	@pnpm playwright:open
 
-ampValidation: clean-dist install
-	$(call log, "starting AMP Validation test")
-	@node scripts/test/amp-validation.js
+# AMP validation has been temporarly turned off whilst we trial removing AMP pages.
+# If AMP is permanently removed, this check should be deleted.
+
+# ampValidation: clean-dist install
+# 	$(call log, "starting AMP Validation test")
+# 	@node scripts/test/amp-validation.js
 
 buildCheck:
 	$(call log, "checking build files")

--- a/dotcom-rendering/playwright/tests/article.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.e2e.spec.ts
@@ -96,7 +96,7 @@ test.describe('E2E Page rendering', () => {
 		});
 	});
 
-	test.describe('for AMP', function () {
+	test.skip('for AMP', function () {
 		test(`It should load render an AMP page`, async ({ page }) => {
 			await loadPage(
 				page,


### PR DESCRIPTION
## What does this change?
Disables AMP test and checks whilst AMP has been turned off.

## Why?
These were failing - as AMP articles are not being served - which was breaking the main build.
