### PR TITLE
Media Cards: Special palette variations for podcast waveform

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1290,21 +1290,22 @@ export const WithSpecialPaletteVariations = () => {
 						isLabs
 							? {
 									display: ArticleDisplay.Standard,
-									design: ArticleDesign.Gallery,
+									design: ArticleDesign.Audio,
 									theme: ArticleSpecial.Labs,
 							  }
 							: {
 									display: ArticleDisplay.Standard,
-									design: ArticleDesign.Gallery,
+									design: ArticleDesign.Audio,
 									theme: Pillar.Lifestyle,
 							  }
 					}
+					headlineText="Audio"
 					kickerText="Kicker"
 					trailText=""
 					imagePositionOnDesktop="top"
 					imagePositionOnMobile="left"
 					imageSize="medium"
-					mainMedia={mainGallery}
+					mainMedia={{ ...mainAudio, duration: 90 }}
 					containerPalette={containerPalette}
 				/>
 			</LI>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -515,7 +515,6 @@ export const Card = ({
 	 * Currently pills are only shown within beta containers.
 	 */
 	const showPill =
-		isBetaContainer &&
 		mainMedia &&
 		(mainMedia.type === 'Audio' || mainMedia.type === 'Gallery');
 
@@ -715,7 +714,7 @@ export const Card = ({
 							cardHasImage={!!image}
 						/>
 					) : null}
-					{!!mainMedia && mainMedia.type !== 'Video' && !showPill && (
+					{!showPill && !!mainMedia && mainMedia.type !== 'Video' && (
 						<MediaMeta
 							mediaType={mainMedia.type}
 							hasKicker={!!kickerText}
@@ -738,7 +737,7 @@ export const Card = ({
 				 * Waveform for podcasts is absolutely positioned at bottom of
 				 * card, behind everything else
 				 */}
-				{isBetaContainer && mainMedia?.type === 'Audio' && (
+				{mainMedia?.type === 'Audio' && (
 					<div
 						css={waveformWrapper(
 							imagePositionOnMobile,
@@ -1014,9 +1013,9 @@ export const Card = ({
 											cardHasImage={!!image}
 										/>
 									) : null}
-									{!!mainMedia &&
-										mainMedia.type !== 'Video' &&
-										!showPill && (
+									{!showPill &&
+										!!mainMedia &&
+										mainMedia.type !== 'Video' && (
 											<MediaMeta
 												mediaType={mainMedia.type}
 												hasKicker={!!kickerText}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -515,6 +515,7 @@ export const Card = ({
 	 * Currently pills are only shown within beta containers.
 	 */
 	const showPill =
+		isBetaContainer &&
 		mainMedia &&
 		(mainMedia.type === 'Audio' || mainMedia.type === 'Gallery');
 
@@ -737,7 +738,7 @@ export const Card = ({
 				 * Waveform for podcasts is absolutely positioned at bottom of
 				 * card, behind everything else
 				 */}
-				{mainMedia?.type === 'Audio' && (
+				{isBetaContainer && mainMedia?.type === 'Audio' && (
 					<div
 						css={waveformWrapper(
 							imagePositionOnMobile,

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -590,14 +590,49 @@ const cardMediaIconLight: ContainerFunction = (containerPalette) =>
 const cardMediaIconDark: ContainerFunction = (containerPalette) =>
 	cardBackgroundDark(containerPalette);
 
-/**
- * TODO: These are placeholder colours based on existing overrides and should
- * be updated when designs have been finalised.
- */
-const cardMediaWaveformLight: ContainerFunction = (containerPalette) =>
-	transparentColour(cardHeadlineLight(containerPalette), 0.2);
-const cardMediaWaveformDark: ContainerFunction = (containerPalette) =>
-	transparentColour(cardHeadlineDark(containerPalette), 0.2);
+const cardMediaWaveformLight: ContainerFunction = (containerPalette) => {
+	switch (containerPalette) {
+		case 'InvestigationPalette':
+		case 'SombrePalette':
+		case 'SombreAltPalette':
+			return sourcePalette.neutral[46];
+		case 'LongRunningPalette':
+		case 'EventPalette':
+		case 'MediaPalette':
+		case 'PodcastPalette':
+		case 'Branded':
+			return sourcePalette.neutral[86];
+		case 'LongRunningAltPalette':
+			return sourcePalette.neutral[73];
+		case 'BreakingPalette':
+			return sourcePalette.news[300];
+		case 'EventAltPalette':
+			return sourcePalette.culture[600];
+		case 'SpecialReportAltPalette':
+			return sourcePalette.specialReportAlt[800];
+	}
+};
+
+const cardMediaWaveformDark: ContainerFunction = (containerPalette) => {
+	switch (containerPalette) {
+		case 'InvestigationPalette':
+		case 'LongRunningAltPalette':
+		case 'SombrePalette':
+		case 'SombreAltPalette':
+		case 'EventPalette':
+		case 'SpecialReportAltPalette':
+		case 'MediaPalette':
+		case 'PodcastPalette':
+		case 'Branded':
+			return sourcePalette.neutral[38];
+		case 'LongRunningPalette':
+			return sourcePalette.brand[400];
+		case 'BreakingPalette':
+			return sourcePalette.news[300];
+		case 'EventAltPalette':
+			return sourcePalette.culture[300];
+	}
+};
 
 const sectionBackgroundLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -590,6 +590,15 @@ const cardMediaIconLight: ContainerFunction = (containerPalette) =>
 const cardMediaIconDark: ContainerFunction = (containerPalette) =>
 	cardBackgroundDark(containerPalette);
 
+/**
+ * TODO: These are placeholder colours based on existing overrides and should
+ * be updated when designs have been finalised.
+ */
+const cardMediaWaveformLight: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineLight(containerPalette), 0.2);
+const cardMediaWaveformDark: ContainerFunction = (containerPalette) =>
+	transparentColour(cardHeadlineDark(containerPalette), 0.2);
+
 const sectionBackgroundLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
 		case 'InvestigationPalette':
@@ -1086,6 +1095,10 @@ const containerColours = {
 	'--card-media-icon': {
 		light: cardMediaIconLight,
 		dark: cardMediaIconDark,
+	},
+	'--card-media-waveform': {
+		light: cardMediaWaveformLight,
+		dark: cardMediaWaveformDark,
 	},
 	'--card-sublinks-background': {
 		light: cardSublinksBackgroundLight,


### PR DESCRIPTION
## What does this change?

Adds special palette overrides for audio waveform displayed on podcast media cards

## Why?

So podcast media cards display correctly when placed in a container with a special palette

## Screenshots

