### PR TITLE
Set background colour for trending topics and podcast sections

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -1,6 +1,5 @@
 import { isOneOf } from '@guardian/libs';
 import {
-	background,
 	brandBackground,
 	brandBorder,
 	palette as sourcePalette,
@@ -358,43 +357,33 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										)}
 									/>
 								)}
-
 								{!!trail.embedUri && (
-									<ContainerOverrides
-										key={ophanName}
-										containerPalette={
-											collection.containerPalette
-										}
-									>
-										<SnapCssSandbox
-											snapData={trail.snapData}
+									<SnapCssSandbox snapData={trail.snapData}>
+										<Section
+											fullWidth={true}
+											padSides={false}
+											showTopBorder={false}
+											showSideBorders={false}
+											ophanComponentLink={
+												ophanComponentLink
+											}
+											ophanComponentName={ophanName}
+											containerName={
+												collection.collectionType
+											}
+											hasPageSkin={hasPageSkin}
+											backgroundColour={schemePalette(
+												'--front-container-background',
+											)}
 										>
-											<Section
-												fullWidth={true}
-												padSides={false}
-												showTopBorder={false}
-												showSideBorders={false}
-												ophanComponentLink={
-													ophanComponentLink
+											<Snap
+												snapData={trail.snapData}
+												dataLinkName={
+													trail.dataLinkName
 												}
-												ophanComponentName={ophanName}
-												containerName={
-													collection.collectionType
-												}
-												hasPageSkin={hasPageSkin}
-												backgroundColour={schemePalette(
-													'--section-background',
-												)}
-											>
-												<Snap
-													snapData={trail.snapData}
-													dataLinkName={
-														trail.dataLinkName
-													}
-												/>
-											</Section>
-										</SnapCssSandbox>
-									</ContainerOverrides>
+											/>
+										</Section>
+									</SnapCssSandbox>
 								)}
 								{mobileAdPositions.includes(index) && (
 									<MobileAdSlot
@@ -608,7 +597,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										}
 										editionId={front.editionId}
 										backgroundColour={schemePalette(
-											'--section-background',
+											'--front-container-background',
 										)}
 										innerBackgroundColour={
 											containerPalette === 'MediaPalette'
@@ -772,7 +761,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				ophanComponentName="trending-topics"
 				data-component="trending-topics"
 				hasPageSkin={hasPageSkin}
-				backgroundColour={schemePalette('--section-background')}
+				backgroundColour={schemePalette('--front-container-background')}
 			>
 				<TrendingTopics trendingTopics={front.trendingTopics} />
 			</Section>
@@ -789,9 +778,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					data-print-layout="hide"
 					padSides={false}
 					element="aside"
-					backgroundColour={
-						hasPageSkin ? background.primary : undefined
-					}
+					backgroundColour={schemePalette(
+						'--front-container-background',
+					)}
 				>
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav


### PR DESCRIPTION
## What does this change?

- Sets a background colour on the trending topics and thrasher sections
- Ensures `ContainerOverrides` wraps the other sections that need it (Podcast/Media)
- Removes `ContainerOverrides` wrapper from sections that don't need it (thrashers)

## Why?

Resolves visual bug when viewing front pages with a page skin applied where sections had a transparent background colour


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/2192c692-8462-43de-bf2f-095e851d2419
[after]: https://github.com/user-attachments/assets/a63b62ad-a0b6-42c7-b619-0eede3055ef2
[before2]: https://github.com/user-attachments/assets/f1d1aea5-5aba-47f0-8166-af4dfa132555
[after2]: https://github.com/user-attachments/assets/50591d71-cfbf-4d9b-bfec-16e570195784
