### PR TITLE
Get fastly id from header and add it to all logs

### DIFF
--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -16,11 +16,15 @@ const hasPageId = (body: unknown): body is { pageId: string } => {
  * completed.
  */
 export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
+	const headerValue = req.headers['x-gu-xid'];
+	const requestId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
 	const loggerState = {
 		request: {
 			pageId: hasPageId(req.body) ? req.body.pageId : 'no-page-id-found',
 			path: req.path,
 			method: req.method,
+			fastlyRequestId: requestId ?? 'fastly-id-not-provided',
 		},
 		timing: {},
 	};

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -24,8 +24,8 @@ export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
 			pageId: hasPageId(req.body) ? req.body.pageId : 'no-page-id-found',
 			path: req.path,
 			method: req.method,
-			fastlyRequestId: requestId ?? 'fastly-id-not-provided',
 		},
+		fastlyRequestId: requestId ?? 'fastly-id-not-provided',
 		timing: {},
 	};
 

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -18,6 +18,7 @@ type DCRLoggingStore = {
 		method: string;
 		type?: string;
 		platform?: string;
+		fastlyRequestId?: string;
 	};
 	error?: {
 		message?: string;

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -18,8 +18,8 @@ type DCRLoggingStore = {
 		method: string;
 		type?: string;
 		platform?: string;
-		fastlyRequestId?: string;
 	};
+	fastlyRequestId: string;
 	error?: {
 		message?: string;
 		stack?: string;

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -12,7 +12,7 @@ const logLocation =
 		: `${path.resolve('logs')}/${logName}`;
 
 const logFields = (logEvent: LoggingEvent): unknown => {
-	const { request } = loggingStore.getStore() ?? {
+	const { request, fastlyRequestId } = loggingStore.getStore() ?? {
 		request: { pageId: 'outside-request-context' },
 	};
 
@@ -28,6 +28,7 @@ const logFields = (logEvent: LoggingEvent): unknown => {
 		level: logEvent.level.levelStr,
 		level_value: logEvent.level.level,
 		request,
+		fastlyRequestId,
 		// NODE_APP_INSTANCE is set by cluster mode
 		thread_name: process.env.NODE_APP_INSTANCE ?? '0',
 	};


### PR DESCRIPTION
## What does this change?
This PR extracts the `x-gu-xid` header from the request within the logging middleware. If the header is present, its value is added to the logging context under the `fastlyRequestId` field, ensuring that all logs include this field.

This PR extracts the x-gu-xid header from incoming requests within the logging middleware. If the header is present, its value is added to the logging context under the fastlyRequestId field, ensuring that all logs include this field. 

If the header is not present, the `fastlyRequestId` will default to `fastly-id-not-provided`. 

## Why?
By doing so, we enable correlation between request logs captured by the frontend and the corresponding logs in DCAR, improving traceability across systems.
The relevant PR in frontend: https://github.com/guardian/frontend/pull/27735

![image](https://github.com/user-attachments/assets/420e4a02-ff8e-407f-ad0e-8448c859d7b7)
