### PR TITLE
Adjust mobile ad positions for beta fronts

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -254,13 +254,13 @@ describe('Mobile Ads', () => {
 			{
 				collectionType: 'scrollable/feature',
 				containerLevel: 'Secondary',
-			}, // Ad position (21)
+			}, // Ignored - is merch high position
 			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 4, 6, 8, 10, 14, 19, 21]);
+		expect(mobileAdPositions).toEqual([0, 4, 6, 8, 10, 14, 19]);
 	});
 });
 

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -100,7 +100,7 @@ const isEvenIndex = (_collection: unknown, index: number): boolean =>
  * up to a maximum of `MAX_FRONTS_MOBILE_ADS`
  */
 const getMobileAdPositions = (collections: AdCandidate[]): number[] => {
-	const merchHighPosition = getMerchHighPosition(collections.length);
+	const merchHighPosition = getMerchHighPosition(collections);
 	const hasSecondaryContainers = hasSecondaryLevelContainers(collections);
 
 	return (


### PR DESCRIPTION
## What does this change?

Adjusts the mobile ad positioning logic to account for "beta" fronts with a combination of Primary and Secondary level containers

<details><summary>Example of Primary level container on mobile screen size</summary>
<img width="411" alt="Screenshot 2025-01-16 at 10 46 56" src="https://github.com/user-attachments/assets/c325018f-5f6c-4238-8937-7f06ee0b45bd" />
</details>

<details><summary>Example of Secondary level containers on mobile screen size</summary>
<img width="411" alt="Screenshot 2025-01-16 at 10 47 12" src="https://github.com/user-attachments/assets/3d86bd6e-dd35-44a9-8c3e-b566a45fabeb" />
</details>

We now have two sets of rules that must be applied for fronts with Secondary level containers present, and one set of rules to apply in other scenarios. This avoids making changes to the ad positioning logic in place already for existing fronts and allows us to more safely change the logic for beta fronts.

## Why?

The front pages have been undergoing some redesigns and as such the ad positioning logic needs to be updated to fit in with the new flow of containers.

The new page layout has Primary and Secondary level containers. This lightly infers a connection between a Primary container and any subsequent Secondary level containers but does not link them explicitly.
The ad placement logic should try not to break the flow of information between a Primary and the Secondary containers that follow it. There is an exception to this rule for the first container, where we allow ad placement directly underneath it, as otherwise this will push ads too far down the page and impact revenue significantly.

[Document link](https://docs.google.com/document/d/1_Hk5RDl26H3DKOUpNRi3wgl0IV7ifChg3wE6huydNJw/edit?usp=sharing)

## Screenshots

|       | Before      | After      |
| ----- | ----------- | ---------- |
| Europe | ![before][] | ![after][] |
| Europe beta | ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/968a26a6-87d0-454a-ad7c-48422dedbd29
[after]: https://github.com/user-attachments/assets/d3dabf85-5913-4acb-8f6a-cad4680bd653
[before2]: https://github.com/user-attachments/assets/ee9ea584-93ad-4d1d-8ac5-fa5e0413b316
[after2]: https://github.com/user-attachments/assets/dfdd0191-e291-4ec5-9272-ca17f4f773d8
