### PR TITLE
Use SDC prop types when fetching data

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -54,7 +54,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",
-		"@guardian/support-dotcom-components": "3.2.0",
+		"@guardian/support-dotcom-components": "4.0.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.45.3",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -400,7 +400,6 @@ describe('Island: server-side rendering', () => {
 						tags={[]}
 						contributionsServiceUrl={''}
 						idApiUrl={''}
-						stage={''}
 						pageId={''}
 						renderAds={true}
 						isLabs={false}

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -39,7 +39,6 @@ const useEpic = ({ name }: { name: string }) => {
 			/* webpackChunkName: "contributions-liveblog-epic" */ `./marketing/epics/ContributionsLiveblogEpic`
 		)
 			.then((epicModule) => {
-				// @ts-expect-error -- currently the type of the props in the response is too general
 				setEpic(() => epicModule.ContributionsLiveblogEpic);
 			})
 			.catch((err) => {

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -4,6 +4,7 @@ import { getCookie, isUndefined, log, storage } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
 import { getEpicViewLog } from '@guardian/support-dotcom-components';
 import type { EpicPayload } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { submitComponentEvent } from '../client/ophan/ophan';
@@ -31,8 +32,7 @@ type Props = {
 const useEpic = ({ name }: { name: string }) => {
 	// Using state here to store the Epic component that gets imported allows
 	// us to render it with React (instead of inserting it into the dom manually)
-	const [Epic, setEpic] =
-		useState<React.ElementType<{ [key: string]: unknown }>>();
+	const [Epic, setEpic] = useState<React.ElementType<EpicProps>>();
 
 	useEffect(() => {
 		import(
@@ -140,17 +140,11 @@ const usePayload = ({
  * Dynamically imports and renders a given module
  *
  * @param props
- * @param props.name tring - The name of the component
+ * @param name string - The name of the component
  * @param props.props object - The props of the component
  * @returns The resulting react component
  */
-const Render = ({
-	name,
-	props,
-}: {
-	name: string;
-	props: { [key: string]: unknown };
-}) => {
+const Render = ({ name, props }: { name: string; props: EpicProps }) => {
 	const { Epic } = useEpic({ name });
 
 	if (isUndefined(Epic)) return null;
@@ -192,7 +186,7 @@ const Fetch = ({
 	log('dotcom', 'LiveBlogEpic has a module');
 
 	// Add submitComponentEvent function to props to enable Ophan tracking in the component
-	const props = {
+	const props: EpicProps = {
 		...response.data.module.props,
 		submitComponentEvent: (componentEvent: OphanComponentEvent) =>
 			submitComponentEvent(componentEvent, renderingTarget),

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -8,6 +8,8 @@ import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString, isUndefined } from '@guardian/libs';
 import { palette } from '@guardian/source/foundations';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { ModuleData } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
 import type {
@@ -28,10 +30,7 @@ import {
 	canShowReaderRevenueEpic,
 	ReaderRevenueEpic,
 } from './SlotBodyEnd/ReaderRevenueEpic';
-import type {
-	CanShowData as RRCanShowData,
-	EpicConfig as RREpicConfig,
-} from './SlotBodyEnd/ReaderRevenueEpic';
+import type { CanShowData as RRCanShowData } from './SlotBodyEnd/ReaderRevenueEpic';
 
 type Props = {
 	contentType: string;
@@ -42,7 +41,6 @@ type Props = {
 	tags: TagType[];
 	contributionsServiceUrl: string;
 	idApiUrl: string;
-	stage: string;
 	pageId: string;
 	renderAds: boolean;
 	isLabs: boolean;
@@ -55,13 +53,13 @@ const slotStyles = css`
 
 const buildReaderRevenueEpicConfig = (
 	canShowData: RRCanShowData,
-): CandidateConfig<RREpicConfig> => {
+): CandidateConfig<ModuleData<EpicProps>> => {
 	return {
 		candidate: {
 			id: 'reader-revenue-banner',
 			canShow: () => canShowReaderRevenueEpic(canShowData),
-			show: (meta: RREpicConfig) => () => {
-				return <ReaderRevenueEpic {...meta} />;
+			show: (data: ModuleData<EpicProps>) => () => {
+				return <ReaderRevenueEpic {...data} />;
 			},
 		},
 		timeoutMillis: null,
@@ -123,7 +121,6 @@ export const SlotBodyEnd = ({
 	tags,
 	contributionsServiceUrl,
 	idApiUrl,
-	stage,
 	pageId,
 	renderAds,
 	isLabs,
@@ -186,9 +183,9 @@ export const SlotBodyEnd = ({
 			tags,
 			contributionsServiceUrl,
 			idApiUrl,
-			stage,
 			asyncArticleCount,
 			browserId,
+			renderingTarget,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
@@ -225,7 +222,6 @@ export const SlotBodyEnd = ({
 		renderingTarget,
 		sectionId,
 		shouldHideReaderRevenue,
-		stage,
 		tags,
 	]);
 

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -143,7 +143,7 @@ export const canShowReaderRevenueEpic = async (
 			props: {
 				...module.props,
 				hasConsentForArticleCount,
-				...(fetchEmail ? { fetchEmail } : {}),
+				fetchEmail,
 				submitComponentEvent: (componentEvent: OphanComponentEvent) =>
 					void submitComponentEvent(componentEvent, renderingTarget),
 				openCmp,

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/react';
+import type { OphanComponentEvent } from '@guardian/libs';
 import {
 	cmp,
 	getCookie,
 	startPerformanceMeasure,
 	storage,
 } from '@guardian/libs';
-import type { ComponentEvent } from '@guardian/ophan-tracker-js';
 import { getEpic, getEpicViewLog } from '@guardian/support-dotcom-components';
 import type {
 	EpicPayload,
@@ -13,6 +13,7 @@ import type {
 	ModuleDataResponse,
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import {
@@ -24,15 +25,8 @@ import {
 import { lazyFetchEmailWithTimeout } from '../../lib/fetchEmail';
 import type { CanShowResult } from '../../lib/messagePicker';
 import { setAutomat } from '../../lib/setAutomat';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type { TagType } from '../../types/tag';
-import { useConfig } from '../ConfigContext';
-
-export type EpicConfig = {
-	module: ModuleData;
-	fetchEmail?: () => Promise<string | null>;
-	hasConsentForArticleCount: boolean;
-	stage: string;
-};
 
 const wrapperMargins = css`
 	margin: 18px 0;
@@ -50,9 +44,9 @@ export type CanShowData = {
 	tags: TagType[];
 	contributionsServiceUrl: string;
 	idApiUrl: string;
-	stage: string;
 	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
 	browserId?: string;
+	renderingTarget: RenderingTarget;
 };
 
 const buildPayload = async (
@@ -88,26 +82,26 @@ const buildPayload = async (
 
 export const canShowReaderRevenueEpic = async (
 	data: CanShowData,
-): Promise<CanShowResult<EpicConfig>> => {
+): Promise<CanShowResult<ModuleData<EpicProps>>> => {
 	const {
 		isSignedIn,
 		shouldHideReaderRevenue,
 		isPaidContent,
 		contributionsServiceUrl,
 		idApiUrl,
-		stage,
+		renderingTarget,
 	} = data;
 
 	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
 
 	if (hideSupportMessagingForUser === 'Pending') {
 		// We don't yet know the user's supporter status
-		return Promise.resolve({ show: false });
+		return { show: false };
 	}
 
 	if (shouldHideReaderRevenue || isPaidContent) {
 		// We never serve Reader Revenue epics in this case
-		return Promise.resolve({ show: false });
+		return { show: false };
 	}
 	const { endPerformanceMeasure } = startPerformanceMeasure(
 		'supporterRevenue',
@@ -119,11 +113,11 @@ export const canShowReaderRevenueEpic = async (
 		hideSupportMessagingForUser,
 	});
 
-	const response: ModuleDataResponse = await getEpic(
+	const response: ModuleDataResponse<EpicProps> = await getEpic(
 		contributionsServiceUrl,
 		contributionsPayload,
 	);
-	const module: ModuleData | undefined = response.data?.module;
+	const module: ModuleData<EpicProps> | undefined = response.data?.module;
 
 	endPerformanceMeasure();
 
@@ -138,29 +132,28 @@ export const canShowReaderRevenueEpic = async (
 	const hasConsentForArticleCount =
 		await hasCmpConsentForWeeklyArticleCount();
 
+	const openCmp = () => {
+		cmp.showPrivacyManager();
+	};
+
 	return {
 		show: true,
 		meta: {
-			module,
-			fetchEmail,
-			hasConsentForArticleCount,
-			stage,
+			name: module.name,
+			props: {
+				...module.props,
+				hasConsentForArticleCount,
+				...(fetchEmail ? { fetchEmail } : {}),
+				submitComponentEvent: (componentEvent: OphanComponentEvent) =>
+					void submitComponentEvent(componentEvent, renderingTarget),
+				openCmp,
+			},
 		},
 	};
 };
 
-export const ReaderRevenueEpic = ({
-	module,
-	fetchEmail,
-	hasConsentForArticleCount,
-	stage,
-}: EpicConfig) => {
+export const ReaderRevenueEpic = ({ props }: ModuleData<EpicProps>) => {
 	const [Epic, setEpic] = useState<React.ElementType | null>(null);
-	const { renderingTarget } = useConfig();
-
-	const openCmp = () => {
-		cmp.showPrivacyManager();
-	};
 
 	useEffect(() => {
 		setAutomat();
@@ -196,16 +189,7 @@ export const ReaderRevenueEpic = ({
 		return (
 			<div css={wrapperMargins}>
 				{}
-				<Epic
-					{...module.props}
-					fetchEmail={fetchEmail}
-					submitComponentEvent={(event: ComponentEvent) =>
-						void submitComponentEvent(event, renderingTarget)
-					}
-					openCmp={openCmp}
-					hasConsentForArticleCount={hasConsentForArticleCount}
-					stage={stage}
-				/>
+				<Epic {...props} />
 			</div>
 		);
 	}

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -31,6 +31,8 @@ import type {
 	BannerProps,
 	CanShowFunctionType,
 } from './StickyBottomBanner/ReaderRevenueBanner';
+import { RenderingTarget } from '../types/renderingTarget';
+import { ModuleData } from '@guardian/support-dotcom-components/dist/dotcom/types';
 
 type Props = {
 	contentType: string;
@@ -50,7 +52,7 @@ type Props = {
 type RRBannerConfig = {
 	id: string;
 	BannerComponent: typeof ReaderRevenueBanner;
-	canShowFn: CanShowFunctionType<BannerProps>;
+	canShowFn: CanShowFunctionType<ModuleData<BannerProps>>;
 	isEnabled: boolean;
 };
 
@@ -100,6 +102,7 @@ const buildRRBannerConfigWith = ({
 		tags,
 		contributionsServiceUrl,
 		idApiUrl,
+		renderingTarget,
 	}: {
 		isSignedIn: boolean;
 		countryCode: CountryCode;
@@ -115,7 +118,8 @@ const buildRRBannerConfigWith = ({
 		tags: TagType[];
 		contributionsServiceUrl: string;
 		idApiUrl: string;
-	}): CandidateConfig<BannerProps> => {
+		renderingTarget: RenderingTarget;
+	}): CandidateConfig<ModuleData<BannerProps>> => {
 		return {
 			candidate: {
 				id,
@@ -147,6 +151,7 @@ const buildRRBannerConfigWith = ({
 							),
 						isPreview,
 						idApiUrl,
+						renderingTarget,
 						signInGateWillShow,
 						asyncArticleCounts,
 					}),
@@ -278,6 +283,7 @@ export const StickyBottomBanner = ({
 			tags,
 			contributionsServiceUrl,
 			idApiUrl,
+			renderingTarget,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -4,6 +4,8 @@ import type {
 } from '@guardian/braze-components/logic';
 import type { CountryCode } from '@guardian/libs';
 import { cmp, isString, isUndefined, storage } from '@guardian/libs';
+import type { ModuleData } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { BannerProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { getArticleCounts } from '../lib/articleCount';
 import type { ArticleCounts } from '../lib/articleCount';
@@ -17,6 +19,7 @@ import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
+import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import {
@@ -27,12 +30,7 @@ import {
 	canShowRRBanner,
 	ReaderRevenueBanner,
 } from './StickyBottomBanner/ReaderRevenueBanner';
-import type {
-	BannerProps,
-	CanShowFunctionType,
-} from './StickyBottomBanner/ReaderRevenueBanner';
-import { RenderingTarget } from '../types/renderingTarget';
-import { ModuleData } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { CanShowFunctionType } from './StickyBottomBanner/ReaderRevenueBanner';
 
 type Props = {
 	contentType: string;
@@ -156,14 +154,8 @@ const buildRRBannerConfigWith = ({
 						asyncArticleCounts,
 					}),
 				show:
-					({ meta, module, fetchEmail }: BannerProps) =>
-					() => (
-						<BannerComponent
-							meta={meta}
-							module={module}
-							fetchEmail={fetchEmail}
-						/>
-					),
+					({ name, props }: ModuleData<BannerProps>) =>
+					() => <BannerComponent name={name} props={props} />,
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 		};

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
-import type { ConsentState, CountryCode } from '@guardian/libs';
-import { getCookie, onConsent, OphanComponentEvent } from '@guardian/libs';
+import type {
+	ConsentState,
+	CountryCode,
+	OphanComponentEvent,
+} from '@guardian/libs';
+import { getCookie, onConsent } from '@guardian/libs';
 import {
 	abandonedBasketSchema,
 	getBanner,
@@ -31,8 +35,8 @@ import { lazyFetchEmailWithTimeout } from '../../lib/fetchEmail';
 import { getZIndex } from '../../lib/getZIndex';
 import type { CanShowResult } from '../../lib/messagePicker';
 import { setAutomat } from '../../lib/setAutomat';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import type { TagType } from '../../types/tag';
-import { RenderingTarget } from '../../types/renderingTarget';
 
 type BaseProps = {
 	isSignedIn: boolean;
@@ -48,7 +52,6 @@ type BaseProps = {
 	subscriptionBannerLastClosedAt?: string;
 	signInBannerLastClosedAt?: string;
 	abandonedBasketBannerLastClosedAt?: string;
-	renderingTarget: RenderingTarget;
 };
 
 type BuildPayloadProps = BaseProps & {
@@ -59,6 +62,24 @@ type BuildPayloadProps = BaseProps & {
 	hideSupportMessagingForUser: boolean;
 };
 
+/**
+ *      isSignedIn: boolean;
+ * 		countryCode: CountryCode;
+ * 		isPreview: boolean;
+ * 		asyncArticleCounts: Promise<ArticleCounts | undefined>;
+ * 		signInGateWillShow?: boolean;
+ * 		contentType: string;
+ * 		sectionId: string;
+ * 		shouldHideReaderRevenue: boolean;
+ * 		isMinuteArticle: boolean;
+ * 		isPaidContent: boolean;
+ * 		isSensitive: boolean;
+ * 		tags: TagType[];
+ * 		contributionsServiceUrl: string;
+ * 		idApiUrl: string;
+ * 		renderingTarget: RenderingTarget;
+ */
+
 type CanShowProps = BaseProps & {
 	countryCode: CountryCode;
 	remoteBannerConfig: boolean;
@@ -66,6 +87,7 @@ type CanShowProps = BaseProps & {
 	idApiUrl: string;
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
+	renderingTarget: RenderingTarget;
 };
 
 export type CanShowFunctionType<T> = (

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -62,24 +62,6 @@ type BuildPayloadProps = BaseProps & {
 	hideSupportMessagingForUser: boolean;
 };
 
-/**
- *      isSignedIn: boolean;
- * 		countryCode: CountryCode;
- * 		isPreview: boolean;
- * 		asyncArticleCounts: Promise<ArticleCounts | undefined>;
- * 		signInGateWillShow?: boolean;
- * 		contentType: string;
- * 		sectionId: string;
- * 		shouldHideReaderRevenue: boolean;
- * 		isMinuteArticle: boolean;
- * 		isPaidContent: boolean;
- * 		isSensitive: boolean;
- * 		tags: TagType[];
- * 		contributionsServiceUrl: string;
- * 		idApiUrl: string;
- * 		renderingTarget: RenderingTarget;
- */
-
 type CanShowProps = BaseProps & {
 	countryCode: CountryCode;
 	remoteBannerConfig: boolean;

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -299,16 +299,6 @@ export const canShowRRBanner: CanShowFunctionType<
 	};
 };
 
-// export type BannerProps = {
-// 	module: ModuleData;
-// 	fetchEmail?: () => Promise<string | null>;
-// };
-//
-// type RemoteBannerProps = BannerProps & {
-// 	componentTypeName: ReaderRevenueComponentType;
-// 	displayEvent: string;
-// };
-
 export const ReaderRevenueBanner = ({
 	name,
 	props,

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -49,7 +49,7 @@ const ReaderRevenueLinksRemote = ({
 	const [supportHeaderResponse, setSupportHeaderResponse] =
 		useState<ModuleData<HeaderProps> | null>(null);
 	const [SupportHeader, setSupportHeader] =
-		useState<React.ComponentType<HeaderProps> | null>(null);
+		useState<React.ElementType<HeaderProps> | null>(null);
 	const isSignedIn = useIsSignedIn();
 
 	const { renderingTarget } = useConfig();
@@ -103,7 +103,7 @@ const ReaderRevenueLinksRemote = ({
 						  import(`./marketing/header/Header`)
 				).then(
 					(headerModule: {
-						[key: string]: React.ComponentType<HeaderProps>;
+						[key: string]: React.ElementType<HeaderProps>;
 					}) => {
 						setSupportHeader(
 							() => headerModule[module.name] ?? null,

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -11,6 +11,7 @@ import type {
 	ModuleData,
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type { HeaderProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import {
@@ -46,9 +47,9 @@ const ReaderRevenueLinksRemote = ({
 	contributionsServiceUrl,
 }: ReaderRevenueLinksRemoteProps) => {
 	const [supportHeaderResponse, setSupportHeaderResponse] =
-		useState<ModuleData | null>(null);
+		useState<ModuleData<HeaderProps> | null>(null);
 	const [SupportHeader, setSupportHeader] =
-		useState<React.ElementType | null>(null);
+		useState<React.ComponentType<HeaderProps> | null>(null);
 	const isSignedIn = useIsSignedIn();
 
 	const { renderingTarget } = useConfig();
@@ -86,7 +87,7 @@ const ReaderRevenueLinksRemote = ({
 		};
 
 		getHeader(contributionsServiceUrl, requestData)
-			.then((response: ModuleDataResponse) => {
+			.then((response: ModuleDataResponse<HeaderProps>) => {
 				if (!response.data) {
 					return null;
 				}
@@ -100,9 +101,15 @@ const ReaderRevenueLinksRemote = ({
 						  import(`./marketing/header/SignInPromptHeader`)
 						: /* webpackChunkName: "header" */
 						  import(`./marketing/header/Header`)
-				).then((headerModule: { [key: string]: React.ElementType }) => {
-					setSupportHeader(() => headerModule[module.name] ?? null);
-				});
+				).then(
+					(headerModule: {
+						[key: string]: React.ComponentType<HeaderProps>;
+					}) => {
+						setSupportHeader(
+							() => headerModule[module.name] ?? null,
+						);
+					},
+				);
 			})
 			.catch((error) => {
 				const msg = `Error importing RR header links: ${String(error)}`;

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -309,7 +309,6 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	submitComponentEvent,
 	openCmp,
 	hasConsentForArticleCount,
-	stage,
 }: EpicProps) => {
 	const { image, tickerSettings, choiceCardAmounts, newsletterSignup } =
 		variant;
@@ -341,7 +340,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 				);
 			}
 		}
-	}, [hasBeenSeen, submitComponentEvent, countryCode, stage, tracking]);
+	}, [hasBeenSeen, submitComponentEvent, countryCode, tracking]);
 
 	useEffect(() => {
 		if (submitComponentEvent) {

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -375,7 +375,6 @@ export const AudioLayout = (props: WebProps) => {
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
-											stage={article.config.stage}
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -619,7 +619,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 												shouldHideReaderRevenue={
 													article.shouldHideReaderRevenue
 												}
-												stage={article.config.stage}
 												tags={article.tags}
 												renderAds={renderAds}
 												isLabs={false}

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -420,7 +420,6 @@ export const CrosswordLayout = (props: WebProps) => {
 								shouldHideReaderRevenue={
 									article.shouldHideReaderRevenue
 								}
-								stage={article.config.stage}
 								tags={article.tags}
 								renderAds={renderAds}
 								isLabs={false}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -689,7 +689,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
-											stage={article.config.stage}
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -561,7 +561,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								shouldHideReaderRevenue={
 									article.shouldHideReaderRevenue
 								}
-								stage={article.config.stage}
 								tags={article.tags}
 								renderAds={renderAds}
 								isLabs={false}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -589,7 +589,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
-											stage={article.config.stage}
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -761,7 +761,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 											shouldHideReaderRevenue={
 												article.shouldHideReaderRevenue
 											}
-											stage={article.config.stage}
 											tags={article.tags}
 											renderAds={renderAds}
 											isLabs={isLabs}

--- a/dotcom-rendering/src/lib/useSDC.ts
+++ b/dotcom-rendering/src/lib/useSDC.ts
@@ -8,12 +8,19 @@ import type {
 	BannerPayload,
 	EpicPayload,
 } from '@guardian/support-dotcom-components/dist/dotcom/types';
+import type {
+	BannerProps,
+	EpicProps,
+} from '@guardian/support-dotcom-components/dist/shared/types';
 import useSWRImmutable from 'swr/immutable';
 
-const useSDC = <T>(
+const useSDC = <PAYLOAD, PROPS>(
 	key: string,
-	fetcher: (baseUrl: string, payload: T) => Promise<ModuleDataResponse>,
-): ModuleDataResponse | undefined => {
+	fetcher: (
+		baseUrl: string,
+		payload: PAYLOAD,
+	) => Promise<ModuleDataResponse<PROPS>>,
+): ModuleDataResponse<PROPS> | undefined => {
 	const { data, error } = useSWRImmutable(key, fetcher, {
 		revalidateOnFocus: false,
 	});
@@ -26,16 +33,20 @@ const useSDC = <T>(
 /**
  * Hooks for making requests to the support-dotcom-components API
  */
-type UseSDC<T> = (
+type UseSDC<PAYLOAD, PROPS> = (
 	baseUrl: string,
-	payload: T,
-) => ModuleDataResponse | undefined;
+	payload: PAYLOAD,
+) => ModuleDataResponse<PROPS> | undefined;
 
-export const useSDCEpic: UseSDC<EpicPayload> = (baseUrl, payload) =>
+export const useSDCEpic: UseSDC<EpicPayload, EpicProps> = (baseUrl, payload) =>
 	useSDC('epic', () => getEpic(baseUrl, payload));
 
-export const useSDCLiveblogEpic: UseSDC<EpicPayload> = (baseUrl, payload) =>
-	useSDC('liveblog-epic', () => getLiveblogEpic(baseUrl, payload));
+export const useSDCLiveblogEpic: UseSDC<EpicPayload, EpicProps> = (
+	baseUrl,
+	payload,
+) => useSDC('liveblog-epic', () => getLiveblogEpic(baseUrl, payload));
 
-export const useSDCBanner: UseSDC<BannerPayload> = (baseUrl, payload) =>
-	useSDC('banner', () => getBanner(baseUrl, payload));
+export const useSDCBanner: UseSDC<BannerPayload, BannerProps> = (
+	baseUrl,
+	payload,
+) => useSDC('banner', () => getBanner(baseUrl, payload));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 12.0.0
         version: 12.0.0(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 3.2.0
-        version: 3.2.0(@guardian/libs@20.0.0)(zod@3.22.4)
+        specifier: 4.0.0
+        version: 4.0.0(@guardian/libs@20.0.0)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4408,8 +4408,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@3.2.0(@guardian/libs@20.0.0)(zod@3.22.4):
-    resolution: {integrity: sha512-jxsOmP+DTGdpy3oitRGFjnRfznvOAW+ojRltZQT3qT6Eoe5nkuNc5ip0ok0y4qSnov/3MKn1UxJpvqTQT6okTw==}
+  /@guardian/support-dotcom-components@4.0.0(@guardian/libs@20.0.0)(zod@3.22.4):
+    resolution: {integrity: sha512-MJlL2ToCHUXTe0pwZv/9xVftpzOXNuOPa0lm014qpn978Mue8wFBYYjfZjooW8e8qaIR6eYW3NRx4kpSl76b5A==}
     peerDependencies:
       '@guardian/libs': ^17.0.0
       zod: ^3.22.4
@@ -4423,11 +4423,9 @@ packages:
       jsonschema: 1.4.1
       lodash.debounce: 4.0.8
       log4js: 6.9.1
-      node-fetch: 2.7.0
       seedrandom: 3.0.5
       zod: 3.22.4
     transitivePeerDependencies:
-      - encoding
       - supports-color
     dev: false
 
@@ -14533,18 +14531,6 @@ packages:
     engines: {node: '>=10.5.0'}
     dev: false
 
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: false
-
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -17076,10 +17062,6 @@ packages:
       url-parse: 1.5.10
     dev: false
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
-
   /tr46@2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
     engines: {node: '>=8'}
@@ -17841,10 +17823,6 @@ packages:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
     dev: false
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
-
   /webidl-conversions@5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -18275,13 +18253,6 @@ packages:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
-    dev: false
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
     dev: false
 
   /whatwg-url@8.7.0:


### PR DESCRIPTION
A [recent change](https://github.com/guardian/support-dotcom-components/pull/1279) to support-dotcom-components (SDC) improved the functions used by DCR for fetching data.
The response type now includes the type of the component props, e.g. `EpicProps`.

This PR updates the client to use the new version of SDC. This led to a refactor that hopefully simplifies things a little.
Previously we had some models defined in DCR that can now be replaced with the `ModuleData<PROPS>` type from SDC.