### PR TITLE
Feature card audio image and footer

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1072,7 +1072,6 @@ export const Card = ({
 												branding && (
 													<CardBranding
 														branding={branding}
-														format={format}
 														onwardsSource={
 															onwardsSource
 														}
@@ -1091,7 +1090,6 @@ export const Card = ({
 												branding ? (
 													<CardBranding
 														branding={branding}
-														format={format}
 														onwardsSource={
 															onwardsSource
 														}
@@ -1194,7 +1192,6 @@ export const Card = ({
 							branding ? (
 								<CardBranding
 									branding={branding}
-									format={format}
 									onwardsSource={onwardsSource}
 								/>
 							) : undefined

--- a/dotcom-rendering/src/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardBranding.tsx
@@ -5,7 +5,6 @@ import {
 	visuallyHidden,
 } from '@guardian/source/foundations';
 import { useConfig } from '../../../components/ConfigContext';
-import type { ArticleFormat } from '../../../lib/articleFormat';
 import { decideCardLogo } from '../../../lib/decideLogo';
 import { getZIndex } from '../../../lib/getZIndex';
 import { getOphanComponents } from '../../../lib/labs';
@@ -16,7 +15,6 @@ import type { OnwardsSource } from '../../../types/onwards';
 
 type Props = {
 	branding: Branding;
-	format: ArticleFormat;
 	onwardsSource: OnwardsSource | undefined;
 	containerPalette?: DCRContainerPalette;
 };
@@ -46,11 +44,10 @@ const labelStyle = css`
 
 export const CardBranding = ({
 	branding,
-	format,
 	onwardsSource,
 	containerPalette,
 }: Props) => {
-	const logo = decideCardLogo(branding, format, containerPalette);
+	const logo = decideCardLogo(branding, containerPalette);
 
 	const { darkModeAvailable } = useConfig();
 

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { palette, space, textSansBold12 } from '@guardian/source/foundations';
 import { SvgCamera } from '@guardian/source/react-components';
 import { Pill } from '../../../components/Pill';
+import { SvgMediaControlsPlay } from '../../../components/SvgMediaControlsPlay';
 import { type ArticleFormat, ArticleSpecial } from '../../../lib/articleFormat';
 import type { MainMedia } from '../../../types/mainMedia';
 
@@ -46,6 +47,7 @@ type Props = {
 	cardBranding?: JSX.Element;
 	mediaType?: MainMedia['type'];
 	galleryCount?: number;
+	audioDuration?: string;
 };
 
 export const CardFooter = ({
@@ -56,11 +58,23 @@ export const CardFooter = ({
 	showLivePlayable,
 	mediaType,
 	galleryCount,
+	audioDuration,
 }: Props) => {
 	if (showLivePlayable) return null;
 
 	if (format.theme === ArticleSpecial.Labs && cardBranding) {
 		return <footer css={labStyles}>{cardBranding}</footer>;
+	}
+
+	if (mediaType === 'Audio' && audioDuration !== undefined) {
+		return (
+			<footer css={contentStyles}>
+				<Pill
+					content={<time>{audioDuration}</time>}
+					icon={<SvgMediaControlsPlay />}
+				/>
+			</footer>
+		);
 	}
 
 	if (mediaType === 'Gallery') {

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -24,6 +24,7 @@ export type ImageSizeType =
 	| 'large'
 	| 'jumbo'
 	| 'carousel'
+	| 'podcast'
 	| 'feature'
 	| 'feature-large';
 

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -50,6 +50,7 @@ const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
 	switch (imageSize) {
 		case 'jumbo':
 		case 'large':
+		case 'podcast':
 		case 'carousel':
 		case 'medium':
 		case 'feature':

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -39,6 +39,9 @@ const decideImageWidths = (
 		// 		{ breakpoint: breakpoints.desktop, width: 140 },
 		// 	];
 
+		case 'podcast':
+			return [{ breakpoint: breakpoints.mobile, width: 80 }];
+
 		case 'carousel':
 			return [{ breakpoint: breakpoints.mobile, width: 220 }];
 

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -118,6 +118,24 @@ export const Opinion: Story = {
 	},
 };
 
+export const Podcast: Story = {
+	args: {
+		image: {
+			src: 'https://media.guim.co.uk/ecb7f0bebe473d6ef1375b5cb60b78f9466a5779/0_229_3435_2061/master/3435.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Audio',
+			duration: 120,
+		},
+		podcastImage: {
+			src: 'https://media.guim.co.uk/be8830289638b0948b1ba4ade906e540554ada88/0_0_5000_3000/master/5000.jpg',
+			altText: 'Football Weekly',
+		},
+		audioDuration: '55:09',
+	},
+};
+
 export const Gallery: Story = {
 	args: {
 		image: {

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -435,7 +435,7 @@ export const FeatureCard = ({
 															''
 														}
 														loading="lazy"
-														roundedCorners={true}
+														roundedCorners={false}
 														aspectRatio="1:1"
 													/>
 												</div>

--- a/dotcom-rendering/src/components/Pill.stories.tsx
+++ b/dotcom-rendering/src/components/Pill.stories.tsx
@@ -34,9 +34,7 @@ export const WithGalleryIcon = {
 
 export const WithGalleryIconAndPrefix = {
 	args: {
-		content: '10',
+		...WithGalleryIcon.args,
 		prefix: 'Gallery',
-		icon: <SvgCamera />,
-		iconSide: 'right',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -72,6 +72,8 @@ export const ScrollableFeature = ({
 								mobile: 'xsmall',
 							}}
 							galleryCount={card.galleryCount}
+							podcastImage={card.podcastImage}
+							audioDuration={card.audioDuration}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/lib/cardHelpers.test.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.test.ts
@@ -1,70 +1,41 @@
 import type { DCRContainerPalette } from '../types/front';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	type ArticleFormat,
-	Pillar,
-} from './articleFormat';
 import { cardHasDarkBackground } from './cardHelpers';
 
 describe('cardHasDarkBackground', () => {
-	const standardArticleFormat = {
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-		theme: Pillar.News,
-	};
-
-	const pictureFormat = {
-		...standardArticleFormat,
-		design: ArticleDesign.Picture,
-	};
-
-	const galleryFormat = {
-		...standardArticleFormat,
-		design: ArticleDesign.Gallery,
-	};
-
 	const testCases = [
 		{
-			format: pictureFormat,
 			containerPalette: undefined,
 			expectedResult: false,
 		},
 		{
-			format: galleryFormat,
 			containerPalette: undefined,
 			expectedResult: false,
 		},
 		{
-			format: pictureFormat,
 			containerPalette: 'Branded',
 			expectedResult: false,
 		},
 		{
-			format: galleryFormat,
 			containerPalette: 'Branded',
 			expectedResult: false,
 		},
 		{
-			format: pictureFormat,
 			containerPalette: 'SombrePalette',
 			expectedResult: true,
 		},
 		{
-			format: galleryFormat,
 			containerPalette: 'SombrePalette',
 			expectedResult: true,
 		},
 	] satisfies {
-		format: ArticleFormat;
 		containerPalette?: DCRContainerPalette;
 		expectedResult: boolean;
 	}[];
 
 	it.each(testCases)(
 		'returns $expectedResult for $format format, $containerPalette containerPalette',
-		({ format, containerPalette, expectedResult }) => {
-			expect(cardHasDarkBackground(format, containerPalette)).toBe(
+		({ containerPalette, expectedResult }) => {
+			expect(cardHasDarkBackground(containerPalette)).toBe(
 				expectedResult,
 			);
 		},

--- a/dotcom-rendering/src/lib/cardHelpers.ts
+++ b/dotcom-rendering/src/lib/cardHelpers.ts
@@ -15,7 +15,6 @@ export const isMediaCard = (format: ArticleFormat): boolean => {
 };
 
 export const cardHasDarkBackground = (
-	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
 ): boolean => {
 	switch (containerPalette) {
@@ -38,6 +37,7 @@ export const cardHasDarkBackground = (
 		// Special palettes which act more like standard containers
 		case 'MediaPalette':
 		case 'PodcastPalette':
+
 		// If no containerPalette provided, card is in a standard container
 		case undefined: {
 			return false;

--- a/dotcom-rendering/src/lib/decideLogo.ts
+++ b/dotcom-rendering/src/lib/decideLogo.ts
@@ -1,14 +1,12 @@
 import type { Branding } from '../types/branding';
 import type { DCRContainerPalette } from '../types/front';
-import type { ArticleFormat } from './articleFormat';
 import { cardHasDarkBackground } from './cardHelpers';
 
 export const decideCardLogo = (
 	branding: Branding,
-	format: ArticleFormat,
 	containerPalette?: DCRContainerPalette,
 ): Branding['logo'] => {
-	return cardHasDarkBackground(format, containerPalette) &&
+	return cardHasDarkBackground(containerPalette) &&
 		branding.logoForDarkBackground
 		? branding.logoForDarkBackground
 		: branding.logo;

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -92,6 +92,7 @@ const indices = [
 	// See: https://www.sarasoueidan.com/blog/nested-links/
 	'card-nested-link',
 	'card-link',
+	'card-podcast-image',
 ] as const;
 
 // Implementation code - you don't need to change this to get a new index


### PR DESCRIPTION
## What does this change?

Use new audio image and footer for feature cards of audio articles.

## Why?

To match [Figma designs](https://www.figma.com/design/6NWdhzJfb3uraFgalGaNAE/Card-Components?node-id=4346-23890&t=0s1SOsVWK6vjNIfQ-0).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/426f9500-1912-428b-a419-eae018a497c1
[after]: https://github.com/user-attachments/assets/c1e80efb-94b7-4baf-a824-225d854990ee

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
