### PR TITLE
Show / Hide alignment

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -288,6 +288,7 @@ const sectionControls = css`
 		flex-direction: column-reverse;
 		justify-content: flex-end;
 		align-items: flex-end;
+		gap: ${space[2]}px;
 		/* we want to add space between the items in the controls section only when there are at least 2 children and neither are hidden */
 		:has(> :not(.hidden):nth-of-type(2)) {
 			justify-content: space-between;

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -411,7 +411,7 @@ const secondaryLevelTopBorder = css`
 `;
 
 const carouselNavigationPlaceholder = css`
-	${until.leftCol} {
+	${between.tablet.and.leftCol} {
 		min-height: 44px;
 	}
 	.hidden & {

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -288,8 +288,8 @@ const sectionControls = css`
 		flex-direction: column-reverse;
 		justify-content: flex-end;
 		align-items: flex-end;
-		/** we want to add space between the items in the controls section only when both items are there and visible */
-		:has(.carouselNavigationPlaceholder:not(.hidden)) {
+		/* we want to add space between the items in the controls section only when there are at least 2 children and neither are hidden */
+		:has(> :not(.hidden):nth-of-type(2)) {
 			justify-content: space-between;
 		}
 	}

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { textSans14 } from '@guardian/source/foundations';
+import { space, textSans14 } from '@guardian/source/foundations';
 import { ButtonLink } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
@@ -10,9 +10,8 @@ type Props = {
 
 const showHideButtonCss = css`
 	${textSans14};
-	margin-right: 10px;
+	margin-right: ${space[2]}px;
 	position: relative;
-	align-items: bottom;
 	text-decoration: none;
 	&.hidden {
 		display: none;

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -11,6 +11,7 @@ type Props = {
 const showHideButtonCss = css`
 	${textSans14};
 	margin-right: ${space[2]}px;
+	margin-bottom: ${space[2]}px;
 	position: relative;
 	text-decoration: none;
 	&.hidden {


### PR DESCRIPTION
## What does this change?
Updates the alignment for show hide so that 

- there is 8px space between the show/hide button and carousel  nav buttons  when there is no meta
- the controls section (which houses show hide and the carousel nav buttons) only sets content to have space-between spacing when both both components are available and neither are hidden.


## Why?
The ability to show/hide containers is behind a sign in flag. The component is visually hidden with a class when the user is signed out. However the css still considers the controls container to have 2 children and so add space-between. By adding an additional check that neither children are hidden we ensure this rule is only applied when both children are rendered and visible.  

These are design tweaks that have come out of QA. 

This fixes both https://trello.com/c/flwh5FTG and https://trello.com/c/Pgh4oOhe

## Screenshots

| before      | after      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before1][] | ![after1][] |

[before]: https://github.com/user-attachments/assets/4804b565-ac24-4aa8-9ec3-cd7f7f85c591
[after]: https://github.com/user-attachments/assets/90e8ad26-5f3f-4102-8c7f-b842f1d92888
[before1]: https://github.com/user-attachments/assets/9cedbb0b-439e-45dd-a3cb-3278a71824d7
[after1]: https://github.com/user-attachments/assets/b12ba65d-89d1-4eaf-aa81-6a61110fce48

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
