### PR TITLE
Feature Card video time pill

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
 import { palette, space, textSansBold12 } from '@guardian/source/foundations';
 import { SvgCamera } from '@guardian/source/react-components';
+import { secondsToDuration } from '../../../components/MediaDuration';
 import { Pill } from '../../../components/Pill';
 import { SvgMediaControlsPlay } from '../../../components/SvgMediaControlsPlay';
 import { type ArticleFormat, ArticleSpecial } from '../../../lib/articleFormat';
-import type { MainMedia } from '../../../types/mainMedia';
 
 const contentStyles = css`
 	margin-top: auto;
@@ -45,9 +45,12 @@ type Props = {
 	age?: JSX.Element;
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
-	mediaType?: MainMedia['type'];
-	galleryCount?: number;
+	isVideo?: boolean;
+	videoDuration?: number;
+	isAudio?: boolean;
 	audioDuration?: string;
+	isGallery?: boolean;
+	galleryCount?: number;
 };
 
 export const CardFooter = ({
@@ -56,9 +59,12 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	showLivePlayable,
-	mediaType,
-	galleryCount,
+	isVideo,
+	videoDuration,
+	isAudio,
 	audioDuration,
+	isGallery,
+	galleryCount,
 }: Props) => {
 	if (showLivePlayable) return null;
 
@@ -66,7 +72,18 @@ export const CardFooter = ({
 		return <footer css={labStyles}>{cardBranding}</footer>;
 	}
 
-	if (mediaType === 'Audio' && audioDuration !== undefined) {
+	if (isVideo && videoDuration !== undefined) {
+		return (
+			<footer css={contentStyles}>
+				<Pill
+					content={<time>{secondsToDuration(videoDuration)}</time>}
+					icon={<SvgMediaControlsPlay />}
+				/>
+			</footer>
+		);
+	}
+
+	if (isAudio && audioDuration !== undefined) {
 		return (
 			<footer css={contentStyles}>
 				<Pill
@@ -77,11 +94,11 @@ export const CardFooter = ({
 		);
 	}
 
-	if (mediaType === 'Gallery') {
+	if (isGallery && galleryCount !== undefined) {
 		return (
 			<footer css={contentStyles}>
 				<Pill
-					content={galleryCount?.toString() ?? ''}
+					content={galleryCount.toString()}
 					prefix="Gallery"
 					icon={<SvgCamera />}
 					iconSide="right"

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -120,6 +120,10 @@ export const Opinion: Story = {
 
 export const Podcast: Story = {
 	args: {
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Audio,
+		},
 		image: {
 			src: 'https://media.guim.co.uk/ecb7f0bebe473d6ef1375b5cb60b78f9466a5779/0_229_3435_2061/master/3435.jpg',
 			altText: 'alt text',
@@ -138,6 +142,10 @@ export const Podcast: Story = {
 
 export const Gallery: Story = {
 	args: {
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Gallery,
+		},
 		image: {
 			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
 			altText: 'alt text',
@@ -146,6 +154,52 @@ export const Gallery: Story = {
 			type: 'Gallery',
 		},
 		galleryCount: 12,
+	},
+};
+
+// A video article
+export const Video: Story = {
+	args: {
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Video,
+		},
+		image: {
+			src: 'https://media.guim.co.uk/f2aedd24e5414073a653f68112e0ad070c6f4a2b/254_0_7493_4500/master/7493.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Video',
+			id: 'video-id',
+			videoId: 'video-id',
+			height: 1080,
+			width: 1920,
+			origin: 'origin',
+			title: 'Video Title',
+			duration: 120,
+			expired: false,
+			images: [
+				{
+					url: 'https://media.guim.co.uk/video-thumbnail.jpg',
+					width: 1920,
+				},
+			],
+		},
+	},
+};
+
+// A standard (non-video) article with a video main media
+export const VideoMainMedia: Story = {
+	args: {
+		...Video.args,
+		image: {
+			src: 'https://media.guim.co.uk/4612af5f4667888fa697139cf570b6373d93a710/2446_345_3218_1931/master/3218.jpg',
+			altText: 'alt text',
+		},
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Standard,
+		},
 	},
 };
 

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
-import { Link } from '@guardian/source/react-components';
+import { Link, SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../lib/useCommentCount';
@@ -29,7 +29,8 @@ import { CardPicture } from './CardPicture';
 import { ContainerOverrides } from './ContainerOverrides';
 import { FormatBoundary } from './FormatBoundary';
 import { Island } from './Island';
-import { MediaDuration } from './MediaDuration';
+import { MediaDuration, secondsToDuration } from './MediaDuration';
+import { Pill } from './Pill';
 import { StarRating } from './StarRating/StarRating';
 import { SupportingContent } from './SupportingContent';
 
@@ -186,6 +187,12 @@ const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
 `;
 
