### PR TITLE
Remove `hasPageSkin` prop from `MerchHighAdSlot`

### DIFF
--- a/dotcom-rendering/src/components/FrontsAdSlots.test.tsx
+++ b/dotcom-rendering/src/components/FrontsAdSlots.test.tsx
@@ -29,20 +29,6 @@ describe('MerchHighAdSlot', () => {
 		const { container } = render(
 			<MerchHighAdSlot
 				renderAds={false}
-				hasPageSkin={false}
-				isPaidContent={false}
-				collectionCount={4}
-			/>,
-		);
-
-		expect(container.innerHTML).toBe('');
-	});
-
-	it('should return null if there is a page skin', () => {
-		const { container } = render(
-			<MerchHighAdSlot
-				renderAds={true}
-				hasPageSkin={true}
 				isPaidContent={false}
 				collectionCount={4}
 			/>,
@@ -55,7 +41,6 @@ describe('MerchHighAdSlot', () => {
 		const { container } = render(
 			<MerchHighAdSlot
 				renderAds={true}
-				hasPageSkin={false}
 				isPaidContent={false}
 				collectionCount={2}
 			/>,
@@ -68,7 +53,6 @@ describe('MerchHighAdSlot', () => {
 		const { container } = render(
 			<MerchHighAdSlot
 				renderAds={true}
-				hasPageSkin={false}
 				isPaidContent={true}
 				collectionCount={1}
 			/>,
@@ -81,7 +65,6 @@ describe('MerchHighAdSlot', () => {
 		const { container } = render(
 			<MerchHighAdSlot
 				renderAds={true}
-				hasPageSkin={false}
 				isPaidContent={false}
 				collectionCount={4}
 			/>,

--- a/dotcom-rendering/src/components/FrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/FrontsAdSlots.tsx
@@ -25,18 +25,16 @@ export const MobileAdSlot = ({
 
 export const MerchHighAdSlot = ({
 	renderAds,
-	hasPageSkin,
 	isPaidContent,
 	collectionCount,
 }: {
 	renderAds: boolean;
-	hasPageSkin: boolean;
 	isPaidContent: boolean;
 	collectionCount: number;
 }) => {
 	const minContainers = isPaidContent ? 1 : 2;
 	const shouldInsertMerchHighSlot =
-		renderAds && !hasPageSkin && collectionCount > minContainers;
+		renderAds && collectionCount > minContainers;
 
 	return (
 		shouldInsertMerchHighSlot && (

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -410,7 +410,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 													.frontProperties
 													.isPaidContent
 											}
-											hasPageSkin={hasPageSkin}
 										/>
 									)}
 								</div>
@@ -500,7 +499,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											!!front.pressedPage.frontProperties
 												.isPaidContent
 										}
-										hasPageSkin={hasPageSkin}
 									/>
 								)}
 							</div>
@@ -570,7 +568,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											!!front.pressedPage.frontProperties
 												.isPaidContent
 										}
-										hasPageSkin={hasPageSkin}
 									/>
 								)}
 							</div>
@@ -668,7 +665,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											!!front.pressedPage.frontProperties
 												.isPaidContent
 										}
-										hasPageSkin={hasPageSkin}
 									/>
 								)}
 							</div>
@@ -766,7 +762,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										!!front.pressedPage.frontProperties
 											.isPaidContent
 									}
-									hasPageSkin={hasPageSkin}
 								/>
 							)}
 						</div>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -201,7 +201,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 										tagPage.groupedTrails.length
 									}
 									isPaidContent={!!isPaidContent}
-									hasPageSkin={hasPageSkin}
 								/>
 							)}
 						</Fragment>


### PR DESCRIPTION
## What does this change?

Removes the `hasPageSkin` prop and logic including this from the `MerchHighAdSlot` component

## Why?

We don't render the merch high slot anywhere above the desktop breakpoint on DCR. We even have a `<Hide>` component wrapping the ad slot which prevents it from appearing on viewports above the desktop breakpoint.

As a result of this, we can remove the `hasPageSkin` condition from the rendering logic since this should have no impact on whether to render the ad or not.

Noticed in this comment thread https://github.com/guardian/dotcom-rendering/pull/13138#discussion_r1915244080

