### PR TITLE
Create stories for web ad slots

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -1,33 +1,66 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/test';
+import { css } from '@emotion/react';
+import { remSpace, textSans14 } from '@guardian/source/foundations';
 import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
-import { allModes } from '../../.storybook/modes';
 import { AdSlot } from './AdSlot.web';
+import { palette } from '../palette';
 import { ArticleDisplay } from '../lib/articleFormat';
+import { createRoot } from 'react-dom/client';
 
 const meta = {
 	component: AdSlot,
 	title: 'Components/Ad Slot (web)',
 	decorators: [rightColumnDecorator],
-	parameters: {
-		chromatic: {
-			modes: {
-				'vertical mobileMedium': allModes['vertical mobileMedium'],
-				'light desktop': allModes['light desktop'],
-			},
-		},
-		viewport: {
-			defaultViewport: 'mobileMedium',
-		},
-	},
 } satisfies Meta<typeof AdSlot>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const adLabelsStyles = css`
+	${textSans14}
+	padding: ${remSpace[3]};
+	float: left;
+	display: flex;
+	justify-content: center;
+
+	/* We need to account for padding on both sides */
+	width: calc(100% - 2 * ${remSpace[3]});
+
+	p {
+		margin: 0;
+		float: left;
+		font-size: 16px;
+		font-weight: 400;
+		color: ${palette('--ad-labels-text')};
+	}
+`;
+
+const adSlotStyles = css`
+	clear: both;
+	padding-bottom: 258px;
+	width: 100%;
+`;
+
 export const RightStandard = {
 	args: {
 		position: 'right',
 		display: ArticleDisplay.Standard,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId('slot');
+
+		const root = createRoot(slot);
+
+		root.render(
+			<aside>
+				<div css={adLabelsStyles}>
+					<p>Advertisement</p>
+				</div>
+				<div css={adSlotStyles}></div>
+			</aside>,
+		);
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -9,7 +9,6 @@ import {
 	rightColumnDecorator,
 } from '../../.storybook/decorators/gridDecorators';
 import { ArticleDisplay } from '../lib/articleFormat';
-import { palette } from '../palette';
 import { AdSlot } from './AdSlot.web';
 
 const meta = {
@@ -31,31 +30,37 @@ const adLabelsStyles = css`
 		margin: 0;
 		font-size: 16px;
 		font-weight: 400;
-		color: ${palette('--ad-labels-text')};
 	}
 `;
 
-const rightAdSlotStyles = css`
+const squareAdStyles = css`
 	padding-bottom: 250px;
 	width: 300px;
 `;
 
-const topAboveNavAdSlotStyles = css`
+const bannerAdStyles = css`
 	padding-bottom: 250px;
 	width: 100%;
 `;
 
-function renderTestAd(adStyles: SerializedStyles, slot: HTMLElement) {
-	const root = createRoot(slot);
+function renderTestAd(
+	adStyles: SerializedStyles,
+	slotId = 'slot',
+): Story['play'] {
+	return async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId(slotId);
+		const root = createRoot(slot);
 
-	root.render(
-		<aside>
-			<div css={adLabelsStyles}>
-				<p>Advertisement</p>
-			</div>
-			<div css={adStyles}></div>
-		</aside>,
-	);
+		root.render(
+			<aside>
+				<div css={adLabelsStyles}>
+					<p>Advertisement</p>
+				</div>
+				<div css={adStyles}></div>
+			</aside>,
+		);
+	};
 }
 
 export const Right = {
@@ -64,24 +69,14 @@ export const Right = {
 		display: ArticleDisplay.Standard,
 	},
 	decorators: [rightColumnDecorator],
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const slot = await canvas.findByTestId('slot');
-
-		renderTestAd(rightAdSlotStyles, slot);
-	},
+	play: renderTestAd(squareAdStyles),
 } satisfies Story;
 
 export const TopAboveNav = {
 	args: {
 		position: 'top-above-nav',
 	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const slot = await canvas.findByTestId('slot');
-
-		renderTestAd(topAboveNavAdSlotStyles, slot);
-	},
+	play: renderTestAd(bannerAdStyles),
 } satisfies Story;
 
 export const FrontsBanner = {
@@ -89,12 +84,7 @@ export const FrontsBanner = {
 		position: 'fronts-banner',
 		index: 1,
 	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const slot = await canvas.findByTestId('slot');
-
-		renderTestAd(topAboveNavAdSlotStyles, slot);
-	},
+	play: renderTestAd(bannerAdStyles),
 } satisfies Story;
 
 export const LiveblogInline = {
@@ -103,12 +93,7 @@ export const LiveblogInline = {
 		index: 0,
 	},
 	decorators: [centreColumnDecorator],
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const slot = await canvas.findByTestId('liveblog-inline--inline1');
-
-		renderTestAd(topAboveNavAdSlotStyles, slot);
-	},
+	play: renderTestAd(bannerAdStyles, 'liveblog-inline--inline1'),
 } satisfies Story;
 
 export const Merchandising = {
@@ -116,10 +101,5 @@ export const Merchandising = {
 		position: 'merchandising',
 	},
 	decorators: [centreColumnDecorator],
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const slot = await canvas.findByTestId('slot');
-
-		renderTestAd(topAboveNavAdSlotStyles, slot);
-	},
+	play: renderTestAd(bannerAdStyles),
 } satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -1,12 +1,13 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { within } from '@storybook/test';
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { remSpace, textSans14 } from '@guardian/source/foundations';
-import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
-import { AdSlot } from './AdSlot.web';
-import { palette } from '../palette';
-import { ArticleDisplay } from '../lib/articleFormat';
+import type { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/test';
 import { createRoot } from 'react-dom/client';
+import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { ArticleDisplay } from '../lib/articleFormat';
+import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
 
 const meta = {
 	component: AdSlot,
@@ -37,13 +38,26 @@ const adLabelsStyles = css`
 	}
 `;
 
-const adSlotStyles = css`
+const rightAdSlotStyles = css`
 	clear: both;
 	padding-bottom: 258px;
 	width: 100%;
 `;
 
-export const RightStandard = {
+function renderTestAd(adStyles: SerializedStyles, slot: HTMLElement) {
+	const root = createRoot(slot);
+
+	root.render(
+		<aside>
+			<div css={adLabelsStyles}>
+				<p>Advertisement</p>
+			</div>
+			<div css={adStyles}></div>
+		</aside>,
+	);
+}
+
+export const Right = {
 	args: {
 		position: 'right',
 		display: ArticleDisplay.Standard,
@@ -52,15 +66,6 @@ export const RightStandard = {
 		const canvas = within(canvasElement);
 		const slot = await canvas.findByTestId('slot');
 
-		const root = createRoot(slot);
-
-		root.render(
-			<aside>
-				<div css={adLabelsStyles}>
-					<p>Advertisement</p>
-				</div>
-				<div css={adSlotStyles}></div>
-			</aside>,
-		);
+		renderTestAd(rightAdSlotStyles, slot);
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -12,7 +12,6 @@ import { AdSlot } from './AdSlot.web';
 const meta = {
 	component: AdSlot,
 	title: 'Components/Ad Slot (web)',
-	decorators: [rightColumnDecorator],
 } satisfies Meta<typeof AdSlot>;
 
 export default meta;
@@ -22,16 +21,11 @@ type Story = StoryObj<typeof meta>;
 const adLabelsStyles = css`
 	${textSans14}
 	padding: ${remSpace[3]};
-	float: left;
 	display: flex;
 	justify-content: center;
-
-	/* We need to account for padding on both sides */
-	width: calc(100% - 2 * ${remSpace[3]});
-
+	width: 100%;
 	p {
 		margin: 0;
-		float: left;
 		font-size: 16px;
 		font-weight: 400;
 		color: ${palette('--ad-labels-text')};
@@ -39,8 +33,12 @@ const adLabelsStyles = css`
 `;
 
 const rightAdSlotStyles = css`
-	clear: both;
-	padding-bottom: 258px;
+	padding-bottom: 250px;
+	width: 300px;
+`;
+
+const topAboveNavAdSlotStyles = css`
+	padding-bottom: 250px;
 	width: 100%;
 `;
 
@@ -62,10 +60,23 @@ export const Right = {
 		position: 'right',
 		display: ArticleDisplay.Standard,
 	},
+	decorators: [rightColumnDecorator],
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const slot = await canvas.findByTestId('slot');
 
 		renderTestAd(rightAdSlotStyles, slot);
+	},
+} satisfies Story;
+
+export const TopAboveNav = {
+	args: {
+		position: 'top-above-nav',
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId('slot');
+
+		renderTestAd(topAboveNavAdSlotStyles, slot);
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -4,7 +4,10 @@ import { remSpace, textSans14 } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within } from '@storybook/test';
 import { createRoot } from 'react-dom/client';
-import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import {
+	centreColumnDecorator,
+	rightColumnDecorator,
+} from '../../.storybook/decorators/gridDecorators';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { palette } from '../palette';
 import { AdSlot } from './AdSlot.web';
@@ -73,6 +76,46 @@ export const TopAboveNav = {
 	args: {
 		position: 'top-above-nav',
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId('slot');
+
+		renderTestAd(topAboveNavAdSlotStyles, slot);
+	},
+} satisfies Story;
+
+export const FrontsBanner = {
+	args: {
+		position: 'fronts-banner',
+		index: 1,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId('slot');
+
+		renderTestAd(topAboveNavAdSlotStyles, slot);
+	},
+} satisfies Story;
+
+export const LiveblogInline = {
+	args: {
+		position: 'liveblog-inline',
+		index: 0,
+	},
+	decorators: [centreColumnDecorator],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const slot = await canvas.findByTestId('liveblog-inline--inline1');
+
+		renderTestAd(topAboveNavAdSlotStyles, slot);
+	},
+} satisfies Story;
+
+export const Merchandising = {
+	args: {
+		position: 'merchandising',
+	},
+	decorators: [centreColumnDecorator],
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const slot = await canvas.findByTestId('slot');

--- a/dotcom-rendering/src/components/AdSlot.web.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { rightColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
+import { AdSlot } from './AdSlot.web';
+import { ArticleDisplay } from '../lib/articleFormat';
+
+const meta = {
+	component: AdSlot,
+	title: 'Components/Ad Slot (web)',
+	decorators: [rightColumnDecorator],
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+				'light desktop': allModes['light desktop'],
+			},
+		},
+		viewport: {
+			defaultViewport: 'mobileMedium',
+		},
+	},
+} satisfies Meta<typeof AdSlot>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const RightStandard = {
+	args: {
+		position: 'right',
+		display: ArticleDisplay.Standard,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -397,6 +397,7 @@ export const AdSlot = ({
 								].join(' ')}
 								data-link-name="ad slot right"
 								data-name="right"
+								data-testid="slot"
 								aria-hidden="true"
 							/>
 						</div>
@@ -422,6 +423,7 @@ export const AdSlot = ({
 								].join(' ')}
 								data-link-name="ad slot right"
 								data-name="right"
+								data-testid="slot"
 								aria-hidden="true"
 							/>
 						</div>
@@ -505,6 +507,7 @@ export const AdSlot = ({
 						].join(' ')}
 						data-link-name="ad slot comments"
 						data-name="comments"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -552,6 +555,7 @@ export const AdSlot = ({
 							css={[mostPopAdStyles]}
 							data-link-name="ad slot mostpop"
 							data-name="mostpop"
+							data-testid="slot"
 							aria-hidden="true"
 						/>
 					</div>
@@ -575,6 +579,7 @@ export const AdSlot = ({
 						data-link-name="ad slot merchandising-high"
 						data-name="merchandising-high"
 						data-refresh="false"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -596,6 +601,7 @@ export const AdSlot = ({
 						css={[merchandisingAdStyles]}
 						data-link-name="ad slot merchandising"
 						data-name="merchandising"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -627,6 +633,7 @@ export const AdSlot = ({
 							css={[frontsBannerAdStyles]}
 							data-link-name={`ad slot ${advertId}`}
 							data-name={`${advertId}`}
+							data-testid="slot"
 							aria-hidden="true"
 						/>
 					</div>
@@ -648,6 +655,7 @@ export const AdSlot = ({
 					data-label="false"
 					data-refresh="false"
 					data-out-of-page="true"
+					data-testid="slot"
 					aria-hidden="true"
 				/>
 			);
@@ -719,6 +727,7 @@ export const AdSlot = ({
 						css={[liveBlogTopAdStyles]}
 						data-link-name="ad slot liveblog-top"
 						data-name="liveblog-top"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -742,6 +751,7 @@ export const AdSlot = ({
 						css={[mobileFrontAdStyles]}
 						data-link-name={`ad slot ${advertId}`}
 						data-name={advertId}
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -765,6 +775,7 @@ export const AdSlot = ({
 						data-refresh="false"
 						data-out-of-page="true"
 						data-wide="1,1"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>
@@ -784,6 +795,7 @@ export const AdSlot = ({
 						css={[articleEndAdStyles]}
 						data-link-name="ad slot article-end"
 						data-name="article-end"
+						data-testid="slot"
 						aria-hidden="true"
 					/>
 				</div>

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -527,6 +527,7 @@ export const AdSlot = ({
 						].join(' ')}
 						data-link-name="ad slot top-above-nav"
 						data-name="top-above-nav"
+						data-testid="slot"
 						aria-hidden="true"
 					></div>
 				</div>

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -480,6 +480,7 @@ export const AdSlot = ({
 									]}
 									data-link-name="ad slot right"
 									data-name="right"
+									data-testid="slot"
 									aria-hidden="true"
 								/>
 							</div>


### PR DESCRIPTION
## What does this change?

This adds stories for various DCR-rendered ad slots.

## Why?

There have been some recent issues with visual regressions in ad styling- see https://github.com/guardian/dotcom-rendering/pull/13111. Adding stories enables us to catch these early rather than relying on reports after the fact.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
