### PR TITLE
Remove unused palette colours

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1953,31 +1953,6 @@ const articleInnerAdBorderLight: PaletteFunction = ({ design, theme }) => {
 
 const adBorderDark: PaletteFunction = () => sourcePalette.neutral[38];
 
-const adSupportBannerBackgroundLight: PaletteFunction = () => {
-	return sourcePalette.neutral[93];
-};
-const adSupportBannerBackgroundDark: PaletteFunction = () => {
-	return sourcePalette.neutral[46];
-};
-const adSupportBannerButtonBackgroundLight: PaletteFunction = () => {
-	return sourcePalette.brand[400];
-};
-const adSupportBannerButtonBackgroundDark: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const adSupportBannerButtonTextLight: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-const adSupportBannerButtonTextDark: PaletteFunction = () => {
-	return sourcePalette.neutral[0];
-};
-const adSupportBannerTextLight: PaletteFunction = () => {
-	return sourcePalette.brand[400];
-};
-const adSupportBannerTextDark: PaletteFunction = () => {
-	return sourcePalette.neutral[100];
-};
-
 const appsFooterLinksTextLight: PaletteFunction = () =>
 	sourcePalette.neutral[7];
 const appsFooterLinksTextDark: PaletteFunction = () =>
@@ -5862,22 +5837,6 @@ const paletteColours = {
 	'--ad-labels-text-article-inner': {
 		light: articleInnerAdLabelsTextLight,
 		dark: adLabelsTextDark,
-	},
-	'--ad-support-banner-background': {
-		light: adSupportBannerBackgroundLight,
-		dark: adSupportBannerBackgroundDark,
-	},
-	'--ad-support-banner-button-background': {
-		light: adSupportBannerButtonBackgroundLight,
-		dark: adSupportBannerButtonBackgroundDark,
-	},
-	'--ad-support-banner-button-text': {
-		light: adSupportBannerButtonTextLight,
-		dark: adSupportBannerButtonTextDark,
-	},
-	'--ad-support-banner-text': {
-		light: adSupportBannerTextLight,
-		dark: adSupportBannerTextDark,
 	},
 	'--affiliate-disclaimer-background': {
 		light: affiliateDisclaimerBackgroundLight,


### PR DESCRIPTION
## What does this change?

Removes palette declarations for:
 - `--ad-support-banner-background`
 - `--ad-support-banner-button-background`
 - `--ad-support-banner-button-text`
 - `--ad-support-banner-text`

## Why?

These colours were not being used anywhere in the codebase

Looks like they were added in https://github.com/guardian/dotcom-rendering/pull/9316 for use in the `AdSlot.apps` file but these colours are no longer used here (they were removed in https://github.com/guardian/dotcom-rendering/pull/12539)