### PR TITLE
Remove show hide toggle switch test

### DIFF
--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -72,11 +72,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 				/>
 			</Island>
 			<Island priority="enhancement" defer={{ until: 'idle' }}>
-				<ShowHideContainers
-					disableFrontContainerToggleSwitch={
-						!!front.config.switches.disableFrontContainerShowHide
-					}
-				/>
+				<ShowHideContainers />
 			</Island>
 			<Island priority="critical">
 				<SetABTests

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -365,13 +365,7 @@ describe('Island: server-side rendering', () => {
 	});
 
 	test('ShowHideContainers', () => {
-		expect(() =>
-			renderToString(
-				<ShowHideContainers
-					disableFrontContainerToggleSwitch={false}
-				/>,
-			),
-		).not.toThrow();
+		expect(() => renderToString(<ShowHideContainers />)).not.toThrow();
 	});
 
 	test('SignInGateSelector', () => {

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -18,15 +18,7 @@ const getContainerStates = (): ContainerStates => {
 	return item;
 };
 
-type Props = {
-	/** When in the ON position, we remove the show/hide functionality for all
-	 * containers on the page if the user does not have any hidden containers */
-	disableFrontContainerToggleSwitch: boolean;
-};
-
-export const ShowHideContainers = ({
-	disableFrontContainerToggleSwitch,
-}: Props) => {
+export const ShowHideContainers = () => {
 	useEffect(() => {
 		const containerStates = getContainerStates();
 
@@ -59,20 +51,7 @@ export const ShowHideContainers = ({
 			),
 		);
 
-		const allContainersAreExpanded = allShowHideButtons
-			.map((el) => {
-				const sectionId = el.getAttribute('data-show-hide-button');
-				return sectionId && containerStates[sectionId];
-			})
-			.every((state) => state !== 'closed');
-
 		for (const e of allShowHideButtons) {
-			// We want to remove the ability to toggle front containers between expanded and collapsed states.
-			// The first part of doing this is removing the feature for those who do not currently use it.
-			if (disableFrontContainerToggleSwitch && allContainersAreExpanded) {
-				e.remove();
-			}
-
 			const sectionId = e.getAttribute('data-show-hide-button');
 			if (!sectionId) continue;
 
@@ -82,7 +61,7 @@ export const ShowHideContainers = ({
 				toggleContainer(sectionId, e);
 			}
 		}
-	}, [disableFrontContainerToggleSwitch]);
+	}, []);
 
 	return <></>;
 };


### PR DESCRIPTION
## What does this change?
Removes the switch to toggle show/hide functionality off for users who have not hidden any containers. 

## Why?
[Last year, there was a test to understand the impact of removing show / hide containers](https://github.com/guardian/dotcom-rendering/pull/11941). This code was part of this test and is no longer required as the product decision for show / hide functionality is that we will now support this feature on new containers.

