### PR TITLE
Render star rating on highlights card

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -92,3 +92,16 @@ export const WithLiveKicker: Story = {
 	parameters: {},
 	name: 'With Live Kicker',
 };
+
+export const WithStarRating: Story = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Culture,
+		},
+		starRating: 4,
+	},
+	parameters: {},
+	name: 'With Star Rating',
+};

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -186,7 +186,7 @@ export const HighlightsCard = ({
 					/>
 				</div>
 
-				{!!starRating ? (
+				{starRating ? (
 					<div css={starWrapper}>
 						<StarRating rating={starRating} size="small" />
 					</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import { between, from, until } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard } from '../../lib/cardHelpers';
@@ -186,7 +187,7 @@ export const HighlightsCard = ({
 					/>
 				</div>
 
-				{starRating ? (
+				{!isUndefined(starRating) ? (
 					<div css={starWrapper}>
 						<StarRating rating={starRating} size="small" />
 					</div>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -3,6 +3,7 @@ import { between, from, until } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
+import type { StarRating as Rating } from '../../types/content';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
 import { Avatar } from '../Avatar';
@@ -12,6 +13,7 @@ import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { FormatBoundary } from '../FormatBoundary';
 import { Icon } from '../MediaMeta';
+import { StarRating } from '../StarRating/StarRating';
 
 export type HighlightsCardProps = {
 	linkTo: string;
@@ -26,6 +28,7 @@ export type HighlightsCardProps = {
 	dataLinkName: string;
 	byline?: string;
 	isExternalLink: boolean;
+	starRating?: Rating;
 };
 
 const gridContainer = css`
@@ -37,6 +40,7 @@ const gridContainer = css`
 	gap: 8px;
 	grid-template-areas:
 		'headline 	headline'
+		'rating rating'
 		'media-icon image';
 
 	/* Applied word-break: break-word to prevent text overflow
@@ -121,6 +125,18 @@ const hoverStyles = css`
 	}
 `;
 
+const starWrapper = css`
+	background-color: ${palette('--star-rating-background')};
+	color: ${palette('--star-rating-fill')};
+	width: fit-content;
+	height: fit-content;
+	grid-area: rating;
+	${from.desktop} {
+		grid-area: media-icon;
+		align-self: flex-end;
+	}
+`;
+
 export const HighlightsCard = ({
 	linkTo,
 	format,
@@ -134,6 +150,7 @@ export const HighlightsCard = ({
 	dataLinkName,
 	byline,
 	isExternalLink,
+	starRating,
 }: HighlightsCardProps) => {
 	const showMediaIcon = isMediaCard(format);
 
@@ -168,6 +185,12 @@ export const HighlightsCard = ({
 						isBetaContainer={true}
 					/>
 				</div>
+
+				{!!starRating ? (
+					<div css={starWrapper}>
+						<StarRating rating={starRating} size="small" />
+					</div>
+				) : null}
 
 				{!!mainMedia && showMediaIcon && (
 					<div css={mediaIcon}>

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -262,6 +262,7 @@ export const ScrollableHighlights = ({ trails }: Props) => {
 								isExternalLink={trail.isExternalLink}
 								showQuotedHeadline={trail.showQuotedHeadline}
 								mainMedia={trail.mainMedia}
+								starRating={trail.starRating}
 							/>
 						</li>
 					);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -151,7 +151,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
-	const { abTests, isPreview } = front.config;
+	// const { abTests, isPreview } = front.config;
 
 	const { absoluteServerTimes = false } = front.config.switches;
 
@@ -174,9 +174,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	};
 
 	const Highlights = () => {
-		const showHighlights =
-			// Must be opted into the Europe beta test or in preview
-			abTests.europeBetaFrontVariant === 'variant' || isPreview;
+		const showHighlights = true;
+		// Must be opted into the Europe beta test or in preview
+		// abTests.europeBetaFrontVariant === 'variant' || isPreview;
 
 		const highlightsCollection =
 			front.pressedPage.collections.find(isHighlights);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -151,7 +151,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
-	// const { abTests, isPreview } = front.config;
+	const { abTests, isPreview } = front.config;
 
 	const { absoluteServerTimes = false } = front.config.switches;
 
@@ -174,9 +174,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	};
 
 	const Highlights = () => {
-		const showHighlights = true;
-		// Must be opted into the Europe beta test or in preview
-		// abTests.europeBetaFrontVariant === 'variant' || isPreview;
+		const showHighlights =
+			// Must be opted into the Europe beta test or in preview
+			abTests.europeBetaFrontVariant === 'variant' || isPreview;
 
 		const highlightsCollection =
 			front.pressedPage.collections.find(isHighlights);


### PR DESCRIPTION
## What does this change?
Adds star rating into the highlights card.

Depending on the breakpoint, the star rating appears in either the `rating` grid area or the `media-icon` grid area. 

## Why?
This is a requirement for the highlights container go-live. By switching the grid area on breakpoint change we can position the rating either below the headline or at the bottom of the card. 

## Screenshots

| mobile      | tablet      | desktop      |
| ----------- | ---------- | ---------- |
| ![mobile][] | ![tablet][] | ![desktop][] |

[mobile]: https://github.com/user-attachments/assets/d5dbcae4-a7c6-4eee-9c49-9d233520122f
[tablet]: https://github.com/user-attachments/assets/00612d6b-e3a2-4236-8c78-5c3082b30e92
[desktop]: https://github.com/user-attachments/assets/09162d0c-f965-4e38-9b0e-bc8a1c85c903


<!--


You can add extra rows by repeating the last row in the table and then using
 new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
