### PR TITLE
Revert changes to remove ad free as a benefit

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -39,6 +39,7 @@ export const ChoiceCardTestData_REGULAR: ChoiceInfo[] = [
 		benefits: () => [
 			'Unlimited access to the Guardian app',
 			'Unlimited access to our new Feast App',
+			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 			'Far fewer asks for support',
 		],
@@ -72,6 +73,7 @@ export const ChoiceCardTestData_US: ChoiceInfo[] = [
 		benefits: () => [
 			'Unlimited access to the Guardian app',
 			'Unlimited access to our new Feast App',
+			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 			'Far fewer asks for support',
 		],
@@ -116,6 +118,7 @@ export const ChoiceCardTestData_TwoTier_REGULAR: ChoiceInfo[] = [
 		benefitsLabel: 'All-access digital',
 		benefits: () => [
 			'Unlimited access to the Guardian app',
+			'Ad-free reading on all your devices',
 			'Exclusive newsletter for supporters',
 			'And much more!',
 		],


### PR DESCRIPTION
## What does this change?

This  is to revert changes made to epic and liveblog epic choice cards to remove ad free as a benefit in the [PR](https://github.com/guardian/dotcom-rendering/pull/13063)

## Why?
We had removed ad free as a benefit on epic and live blog epic choice cards  to support the Portfolio team to run a test  on all marketing channels and landing page on the 6th of Jan.Ad free smoke test has finished and did not have significant results.
So reverting the changes

[ Trello card](https://trello.com/c/U44b1uY4/889-revert-changes-made-to-epic-and-liveblog-epic-choice-cards-to-remove-ad-free-as-a-benefit)

## Screenshots

## After Change

## Epic
<img width="601" alt="image" src="https://github.com/user-attachments/assets/186a1055-3607-460c-b269-16a3618a8915" />

## Liveblog Epic
<img width="891" alt="image" src="https://github.com/user-attachments/assets/f3cc46a1-0c51-4fe9-8267-c54fa37994f2" />


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
