### PR TITLE
Auxia Integration (Experimental) Part 6: call proxy log treatment interaction

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -25,6 +25,7 @@ export const SignInGateAuxia = ({
 	ophanComponentId,
 	isMandatory = false,
 	userTreatment,
+	logTreatmentInteractionCall,
 }: SignInGatePropsAuxia) => {
 	const { renderingTarget } = useConfig();
 
@@ -95,6 +96,12 @@ export const SignInGateAuxia = ({
 								renderingTarget,
 								abTest,
 							);
+							logTreatmentInteractionCall().catch((error) => {
+								console.error(
+									'Failed to log treatment interaction:',
+									error,
+								);
+							});
 						}}
 					>
 						I’ll do it later

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -118,4 +118,5 @@ export type SignInGatePropsAuxia = {
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
 	personaliseSignInGateAfterCheckoutSwitch?: boolean;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
+	logTreatmentInteractionCall: () => Promise<void>;
 };

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -450,20 +450,35 @@ const fetchProxyGetTreatments = async (
 	return Promise.resolve(data);
 };
 
+/*
+export interface AuxiaAPIResponseDataUserTreatment {
+	treatmentId: string;
+	treatmentTrackingId: string;
+	rank: string;
+	contentLanguageCode: string;
+	treatmentContent: string;
+	treatmentType: string;
+	surface: string;
+}
+*/
+
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
+	userTreatment: AuxiaAPIResponseDataUserTreatment,
+	actionName: string,
 ): Promise<void> => {
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
 		'Content-Type': 'application/json',
 	};
