### PR TITLE
Remove podcast palette

### DIFF
--- a/dotcom-rendering/fixtures/manual/frontCollections.ts
+++ b/dotcom-rendering/fixtures/manual/frontCollections.ts
@@ -235,7 +235,7 @@ const testCollectionsUs: Pick<
 	},
 	{
 		collectionType: 'fixed/medium/slow-VII',
-		containerPalette: 'PodcastPalette',
+		containerPalette: undefined,
 		displayName: 'Podcasts',
 		grouped: defaultGrouped,
 	},

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1152,10 +1152,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithBranding = () => {
 	const branding = {

--- a/dotcom-rendering/src/components/CardHeadline.stories.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.stories.tsx
@@ -446,7 +446,6 @@ const containerPalettes = [
 	'SpecialReportAltPalette',
 	'Branded',
 	'MediaPalette',
-	'PodcastPalette',
 ] as const satisfies readonly DCRContainerPalette[];
 export const WithContainerOverrides: StoryObj = ({ format }: StoryProps) => (
 	<>

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -50,7 +50,7 @@ type ArticleProps = Props & {
 };
 
 type FrontProps = Props & {
-	palette: DCRContainerPalette;
+	palette?: DCRContainerPalette;
 	containerType?: DCRContainerType;
 	hasPageSkin?: boolean;
 	isOnwardContent?: false;
@@ -96,7 +96,7 @@ const CarouselColours = ({
 	props,
 	children,
 }: {
-	props: { format: ArticleFormat } | { palette: DCRContainerPalette };
+	props: { format: ArticleFormat } | { palette?: DCRContainerPalette };
 	children: React.ReactElement;
 }): React.ReactElement => {
 	if ('palette' in props) {

--- a/dotcom-rendering/src/components/Carousel.stories.tsx
+++ b/dotcom-rendering/src/components/Carousel.stories.tsx
@@ -661,7 +661,6 @@ export const FrontCarousel = () => (
 				leftColSize="compact"
 				url={'https://www.theguardian.com'}
 				discussionApiUrl={discussionApiUrl}
-				palette="PodcastPalette"
 				absoluteServerTimes={true}
 			/>
 		</Section>

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -28,8 +28,6 @@ const cardHeadlineLight: ContainerFunction = (
 			return sourcePalette.neutral[93];
 		case 'SpecialReportAltPalette':
 			return sourcePalette.specialReportAlt[100];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 		case 'Branded':
 			return sourcePalette.neutral[20];
 		case 'MediaPalette':
@@ -58,8 +56,6 @@ const cardHeadlineDark: ContainerFunction = (
 			return sourcePalette.neutral[93];
 		case 'SpecialReportAltPalette':
 			return sourcePalette.specialReportAlt[700];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 		case 'Branded':
 			return sourcePalette.neutral[86];
 		case 'MediaPalette':
@@ -89,8 +85,6 @@ const cardTrailTextLight: ContainerFunction = (
 			return sourcePalette.neutral[86];
 		case 'SpecialReportAltPalette':
 			return sourcePalette.specialReportAlt[100];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[93];
 		case 'Branded':
 			return sourcePalette.neutral[38];
 		case 'MediaPalette':
@@ -119,8 +113,6 @@ const cardTrailTextDark: ContainerFunction = (
 			return sourcePalette.neutral[93];
 		case 'SpecialReportAltPalette':
 			return sourcePalette.specialReportAlt[700];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 		case 'Branded':
 			return sourcePalette.neutral[86];
 		case 'MediaPalette':
@@ -150,7 +142,6 @@ const cardKickerTextLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.specialReportAlt[100];
 		case 'Branded':
 			return sourcePalette.labs[200];
-		case 'PodcastPalette':
 		case 'MediaPalette':
 			return sourcePalette.neutral[7];
 	}
@@ -178,7 +169,6 @@ const cardKickerTextDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.specialReportAlt[700];
 		case 'Branded':
 			return sourcePalette.labs[400];
-		case 'PodcastPalette':
 		case 'MediaPalette':
 			return sourcePalette.neutral[7];
 	}
@@ -207,7 +197,6 @@ const kickerTextLiveLight: ContainerFunction = (containerPalette) => {
 		case 'Branded':
 			return sourcePalette.neutral[97];
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
@@ -235,7 +224,6 @@ const kickerTextLiveDark: ContainerFunction = (containerPalette) => {
 		case 'Branded':
 			return sourcePalette.neutral[20];
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
@@ -262,7 +250,6 @@ const kickerBackgroundLiveLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.specialReportAlt[100];
 		case 'Branded':
 			return sourcePalette.labs[200];
-		case 'PodcastPalette':
 		case 'MediaPalette':
 			return sourcePalette.neutral[7];
 	}
@@ -289,7 +276,6 @@ const kickerBackgroundLiveDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.specialReportAlt[700];
 		case 'Branded':
 			return sourcePalette.labs[400];
-		case 'PodcastPalette':
 		case 'MediaPalette':
 			return sourcePalette.neutral[7];
 	}
@@ -319,8 +305,6 @@ const sectionToggleButtonLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[7];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 const sectionToggleButtonDark: ContainerFunction = (containerPalette) => {
@@ -347,8 +331,6 @@ const sectionToggleButtonDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[7];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 const sectionToggleButtonHoverLight: ContainerFunction = (containerPalette) => {
@@ -375,8 +357,6 @@ const sectionToggleButtonHoverLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[20];
 		case 'MediaPalette':
 			return sourcePalette.neutral[7];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 	}
 };
 const sectionToggleButtonHoverDark: ContainerFunction = (containerPalette) => {
@@ -402,8 +382,6 @@ const sectionToggleButtonHoverDark: ContainerFunction = (containerPalette) => {
 		case 'Branded':
 			return 'inherit';
 		case 'MediaPalette':
-			return 'inherit';
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
@@ -431,8 +409,6 @@ const cardBorderTopLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[73];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 
@@ -458,8 +434,6 @@ const cardBorderTopDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[60];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 
@@ -494,8 +468,6 @@ const articleBorderLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[73];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 
@@ -520,8 +492,6 @@ const articleBorderDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[38];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[10];
 	}
 };
 
@@ -549,8 +519,6 @@ const cardBackgroundLight: ContainerFunction = (containerPalette) => {
 			return palette('--section-background');
 		case 'MediaPalette':
 			return sourcePalette.neutral[0];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 	}
 };
 
@@ -575,7 +543,6 @@ const cardBackgroundDark: ContainerFunction = (containerPalette) => {
 		case 'SombreAltPalette':
 		case 'EventPalette':
 		case 'EventAltPalette':
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
@@ -613,9 +580,8 @@ const sectionBackgroundLight: ContainerFunction = (containerPalette) => {
 		case 'Branded':
 			return sourcePalette.neutral[93];
 		case 'MediaPalette':
+		default:
 			return 'transparent';
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 	}
 };
 
@@ -642,8 +608,6 @@ const sectionBackgroundDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[20];
 		case 'MediaPalette':
 			return sectionBackgroundLight(containerPalette);
-		case 'PodcastPalette':
-			return sourcePalette.neutral[7];
 	}
 };
 
@@ -661,7 +625,6 @@ const sectionBackgroundLeftLight: ContainerFunction = (containerPalette) => {
 		case 'SombreAltPalette':
 		case 'SpecialReportAltPalette':
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return palette('--section-background');
 	}
 };
@@ -680,7 +643,6 @@ const sectionBackgroundLeftDark: ContainerFunction = (containerPalette) => {
 		case 'SombreAltPalette':
 		case 'SpecialReportAltPalette':
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return palette('--section-background');
 	}
 };
@@ -708,8 +670,6 @@ const cardBorderSupportingLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[73];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 const cardBorderSupportingDark: ContainerFunction = (containerPalette) => {
@@ -734,8 +694,6 @@ const cardBorderSupportingDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[46];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 
@@ -746,7 +704,6 @@ const sectionBorderLight: ContainerFunction = (containerPalette) => {
 		case 'EventPalette':
 		case 'EventAltPalette':
 		case 'Branded':
-		case 'PodcastPalette':
 			return sourcePalette.neutral[86];
 		case 'SombrePalette':
 		case 'SombreAltPalette':
@@ -783,8 +740,6 @@ const sectionBorderDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[46];
 		case 'MediaPalette':
 			return sourcePalette.neutral[46];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 	}
 };
 
@@ -812,8 +767,6 @@ const sectionDateLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[100];
 		case 'MediaPalette':
 			return sourcePalette.neutral[100];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 	}
 };
 
@@ -837,8 +790,6 @@ const sectionDateDark: ContainerFunction = (containerPalette) => {
 		case 'Branded':
 			return sourcePalette.neutral[100];
 		case 'MediaPalette':
-			return sourcePalette.neutral[100];
-		case 'PodcastPalette':
 			return sourcePalette.neutral[100];
 	}
 };
@@ -868,8 +819,6 @@ const sectionTitleLight: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[100];
 		case 'MediaPalette':
 			return sourcePalette.neutral[100];
-		case 'PodcastPalette':
-			return sourcePalette.neutral[7];
 	}
 };
 
