### PR TITLE
Auxia Integration (Experimental) (Part 3) 

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -2,7 +2,7 @@ import { cmp } from '@guardian/libs';
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
-import type { SignInGateProps } from '../types';
+import type { SignInGatePropsAuxia, treatmentContentDecoded } from '../types';
 import {
 	actionButtons,
 	bodyBold,
@@ -28,23 +28,26 @@ export const SignInGateAuxia = ({
 	abTest,
 	ophanComponentId,
 	isMandatory = false,
-}: SignInGateProps) => {
+	userTreatment,
+}: SignInGatePropsAuxia) => {
 	const { renderingTarget } = useConfig();
+
+	const treatmentContent = JSON.parse(
+		userTreatment.treatmentContent,
+	) as treatmentContentDecoded;
+	const title = treatmentContent.title;
+	const body = treatmentContent.body;
 
 	return (
 		<div css={signInGateContainer} data-testid="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
 			<div css={firstParagraphOverlay} />
-			<h1 css={headingStyles}>Register: it’s quick and easy (\pi)</h1>
+			<h1 css={headingStyles}>{title}</h1>
 			<p css={bodyBold}>
 				It’s still free to read – this is not a paywall
 			</p>
 			<p css={bodyText}>
-				We’re committed to keeping our quality reporting open. By
-				registering and providing us with insight into your preferences,
-				you’re helping us to engage with you more deeply, and that
-				allows us to keep our journalism free for all. You’ll always be
-				able to control your own{' '}
+				{body}{' '}
 				<button
 					data-testid="sign-in-gate-main_privacy"
 					css={privacyLink}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -1,0 +1,175 @@
+import { cmp } from '@guardian/libs';
+import { Button, Link, LinkButton } from '@guardian/source/react-components';
+import { useConfig } from '../../ConfigContext';
+import { trackLink } from '../componentEventTracking';
+import type { SignInGateProps } from '../types';
+import {
+	actionButtons,
+	bodyBold,
+	bodySeparator,
+	bodyText,
+	faq,
+	firstParagraphOverlay,
+	headingStyles,
+	hideElementsCss,
+	laterButton,
+	privacyLink,
+	registerButton,
+	signInGateContainer,
+	signInHeader,
+	signInLink,
+} from './shared';
+
+export const SignInGateAuxia = ({
+	signInUrl,
+	registerUrl,
+	guUrl,
+	dismissGate,
+	abTest,
+	ophanComponentId,
+	isMandatory = false,
+}: SignInGateProps) => {
+	const { renderingTarget } = useConfig();
+
+	return (
+		<div css={signInGateContainer} data-testid="sign-in-gate-main">
+			<style>{hideElementsCss}</style>
+			<div css={firstParagraphOverlay} />
+			<h1 css={headingStyles}>Register: it’s quick and easy (\pi)</h1>
+			<p css={bodyBold}>
+				It’s still free to read – this is not a paywall
+			</p>
+			<p css={bodyText}>
+				We’re committed to keeping our quality reporting open. By
+				registering and providing us with insight into your preferences,
+				you’re helping us to engage with you more deeply, and that
+				allows us to keep our journalism free for all. You’ll always be
+				able to control your own{' '}
+				<button
+					data-testid="sign-in-gate-main_privacy"
+					css={privacyLink}
+					onClick={() => {
+						cmp.showPrivacyManager();
+						trackLink(
+							ophanComponentId,
+							'privacy',
+							renderingTarget,
+							abTest,
+						);
+					}}
+				>
+					privacy settings
+				</button>
+				.
+			</p>
+			<div css={actionButtons}>
+				<LinkButton
+					data-testid="sign-in-gate-main_register"
+					data-ignore="global-link-styling"
+					cssOverrides={registerButton}
+					priority="primary"
+					size="small"
+					href={registerUrl}
+					onClick={() => {
+						trackLink(
+							ophanComponentId,
+							'register-link',
+							renderingTarget,
+							abTest,
+						);
+					}}
+				>
+					Register for free
+				</LinkButton>
+				{!isMandatory && (
+					<Button
+						data-testid="sign-in-gate-main_dismiss"
+						data-ignore="global-link-styling"
+						cssOverrides={laterButton}
+						priority="subdued"
+						size="small"
+						onClick={() => {
+							dismissGate();
+							trackLink(
+								ophanComponentId,
+								'not-now',
+								renderingTarget,
+								abTest,
+							);
+						}}
+					>
+						I’ll do it later
+					</Button>
+				)}
+			</div>
+
+			<p css={[bodySeparator, bodyBold, signInHeader]}>
+				Have a subscription? Made a contribution? Already registered?
+			</p>
+
+			<Link
+				data-testid="sign-in-gate-main_signin"
+				data-ignore="global-link-styling"
+				cssOverrides={signInLink}
+				href={signInUrl}
+				onClick={() => {
+					trackLink(
+						ophanComponentId,
+						'sign-in-link',
+						renderingTarget,
+						abTest,
+					);
+				}}
+			>
+				Sign In
+			</Link>
+
+			<div css={faq}>
+				<Link
+					data-ignore="global-link-styling"
+					href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
+					onClick={() => {
+						trackLink(
+							ophanComponentId,
+							'how-link',
+							renderingTarget,
+							abTest,
+						);
+					}}
+				>
+					Why register & how does it help?
+				</Link>
+
+				<Link
+					data-ignore="global-link-styling"
+					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
+					onClick={() => {
+						trackLink(
+							ophanComponentId,
+							'why-link',
+							renderingTarget,
+							abTest,
+						);
+					}}
+				>
+					How will my information & data be used?
+				</Link>
+
+				<Link
+					data-ignore="global-link-styling"
+					href={`${guUrl}/help/identity-faq`}
+					onClick={() => {
+						trackLink(
+							ophanComponentId,
+							'help-link',
+							renderingTarget,
+							abTest,
+						);
+					}}
+				>
+					Get help with registering or signing in
+				</Link>
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -76,3 +76,48 @@ export type CurrentSignInGateABTest = {
 };
 
 export type SignInGateTestMap = { [name: string]: SignInGateComponent };
+
+// -------------------------------
+// Auxia Integration Experiment //
+// -------------------------------
+/*
+	comment group: auxia-prototype-e55a86ef
+*/
+
+export interface treatmentContentDecoded {
+	title: string;
+	body: string;
+	first_cta_name: string;
+	first_cta_link: string;
+	second_cta_name: string;
+	second_cta_link: string;
+	subtitle: string;
+}
+
+export interface AuxiaAPIResponseDataUserTreatment {
+	treatmentId: string;
+	treatmentTrackingId: string;
+	rank: string;
+	contentLanguageCode: string;
+	treatmentContent: string;
+	treatmentType: string;
+	surface: string;
+}
+
+export interface SDCAuxiaProxyResponseData {
+	responseId: string;
+	userTreatment?: AuxiaAPIResponseDataUserTreatment;
+}
+
+export type SignInGatePropsAuxia = {
+	signInUrl: string;
+	registerUrl: string;
+	guUrl: string;
+	dismissGate: () => void;
+	ophanComponentId: string;
+	abTest?: CurrentSignInGateABTest;
+	isMandatory?: boolean;
+	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
+	personaliseSignInGateAfterCheckoutSwitch?: boolean;
+	userTreatment: AuxiaAPIResponseDataUserTreatment;
+};

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -20,6 +20,7 @@ import {
 	incrementUserDismissedGateCount,
 	setUserDismissedGate,
 } from './SignInGate/dismissGate';
+import { SignInGateAuxia } from './SignInGate/gateDesigns/SignInGateAuxia';
 import { signInGateComponent as gateMainVariant } from './SignInGate/gates/main-variant';
 import { signInGateTestIdToComponentId } from './SignInGate/signInGateMappings';
 import type {
@@ -426,7 +427,6 @@ interface ShowSignInGateAuxiaProps {
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	signInUrl: string;
 	registerUrl: string;
-	gateVariant: SignInGateComponent;
 	host: string;
 }
 
@@ -554,7 +554,6 @@ const SignInGateSelectorAuxia = ({
 					setShowGate={(show) => setIsGateDismissed(!show)}
 					signInUrl={generateGatewayUrl('signin', ctaUrlParams)}
 					registerUrl={generateGatewayUrl('register', ctaUrlParams)}
-					gateVariant={gateVariant}
 					host={host}
 				/>
 			)}
@@ -566,12 +565,11 @@ const ShowSignInGateAuxia = ({
 	setShowGate,
 	signInUrl,
 	registerUrl,
-	gateVariant,
 	host,
 }: ShowSignInGateAuxiaProps) => {
 	/*
 		comment group: auxia-prototype-e55a86ef
-		This function if the Auxia prototype for the ShowSignInGate component.
+		This function is the Auxia version of the ShowSignInGate component.
 	*/
 
 	const componentId = 'main_variant_5';
@@ -579,24 +577,16 @@ const ShowSignInGateAuxia = ({
 	const checkoutCompleteCookieData = undefined;
 	const personaliseSignInGateAfterCheckoutSwitch = undefined;
 
-	// some sign in gate ab test variants may not need to show a gate
-	// therefore the gate is optional
-	// this is because we want a section of the audience to never see the gate
-	// but still fire a view event if they are eligible to see the gate
-	if (gateVariant.gate) {
-		return gateVariant.gate({
-			guUrl: host,
-			signInUrl,
-			registerUrl,
-			dismissGate: () => {
-				dismissGateAuxia(setShowGate);
-			},
-			abTest,
-			ophanComponentId: componentId,
-			checkoutCompleteCookieData,
-			personaliseSignInGateAfterCheckoutSwitch,
-		});
-	}
-	// return nothing if no gate needs to be shown
-	return <></>;
+	return SignInGateAuxia({
+		guUrl: host,
+		signInUrl,
+		registerUrl,
+		dismissGate: () => {
+			dismissGateAuxia(setShowGate);
+		},
+		abTest,
+		ophanComponentId: componentId,
+		checkoutCompleteCookieData,
+		personaliseSignInGateAfterCheckoutSwitch,
+	});
 };


### PR DESCRIPTION
Previously on Auxia Integration (Experimental) ...

Part 1: https://github.com/guardian/dotcom-rendering/pull/13198
Part 2: https://github.com/guardian/dotcom-rendering/pull/13237

In this episode, we define a dedicated SignIn Gate Component for Auxia and use the information from their API to customise the display.

With http://localhost:3030/Article/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software#ab-AuxiaSignInGate=auxia-signin-gate

And

```
{
    "title": "Sign in for a personlised experience",
    "body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
    "first_cta_name": "Sign in",
    "first_cta_link": "https://profile.theguardian.com/signin?",
    "second_cta_name": "I'll do it later",
    "second_cta_link": "https://profile.theguardian.com/signin?",
    "subtitle": ""
}
```

We get

![Screenshot 2025-01-29 at 16 47 25](https://github.com/user-attachments/assets/d5dd478d-48c4-4caa-902f-3700e19ab2b7)
