### PR TITLE
Change crossword component name to fix renaming issue with build

### DIFF
--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -1,6 +1,10 @@
 import { Crossword as ReactCrossword } from '@guardian/react-crossword-next';
 import type { CrosswordProps } from '@guardian/react-crossword-next';
 
+/*
+	The name of this component is important, when it was "Crossword"
+	webpack was renaming it and the JS wasn't loading in the client.
+ */
 export const CrosswordComponent = ({
 	data,
 }: {

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -1,6 +1,8 @@
 import { Crossword as ReactCrossword } from '@guardian/react-crossword-next';
 import type { CrosswordProps } from '@guardian/react-crossword-next';
 
-export const Crossword = ({ data }: { data: CrosswordProps['data'] }) => (
-	<ReactCrossword data={data} clueMinWidth={150} />
-);
+export const CrosswordComponent = ({
+	data,
+}: {
+	data: CrosswordProps['data'];
+}) => <ReactCrossword data={data} clueMinWidth={150} />;

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -9,7 +9,7 @@ import { CartoonComponent } from '../components/CartoonComponent';
 import { ChartAtom } from '../components/ChartAtom.importable';
 import { CodeBlockComponent } from '../components/CodeBlockComponent';
 import { CommentBlockComponent } from '../components/CommentBlockComponent';
-import { Crossword } from '../components/Crossword.importable';
+import { CrosswordComponent } from '../components/CrosswordComponent.importable';
 import { DividerBlockComponent } from '../components/DividerBlockComponent';
 import { DocumentBlockComponent } from '../components/DocumentBlockComponent.importable';
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper';
@@ -864,7 +864,7 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.CrosswordElement':
 			return (
 				<Island priority="critical" defer={{ until: 'visible' }}>
-					<Crossword data={element.crossword} />
+					<CrosswordComponent data={element.crossword} />
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':


### PR DESCRIPTION
The crossword component island is not finding the JS to load.
There is an issue with the name of the island being changed during the build.

<img width="1213" alt="Screenshot 2025-01-17 at 14 21 59" src="https://github.com/user-attachments/assets/5c57884f-71bf-48cc-848c-2003ba6d589d" />
