### PR TITLE
Video timestamp pills on cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -12,6 +12,7 @@ import {
 	ArticleSpecial,
 } from '../../lib/articleFormat';
 import { isMediaCard as isAMediaCard } from '../../lib/cardHelpers';
+import { isWithinTwelveHours, secondsToDuration } from '../../lib/formatTime';
 import { getZIndex } from '../../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { palette } from '../../palette';
@@ -37,7 +38,6 @@ import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
 import { MediaMeta } from '../MediaMeta';
-import { isWithinTwelveHours, secondsToDuration } from '../../lib/formatTime';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
 import { SlideshowCarousel } from '../SlideshowCarousel.importable';

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -36,7 +36,7 @@ import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.importable';
-import { MediaDuration } from '../MediaDuration';
+import { MediaDuration, secondsToDuration } from '../MediaDuration';
 import { MediaMeta } from '../MediaMeta';
 import { Pill } from '../Pill';
 import { Slideshow } from '../Slideshow';
@@ -485,6 +485,14 @@ export const Card = ({
 				margin-top: auto;
 			`}
 		>
+			{mainMedia?.type === 'Video' &&
+				format.design === ArticleDesign.Video && (
+					<Pill
+						content={secondsToDuration(mainMedia.duration)}
+						icon={<SvgMediaControlsPlay />}
+						iconSize={'small'}
+					/>
+				)}
 			{mainMedia?.type === 'Audio' && (
 				<Pill
 					content={audioDuration ?? ''}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -426,11 +426,17 @@ export const Card = ({
 
 	const isBetaContainer = BETA_CONTAINERS.includes(containerType ?? '');
 
-	/** A video article is standalone video content and is considered a media card.  */
+	/**
+	 * A "video article" refers to standalone video content presented as the main focus of the article.
+	 * It is treated as a media card in the design system.
+	 */
 	const isVideoArticle =
 		mainMedia?.type === 'Video' && format.design === ArticleDesign.Video;
 
-	/** Article that have video as the main media but are not a video article are not considered a media card and are styled differenently as a consequence. */
+	/**
+	 * Articles with a video as the main media but not classified as "video articles"
+	 * are styled differently and are not treated as media cards.
+	 */
 	const isVideoMainMedia =
 		mainMedia?.type === 'Video' && format.design !== ArticleDesign.Video;
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -426,6 +426,14 @@ export const Card = ({
 
 	const isBetaContainer = BETA_CONTAINERS.includes(containerType ?? '');
 
+	/** A video article is standalone video content and is considered a media card.  */
+	const isVideoArticle =
+		mainMedia?.type === 'Video' && format.design === ArticleDesign.Video;
+
+	/** Article that have video as the main media but are not a video article are not considered a media card and are styled differenently as a consequence. */
+	const isVideoMainMedia =
+		mainMedia?.type === 'Video' && format.design !== ArticleDesign.Video;
+
 	const decideAge = () => {
 		if (!webPublicationDate) return undefined;
 		const withinTwelveHours = isWithinTwelveHours(webPublicationDate);
@@ -485,14 +493,13 @@ export const Card = ({
 				margin-top: auto;
 			`}
 		>
-			{mainMedia?.type === 'Video' &&
-				format.design === ArticleDesign.Video && (
-					<Pill
-						content={secondsToDuration(mainMedia.duration)}
-						icon={<SvgMediaControlsPlay />}
-						iconSize={'small'}
-					/>
-				)}
+			{isVideoArticle && (
+				<Pill
+					content={secondsToDuration(mainMedia.duration)}
+					icon={<SvgMediaControlsPlay />}
+					iconSize={'small'}
+				/>
+			)}
 			{mainMedia?.type === 'Audio' && (
 				<Pill
 					content={audioDuration ?? ''}
@@ -946,18 +953,23 @@ export const Card = ({
 									roundedCorners={isOnwardContent}
 									aspectRatio={aspectRatio}
 								/>
-								{mainMedia?.type === 'Video' &&
-									mainMedia.duration > 0 && (
-										<MediaDuration
-											mediaDuration={mainMedia.duration}
-											imagePositionOnDesktop={
-												imagePositionOnDesktop
-											}
-											imagePositionOnMobile={
-												imagePositionOnMobile
-											}
+								{isVideoMainMedia && mainMedia.duration > 0 && (
+									<div
+										css={css`
+											position: absolute;
+											top: ${space[2]}px;
+											right: ${space[2]}px;
+										`}
+									>
+										<Pill
+											content={secondsToDuration(
+												mainMedia.duration,
+											)}
+											icon={<SvgMediaControlsPlay />}
+											iconSize={'small'}
 										/>
-									)}
+									</div>
+								)}
 							</>
 						)}
 						{media.type === 'crossword' && (

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import { Link, SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
-import { secondsToDuration } from '../lib/formatTime';
+import { isWithinTwelveHours, secondsToDuration } from '../lib/formatTime';
 import { getZIndex } from '../lib/getZIndex';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../lib/useCommentCount';
 import { palette } from '../palette';
@@ -216,14 +216,6 @@ const getMedia = ({
 		return { type: 'picture', imageUrl, imageAltText } as const;
 	}
 	return undefined;
-};
-
-export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
-	const timeDiffMs = Math.abs(
-		new Date().getTime() - new Date(webPublicationDate).getTime(),
-	);
-	const timeDiffHours = timeDiffMs / (1000 * 60 * 60);
-	return timeDiffHours <= 12;
 };
 
 const CardAge = ({

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -76,26 +76,12 @@ const pillStyles = css`
 	right: ${space[2]}px;
 `;
 
-const livePillStyles = css`
-	border-radius: ${space[10]}px;
-	padding: ${space[1]}px ${space[2]}px;
-	gap: ${space[2]}px;
-	background-color: ${palette('--pill-background')};
-	display: flex;
-	align-items: center;
-`;
-
 const liveBulletStyles = css`
-	::before {
-		content: '';
-		width: 9px;
-		height: 9px;
-		border-radius: 50%;
-		background-color: ${palette('--pill-bullet')};
-		display: inline-block;
-		position: relative;
-		margin-right: 0.1875rem;
-	}
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	background-color: ${palette('--pill-bullet')};
+	margin-right: ${space[1]}px;
 `;
 
 const textOverlayStyles = css`
@@ -167,8 +153,20 @@ export const YoutubeAtomOverlay = ({
 					/>
 				)}
 				{isLiveStream && (
-					<div css={[pillStyles, livePillStyles, liveBulletStyles]}>
-						Live
+					<div
+						css={
+							hidePillOnMobile
+								? css`
+										display: none;
+								  `
+								: pillStyles
+						}
+					>
+						<Pill
+							content={'Live'}
+							icon={<div css={[liveBulletStyles]} />}
+							iconSize={'small'}
+						/>
 					</div>
 				)}
 				{hasDuration && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -6,7 +6,6 @@ import {
 	headlineMedium20,
 	palette as sourcePalette,
 	space,
-	textSansBold12,
 } from '@guardian/source/foundations';
 import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
@@ -19,9 +18,9 @@ import type {
 import { PlayIcon } from '../Card/components/PlayIcon';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
-import { YoutubeAtomPicture } from './YoutubeAtomPicture';
 import { Pill } from '../Pill';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
+import { YoutubeAtomPicture } from './YoutubeAtomPicture';
 
 type Props = {
 	uniqueId: string;
@@ -129,7 +128,7 @@ export const YoutubeAtomOverlay = ({
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
 	//** We infer that a video is a livestream if the duration is set to 0. This is a soft contract with Editorial who manual set the duration of videos   */
-	const isLiveStream = duration === 0;
+	const isLiveStream = !isUndefined(duration) && duration === 0;
 	const image = overrideImage ?? posterImage;
 	const hidePillOnMobile =
 		imagePositionOnMobile === 'right' || imagePositionOnMobile === 'left';

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -20,6 +20,8 @@ import { PlayIcon } from '../Card/components/PlayIcon';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
+import { Pill } from '../Pill';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 
 type Props = {
 	uniqueId: string;
@@ -72,16 +74,6 @@ const pillStyles = css`
 	position: absolute;
 	top: ${space[2]}px;
 	right: ${space[2]}px;
-	${textSansBold12};
-	color: ${palette('--pill-text')};
-`;
-
-const durationPillStyles = css`
-	background-color: rgba(0, 0, 0, 0.7);
-	border-radius: ${space[3]}px;
-	padding: ${space[1]}px ${space[3]}px;
-	display: inline-flex;
-	line-height: ${space[4]}px;
 `;
 
 const livePillStyles = css`
@@ -186,10 +178,14 @@ export const YoutubeAtomOverlay = ({
 								? css`
 										display: none;
 								  `
-								: [pillStyles, durationPillStyles]
+								: pillStyles
 						}
 					>
-						{secondsToDuration(duration)}
+						<Pill
+							content={secondsToDuration(duration)}
+							icon={<SvgMediaControlsPlay />}
+							iconSize={'small'}
+						/>
 					</div>
 				)}
 				<PlayIcon

--- a/dotcom-rendering/src/lib/formatTime.ts
+++ b/dotcom-rendering/src/lib/formatTime.ts
@@ -44,3 +44,11 @@ export const secondsToDuration = (secs?: number): string => {
 	}
 	return duration.join(':');
 };
+
+export const isWithinTwelveHours = (webPublicationDate: string): boolean => {
+	const timeDiffMs = Math.abs(
+		new Date().getTime() - new Date(webPublicationDate).getTime(),
+	);
+	const timeDiffHours = timeDiffMs / (1000 * 60 * 60);
+	return timeDiffHours <= 12;
+};

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5510,7 +5510,7 @@ const highlightsCardKickerText: PaletteFunction = (format) => {
 };
 const highlightsCardAudioIcon: PaletteFunction = () => sourcePalette.brand[100];
 const highlightsCardAudioText: PaletteFunction = () =>
-	sourcePalette.neutral[10];
+	sourcePalette.neutral[20];
 
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5510,7 +5510,7 @@ const highlightsCardKickerText: PaletteFunction = (format) => {
 };
 const highlightsCardAudioIcon: PaletteFunction = () => sourcePalette.brand[100];
 const highlightsCardAudioText: PaletteFunction = () =>
-	sourcePalette.neutral[20];
+	sourcePalette.neutral[10];
 
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {


### PR DESCRIPTION
## What does this change?
Puts rules in place to determine to position of the timestamp pill for video on fronts for beta containers only. 

The new rules state that if video media has a duration:
 - If the article is a video article (i.e. has "Video" design type in formats) display the timestamp pill on the bottom left of the card content
 -  If the article has video main media but isn't a video article, display the timestamp in the top right of the image. 

In addition, for consistency, this PR also updates the youtube block component so that it uses the pill component rather than its own implementation 

## Why?
There is a desire from design to visually distinguish video articles from articles that contain video. 

## Screenshots

### Video Article

| Before      | After        |
| ----------- | ---------- |
| ![after][] | ![before][] |

### Article with Video

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |


[before]: https://github.com/user-attachments/assets/c31fb6a7-5c73-4891-8f1c-3c74652a3a7a
[after]: https://github.com/user-attachments/assets/2ea61640-a29e-44c0-96a5-a6e769e32233
[before1]: https://github.com/user-attachments/assets/9b9d6e71-de32-43d3-a6d3-95492f5b6fce
[after1]: https://github.com/user-attachments/assets/346d0268-f2ff-4597-9fe2-54a68c681352




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
