### PR TITLE
Use article's contributionsServiceUrl

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -228,6 +228,7 @@ export const ArticleBody = ({
 					isSensitive={isSensitive}
 					abTests={abTests}
 					editionId={editionId}
+					contributionsServiceUrl={contributionsServiceUrl}
 				/>
 			</div>
 		</>

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -380,6 +380,7 @@ describe('Island: server-side rendering', () => {
 						isPreview={false}
 						pageId={''}
 						switches={{}}
+						contributionsServiceUrl={''}
 					/>
 				</WithConfig>,
 			),

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -42,6 +42,7 @@ type Props = {
 	pageId: string;
 	idUrl?: string;
 	switches: Switches;
+	contributionsServiceUrl: string;
 };
 
 // interface for the component which shows the sign in gate
@@ -199,7 +200,14 @@ const SignInGateSelectorDefault = ({
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 	switches,
+	contributionsServiceUrl,
 }: Props) => {
+	// comment group: auxia-prototype-e55a86ef
+	// The following (useless) instruction only exists to avoid linting error
+	// so that SignInGateSelectorDefault, SignInGateSelectorAuxia and SignInGateSelector
+	// all have the same signature, while we give shape to the Auxia prototype.
+	contributionsServiceUrl;
+
 	const authStatus = useAuthStatus();
 	const isSignedIn =
 		authStatus.kind === 'SignedInWithOkta' ||
@@ -349,6 +357,7 @@ export const SignInGateSelector = ({
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 	switches,
+	contributionsServiceUrl,
 }: Props) => {
 	const abTestAPI = useAB()?.api;
 	const userIsInAuxiaExperiment = !!abTestAPI?.isUserInVariant(
@@ -367,12 +376,14 @@ export const SignInGateSelector = ({
 			pageId,
 			idUrl,
 			switches,
+			contributionsServiceUrl,
 		});
 	} else {
 		return SignInGateSelectorAuxia({
 			host,
 			pageId,
 			idUrl,
+			contributionsServiceUrl,
 		});
 	}
 };
@@ -404,6 +415,7 @@ type PropsAuxia = {
 	host?: string;
 	pageId: string;
 	idUrl?: string;
+	contributionsServiceUrl: string;
 };
 
 /*
@@ -432,8 +444,10 @@ const dismissGateAuxia = (
 	setShowGate(false);
 };
 
-const fetchAuxiaDisplayDataFromProxy = async (): Promise<SDCProxyData> => {
-	const url = 'https://contributions.guardianapis.com/auxia';
+const fetchAuxiaDisplayDataFromProxy = async (
+	contributionsServiceUrl: string,
+): Promise<SDCProxyData> => {
+	const url = `${contributionsServiceUrl}/auxia`;
 	const headers = {
 		'Content-Type': 'application/json',
 	};
@@ -455,6 +469,7 @@ const SignInGateSelectorAuxia = ({
 	host = 'https://theguardian.com/',
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
+	contributionsServiceUrl,
 }: PropsAuxia) => {
 	/*
 		comment group: auxia-prototype-e55a86ef
@@ -494,7 +509,9 @@ const SignInGateSelectorAuxia = ({
 
 	useOnce(() => {
 		void (async () => {
-			const data = await fetchAuxiaDisplayDataFromProxy();
+			const data = await fetchAuxiaDisplayDataFromProxy(
+				contributionsServiceUrl,
+			);
 			setShouldShowSignInGateUsingAuxiaAnswer(data.shouldShowSignInGate);
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -34,6 +34,7 @@ type Props = {
 	isSensitive: boolean;
 	abTests: ServerSideTests;
 	editionId: EditionId;
+	contributionsServiceUrl: string;
 };
 
 export const ArticleRenderer = ({
@@ -55,6 +56,7 @@ export const ArticleRenderer = ({
 	isDev,
 	abTests,
 	editionId,
+	contributionsServiceUrl,
 }: Props) => {
 	const isSectionedMiniProfilesArticle =
 		elements.filter(
@@ -129,6 +131,7 @@ export const ArticleRenderer = ({
 						switches,
 						isSensitive,
 						isDev,
+						contributionsServiceUrl,
 				  })}
 		</div>
 	); // classname that space finder is going to target for in-body ads in DCR

--- a/dotcom-rendering/src/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/lib/withSignInGateSlot.tsx
@@ -20,6 +20,7 @@ type Props = {
 	switches: Switches;
 	isSensitive?: boolean;
 	isDev?: boolean;
+	contributionsServiceUrl: string;
 };
 
 export const withSignInGateSlot = ({
@@ -33,6 +34,7 @@ export const withSignInGateSlot = ({
 	pageId,
 	idUrl,
 	switches,
+	contributionsServiceUrl,
 }: Props): React.ReactNode => {
 	return renderedElements.map((element, i) => {
 		return (
@@ -52,6 +54,9 @@ export const withSignInGateSlot = ({
 								pageId={pageId}
 								idUrl={idUrl}
 								switches={switches}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
 							/>
 						</Island>
 					</div>


### PR DESCRIPTION
Here, we perform a follow up of https://github.com/guardian/dotcom-rendering/pull/13198 , to pass the `contributionsServiceUrl`, along this chain:

```
StandardLayout
   -> ArticleBody
   -> ArticleRenderer
   -> withSignInGateSlot
   -> SignInGateSelector
   -> SignInGateSelectorAuxia
```