### PR TITLE
Simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,5 @@
 # By default all files are owned by these teams:
 * 												@guardian/dotcom-platform
 
-# These folders and all their contents are owned by the following teams.
-/dotcom-rendering/ 								@guardian/dotcom-platform
-/apps-rendering/ 								@guardian/dotcom-platform
 /dotcom-rendering/src/components/marketing/ 	@guardian/growth
 /dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
-
-# These file types, wherever they are, are co-owned by the following teams.
-package.json 									@guardian/dotcom-platform
-tsconfig.json 									@guardian/dotcom-platform


### PR DESCRIPTION
Since all files are owned by `dotcom-platform` due to the first rule, these extra rules shouldn't be needed.
