### PR TITLE
Apply padding to immersive image captions

### DIFF
--- a/dotcom-rendering/src/components/Caption.stories.tsx
+++ b/dotcom-rendering/src/components/Caption.stories.tsx
@@ -217,3 +217,25 @@ export const ForVideos = {
 		},
 	},
 } satisfies Story;
+
+export const WhenImmersive = {
+	args: {
+		captionText:
+			'This is how a caption looks with immersive padding. Additional padding is added to the left and right of the caption to compensate for the negative margins applied to immersive images.',
+		format: Standard.args.format,
+		isImmersive: true,
+	},
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': { disable: true },
+				'vertical mobile': allModes['vertical mobile'],
+				'vertical mobileLandscape':
+					allModes['vertical mobileLandscape'],
+				'vertical phablet': allModes['vertical tablet'],
+				'vertical desktop': allModes['vertical desktop'],
+				'vertical leftCol': allModes['vertical leftCol'],
+			},
+		},
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -28,6 +28,7 @@ type Props = {
 	isLeftCol?: boolean;
 	mediaType?: MediaType;
 	isMainMedia?: boolean;
+	isImmersive?: boolean;
 };
 
 type IconProps = {
@@ -120,6 +121,25 @@ const captionPadding = css`
 const tabletCaptionPadding = css`
 	${until.desktop} {
 		${captionPadding}
+	}
+`;
+
+const immersivePadding = css`
+	padding-left: 10px;
+	padding-right: 10px;
+	${from.mobileLandscape} {
+		padding-left: 20px;
+		padding-right: 20px;
+	}
+	${from.tablet} {
+		padding-right: 100px;
+	}
+	${from.desktop} {
+		padding-right: 340px;
+	}
+	${from.leftCol} {
+		padding-left: 0;
+		padding-right: 0;
 	}
 `;
 
@@ -228,6 +248,7 @@ export const Caption = ({
 	isLeftCol,
 	mediaType = 'Gallery',
 	isMainMedia = false,
+	isImmersive = false,
 }: Props) => {
 	// Sometimes captions come thorough as a single blank space, so we trim here to ignore those
 	const noCaption = !captionText?.trim();
@@ -249,6 +270,7 @@ export const Caption = ({
 					(isBlog || mediaType === 'Video') &&
 					tabletCaptionPadding,
 				padCaption && captionPadding,
+				isImmersive && immersivePadding,
 			]}
 			data-spacefinder-role="inline"
 		>

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -568,6 +568,7 @@ export const ImageComponent = ({
 					shouldLimitWidth={shouldLimitWidth}
 					isMainMedia={isMainMedia}
 					padCaption={role === 'showcase' && isTimeline}
+					isImmersive={role === 'immersive'}
 				/>
 			)}
 		</>


### PR DESCRIPTION
## What does this change?

Applies padding to immersive image captions to compensate for the negative margins used to pull the image outside the article container.

## Why?

To ensure the caption matches the width of the article text and does not touch the edges of the viewport.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://github.com/user-attachments/assets/e63e4314-4b17-4196-8673-66a9dcade3a9
[after1]: https://github.com/user-attachments/assets/e5f427d3-d053-4ecf-b318-9a613a0bed16
[before2]: https://github.com/user-attachments/assets/cfd2b0bf-338b-4539-8f48-7f1039d72128
[after2]: https://github.com/user-attachments/assets/75fb1969-4124-4109-b4ec-b564fbc134bc
