### PR TITLE
Bump end value of standard cards slice in flex gen

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -445,7 +445,7 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
-	const cards = [...groupedTrails.standard].slice(0, 8);
+	const cards = [...groupedTrails.standard].slice(0, 19);
 	const groupedCards = decideCardPositions(cards);
 
 	return (


### PR DESCRIPTION
## What does this change?

The upper limit of the number of flexible general stories is being bumped as part of [this fronts tool PR](https://github.com/guardian/facia-tool/pull/1746) (which enables editorial to dynamically set the number of visible stories for flexible general).

The maximum number of stories visible is being limited in by the number of cards in an array in the flexible general component, so we need to increase it in line with the new upper limit of 20. 

The only chromatic diffs were for flexible general stories, which are now displaying the maximum of 20 stories (which I'm preferring to setting a limit in the story args, in case this helps surface any issues about the number of stories getting displayed on this container).

## Why?

Part of this [curation ticket](https://trello.com/c/EfocPE97/854-flexible-general-tooling-respect-story-limit-on-web)

## Screenshots

A flexible general container showing 12 standard stories:

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/d9902ef5-7fde-4932-aab4-c733e4d19d89" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
