### PR TITLE
Replace hardcoded blog colours in palette

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1052,9 +1052,7 @@ const datelineDark: PaletteFunction = ({ design, theme }) => {
 const headlineBorder: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
-			return 'rgba(255,255,255, 0.2)';
-		case ArticleDesign.DeadBlog:
-			return '#CDCDCD';
+			return transparentColour(sourcePalette.neutral[100], 0.2);
 		default:
 			return sourcePalette.neutral[86];
 	}
@@ -2282,9 +2280,7 @@ const standfirstBackgroundDark: PaletteFunction = ({ design, theme }) => {
 const standfirstBorder: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
-			return 'rgba(255,255,255, 0.2)';
-		case ArticleDesign.DeadBlog:
-			return '#BDBDBD';
+			return transparentColour(sourcePalette.neutral[100], 0.2);
 		default:
 			return sourcePalette.neutral[86];
 	}


### PR DESCRIPTION
## What does this change?

Replaces hardcoded 'one-off' colours for liveblogs and deadblogs with colours from the Source palette.

## Why?

To improve visual consistency and simplify maintenance of the colour palette.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f9e566b0-5034-4d78-a6a3-f11f226b2fb0
[after]: https://github.com/user-attachments/assets/d7f64218-952e-43e7-a352-5512d402ac8e