### PR TITLE
Placeholder testing [DO NOT MERGE]

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -76,6 +76,10 @@ export const MostViewedFooterData = ({
 		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);
 
+	console.log('error', error);
+	console.log('loading', loading);
+	console.log('data', data);
+
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
 		return null;

--- a/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterData.importable.tsx
@@ -7,7 +7,7 @@ import { useApi } from '../lib/useApi';
 import { palette } from '../palette';
 import type { FETrailTabType, TrailTabType } from '../types/trails';
 import { MostViewedFooter } from './MostViewedFooter.importable';
-import { Placeholder } from './Placeholder';
+import { MostViewedFooterPlaceholder } from './MostViewedFooterPlaceholder';
 
 interface Props {
 	sectionId?: string;
@@ -72,13 +72,17 @@ export const MostViewedFooterData = ({
 	const variantFromRunnable = runnableTest?.variantToRun.id ?? 'not-runnable';
 
 	const url = buildSectionUrl(ajaxUrl, edition, sectionId);
-	const { data, error } = useApi<
+	const { data, loading, error } = useApi<
 		MostViewedFooterPayloadType | FETrailTabType[]
 	>(url);
 
 	if (error) {
 		window.guardian.modules.sentry.reportError(error, 'most-viewed-footer');
 		return null;
+	}
+
+	if (loading) {
+		return <MostViewedFooterPlaceholder />;
 	}
 
 	if (data) {
@@ -94,5 +98,5 @@ export const MostViewedFooterData = ({
 		);
 	}
 
-	return <Placeholder height={360} />;
+	return null;
 };

--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.stories.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.stories.tsx
@@ -1,0 +1,22 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MostViewedFooterPlaceholder as MostViewedFooterPlaceholderComponent } from './MostViewedFooterPlaceholder';
+
+const meta = {
+	component: MostViewedFooterPlaceholderComponent,
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
+} satisfies Meta<typeof MostViewedFooterPlaceholderComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MostViewedFooterPlaceholder = {} satisfies Story;

--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
@@ -1,0 +1,64 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
+import { palette } from '../palette';
+import { BigNumber } from './BigNumber';
+
+/**
+ * A tab list is usually rendered above the list items.
+ * We reduce CLS for the majority of page views by expecting them to be rendered.
+ */
+const tabs = css`
+	height: 44px;
+	border-left: 1px solid var(--article-border);
+`;
+
+const listContainer = css`
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-template-rows: repeat(10, 70px);
+	grid-auto-flow: column;
+
+	${from.mobileLandscape} {
+		grid-template-columns: 1fr;
+		grid-template-rows: repeat(10, 60px);
+	}
+
+	${from.tablet} {
+		grid-template-columns: 1fr 1fr;
+		grid-template-rows: repeat(5, 80px);
+	}
+`;
+
+const listItem = css`
+	position: relative;
+	border-top: 1px solid var(--article-border);
+	border-left: 1px solid var(--article-border);
+	border-right: 1px solid var(--article-border);
+`;
+
+const bigNumber = css`
+	position: absolute;
+	top: 6px;
+	left: 10px;
+	fill: ${palette('--article-text')};
+	svg {
+		height: 40px;
+	}
+`;
+
+export const MostViewedFooterPlaceholder = () => {
+	return (
+		<>
+			<div css={tabs} />
+			<ol css={listContainer}>
+				{Array.from(Array(10), (_, i) => (
+					<li key={i} css={listItem}>
+						<span css={bigNumber}>
+							<BigNumber index={i + 1} />
+						</span>
+					</li>
+				))}
+			</ol>
+		</>
+	);
+};


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
