### PR TITLE
JUST FOR TEST test commit

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -2,6 +2,8 @@
 
 Frontend rendering framework for theguardian.com. It uses [React](https://reactjs.org/), with [Emotion](https://emotion.sh) for styling.
 
+Test
+
 ## Getting started
 
 This guide will help you get the `dotcom-rendering` application running on your development machine.

--- a/dotcom-rendering/src/lib/articleFormat.ts
+++ b/dotcom-rendering/src/lib/articleFormat.ts
@@ -7,6 +7,7 @@ export enum ArticleDesign {
 	Gallery,
 	Audio,
 	Video,
+	Crossword,
 	Review,
 	Analysis,
 	Explainer,
@@ -75,6 +76,8 @@ export const decideDesign = ({ design }: Partial<FEFormat>): ArticleDesign => {
 			return ArticleDesign.Audio;
 		case 'VideoDesign':
 			return ArticleDesign.Video;
+		case 'CrosswordDesign':
+			return ArticleDesign.Crossword;
 		case 'ReviewDesign':
 			return ArticleDesign.Review;
 		case 'AnalysisDesign':
@@ -226,6 +229,8 @@ const designToFEDesign = (design: ArticleDesign): FEDesign => {
 			return 'PictureDesign';
 		case ArticleDesign.Gallery:
 			return 'GalleryDesign';
+		case ArticleDesign.Crossword:
+			return 'CrosswordDesign';
 		case ArticleDesign.Audio:
 			return 'AudioDesign';
 		case ArticleDesign.Video:

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4220,7 +4220,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
-				"CrosswordDesign",
+                "CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -4220,6 +4220,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
+				"CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3055,7 +3055,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
-				"CrosswordDesign",
+                "CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -3055,6 +3055,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
+				"CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1282,6 +1282,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
+				"CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/model/tag-page-schema.json
+++ b/dotcom-rendering/src/model/tag-page-schema.json
@@ -1282,7 +1282,7 @@
                 "ArticleDesign",
                 "AudioDesign",
                 "CommentDesign",
-				"CrosswordDesign",
+                "CrosswordDesign",
                 "DeadBlogDesign",
                 "EditorialDesign",
                 "ExplainerDesign",

--- a/dotcom-rendering/src/types/frontend.ts
+++ b/dotcom-rendering/src/types/frontend.ts
@@ -184,6 +184,7 @@ export type FEDesign =
 	| 'AudioDesign'
 	| 'VideoDesign'
 	| 'ReviewDesign'
+	| 'CrosswordDesign'
 	| 'AnalysisDesign'
 	| 'CommentDesign'
 	| 'ExplainerDesign'


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
