### PR TITLE
Use `id` from `AudioBlockElement` for `media-id` if available

### DIFF
--- a/dotcom-rendering/src/lib/audio-data.ts
+++ b/dotcom-rendering/src/lib/audio-data.ts
@@ -8,10 +8,10 @@ export const getAudioData = (
 			element._type ===
 			'model.dotcomrendering.pageElements.AudioBlockElement',
 	);
-	if (audioBlockElement?.assets[0] && audioBlockElement.elementId) {
+	if (audioBlockElement?.assets[0] && audioBlockElement.id) {
 		return {
 			audioDownloadUrl: audioBlockElement.assets[0].url,
-			mediaId: audioBlockElement.elementId,
+			mediaId: audioBlockElement.id,
 		};
 	}
 	return undefined;

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -841,6 +841,9 @@
                     "type": "string",
                     "const": "model.dotcomrendering.pageElements.AudioBlockElement"
                 },
+                "id": {
+                    "type": "string"
+                },
                 "elementId": {
                     "type": "string"
                 },

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -428,6 +428,9 @@
                     "type": "string",
                     "const": "model.dotcomrendering.pageElements.AudioBlockElement"
                 },
+                "id": {
+                    "type": "string"
+                },
                 "elementId": {
                     "type": "string"
                 },

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -45,6 +45,7 @@ export interface AudioAtomBlockElement {
 
 interface AudioBlockElement {
 	_type: 'model.dotcomrendering.pageElements.AudioBlockElement';
+	id?: string;
 	elementId: string;
 	assets: AudioAsset[];
 }


### PR DESCRIPTION
## What does this change?

Use `id` from `AudioBlockElement` for `media-id` if available

Frontend PR that adds the id to the DCR model: https://github.com/guardian/frontend/pull/27686

## Why?

The current implementation uses element-id which is generated by Frontend and hence is unstable and changes on every render.

This causes issues for Ophan tracking as the id for audio assets on podcast pages are not stable.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/305a3f9a-734c-4727-a36e-7cb4fbf2a740
[after]: https://github.com/user-attachments/assets/64ea207a-d010-4703-bff4-9a8a651c76d6
