### PR TITLE
New Supporter Revenue cookie lifecycle

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
@@ -1,10 +1,8 @@
 import { getCookie } from '@guardian/libs';
-import { cookieIsValid } from './cookieHelpers';
 
 export const AD_FREE_USER_COOKIE = 'GU_AF1';
 
-export const adFreeDataIsPresent = (): boolean =>
-	cookieIsValid(AD_FREE_USER_COOKIE);
+export const adFreeDataIsPresent = (): boolean => getAdFreeCookie() !== null;
 
 export const getAdFreeCookie = (): string | null =>
 	getCookie({ name: AD_FREE_USER_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
@@ -1,8 +1,11 @@
 import { getCookie } from '@guardian/libs';
+import { userBenefitsDataIsUpToDate } from './userBenefitsExpiry';
 
 export const AD_FREE_USER_COOKIE = 'GU_AF1';
 
-export const adFreeDataIsPresent = (): boolean => getAdFreeCookie() !== null;
+export const adFreeDataIsPresent = (isSignedIn: boolean): boolean =>
+	getAdFreeCookie() !== null || // If the user has an ad-free cookie give them ad-free
+	(isSignedIn && !userBenefitsDataIsUpToDate()); // If they are signed in and their benefits are out of date, give them ad-free for now
 
 export const getAdFreeCookie = (): string | null =>
 	getCookie({ name: AD_FREE_USER_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/adFree.ts
@@ -1,30 +1,10 @@
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
+import { cookieIsValid } from './cookieHelpers';
 
-const AD_FREE_USER_COOKIE = 'GU_AF1';
+export const AD_FREE_USER_COOKIE = 'GU_AF1';
+
+export const adFreeDataIsPresent = (): boolean =>
+	cookieIsValid(AD_FREE_USER_COOKIE);
 
 export const getAdFreeCookie = (): string | null =>
 	getCookie({ name: AD_FREE_USER_COOKIE });
-
-/*
- * Set the ad free cookie
- *
- * @param daysToLive - number of days the cookie should be valid
- */
-export const setAdFreeCookie = (daysToLive = 1): void => {
-	const expires = new Date();
-	expires.setMonth(expires.getMonth() + 6);
-	setCookie({
-		name: AD_FREE_USER_COOKIE,
-		value: expires.getTime().toString(),
-		daysToLive,
-	});
-};
-
-export const adFreeDataIsPresent = (): boolean => {
-	const cookieVal = getAdFreeCookie();
-	if (!cookieVal) return false;
-	return !Number.isNaN(parseInt(cookieVal, 10));
-};
-
-export const removeAdFreeCookie = (): void =>
-	removeCookie({ name: AD_FREE_USER_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
@@ -1,8 +1,11 @@
 import { getCookie } from '@guardian/libs';
+import { userBenefitsDataIsUpToDate } from './userBenefitsExpiry';
 
 export const ALLOW_REJECT_ALL_COOKIE = 'gu_allow_reject_all';
 
-export const allowRejectAll = (): boolean => getAllowRejectAllCookie() !== null;
+export const allowRejectAll = (isSignedIn: boolean): boolean =>
+	getAllowRejectAllCookie() !== null || // If the user has an allow-reject-all cookie, respect it
+	(isSignedIn && !userBenefitsDataIsUpToDate()); // If they are signed in and their benefits are out of date, allow reject all for now
 
 export const getAllowRejectAllCookie = (): string | null =>
 	getCookie({ name: ALLOW_REJECT_ALL_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
@@ -1,25 +1,10 @@
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
+import { cookieIsValid } from './cookieHelpers';
 
-const ALLOW_REJECT_ALL_COOKIE = 'gu_allow_reject_all';
+export const ALLOW_REJECT_ALL_COOKIE = 'gu_allow_reject_all';
+
+export const allowRejectAll = (): boolean =>
+	cookieIsValid(ALLOW_REJECT_ALL_COOKIE);
 
 export const getAllowRejectAllCookie = (): string | null =>
 	getCookie({ name: ALLOW_REJECT_ALL_COOKIE });
-
-export const setAllowRejectAllCookie = (daysToLive = 1): void => {
-	const expires = new Date();
-	expires.setMonth(expires.getMonth() + 6);
-	setCookie({
-		name: ALLOW_REJECT_ALL_COOKIE,
-		value: expires.getTime().toString(),
-		daysToLive,
-	});
-};
-
-export const removeAllowRejectAllCookie = (): void =>
-	removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
-
-export const allowRejectAll = (): boolean => {
-	const cookieVal = getAllowRejectAllCookie();
-	if (!cookieVal) return false;
-	return !Number.isNaN(parseInt(cookieVal, 10));
-};

--- a/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/allowRejectAll.ts
@@ -1,10 +1,8 @@
 import { getCookie } from '@guardian/libs';
-import { cookieIsValid } from './cookieHelpers';
 
 export const ALLOW_REJECT_ALL_COOKIE = 'gu_allow_reject_all';
 
-export const allowRejectAll = (): boolean =>
-	cookieIsValid(ALLOW_REJECT_ALL_COOKIE);
+export const allowRejectAll = (): boolean => getAllowRejectAllCookie() !== null;
 
 export const getAllowRejectAllCookie = (): string | null =>
 	getCookie({ name: ALLOW_REJECT_ALL_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
@@ -1,4 +1,8 @@
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { removeCookie, setCookie } from '@guardian/libs';
+import { AD_FREE_USER_COOKIE } from './adFree';
+import { ALLOW_REJECT_ALL_COOKIE } from './allowRejectAll';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from './hideSupportMessaging';
+import { USER_BENEFITS_EXPIRY_COOKIE } from './userBenefitsExpiry';
 
 export const timeInDaysFromNow = (daysFromNow: number): number => {
 	const tmpDate = new Date();
@@ -6,47 +10,21 @@ export const timeInDaysFromNow = (daysFromNow: number): number => {
 	return tmpDate.getTime();
 };
 
-export const setUserBenefitCookie = (
+export const extendCookieExpiry = (
 	cookieName: string,
-	daysTillExpiry: number,
+	daysTillExpiry: number = 1,
 ): void => {
 	const expiresValue = timeInDaysFromNow(daysTillExpiry);
 	setCookie({
 		name: cookieName,
 		value: expiresValue.toString(),
-		daysToLive: 30,
+		daysToLive: daysTillExpiry,
 	});
 };
 
-// Extend the expiry date of the cookie by 1 day unless it already has a longer expiry date
-export const renewUserBenefitCookie = (cookieName: string): void => {
-	const newExpiresValue = timeInDaysFromNow(1);
-	const existingExpiresValue = getCookieExpiry(cookieName);
-	if (
-		existingExpiresValue == undefined ||
-		newExpiresValue > existingExpiresValue
-	) {
-		setUserBenefitCookie(cookieName, 1);
-	}
-};
-
-export const getCookieExpiry = (cookieName: string): number | undefined => {
-	const cookieValue = getCookie({ name: cookieName });
-	if (!cookieValue) return;
-	return parseInt(cookieValue, 10);
-};
-
-export const cookieIsExpired = (cookieName: string): boolean =>
-	!cookieIsValid(cookieName);
-
-export const cookieIsValid = (cookieName: string): boolean => {
-	const timeNow = new Date().getTime();
-	const expiryTime = getCookieExpiry(cookieName);
-	return expiryTime !== undefined && timeNow < expiryTime;
-};
-
-export const removeCookieIfExpired = (cookieName: string): void => {
-	if (cookieIsExpired(cookieName)) {
-		removeCookie({ name: cookieName });
-	}
+export const deleteAllCookies = (): void => {
+	removeCookie({ name: USER_BENEFITS_EXPIRY_COOKIE });
+	removeCookie({ name: AD_FREE_USER_COOKIE });
+	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
+	removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
 };

--- a/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
@@ -1,0 +1,52 @@
+import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+
+export const timeInDaysFromNow = (daysFromNow: number): number => {
+	const tmpDate = new Date();
+	tmpDate.setDate(tmpDate.getDate() + daysFromNow);
+	return tmpDate.getTime();
+};
+
+export const setUserBenefitCookie = (
+	cookieName: string,
+	daysTillExpiry: number,
+): void => {
+	const expiresValue = timeInDaysFromNow(daysTillExpiry);
+	setCookie({
+		name: cookieName,
+		value: expiresValue.toString(),
+		daysToLive: 30,
+	});
+};
+
+// Extend the expiry date of the cookie by 1 day unless it already has a longer expiry date
+export const renewUserBenefitCookie = (cookieName: string): void => {
+	const newExpiresValue = timeInDaysFromNow(1);
+	const existingExpiresValue = getCookieExpiry(cookieName);
+	if (
+		existingExpiresValue == undefined ||
+		newExpiresValue > existingExpiresValue
+	) {
+		setUserBenefitCookie(cookieName, 1);
+	}
+};
+
+export const getCookieExpiry = (cookieName: string): number | undefined => {
+	const cookieValue = getCookie({ name: cookieName });
+	if (!cookieValue) return;
+	return parseInt(cookieValue, 10);
+};
+
+export const cookieIsExpired = (cookieName: string): boolean =>
+	!cookieIsValid(cookieName);
+
+export const cookieIsValid = (cookieName: string): boolean => {
+	const timeNow = new Date().getTime();
+	const expiryTime = getCookieExpiry(cookieName);
+	return expiryTime !== undefined && timeNow < expiryTime;
+};
+
+export const removeCookieIfExpired = (cookieName: string): void => {
+	if (cookieIsExpired(cookieName)) {
+		removeCookie({ name: cookieName });
+	}
+};

--- a/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/cookieHelpers.ts
@@ -10,7 +10,7 @@ export const timeInDaysFromNow = (daysFromNow: number): number => {
 	return tmpDate.getTime();
 };
 
-export const extendCookieExpiry = (
+export const createOrRenewCookie = (
 	cookieName: string,
 	daysTillExpiry: number = 1,
 ): void => {

--- a/dotcom-rendering/src/client/userFeatures/cookies/hideSupportMessaging.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/hideSupportMessaging.ts
@@ -1,16 +1,10 @@
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
+import { cookieIsValid } from './cookieHelpers';
 
-const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
+
+export const hideSupportMessaging = (): boolean =>
+	cookieIsValid(HIDE_SUPPORT_MESSAGING_COOKIE);
 
 export const getHideSupportMessagingCookie = (): string | null =>
 	getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
-
-export const setHideSupportMessagingCookie = (value: boolean): void => {
-	setCookie({
-		name: HIDE_SUPPORT_MESSAGING_COOKIE,
-		value: String(value),
-	});
-};
-
-export const removeHideSupportMessagingCookie = (): void =>
-	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/hideSupportMessaging.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/hideSupportMessaging.ts
@@ -1,10 +1,9 @@
 import { getCookie } from '@guardian/libs';
-import { cookieIsValid } from './cookieHelpers';
 
 export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 
 export const hideSupportMessaging = (): boolean =>
-	cookieIsValid(HIDE_SUPPORT_MESSAGING_COOKIE);
+	getHideSupportMessagingCookie() !== null;
 
 export const getHideSupportMessagingCookie = (): string | null =>
 	getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/userBenefitsExpiry.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/userBenefitsExpiry.ts
@@ -1,6 +1,6 @@
 import { getCookie } from '@guardian/libs';
 
-export const USER_BENEFITS_EXPIRY_COOKIE = 'gu_user_features_expiry';
+export const USER_BENEFITS_EXPIRY_COOKIE = 'gu_user_benefits_expiry';
 
 export const getUserBenefitsExpiryCookie = (): string | null =>
 	getCookie({ name: USER_BENEFITS_EXPIRY_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/cookies/userBenefitsExpiry.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/userBenefitsExpiry.ts
@@ -1,0 +1,17 @@
+import { getCookie } from '@guardian/libs';
+
+export const USER_BENEFITS_EXPIRY_COOKIE = 'gu_user_features_expiry';
+
+export const getUserBenefitsExpiryCookie = (): string | null =>
+	getCookie({ name: USER_BENEFITS_EXPIRY_COOKIE });
+
+export const userBenefitsDataNeedsRefreshing = (): boolean =>
+	!userBenefitsDataIsUpToDate();
+
+export const userBenefitsDataIsUpToDate = (): boolean => {
+	const cookieValue = getUserBenefitsExpiryCookie();
+	if (!cookieValue) return false;
+	const expiryTime = parseInt(cookieValue, 10);
+	const timeNow = new Date().getTime();
+	return timeNow < expiryTime;
+};

--- a/dotcom-rendering/src/client/userFeatures/cookies/userFeaturesExpiry.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/userFeaturesExpiry.ts
@@ -1,20 +1,6 @@
-import { getCookie, removeCookie, setCookie } from '@guardian/libs';
+import { getCookie } from '@guardian/libs';
 
-const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
+export const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
 
 export const getUserFeaturesExpiryCookie = (): string | null =>
 	getCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
-
-export const setUserFeaturesExpiryCookie = (expiryTime: string): void =>
-	setCookie({ name: USER_FEATURES_EXPIRY_COOKIE, value: expiryTime });
-
-export const removeUserFeaturesExpiryCookie = (): void =>
-	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
-
-export const featuresDataIsOld = (): boolean => {
-	const cookie = getUserFeaturesExpiryCookie();
-	if (!cookie) return true;
-	const expiryTime = parseInt(cookie, 10);
-	const timeNow = new Date().getTime();
-	return timeNow >= expiryTime;
-};

--- a/dotcom-rendering/src/client/userFeatures/cookies/userFeaturesExpiry.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/userFeaturesExpiry.ts
@@ -1,6 +1,0 @@
-import { getCookie } from '@guardian/libs';
-
-export const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
-
-export const getUserFeaturesExpiryCookie = (): string | null =>
-	getCookie({ name: USER_FEATURES_EXPIRY_COOKIE });

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -58,7 +58,7 @@ const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
 	typeof getAuthStatus_
 >;
 
-const setAllFeaturesData = (opts: { isExpired: boolean }) => {
+const setAllBenefitsData = (opts: { isExpired: boolean }) => {
 	const daysToExpiry = opts.isExpired ? -1 : 1;
 	extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE, daysToExpiry);
 	extendCookieExpiry(AD_FREE_USER_COOKIE, daysToExpiry);
@@ -71,7 +71,7 @@ beforeAll(() => {
 	window.guardian.config.tests['useUserBenefitsApiVariant'] = 'variant';
 });
 
-const expectUserFeatureExpiryCookieHasBeenSetCorrectly = () => {
+const expectUserBenefitExpiryCookieHasBeenSetCorrectly = () => {
 	const expectedNextRefreshDate = new Date(
 		timeInDaysFromNow(1),
 	).toDateString();
@@ -92,10 +92,10 @@ const expectAllCookiesToBeSet = () => {
 	expect(getAdFreeCookie()).toBeTruthy();
 	expect(getHideSupportMessagingCookie()).toBeTruthy();
 	expect(getAllowRejectAllCookie()).toBeTruthy();
-	expectUserFeatureExpiryCookieHasBeenSetCorrectly();
+	expectUserBenefitExpiryCookieHasBeenSetCorrectly();
 };
 
-describe('Refreshing the features data', () => {
+describe('Refreshing the benefits data', () => {
 	describe('If user signed in', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
@@ -110,36 +110,36 @@ describe('Refreshing the features data', () => {
 			deleteAllCookies();
 			await refresh();
 			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-			expectUserFeatureExpiryCookieHasBeenSetCorrectly();
+			expectUserBenefitExpiryCookieHasBeenSetCorrectly();
 		});
 
 		it('Performs an update if the user has expired data', async () => {
-			setAllFeaturesData({ isExpired: true });
+			setAllBenefitsData({ isExpired: true });
 			await refresh();
 			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it(
 			'Deletes all expired user benefits cookies if the api response does not contain the benefit, ' +
-				'but does not delete the user features expiry cookie (so we know when next to check for benefits)',
+				'but does not delete the user benefits expiry cookie (so we know when next to check for benefits)',
 			async () => {
 				fetchJsonSpy.mockReturnValueOnce(Promise.resolve(noBenefits));
-				setAllFeaturesData({ isExpired: true });
+				setAllBenefitsData({ isExpired: true });
 				await refresh();
 				expectAllBenefitsCookiesToBeDeleted();
-				expectUserFeatureExpiryCookieHasBeenSetCorrectly();
+				expectUserBenefitExpiryCookieHasBeenSetCorrectly();
 			},
 		);
 
 		it('Does not delete non-expired user benefits cookies even if the api response does not contain the benefit', async () => {
 			fetchJsonSpy.mockReturnValueOnce(Promise.resolve(noBenefits));
-			setAllFeaturesData({ isExpired: false });
+			setAllBenefitsData({ isExpired: false });
 			await refresh();
 			expectAllCookiesToBeSet();
 		});
 
 		it('Does not perform an update if user has non-expired user benefits data', async () => {
-			setAllFeaturesData({ isExpired: false });
+			setAllBenefitsData({ isExpired: false });
 			await refresh();
 			expect(fetchJsonSpy).not.toHaveBeenCalled();
 		});
@@ -159,13 +159,13 @@ describe('If user signed out', () => {
 	});
 
 	it('Does not delete non-expired user benefits cookies', async () => {
-		setAllFeaturesData({ isExpired: false });
+		setAllBenefitsData({ isExpired: false });
 		await refresh();
 		expectAllCookiesToBeSet();
 	});
 
 	it('Does delete expired user benefits cookies', async () => {
-		setAllFeaturesData({ isExpired: true });
+		setAllBenefitsData({ isExpired: true });
 		await refresh();
 		expectAllBenefitsCookiesToBeDeleted();
 		expect(getUserBenefitsExpiryCookie()).toBeNull();

--- a/dotcom-rendering/src/client/userFeatures/user-features.test.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.test.ts
@@ -10,8 +10,8 @@ import {
 	getAllowRejectAllCookie,
 } from './cookies/allowRejectAll';
 import {
+	createOrRenewCookie,
 	deleteAllCookies,
-	extendCookieExpiry,
 	timeInDaysFromNow,
 } from './cookies/cookieHelpers';
 import {
@@ -60,10 +60,10 @@ const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
 
 const setAllBenefitsData = (opts: { isExpired: boolean }) => {
 	const daysToExpiry = opts.isExpired ? -1 : 1;
-	extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE, daysToExpiry);
-	extendCookieExpiry(AD_FREE_USER_COOKIE, daysToExpiry);
-	extendCookieExpiry(ALLOW_REJECT_ALL_COOKIE, daysToExpiry);
-	extendCookieExpiry(USER_BENEFITS_EXPIRY_COOKIE, daysToExpiry);
+	createOrRenewCookie(HIDE_SUPPORT_MESSAGING_COOKIE, daysToExpiry);
+	createOrRenewCookie(AD_FREE_USER_COOKIE, daysToExpiry);
+	createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE, daysToExpiry);
+	createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE, daysToExpiry);
 };
 
 beforeAll(() => {

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -4,26 +4,15 @@
  * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
  */
 
-import { removeCookie } from '@guardian/libs';
 import { getAuthStatus, isUserLoggedInOktaRefactor } from '../../lib/identity';
-import { AD_FREE_USER_COOKIE, getAdFreeCookie } from './cookies/adFree';
+import { AD_FREE_USER_COOKIE } from './cookies/adFree';
+import { ALLOW_REJECT_ALL_COOKIE } from './cookies/allowRejectAll';
+import { extendCookieExpiry } from './cookies/cookieHelpers';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from './cookies/hideSupportMessaging';
 import {
-	ALLOW_REJECT_ALL_COOKIE,
-	getAllowRejectAllCookie,
-} from './cookies/allowRejectAll';
-import {
-	cookieIsExpired,
-	removeCookieIfExpired,
-	renewUserBenefitCookie,
-} from './cookies/cookieHelpers';
-import {
-	getHideSupportMessagingCookie,
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-} from './cookies/hideSupportMessaging';
-import {
-	getUserFeaturesExpiryCookie,
-	USER_FEATURES_EXPIRY_COOKIE,
-} from './cookies/userFeaturesExpiry';
+	USER_BENEFITS_EXPIRY_COOKIE,
+	userBenefitsDataNeedsRefreshing,
+} from './cookies/userBenefitsExpiry';
 import { syncDataFromUserBenefitsApi } from './userBenefitsApi';
 
 export type UserBenefits = {
@@ -32,29 +21,12 @@ export type UserBenefits = {
 	allowRejectAll: boolean;
 };
 
-const userHasData = () => {
-	const cookie =
-		getAdFreeCookie() ??
-		getUserFeaturesExpiryCookie() ??
-		getHideSupportMessagingCookie() ??
-		getAllowRejectAllCookie();
-	return !!cookie;
-};
-
-const userHasDataAfterSignOut = async (): Promise<boolean> =>
-	!(await isUserLoggedInOktaRefactor()) && userHasData();
-
-export const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(
-	window.location.hash,
-);
 const refresh = async (): Promise<void> => {
 	if (
 		(await isUserLoggedInOktaRefactor()) &&
-		cookieIsExpired(USER_FEATURES_EXPIRY_COOKIE)
+		userBenefitsDataNeedsRefreshing()
 	) {
-		return requestNewData();
-	} else if (await userHasDataAfterSignOut()) {
-		removeExpiredUserBenefitsCookies();
+		await requestNewData();
 	}
 };
 
@@ -70,36 +42,16 @@ const requestNewData = async () => {
 };
 
 const persistResponse = (userBenefitsResponse: UserBenefits) => {
-	renewUserBenefitCookie(USER_FEATURES_EXPIRY_COOKIE);
+	extendCookieExpiry(USER_BENEFITS_EXPIRY_COOKIE);
 	if (userBenefitsResponse.hideSupportMessaging) {
-		renewUserBenefitCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
-	} else {
-		removeCookieIfExpired(HIDE_SUPPORT_MESSAGING_COOKIE);
+		extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE);
 	}
 	if (userBenefitsResponse.allowRejectAll) {
-		renewUserBenefitCookie(ALLOW_REJECT_ALL_COOKIE);
-	} else {
-		removeCookieIfExpired(ALLOW_REJECT_ALL_COOKIE);
+		extendCookieExpiry(ALLOW_REJECT_ALL_COOKIE);
 	}
 	if (userBenefitsResponse.adFree) {
-		renewUserBenefitCookie(AD_FREE_USER_COOKIE);
-	} else if (!forcedAdFreeMode) {
-		removeCookieIfExpired(AD_FREE_USER_COOKIE);
+		extendCookieExpiry(AD_FREE_USER_COOKIE);
 	}
-};
-
-export const removeExpiredUserBenefitsCookies = (): void => {
-	removeCookieIfExpired(USER_FEATURES_EXPIRY_COOKIE);
-	removeCookieIfExpired(AD_FREE_USER_COOKIE);
-	removeCookieIfExpired(HIDE_SUPPORT_MESSAGING_COOKIE);
-	removeCookieIfExpired(ALLOW_REJECT_ALL_COOKIE);
-};
-
-export const deleteAllCookies = (): void => {
-	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
-	removeCookie({ name: AD_FREE_USER_COOKIE });
-	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
-	removeCookie({ name: ALLOW_REJECT_ALL_COOKIE });
 };
 
 export { refresh };

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -7,7 +7,7 @@
 import { getAuthStatus, isUserLoggedInOktaRefactor } from '../../lib/identity';
 import { AD_FREE_USER_COOKIE } from './cookies/adFree';
 import { ALLOW_REJECT_ALL_COOKIE } from './cookies/allowRejectAll';
-import { extendCookieExpiry } from './cookies/cookieHelpers';
+import { createOrRenewCookie } from './cookies/cookieHelpers';
 import { HIDE_SUPPORT_MESSAGING_COOKIE } from './cookies/hideSupportMessaging';
 import {
 	USER_BENEFITS_EXPIRY_COOKIE,
@@ -42,15 +42,15 @@ const requestNewData = async () => {
 };
 
 const persistResponse = (userBenefitsResponse: UserBenefits) => {
-	extendCookieExpiry(USER_BENEFITS_EXPIRY_COOKIE);
+	createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE);
 	if (userBenefitsResponse.hideSupportMessaging) {
-		extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE);
+		createOrRenewCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
 	}
 	if (userBenefitsResponse.allowRejectAll) {
-		extendCookieExpiry(ALLOW_REJECT_ALL_COOKIE);
+		createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE);
 	}
 	if (userBenefitsResponse.adFree) {
-		extendCookieExpiry(AD_FREE_USER_COOKIE);
+		createOrRenewCookie(AD_FREE_USER_COOKIE);
 	}
 };
 

--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -4,17 +4,26 @@
  * https://github.com/guardian/commercial/blob/1a429d6be05657f20df4ca909df7d01a5c3d7402/src/lib/user-features.ts
  */
 
-import { getCookie, removeCookie } from '@guardian/libs';
+import { removeCookie } from '@guardian/libs';
 import { getAuthStatus, isUserLoggedInOktaRefactor } from '../../lib/identity';
-import { AD_FREE_USER_COOKIE } from './cookies/adFree';
-import { ALLOW_REJECT_ALL_COOKIE } from './cookies/allowRejectAll';
+import { AD_FREE_USER_COOKIE, getAdFreeCookie } from './cookies/adFree';
+import {
+	ALLOW_REJECT_ALL_COOKIE,
+	getAllowRejectAllCookie,
+} from './cookies/allowRejectAll';
 import {
 	cookieIsExpired,
 	removeCookieIfExpired,
 	renewUserBenefitCookie,
 } from './cookies/cookieHelpers';
-import { HIDE_SUPPORT_MESSAGING_COOKIE } from './cookies/hideSupportMessaging';
-import { USER_FEATURES_EXPIRY_COOKIE } from './cookies/userFeaturesExpiry';
+import {
+	getHideSupportMessagingCookie,
+	HIDE_SUPPORT_MESSAGING_COOKIE,
+} from './cookies/hideSupportMessaging';
+import {
+	getUserFeaturesExpiryCookie,
+	USER_FEATURES_EXPIRY_COOKIE,
+} from './cookies/userFeaturesExpiry';
 import { syncDataFromUserBenefitsApi } from './userBenefitsApi';
 
 export type UserBenefits = {
@@ -25,10 +34,10 @@ export type UserBenefits = {
 
 const userHasData = () => {
 	const cookie =
-		getCookie({ name: AD_FREE_USER_COOKIE }) ??
-		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
-		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }) ??
-		getCookie({ name: ALLOW_REJECT_ALL_COOKIE });
+		getAdFreeCookie() ??
+		getUserFeaturesExpiryCookie() ??
+		getHideSupportMessagingCookie() ??
+		getAllowRejectAllCookie();
 	return !!cookie;
 };
 

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -1,6 +1,6 @@
 import { setCookie, storage } from '@guardian/libs';
 import MockDate from 'mockdate';
-import { extendCookieExpiry } from '../client/userFeatures/cookies/cookieHelpers';
+import { createOrRenewCookie } from '../client/userFeatures/cookies/cookieHelpers';
 import { HIDE_SUPPORT_MESSAGING_COOKIE } from '../client/userFeatures/cookies/hideSupportMessaging';
 import { USER_BENEFITS_EXPIRY_COOKIE } from '../client/userFeatures/cookies/userBenefitsExpiry';
 import {
@@ -182,12 +182,12 @@ describe('hasSupporterCookie', () => {
 	beforeEach(clearAllCookies);
 
 	it('returns false if user features expiry cookie exists but hide support messaging does not', () => {
-		extendCookieExpiry(USER_BENEFITS_EXPIRY_COOKIE);
+		createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE);
 		expect(hasHideSupportMessagingCookie(true)).toEqual(false);
 	});
 
 	it('returns true if cookie exists and is non-expired', () => {
-		extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE);
+		createOrRenewCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
 		expect(hasHideSupportMessagingCookie(true)).toEqual(true);
 	});
 

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -1,8 +1,8 @@
 import { setCookie, storage } from '@guardian/libs';
 import MockDate from 'mockdate';
-import { renewUserBenefitCookie } from '../client/userFeatures/cookies/cookieHelpers';
+import { extendCookieExpiry } from '../client/userFeatures/cookies/cookieHelpers';
 import { HIDE_SUPPORT_MESSAGING_COOKIE } from '../client/userFeatures/cookies/hideSupportMessaging';
-import { USER_FEATURES_EXPIRY_COOKIE } from '../client/userFeatures/cookies/userFeaturesExpiry';
+import { USER_BENEFITS_EXPIRY_COOKIE } from '../client/userFeatures/cookies/userBenefitsExpiry';
 import {
 	getLastOneOffContributionTimestamp,
 	hasHideSupportMessagingCookie,
@@ -182,12 +182,12 @@ describe('hasSupporterCookie', () => {
 	beforeEach(clearAllCookies);
 
 	it('returns false if user features expiry cookie exists but hide support messaging does not', () => {
-		renewUserBenefitCookie(USER_FEATURES_EXPIRY_COOKIE);
+		extendCookieExpiry(USER_BENEFITS_EXPIRY_COOKIE);
 		expect(hasHideSupportMessagingCookie(true)).toEqual(false);
 	});
 
 	it('returns true if cookie exists and is non-expired', () => {
-		renewUserBenefitCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+		extendCookieExpiry(HIDE_SUPPORT_MESSAGING_COOKIE);
 		expect(hasHideSupportMessagingCookie(true)).toEqual(true);
 	});
 

--- a/dotcom-rendering/src/lib/contributions.test.ts
+++ b/dotcom-rendering/src/lib/contributions.test.ts
@@ -1,9 +1,11 @@
 import { setCookie, storage } from '@guardian/libs';
 import MockDate from 'mockdate';
+import { renewUserBenefitCookie } from '../client/userFeatures/cookies/cookieHelpers';
+import { HIDE_SUPPORT_MESSAGING_COOKIE } from '../client/userFeatures/cookies/hideSupportMessaging';
+import { USER_FEATURES_EXPIRY_COOKIE } from '../client/userFeatures/cookies/userFeaturesExpiry';
 import {
 	getLastOneOffContributionTimestamp,
-	hasSupporterCookie,
-	HIDE_SUPPORT_MESSAGING_COOKIE,
+	hasHideSupportMessagingCookie,
 	isRecentOneOffContributor,
 	NO_RR_BANNER_KEY,
 	recentlyClosedBanner,
@@ -179,27 +181,21 @@ describe('withinLocalNoBannerCachePeriod', () => {
 describe('hasSupporterCookie', () => {
 	beforeEach(clearAllCookies);
 
-	it('returns false if cookie exists and is set to false', () => {
-		setCookie({
-			name: HIDE_SUPPORT_MESSAGING_COOKIE,
-			value: 'false',
-		});
-		expect(hasSupporterCookie(true)).toEqual(false);
+	it('returns false if user features expiry cookie exists but hide support messaging does not', () => {
+		renewUserBenefitCookie(USER_FEATURES_EXPIRY_COOKIE);
+		expect(hasHideSupportMessagingCookie(true)).toEqual(false);
 	});
 
-	it('returns true if cookie exists and is set to true', () => {
-		setCookie({
-			name: HIDE_SUPPORT_MESSAGING_COOKIE,
-			value: 'true',
-		});
-		expect(hasSupporterCookie(true)).toEqual(true);
+	it('returns true if cookie exists and is non-expired', () => {
+		renewUserBenefitCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+		expect(hasHideSupportMessagingCookie(true)).toEqual(true);
 	});
 
 	it('returns false if cookie does not exist and user is signed out', () => {
-		expect(hasSupporterCookie(false)).toEqual(false);
+		expect(hasHideSupportMessagingCookie(false)).toEqual(false);
 	});
 
-	it('returns Pending if cookie does not exist and user is signed in', () => {
-		expect(hasSupporterCookie(true)).toEqual('Pending');
+	it('returns Pending if user is signed in and the user features expiry cookie does not exist', () => {
+		expect(hasHideSupportMessagingCookie(true)).toEqual('Pending');
 	});
 });

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -7,7 +7,7 @@ import {
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/types';
 import { useEffect, useState } from 'react';
 import { hideSupportMessaging } from '../client/userFeatures/cookies/hideSupportMessaging';
-import { getUserFeaturesExpiryCookie } from '../client/userFeatures/cookies/userFeaturesExpiry';
+import { getUserBenefitsExpiryCookie } from '../client/userFeatures/cookies/userBenefitsExpiry';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -39,7 +39,7 @@ export const hasHideSupportMessagingCookie = (
 ): boolean | 'Pending' => {
 	if (hideSupportMessaging()) {
 		return true;
-	} else if (isSignedIn && getUserFeaturesExpiryCookie() === null) {
+	} else if (isSignedIn && getUserBenefitsExpiryCookie() === null) {
 		/**
 		 * If the user is signed in, but we don't have data from the user-benefits API yet,
 		 * we do not want to show any messaging.

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -6,13 +6,14 @@ import {
 } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/types';
 import { useEffect, useState } from 'react';
+import { hideSupportMessaging } from '../client/userFeatures/cookies/hideSupportMessaging';
+import { getUserFeaturesExpiryCookie } from '../client/userFeatures/cookies/userFeaturesExpiry';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
 import type { DCRTagPageType } from '../types/tagPage';
 
 // User Attributes API cookies (created on sign-in)
-export const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
 export const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
 export const OPT_OUT_OF_ARTICLE_COUNT_COOKIE = 'gu_article_count_opt_out';
 
@@ -27,34 +28,27 @@ export const NO_RR_BANNER_KEY = 'gu.noRRBanner';
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
 export const MODULES_VERSION = 'v3';
 
-// Returns whether or not the user has a supporter cookie (which is a proxy to deciding if they are a supporter)
-// Note the fact that the return value is not exactly a boolean, but can also be 'Pending'.
-// Checks the cookie that is set by the User Attributes API upon signing in.
+// Returns true if we should hide support messaging because the user is a supporter.
+// Checks the cookie that is set by the user benefits API upon signing in.
 // Value computed server-side and looks at all of the user's active products,
 // including but not limited to recurring & one-off contributions,
 // paper & digital subscriptions, as well as user tiers (GU supporters/staff/partners/patrons).
-// https://github.com/guardian/members-data-api/blob/3a72dc00b9389968d91e5930686aaf34d8040c52/membership-attribute-service/app/models/Attributes.scala
-export const hasSupporterCookie = (
+// https://github.com/guardian/support-service-lambdas/blob/6e6865f47af54c5b0e7af6408ad53500d18847e0/modules/product-benefits/src/productBenefit.ts#L25
+export const hasHideSupportMessagingCookie = (
 	isSignedIn: boolean,
 ): boolean | 'Pending' => {
-	const cookie = getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
-	switch (cookie) {
-		case 'true':
-			return true;
-		case 'false':
-			return false;
-		default:
-			/**
-			 * If cookie is not present but user is signed in, we do not want to show any messaging.
-			 * This is because of a race condition on the first page view after signing in, where
-			 * we may be awaiting the response from the API to find out if they're a supporter.
-			 */
-			if (isSignedIn) {
-				return 'Pending';
-			} else {
-				return false;
-			}
+	if (hideSupportMessaging()) {
+		return true;
+	} else if (isSignedIn && getUserFeaturesExpiryCookie() === null) {
+		/**
+		 * If the user is signed in, but we don't have data from the user-benefits API yet,
+		 * we do not want to show any messaging.
+		 * This is because of a race condition on the first page view after signing in, where
+		 * we may be awaiting the response from the API to find out if they're a supporter.
+		 */
+		return 'Pending';
 	}
+	return false;
 };
 
 // looks at the SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE (set by support-frontend when making one-off contribution)
@@ -98,7 +92,7 @@ export const isRecentOneOffContributor = (): boolean => {
 export const shouldHideSupportMessaging = (
 	isSignedIn: boolean,
 ): boolean | 'Pending' => {
-	const hasCookie = hasSupporterCookie(isSignedIn);
+	const hasCookie = hasHideSupportMessagingCookie(isSignedIn);
 	if (hasCookie === 'Pending') {
 		return 'Pending';
 	} else {

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -7,7 +7,7 @@ import {
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/types';
 import { useEffect, useState } from 'react';
 import { hideSupportMessaging } from '../client/userFeatures/cookies/hideSupportMessaging';
-import { getUserBenefitsExpiryCookie } from '../client/userFeatures/cookies/userBenefitsExpiry';
+import { userBenefitsDataIsUpToDate } from '../client/userFeatures/cookies/userBenefitsExpiry';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -39,7 +39,7 @@ export const hasHideSupportMessagingCookie = (
 ): boolean | 'Pending' => {
 	if (hideSupportMessaging()) {
 		return true;
-	} else if (isSignedIn && getUserBenefitsExpiryCookie() === null) {
+	} else if (isSignedIn && !userBenefitsDataIsUpToDate()) {
 		/**
 		 * If the user is signed in, but we don't have data from the user-benefits API yet,
 		 * we do not want to show any messaging.

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -1,5 +1,5 @@
 import { getCookie, removeCookie, setCookie, storage } from '@guardian/libs';
-import { deleteAllCookies } from '../client/userFeatures/user-features';
+import { deleteAllCookies } from '../client/userFeatures/cookies/cookieHelpers';
 import { SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE } from './contributions';
 import { getLocaleCode } from './getCountryCode';
 

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -64,6 +64,7 @@ const clearCommonReaderRevenueStateAndReload = (
 		return;
 	}
 
+	removeCookie({ name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE });
 	deleteAllCookies();
 	clearEpicViewLog();
 

--- a/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
+++ b/dotcom-rendering/src/lib/readerRevenueDevUtils.ts
@@ -1,16 +1,7 @@
 import { getCookie, removeCookie, setCookie, storage } from '@guardian/libs';
-import {
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-} from './contributions';
+import { deleteAllCookies } from '../client/userFeatures/user-features';
+import { SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE } from './contributions';
 import { getLocaleCode } from './getCountryCode';
-
-const readerRevenueCookies = [
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-];
 
 const clearEpicViewLog = (): void =>
 	storage.local.remove('gu.contributions.views');
@@ -73,7 +64,7 @@ const clearCommonReaderRevenueStateAndReload = (
 		return;
 	}
 
-	for (const cookie of readerRevenueCookies) removeCookie({ name: cookie });
+	deleteAllCookies();
 	clearEpicViewLog();
 
 	if (asExistingSupporter) {

--- a/dotcom-rendering/src/lib/useAdBlockAsk.ts
+++ b/dotcom-rendering/src/lib/useAdBlockAsk.ts
@@ -3,6 +3,7 @@ import { getConsentFor, onConsentChange } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import { adFreeDataIsPresent } from '../client/userFeatures/cookies/adFree';
 import { useAB } from './useAB';
+import { useIsSignedIn } from './useAuthStatus';
 import { useDetectAdBlock } from './useDetectAdBlock';
 
 const useIsInAdBlockAskVariant = (): boolean => {
@@ -20,6 +21,7 @@ export const useAdblockAsk = ({
 	shouldHideReaderRevenue: boolean;
 	isPaidContent: boolean;
 }): boolean => {
+	const isSignedInOrPending: boolean | 'Pending' = useIsSignedIn();
 	const isInVariant = useIsInAdBlockAskVariant();
 	const adBlockerDetected = useDetectAdBlock();
 	const [isAdFree, setIsAdFree] = useState<boolean>(false);
@@ -43,8 +45,13 @@ export const useAdblockAsk = ({
 	}, []);
 
 	useEffect(() => {
-		setIsAdFree(adFreeDataIsPresent());
-	}, []);
+		// If the user's signed in status is pending, assume they are signed in for the purposes of ad-free
+		setIsAdFree(
+			adFreeDataIsPresent(
+				isSignedInOrPending === 'Pending' ? true : isSignedInOrPending,
+			),
+		);
+	}, [isSignedInOrPending]);
 
 	useEffect(() => {
 		// Only perform the detection check in the variant of the AB test, if we haven't already detected an ad-blocker and the reader/content is eligible for displaying such a message


### PR DESCRIPTION
## What does this change?
This PR changes the way that DCR handles supporter-revenue cookies to be consistent with [this document](https://docs.google.com/document/d/19ExTKgMhCJbrSLD9GFTeNKy3ArjoS2GR8wVc2ONbNXo/edit?tab=t.0)
## Why?
As described in the document, this gives us greater control over the benefits received by users on DCR, particularly in the way they can be set from support.theguardian.com.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
