### PR TITLE
Add media cards to highlights container

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { between, from, until } from '@guardian/source/foundations';
+import {
+	between,
+	from,
+	textSansBold12,
+	until,
+} from '@guardian/source/foundations';
+import { SvgCamera } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { isMediaCard } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
@@ -13,8 +19,10 @@ import { CardHeadline } from '../CardHeadline';
 import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { FormatBoundary } from '../FormatBoundary';
-import { Icon } from '../MediaMeta';
+import { secondsToDuration } from '../MediaDuration';
+import { Pill } from '../Pill';
 import { StarRating } from '../StarRating/StarRating';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 
 export type HighlightsCardProps = {
 	linkTo: string;
@@ -30,6 +38,8 @@ export type HighlightsCardProps = {
 	byline?: string;
 	isExternalLink: boolean;
 	starRating?: Rating;
+	galleryCount?: number;
+	audioDuration?: string;
 };
 
 const gridContainer = css`
@@ -79,22 +89,32 @@ const headline = css`
 const mediaIcon = css`
 	grid-area: media-icon;
 	align-self: end;
-	width: 24px;
-	height: 24px;
+`;
+
+const audioPill = css`
+	display: flex;
+	align-items: center;
+	column-gap: 4px;
+`;
+
+const audioPillIcon = css`
+	width: 26px;
+	height: 26px;
 	/* We’re using the text colour for the icon badge */
-	background-color: ${palette('--highlights-card-headline')};
+	background-color: ${palette('--highlight-card-audio-icon')};
 	border-radius: 50%;
-	display: inline-block;
 
 	> svg {
-		width: 20px;
-		height: 20px;
 		margin-left: auto;
 		margin-right: auto;
-		margin-top: 2px;
 		display: block;
 		fill: ${palette('--highlights-container-background')};
 	}
+`;
+
+const audioPillText = css`
+	${textSansBold12};
+	color: ${palette('--highlight-card-audio-text')};
 `;
 
 const imageArea = css`
@@ -152,9 +172,37 @@ export const HighlightsCard = ({
 	byline,
 	isExternalLink,
 	starRating,
+	galleryCount,
+	audioDuration,
 }: HighlightsCardProps) => {
 	const showMediaIcon = isMediaCard(format);
-
+	const MediaPill = () => (
+		<div css={mediaIcon}>
+			{mainMedia?.type === 'Video' && (
+				<Pill
+					content={secondsToDuration(mainMedia.duration)}
+					icon={<SvgMediaControlsPlay />}
+					iconSize={'small'}
+				/>
+			)}
+			{mainMedia?.type === 'Audio' && (
+				<div css={audioPill}>
+					<div css={audioPillIcon}>
+						<SvgMediaControlsPlay />
+					</div>
+					<span css={audioPillText}>{audioDuration}</span>
+				</div>
+			)}
+			{mainMedia?.type === 'Gallery' && (
+				<Pill
+					prefix="Gallery"
+					content={galleryCount?.toString() ?? ''}
+					icon={<SvgCamera />}
+					iconSide="right"
+				/>
+			)}
+		</div>
+	);
 	return (
 		<FormatBoundary format={format}>
 			<div css={[gridContainer, hoverStyles]}>
@@ -193,11 +241,7 @@ export const HighlightsCard = ({
 					</div>
 				) : null}
 
-				{!!mainMedia && showMediaIcon && (
-					<div css={mediaIcon}>
-						<Icon mediaType={mainMedia.type} />
-					</div>
-				)}
+				{!!mainMedia && showMediaIcon && MediaPill()}
 
 				<div css={imageArea}>
 					{(avatarUrl && (

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import {
 	between,
 	from,
+	space,
 	textSansBold12,
 	until,
 } from '@guardian/source/foundations';
@@ -103,6 +104,8 @@ const headline = css`
 const mediaIcon = css`
 	grid-area: media-icon;
 	align-self: end;
+	display: flex;
+	align-items: flex-end;
 `;
 
 const audioPill = css`
@@ -112,10 +115,9 @@ const audioPill = css`
 `;
 
 const audioPillIcon = css`
-	width: 26px;
-	height: 26px;
-	/* We’re using the text colour for the icon badge */
-	background-color: ${palette('--highlight-card-audio-icon')};
+	width: ${space[6]}px;
+	height: ${space[6]}px;
+	background-color: ${palette('--pill-background')};
 	border-radius: 50%;
 
 	> svg {

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -121,9 +121,6 @@ const audioPillIcon = css`
 	border-radius: 50%;
 
 	> svg {
-		margin-left: auto;
-		margin-right: auto;
-		display: block;
 		fill: ${palette('--highlights-container-background')};
 	}
 `;

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/source/foundations';
 import { SvgCamera } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
-import { isMediaCard } from '../../lib/cardHelpers';
+import { isMediaCard as isMedia } from '../../lib/cardHelpers';
 import { palette } from '../../palette';
 import type { StarRating as Rating } from '../../types/content';
 import type { DCRFrontImage } from '../../types/front';
@@ -79,6 +79,20 @@ const gridContainer = css`
 		grid-template-areas:
 			'headline 	image'
 			'media-icon image';
+	}
+`;
+
+const mediaGrid = css`
+	grid-template-areas:
+		'image'
+		'headline'
+		'media-icon';
+
+	${from.desktop} {
+		width: 300px;
+		grid-template-areas:
+			'image headline'
+			'image media-icon';
 	}
 `;
 
@@ -175,7 +189,7 @@ export const HighlightsCard = ({
 	galleryCount,
 	audioDuration,
 }: HighlightsCardProps) => {
-	const showMediaIcon = isMediaCard(format);
+	const isMediaCard = isMedia(format);
 	const MediaPill = () => (
 		<div css={mediaIcon}>
 			{mainMedia?.type === 'Video' && (
@@ -205,7 +219,7 @@ export const HighlightsCard = ({
 	);
 	return (
 		<FormatBoundary format={format}>
-			<div css={[gridContainer, hoverStyles]}>
+			<div css={[gridContainer, hoverStyles, isMediaCard && mediaGrid]}>
 				<CardLink
 					linkTo={linkTo}
 					headlineText={headlineText}
@@ -241,7 +255,7 @@ export const HighlightsCard = ({
 					</div>
 				) : null}
 
-				{!!mainMedia && showMediaIcon && MediaPill()}
+				{!!mainMedia && isMediaCard && MediaPill()}
 
 				<div css={imageArea}>
 					{(avatarUrl && (

--- a/dotcom-rendering/src/components/Pill.tsx
+++ b/dotcom-rendering/src/components/Pill.tsx
@@ -26,7 +26,7 @@ const pillStyles = css`
 	align-items: center;
 	gap: ${space[1]}px;
 	padding: 0 10px;
-	border-radius: ${space[3]}px;
+	border-radius: ${space[10]}px;
 	${textSansBold12};
 	color: ${palette('--pill-text')};
 	background-color: ${palette('--pill-background')};
@@ -38,6 +38,9 @@ const pillStyles = css`
 
 const pillContentStyles = css`
 	padding: ${space[1]}px 0;
+	display: flex;
+	align-items: center;
+	gap: ${space[1]}px;
 `;
 
 const pillPrefixStyles = css`
@@ -68,8 +71,10 @@ export const Pill = ({
 					{prefix}
 				</span>
 			)}
-			<span css={pillContentStyles}>{content}</span>
-			{iconSide === 'right' && <Icon />}
+			<span css={pillContentStyles}>
+				{content}
+				{iconSide === 'right' && <Icon />}
+			</span>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/Pill.tsx
+++ b/dotcom-rendering/src/components/Pill.tsx
@@ -17,6 +17,8 @@ interface Props {
 	icon?: ReactElement;
 	/** Optional icon position (icon is on the left by default) */
 	iconSide?: IconSide;
+	/** Optional icon size */
+	iconSize?: 'xsmall' | 'small' | 'medium' | 'large';
 }
 
 const pillStyles = css`
@@ -44,15 +46,20 @@ const pillPrefixStyles = css`
 	border-right: 1px solid ${palette('--pill-divider')};
 `;
 
-export const Pill = ({ content, prefix, icon, iconSide = 'left' }: Props) => {
+export const Pill = ({
+	content,
+	prefix,
+	icon,
+	iconSide = 'left',
+	iconSize = 'xsmall',
+}: Props) => {
 	const Icon = () =>
 		icon
 			? cloneElement(icon, {
-					size: 'xsmall',
+					size: iconSize,
 					theme: { fill: 'currentColor' },
 			  })
 			: null;
-
 	return (
 		<div css={pillStyles}>
 			{iconSide === 'left' && <Icon />}

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -263,6 +263,8 @@ export const ScrollableHighlights = ({ trails }: Props) => {
 								showQuotedHeadline={trail.showQuotedHeadline}
 								mainMedia={trail.mainMedia}
 								starRating={trail.starRating}
+								galleryCount={trail.galleryCount}
+								audioDuration={trail.audioDuration}
 							/>
 						</li>
 					);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5508,6 +5508,9 @@ const highlightsCardKickerText: PaletteFunction = (format) => {
 			return sourcePalette.specialReportAlt[200];
 	}
 };
+const highlightsCardAudioIcon: PaletteFunction = () => sourcePalette.brand[100];
+const highlightsCardAudioText: PaletteFunction = () =>
+	sourcePalette.neutral[10];
 
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
@@ -6518,6 +6521,14 @@ const paletteColours = {
 	'--headline-match-colour': {
 		light: headlineMatchTextLight,
 		dark: headlineMatchTextDark,
+	},
+	'--highlight-card-audio-icon': {
+		light: highlightsCardAudioIcon,
+		dark: highlightsCardAudioIcon,
+	},
+	'--highlight-card-audio-text': {
+		light: highlightsCardAudioText,
+		dark: highlightsCardAudioText,
 	},
 	'--highlights-card-headline': {
 		light: highlightsCardHeadline,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5510,7 +5510,7 @@ const highlightsCardKickerText: PaletteFunction = (format) => {
 };
 const highlightsCardAudioIcon: PaletteFunction = () => sourcePalette.brand[100];
 const highlightsCardAudioText: PaletteFunction = () =>
-	sourcePalette.neutral[10];
+	sourcePalette.neutral[20];
 
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {


### PR DESCRIPTION
## What does this change?
Updates the display of cards in the highlights container when they are a media type (video, podcast or gallery).
The new design includes the relevant pill for each media type, as well as updating the border radius of the pill to 40px.
It also adds a new media grid for the hightlights cards as media cards have a distinct layout to standard highlight cards.

As part of this work, the Pill component has been refactored and extended to include adjustable icon size.

There is a further piece of work to update the shape of podcast images that will be made in a follow up pr.

## Why?
Previously, media cards had little visual distinction to other cards. This change is requested by Design.

## How to test?
The Highlights container is currently only available on the Europe beta network front which makes testing tricky.

You can opt in to the europe beta test via https://www.theguardian.com/opt/in/europe-beta-front and then visiting www.theguardian.com/europe

Or you need make the following amendments to the dotcom-rendering/src/layouts/FrontLayout.tsx file:
- on line line 141, comment out   `const { abTests, isPreview } = front.config;`
- on line 164, hardcode the value the showHighlights value to true
Once these amendments have been made, the highlights container should be visible on the https://m.code.dev-theguardian.com/app/fairground front

## Screenshots

| mobile      | desktop      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6c8ed569-e389-4bfd-8678-6491fd0f9d1d
[after]: https://github.com/user-attachments/assets/16a40ab7-c6a5-4482-bf41-128055e15d09


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
