### PR TITLE
Don't load Most Viewed placeholder when page is adapted

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterPlaceholder.tsx
@@ -48,7 +48,7 @@ const bigNumber = css`
 
 export const MostViewedFooterPlaceholder = () => {
 	return (
-		<>
+		<div data-name="placeholder">
 			<div css={tabs} />
 			<ol css={listContainer}>
 				{Array.from(Array(10), (_, i) => (
@@ -59,6 +59,6 @@ export const MostViewedFooterPlaceholder = () => {
 					</li>
 				))}
 			</ol>
-		</>
+		</div>
 	);
 };


### PR DESCRIPTION
## Why?

When the page is [adapted](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/client/adaptiveSite.ts#L8), match the behaviour before the new Most Viewed placeholder [was added](https://github.com/guardian/dotcom-rendering/pull/13123).

## Screenshots

http://localhost:3030/Article/https://www.theguardian.com/football/2024/oct/06/brighton-tottenham-premier-league-match-report#adapt

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6b8a447c-4d33-4fc5-b21a-d08d1fb41887
[after]: https://github.com/user-attachments/assets/9e494e13-d5e0-468d-8769-2ce815c9f303

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

## Follow up

A good follow-up would be to remove the containers that do not render content when the site is adapted. However, this is a bit more tricky - Do we want the page removing large containers after page load for users on a poor connection - what would that experience be like? Would the CLS be worth it?

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
