### PR TITLE
Add audio duration to card models and use in audio pill

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -46,6 +46,7 @@ const basicCardProps: CardProps = {
 	showMainVideo: true,
 	absoluteServerTimes: true,
 	galleryCount: 8,
+	audioDuration: '20:25',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -150,6 +150,7 @@ export type Props = {
 	/** A kicker image is seperate to the main media and renders as part of the kicker */
 	showKickerImage?: boolean;
 	galleryCount?: number;
+	audioDuration?: string;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -385,6 +386,7 @@ export const Card = ({
 	podcastImage,
 	showKickerImage = false,
 	galleryCount,
+	audioDuration,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -464,7 +466,7 @@ export const Card = ({
 		>
 			{mainMedia?.type === 'Audio' && (
 				<Pill
-					content="0:00" // TODO: get podcast duration
+					content={audioDuration ?? ''}
 					icon={<SvgMediaControlsPlay />}
 				/>
 			)}

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -57,6 +57,7 @@ export const FrontCard = (props: Props) => {
 		showMainVideo: trail.showMainVideo,
 		galleryCount: trail.galleryCount,
 		podcastImage: trail.podcastImage,
+		audioDuration: trail.audioDuration,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -329,5 +329,6 @@ export const enhanceCards = (
 			}),
 			podcastImage,
 			galleryCount: faciaCard.card.galleryCount,
+			audioDuration: faciaCard.card.audioDuration,
 		};
 	});

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -1030,6 +1030,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -1781,6 +1784,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
@@ -2532,6 +2538,9 @@
                                                 },
                                                 "galleryCount": {
                                                     "type": "number"
+                                                },
+                                                "audioDuration": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -555,6 +555,9 @@
                             },
                             "galleryCount": {
                                 "type": "number"
+                            },
+                            "audioDuration": {
+                                "type": "string"
                             }
                         },
                         "required": [

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -291,6 +291,7 @@ export type FEFrontCard = {
 		group: string;
 		isLive: boolean;
 		galleryCount?: number;
+		audioDuration?: string;
 	};
 	discussion: {
 		isCommentable: boolean;
@@ -350,6 +351,7 @@ export type DCRFrontCard = {
 	showMainVideo?: boolean;
 	galleryCount?: number;
 	podcastImage?: PodcastSeriesImage;
+	audioDuration?: string;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

Provides the media pill in beta containers with the audio duration value provided by frontend in [this PR](https://github.com/guardian/frontend/pull/27676). 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/23b1c4f8-08a9-43dc-b0b4-edb1a3874351
[after]: https://github.com/user-attachments/assets/a896261a-9705-4ea8-b8b1-1bd29d64501e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
