### PR TITLE
Fix separator styling for list elements

### DIFF
--- a/dotcom-rendering/src/components/KeyTakeaways.tsx
+++ b/dotcom-rendering/src/components/KeyTakeaways.tsx
@@ -28,6 +28,7 @@ interface KeyTakeawaysProps {
 }
 
 const separatorStyles = css`
+	border: none;
 	width: 140px;
 	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette('--article-border')};

--- a/dotcom-rendering/src/components/MiniProfiles.tsx
+++ b/dotcom-rendering/src/components/MiniProfiles.tsx
@@ -29,6 +29,7 @@ interface MiniProfilesProps {
 }
 
 const separatorStyles = css`
+	border: none;
 	width: 140px;
 	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette('--article-border')};

--- a/dotcom-rendering/src/components/MultiBylines.tsx
+++ b/dotcom-rendering/src/components/MultiBylines.tsx
@@ -31,6 +31,7 @@ interface MultiBylineProps {
 }
 
 const separatorStyles = css`
+	border: none;
 	width: 140px;
 	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette('--article-border')};

--- a/dotcom-rendering/src/components/QAndAExplainers.tsx
+++ b/dotcom-rendering/src/components/QAndAExplainers.tsx
@@ -28,6 +28,7 @@ interface Props {
 }
 
 const separatorStyles = css`
+	border: none;
 	width: 140px;
 	margin: 8px 0 2px 0;
 	border-top: 1px solid ${palette('--article-border')};


### PR DESCRIPTION
## What does this change?

Makes a tiny improvement in the appearance of the horizontal rule which goes between list elements and closing copy.

## Why?

In response to the following feedback from Rich:

> With the horizontal rule appearing before the closing copy, it looks like it's missing some styling. It should be 1px deep, not 2px. Also I think there is a odd thing with the colouring where a small pixel of black is appearing to the left. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="197" alt="Screenshot 2025-01-13 at 16 40 13" src="https://github.com/user-attachments/assets/bbb68d60-585c-45f7-beb4-44f29192ecbf" /> | <img width="197" alt="Screenshot 2025-01-13 at 16 40 31" src="https://github.com/user-attachments/assets/21ca1f31-0a2c-47c8-b301-f1c045359a70" /> |
