### PR TITLE
Reverts "Add play icon on Feature Cards"

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
-import { Link } from '@guardian/source/react-components';
-import { SvgMediaControlsPlay } from '../components/SvgMediaControlsPlay';
+import { Link, SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { isWithinTwelveHours, secondsToDuration } from '../lib/formatTime';
 import { getZIndex } from '../lib/getZIndex';
@@ -187,24 +186,6 @@ const starRatingWrapper = css`
 
 const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
-`;
-
-const playIconWidth = 56;
-const playIconStyles = css`
-	position: absolute;
-	/**
-	 * Subject to change. We will wait to see how fronts editors use the
-	 * headlines and standfirsts before we decide on a final position.
-	 */
-	top: 35%;
-	left: calc(50% - ${playIconWidth / 2}px);
-	width: ${playIconWidth}px;
-	height: ${playIconWidth}px;
-	background-color: ${palette('--feature-card-play-icon-background')};
-	opacity: 0.7;
-	border-radius: 50%;
-	border: 1px solid ${palette('--feature-card-play-icon-border')};
-	fill: ${palette('--feature-card-play-icon-fill')};
 `;
 
 const videoPillStyles = css`
@@ -572,13 +553,8 @@ export const FeatureCard = ({
 										/>
 									</div>
 								</div>
-								{canPlayInline && isVideoMainMedia && (
-									<div css={playIconStyles}>
-										<SvgMediaControlsPlay />
-									</div>
-								)}
 								{/* On video article cards, the duration is displayed in the footer */}
-								{isVideoArticle &&
+								{!isVideoArticle &&
 								isVideoMainMedia &&
 								videoDuration !== undefined ? (
 									<div css={videoPillStyles}>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6462,18 +6462,6 @@ const paletteColours = {
 		light: featureCardKickerTextLight,
 		dark: () => sourcePalette.neutral[20],
 	},
-	'--feature-card-play-icon-background': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[7],
-	},
-	'--feature-card-play-icon-border': {
-		light: () => sourcePalette.neutral[60],
-		dark: () => sourcePalette.neutral[60],
-	},
-	'--feature-card-play-icon-fill': {
-		light: () => sourcePalette.neutral[100],
-		dark: () => sourcePalette.neutral[100],
-	},
 	'--feature-card-trail-text': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],


### PR DESCRIPTION
## What does this change?

Reverts ["Add play icon on Feature Cards"](https://github.com/guardian/dotcom-rendering/pull/13192)

We will use the Youtube components to control the play icon, instead of custom code in this file.

This PR also introduced a bug where [a boolean was inverted](https://github.com/guardian/dotcom-rendering/pull/13253/files#diff-7bdcbda8b4039b530d8ad3dd4b4324cb5d105d53d81dd65339f857e2d1193c78R557), causing the timestamp to appear twice on video article cards.