### PR TITLE
Football pages - Add support for all match types in Match list

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -1,11 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { userEvent, within } from '@storybook/test';
+import type { FootballMatches } from '../footballMatches';
 import { error, ok } from '../lib/result';
-import { FootballLiveMatches as FootballLiveMatchesComponent } from './FootballLiveMatches';
+import { FootballMatchList } from './FootballMatchList';
 
 const meta = {
-	title: 'Components/Football Live Matches',
-	component: FootballLiveMatchesComponent,
+	title: 'Components/Football Match List',
+	component: FootballMatchList,
 	decorators: [
 		// To make it easier to see the top border above the date
 		(Story) => (
@@ -15,13 +16,13 @@ const meta = {
 			</>
 		),
 	],
-} satisfies Meta<typeof FootballLiveMatchesComponent>;
+} satisfies Meta<typeof FootballMatchList>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const initialDays = [
+const initialDays: FootballMatches = [
 	{
 		date: new Date('2025-01-24T00:00:00Z'),
 		competitions: [
@@ -31,6 +32,7 @@ const initialDays = [
 				nation: 'European',
 				matches: [
 					{
+						kind: 'Live',
 						dateTime: new Date('2025-01-24T11:11:00Z'),
 						paId: '4482093',
 						homeTeam: {
@@ -44,17 +46,11 @@ const initialDays = [
 						status: 'FT',
 					},
 					{
+						kind: 'Fixture',
 						dateTime: new Date('2025-01-24T19:45:00Z'),
 						paId: '4482890',
-						homeTeam: {
-							name: 'Auxerre',
-							score: 0,
-						},
-						awayTeam: {
-							name: 'St Etienne',
-							score: 0,
-						},
-						status: 'FT',
+						homeTeam: 'Auxerre',
+						awayTeam: 'St Etienne',
 					},
 				],
 			},
@@ -64,6 +60,7 @@ const initialDays = [
 				nation: 'European',
 				matches: [
 					{
+						kind: 'Result',
 						dateTime: new Date('2025-01-24T20:00:00Z'),
 						paId: '4482835',
 						homeTeam: {
@@ -74,7 +71,6 @@ const initialDays = [
 							name: 'Osasuna',
 							score: 3,
 						},
-						status: 'FT',
 					},
 				],
 			},
@@ -82,7 +78,7 @@ const initialDays = [
 	},
 ];
 
-export const FootballLiveMatches = {
+export const Default = {
 	args: {
 		edition: 'UK',
 		initialDays,
@@ -97,8 +93,8 @@ export const FootballLiveMatches = {
 
 export const ErrorGettingMore = {
 	args: {
-		...FootballLiveMatches.args,
+		...Default.args,
 		getMoreDays: () => Promise.resolve(error('failed')),
 	},
-	play: FootballLiveMatches.play,
+	play: Default.play,
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -13,7 +13,7 @@ import {
 	SvgPlus,
 } from '@guardian/source/react-components';
 import { Fragment, type ReactNode, useState } from 'react';
-import type { FootballMatches } from '../footballMatches';
+import type { FootballMatch, FootballMatches } from '../footballMatches';
 import { grid } from '../grid';
 import {
 	type EditionId,
@@ -103,9 +103,14 @@ const Matches = (props: { children: ReactNode }) => (
 	/>
 );
 
-const Match = (props: { children: ReactNode }) => (
+const Match = ({
+	match,
+	timeFormatter,
+}: {
+	match: FootballMatch;
+	timeFormatter: Intl.DateTimeFormat;
+}) => (
 	<li
-		{...props}
 		css={css`
 			${textSans14}
 			background-color: ${palette('--football-match-list-background')};
@@ -125,20 +130,45 @@ const Match = (props: { children: ReactNode }) => (
 				}
 			}
 		`}
-	/>
+	>
+		{match.kind === 'Result' ? (
+			<span css={matchLeftStyle}>FT</span>
+		) : (
+			<MatchTime dateTime={match.dateTime.toISOString()}>
+				{timeFormatter.format(match.dateTime)}
+			</MatchTime>
+		)}
+		{match.kind === 'Fixture' ? (
+			<>
+				<HomeTeam>{match.homeTeam}</HomeTeam>
+
+				<Versus />
+				<AwayTeam>{match.awayTeam}</AwayTeam>
+			</>
+		) : (
+			<>
+				<HomeTeam>{match.homeTeam.name}</HomeTeam>
+
+				<Scores
+					homeScore={match.homeTeam.score}
+					awayScore={match.awayTeam.score}
+				/>
+				<AwayTeam>{match.awayTeam.name}</AwayTeam>
+			</>
+		)}
+	</li>
 );
 
-const MatchTime = (props: { children: ReactNode; dateTime: string }) => (
-	<time
-		{...props}
-		css={css`
-			width: 5rem;
+const matchLeftStyle = css`
+	width: 5rem;
 
-			${until.mobileMedium} {
-				flex-basis: 100%;
-			}
-		`}
-	/>
+	${until.mobileMedium} {
+		flex-basis: 100%;
+	}
+`;
+
+const MatchTime = (props: { children: ReactNode; dateTime: string }) => (
+	<time {...props} css={matchLeftStyle} />
 );
 
 const HomeTeam = (props: { children: ReactNode }) => (
@@ -175,6 +205,19 @@ const Battleline = () => (
 	/>
 );
 
+const Versus = () => (
+	<span
+		css={css`
+			width: 3rem;
+			display: block;
+			padding: 0 4px;
+			text-align: center;
+		`}
+	>
+		v
+	</span>
+);
+
 const Scores = ({
 	homeScore,
 	awayScore,
@@ -208,7 +251,7 @@ const Scores = ({
 	</span>
 );
 
-export const FootballLiveMatches = ({
+export const FootballMatchList = ({
 	edition,
 	initialDays,
 	getMoreDays,
@@ -231,25 +274,11 @@ export const FootballLiveMatches = ({
 							</CompetitionName>
 							<Matches>
 								{competition.matches.map((match) => (
-									<Match key={match.paId}>
-										<MatchTime
-											dateTime={match.dateTime.toISOString()}
-										>
-											{timeFormatter.format(
-												match.dateTime,
-											)}
-										</MatchTime>
-										<HomeTeam>
-											{match.homeTeam.name}
-										</HomeTeam>
-										<Scores
-											homeScore={match.homeTeam.score}
-											awayScore={match.awayTeam.score}
-										/>
-										<AwayTeam>
-											{match.awayTeam.name}
-										</AwayTeam>
-									</Match>
+									<Match
+										key={match.paId}
+										match={match}
+										timeFormatter={timeFormatter}
+									/>
 								))}
 							</Matches>
 						</Fragment>

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -9,26 +9,31 @@ type MatchData = {
 };
 
 export type MatchResult = MatchData & {
+	kind: 'Result';
 	homeTeam: TeamScore;
 	awayTeam: TeamScore;
 };
 
 export type MatchFixture = MatchData & {
+	kind: 'Fixture';
 	homeTeam: string;
 	awayTeam: string;
 };
 
 export type LiveMatch = MatchData & {
+	kind: 'Live';
 	homeTeam: TeamScore;
 	awayTeam: TeamScore;
 	status: string;
 };
 
+export type FootballMatch = MatchResult | MatchFixture | LiveMatch;
+
 type Competition = {
 	competitionId: string;
 	name: string;
 	nation: string;
-	matches: LiveMatch[];
+	matches: FootballMatch[];
 };
 
 export type FootballMatches = Array<{


### PR DESCRIPTION
## What does this change?

- Adds `kind` property to the different `FootballMatch` types
- Add support for different match types to the match list
- Add versus component for match fixtures