### PR TITLE
Highlights container tracking

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -44,6 +44,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	sectionId: string;
+	frontId?: string;
 };
 
 export const DecideContainer = ({
@@ -56,6 +57,7 @@ export const DecideContainer = ({
 	imageLoading,
 	aspectRatio,
 	sectionId,
+	frontId,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -236,7 +238,7 @@ export const DecideContainer = ({
 		case 'scrollable/highlights':
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
-					<ScrollableHighlights trails={trails} />
+					<ScrollableHighlights trails={trails} frontId={frontId} />
 				</Island>
 			);
 		case 'flexible/special':

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -8,11 +8,12 @@ import {
 } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { ophanComponentId } from '../layouts/FrontLayout';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
 import { HighlightsCard } from './Masthead/HighlightsCard';
 
-type Props = { trails: DCRFrontCard[] };
+type Props = { trails: DCRFrontCard[]; frontId?: string };
 
 const containerStyles = css`
 	${from.tablet} {
@@ -160,7 +161,22 @@ const generateCarouselColumnStyles = (totalCards: number) => {
 	`;
 };
 
-export const ScrollableHighlights = ({ trails }: Props) => {
+/**
+ * Typically, Ophan tracking data gets determined in the front layout component.
+ * As the highlights exists outside of this front layout (in the header), we need to construct these fields here.
+ * */
+const getOphanInfo = (frontId?: string) => {
+	const ophanComponentName = ophanComponentId('highlights');
+	const ophanComponentLink = `container-${0} | ${ophanComponentName}`;
+	const ophanFrontName = `Front | /${frontId}`;
+	return {
+		ophanComponentName,
+		ophanComponentLink,
+		ophanFrontName,
+	};
+};
+
+export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const carouselLength = trails.length;
 	const imageLoading = 'eager';
@@ -232,10 +248,15 @@ export const ScrollableHighlights = ({ trails }: Props) => {
 		);
 	}, []);
 
+	const { ophanComponentLink, ophanComponentName, ophanFrontName } =
+		getOphanInfo(frontId);
+
 	return (
-		<div css={containerStyles}>
+		<div css={containerStyles} data-link-name={ophanFrontName}>
 			<ol
-				data-component="home-highlights"
+				data-link-name={ophanComponentLink}
+				data-component={ophanComponentName}
+				data-container-name={'scrollable/highlights'}
 				ref={carouselRef}
 				css={[
 					carouselStyles,

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -8,7 +8,7 @@ import {
 } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
-import { ophanComponentId } from '../layouts/FrontLayout';
+import { ophanComponentId } from '../lib/ophan-helpers';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
 import { HighlightsCard } from './Masthead/HighlightsCard';

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -43,6 +43,7 @@ import {
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
+import { ophanComponentId } from '../lib/ophan-helpers';
 import type { NavType } from '../model/extract-nav';
 import { palette as schemePalette } from '../palette';
 import type {
@@ -58,11 +59,6 @@ interface Props {
 	front: DCRFrontType;
 	NAV: NavType;
 }
-
-const spaces = / /g;
-/** TODO: Confirm with is a valid way to generate component IDs. */
-export const ophanComponentId = (name: string) =>
-	name.toLowerCase().replace(spaces, '-');
 
 const isNetworkFrontPageId = isOneOf(editionList.map(({ pageId }) => pageId));
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -61,7 +61,7 @@ interface Props {
 
 const spaces = / /g;
 /** TODO: Confirm with is a valid way to generate component IDs. */
-const ophanComponentId = (name: string) =>
+export const ophanComponentId = (name: string) =>
 	name.toLowerCase().replace(spaces, '-');
 
 const isNetworkFrontPageId = isOneOf(editionList.map(({ pageId }) => pageId));
@@ -191,6 +191,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					sectionId={ophanComponentId(
 						highlightsCollection.displayName,
 					)}
+					frontId={front.pressedPage.id}
 				/>
 			)
 		);

--- a/dotcom-rendering/src/lib/ophan-helpers.ts
+++ b/dotcom-rendering/src/lib/ophan-helpers.ts
@@ -1,2 +1,7 @@
 export const nestedOphanComponents = (...components: string[]): string =>
 	components.join(' : ');
+
+const spaces = / /g;
+
+export const ophanComponentId = (name: string) =>
+	name.toLowerCase().replace(spaces, '-');

--- a/dotcom-rendering/src/lib/ophan-helpers.ts
+++ b/dotcom-rendering/src/lib/ophan-helpers.ts
@@ -3,5 +3,5 @@ export const nestedOphanComponents = (...components: string[]): string =>
 
 const spaces = / /g;
 
-export const ophanComponentId = (name: string) =>
+export const ophanComponentId = (name: string): string =>
 	name.toLowerCase().replace(spaces, '-');


### PR DESCRIPTION
## What does this change?
Updates the highlights container to pass through additional data for tracking in the lake.

## Why?
This brings the highlights container [in line with tracking for other containers](https://docs.google.com/spreadsheets/d/1VePC7Z8bv_IFx37qjud_TjBJvioluMZNNlOP-XgYCIk/edit?gid=1873730181#gid=1873730181), making comparison easier for Data and Insight when we begin the europe beta test.


## Screenshots
![Screenshot 2025-01-29 at 15 05 38](https://github.com/user-attachments/assets/52cb7315-abce-4783-8e87-46c6f9a0e2ef)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

## How to test?
The Highlights container is currently only available on the Europe beta network front when opted in to the europe beta test and the following steps are required to test this PR. 

1. Deploy the branch to CODE
2. Opt in to the test using the opt/in/europe-beta-front on CODE
3. Visit the /europe front on code 
4. Validate that the correct tracking is sent in the network tab when a card in the highlight container is clicked.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
