### PR TITLE
Add code to check whether a user is allowed to reject all on the CMP

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
@@ -1,0 +1,25 @@
+import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+
+const ALLOW_REJECT_ALL_COOKIE = 'gu_allow_reject_all';
+
+export const getAllowRejectAllCookie = (): string | null =>
+	getCookie({ name: ALLOW_REJECT_ALL_COOKIE });
+
+export const setAllowRejectAllCookie = (daysToLive = 1): void => {
+	const expires = new Date();
+	expires.setMonth(expires.getMonth() + 6);
+	setCookie({
+		name: ALLOW_REJECT_ALL_COOKIE,
+		value: expires.getTime().toString(),
+		daysToLive,
+	});
+};
+
+export const removeAllowRejectAllCookie = (): void =>
+	removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
+
+export const allowRejectAll = (): boolean => {
+	const cookieVal = getAllowRejectAllCookie();
+	if (!cookieVal) return false;
+	return !Number.isNaN(parseInt(cookieVal, 10));
+};

--- a/dotcom-rendering/src/client/userFeatures/membersDataApi.ts
+++ b/dotcom-rendering/src/client/userFeatures/membersDataApi.ts
@@ -101,6 +101,7 @@ export const syncDataFromMembersDataApi: (
 	return {
 		hideSupportMessaging: !response.showSupportMessaging,
 		adFree: response.contentAccess.digitalPack,
+		allowRejectAll: false, // TODO: Placeholder until Guardian Light has been renamed to Guardian AdLite in the mdapi response
 	};
 };
 

--- a/dotcom-rendering/src/client/userFeatures/membersDataApi.ts
+++ b/dotcom-rendering/src/client/userFeatures/membersDataApi.ts
@@ -101,7 +101,7 @@ export const syncDataFromMembersDataApi: (
 	return {
 		hideSupportMessaging: !response.showSupportMessaging,
 		adFree: response.contentAccess.digitalPack,
-		allowRejectAll: false, // TODO: Placeholder until Guardian Light has been renamed to Guardian AdLite in the mdapi response
+		allowRejectAll: response.contentAccess.digitalPack || false, // TODO: Placeholder until Guardian Light has been renamed to Guardian AdLite in the mdapi response
 	};
 };
 

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -54,8 +54,8 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 		: new Date(currentTime + msInOneDay);
 
 	setHideSupportMessagingCookie(true);
-	setAdFreeCookie(2);
-	setAllowRejectAllCookie(2);
+	setAdFreeCookie();
+	setAllowRejectAllCookie();
 	setUserFeaturesExpiryCookie(expiryDate.getTime().toString());
 };
 

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -4,6 +4,11 @@ import {
 	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
 } from '../../lib/identity';
 import { getAdFreeCookie, setAdFreeCookie } from './cookies/adFree';
+import {
+	allowRejectAll,
+	getAllowRejectAllCookie,
+	setAllowRejectAllCookie,
+} from './cookies/allowRejectAll';
 import { setHideSupportMessagingCookie } from './cookies/hideSupportMessaging';
 import {
 	getUserFeaturesExpiryCookie,
@@ -50,6 +55,7 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 
 	setHideSupportMessagingCookie(true);
 	setAdFreeCookie(2);
+	setAllowRejectAllCookie(2);
 	setUserFeaturesExpiryCookie(expiryDate.getTime().toString());
 };
 
@@ -154,6 +160,37 @@ describe('Storing new feature data', () => {
 					parseInt(
 						// @ts-expect-error -- we’re testing it
 						getAdFreeCookie(),
+						10,
+					),
+				),
+			).toBe(false);
+		});
+	});
+
+	it('Puts the allowRejectAll state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				benefits: [],
+			}),
+		);
+		return refresh().then(() => {
+			expect(getAllowRejectAllCookie()).toBeNull();
+		});
+	});
+
+	it('Puts the allowRejectAll state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				benefits: ['allowRejectAll'],
+			}),
+		);
+		return refresh().then(() => {
+			expect(allowRejectAll()).toBe(true);
+			expect(
+				Number.isNaN(
+					parseInt(
+						// @ts-expect-error -- we’re testing it
+						getAllowRejectAllCookie(),
 						10,
 					),
 				),

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -12,6 +12,11 @@ import {
 	setAdFreeCookie,
 } from './cookies/adFree';
 import {
+	getAllowRejectAllCookie,
+	removeAllowRejectAllCookie,
+	setAllowRejectAllCookie,
+} from './cookies/allowRejectAll';
+import {
 	getHideSupportMessagingCookie,
 	removeHideSupportMessagingCookie,
 	setHideSupportMessagingCookie,
@@ -28,13 +33,15 @@ import { syncDataFromUserBenefitsApi } from './userBenefitsApi';
 export type UserBenefits = {
 	adFree: boolean;
 	hideSupportMessaging: boolean;
+	allowRejectAll: boolean;
 };
 
 const userHasData = () => {
 	const cookie =
 		getAdFreeCookie() ??
 		getUserFeaturesExpiryCookie() ??
-		getHideSupportMessagingCookie();
+		getHideSupportMessagingCookie() ??
+		getAllowRejectAllCookie();
 	return !!cookie;
 };
 
@@ -86,12 +93,18 @@ const persistResponse = (userBenefitsResponse: UserBenefits) => {
 	} else if (adFreeDataIsPresent() && !forcedAdFreeMode) {
 		removeAdFreeCookie();
 	}
+	if (userBenefitsResponse.allowRejectAll) {
+		setAllowRejectAllCookie(2);
+	} else {
+		removeAllowRejectAllCookie();
+	}
 };
 
 export const deleteAllCookies = (): void => {
 	removeAdFreeCookie();
 	removeHideSupportMessagingCookie();
 	removeUserFeaturesExpiryCookie();
+	removeAllowRejectAllCookie();
 };
 
 export { refresh };

--- a/dotcom-rendering/src/client/userFeatures/userBenefitsApi.ts
+++ b/dotcom-rendering/src/client/userFeatures/userBenefitsApi.ts
@@ -29,6 +29,7 @@ export const syncDataFromUserBenefitsApi = async (
 			'hideSupportMessaging',
 		),
 		adFree: response.benefits.includes('adFree'),
+		allowRejectAll: response.benefits.includes('allowRejectAll'),
 	};
 };
 


### PR DESCRIPTION
## What does this change?
This PR adds code to retrieve and store a user's 'allow reject all' status from either the user-benefits api or the members-data-api (depending on the AB cohort the user is in).
## Why?
To enable us to tell which version of the consent management banner to show for signed in users, we need to check whether they are subscribed to either a product which gives them ad-free reading or to Guardian Ad-Lite. 

This code does that check and then caches that result in a cookie which is refreshed every 24hrs in the same way as the other user features cookies (ad-free, hide support messaging).

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
