### PR TITLE
Revert "Update Some Workflows To Use `ubuntu-latest`"

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deno:
     name: 🦕 Deno health
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   playwright:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   scheduled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
CI is failing on Node setup.

Reverts guardian/dotcom-rendering#13206