### PR TITLE
Carousel container portal navigation

### DIFF
--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -39,7 +39,6 @@ const buttonStyles = css`
 		display: flex;
 		gap: ${space[1]}px;
 		margin-left: auto;
-		padding-top: ${space[2]}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
+import { from, space } from '@guardian/source/foundations';
 import {
 	Button,
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
-	ThemeButton,
+	type ThemeButton,
 } from '@guardian/source/react-components';
-import { from, space } from '@guardian/source/foundations';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { palette } from '../palette';
@@ -40,9 +40,6 @@ const buttonStyles = css`
 		gap: ${space[1]}px;
 		margin-left: auto;
 		padding-top: ${space[2]}px;
-		.hidden > & {
-			display: none;
-		}
 	}
 `;
 
@@ -84,7 +81,7 @@ export const CarouselNavigationButtons = ({
 			);
 		}
 		setPortalNode(node);
-	}, []);
+	}, [sectionId]);
 
 	if (!portalNode) return null;
 

--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -40,6 +40,9 @@ const buttonStyles = css`
 		gap: ${space[1]}px;
 		margin-left: auto;
 		padding-top: ${space[2]}px;
+		.hidden > & {
+			display: none;
+		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -18,7 +18,7 @@ type CarouselNavigationProps = {
 	dataLinkNameNextButton: string;
 	dataLinkNamePreviousButton: string;
 	/** Unique identifier for the carousel navigation container. */
-	displayName: string;
+	sectionId: string;
 };
 
 const themeButton: Partial<ThemeButton> = {
@@ -54,7 +54,7 @@ const buttonStyles = css`
  * useful when the buttons need to be positioned outside the visual boundaries of the carousel component itself,
  * such as on the fronts containers.
  *
- * The portal dynamically identifies a DOM element by constructing its ID using the `displayName` prop and
+ * The portal dynamically identifies a DOM element by constructing its ID using the `sectionId` prop and
  * appends the suffix `-carousel-navigation`. This allows us to create distinct navigation portals per carousel.
  *
  * If the target DOM element is not found, a warning is logged in the
@@ -68,17 +68,16 @@ export const CarouselNavigationButtons = ({
 	onClickNextButton,
 	dataLinkNamePreviousButton,
 	dataLinkNameNextButton,
-	displayName,
+	sectionId,
 }: CarouselNavigationProps) => {
 	const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
-
 	useEffect(() => {
 		const node = document.getElementById(
-			`${displayName}-carousel-navigation`,
+			`${sectionId}-carousel-navigation`,
 		);
 		if (!node) {
 			console.warn(
-				`Portal node with ID "${displayName}-carousel-navigation" not found.`,
+				`Portal node with ID "${sectionId}-carousel-navigation" not found.`,
 			);
 		}
 		setPortalNode(node);

--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -1,20 +1,24 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
-import type { ThemeButton } from '@guardian/source/react-components';
 import {
 	Button,
 	SvgChevronLeftSingle,
 	SvgChevronRightSingle,
+	ThemeButton,
 } from '@guardian/source/react-components';
+import { from, space } from '@guardian/source/foundations';
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
 import { palette } from '../palette';
 
-type Props = {
+type CarouselNavigationProps = {
 	previousButtonEnabled: boolean;
 	nextButtonEnabled: boolean;
 	onClickPreviousButton: () => void;
 	onClickNextButton: () => void;
 	dataLinkNameNextButton: string;
 	dataLinkNamePreviousButton: string;
+	/** Unique identifier for the carousel navigation container. */
+	displayName: string;
 };
 
 const themeButton: Partial<ThemeButton> = {
@@ -35,21 +39,54 @@ const buttonStyles = css`
 		display: flex;
 		gap: ${space[1]}px;
 		margin-left: auto;
+		padding-top: ${space[2]}px;
 	}
 `;
 
 /**
- * Navigation buttons for use in a carousel-like component
+ *
+ * Navigation buttons for a carousel-like component.
+ *
+ * This component renders "Previous" and "Next" navigation buttons, designed for controlling a carousel-like component.
+ *
+ * These buttons are rendered using a React portal. A portal allows rendering the button elements outside of the
+ * normal React component hierarchy, enabling flexibility in their placement within the DOM. This is particularly
+ * useful when the buttons need to be positioned outside the visual boundaries of the carousel component itself,
+ * such as on the fronts containers.
+ *
+ * The portal dynamically identifies a DOM element by constructing its ID using the `displayName` prop and
+ * appends the suffix `-carousel-navigation`. This allows us to create distinct navigation portals per carousel.
+ *
+ * If the target DOM element is not found, a warning is logged in the
+ * console. The buttons will not be rendered if the portal target is unavailable.
+ *
  */
 export const CarouselNavigationButtons = ({
 	previousButtonEnabled,
 	nextButtonEnabled,
 	onClickPreviousButton,
 	onClickNextButton,
-	dataLinkNameNextButton,
 	dataLinkNamePreviousButton,
-}: Props) => {
-	return (
+	dataLinkNameNextButton,
+	displayName,
+}: CarouselNavigationProps) => {
+	const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
+
+	useEffect(() => {
+		const node = document.getElementById(
+			`${displayName}-carousel-navigation`,
+		);
+		if (!node) {
+			console.warn(
+				`Portal node with ID "${displayName}-carousel-navigation" not found.`,
+			);
+		}
+		setPortalNode(node);
+	}, []);
+
+	if (!portalNode) return null;
+
+	return ReactDOM.createPortal(
 		<div
 			aria-controls="carousel"
 			aria-label="carousel arrows"
@@ -84,6 +121,7 @@ export const CarouselNavigationButtons = ({
 				value="next"
 				data-link-name={dataLinkNameNextButton}
 			/>
-		</div>
+		</div>,
+		portalNode,
 	);
 };

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -43,6 +43,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	displayName: string;
 };
 
 export const DecideContainer = ({
@@ -54,6 +55,7 @@ export const DecideContainer = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	displayName,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -270,6 +272,7 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
+						displayName={displayName}
 					/>
 				</Island>
 			);
@@ -284,6 +287,7 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
+						displayName={displayName}
 					/>
 				</Island>
 			);
@@ -307,6 +311,7 @@ export const DecideContainer = ({
 						containerPalette={containerPalette}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
+						displayName={displayName}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -43,7 +43,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
-	displayName: string;
+	sectionId: string;
 };
 
 export const DecideContainer = ({
@@ -55,7 +55,7 @@ export const DecideContainer = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
-	displayName,
+	sectionId,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -272,7 +272,7 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
-						displayName={displayName}
+						sectionId={sectionId}
 					/>
 				</Island>
 			);
@@ -287,7 +287,7 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
-						displayName={displayName}
+						sectionId={sectionId}
 					/>
 				</Island>
 			);
@@ -311,7 +311,6 @@ export const DecideContainer = ({
 						containerPalette={containerPalette}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
-						displayName={displayName}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -610,7 +610,12 @@ export const FrontSection = ({
 						{isScrollableContainer && (
 							<div
 								css={css`
-									height: 44px;
+									${until.leftCol} {
+										height: 44px;
+									}
+									.hidden & {
+										display: none;
+									}
 								`}
 								id={`${sectionId}-carousel-navigation`}
 							></div>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -90,6 +90,7 @@ type Props = {
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
+	isScrollableContainer?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -169,6 +170,17 @@ const containerStylesUntilLeftCol = css`
 			60px
 			[decoration-end content-end title-end hide-end]
 			minmax(0, 1fr);
+	}
+`;
+
+const containerScrollableStylesFromLeftCol = css`
+	${between.leftCol.and.wide} {
+		grid-template-rows:
+			[headline-start show-hide-start] auto
+			[show-hide-end content-toggleable-start content-start] auto
+			[headline-end treats-start] auto
+			[content-end content-toggleable-end treats-end bottom-content-start] auto
+			[bottom-content-end];
 	}
 `;
 
@@ -261,6 +273,13 @@ const sectionShowHide = css`
 	grid-row: show-hide;
 	grid-column: hide;
 	justify-self: end;
