### PR TITLE
Remove weatherapiurl from schema and FEFrontConfigType

### DIFF
--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -241,9 +241,6 @@
                 "discussionD2Uid": {
                     "type": "string"
                 },
-                "weatherapiurl": {
-                    "type": "string"
-                },
                 "googleSearchUrl": {
                     "type": "string"
                 },
@@ -346,7 +343,6 @@
                 "supportUrl",
                 "switches",
                 "userAttributesApiUrl",
-                "weatherapiurl",
                 "webTitle"
             ]
         },

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1131,9 +1131,6 @@
                 "discussionD2Uid": {
                     "type": "string"
                 },
-                "weatherapiurl": {
-                    "type": "string"
-                },
                 "googleSearchUrl": {
                     "type": "string"
                 },
@@ -1236,7 +1233,6 @@
                 "supportUrl",
                 "switches",
                 "userAttributesApiUrl",
-                "weatherapiurl",
                 "webTitle"
             ]
         },

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -520,7 +520,6 @@ export type FEFrontConfigType = {
 	stripePublicToken: string;
 	googleRecaptchaSiteKey: string;
 	discussionD2Uid: string;
-	weatherapiurl: string;
 	googleSearchUrl: string;
 	optimizeEpicUrl: string;
 	stage: StageType;


### PR DESCRIPTION
## Why?

This was missed from the original PR: [Remove Weather component](https://github.com/guardian/dotcom-rendering/pull/12964)
