### PR TITLE
hide show hide if user is not signed in

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -189,7 +189,7 @@ const containerScrollableStylesFromLeftCol = css`
 			[headline-start content-start content-toggleable-start controls-start] auto
 			[headline-end treats-start] auto
 			[content-end content-toggleable-end treats-end controls-end bottom-content-start] auto
-			[ bottom-content-end];
+			[bottom-content-end];
 	}
 `;
 

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -626,7 +626,10 @@ export const FrontSection = ({
 				{(isToggleable || hasNavigationButtons) && (
 					<div css={sectionControls}>
 						{isToggleable && (
-							<ShowHideButton sectionId={sectionId} />
+							<ShowHideButton
+								sectionId={sectionId}
+								betaContainer={!!containerLevel}
+							/>
 						)}
 						{hasNavigationButtons && (
 							<div

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -91,6 +91,7 @@ type Props = {
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
 	hasNavigationButtons?: boolean;
+	isBetaContainer?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -529,6 +530,7 @@ export const FrontSection = ({
 	collectionBranding,
 	isTagPage = false,
 	hasNavigationButtons = false,
+	isBetaContainer,
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
 	const showMore =
@@ -628,7 +630,7 @@ export const FrontSection = ({
 						{isToggleable && (
 							<ShowHideButton
 								sectionId={sectionId}
-								betaContainer={!!containerLevel}
+								isBetaContainer={!!isBetaContainer}
 							/>
 						)}
 						{hasNavigationButtons && (

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -411,7 +411,7 @@ const secondaryLevelTopBorder = css`
 
 const carouselNavigationPlaceholder = css`
 	${until.leftCol} {
-		height: 44px;
+		min-height: 44px;
 	}
 	.hidden & {
 		display: none;

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -364,7 +364,10 @@ export const Section = ({
 							/>
 						</MaybeHideAboveLeftCol>
 						{toggleable && !!sectionId && (
-							<ShowHideButton sectionId={sectionId} />
+							<ShowHideButton
+								sectionId={sectionId}
+								betaContainer={false}
+							/>
 						)}
 					</div>
 					{toggleable && sectionId ? (

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -366,7 +366,7 @@ export const Section = ({
 						{toggleable && !!sectionId && (
 							<ShowHideButton
 								sectionId={sectionId}
-								betaContainer={false}
+								isBetaContainer={false}
 							/>
 						)}
 					</div>

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -13,6 +13,9 @@ const showHideButtonCss = css`
 	position: relative;
 	align-items: bottom;
 	text-decoration: none;
+	.hidden & {
+		display: none;
+	}
 `;
 
 /**

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -5,6 +5,7 @@ import { palette } from '../palette';
 
 type Props = {
 	sectionId: string;
+	betaContainer: boolean;
 };
 
 const showHideButtonCss = css`
@@ -22,13 +23,14 @@ const showHideButtonCss = css`
  * This component creates the styled button for showing & hiding a container,
  * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
  **/
-export const ShowHideButton = ({ sectionId }: Props) => {
+export const ShowHideButton = ({ sectionId, betaContainer }: Props) => {
 	return (
 		<ButtonLink
 			priority="secondary"
 			data-link-name="Hide"
 			cssOverrides={showHideButtonCss}
 			data-show-hide-button={sectionId}
+			data-beta-container={betaContainer}
 			aria-controls={sectionId}
 			aria-expanded={true}
 			theme={{

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -5,7 +5,7 @@ import { palette } from '../palette';
 
 type Props = {
 	sectionId: string;
-	betaContainer: boolean;
+	isBetaContainer: boolean;
 };
 
 const showHideButtonCss = css`
@@ -23,14 +23,14 @@ const showHideButtonCss = css`
  * This component creates the styled button for showing & hiding a container,
  * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
  **/
-export const ShowHideButton = ({ sectionId, betaContainer }: Props) => {
+export const ShowHideButton = ({ sectionId, isBetaContainer }: Props) => {
 	return (
 		<ButtonLink
 			priority="secondary"
 			data-link-name="Hide"
 			cssOverrides={showHideButtonCss}
 			data-show-hide-button={sectionId}
-			data-beta-container={betaContainer}
+			data-beta-container={isBetaContainer}
 			aria-controls={sectionId}
 			aria-expanded={true}
 			theme={{

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -13,7 +13,7 @@ const showHideButtonCss = css`
 	position: relative;
 	align-items: bottom;
 	text-decoration: none;
-	.hidden & {
+	&.hidden {
 		display: none;
 	}
 `;

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -1,5 +1,6 @@
 import { isObject, isString, storage } from '@guardian/libs';
 import { useEffect } from 'react';
+import { useIsSignedIn } from 'src/lib/useAuthStatus';
 
 type ContainerStates = { [id: string]: string };
 
@@ -19,6 +20,7 @@ const getContainerStates = (): ContainerStates => {
 };
 
 export const ShowHideContainers = () => {
+	const isSignedIn = useIsSignedIn();
 	useEffect(() => {
 		const containerStates = getContainerStates();
 
@@ -63,13 +65,26 @@ export const ShowHideContainers = () => {
 			const sectionId = e.getAttribute('data-show-hide-button');
 			if (!sectionId) continue;
 
-			e.onclick = () => toggleContainer(sectionId, e);
+			for (const e of allShowHideButtons) {
+				if (isSignedIn === false) {
+					// hide all show hide buttons
+					e.classList.add('hidden');
+				} else if (isSignedIn === true) {
+					// unhide buttons then....
+					e.classList.remove('hidden');
 
-			if (containerStates[sectionId] === 'closed') {
-				toggleContainer(sectionId, e);
+					const sectionId = e.getAttribute('data-show-hide-button');
+					if (!sectionId) continue;
+
+					e.onclick = () => toggleContainer(sectionId, e);
+
+					if (containerStates[sectionId] === 'closed') {
+						toggleContainer(sectionId, e);
+					}
+				}
 			}
 		}
-	}, []);
+	}, [isSignedIn]);
 
 	return <></>;
 };

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -2,8 +2,14 @@ import { isObject, isString, storage } from '@guardian/libs';
 import { useEffect } from 'react';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 
+/**
+ * A mapping of container IDs to their states ('opened' or 'closed').
+ */
 type ContainerStates = { [id: string]: string };
 
+/**
+ * Type guard to check if an item is a valid `ContainerStates` object.
+ */
 const isContainerStates = (item: unknown): item is ContainerStates => {
 	if (!isObject(item)) return false;
 	if (!Object.keys(item).every(isString)) return false;
@@ -19,6 +25,18 @@ const getContainerStates = (): ContainerStates => {
 	return item;
 };
 
+/**
+ * A component that manages the show/hide functionality of containers
+ * based on user interaction and signed-in status.
+ *
+ * This component:
+ * - Reads container states from local storage.
+ * - Toggles the visibility of containers when buttons are clicked.
+ * - Updates container states in local storage.
+ * - Hides or shows buttons based on the signed-in status of the user.
+ *
+ * @returns {JSX.Element} - A React fragment (renders nothing to the DOM directly).
+ */
 export const ShowHideContainers = () => {
 	const isSignedIn = useIsSignedIn();
 	useEffect(() => {
@@ -65,22 +83,19 @@ export const ShowHideContainers = () => {
 			const sectionId = e.getAttribute('data-show-hide-button');
 			if (!sectionId) continue;
 
-			for (const e of allShowHideButtons) {
-				if (isSignedIn === false) {
-					// hide all show hide buttons
-					e.classList.add('hidden');
-				} else if (isSignedIn === true) {
-					// unhide buttons then....
-					e.classList.remove('hidden');
+			if (isSignedIn === false) {
+				// Only signed in users can show/hide containers so we visually hide these buttons.
+				e.classList.add('hidden');
+			} else if (isSignedIn === true) {
+				e.classList.remove('hidden');
 
-					const sectionId = e.getAttribute('data-show-hide-button');
-					if (!sectionId) continue;
+				const sectionId = e.getAttribute('data-show-hide-button');
+				if (!sectionId) continue;
 
-					e.onclick = () => toggleContainer(sectionId, e);
+				e.onclick = () => toggleContainer(sectionId, e);
 
-					if (containerStates[sectionId] === 'closed') {
-						toggleContainer(sectionId, e);
-					}
+				if (containerStates[sectionId] === 'closed') {
+					toggleContainer(sectionId, e);
 				}
 			}
 		}

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -1,6 +1,6 @@
 import { isObject, isString, storage } from '@guardian/libs';
 import { useEffect } from 'react';
-import { useIsSignedIn } from 'src/lib/useAuthStatus';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 
 type ContainerStates = { [id: string]: string };
 

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -113,7 +113,6 @@ export const ShowHideContainers = () => {
 			 */
 			if (isBetaContainer === 'true' && !isSignedIn) {
 				button.classList.add('hidden');
-				return;
 			} else {
 				initialiseShowHide(sectionId, button, containerStates);
 			}

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -94,7 +94,7 @@ export const ShowHideContainers = () => {
 
 		for (const button of showHideButtons) {
 			/**
-			 * We need if a user is signed in before we can make any further decisions about show/hide buttons.
+			 * We need to know if a user is signed in before we can make any further decisions about show/hide buttons.
 			 * If the state is still pending, return early to prevent any flickering of the buttons.
 			 */
 			if (isSignedIn === 'Pending') return;

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -81,17 +81,14 @@ export const ShowHideContainers = () => {
 
 		for (const e of allShowHideButtons) {
 			const sectionId = e.getAttribute('data-show-hide-button');
+			const isBetaContainer = e.getAttribute('data-beta-container');
 			if (!sectionId) continue;
 
-			if (isSignedIn === false) {
+			if (isSignedIn === false && isBetaContainer === 'true') {
 				// Only signed in users can show/hide containers so we visually hide these buttons.
 				e.classList.add('hidden');
-			} else if (isSignedIn === true) {
+			} else if (isSignedIn === true || isBetaContainer === 'false') {
 				e.classList.remove('hidden');
-
-				const sectionId = e.getAttribute('data-show-hide-button');
-				if (!sectionId) continue;
-
 				e.onclick = () => toggleContainer(sectionId, e);
 
 				if (containerStates[sectionId] === 'closed') {

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -83,7 +83,7 @@ export const ShowHideContainers = () => {
 			const sectionId = e.getAttribute('data-show-hide-button');
 			const isBetaContainer = e.getAttribute('data-beta-container');
 			if (!sectionId) continue;
-
+			if (isSignedIn === 'Pending') return;
 			if (isSignedIn === false && isBetaContainer === 'true') {
 				// Only signed in users can show/hide containers so we visually hide these buttons.
 				e.classList.add('hidden');

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -93,6 +93,10 @@ export const ShowHideContainers = () => {
 		);
 
 		for (const button of showHideButtons) {
+			/**
+			 * We need if a user is signed in before we can make any further decisions about show/hide buttons.
+			 * If the state is still pending, return early to prevent any flickering of the buttons.
+			 */
 			if (isSignedIn === 'Pending') return;
 
 			const sectionId = button.getAttribute('data-show-hide-button');

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -25,6 +25,52 @@ const getContainerStates = (): ContainerStates => {
 	return item;
 };
 
+const toggleContainer = (
+	sectionId: string,
+	button: HTMLElement,
+	containerStates: ContainerStates,
+) => {
+	const isExpanded = button.getAttribute('aria-expanded') === 'true';
+	const section = document.getElementById(sectionId);
+	const carouselButtons: Element | null = document.getElementById(
+		`${sectionId}-carousel-navigation`,
+	);
+
+	if (isExpanded) {
+		containerStates[sectionId] = 'closed';
+		section?.classList.add('hidden');
+		carouselButtons?.classList.add('hidden');
+
+		button.innerHTML = 'Show';
+		button.setAttribute('aria-expanded', 'false');
+		button.setAttribute('data-link-name', 'Show');
+	} else {
+		containerStates[sectionId] = 'opened';
+		section?.classList.remove('hidden');
+		carouselButtons?.classList.remove('hidden');
+		button.innerHTML = 'Hide';
+		button.setAttribute('aria-expanded', 'true');
+		button.setAttribute('data-link-name', 'Hide');
+	}
+
+	storage.local.set(`gu.prefs.container-states`, containerStates);
+};
+
+/**
+ * Initializes the show/hide functionality for a button and its associated container.
+ */
+const initialiseShowHide = (
+	sectionId: string,
+	button: HTMLElement,
+	containerStates: ContainerStates,
+) => {
+	button.classList.remove('hidden');
+	button.onclick = () => toggleContainer(sectionId, button, containerStates);
+
+	if (containerStates[sectionId] === 'closed') {
+		toggleContainer(sectionId, button, containerStates);
+	}
+};
 /**
  * A component that manages the show/hide functionality of containers
  * based on user interaction and signed-in status.
@@ -40,63 +86,32 @@ const getContainerStates = (): ContainerStates => {
 export const ShowHideContainers = () => {
 	const isSignedIn = useIsSignedIn();
 	const containerStates = getContainerStates();
+
 	useEffect(() => {
-		const toggleContainer = (sectionId: string, element: HTMLElement) => {
-			const isExpanded = element.getAttribute('aria-expanded') === 'true';
-
-			const section: Element | null =
-				window.document.getElementById(sectionId);
-
-			const carouselButtons: Element | null =
-				window.document.getElementById(
-					`${sectionId}-carousel-navigation`,
-				);
-
-			if (isExpanded) {
-				containerStates[sectionId] = 'closed';
-				section?.classList.add('hidden');
-				carouselButtons?.classList.add('hidden');
-
-				element.innerHTML = 'Show';
-				element.setAttribute('aria-expanded', 'false');
-				element.setAttribute('data-link-name', 'Show');
-			} else {
-				containerStates[sectionId] = 'opened';
-				section?.classList.remove('hidden');
-				carouselButtons?.classList.remove('hidden');
-				element.innerHTML = 'Hide';
-				element.setAttribute('aria-expanded', 'true');
-				element.setAttribute('data-link-name', 'Hide');
-			}
-
-			storage.local.set(`gu.prefs.container-states`, containerStates);
-		};
-
-		const allShowHideButtons = Array.from(
-			window.document.querySelectorAll<HTMLElement>(
-				'[data-show-hide-button]',
-			),
+		const showHideButtons = document.querySelectorAll<HTMLElement>(
+			'[data-show-hide-button]',
 		);
 
-		for (const e of allShowHideButtons) {
-			const sectionId = e.getAttribute('data-show-hide-button');
-			const isBetaContainer = e.getAttribute('data-beta-container');
+		for (const button of showHideButtons) {
+			if (isSignedIn === 'Pending') return;
+
+			const sectionId = button.getAttribute('data-show-hide-button');
+			const isBetaContainer = button.getAttribute('data-beta-container');
+
 			if (!sectionId) continue;
 
-			if (isSignedIn === 'Pending') return;
-			/** We have disabled show hide for beta containers when the user is not signed in.
-			 *  It is still available for legacy containers regardless of sign in state.
+			/**
+			 * We have disabled show hide for beta containers when the user is not signed in.
+			 * It is currently still available for legacy containers regardless of sign in state.
+			 *
+			 * Once beta containers are in production, show hide will be behind a sign in flag for all containers.
+			 * At this point, the isBetaContainer check can be removed from the below code.
 			 */
-			if (isSignedIn === false && isBetaContainer === 'true') {
-				e.classList.add('hidden');
-				/** if either the user is signed in, or we are in a legacy container, show the toggle */
-			} else if (isSignedIn === true || isBetaContainer === 'false') {
-				e.classList.remove('hidden');
-				e.onclick = () => toggleContainer(sectionId, e);
-
-				if (containerStates[sectionId] === 'closed') {
-					toggleContainer(sectionId, e);
-				}
+			if (isBetaContainer === 'true' && !isSignedIn) {
+				button.classList.add('hidden');
+				return;
+			} else {
+				initialiseShowHide(sectionId, button, containerStates);
 			}
 		}
 	}, [isSignedIn, containerStates]);

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -39,9 +39,8 @@ const getContainerStates = (): ContainerStates => {
  */
 export const ShowHideContainers = () => {
 	const isSignedIn = useIsSignedIn();
+	const containerStates = getContainerStates();
 	useEffect(() => {
-		const containerStates = getContainerStates();
-
 		const toggleContainer = (sectionId: string, element: HTMLElement) => {
 			const isExpanded = element.getAttribute('aria-expanded') === 'true';
 
@@ -83,10 +82,14 @@ export const ShowHideContainers = () => {
 			const sectionId = e.getAttribute('data-show-hide-button');
 			const isBetaContainer = e.getAttribute('data-beta-container');
 			if (!sectionId) continue;
+
 			if (isSignedIn === 'Pending') return;
+			/** We have disabled show hide for beta containers when the user is not signed in.
+			 *  It is still available for legacy containers regardless of sign in state.
+			 */
 			if (isSignedIn === false && isBetaContainer === 'true') {
-				// Only signed in users can show/hide containers so we visually hide these buttons.
 				e.classList.add('hidden');
+				/** if either the user is signed in, or we are in a legacy container, show the toggle */
 			} else if (isSignedIn === true || isBetaContainer === 'false') {
 				e.classList.remove('hidden');
 				e.onclick = () => toggleContainer(sectionId, e);
@@ -96,7 +99,7 @@ export const ShowHideContainers = () => {
 				}
 			}
 		}
-	}, [isSignedIn]);
+	}, [isSignedIn, containerStates]);
 
 	return <></>;
 };

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -5,6 +5,7 @@ import {
 	palette as sourcePalette,
 } from '@guardian/source/foundations';
 import { AdSlot } from '../components/AdSlot.web';
+import { BETA_CONTAINERS } from '../components/Card/Card';
 import { Carousel } from '../components/Carousel.importable';
 import { ContainerOverrides } from '../components/ContainerOverrides';
 import { CPScottHeader } from '../components/CPScottHeader';
@@ -448,6 +449,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
+									isBetaContainer={BETA_CONTAINERS.includes(
+										collection.collectionType,
+									)}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -704,6 +708,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection.collectionType ===
 										'scrollable/medium'
 								}
+								isBetaContainer={BETA_CONTAINERS.includes(
+									collection.collectionType,
+								)}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}


### PR DESCRIPTION
## What does this change?
This update places the show/hide container toggles behind a sign-in requirement for users interacting with beta containers. 

In the immediate, the behaviour is as follows:

- If the container is a beta container, we only allow show hide if the user is signed in
- If the container is a existing / legacy container, we always allow show hide.

Following the launch of the new containers, this feature will be extended to all containers (ie users must be signed in to use show/hide on any container), ensuring consistent functionality across the platform. A tracking ticket has been created for this follow-up work.

The feature operates as follows: each show/hide button is associated with a beta container data flag. If the flag is set to true and the user is not signed in, the button is hidden from view. Since this logic resides within a useEffect hook dependent on the user's sign-in status, signing in will dynamically make the buttons visible again. As the code needs to know if the user is signed in or not, the code has an early return when the sign in status is "Pending" to prevent any incorrect renders of the toggle. 

Additionally, this PR includes a refactor of the show/hide island and adds comments with the aim to improve readability of maintainability of the island. 

This PR is dependent on https://github.com/guardian/dotcom-rendering/pull/13162, otherwise - as seen in the screenshots - the scrollable nav buttons and the show / hide controls overlap.

## Why?
This change supports the goal of restricting the show/hide functionality to signed-in users.

## Screenshots

| Exisiting containers & not signed in       |  Beta containers & not signed in           |  Beta containers & signed in          |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![after1][] |


[before]: https://github.com/user-attachments/assets/0f9d6fe5-fbdf-412a-ac24-28f3242354e9
[after]: https://github.com/user-attachments/assets/0cb68b35-9431-4ad1-bc49-73bb276aaeec
[after1]: https://github.com/user-attachments/assets/05625d75-8850-4b01-bf3b-a45814321369


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
