### PR TITLE
Better loading container for Most Viewed component at end of articles 

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -7,7 +7,7 @@ import { useApi } from '../lib/useApi';
 import { palette } from '../palette';
 import type { FETrailTabType, TrailTabType } from '../types/trails';
 import { MostViewedFooter } from './MostViewedFooter.importable';
-import { Placeholder } from './Placeholder';
+import { MostViewedFooterPlaceholder } from './MostViewedFooterPlaceholder';
 
 interface Props {
 	sectionId?: string;
@@ -72,13 +72,17 @@ export const MostViewedFooterData = ({
 	const variantFromRunnable = runnableTest?.variantToRun.id ?? 'not-runnable';
 
 	const url = buildSectionUrl(ajaxUrl, edition, sectionId);
-	const { data, error } = useApi<
+	const { data, loading, error } = useApi<
 		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);
 
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
 		return null;
+	}
+
+	if (loading) {
+		return <MostViewedFooterPlaceholder />;
 	}
 
 	if (data) {
@@ -94,5 +98,5 @@ export const MostViewedFooterData = ({
 		);
 	}
 
-	return <Placeholder height={360} />;
+	return null;
 };

--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.stories.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.stories.tsx
@@ -1,0 +1,22 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MostViewedFooterPlaceholder as MostViewedFooterPlaceholderComponent } from './MostViewedFooterPlaceholder';
+
+const meta = {
+	component: MostViewedFooterPlaceholderComponent,
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+} satisfies Meta<typeof MostViewedFooterPlaceholderComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MostViewedFooterPlaceholder = {} satisfies Story;

--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
@@ -1,0 +1,64 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
+import { palette } from '../palette';
+import { BigNumber } from './BigNumber';
+
+/**
+ * A tab list is usually rendered above the list items.
+ * We reduce CLS for the majority of page views by expecting them to be rendered.
+ */
+const tabs = css`
+	height: 44px;
+	border-left: 1px solid var(--article-border);
+`;
+
+const listContainer = css`
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-template-rows: repeat(10, 70px);
+	grid-auto-flow: column;
+
+	${from.mobileLandscape} {
+		grid-template-columns: 1fr;
+		grid-template-rows: repeat(10, 60px);
+	}
+
+	${from.tablet} {
+		grid-template-columns: 1fr 1fr;
+		grid-template-rows: repeat(5, 80px);
+	}
+`;
+
+const listItem = css`
+	position: relative;
+	border-top: 1px solid var(--article-border);
+	border-left: 1px solid var(--article-border);
+	border-right: 1px solid var(--article-border);
+`;
+
+const bigNumber = css`
+	position: absolute;
+	top: 6px;
+	left: 10px;
+	fill: ${palette('--article-text')};
+	svg {
+		height: 40px;
+	}
+`;
+
+export const MostViewedFooterPlaceholder = () => {
+	return (
+		<>
+			<div css={tabs} />
+			<ol css={listContainer}>
+				{Array.from(Array(10), (_, i) => (
+					<li key={i} css={listItem}>
+						<span css={bigNumber}>
+							<BigNumber index={i + 1} />
+						</span>
+					</li>
+				))}
+			</ol>
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
@@ -17,6 +17,7 @@ const listContainer = css`
 	grid-template-columns: 1fr;
 	grid-template-rows: repeat(10, 70px);
 	grid-auto-flow: column;
+	border-left: 1px solid var(--article-border);
 
 	${from.mobileLandscape} {
 		grid-template-columns: 1fr;
@@ -32,7 +33,6 @@ const listContainer = css`
 const listItem = css`
 	position: relative;
 	border-top: 1px solid var(--article-border);
-	border-left: 1px solid var(--article-border);
 	border-right: 1px solid var(--article-border);
 `;
 


### PR DESCRIPTION
Closes #13050

## What does this change?

Introduces a new loading container for the Most Viewed component that appears at the end of article pages.

Adds a Chromatic story for this component at three breakpoints.

## Why?

Better UX. A large loading container does not indicate to the user anything about the content that is loading. This could lead the user to thinking the page is "broken" when on weaker network connections, when this loading container may be displayed for several seconds. This is especially true in this case as the two onwards content carousels above this component can also have this loading placeholder.

Reduced CLS. The height of the current placeholder is set to 360px for this component, regardless of screen size. The component when loaded does not have a fixed height (it depends on the text in the links), but there is a strong correlation between the screen size and component height. For example, the component is a lot taller on mobile than on tablet, as the content is divided into two columns from the tablet breakpoint. If the height of the loading component more closely matches the height of the component when loaded, CLS will be reduced.

## Screenshots

| <img width=420 /> | Loading (before)      | Loading (after)      | Loaded      |
| --- | ----------- | ---------- | ---------- |
| mobile | ![mobile-before][] | ![mobile-after][] | ![mobile-loaded][] |
| tablet (dark) | ![tablet-before][] | ![tablet-after][] | ![tablet-loaded][] |
| desktop | ![desktop-before][] | ![desktop-after][] | ![desktop-loaded][] |
| wide | ![wide-before][] | ![wide-after][] | ![wide-loaded][] |

[mobile-before]: https://github.com/user-attachments/assets/3d14df93-e5f6-4c1c-9738-2dec7ee82903
[mobile-after]: https://github.com/user-attachments/assets/638c2b25-cb84-40d0-a9b1-26e6dbbf7774
[mobile-loaded]: https://github.com/user-attachments/assets/524d50b9-40b4-4001-b56d-d2d0aeca6e3a
[tablet-before]: https://github.com/user-attachments/assets/a622dd34-7dfe-44f2-ac9e-34955b1e9e22
[tablet-after]: https://github.com/user-attachments/assets/b48ae64f-2a74-4c4b-abc0-30d105506261
[tablet-loaded]: https://github.com/user-attachments/assets/57e99878-013c-4853-a36c-dc4d37157684
[desktop-before]: https://github.com/user-attachments/assets/a9bad359-2a6e-44d6-aff3-cf887b257b9d
[desktop-after]: https://github.com/user-attachments/assets/007e9432-36a8-4a68-92c7-b5da6a164da0
[desktop-loaded]: https://github.com/user-attachments/assets/06ada4f6-635d-4e1e-a9a6-4da630137767
[wide-before]: https://github.com/user-attachments/assets/fb5eb720-df38-4f00-a09f-1048da52ed84
[wide-after]: https://github.com/user-attachments/assets/2227a1db-ff46-4a1a-84bd-ab9697a696e7
[wide-loaded]: https://github.com/user-attachments/assets/fa0d071f-f16f-423d-90bb-3d57914ccfd9

https://github.com/user-attachments/assets/2b3320da-891d-45f6-a22c-1ce5dabba1b7

## Data

I took the height of the Most Viewed component (excluding section header) for rendered content, the old placeholder and the new placeholder, at each of our breakpoints. Note that the rendered content does not have a fixed height, i.e. it is not always 762px tall on MobileMedium, but it was at 10:30am 14/01/2025. This shows that CLS will be reduced at all breakpoints.

Height (px) | Loaded | Old placeholder | New placeholder
-- | -- | -- | --
Wide | 467 | 360 | 444
Left-col | 525 | 360 | 444
Desktop | 525 | 360 | 444
Tablet | 466 | 360 | 444
MobileLandscape (600px) | 646 | 360 | 653
MobileMedium (420px) | 762 | 360 | 753
Mobile (350px) | 896 | 360 | 753