### PR TITLE
upgrade auxia sign in gate interface

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -1,4 +1,3 @@
-import { cmp } from '@guardian/libs';
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
@@ -13,7 +12,6 @@ import {
 	headingStyles,
 	hideElementsCss,
 	laterButton,
-	privacyLink,
 	registerButton,
 	signInGateContainer,
 	signInHeader,
@@ -21,8 +19,6 @@ import {
 } from './shared';
 
 export const SignInGateAuxia = ({
-	signInUrl,
-	registerUrl,
 	guUrl,
 	dismissGate,
 	abTest,
@@ -35,8 +31,26 @@ export const SignInGateAuxia = ({
 	const treatmentContent = JSON.parse(
 		userTreatment.treatmentContent,
 	) as treatmentContentDecoded;
+
+	/*
+	sample: {
+		"title": "Sign in for a personlised experience",
+		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
+		"first_cta_name": "Sign in",
+		"first_cta_link": "https://profile.theguardian.com/signin?",
+		"second_cta_name": "I'll do it later",
+		"second_cta_link": "https://profile.theguardian.com/signin?",
+		"subtitle": ""
+	}
+	*/
+
 	const title = treatmentContent.title;
 	const body = treatmentContent.body;
+	const firstCtaName = treatmentContent.first_cta_name;
+	const firstCtaLink = treatmentContent.first_cta_link;
+	const secondCtaName = treatmentContent.second_cta_name;
+	const secondCtaLink = treatmentContent.second_cta_link;
+	//const subtitle = treatmentContent.subtitle;
 
 	return (
 		<div css={signInGateContainer} data-testid="sign-in-gate-main">
@@ -46,25 +60,7 @@ export const SignInGateAuxia = ({
 			<p css={bodyBold}>
 				It’s still free to read – this is not a paywall
 			</p>
-			<p css={bodyText}>
-				{body}{' '}
-				<button
-					data-testid="sign-in-gate-main_privacy"
-					css={privacyLink}
-					onClick={() => {
-						cmp.showPrivacyManager();
-						trackLink(
-							ophanComponentId,
-							'privacy',
-							renderingTarget,
-							abTest,
-						);
-					}}
-				>
-					privacy settings
-				</button>
-				.
-			</p>
+			<p css={bodyText}>{body}</p>
 			<div css={actionButtons}>
 				<LinkButton
 					data-testid="sign-in-gate-main_register"
@@ -72,7 +68,7 @@ export const SignInGateAuxia = ({
 					cssOverrides={registerButton}
 					priority="primary"
 					size="small"
-					href={registerUrl}
+					href={firstCtaLink}
 					onClick={() => {
 						trackLink(
 							ophanComponentId,
@@ -82,7 +78,7 @@ export const SignInGateAuxia = ({
 						);
 					}}
 				>
-					Register for free
+					{firstCtaName}
 				</LinkButton>
 				{!isMandatory && (
 					<Button
@@ -114,7 +110,7 @@ export const SignInGateAuxia = ({
 				data-testid="sign-in-gate-main_signin"
 				data-ignore="global-link-styling"
 				cssOverrides={signInLink}
-				href={signInUrl}
+				href={secondCtaLink}
 				onClick={() => {
 					trackLink(
 						ophanComponentId,
@@ -124,7 +120,7 @@ export const SignInGateAuxia = ({
 					);
 				}}
 			>
-				Sign In
+				{secondCtaName}
 			</Link>
 
 			<div css={faq}>

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -110,8 +110,6 @@ export interface SDCAuxiaProxyResponseData {
 }
 
 export type SignInGatePropsAuxia = {
-	signInUrl: string;
-	registerUrl: string;
 	guUrl: string;
 	dismissGate: () => void;
 	ophanComponentId: string;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -383,8 +383,6 @@ export const SignInGateSelector = ({
 	} else {
 		return SignInGateSelectorAuxia({
 			host,
-			pageId,
-			idUrl,
 			contributionsServiceUrl,
 		});
 	}
@@ -415,8 +413,6 @@ export const SignInGateSelector = ({
 
 type PropsAuxia = {
 	host?: string;
-	pageId: string;
-	idUrl?: string;
 	contributionsServiceUrl: string;
 };
 
@@ -425,10 +421,8 @@ type PropsAuxia = {
 	Signature for the ShowSignInGateAuxia component.
 */
 interface ShowSignInGateAuxiaProps {
-	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
-	signInUrl: string;
-	registerUrl: string;
 	host: string;
+	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 }
 
@@ -465,8 +459,6 @@ const fetchAuxiaDisplayDataFromProxy = async (
 
 const SignInGateSelectorAuxia = ({
 	host = 'https://theguardian.com/',
-	pageId,
-	idUrl = 'https://profile.theguardian.com',
 	contributionsServiceUrl,
 }: PropsAuxia) => {
 	/*
@@ -517,30 +509,14 @@ const SignInGateSelectorAuxia = ({
 		return null;
 	}
 
-	const componentId = 'main_variant_5';
-
-	const ctaUrlParams = {
-		pageId,
-		host,
-		pageViewId,
-		idUrl,
-		currentTest,
-		componentId,
-	} satisfies Parameters<typeof generateGatewayUrl>[1];
-
 	return (
 		<>
 			{!isGateDismissed &&
 				auxiaAPIResponseData?.userTreatment !== undefined && (
 					<ShowSignInGateAuxia
+						host={host}
 						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 						setShowGate={(show) => setIsGateDismissed(!show)}
-						signInUrl={generateGatewayUrl('signin', ctaUrlParams)}
-						registerUrl={generateGatewayUrl(
-							'register',
-							ctaUrlParams,
-						)}
-						host={host}
 						userTreatment={auxiaAPIResponseData.userTreatment}
 					/>
 				)}
@@ -549,10 +525,8 @@ const SignInGateSelectorAuxia = ({
 };
 
 const ShowSignInGateAuxia = ({
-	setShowGate,
-	signInUrl,
-	registerUrl,
 	host,
+	setShowGate,
 	userTreatment,
 }: ShowSignInGateAuxiaProps) => {
 	/*
@@ -567,8 +541,6 @@ const ShowSignInGateAuxia = ({
 
 	return SignInGateAuxia({
 		guUrl: host,
-		signInUrl,
-		registerUrl,
 		dismissGate: () => {
 			dismissGateAuxia(setShowGate);
 		},


### PR DESCRIPTION
Previously on Auxia Integration (Experimental) ...

Part 1: https://github.com/guardian/dotcom-rendering/pull/13198
Part 2: https://github.com/guardian/dotcom-rendering/pull/13237
Part 3: https://github.com/guardian/dotcom-rendering/pull/13247

In this episode we slightly update the signature and contents of the Auxia sign in gate to fully consume the `treatmentContent`. This is not the end of the story because more content may be added to the object on the Auxia's console, but at least we take this opportunity to normalise passing the sign in urls into the component. 