@@ -897,8 +846,6 @@ const sectionTitleDark: ContainerFunction = (containerPalette) => {
 			return sourcePalette.neutral[97];
 		case 'MediaPalette':
 			return sourcePalette.neutral[100];
-		case 'PodcastPalette':
-			return 'inherit';
 	}
 };
 
@@ -916,7 +863,6 @@ const treatTextLight: ContainerFunction = (containerPalette) => {
 		case 'BreakingPalette':
 		case 'SpecialReportAltPalette':
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
@@ -935,15 +881,12 @@ const treatTextDark: ContainerFunction = (containerPalette) => {
 		case 'BreakingPalette':
 		case 'SpecialReportAltPalette':
 		case 'MediaPalette':
-		case 'PodcastPalette':
 			return 'inherit';
 	}
 };
 
 const carouselDotLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 		case 'MediaPalette':
 			return sourcePalette.neutral[86];
 		default:
@@ -953,8 +896,6 @@ const carouselDotLight: ContainerFunction = (containerPalette) => {
 
 const carouselDotDark: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[20];
 		case 'MediaPalette':
 			return carouselDotLight(containerPalette);
 		default:
@@ -964,8 +905,6 @@ const carouselDotDark: ContainerFunction = (containerPalette) => {
 
 const carouselActiveDotLight: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[7];
 		case 'MediaPalette':
 			return sourcePalette.brandAlt[400];
 		default:
@@ -975,8 +914,6 @@ const carouselActiveDotLight: ContainerFunction = (containerPalette) => {
 
 const carouselActiveDotDark: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.news[400];
 	}
@@ -984,8 +921,6 @@ const carouselActiveDotDark: ContainerFunction = (containerPalette) => {
 
 const carouselArrow: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[100];
 		default:
 			return sourcePalette.neutral[7];
 	}
@@ -993,8 +928,6 @@ const carouselArrow: ContainerFunction = (containerPalette) => {
 
 const carouselArrowBackground: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.neutral[7];
 		default:
 			return sourcePalette.brandAlt[400];
 	}
@@ -1002,8 +935,6 @@ const carouselArrowBackground: ContainerFunction = (containerPalette) => {
 
 const carouselArrowBackgroundHover: ContainerFunction = (containerPalette) => {
 	switch (containerPalette) {
-		case 'PodcastPalette':
-			return sourcePalette.brandAlt[400];
 		default:
 			return sourcePalette.brandAlt[200];
 	}

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -353,10 +353,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	name: 'With special palette variations',

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -111,10 +111,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	name: 'With special palette variations',

--- a/dotcom-rendering/src/components/Kicker.stories.tsx
+++ b/dotcom-rendering/src/components/Kicker.stories.tsx
@@ -20,7 +20,6 @@ const containerPalettes = [
 	'SpecialReportAltPalette',
 	'Branded',
 	'MediaPalette',
-	'PodcastPalette',
 ] as const satisfies readonly DCRContainerPalette[];
 
 const kickerWrapperStyles: CSSProperties = {

--- a/dotcom-rendering/src/components/Palettes.stories.tsx
+++ b/dotcom-rendering/src/components/Palettes.stories.tsx
@@ -260,27 +260,3 @@ export const MediaPalette = {
 		</FrontSection>
 	),
 } satisfies Story;
-
-export const PodcastPalette = {
-	render: () => (
-		<FrontSection
-			title="Podcast Palette"
-			collectionId={''}
-			pageId={''}
-			ajaxUrl={''}
-			sectionId={'podcast-palette'}
-			ophanComponentName={'podcast-palette'}
-			ophanComponentLink={'podcast-palette'}
-			discussionApiUrl={discussionApiUrl}
-			editionId={'UK'}
-		>
-			<DynamicFast
-				groupedTrails={groupedTrails}
-				containerPalette="PodcastPalette"
-				showAge={true}
-				absoluteServerTimes={true}
-				imageLoading="eager"
-			/>
-		</FrontSection>
-	),
-} satisfies Story;

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -113,10 +113,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
@@ -93,10 +93,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -93,10 +93,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -127,10 +127,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
@@ -53,10 +53,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
@@ -80,10 +80,7 @@ const containerPalettes = [
 	'SombreAltPalette',
 	'SpecialReportAltPalette',
 	'Branded',
-] as const satisfies readonly Omit<
-	DCRContainerPalette,
-	'MediaPalette' | 'PodcastPalette'
->[];
+] as const satisfies readonly Omit<DCRContainerPalette, 'MediaPalette'>[];
 
 export const WithSpecialPaletteVariations = {
 	parameters: {

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -538,11 +538,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 					if (
 						collection.collectionType === 'fixed/video' ||
-						collection.containerPalette === 'PodcastPalette'
+						collection.collectionType === 'scrollable/podcast'
 					) {
-						const containerPalette =
-							collection.containerPalette ?? 'MediaPalette';
-
 						return (
 							<div key={ophanName}>
 								<FrontsBannerAdSlot
@@ -574,7 +571,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										'--section-background',
 									)}
 									innerBackgroundColour={
-										containerPalette === 'MediaPalette'
+										collection.collectionType ===
+										'fixed/video'
 											? sourcePalette.neutral[0]
 											: undefined
 									}
@@ -589,7 +587,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											heading={collection.displayName}
 											trails={trails}
 											onwardsSource={'unknown-source'}
-											palette={containerPalette}
 											leftColSize={'compact'}
 											containerType={
 												collection.collectionType

--- a/dotcom-rendering/src/lib/cardHelpers.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.ts
@@ -37,7 +37,6 @@ export const cardHasDarkBackground = (
 
 		// Special palettes which act more like standard containers
 		case 'MediaPalette':
-		case 'PodcastPalette':
 		// If no containerPalette provided, card is in a standard container
 		case undefined: {
 			return false;

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -79,16 +79,9 @@ const getMobileAdPositions = (collections: AdCandidate[]): number[] => {
  * A result of 6 indicates a container is at least double the height of a typical desktop viewport.
  */
 const getCollectionHeight = (
-	collction: Pick<
-		DCRCollectionType,
-		'collectionType' | 'containerPalette' | 'grouped'
-	>,
+	collction: Pick<DCRCollectionType, 'collectionType' | 'grouped'>,
 ): 0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 6 => {
-	const { collectionType, containerPalette, grouped } = collction;
-
-	if (containerPalette === 'PodcastPalette') {
-		return 1.5;
-	}
+	const { collectionType, grouped } = collction;
 
 	// The height of some dynamic layouts depend on the sizes of the cards that are passed to them.
 	const groupedCounts: GroupedCounts = {
@@ -123,6 +116,7 @@ const getCollectionHeight = (
 		case 'fixed/video':
 		case 'fixed/video/vertical':
 		case 'scrollable/feature':
+		case 'scrollable/podcast':
 			return 1.5;
 
 		case 'fixed/medium/slow-VI':

--- a/dotcom-rendering/src/model/decideContainerPalette.ts
+++ b/dotcom-rendering/src/model/decideContainerPalette.ts
@@ -25,6 +25,5 @@ export const decideContainerPalette = (
 	if (metadata?.includes('Branded') && options?.canBeBranded) {
 		return 'Branded';
 	}
-	if (metadata?.includes('Podcast')) return 'PodcastPalette';
 	return undefined;
 };

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -97,7 +97,16 @@ export const enhanceCollections = ({
 		);
 
 		const containerSpacing = getContainerSpacing(collections[index + 1]);
+		const isPodcastContainer = collection.config.metadata?.some(
+			(meta) => meta.type === 'Podcast',
+		);
 
+		console.log({ isPodcastContainer });
+		const dcrCollectionType = !!isPodcastContainer
+			? 'scrollable/podcast'
+			: collectionType;
+
+		console.log({ dcrCollectionType });
 		return {
 			id,
 			displayName,
@@ -105,7 +114,7 @@ export const enhanceCollections = ({
 				onPageDescription && index === 0
 					? onPageDescription
 					: description,
-			collectionType,
+			collectionType: dcrCollectionType,
 			href,
 			containerPalette,
 			containerLevel: collection.config.collectionLevel,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -150,11 +150,10 @@ export type DCRContainerPalette =
 	| 'BreakingPalette'
 	| 'SpecialReportAltPalette'
 	| 'Branded'
-	| 'MediaPalette'
-	| 'PodcastPalette';
+	| 'MediaPalette';
 
 // TODO: These may need to be declared differently than the front types in the future
-export type DCRContainerType = FEContainerType;
+export type DCRContainerType = FEContainerType | 'scrollable/podcast';
 
 export type DCRContainerLevel = FEContainerLevel;
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
