### PR TITLE
Only display time on feature cards if they're within 12 hours

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -230,18 +230,21 @@ const CardAge = ({
 	if (!webPublicationDate) return undefined;
 	const withinTwelveHours = isWithinTwelveHours(webPublicationDate);
 
-	return (
-		<AgeStamp
-			webPublication={{
-				date: webPublicationDate,
-				isWithinTwelveHours: withinTwelveHours,
-			}}
-			showClock={showClock}
-			absoluteServerTimes={absoluteServerTimes}
-			isTagPage={false}
-			colour={palette('--feature-card-footer-text')}
-		/>
-	);
+	if (withinTwelveHours) {
+		return (
+			<AgeStamp
+				webPublication={{
+					date: webPublicationDate,
+					isWithinTwelveHours: withinTwelveHours,
+				}}
+				showClock={showClock}
+				absoluteServerTimes={absoluteServerTimes}
+				isTagPage={false}
+				colour={palette('--feature-card-footer-text')}
+			/>
+		);
+	}
+	return <></>;
 };
 
 const CommentCount = ({

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -50,7 +50,6 @@ export const ScrollableFeature = ({
 							showPulsingDot={
 								card.format.design === ArticleDesign.LiveBlog
 							}
-							/** TODO - implement show age */
 							showClock={false}
 							image={card.image}
 							canPlayInline={true}

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -47,7 +47,6 @@ export const StaticFeatureTwo = ({
 							showPulsingDot={
 								card.format.design === ArticleDesign.LiveBlog
 							}
-							/** TODO - implement show age */
 							showClock={false}
 							image={card.image}
 							canPlayInline={true}


### PR DESCRIPTION
## What does this change?
Only display time on feature cards if they're within 12 hours.

## Why?
This is requested by editorial.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/46a7ba7d-37db-4f3b-a8dc-f8f676ff52ee
[after]: https://github.com/user-attachments/assets/84cd8a05-4237-4ca2-9919-839d672058f2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
