### PR TITLE
Auxia Integration (Experimental) Part 5: update get treatments proxy url

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -445,7 +445,7 @@ const dismissGateAuxia = (
 const fetchAuxiaDisplayDataFromProxy = async (
 	contributionsServiceUrl: string,
 ): Promise<SDCAuxiaProxyResponseData> => {
-	const url = `${contributionsServiceUrl}/auxia`;
+	const url = `${contributionsServiceUrl}/auxia/get-treatments`;
 	const headers = {
 		'Content-Type': 'application/json',
 	};


### PR DESCRIPTION
Previously on Auxia Integration (Experimental) ...

- Part 1: https://github.com/guardian/dotcom-rendering/pull/13198
- Part 2: https://github.com/guardian/dotcom-rendering/pull/13237
- Part 3: https://github.com/guardian/dotcom-rendering/pull/13247
- Part 4: https://github.com/guardian/dotcom-rendering/pull/13265

Update the get treatment path at the sdc proxy. (This is in premise of adding the end point to post to log treatment)

Sister PR: https://github.com/guardian/support-dotcom-components/pull/1276