### PR TITLE
Ab/meta alignment

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -732,6 +732,7 @@ export const Card = ({
 			showTopBarMobile={showTopBarMobile}
 			containerPalette={containerPalette}
 			isOnwardContent={isOnwardContent}
+			cardBackgroundColour={backgroundColour}
 		>
 			<CardLink
 				linkTo={linkTo}
@@ -782,7 +783,6 @@ export const Card = ({
 			)}
 
 			<CardLayout
-				cardBackgroundColour={backgroundColour}
 				imagePositionOnDesktop={imagePositionOnDesktop}
 				imagePositionOnMobile={imagePositionOnMobile}
 				minWidthInPixels={minWidthInPixels}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -973,7 +973,8 @@ export const Card = ({
 									aspectRatio={aspectRatio}
 								/>
 								{(isVideoMainMedia ||
-									(isVideoArticle && !isBetaContainer)) &&
+									(isVideoArticle &&
+										containerType === 'fixed/video')) &&
 									mainMedia.duration > 0 && (
 										<div
 											css={css`

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -25,7 +25,18 @@ type Props = {
 
 const containerStyles = css`
 	display: flex;
-	flex-basis: 100%;
+`;
+
+const desktopFlexBasis = css`
+	${from.tablet} {
+		flex-basis: 100%;
+	}
+`;
+
+const mobileFlexBasis = css`
+	${until.tablet} {
+		flex-basis: 100%;
+	}
 `;
 
 // Until mobile landscape, show 1 card on small screens
@@ -156,6 +167,10 @@ const decideGap = (gapSize: GapSize) => {
 	}
 };
 
+const isVerticalLayout = (imagePosition: ImagePositionType) => {
+	return imagePosition === 'top' || imagePosition === 'bottom';
+};
+
 export const CardLayout = ({
 	children,
 	cardBackgroundColour,
@@ -180,6 +195,8 @@ export const CardLayout = ({
 					isBetaContainer,
 					imageType === 'avatar',
 				),
+				isVerticalLayout(imagePositionOnMobile) && mobileFlexBasis,
+				isVerticalLayout(imagePositionOnDesktop) && desktopFlexBasis,
 			]}
 			style={{
 				backgroundColor: cardBackgroundColour,

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -13,7 +13,6 @@ export type GapSizes = { row: GapSize; column: GapSize };
 
 type Props = {
 	children: React.ReactNode;
-	cardBackgroundColour: string;
 	imageType: CardImageType | undefined;
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
@@ -173,7 +172,6 @@ const isVerticalLayout = (imagePosition: ImagePositionType) => {
 
 export const CardLayout = ({
 	children,
-	cardBackgroundColour,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	minWidthInPixels,
@@ -199,7 +197,6 @@ export const CardLayout = ({
 				isVerticalLayout(imagePositionOnDesktop) && desktopFlexBasis,
 			]}
 			style={{
-				backgroundColor: cardBackgroundColour,
 				rowGap: decideGap(gapSizes.row),
 				columnGap: decideGap(gapSizes.column),
 			}}

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -9,6 +9,7 @@ import { FormatBoundary } from '../../FormatBoundary';
 type Props = {
 	children: React.ReactNode;
 	format: ArticleFormat;
+	cardBackgroundColour: string;
 	containerPalette?: DCRContainerPalette;
 	showTopBarDesktop?: boolean;
 	showTopBarMobile?: boolean;
@@ -98,6 +99,7 @@ export const CardWrapper = ({
 	showTopBarDesktop = true,
 	showTopBarMobile = false,
 	isOnwardContent = false,
+	cardBackgroundColour,
 }: Props) => {
 	return (
 		<FormatBoundary format={format}>
@@ -111,6 +113,7 @@ export const CardWrapper = ({
 						showTopBarMobile && mobileTopBarStyles,
 						isOnwardContent && onwardContentStyles,
 					]}
+					style={{ backgroundColor: cardBackgroundColour }}
 				>
 					{children}
 				</div>


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
