### PR TITLE
Add experiment headers to logging

### DIFF
--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -20,6 +20,7 @@ type DCRLoggingStore = {
 		platform?: string;
 	};
 	fastlyRequestId: string;
+	abTests: string;
 	error?: {
 		message?: string;
 		stack?: string;

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -12,7 +12,7 @@ const logLocation =
 		: `${path.resolve('logs')}/${logName}`;
 
 const logFields = (logEvent: LoggingEvent): unknown => {
-	const { request, fastlyRequestId } = loggingStore.getStore() ?? {
+	const { request, fastlyRequestId, abTests } = loggingStore.getStore() ?? {
 		request: { pageId: 'outside-request-context' },
 	};
 
@@ -29,6 +29,7 @@ const logFields = (logEvent: LoggingEvent): unknown => {
 		level_value: logEvent.level.level,
 		request,
 		fastlyRequestId,
+		abTests,
 		// NODE_APP_INSTANCE is set by cluster mode
 		thread_name: process.env.NODE_APP_INSTANCE ?? '0',
 	};


### PR DESCRIPTION
## What does this change?
Adds ab test logging to facia rendering.

## Why?
This will help us understand what impact experiments have on our render time amongst other metrics. 

## Screenshots

The below shows two facia rendering logs, one where the user is part of the europe beta variant and one where they are not part of any tests. 

![Screenshot 2025-02-06 at 08 32 23](https://github.com/user-attachments/assets/c9e06791-0de4-4cf2-aae1-67f45d15556a)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
