### PR TITLE
Fix primary container overlap bug

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -365,6 +365,7 @@ const primaryLevelTopBorder = css`
 	border-top: 2px solid ${schemePalette('--section-border-primary')};
 	/** Ensures the top border sits above the side borders */
 	z-index: 1;
+	height: fit-content;
 `;
 
 const secondaryLevelTopBorder = css`


### PR DESCRIPTION
## What does this change?
Restricts the height of a primary container border so that it doesnt overlap other content such as nav buttons. 

## Why?
This overhang covered scrollable buttons and prevented clicks. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/98a68a24-d0da-47d2-88e5-b990a201ead8
[after]: https://github.com/user-attachments/assets/e2f218a4-dca5-4b0e-997f-e072d46b47f0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
