### PR TITLE
Remove the action required cookie

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -36,7 +36,6 @@ const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
 const PERSISTENCE_KEYS = {
 	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
 	AD_FREE_USER_COOKIE: 'GU_AF1',
-	ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
 	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
 	HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
 };
@@ -62,16 +61,11 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 		name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
 		value: expiryDate.getTime().toString(),
 	});
-	setCookie({
-		name: PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE,
-		value: 'test',
-	});
 };
 
 const deleteAllFeaturesData = () => {
 	removeCookie({ name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE });
 	removeCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE });
-	removeCookie({ name: PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE });
 	removeCookie({ name: PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE });
 };
 

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -27,7 +27,6 @@ import {
 import type { UserFeaturesResponse } from './user-features-lib';
 
 const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
-const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 
@@ -36,7 +35,6 @@ const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(window.location.hash);
 const userHasData = () => {
 	const cookie =
 		getAdFreeCookie() ??
-		getCookie({ name: ACTION_REQUIRED_FOR_COOKIE }) ??
 		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
 		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 	return !!cookie;
@@ -65,14 +63,6 @@ const persistResponse = (JsonResponse: UserFeaturesResponse) => {
 		value: String(!JsonResponse.showSupportMessaging),
 	});
 
-	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
-	if (JsonResponse.alertAvailableFor) {
-		setCookie({
-			name: ACTION_REQUIRED_FOR_COOKIE,
-			value: JsonResponse.alertAvailableFor,
-		});
-	}
-
 	if (JsonResponse.contentAccess.digitalPack) {
 		setAdFreeCookie(2);
 	} else if (adFreeDataIsPresent() && !forcedAdFreeMode) {
@@ -83,7 +73,6 @@ const persistResponse = (JsonResponse: UserFeaturesResponse) => {
 const deleteOldData = (): void => {
 	removeCookie({ name: AD_FREE_USER_COOKIE });
 	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
-	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
 	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
 };
 


### PR DESCRIPTION
## What does this change?
This PR removes the code which stores the value of the `alertAvailableFor` field which is returned from members-data-api.

## Why?
The value is not used anywhere so this simplifies the code base, removes another unused cookie and potentially allow us to stop generating this value in mdapi which will improve performance.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
