### PR TITLE
Media Cards: Enable pills in beta containers

### DIFF
--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -923,6 +923,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mhe94',
 			group: '0',
 			isLive: false,
+			galleryCount: 11,
 		},
 		discussion: {
 			isCommentable: false,
@@ -1450,6 +1451,7 @@ export const trails: [
 			shortUrl: 'https://www.theguardian.com/p/mgmvx',
 			group: '0',
 			isLive: false,
+			galleryCount: 19,
 		},
 		discussion: {
 			isCommentable: false,

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -45,6 +45,7 @@ const basicCardProps: CardProps = {
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
 	showMainVideo: true,
 	absoluteServerTimes: true,
+	galleryCount: 8,
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -33,7 +33,6 @@ import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
-import { MediaMeta } from '../MediaMeta';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
@@ -42,6 +41,7 @@ import { SnapCssSandbox } from '../SnapCssSandbox';
 import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -454,12 +454,20 @@ export const Card = ({
 				margin-top: auto;
 			`}
 		>
-			<Pill
-				prefix="Gallery"
-				content={galleryCount?.toString() ?? ''}
-				icon={<SvgCamera />}
-				iconSide="right"
-			/>
+			{mainMedia?.type === 'Audio' && (
+				<Pill
+					content="0:00" // TODO: get podcast duration
+					icon={<SvgMediaControlsPlay />}
+				/>
+			)}
+			{mainMedia?.type === 'Gallery' && (
+				<Pill
+					prefix="Gallery"
+					content={galleryCount?.toString() ?? ''}
+					icon={<SvgCamera />}
+					iconSide="right"
+				/>
+			)}
 		</div>
 	);
 
@@ -472,7 +480,8 @@ export const Card = ({
 	}
 
 	// Check media type to determine if we should show a pill or media icon
-	const showPill = mainMedia?.type === 'Gallery';
+	const showPill =
+		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -668,12 +677,6 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
-						<MediaMeta
-							mediaType={mainMedia.type}
-							hasKicker={!!kickerText}
-						/>
-					)}
 				</div>
 			)}
 
@@ -940,14 +943,6 @@ export const Card = ({
 											cardHasImage={!!image}
 										/>
 									) : null}
-									{!!mainMedia &&
-										mainMedia.type !== 'Video' &&
-										!showPill && (
-											<MediaMeta
-												mediaType={mainMedia.type}
-												hasKicker={!!kickerText}
-											/>
-										)}
 								</HeadlineWrapper>
 							)}
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -961,37 +961,47 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && showPill ? (
+							{!showCommentFooter && (
 								<>
-									<MediaPill />
-									{branding && (
-										<CardBranding
-											branding={branding}
+									{showPill ? (
+										<>
+											<MediaPill />
+											{branding && (
+												<CardBranding
+													branding={branding}
+													format={format}
+													onwardsSource={
+														onwardsSource
+													}
+													containerPalette={
+														containerPalette
+													}
+												/>
+											)}
+										</>
+									) : (
+										<CardFooter
 											format={format}
-											onwardsSource={onwardsSource}
-											containerPalette={containerPalette}
+											age={decideAge()}
+											commentCount={<CommentCount />}
+											cardBranding={
+												branding ? (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												) : undefined
+											}
+											showLivePlayable={showLivePlayable}
 										/>
 									)}
 								</>
-							) : (
-								<CardFooter
-									format={format}
-									age={decideAge()}
-									commentCount={<CommentCount />}
-									cardBranding={
-										branding ? (
-											<CardBranding
-												branding={branding}
-												format={format}
-												onwardsSource={onwardsSource}
-												containerPalette={
-													containerPalette
-												}
-											/>
-										) : undefined
-									}
-									showLivePlayable={showLivePlayable}
-								/>
 							)}
 							{showLivePlayable &&
 								liveUpdatesPosition === 'inner' && (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -6,7 +6,11 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
-import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	ArticleSpecial,
+} from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
@@ -961,18 +965,20 @@ export const Card = ({
 									{showPill ? (
 										<>
 											<MediaPill />
-											{branding && (
-												<CardBranding
-													branding={branding}
-													format={format}
-													onwardsSource={
-														onwardsSource
-													}
-													containerPalette={
-														containerPalette
-													}
-												/>
-											)}
+											{format.theme ===
+												ArticleSpecial.Labs &&
+												branding && (
+													<CardBranding
+														branding={branding}
+														format={format}
+														onwardsSource={
+															onwardsSource
+														}
+														containerPalette={
+															containerPalette
+														}
+													/>
+												)}
 										</>
 									) : (
 										<CardFooter

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -376,7 +376,6 @@ export const Card = ({
 	trailTextSize,
 	trailTextColour,
 	podcastImage,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Added in preparation for UI changes to display gallery count
 	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -448,6 +447,21 @@ export const Card = ({
 				</Island>
 			</Link>
 		);
+
+	const MediaPill = () => (
+		<div
+			css={css`
+				margin-top: auto;
+			`}
+		>
+			<Pill
+				prefix="Gallery"
+				content={galleryCount?.toString() ?? ''}
+				icon={<SvgCamera />}
+				iconSide="right"
+			/>
+		</div>
+	);
 
 	if (snapData?.embedHtml) {
 		return (
@@ -948,11 +962,8 @@ export const Card = ({
 							)}
 
 							{!showCommentFooter && showPill ? (
-								<div
-									css={css`
-										margin-top: auto;
-									`}
-								>
+								<>
+									<MediaPill />
 									{branding && (
 										<CardBranding
 											branding={branding}
@@ -961,13 +972,7 @@ export const Card = ({
 											containerPalette={containerPalette}
 										/>
 									)}
-									<Pill
-										prefix="Gallery"
-										content={(galleryCount ?? 0).toString()}
-										icon={<SvgCamera />}
-										iconSide="right"
-									/>
-								</div>
+								</>
 							) : (
 								<CardFooter
 									format={format}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -37,6 +37,7 @@ import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
+import { MediaMeta } from '../MediaMeta';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
@@ -483,9 +484,14 @@ export const Card = ({
 		);
 	}
 
-	// Check media type to determine if we should show a pill or media icon
+	/**
+	 * Check media type to determine if pill, or article metadata & icon shown.
+	 * Currently pills are only shown within beta containers.
+	 */
 	const showPill =
-		mainMedia?.type === 'Audio' || mainMedia?.type === 'Gallery';
+		isBetaContainer &&
+		mainMedia &&
+		(mainMedia.type === 'Audio' || mainMedia.type === 'Gallery');
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -681,6 +687,12 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
+					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
+						<MediaMeta
+							mediaType={mainMedia.type}
+							hasKicker={!!kickerText}
+						/>
+					)}
 				</div>
 			)}
 
@@ -947,6 +959,14 @@ export const Card = ({
 											cardHasImage={!!image}
 										/>
 									) : null}
+									{!!mainMedia &&
+										mainMedia.type !== 'Video' &&
+										!showPill && (
+											<MediaMeta
+												mediaType={mainMedia.type}
+												hasKicker={!!kickerText}
+											/>
+										)}
 								</HeadlineWrapper>
 							)}
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
-import { Hide, Link } from '@guardian/source/react-components';
+import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
 import { getZIndex } from '../../lib/getZIndex';
@@ -34,6 +34,7 @@ import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaDuration } from '../MediaDuration';
 import { MediaMeta } from '../MediaMeta';
+import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';
 import { Snap } from '../Snap';
@@ -456,6 +457,9 @@ export const Card = ({
 		);
 	}
 
+	// Check media type to determine if we should show a pill or media icon
+	const showPill = mainMedia?.type === 'Gallery';
+
 	const media = getMedia({
 		imageUrl: image?.src,
 		imageAltText: image?.altText,
@@ -650,7 +654,7 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && (
+					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
 						<MediaMeta
 							mediaType={mainMedia.type}
 							hasKicker={!!kickerText}
@@ -923,7 +927,8 @@ export const Card = ({
 										/>
 									) : null}
 									{!!mainMedia &&
-										mainMedia.type !== 'Video' && (
+										mainMedia.type !== 'Video' &&
+										!showPill && (
 											<MediaMeta
 												mediaType={mainMedia.type}
 												hasKicker={!!kickerText}
@@ -942,7 +947,28 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && (
+							{!showCommentFooter && showPill ? (
+								<div
+									css={css`
+										margin-top: auto;
+									`}
+								>
+									{branding && (
+										<CardBranding
+											branding={branding}
+											format={format}
+											onwardsSource={onwardsSource}
+											containerPalette={containerPalette}
+										/>
+									)}
+									<Pill
+										prefix="Gallery"
+										content={(galleryCount ?? 0).toString()}
+										icon={<SvgCamera />}
+										iconSide="right"
+									/>
+								</div>
+							) : (
 								<CardFooter
 									format={format}
 									age={decideAge()}


### PR DESCRIPTION
## What does this change?

Updates media cards to show gallery count and podcast duration pills in beta containers _only_. The pill appears below the headline and trail text in place of the existing card metadata.

_NB._ Podcast duration is not currently populated and will be added in a subsequent PR (#13102)

## Why?

This is an incremental change which forms part of a larger body of work to [update the design of media cards](https://trello.com/c/M98Xbjwd/756-web-media-cards-xs-s-m). Following some additional design updates the intention is to enable these in all containers, replacing the existing media icons and card metadata completely.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before1]: https://github.com/user-attachments/assets/66b83ed5-66a7-4880-b72c-8e9cc5d305f1
[after1]: https://github.com/user-attachments/assets/e522f5e4-a2af-4294-8b71-b2e014cf70c9
[before2]: https://github.com/user-attachments/assets/086e222c-9184-4919-9abe-26df466bc2cb
[after2]: https://github.com/user-attachments/assets/70b73f72-bf14-433f-9138-67f0ce9cf72c
[before3]: https://github.com/user-attachments/assets/72b7acea-445c-4619-b467-f1c7214021d5
[after3]: https://github.com/user-attachments/assets/f6509532-f05c-4603-900e-9aadbda04262