### PR TITLE
Auxia Integration (Experimental) (Part 2)

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -430,8 +430,19 @@ interface ShowSignInGateAuxiaProps {
 	host: string;
 }
 
-interface SDCProxyData {
-	shouldShowSignInGate: boolean;
+interface AuxiaAPIResponseDataUserTreatment {
+	treatmentId: string;
+	treatmentTrackingId: string;
+	rank: string;
+	contentLanguageCode: string;
+	treatmentContent: string;
+	treatmentType: string;
+	surface: string;
+}
+
+interface SDCAuxiaProxyResponseData {
+	responseId: string;
+	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
 /*
@@ -446,7 +457,7 @@ const dismissGateAuxia = (
 
 const fetchAuxiaDisplayDataFromProxy = async (
 	contributionsServiceUrl: string,
-): Promise<SDCProxyData> => {
+): Promise<SDCAuxiaProxyResponseData> => {
 	const url = `${contributionsServiceUrl}/auxia`;
 	const headers = {
 		'Content-Type': 'application/json',
@@ -460,7 +471,7 @@ const fetchAuxiaDisplayDataFromProxy = async (
 
 	const response = await fetch(url, params);
 
-	const data = (await response.json()) as SDCProxyData;
+	const data = (await response.json()) as SDCAuxiaProxyResponseData;
 
 	return Promise.resolve(data);
 };
@@ -512,7 +523,9 @@ const SignInGateSelectorAuxia = ({
 			const data = await fetchAuxiaDisplayDataFromProxy(
 				contributionsServiceUrl,
 			);
-			setShouldShowSignInGateUsingAuxiaAnswer(data.shouldShowSignInGate);
+			setShouldShowSignInGateUsingAuxiaAnswer(
+				data.userTreatment !== undefined,
+			);
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);
 		});


### PR DESCRIPTION
Previous step: https://github.com/guardian/dotcom-rendering/pull/13198

In this step, we upgrade shape of the Auxia proxy answer to match the upgrade we have just performed here: https://github.com/guardian/support-dotcom-components/pull/1273

Note the change in semantics, we now interpret the presence or absence of userTreatment as the boolean we are replacing. Information carried by that object will be used to populate the gate in a future PR.