+const videoPillStyles = css`
+	position: absolute;
+	top: 8px;
+	right: 8px;
+`;
+
 const getMedia = ({
 	imageUrl,
 	imageAltText,
@@ -325,6 +332,12 @@ export const FeatureCard = ({
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
 	const isVideoMainMedia = mainMedia?.type === 'Video';
+	const isVideoArticle = format.design === ArticleDesign.Video;
+	const isAudioArticle = format.design === ArticleDesign.Audio;
+	const isGalleryArticle = format.design === ArticleDesign.Gallery;
+
+	const videoDuration =
+		mainMedia?.type === 'Video' ? mainMedia.duration : undefined;
 
 	const media = getMedia({
 		imageUrl: image?.src,
@@ -538,12 +551,35 @@ export const FeatureCard = ({
 											// 	) : undefined
 											// }
 											showLivePlayable={false}
-											mediaType={mainMedia?.type}
-											galleryCount={galleryCount}
+											// The media duration is displayed in the top-right on a video article card
+											isVideo={
+												isVideoMainMedia &&
+												!isVideoArticle
+											}
+											isAudio={isAudioArticle}
+											isGallery={isGalleryArticle}
+											videoDuration={videoDuration}
 											audioDuration={audioDuration}
+											galleryCount={galleryCount}
 										/>
 									</div>
 								</div>
+
+								{isVideoArticle &&
+								videoDuration !== undefined ? (
+									<div css={videoPillStyles}>
+										<Pill
+											content={
+												<time>
+													{secondsToDuration(
+														videoDuration,
+													)}
+												</time>
+											}
+											icon={<SvgMediaControlsPlay />}
+										/>
+									</div>
+								) : null}
 							</div>
 						)}
 					</div>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -189,8 +189,8 @@ const trailTextWrapper = css`
 
 const videoPillStyles = css`
 	position: absolute;
-	top: 8px;
-	right: 8px;
+	top: ${space[2]}px;
+	right: ${space[2]}px;
 `;
 
 const getMedia = ({
@@ -551,11 +551,7 @@ export const FeatureCard = ({
 											// 	) : undefined
 											// }
 											showLivePlayable={false}
-											// The media duration is displayed in the top-right on a video article card
-											isVideo={
-												isVideoMainMedia &&
-												!isVideoArticle
-											}
+											isVideo={isVideoArticle}
 											isAudio={isAudioArticle}
 											isGallery={isGalleryArticle}
 											videoDuration={videoDuration}
@@ -564,8 +560,9 @@ export const FeatureCard = ({
 										/>
 									</div>
 								</div>
-
-								{isVideoArticle &&
+								{/* On video article cards, the duration is displayed in the footer */}
+								{!isVideoArticle &&
+								isVideoMainMedia &&
 								videoDuration !== undefined ? (
 									<div css={videoPillStyles}>
 										<Pill


### PR DESCRIPTION
## What does this change?

Adds a `Pill` component with the duration of the video in the:
- top-right, if the card is a video article
- footer, if the card is a non-video article with a video as the main media in the article

## Why?

To match [designs](https://www.figma.com/design/6NWdhzJfb3uraFgalGaNAE/Card-Components?node-id=4308-11347&t=4VpNCK8OgfQntP6A-0).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3d3251a3-f7ab-4e27-a6b6-164c485b8ab1
[after]: https://github.com/user-attachments/assets/c1f9deba-8ae6-45db-a983-ee652671a768

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
