### PR TITLE
Force anchor tags to have rel='sponsored' if they are affiliate links

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -238,6 +238,16 @@ const styles = (format: ArticleFormat) => css`
 	}
 `;
 
+/** A function to check if a URL represents an affiliate link */
+const isSkimlink = (url?: string): boolean => {
+	try {
+		return !!url && new URL(url).host === 'go.skimresources.com';
+	} catch (err: unknown) {
+		// If not a valid URL, it won't be an affiliate link
+		return false;
+	}
+};
+
 const buildElementTree =
 	(format: ArticleFormat, showDropCaps: boolean) =>
 	(node: Node, key: number): ReactNode => {
@@ -256,8 +266,6 @@ const buildElementTree =
 				});
 			case 'A': {
 				const href = getAttrs(node)?.getNamedItem('href')?.value;
-				const isSkimlink =
-					!!href && new URL(href).host === 'go.skimresources.com';
 
 				return jsx('a', {
 					href,
@@ -270,7 +278,7 @@ const buildElementTree =
 					 * Affiliate links must have the rel attribute set to "sponsored"
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
-					rel: isSkimlink
+					rel: isSkimlink(href)
 						? 'sponsored'
 						: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,


### PR DESCRIPTION
## What does this change?

Forces links to have `rel="sponsored"` if the `href` starts with "https://go.skimresources.com" 

## Why?

It is possible to manually insert a skimlink into the article body without correctly assigning the `rel` attribute.


## Screenshots

From https://www.theguardian.com/thefilter/2025/jan/24/products-you-loved-most-january

|  | Screenshot     | 
| ------ | ----------- | 
| **Before** | ![before][] | 
| **After**  | ![after][]  | 

## HTML
**Before**
```html
<a 
  href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.sportsshoes.com%2Fproduct%2Fino2246%2Finov8-parkclaw-g-280-trail-running-shoes&amp;sref=https://www.theguardian.com/thefilter/2025/jan/02/best-running-shoes" 
  data-link-name="in body link">
    grippy running shoes
</a>
```
**After**
```html
<a 
  href="https://go.skimresources.com/?id=114047X1572903&amp;url=https%3A%2F%2Fwww.sportsshoes.com%2Fproduct%2Fino2246%2Finov8-parkclaw-g-280-trail-running-shoes&amp;sref=https://www.theguardian.com/thefilter/2025/jan/02/best-running-shoes" 
  data-link-name="in body link" 
  rel="sponsored">
    grippy running shoes
</a>
```

[before]: https://github.com/user-attachments/assets/bd365fae-917b-49b4-b2a9-a4ab0ff101b4
[after]: https://github.com/user-attachments/assets/d45e982f-8686-411e-ae5d-76a8f3b3219d


<details>
<summary>JS snippet to identify sponsored links without rel="sponsored"</summary>

```javascript
Array.from(document.getElementsByTagName('a'))
  .filter(l => l.href && new URL(l.href).host === 'go.skimresources.com' && l.rel !== "sponsored")
  .map(({ text, href, rel }) => ({ text, href, rel }))
```
</details>
