### PR TITLE
Added comments to the football match list

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -71,6 +71,29 @@ const initialDays: FootballMatches = [
 							name: 'Osasuna',
 							score: 3,
 						},
+						comment: 'AET',
+					},
+				],
+			},
+			{
+				competitionId: '650',
+				name: 'FA Cup',
+				nation: 'European',
+				matches: [
+					{
+						kind: 'Result',
+						dateTime: new Date('2025-01-25T20:00:00Z'),
+						paId: '4482836',
+						homeTeam: {
+							name: 'Brighton & Hove Albion Women',
+							score: 1,
+						},
+						awayTeam: {
+							name: 'Crystal Palace Women',
+							score: 1,
+						},
+						comment:
+							'Brighton & Hove Albion Women won 4 - 3 on penalties...',
 					},
 				],
 			},

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	headlineBold17,
@@ -117,10 +118,7 @@ const Match = ({
 			padding: ${space[2]}px;
 			display: flex;
 			border: 1px solid ${palette('--football-match-list-border')};
-
-			${until.mobileMedium} {
-				flex-wrap: wrap;
-			}
+			flex-wrap: wrap;
 
 			${from.leftCol} {
 				&:first-of-type {
@@ -154,6 +152,21 @@ const Match = ({
 					awayScore={match.awayTeam.score}
 				/>
 				<AwayTeam>{match.awayTeam.name}</AwayTeam>
+				{isUndefined(match.comment) ? null : (
+					<small
+						css={css`
+							color: ${palette('--football-match-list-sub-text')};
+							flex-basis: 100%;
+							text-align: center;
+							padding-top: ${space[2]}px;
+							${from.mobileMedium} {
+								padding-left: 5rem;
+							}
+						`}
+					>
+						{match.comment}
+					</small>
+				)}
 			</>
 		)}
 	</li>
@@ -161,6 +174,7 @@ const Match = ({
 
 const matchLeftStyle = css`
 	width: 5rem;
+	color: ${palette('--football-match-list-sub-text')};
 
 	${until.mobileMedium} {
 		flex-basis: 100%;
@@ -208,6 +222,7 @@ const Battleline = () => (
 const Versus = () => (
 	<span
 		css={css`
+			color: ${palette('--football-match-list-sub-text')};
 			width: 3rem;
 			display: block;
 			padding: 0 4px;
@@ -229,6 +244,7 @@ const Scores = ({
 		css={css`
 			width: 3rem;
 			display: flex;
+			color: ${palette('--football-match-list-sub-text')};
 		`}
 	>
 		<span

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -32,8 +32,8 @@ type Props = {
 
 const REMOVE_TRAILING_DOTS_REGEX = /\.+$/;
 
-const removeTrailingDots = (string: string): string => {
-	return string.replace(REMOVE_TRAILING_DOTS_REGEX, '');
+const removeTrailingDots = (str: string): string => {
+	return str.replace(REMOVE_TRAILING_DOTS_REGEX, '');
 };
 
 const getDateFormatter = (edition: EditionId): Intl.DateTimeFormat =>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -30,6 +30,12 @@ type Props = {
 	getMoreDays: () => Promise<Result<'failed', FootballMatches>>;
 };
 
+const removeTrailingDotsRegex = /\.+$/;
+
+const removeTrailingDots = (string: string): string => {
+	return string.replace(removeTrailingDotsRegex, '');
+};
+
 const getDateFormatter = (edition: EditionId): Intl.DateTimeFormat =>
 	new Intl.DateTimeFormat('en-GB', {
 		weekday: 'long',
@@ -164,7 +170,7 @@ const Match = ({
 							}
 						`}
 					>
-						{match.comment}
+						{removeTrailingDots(match.comment)}
 					</small>
 				)}
 			</>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -30,10 +30,10 @@ type Props = {
 	getMoreDays: () => Promise<Result<'failed', FootballMatches>>;
 };
 
-const removeTrailingDotsRegex = /\.+$/;
+const REMOVE_TRAILING_DOTS_REGEX = /\.+$/;
 
 const removeTrailingDots = (string: string): string => {
-	return string.replace(removeTrailingDotsRegex, '');
+	return string.replace(REMOVE_TRAILING_DOTS_REGEX, '');
 };
 
 const getDateFormatter = (edition: EditionId): Intl.DateTimeFormat =>

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -12,6 +12,7 @@ export type MatchResult = MatchData & {
 	kind: 'Result';
 	homeTeam: TeamScore;
 	awayTeam: TeamScore;
+	comment?: string;
 };
 
 export type MatchFixture = MatchData & {
@@ -25,6 +26,7 @@ export type LiveMatch = MatchData & {
 	homeTeam: TeamScore;
 	awayTeam: TeamScore;
 	status: string;
+	comment?: string;
 };
 
 export type FootballMatch = MatchResult | MatchFixture | LiveMatch;

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6498,6 +6498,10 @@ const paletteColours = {
 		light: () => sourcePalette.error[400],
 		dark: () => sourcePalette.error[500],
 	},
+	'--football-match-list-sub-text': {
+		light: () => sourcePalette.neutral[46],
+		dark: () => sourcePalette.neutral[73],
+	},
 	'--football-match-list-top-border': {
 		light: () => sourcePalette.sport[500],
 		dark: () => sourcePalette.neutral[60],


### PR DESCRIPTION
## What does this change?

- Adds a comment to the bottom of the match list. 
- Changes the colour of the score and the left column of the table to a lighter text colour
- Adds a new lighter text colour to the palette.
- removes any trailing '..' as seen here https://github.com/guardian/frontend/blob/379308cd00f6e1e75edef0e8637f5d3683c075f5/sport/app/football/views/matchList/matchesList.scala.html#L76