### PR TITLE
Add play icon on Feature Cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
-import { Link, SvgMediaControlsPlay } from '@guardian/source/react-components';
+import { Link } from '@guardian/source/react-components';
+import { SvgMediaControlsPlay } from '../components/SvgMediaControlsPlay';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
 import { getZIndex } from '../lib/getZIndex';
@@ -186,6 +187,24 @@ const starRatingWrapper = css`
 
 const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
+`;
+
+const playIconWidth = 56;
+const playIconStyles = css`
+	position: absolute;
+	/**
+	 * Subject to change. We will wait to see how fronts editors use the
+	 * headlines and standfirsts before we decide on a final position.
+	 */
+	top: 35%;
+	left: calc(50% - ${playIconWidth / 2}px);
+	width: ${playIconWidth}px;
+	height: ${playIconWidth}px;
+	background-color: ${palette('--feature-card-play-icon-background')};
+	opacity: 0.7;
+	border-radius: 50%;
+	border: 1px solid ${palette('--feature-card-play-icon-border')};
+	fill: ${palette('--feature-card-play-icon-fill')};
 `;
 
 const videoPillStyles = css`
@@ -561,8 +580,13 @@ export const FeatureCard = ({
 										/>
 									</div>
 								</div>
+								{canPlayInline && isVideoMainMedia && (
+									<div css={playIconStyles}>
+										<SvgMediaControlsPlay />
+									</div>
+								)}
 								{/* On video article cards, the duration is displayed in the footer */}
-								{!isVideoArticle &&
+								{isVideoArticle &&
 								isVideoMainMedia &&
 								videoDuration !== undefined ? (
 									<div css={videoPillStyles}>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6465,6 +6465,18 @@ const paletteColours = {
 		light: featureCardKickerTextLight,
 		dark: () => sourcePalette.neutral[20],
 	},
+	'--feature-card-play-icon-background': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
+	'--feature-card-play-icon-border': {
+		light: () => sourcePalette.neutral[60],
+		dark: () => sourcePalette.neutral[60],
+	},
+	'--feature-card-play-icon-fill': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[100],
+	},
 	'--feature-card-trail-text': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],


### PR DESCRIPTION
## What does this change?

Adds play icon on Feature Cards when the video can be played inline

## Why?

To match [Figma designs](https://www.figma.com/design/6NWdhzJfb3uraFgalGaNAE/Card-Components?node-id=4308-11347&t=4VpNCK8OgfQntP6A-0).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/334b790b-d307-4f88-8ca5-d8ccddc71e4f
[after]: https://github.com/user-attachments/assets/70a39274-cabb-46a2-a750-e2aea9bf9c98

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
