### PR TITLE
Feature card gallery footer

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1004,7 +1004,7 @@ export const Card = ({
 										kickerImage={
 											showKickerImage &&
 											media?.type === 'podcast'
-												? media?.podcastImage
+												? media.podcastImage
 												: undefined
 										}
 									/>

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import { palette, space, textSansBold12 } from '@guardian/source/foundations';
+import { SvgCamera } from '@guardian/source/react-components';
+import { Pill } from '../../../components/Pill';
 import { type ArticleFormat, ArticleSpecial } from '../../../lib/articleFormat';
-import CameraSvg from '../../../static/icons/camera.svg';
 import type { MainMedia } from '../../../types/mainMedia';
 
 const contentStyles = css`
@@ -9,10 +10,12 @@ const contentStyles = css`
 	padding-top: ${space[1]}px;
 	display: flex;
 	justify-content: 'flex-start';
+	width: fit-content;
 	align-items: center;
 	${textSansBold12}
 	> {
-		/* The dividing line is applied only to the second child. This ensures that no dividing line is added when there is only one child in the container. */
+		/* The dividing line is applied only to the second child. This ensures that no
+		   dividing line is added when there is only one child in the container. */
 		:nth-child(2) {
 			::before {
 				content: '';
@@ -33,52 +36,6 @@ const contentStyles = css`
 
 const labStyles = css`
 	margin-top: ${space[1]}px;
-`;
-
-const galleryContentStyles = css`
-	${contentStyles}
-	padding: ${space[1]}px ${space[2]}px;
-	background-color: ${palette.neutral[7]};
-	width: fit-content;
-	color: ${palette.neutral[100]};
-	border-radius: 40px;
-	> {
-		/* The dividing line is applied only to the second child. This ensures that no dividing line is added when there is only one child in the container. */
-		:nth-child(2) {
-			::before {
-				content: '';
-				display: block;
-				width: 1px;
-				height: 23px;
-				position: absolute;
-				bottom: -4px;
-				left: 0;
-				background-color: ${palette.neutral[100]};
-				opacity: 0.5;
-				margin-right: ${space[1]}px;
-			}
-			position: relative;
-			padding-left: ${space[1]}px;
-		}
-	}
-`;
-
-const galleryMetaStyles = css`
-	margin-left: ${space[1]}px;
-	display: flex;
-	gap: ${space[1]}px;
-	align-items: center;
-`;
-
-const galleryIconContainerStyles = css`
-	display: flex;
-	fill: ${palette.neutral[100]};
-	svg {
-		top: 0px;
-		left: 0px;
-		height: 14px;
-		width: 14px;
-	}
 `;
 
 type Props = {
@@ -108,14 +65,13 @@ export const CardFooter = ({
 
 	if (mediaType === 'Gallery') {
 		return (
-			<footer css={galleryContentStyles}>
-				<div>Gallery</div>
-				<div css={galleryMetaStyles}>
-					{galleryCount}
-					<span css={galleryIconContainerStyles}>
-						<CameraSvg />
-					</span>
-				</div>
+			<footer css={contentStyles}>
+				<Pill
+					content={galleryCount?.toString() ?? ''}
+					prefix="Gallery"
+					icon={<SvgCamera />}
+					iconSide="right"
+				/>
 			</footer>
 		);
 	}

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -1,14 +1,8 @@
 import { css } from '@emotion/react';
 import { palette, space, textSansBold12 } from '@guardian/source/foundations';
 import { type ArticleFormat, ArticleSpecial } from '../../../lib/articleFormat';
-
-type Props = {
-	format: ArticleFormat;
-	age?: JSX.Element;
-	commentCount?: JSX.Element;
-	cardBranding?: JSX.Element;
-	showLivePlayable?: boolean;
-};
+import CameraSvg from '../../../static/icons/camera.svg';
+import type { MainMedia } from '../../../types/mainMedia';
 
 const contentStyles = css`
 	margin-top: auto;
@@ -41,17 +35,89 @@ const labStyles = css`
 	margin-top: ${space[1]}px;
 `;
 
+const galleryContentStyles = css`
+	${contentStyles}
+	padding: ${space[1]}px ${space[2]}px;
+	background-color: ${palette.neutral[7]};
+	width: fit-content;
+	color: ${palette.neutral[100]};
+	border-radius: 40px;
+	> {
+		/* The dividing line is applied only to the second child. This ensures that no dividing line is added when there is only one child in the container. */
+		:nth-child(2) {
+			::before {
+				content: '';
+				display: block;
+				width: 1px;
+				height: 23px;
+				position: absolute;
+				bottom: -4px;
+				left: 0;
+				background-color: ${palette.neutral[100]};
+				opacity: 0.5;
+				margin-right: ${space[1]}px;
+			}
+			position: relative;
+			padding-left: ${space[1]}px;
+		}
+	}
+`;
+
+const galleryMetaStyles = css`
+	margin-left: ${space[1]}px;
+	display: flex;
+	gap: ${space[1]}px;
+	align-items: center;
+`;
+
+const galleryIconContainerStyles = css`
+	display: flex;
+	fill: ${palette.neutral[100]};
+	svg {
+		top: 0px;
+		left: 0px;
+		height: 14px;
+		width: 14px;
+	}
+`;
+
+type Props = {
+	format: ArticleFormat;
+	showLivePlayable: boolean;
+	age?: JSX.Element;
+	commentCount?: JSX.Element;
+	cardBranding?: JSX.Element;
+	mediaType?: MainMedia['type'];
+	galleryCount?: number;
+};
+
 export const CardFooter = ({
 	format,
 	age,
 	commentCount,
 	cardBranding,
-	showLivePlayable = false,
+	showLivePlayable,
+	mediaType,
+	galleryCount,
 }: Props) => {
 	if (showLivePlayable) return null;
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer css={labStyles}>{cardBranding}</footer>;
+	}
+
+	if (mediaType === 'Gallery') {
+		return (
+			<footer css={galleryContentStyles}>
+				<div>Gallery</div>
+				<div css={galleryMetaStyles}>
+					{galleryCount}
+					<span css={galleryIconContainerStyles}>
+						<CameraSvg />
+					</span>
+				</div>
+			</footer>
+		);
 	}
 
 	return (

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -118,6 +118,19 @@ export const Opinion: Story = {
 	},
 };
 
+export const Gallery: Story = {
+	args: {
+		image: {
+			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Gallery',
+		},
+		galleryCount: 12,
+	},
+};
+
 export const WithTrailText: Story = {
 	args: {
 		kickerText: undefined,

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -375,11 +375,6 @@ export const FeatureCard = ({
 											roundedCorners={false}
 											aspectRatio={aspectRatio}
 										/>
-										{/**
-										 * If the card isn't playable, we need to show a play icon.
-										 * Otherwise, this is handled by the YoutubeAtom.
-										 * TODO: Determine if these cards should be playable
-										 */}
 										{isVideoMainMedia &&
 											mainMedia.duration > 0 && (
 												<MediaDuration

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -73,6 +73,7 @@ export type Props = {
 	/** Alows the consumer to set an aspect ratio on the image of 5:3 or 5:4 */
 	aspectRatio?: AspectRatio;
 	showQuotes?: boolean;
+	galleryCount?: number;
 };
 
 const baseCardStyles = css`
@@ -231,6 +232,7 @@ const CommentCount = ({
 }) => {
 	if (!discussionId) return null;
 	if (!discussionApiUrl) return null;
+
 	return (
 		<Link
 			{...{
@@ -293,13 +295,11 @@ export const FeatureCard = ({
 	aspectRatio,
 	starRating,
 	showQuotes,
+	galleryCount,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
-	// If the card isn't playable, we need to show a play icon.
-	// Otherwise, this is handled by the YoutubeAtom
-	/**TODO: Determin if these cards should be playable */
-	const showPlayIcon = mainMedia?.type === 'Video';
+	const isVideoMainMedia = mainMedia?.type === 'Video';
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -318,7 +318,6 @@ export const FeatureCard = ({
 						dataLinkName={dataLinkName}
 						isExternalLink={isExternalLink}
 					/>
-
 					<div
 						css={[
 							css`
@@ -344,31 +343,26 @@ export const FeatureCard = ({
 								`}
 							>
 								{media.type === 'video' && (
-									<>
-										<div>
-											<CardPicture
-												mainImage={
-													media.imageUrl
-														? media.imageUrl
-														: media.mainMedia.images.reduce(
-																(
-																	prev,
-																	current,
-																) =>
-																	prev.width >
-																	current.width
-																		? prev
-																		: current,
-														  ).url
-												}
-												imageSize={imageSize}
-												alt={headlineText}
-												loading={imageLoading}
-												roundedCorners={false}
-												aspectRatio={aspectRatio}
-											/>
-										</div>
-									</>
+									<div>
+										<CardPicture
+											mainImage={
+												media.imageUrl
+													? media.imageUrl
+													: media.mainMedia.images.reduce(
+															(prev, current) =>
+																prev.width >
+																current.width
+																	? prev
+																	: current,
+													  ).url
+											}
+											imageSize={imageSize}
+											alt={headlineText}
+											loading={imageLoading}
+											roundedCorners={false}
+											aspectRatio={aspectRatio}
+										/>
+									</div>
 								)}
 
 								{media.type === 'picture' && (
@@ -381,7 +375,12 @@ export const FeatureCard = ({
 											roundedCorners={false}
 											aspectRatio={aspectRatio}
 										/>
-										{showPlayIcon &&
+										{/**
+										 * If the card isn't playable, we need to show a play icon.
+										 * Otherwise, this is handled by the YoutubeAtom.
+										 * TODO: Determine if these cards should be playable
+										 */}
+										{isVideoMainMedia &&
 											mainMedia.duration > 0 && (
 												<MediaDuration
 													mediaDuration={
@@ -460,7 +459,6 @@ export const FeatureCard = ({
 											/>
 										</div>
 									)}
-
 									<CardFooter
 										format={format}
 										age={
@@ -499,12 +497,13 @@ export const FeatureCard = ({
 										// 	) : undefined
 										// }
 										showLivePlayable={false}
+										mediaType={mainMedia?.type}
+										galleryCount={galleryCount}
 									/>
 								</div>
 							</div>
 						)}
 					</div>
-
 					{hasSublinks && (
 						<SupportingContent
 							supportingContent={supportingContent}

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -71,6 +71,7 @@ export const ScrollableFeature = ({
 								tablet: 'xxsmall',
 								mobile: 'xsmall',
 							}}
+							galleryCount={card.galleryCount}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -66,6 +66,7 @@ export const StaticFeatureTwo = ({
 							imageSize="feature-large"
 							headlineSizes={{ desktop: 'small' }}
 							supportingContent={card.supportingContent}
+							galleryCount={card.galleryCount}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
## What does this change?

Use new gallery footer for feature cards of gallery articles.

## Why?

To match [Figma designs](https://www.figma.com/design/6NWdhzJfb3uraFgalGaNAE/Card-Components?node-id=4308-11409&t=0s1SOsVWK6vjNIfQ-0).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/38bd8b5c-e842-4d73-882a-dfee754b39f2
[after]: https://github.com/user-attachments/assets/3d12c494-69ca-43f8-a151-9654a93599e0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