+	const microTime = Date.now() * 1000;
 	const payload = {
-		treatmentTrackingId: '105889_336_ad5eb464-68c6-4ca1-805c-294375422b48',
-		treatmentId: '105889',
-		surface: 'ARTICLE_PAGE',
+		treatmentTrackingId: userTreatment.treatmentTrackingId,
+		treatmentId: userTreatment.treatmentId,
+		surface: userTreatment.surface,
 		interactionType: 'CLICKED',
-		interactionTimeMicros: 1667829258250000,
-		actionName: 'someActionName',
+		interactionTimeMicros: microTime,
+		actionName,
 	};
 	const params = {
 		method: 'POST',
@@ -536,6 +551,8 @@ const SignInGateSelectorAuxia = ({
 						logTreatmentInteractionCall={async () => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
+								auxiaGetTreatmentsData.userTreatment!,
+								'gate-dismissed',
 							);
 						}}
 					/>

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -486,7 +486,7 @@ const SignInGateSelectorAuxia = ({
 		undefined,
 	);
 
-	const [auxiaAPIResponseData, setAuxiaAPIResponseData] = useState<
+	const [auxiaGetTreatmentsData, setAuxiaGetTreatmentsData] = useState<
 		SDCAuxiaProxyResponseData | undefined
 	>(undefined);
 
@@ -514,7 +514,7 @@ const SignInGateSelectorAuxia = ({
 	useOnce(() => {
 		void (async () => {
 			const data = await fetchProxyGetTreatments(contributionsServiceUrl);
-			setAuxiaAPIResponseData(data);
+			setAuxiaGetTreatmentsData(data);
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);
 		});
@@ -527,12 +527,12 @@ const SignInGateSelectorAuxia = ({
 	return (
 		<>
 			{!isGateDismissed &&
-				auxiaAPIResponseData?.userTreatment !== undefined && (
+				auxiaGetTreatmentsData?.userTreatment !== undefined && (
 					<ShowSignInGateAuxia
 						host={host}
 						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 						setShowGate={(show) => setIsGateDismissed(!show)}
-						userTreatment={auxiaAPIResponseData.userTreatment}
+						userTreatment={auxiaGetTreatmentsData.userTreatment}
 						logTreatmentInteractionCall={async () => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -416,27 +416,20 @@ type PropsAuxia = {
 	contributionsServiceUrl: string;
 };
 
-/*
-	comment group: auxia-prototype-e55a86ef
-	Signature for the ShowSignInGateAuxia component.
-*/
 interface ShowSignInGateAuxiaProps {
 	host: string;
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
+	logTreatmentInteractionCall: () => Promise<void>;
 }
 
-/*
-	comment group: auxia-prototype-e55a86ef
-	Auxia version of the dismissGate function.
-*/
 const dismissGateAuxia = (
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>,
 ) => {
 	setShowGate(false);
 };
 
-const fetchAuxiaDisplayDataFromProxy = async (
+const fetchProxyGetTreatments = async (
 	contributionsServiceUrl: string,
 ): Promise<SDCAuxiaProxyResponseData> => {
 	const url = `${contributionsServiceUrl}/auxia/get-treatments`;
@@ -455,6 +448,30 @@ const fetchAuxiaDisplayDataFromProxy = async (
 	const data = (await response.json()) as SDCAuxiaProxyResponseData;
 
 	return Promise.resolve(data);
+};
+
+const auxiaLogTreatmentInteraction = async (
+	contributionsServiceUrl: string,
+): Promise<void> => {
+	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
+	const headers = {
+		'Content-Type': 'application/json',
+	};
+	const payload = {
+		treatmentTrackingId: '105889_336_ad5eb464-68c6-4ca1-805c-294375422b48',
+		treatmentId: '105889',
+		surface: 'ARTICLE_PAGE',
+		interactionType: 'CLICKED',
+		interactionTimeMicros: 1667829258250000,
+		actionName: 'someActionName',
+	};
+	const params = {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(payload),
+	};
+
+	await fetch(url, params);
 };
 
 const SignInGateSelectorAuxia = ({
@@ -496,9 +513,7 @@ const SignInGateSelectorAuxia = ({
 
 	useOnce(() => {
 		void (async () => {
-			const data = await fetchAuxiaDisplayDataFromProxy(
-				contributionsServiceUrl,
-			);
+			const data = await fetchProxyGetTreatments(contributionsServiceUrl);
 			setAuxiaAPIResponseData(data);
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);
@@ -518,6 +533,11 @@ const SignInGateSelectorAuxia = ({
 						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 						setShowGate={(show) => setIsGateDismissed(!show)}
 						userTreatment={auxiaAPIResponseData.userTreatment}
+						logTreatmentInteractionCall={async () => {
+							await auxiaLogTreatmentInteraction(
+								contributionsServiceUrl,
+							);
+						}}
 					/>
 				)}
 		</>
@@ -528,12 +548,8 @@ const ShowSignInGateAuxia = ({
 	host,
 	setShowGate,
 	userTreatment,
+	logTreatmentInteractionCall,
 }: ShowSignInGateAuxiaProps) => {
-	/*
-		comment group: auxia-prototype-e55a86ef
-		This function is the Auxia version of the ShowSignInGate component.
-	*/
-
 	const componentId = 'main_variant_5';
 	const abTest = undefined;
 	const checkoutCompleteCookieData = undefined;
@@ -549,5 +565,6 @@ const ShowSignInGateAuxia = ({
 		checkoutCompleteCookieData,
 		personaliseSignInGateAfterCheckoutSwitch,
 		userTreatment,
+		logTreatmentInteractionCall,
 	});
 };

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -450,18 +450,6 @@ const fetchProxyGetTreatments = async (
 	return Promise.resolve(data);
 };
 
-/*
-export interface AuxiaAPIResponseDataUserTreatment {
-	treatmentId: string;
-	treatmentTrackingId: string;
-	rank: string;
-	contentLanguageCode: string;
-	treatmentContent: string;
-	treatmentType: string;
-	surface: string;
-}
-*/
-
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,


### PR DESCRIPTION
Previously on Auxia Integration (Experimental) ...

- Part 1: https://github.com/guardian/dotcom-rendering/pull/13198
- Part 2: https://github.com/guardian/dotcom-rendering/pull/13237
- Part 3: https://github.com/guardian/dotcom-rendering/pull/13247
- Part 4: https://github.com/guardian/dotcom-rendering/pull/13265
- Part 5: https://github.com/guardian/dotcom-rendering/pull/13267

Here we use the new end point that was defined here: https://github.com/guardian/support-dotcom-components/pull/1277 and implement the proxy call for log treatment interaction. At the moment we default to 'gate-dismissed' action name, but this might be abstracted away in a future PR depending how many of these calls we need to perform from the gate.