+	display: flex;
+	align-items: flex-end;
+	${from.wide} {
+		flex-direction: column-reverse;
+		justify-content: flex-end;
+		align-items: flex-end;
+	}
 `;
 
 const sectionContent = css`
@@ -488,8 +507,9 @@ export const FrontSection = ({
 	discussionApiUrl,
 	collectionBranding,
 	isTagPage = false,
+	isScrollableContainer = false,
 }: Props) => {
-	const isToggleable = toggleable && !!sectionId && !containerLevel;
+	const isToggleable = toggleable && !!sectionId;
 	const showMore =
 		canShowMore &&
 		!!title &&
@@ -515,6 +535,10 @@ export const FrontSection = ({
 					fallbackStyles,
 					containerStylesUntilLeftCol,
 					!hasPageSkin && containerStylesFromLeftCol,
+					!hasPageSkin &&
+						isScrollableContainer &&
+						containerScrollableStylesFromLeftCol,
+
 					hasPageSkin && pageSkinContainer,
 				]}
 				style={{
@@ -578,9 +602,10 @@ export const FrontSection = ({
 					{leftContent}
 				</div>
 
-				{isToggleable && (
+				{(isToggleable || isScrollableContainer) && (
 					<div css={sectionShowHide}>
 						<ShowHideButton sectionId={sectionId} />
+						{/* <div id={`${sectionId}-carousel-navigation`}></div> */}
 					</div>
 				)}
 

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -282,7 +282,7 @@ const sectionControls = css`
 	grid-column: hide;
 	justify-self: end;
 	display: flex;
-	align-items: flex-end;
+	padding-top: ${space[2]}px;
 	${from.wide} {
 		flex-direction: column-reverse;
 		justify-content: flex-end;

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -90,7 +90,7 @@ type Props = {
 	discussionApiUrl: string;
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
-	isScrollableContainer?: boolean;
+	hasNavigationButtons?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -128,8 +128,8 @@ const containerStylesUntilLeftCol = css`
 	display: grid;
 
 	grid-template-rows:
-		[headline-start show-hide-start] auto
-		[show-hide-end headline-end content-toggleable-start content-start] auto
+		[headline-start controls-start] auto
+		[controls-end headline-end content-toggleable-start content-start] auto
 		[content-end content-toggleable-end bottom-content-start] auto
 		[bottom-content-end];
 
@@ -176,19 +176,27 @@ const containerStylesUntilLeftCol = css`
 const containerScrollableStylesFromLeftCol = css`
 	${between.leftCol.and.wide} {
 		grid-template-rows:
-			[headline-start show-hide-start] auto
-			[show-hide-end content-toggleable-start content-start] auto
+			[headline-start controls-start] auto
+			[controls-end content-toggleable-start content-start] auto
 			[headline-end treats-start] auto
 			[content-end content-toggleable-end treats-end bottom-content-start] auto
 			[bottom-content-end];
+	}
+
+	${from.wide} {
+		grid-template-rows:
+			[headline-start content-start content-toggleable-start controls-start] auto
+			[headline-end treats-start] auto
+			[content-end content-toggleable-end treats-end controls-end bottom-content-start] auto
+			[ bottom-content-end];
 	}
 `;
 
 const containerStylesFromLeftCol = css`
 	${from.leftCol} {
 		grid-template-rows:
-			[headline-start show-hide-start content-start] auto
-			[show-hide-end content-toggleable-start] auto
+			[headline-start controls-start content-start] auto
+			[controls-end content-toggleable-start] auto
 			[headline-end treats-start] auto
 			[content-end content-toggleable-end treats-end bottom-content-start] auto
 			[bottom-content-end];
@@ -207,8 +215,8 @@ const containerStylesFromLeftCol = css`
 
 	${from.wide} {
 		grid-template-rows:
-			[headline-start content-start content-toggleable-start show-hide-start] auto
-			[show-hide-end] auto
+			[headline-start content-start content-toggleable-start controls-start] auto
+			[controls-end] auto
 			[headline-end treats-start] auto
 			[content-end content-toggleable-end treats-end bottom-content-start] auto
 			[bottom-content-end];
@@ -269,8 +277,8 @@ const topPadding = css`
 	padding-top: ${space[2]}px;
 `;
 
-const sectionShowHide = css`
-	grid-row: show-hide;
+const sectionControls = css`
+	grid-row: controls;
 	grid-column: hide;
 	justify-self: end;
 	display: flex;
@@ -279,6 +287,10 @@ const sectionShowHide = css`
 		flex-direction: column-reverse;
 		justify-content: flex-end;
 		align-items: flex-end;
+		/** we want to add space between the items in the controls section only when both items are there and visible */
+		:has(.carouselNavigationPlaceholder:not(.hidden)) {
+			justify-content: space-between;
+		}
 	}
 `;
 
@@ -396,6 +408,15 @@ const secondaryLevelTopBorder = css`
 	}
 `;
 
+const carouselNavigationPlaceholder = css`
+	${until.leftCol} {
+		height: 44px;
+	}
+	.hidden & {
+		display: none;
+	}
+`;
+
 /**
  * # Front Container
  *
@@ -507,7 +528,7 @@ export const FrontSection = ({
 	discussionApiUrl,
 	collectionBranding,
 	isTagPage = false,
-	isScrollableContainer = false,
+	hasNavigationButtons = false,
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
 	const showMore =
@@ -536,7 +557,7 @@ export const FrontSection = ({
 					containerStylesUntilLeftCol,
 					!hasPageSkin && containerStylesFromLeftCol,
 					!hasPageSkin &&
-						isScrollableContainer &&
+						hasNavigationButtons &&
 						containerScrollableStylesFromLeftCol,
 
 					hasPageSkin && pageSkinContainer,
@@ -602,21 +623,15 @@ export const FrontSection = ({
 					{leftContent}
 				</div>
 
-				{(isToggleable || isScrollableContainer) && (
-					<div css={sectionShowHide}>
+				{(isToggleable || hasNavigationButtons) && (
+					<div css={sectionControls}>
 						{isToggleable && (
 							<ShowHideButton sectionId={sectionId} />
 						)}
-						{isScrollableContainer && (
+						{hasNavigationButtons && (
 							<div
-								css={css`
-									${until.leftCol} {
-										height: 44px;
-									}
-									.hidden & {
-										display: none;
-									}
-								`}
+								css={carouselNavigationPlaceholder}
+								className="carouselNavigationPlaceholder"
 								id={`${sectionId}-carousel-navigation`}
 							></div>
 						)}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -604,8 +604,17 @@ export const FrontSection = ({
 
 				{(isToggleable || isScrollableContainer) && (
 					<div css={sectionShowHide}>
-						<ShowHideButton sectionId={sectionId} />
-						{/* <div id={`${sectionId}-carousel-navigation`}></div> */}
+						{isToggleable && (
+							<ShowHideButton sectionId={sectionId} />
+						)}
+						{isScrollableContainer && (
+							<div
+								css={css`
+									height: 44px;
+								`}
+								id={`${sectionId}-carousel-navigation`}
+							></div>
+						)}
 					</div>
 				)}
 

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,11 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	between,
-	from,
-	headlineBold28Object,
-	space,
-	textSansBold17Object,
-} from '@guardian/source/foundations';
+import { from, space } from '@guardian/source/foundations';
 import { useEffect, useRef, useState } from 'react';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { palette } from '../palette';
@@ -16,22 +10,13 @@ type Props = {
 	carouselLength: number;
 	visibleCardsOnMobile: number;
 	visibleCardsOnTablet: number;
+	displayName?: string;
 };
-
-/**
- * Primary and Secondary containers have different typographic styles for the
- * titles. We get the font size and line height values for these from the
- * typography presets so we can calculate the offset needed to align the
- * navigation buttons with the title on tablet and desktop.
- */
-const primaryTitlePreset = headlineBold28Object;
-const secondaryTitlePreset = textSansBold17Object;
 
 /**
  * Grid sizing values to calculate negative margin used to pull navigation
  * buttons outside of container into the outer grid column at wide breakpoint.
  */
-const gridColumnWidth = 60;
 const gridGap = 20;
 const gridGapMobile = 10;
 
@@ -59,49 +44,6 @@ const containerStyles = css`
 	}
 	${from.leftCol} {
 		margin-left: 0;
-	}
-`;
-
-const containerWithNavigationStyles = css`
-	display: flex;
-	flex-direction: column-reverse;
-	${from.tablet} {
-		gap: ${space[2]}px;
-	}
-
-	${from.wide} {
-		flex-direction: row;
-		gap: ${space[1]}px;
-	}
-
-	/**
-	 * From tablet, pull container up so navigation buttons align with title.
-	 * The margin is calculated from the front section title font size and line
-	 * height, and the default container spacing.
-	 *
-	 * From wide, the navigation buttons are pulled out of the main content area
-	 * into the right-hand column.
-	 *
-	 * Between leftCol and wide the top of the fixed dividing line is pushed
-	 * down so it starts below the navigation buttons and gap, and aligns with
-	 * the top of the carousel.
-	 */
-	${between.tablet.and.leftCol} {
-		[data-container-level='Primary'] & {
-			margin-top: calc(
-				-${primaryTitlePreset.fontSize} * ${primaryTitlePreset.lineHeight} -
-					${space[3]}px
-			);
-		}
-		[data-container-level='Secondary'] & {
-			margin-top: calc(
-				-${secondaryTitlePreset.fontSize} * ${secondaryTitlePreset.lineHeight} -
-					${space[3]}px
-			);
-		}
-	}
-	${from.wide} {
-		margin-right: -${gridColumnWidth + gridGap / 2}px;
 	}
 `;
 
@@ -225,6 +167,7 @@ export const ScrollableCarousel = ({
 	carouselLength,
 	visibleCardsOnMobile,
 	visibleCardsOnTablet,
+	displayName,
 }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
@@ -303,7 +246,7 @@ export const ScrollableCarousel = ({
 		<div
 			css={[
 				containerStyles,
-				showNavigation && containerWithNavigationStyles,
+				// showNavigation && containerWithNavigationStyles,
 			]}
 		>
 			<ol
@@ -327,6 +270,7 @@ export const ScrollableCarousel = ({
 					nextButtonEnabled={nextButtonEnabled}
 					onClickPreviousButton={() => scrollTo('left')}
 					onClickNextButton={() => scrollTo('right')}
+					displayName={displayName ?? ''}
 					dataLinkNamePreviousButton={nestedOphanComponents(
 						'carousel',
 						'previous-button',

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -10,7 +10,7 @@ type Props = {
 	carouselLength: number;
 	visibleCardsOnMobile: number;
 	visibleCardsOnTablet: number;
-	displayName?: string;
+	sectionId?: string;
 };
 
 /**
@@ -167,7 +167,7 @@ export const ScrollableCarousel = ({
 	carouselLength,
 	visibleCardsOnMobile,
 	visibleCardsOnTablet,
-	displayName,
+	sectionId,
 }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
@@ -270,7 +270,7 @@ export const ScrollableCarousel = ({
 					nextButtonEnabled={nextButtonEnabled}
 					onClickPreviousButton={() => scrollTo('left')}
 					onClickNextButton={() => scrollTo('right')}
-					displayName={displayName ?? ''}
+					sectionId={sectionId ?? ''}
 					dataLinkNamePreviousButton={nestedOphanComponents(
 						'carousel',
 						'previous-button',

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -243,12 +243,7 @@ export const ScrollableCarousel = ({
 	}, []);
 
 	return (
-		<div
-			css={[
-				containerStyles,
-				// showNavigation && containerWithNavigationStyles,
-			]}
-		>
+		<div css={containerStyles}>
 			<ol
 				ref={carouselRef}
 				css={[

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -16,6 +16,7 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
+	displayName: string;
 };
 
 /**
@@ -33,12 +34,14 @@ export const ScrollableMedium = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
+	displayName,
 }: Props) => {
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
 			visibleCardsOnMobile={2}
 			visibleCardsOnTablet={4}
+			displayName={displayName}
 		>
 			{trails.map((trail) => {
 				const imagePosition = isMediaCard(trail.format)

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -16,7 +16,7 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
-	displayName: string;
+	sectionId: string;
 };
 
 /**
@@ -34,14 +34,14 @@ export const ScrollableMedium = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
-	displayName,
+	sectionId,
 }: Props) => {
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
 			visibleCardsOnMobile={2}
 			visibleCardsOnTablet={4}
-			displayName={displayName}
+			sectionId={sectionId}
 		>
 			{trails.map((trail) => {
 				const imagePosition = isMediaCard(trail.format)

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -15,7 +15,7 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
-	displayName: string;
+	sectionId: string;
 };
 
 /**
@@ -33,14 +33,14 @@ export const ScrollableSmall = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
-	displayName,
+	sectionId,
 }: Props) => {
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
-			displayName={displayName}
+			sectionId={sectionId}
 		>
 			{trails.map((trail) => {
 				return (

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -15,6 +15,7 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
+	displayName: string;
 };
 
 /**
@@ -32,12 +33,14 @@ export const ScrollableSmall = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
+	displayName,
 }: Props) => {
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
+			displayName={displayName}
 		>
 			{trails.map((trail) => {
 				return (

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, textSans14 } from '@guardian/source/foundations';
+import { textSans14 } from '@guardian/source/foundations';
 import { ButtonLink } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
@@ -9,10 +9,7 @@ type Props = {
 
 const showHideButtonCss = css`
 	${textSans14};
-
-	margin-top: ${space[2]}px;
 	margin-right: 10px;
-	margin-bottom: ${space[2]}px;
 	position: relative;
 	align-items: bottom;
 	text-decoration: none;

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -28,15 +28,23 @@ export const ShowHideContainers = () => {
 			const section: Element | null =
 				window.document.getElementById(sectionId);
 
+			const carouselButtons: Element | null =
+				window.document.getElementById(
+					`${sectionId}-carousel-navigation`,
+				);
+
 			if (isExpanded) {
 				containerStates[sectionId] = 'closed';
 				section?.classList.add('hidden');
+				carouselButtons?.classList.add('hidden');
+
 				element.innerHTML = 'Show';
 				element.setAttribute('aria-expanded', 'false');
 				element.setAttribute('data-link-name', 'Show');
 			} else {
 				containerStates[sectionId] = 'opened';
 				section?.classList.remove('hidden');
+				carouselButtons?.classList.remove('hidden');
 				element.innerHTML = 'Hide';
 				element.setAttribute('aria-expanded', 'true');
 				element.setAttribute('data-link-name', 'Hide');

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -199,6 +199,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						highlightsCollection.aspectRatio ??
 						fallbackAspectRatio(highlightsCollection.collectionType)
 					}
+					displayName={highlightsCollection.displayName}
 				/>
 			)
 		);
@@ -528,6 +529,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												collection.collectionType,
 											)
 										}
+										displayName={collection.displayName}
 									/>
 								</LabsSection>
 								{mobileAdPositions.includes(index) && (
@@ -709,6 +711,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								}
 								containerLevel={collection.containerLevel}
 								containerSpacing={collection.containerSpacing}
+								isScrollable={
+									collection.collectionType ===
+										'scrollable/small' ||
+									collection.collectionType ===
+										'scrollable/medium' ||
+									collection.collectionType ===
+										'scrollable/feature'
+								}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}
@@ -730,6 +740,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.collectionType,
 										)
 									}
