### PR TITLE
wip max items to display flex gen

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -43,6 +43,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	maxItemsToDisplay?: number;
 };
 
 export const DecideContainer = ({
@@ -54,6 +55,7 @@ export const DecideContainer = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	maxItemsToDisplay,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -257,6 +259,7 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
+					maxItemsToDisplay={maxItemsToDisplay}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -28,6 +28,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	maxItemsToDisplay?: number;
 };
 
 type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
@@ -443,9 +444,12 @@ export const FlexibleGeneral = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	maxItemsToDisplay,
 }: Props) => {
+	console.log('maxItemsToDisplay', maxItemsToDisplay);
 	const splash = [...groupedTrails.splash].slice(0, 1);
-	const cards = [...groupedTrails.standard].slice(0, 8);
+	const cardNumber = maxItemsToDisplay ?? 8;
+	const cards = [...groupedTrails.standard].slice(0, cardNumber);
 	const groupedCards = decideCardPositions(cards);
 
 	return (

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -278,6 +278,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					</Island>
 				)}
 				{filteredCollections.map((collection, index) => {
+					console.log('collection', collection);
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(
 						collection.backfill,
@@ -513,6 +514,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												collection.collectionType,
 											)
 										}
+										maxItemsToDisplay={
+											collection.config.displayHints
+												?.maxItemsToDisplay
+										}
 									/>
 								</LabsSection>
 								{decideMerchHighAndMobileAdSlots(
@@ -681,6 +686,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										fallbackAspectRatio(
 											collection.collectionType,
 										)
+									}
+									maxItemsToDisplay={
+										collection.config.displayHints
+											?.maxItemsToDisplay
 									}
 								/>
 							</FrontSection>

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -136,6 +136,10 @@ export const enhanceCollections = ({
 			),
 			config: {
 				showDateHeader: collection.config.showDateHeader,
+				displayHints: {
+					maxItemsToDisplay:
+						collection.config.displayHints?.maxItemsToDisplay,
+				},
 			},
 			canShowMore: hasMore && !collection.config.hideShowMore,
 			targetedTerritory: collection.targetedTerritory,

--- a/dotcom-rendering/src/model/front-schema.json
+++ b/dotcom-rendering/src/model/front-schema.json
@@ -2836,6 +2836,14 @@
                                     "platform": {
                                         "type": "string"
                                     },
+                                    "displayHints": {
+                                        "type": "object",
+                                        "properties": {
+                                            "maxItemsToDisplay": {
+                                                "type": "number"
+                                            }
+                                        }
+                                    },
                                     "aspectRatio": {
                                         "$ref": "#/definitions/AspectRatio"
                                     }

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -390,6 +390,9 @@ type FECollectionConfigType = {
 	showTimestamps: boolean;
 	hideShowMore: boolean;
 	platform: string;
+	displayHints?: {
+		maxItemsToDisplay?: number;
+	};
 	aspectRatio?: AspectRatio;
 };
 
@@ -430,6 +433,9 @@ export type DCRCollectionType = {
 	href?: string;
 	config: {
 		showDateHeader: boolean;
+		displayHints?: {
+			maxItemsToDisplay?: number;
+		};
 	};
 	/**
 	 * @property {?boolean} canShowMore - Whether the 'show more' button should be shown.


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
