### PR TITLE
Remove stray underline in byline

### DIFF
--- a/dotcom-rendering/src/components/MultiByline.tsx
+++ b/dotcom-rendering/src/components/MultiByline.tsx
@@ -117,6 +117,7 @@ const bylineStyles = (format: ArticleFormat) => css`
 		text-decoration: none;
 		:hover {
 			text-decoration: underline;
+			cursor: pointer;
 		}
 	}
 	span[data-contributor-rel='author'] {

--- a/dotcom-rendering/src/components/MultiByline.tsx
+++ b/dotcom-rendering/src/components/MultiByline.tsx
@@ -202,6 +202,7 @@ const Byline = ({
 		allowedAttributes: {
 			...defaults.allowedAttributes,
 			span: ['data-contributor-rel'],
+			a: ['data-ignore'],
 		},
 	});
 


### PR DESCRIPTION
## What does this change?

Bylines in multi-byline articles currently have two clashing underline styles. We attempt to disable one of these by applying `data-ignore="global-link-styling"` to the anchor tag in `bylineHtml`, but it gets stripped out when sanitising the field.

Example value of `bylineHtml`:

```
<a data-contributor-rel="author" href="profile/blaine-harden" data-ignore="global-link-styling">Blaine Harden</a>
```

This PR adds `data-ignore` to the list of allowed attributes.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|  ![Kapture 2025-01-30 at 14 10 05](https://github.com/user-attachments/assets/233fed02-8c77-4435-8686-648b0e507794) | ![Kapture 2025-01-30 at 14 11 45](https://github.com/user-attachments/assets/106ec550-7fb6-4ea2-bbc7-277cf1c8f1fe) |
