### PR TITLE
Fix SVG duplication in pill

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -972,23 +972,25 @@ export const Card = ({
 									roundedCorners={isOnwardContent}
 									aspectRatio={aspectRatio}
 								/>
-								{isVideoMainMedia && mainMedia.duration > 0 && (
-									<div
-										css={css`
-											position: absolute;
-											top: ${space[2]}px;
-											right: ${space[2]}px;
-										`}
-									>
-										<Pill
-											content={secondsToDuration(
-												mainMedia.duration,
-											)}
-											icon={<SvgMediaControlsPlay />}
-											iconSize={'small'}
-										/>
-									</div>
-								)}
+								{(isVideoMainMedia ||
+									(isVideoArticle && !isBetaContainer)) &&
+									mainMedia.duration > 0 && (
+										<div
+											css={css`
+												position: absolute;
+												top: ${space[2]}px;
+												right: ${space[2]}px;
+											`}
+										>
+											<Pill
+												content={secondsToDuration(
+													mainMedia.duration,
+												)}
+												icon={<SvgMediaControlsPlay />}
+												iconSize={'small'}
+											/>
+										</div>
+									)}
 							</>
 						)}
 						{media.type === 'crossword' && (

--- a/dotcom-rendering/src/components/Pill.tsx
+++ b/dotcom-rendering/src/components/Pill.tsx
@@ -48,7 +48,6 @@ const pillPrefixStyles = css`
 	padding-right: 6px;
 	border-right: 1px solid ${palette('--pill-divider')};
 `;
-
 export const Pill = ({
 	content,
 	prefix,
@@ -56,16 +55,16 @@ export const Pill = ({
 	iconSide = 'left',
 	iconSize = 'xsmall',
 }: Props) => {
-	const Icon = () =>
-		icon
-			? cloneElement(icon, {
-					size: iconSize,
-					theme: { fill: 'currentColor' },
-			  })
-			: null;
+	const renderedIcon =
+		icon &&
+		cloneElement(icon, {
+			size: iconSize,
+			theme: { fill: 'currentColor' },
+		});
+
 	return (
 		<div css={pillStyles}>
-			{iconSide === 'left' && <Icon />}
+			{iconSide === 'left' && renderedIcon}
 			{!!prefix && (
 				<span css={[pillContentStyles, pillPrefixStyles]}>
 					{prefix}
@@ -73,7 +72,7 @@ export const Pill = ({
 			)}
 			<span css={pillContentStyles}>
 				{content}
-				{iconSide === 'right' && <Icon />}
+				{iconSide === 'right' && renderedIcon}
 			</span>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?
Ensures the icon element of the pill is created only once, avoiding duplication due to multiple invocations. Instead of defining the Icon component as a function that may be invoked multiple times, it is defined once. 

## Why?
Duplicate SVGs were appearing.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/9c51d04e-994d-4323-8d44-def90b09db1b
[after]: https://github.com/user-attachments/assets/6be60a98-3345-4e71-aadd-f900930311f4


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
