### PR TITLE
Pin version 4.1.2 of actions-riff-raff

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       # All rendering apps deployment
       - name: Upload rendering apps to RiffRaff
-        uses: guardian/actions-riff-raff@v4.1.7
+        uses: guardian/actions-riff-raff@v4.1.2
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
## What does this change?

Trials setting a specific version of actions-riff-raff (https://github.com/guardian/actions-riff-raff/releases/tag/v4.1.2)

## Why?

The process keeps timing out so can't upload to riff-raff
