### PR TITLE
Podcast series image on highlights cards

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -105,3 +105,19 @@ export const WithStarRating: Story = {
 	parameters: {},
 	name: 'With Star Rating',
 };
+
+export const WithPodcastSeriesImage: Story = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.Sport,
+		},
+		podcastImage: {
+			src: 'https://uploads.guim.co.uk/2024/08/01/FootballWeekly_FINAL_3000_(1).jpg',
+			altText: 'Football Weekly',
+		},
+	},
+	parameters: {},
+	name: 'With Podcast Series Image',
+};

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -110,7 +110,7 @@ export const WithPodcastSeriesImage: Story = {
 	args: {
 		format: {
 			display: ArticleDisplay.Standard,
-			design: ArticleDesign.Standard,
+			design: ArticleDesign.Audio,
 			theme: Pillar.Sport,
 		},
 		podcastImage: {

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -117,7 +117,9 @@ export const WithPodcastSeriesImage: Story = {
 			src: 'https://uploads.guim.co.uk/2024/08/01/FootballWeekly_FINAL_3000_(1).jpg',
 			altText: 'Football Weekly',
 		},
+		mainMedia: { type: 'Audio', duration: 31.76 },
 	},
+
 	parameters: {},
 	name: 'With Podcast Series Image',
 };

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -9,6 +9,7 @@ import { palette } from '../../palette';
 import type { StarRating as Rating } from '../../types/content';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
+import { PodcastSeriesImage } from '../../types/tag';
 import { Avatar } from '../Avatar';
 import { CardLink } from '../Card/components/CardLink';
 import { CardHeadline } from '../CardHeadline';
@@ -18,8 +19,6 @@ import { FormatBoundary } from '../FormatBoundary';
 import { Pill } from '../Pill';
 import { StarRating } from '../StarRating/StarRating';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
-import { PodcastSeriesImage } from '../../types/tag';
-import { PodcastCoverImage } from '../PodcastCoverImage';
 
 export type HighlightsCardProps = {
 	linkTo: string;

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -9,7 +9,7 @@ import { palette } from '../../palette';
 import type { StarRating as Rating } from '../../types/content';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
-import { PodcastSeriesImage } from '../../types/tag';
+import type { PodcastSeriesImage } from '../../types/tag';
 import { Avatar } from '../Avatar';
 import { CardLink } from '../Card/components/CardLink';
 import { CardHeadline } from '../CardHeadline';

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -18,6 +18,8 @@ import { FormatBoundary } from '../FormatBoundary';
 import { Pill } from '../Pill';
 import { StarRating } from '../StarRating/StarRating';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
+import { PodcastSeriesImage } from '../../types/tag';
+import { PodcastCoverImage } from '../PodcastCoverImage';
 
 export type HighlightsCardProps = {
 	linkTo: string;
@@ -35,6 +37,8 @@ export type HighlightsCardProps = {
 	starRating?: Rating;
 	galleryCount?: number;
 	audioDuration?: string;
+	/** The square podcast series image, if it exists for a card */
+	podcastImage?: PodcastSeriesImage;
 };
 
 const gridContainer = css`
@@ -114,8 +118,10 @@ const hoverStyles = css`
 		right: 0;
 		height: 100%;
 		width: 100%;
-		border-radius: 100%;
 		background-color: ${palette('--card-background-hover')};
+	}
+	:hover .circular {
+		border-radius: 100%;
 	}
 
 	/* Only underline the headline element we want to target (not kickers/sublink headlines) */
@@ -131,6 +137,60 @@ const starWrapper = css`
 	grid-area: media-icon;
 	align-self: flex-end;
 `;
+
+const decideImage = (
+	imageLoading: Loading,
+	format: ArticleFormat,
+	image?: DCRFrontImage,
+	podcastImage?: PodcastSeriesImage,
+	avatarUrl?: string,
+	byline?: string,
+) => {
+	if (!image && !avatarUrl) {
+		return null;
+	}
+	if (avatarUrl) {
+		return (
+			<Avatar
+				src={avatarUrl}
+				alt={byline ?? ''}
+				shape="cutout"
+				imageSize="large"
+			/>
+		);
+	}
+	if (format.design === ArticleDesign.Audio && podcastImage?.src) {
+		return (
+			<>
+				<CardPicture
+					imageSize="medium"
+					mainImage={podcastImage.src}
+					alt={podcastImage.altText}
+					loading={imageLoading}
+					isCircular={false}
+					aspectRatio={'1:1'}
+				/>
+				<div className="image-overlay"> </div>
+			</>
+		);
+	}
+	if (!image) {
+		return null;
+	}
+	return (
+		<>
+			<CardPicture
+				imageSize="medium"
+				mainImage={image.src}
+				alt={image.altText}
+				loading={imageLoading}
+				isCircular={true}
+			/>
+			{/* This image overlay is styled when the CardLink is hovered */}
+			<div className="image-overlay circular"> </div>
+		</>
+	);
+};
 
 export const HighlightsCard = ({
 	linkTo,
@@ -148,6 +208,7 @@ export const HighlightsCard = ({
 	starRating,
 	galleryCount,
 	audioDuration,
+	podcastImage,
 }: HighlightsCardProps) => {
 	const isMediaCard = isMedia(format);
 	const MediaPill = () => (
@@ -217,26 +278,14 @@ export const HighlightsCard = ({
 				{!!mainMedia && isMediaCard && MediaPill()}
 
 				<div css={[imageArea, avatarUrl && avatarAlignmentStyles]}>
-					{(avatarUrl && (
-						<Avatar
-							src={avatarUrl}
-							alt={byline ?? ''}
-							shape="cutout"
-						/>
-					)) ??
-						(image && (
-							<>
-								<CardPicture
-									imageSize="medium"
-									mainImage={image.src}
-									alt={image.altText}
-									loading={imageLoading}
-									isCircular={true}
-								/>
-								{/* This image overlay is styled when the CardLink is hovered */}
-								<div className="image-overlay"> </div>
-							</>
-						))}
+					{decideImage(
+						imageLoading,
+						format,
+						image,
+						podcastImage,
+						avatarUrl,
+						byline,
+					)}
 				</div>
 			</div>
 		</FormatBoundary>

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -265,6 +265,7 @@ export const ScrollableHighlights = ({ trails }: Props) => {
 								starRating={trail.starRating}
 								galleryCount={trail.galleryCount}
 								audioDuration={trail.audioDuration}
+								podcastImage={trail.podcastImage}
 							/>
 						</li>
 					);


### PR DESCRIPTION
## What does this change?
Uses a square podcast series image on highlights cards.

## Why?
This is per design.

## How to test?
The Highlights container is currently only available on the Europe beta network front which makes testing tricky.

You can opt in to the europe beta test via https://www.theguardian.com/opt/in/europe-beta-front and then visiting [www.theguardian.com/europe](http://www.theguardian.com/europe)

Or you need make the following amendments to the dotcom-rendering/src/layouts/FrontLayout.tsx file:

on line line 141, comment out const { abTests, isPreview } = front.config;
on line 164, hardcode the value the showHighlights value to true
Once these amendments have been made, the highlights container should be visible on the https://m.code.dev-theguardian.com/app/fairground front

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f26011ef-c113-43e3-92df-5769a8f95f09
[after]: https://github.com/user-attachments/assets/5afd10be-4027-436a-a343-68e535cae127


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
