### PR TITLE
Add audio duration

### DIFF
--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -923,6 +923,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mhe94',
 			group: '0',
 			isLive: false,
+			galleryCount: 11,
 		},
 		discussion: {
 			isCommentable: false,
@@ -1450,6 +1451,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mgmvx',
 			group: '0',
 			isLive: false,
+			galleryCount: 19,
 		},
 		discussion: {
 			isCommentable: false,

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -46,6 +46,7 @@ const basicCardProps: CardProps = {
 	showMainVideo: true,
 	absoluteServerTimes: true,
 	galleryCount: 8,
+	audioDuration: '37:02',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -45,6 +45,7 @@ const basicCardProps: CardProps = {
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
 	showMainVideo: true,
 	absoluteServerTimes: true,
+	galleryCount: 8,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
-import { Hide, Link } from '@guardian/source/react-components';
+import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
@@ -34,6 +34,7 @@ import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
 import { MediaMeta } from '../MediaMeta';
+import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
 import { Snap } from '../Snap';
@@ -427,6 +428,9 @@ export const Card = ({
 		);
 	}
 
+	// Check media type to determine if we should show a pill or media icon
+	const showPill = mainMedia?.type === 'Gallery';
+
 	const media = getMedia({
 		imageUrl: image?.src,
 		imageAltText: image?.altText,
@@ -621,7 +625,7 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && (
+					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
 						<MediaMeta
 							mediaType={mainMedia.type}
 							hasKicker={!!kickerText}
@@ -869,7 +873,8 @@ export const Card = ({
 										/>
 									) : null}
 									{!!mainMedia &&
-										mainMedia.type !== 'Video' && (
+										mainMedia.type !== 'Video' &&
+										!showPill && (
 											<MediaMeta
 												mediaType={mainMedia.type}
 												hasKicker={!!kickerText}
@@ -888,7 +893,28 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && (
+							{!showCommentFooter && showPill ? (
+								<div
+									css={css`
+										margin-top: auto;
+									`}
+								>
+									{branding && (
+										<CardBranding
+											branding={branding}
+											format={format}
+											onwardsSource={onwardsSource}
+											containerPalette={containerPalette}
+										/>
+									)}
+									<Pill
+										prefix="Gallery"
+										content={(galleryCount ?? 0).toString()}
+										icon={<SvgCamera />}
+										iconSide="right"
+									/>
+								</div>
+							) : (
 								<CardFooter
 									format={format}
 									age={decideAge()}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -147,6 +147,8 @@ export type Props = {
 	/** The square podcast series image, if it exists for a card */
 	podcastImage?: PodcastSeriesImage;
 	galleryCount?: number;
+	// eslint-disable-next-line react/no-unused-prop-types -- adding
+	audioDuration?: string;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -907,37 +907,47 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && showPill ? (
+							{!showCommentFooter && (
 								<>
-									<MediaPill />
-									{branding && (
-										<CardBranding
-											branding={branding}
+									{showPill ? (
+										<>
+											<MediaPill />
+											{branding && (
+												<CardBranding
+													branding={branding}
+													format={format}
+													onwardsSource={
+														onwardsSource
+													}
+													containerPalette={
+														containerPalette
+													}
+												/>
+											)}
+										</>
+									) : (
+										<CardFooter
 											format={format}
-											onwardsSource={onwardsSource}
-											containerPalette={containerPalette}
+											age={decideAge()}
+											commentCount={<CommentCount />}
+											cardBranding={
+												branding ? (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												) : undefined
+											}
+											showLivePlayable={showLivePlayable}
 										/>
 									)}
 								</>
-							) : (
-								<CardFooter
-									format={format}
-									age={decideAge()}
-									commentCount={<CommentCount />}
-									cardBranding={
-										branding ? (
-											<CardBranding
-												branding={branding}
-												format={format}
-												onwardsSource={onwardsSource}
-												containerPalette={
-													containerPalette
-												}
-											/>
-										) : undefined
-									}
-									showLivePlayable={showLivePlayable}
-								/>
 							)}
 							{showLivePlayable &&
 								liveUpdatesPosition === 'inner' && (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -147,7 +147,6 @@ export type Props = {
 	/** The square podcast series image, if it exists for a card */
 	podcastImage?: PodcastSeriesImage;
 	galleryCount?: number;
-	// eslint-disable-next-line react/no-unused-prop-types -- adding
 	audioDuration?: string;
 };
 
@@ -354,6 +353,7 @@ export const Card = ({
 	trailTextColour,
 	podcastImage,
 	galleryCount,
+	audioDuration,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -433,7 +433,7 @@ export const Card = ({
 		>
 			{mainMedia?.type === 'Audio' && (
 				<Pill
-					content="0:00" // TODO: get podcast duration
+					content={audioDuration ?? ''}
 					icon={<SvgMediaControlsPlay />}
 				/>
 			)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -33,7 +33,6 @@ import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
-import { MediaMeta } from '../MediaMeta';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
@@ -42,6 +41,7 @@ import { SnapCssSandbox } from '../SnapCssSandbox';
 import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -425,12 +425,20 @@ export const Card = ({
 				margin-top: auto;
 			`}
 		>
-			<Pill
-				prefix="Gallery"
-				content={galleryCount?.toString() ?? ''}
-				icon={<SvgCamera />}
-				iconSide="right"
-			/>
+			{mainMedia?.type === 'Audio' && (
+				<Pill
+					content="0:00" // TODO: get podcast duration
+					icon={<SvgMediaControlsPlay />}
+				/>
+			)}
+			{mainMedia?.type === 'Gallery' && (
+				<Pill
+					prefix="Gallery"
+					content={galleryCount?.toString() ?? ''}
+					icon={<SvgCamera />}
+					iconSide="right"
+				/>
+			)}
 		</div>
 	);
 
@@ -443,7 +451,8 @@ export const Card = ({
 	}
 
 	// Check media type to determine if we should show a pill or media icon
-	const showPill = mainMedia?.type === 'Gallery';
+	const showPill =
+		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -639,12 +648,6 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
-						<MediaMeta
-							mediaType={mainMedia.type}
-							hasKicker={!!kickerText}
-						/>
-					)}
 				</div>
 			)}
 
@@ -886,14 +889,6 @@ export const Card = ({
 											cardHasImage={!!image}
 										/>
 									) : null}
-									{!!mainMedia &&
-										mainMedia.type !== 'Video' &&
-										!showPill && (
-											<MediaMeta
-												mediaType={mainMedia.type}
-												hasKicker={!!kickerText}
-											/>
-										)}
 								</HeadlineWrapper>
 							)}
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -347,7 +347,6 @@ export const Card = ({
 	trailTextSize,
 	trailTextColour,
 	podcastImage,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Added in preparation for UI changes to display gallery count
 	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -419,6 +418,21 @@ export const Card = ({
 				</Island>
 			</Link>
 		);
+
+	const MediaPill = () => (
+		<div
+			css={css`
+				margin-top: auto;
+			`}
+		>
+			<Pill
+				prefix="Gallery"
+				content={galleryCount?.toString() ?? ''}
+				icon={<SvgCamera />}
+				iconSide="right"
+			/>
+		</div>
+	);
 
 	if (snapData?.embedHtml) {
 		return (
@@ -894,11 +908,8 @@ export const Card = ({
 							)}
 
 							{!showCommentFooter && showPill ? (
-								<div
-									css={css`
-										margin-top: auto;
-									`}
-								>
+								<>
+									<MediaPill />
 									{branding && (
 										<CardBranding
 											branding={branding}
@@ -907,13 +918,7 @@ export const Card = ({
 											containerPalette={containerPalette}
 										/>
 									)}
-									<Pill
-										prefix="Gallery"
-										content={(galleryCount ?? 0).toString()}
-										icon={<SvgCamera />}
-										iconSide="right"
-									/>
-								</div>
+								</>
 							) : (
 								<CardFooter
 									format={format}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -6,7 +6,11 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
-import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
@@ -907,18 +911,20 @@ export const Card = ({
 									{showPill ? (
 										<>
 											<MediaPill />
-											{branding && (
-												<CardBranding
-													branding={branding}
-													format={format}
-													onwardsSource={
-														onwardsSource
-													}
-													containerPalette={
-														containerPalette
-													}
-												/>
-											)}
+											{format.theme ===
+												ArticleSpecial.Labs &&
+												branding && (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												)}
 										</>
 									) : (
 										<CardFooter

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -450,7 +450,7 @@ export const Card = ({
 		);
 	}
 
-	// Check media type to determine if we should show a pill or media icon
+	// Check media type to determine if we show a pill or article metadata
 	const showPill =
 		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
 

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -57,6 +57,7 @@ export const FrontCard = (props: Props) => {
 		showMainVideo: trail.showMainVideo,
 		galleryCount: trail.galleryCount,
 		podcastImage: trail.podcastImage,
+		audioDuration: trail.audioDuration,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -1,43 +1,9 @@
-import { css } from '@emotion/react';
 import {
 	SvgAudio,
 	SvgCamera,
 	SvgVideo,
 } from '@guardian/source/react-components';
-import { palette as themePalette } from '../palette';
 import type { MediaType } from '../types/layout';
-
-type Props = {
-	mediaType: MediaType;
-	hasKicker: boolean;
-};
-
-const iconWrapperStyles = (hasKicker: boolean) => css`
-	width: 24px;
-	height: 24px;
-	/* We’re using the text colour for the icon badge */
-	background-color: ${hasKicker
-		? themePalette('--card-kicker-text')
-		: themePalette('--card-footer-text')};
-	border-radius: 50%;
-	display: inline-block;
-
-	> svg {
-		width: 20px;
-		height: 20px;
-		margin-left: auto;
-		margin-right: auto;
-		margin-top: 2px;
-		display: block;
-		fill: ${themePalette('--card-media-icon')};
-	}
-`;
-
-const wrapperStyles = css`
-	display: flex;
-	align-items: center;
-	margin-top: 4px;
-`;
 
 export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 	switch (mediaType) {
@@ -48,26 +14,4 @@ export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
 		case 'Audio':
 			return <SvgAudio />;
 	}
-};
-
-const MediaIcon = ({
-	mediaType,
-	hasKicker,
-}: {
-	mediaType: MediaType;
-	hasKicker: boolean;
-}) => {
-	return (
-		<span css={iconWrapperStyles(hasKicker)}>
-			<Icon mediaType={mediaType} />
-		</span>
-	);
-};
-
-export const MediaMeta = ({ mediaType, hasKicker }: Props) => {
-	return (
-		<div css={wrapperStyles}>
-			<MediaIcon mediaType={mediaType} hasKicker={hasKicker} />
-		</div>
-	);
 };

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -329,5 +329,6 @@ export const enhanceCards = (
 			}),
 			podcastImage,
 			galleryCount: faciaCard.card.galleryCount,
+			audioDuration: faciaCard.card.audioDuration,
 		};
 	});

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1034,6 +1034,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -1785,6 +1788,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -2536,6 +2542,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -555,6 +555,9 @@
                             },
                             "galleryCount": {
                                 "type": "number"
+                            },
+                            "audioDuration": {
+                                "type": "string"
                             }
                         },
                         "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -291,6 +291,7 @@ export type FEFrontCard = {
 		group: string;
 		isLive: boolean;
 		galleryCount?: number;
+		audioDuration?: string;
 	};
 	discussion: {
 		isCommentable: boolean;
@@ -350,6 +351,7 @@ export type DCRFrontCard = {
 	showMainVideo?: boolean;
 	galleryCount?: number;
 	podcastImage?: PodcastSeriesImage;
+	audioDuration?: string;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

Uses the audio duration value provided by frontend in [this PR](https://github.com/guardian/frontend/pull/27676).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/23b1c4f8-08a9-43dc-b0b4-edb1a3874351
[after]: https://github.com/user-attachments/assets/a896261a-9705-4ea8-b8b1-1bd29d64501e


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
