### PR TITLE
Add Football Matches

### DIFF
--- a/dotcom-rendering/src/components/FootballLiveMatches.stories.tsx
+++ b/dotcom-rendering/src/components/FootballLiveMatches.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { FootballLiveMatches as FootballLiveMatchesComponent } from './FootballLiveMatches';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { FootballLiveMatches as FootballLiveMatchesComponent } from './FootballLiveMatches';
 
 const meta = {
 	title: 'Components/Football Live Matches',

--- a/dotcom-rendering/src/components/FootballLiveMatches.stories.tsx
+++ b/dotcom-rendering/src/components/FootballLiveMatches.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FootballLiveMatches as FootballLiveMatchesComponent } from './FootballLiveMatches';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+
+const meta = {
+	title: 'Components/Football Live Matches',
+	component: FootballLiveMatchesComponent,
+	decorators: [centreColumnDecorator],
+} satisfies Meta<typeof FootballLiveMatchesComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const FootballLiveMatches = {
+	args: {
+		matches: [
+			{
+				date: new Date('2025-01-24T00:00:00Z'),
+				competitions: [
+					{
+						competitionId: '635',
+						name: 'Serie A',
+						nation: 'European',
+						matches: [
+							{
+								dateTime: new Date('2025-01-24T19:45:00Z'),
+								paId: '4482093',
+								homeTeam: {
+									name: 'Torino',
+									score: 1,
+								},
+								awayTeam: {
+									name: 'Cagliari',
+									score: 0,
+								},
+								status: 'FT',
+							},
+							{
+								dateTime: new Date('2025-01-24T19:45:00Z'),
+								paId: '4482890',
+								homeTeam: {
+									name: 'Auxerre',
+									score: 0,
+								},
+								awayTeam: {
+									name: 'St Etienne',
+									score: 0,
+								},
+								status: 'FT',
+							},
+						],
+					},
+					{
+						competitionId: '650',
+						name: 'La Liga',
+						nation: 'European',
+						matches: [
+							{
+								dateTime: new Date('2025-01-24T20:00:00Z'),
+								paId: '4482835',
+								homeTeam: {
+									name: 'Las Palmas',
+									score: 2,
+								},
+								awayTeam: {
+									name: 'Osasuna',
+									score: 3,
+								},
+								status: 'FT',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballLiveMatches.tsx
+++ b/dotcom-rendering/src/components/FootballLiveMatches.tsx
@@ -1,0 +1,35 @@
+import type { FootballMatches } from '../footballMatches';
+
+type Props = {
+	matches: FootballMatches;
+};
+
+export const FootballLiveMatches = ({ matches }: Props) => (
+	<>
+		{matches.map((day) => (
+			<>
+				<h2>{day.date.toString()}</h2>
+				{day.competitions.map((competition) => (
+					<>
+						<h3>{competition.name}</h3>
+						<ul>
+							{competition.matches.map((match) => (
+								<li>
+									<time
+										dateTime={match.dateTime.toISOString()}
+									>
+										{match.dateTime.getUTCHours()}:
+										{match.dateTime.getUTCMinutes()}
+									</time>
+									{match.homeTeam.name} {match.homeTeam.score}
+									-{match.awayTeam.score}{' '}
+									{match.awayTeam.name}
+								</li>
+							))}
+						</ul>
+					</>
+				))}
+			</>
+		))}
+	</>
+);

--- a/dotcom-rendering/src/components/FootballLiveMatches.tsx
+++ b/dotcom-rendering/src/components/FootballLiveMatches.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import type { FootballMatches } from '../footballMatches';
 
 type Props = {
@@ -7,14 +8,14 @@ type Props = {
 export const FootballLiveMatches = ({ matches }: Props) => (
 	<>
 		{matches.map((day) => (
-			<>
+			<Fragment key={day.date.toISOString()}>
 				<h2>{day.date.toString()}</h2>
 				{day.competitions.map((competition) => (
-					<>
+					<Fragment key={competition.competitionId}>
 						<h3>{competition.name}</h3>
 						<ul>
 							{competition.matches.map((match) => (
-								<li>
+								<li key={match.paId}>
 									<time
 										dateTime={match.dateTime.toISOString()}
 									>
@@ -27,9 +28,9 @@ export const FootballLiveMatches = ({ matches }: Props) => (
 								</li>
 							))}
 						</ul>
-					</>
+					</Fragment>
 				))}
-			</>
+			</Fragment>
 		))}
 	</>
 );

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -1,0 +1,37 @@
+type TeamScore = {
+	name: string;
+	score: number;
+};
+
+type MatchData = {
+	paId: string;
+	dateTime: Date;
+};
+
+export type MatchResult = MatchData & {
+	homeTeam: TeamScore;
+	awayTeam: TeamScore;
+};
+
+export type MatchFixture = MatchData & {
+	homeTeam: string;
+	awayTeam: string;
+};
+
+export type LiveMatch = MatchData & {
+	homeTeam: TeamScore;
+	awayTeam: TeamScore;
+	status: string;
+};
+
+type Competition = {
+	competitionId: string;
+	name: string;
+	nation: string;
+	matches: LiveMatch[];
+};
+
+export type FootballMatches = Array<{
+	date: Date;
+	competitions: Competition[];
+}>;


### PR DESCRIPTION
Add football match types and component to render live matches. This will eventually be used for rendering https://www.theguardian.com/football/live on DCAR, but for now we're breaking down the work into pieces.

See #13200 and #13209. Paired with @marjisound 
