### PR TITLE
Change vertical gap to 4px in beta containers

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -604,6 +604,13 @@ export const Card = ({
 		) {
 			return 'large';
 		}
+		if (
+			isBetaContainer &&
+			(imagePositionOnDesktop === 'top' ||
+				imagePositionOnDesktop === 'bottom')
+		) {
+			return 'tiny';
+		}
 		return 'small';
 	};
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -52,7 +52,7 @@ import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
-import { CardLayout, type GapSize } from './components/CardLayout';
+import { CardLayout, type GapSizes } from './components/CardLayout';
 import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
@@ -587,31 +587,51 @@ export const Card = ({
 	};
 
 	/** Determines the gap of between card components based on card properties */
-	const getGapSize = (): GapSize => {
-		if (isOnwardContent) return 'none';
-		if (isMediaCard && !isFlexibleContainer) return 'tiny';
-		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
-			return 'small';
+	const getGapSizes = (): GapSizes => {
+		if (isOnwardContent) {
+			return {
+				row: 'none',
+				column: 'none',
+			};
 		}
-		if (isSmallCard) return 'medium';
+		if (isMediaCard && !isFlexibleContainer) {
+			return {
+				row: 'tiny',
+				column: 'tiny',
+			};
+		}
+		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
+			return {
+				row: 'small',
+				column: 'small',
+			};
+		}
+		if (isSmallCard) {
+			return {
+				row: 'medium',
+				column: 'medium',
+			};
+		}
 		if (isBetaContainer && media?.type === 'avatar') {
-			return 'small';
+			return {
+				row: 'small',
+				column: 'small',
+			};
 		}
 		if (
 			isFlexibleContainer &&
 			(imagePositionOnDesktop === 'left' ||
 				imagePositionOnDesktop === 'right')
 		) {
-			return 'large';
+			return {
+				row: 'large',
+				column: 'large',
+			};
 		}
-		if (
-			isBetaContainer &&
-			(imagePositionOnDesktop === 'top' ||
-				imagePositionOnDesktop === 'bottom')
-		) {
-			return 'tiny';
-		}
-		return 'small';
+		return {
+			row: isBetaContainer ? 'tiny' : 'small',
+			column: 'small',
+		};
 	};
 
 	/**
@@ -738,7 +758,7 @@ export const Card = ({
 				minWidthInPixels={minWidthInPixels}
 				imageType={media?.type}
 				containerType={containerType}
-				gapSize={getGapSize()}
+				gapSizes={getGapSizes()}
 				isBetaContainer={isBetaContainer}
 			>
 				{/**

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -9,6 +9,8 @@ const padding = 20;
 
 export type GapSize = 'none' | 'tiny' | 'small' | 'medium' | 'large';
 
+export type GapSizes = { row: GapSize; column: GapSize };
+
 type Props = {
 	children: React.ReactNode;
 	cardBackgroundColour: string;
@@ -17,7 +19,7 @@ type Props = {
 	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
 	containerType?: DCRContainerType;
-	gapSize?: GapSize;
+	gapSizes?: GapSizes;
 	isBetaContainer: boolean;
 };
 
@@ -162,27 +164,30 @@ export const CardLayout = ({
 	minWidthInPixels,
 	imageType,
 	containerType,
-	gapSize = 'small',
+	gapSizes = { row: 'small', column: 'small' },
 	isBetaContainer,
-}: Props) => (
-	<div
-		css={[
-			containerStyles,
-			containerType === 'fixed/video'
-				? videoWidth
-				: minWidth(minWidthInPixels),
-			decidePosition(
-				imagePositionOnMobile,
-				imagePositionOnDesktop,
-				isBetaContainer,
-				imageType === 'avatar',
-			),
-		]}
-		style={{
-			backgroundColor: cardBackgroundColour,
-			gap: decideGap(gapSize),
-		}}
-	>
-		{children}
-	</div>
-);
+}: Props) => {
+	return (
+		<div
+			css={[
+				containerStyles,
+				containerType === 'fixed/video'
+					? videoWidth
+					: minWidth(minWidthInPixels),
+				decidePosition(
+					imagePositionOnMobile,
+					imagePositionOnDesktop,
+					isBetaContainer,
+					imageType === 'avatar',
+				),
+			]}
+			style={{
+				backgroundColor: cardBackgroundColour,
+				rowGap: decideGap(gapSizes.row),
+				columnGap: decideGap(gapSizes.column),
+			}}
+		>
+			{children}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -19,7 +19,7 @@ type Props = {
 	imagePositionOnMobile: ImagePositionType;
 	minWidthInPixels?: number;
 	containerType?: DCRContainerType;
-	gapSizes?: GapSizes;
+	gapSizes: GapSizes;
 	isBetaContainer: boolean;
 };
 
@@ -164,7 +164,7 @@ export const CardLayout = ({
 	minWidthInPixels,
 	imageType,
 	containerType,
-	gapSizes = { row: 'small', column: 'small' },
+	gapSizes,
 	isBetaContainer,
 }: Props) => {
 	return (


### PR DESCRIPTION
## What does this change?
For cards belonging to a beta container, we want to reduce the vertical gap between the image and the meta (i.e. comment count) to tiny (4px).

To achieve this, I have separated out _row_ gaps (vertical) from _column_ gaps (horizontal). These should be the same except for the new desired condition.

The new condition is low down in the priority order. This means there will be some exceptions to this condition, e.g. a 'scrollable small' container is a beta container, but prefers a medium size gap.

I am unsure if this priority order is correct - would be good to have another pair of eyes.

## Why?
Design spec.

## Screenshots
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/554e1c26-a4e9-4236-be65-4e1953f9d8bd
[after]: https://github.com/user-attachments/assets/68afe966-7d40-4f2b-9ea3-d3032d2c200b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