+									displayName={collection.displayName}
 								/>
 							</FrontSection>
 							{mobileAdPositions.includes(index) && (

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -713,13 +713,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								}
 								containerLevel={collection.containerLevel}
 								containerSpacing={collection.containerSpacing}
-								isScrollableContainer={
+								hasNavigationButtons={
 									collection.collectionType ===
 										'scrollable/small' ||
 									collection.collectionType ===
-										'scrollable/medium' ||
-									collection.collectionType ===
-										'scrollable/feature'
+										'scrollable/medium'
 								}
 							>
 								<DecideContainer

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -199,7 +199,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						highlightsCollection.aspectRatio ??
 						fallbackAspectRatio(highlightsCollection.collectionType)
 					}
-					displayName={highlightsCollection.displayName}
+					sectionId={ophanComponentId(
+						highlightsCollection.displayName,
+					)}
 				/>
 			)
 		);
@@ -529,7 +531,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 												collection.collectionType,
 											)
 										}
-										displayName={collection.displayName}
+										sectionId={ophanName}
 									/>
 								</LabsSection>
 								{mobileAdPositions.includes(index) && (
@@ -711,7 +713,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								}
 								containerLevel={collection.containerLevel}
 								containerSpacing={collection.containerSpacing}
-								isScrollable={
+								isScrollableContainer={
 									collection.collectionType ===
 										'scrollable/small' ||
 									collection.collectionType ===
@@ -740,7 +742,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.collectionType,
 										)
 									}
-									displayName={collection.displayName}
+									sectionId={ophanName}
 								/>
 							</FrontSection>
 							{mobileAdPositions.includes(index) && (


### PR DESCRIPTION
## What does this change?
Refactors the carousel navigation buttons to use a React portal. 

A portal allows rendering the button elements outside of the normal React component hierarchy, enabling flexibility in their placement within the DOM. This is particularly useful when the buttons need to be positioned outside the visual boundaries of the carousel component itself, such as on the fronts containers.

## Why?
Depending on the breakpoint, the carousel front containers have their buttons placed outside of the component, in line with either the section heading or the left column. This had previously been achieved by using negative margins and absolute positioning to move the buttons outside of the container. This however, was quite brittle solution as it had to be calculate using the font size and line height of the container title and it also caused overlapping with the show/hide buttons as they occupied the same space. 

By using portals, we can achieve a distinct position in the dom between the containers and there navigation buttons whilst still coupling the code in the carousel component. 

The portal dynamically identifies a DOM element by constructing its ID using the `sectionId` prop and appends the suffix `-carousel-navigation`. This allows us to create distinct navigation portals per carousel.

If the target DOM element is not found, a warning is logged in the console. The buttons will not be rendered if the portal target is unavailable.

As well as refactoring the nav buttons, this pr also hooks up show/hide with the beta containers and add a hidden class to the nav buttons so that they can also be hidden when a containers is closed. 

## Why Portals?
As highlighted above, the design requirements necessitate that the navigation buttons for the carousel be placed outside the boundaries of the carousel component itself. This positioning ensures alignment with external elements such as section headings or adjacent columns, depending on the screen breakpoint. To implement this, we considered three potential approaches:

**1. **Negative margins**** 
Initially, negative margins were used to manually adjust the position of the buttons relative to the carousel container. However, this solution was brittle and prone to issues:

- It tightly coupled the layout of the carousel to the font size, line height, and other styling of external elements like the container title.
- It introduced maintenance overhead, as layout changes in related components (e.g., title styling) required recalibrating the margins.
- It caused overlapping issues with show/hide buttons, as both occupied the same space.

Overall, this approach was fragile and difficult to scale or adapt to new requirements.

**2. Lifting State to a Shared Parent Component**
Another option was to lift the state to a parent component shared by both the carousel and its navigation buttons. This approach offered some advantages, such as:

- Allowing the buttons to be rendered server-side, reducing potential layout shifts.
- Decoupling the carousel’s visual structure from its button placement.

However, this approach came with significant trade-offs:

- It required hydrating the entire parent layout, significantly increasing the size of the client-side bundle.
- It introduced unnecessary complexity by coupling unrelated components through a shared state.
- This approach was less modular, as it required managing state across a broader scope than necessary.


**3. Portals** 
React Portals emerged as the ideal solution because they allow rendering the navigation buttons in a separate part of the DOM while maintaining their state and logic within the carousel component. This approach offers several benefits:

- Flexibility in DOM Placement: Portals enable precise control over where the buttons are rendered, such as aligning them with section headings or external elements without relying on fragile CSS hacks.
- Scoped State Management: The buttons remain logically tied to the carousel component, ensuring the state and behavior are encapsulated and modular.
- Dynamic Targeting: The portal dynamically identifies the target DOM element using the sectionId prop, allowing distinct navigation portals for each carousel instance. If the target element is missing, the system gracefully handles the error by logging a warning and skipping the rendering of the buttons.
- Compatibility with Show/Hide Logic: Refactoring to use portals also facilitated integrating the navigation buttons with the "show/hide" functionality of beta containers. Buttons can now dynamically inherit a hidden class, ensuring they remain hidden when a container is closed.

Unfortunately, portals are inherently rendered on the client side and cannot be server-side rendered, which can result in some layout shifting. However, this issue has been largely mitigated by introducing a fixed minimum height placeholder to reserve space for the navigation buttons during initial rendering.

## Screenshots


https://github.com/user-attachments/assets/25e14838-460e-40fb-a0dd-8a01a38511b4

![Screenshot 2025-01-21 at 10 17 04](https://github.com/user-attachments/assets/28b2e050-dc6b-48ac-8154-70341d2b31cf)

![Screenshot 2025-01-21 at 10 17 11](https://github.com/user-attachments/assets/225791a9-56a5-4da4-bd4e-3ab506a075b0)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
