### PR TITLE
Add stories for cards with a vertical gap

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1611,3 +1611,106 @@ export const WithALargeGap = () => {
 		</>
 	);
 };
+
+export const WithNoVerticalGap = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						isOnwardContent={true}
+						imagePositionOnDesktop="bottom"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.Opinion,
+						}}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};
+
+export const WithAVerticalGapWhenLegacyContainer = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						containerType={'dynamic/fast'}
+						imagePositionOnDesktop="bottom"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.Opinion,
+						}}
+						discussionId={'p/d8ex5'}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};
+
+export const WithAVerticalGapWhenBetaContainer = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						containerType={'flexible/special'}
+						imagePositionOnDesktop="bottom"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.Opinion,
+						}}
+						discussionId={'p/d8ex5'}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};
+
+export const WithAVerticalGapWhenScrollableSmallContainer = () => {
+	return (
+		<>
+			<CardWrapper>
+				<div
+					css={css`
+						width: 280px;
+					`}
+				>
+					<Card
+						{...basicCardProps}
+						containerType={'scrollable/small'}
+						imagePositionOnDesktop="bottom"
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.Opinion,
+						}}
+						discussionId={'p/d8ex5'}
+					/>
+				</div>
+			</CardWrapper>
+		</>
+	);
+};


### PR DESCRIPTION
## What does this change?

This PR adds some stories for when a card has comments / meta and the image is positioned vertically. 

This will give us some snapshots to compare when we tweak the gap size in https://github.com/guardian/dotcom-rendering/pull/13126.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3bd3afdb-11d5-460b-8de4-0627082e1b49
[after]: https://github.com/user-attachments/assets/0f6e2ce5-b8f1-4a21-8da3-65b7e1b4dffb
