### PR TITLE
Add logic and styles for links from football matches using smart redirect

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 
 const initialDays: FootballMatches = [
 	{
-		date: new Date('2025-01-24T00:00:00Z'),
+		date: new Date('2022-01-01T00:00:00Z'),
 		competitions: [
 			{
 				competitionId: '635',
@@ -43,7 +43,7 @@ const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Live',
-						dateTime: new Date('2025-01-24T11:11:00Z'),
+						dateTime: new Date('2022-01-01T11:11:00Z'),
 						paId: '4482093',
 						homeTeam: {
 							name: 'Torino',
@@ -57,7 +57,7 @@ const initialDays: FootballMatches = [
 					},
 					{
 						kind: 'Fixture',
-						dateTime: new Date('2025-01-24T19:45:00Z'),
+						dateTime: new Date('2022-01-01T19:45:00Z'),
 						paId: '4482890',
 						homeTeam: 'Auxerre',
 						awayTeam: 'St Etienne',
@@ -71,7 +71,7 @@ const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2025-01-24T20:00:00Z'),
+						dateTime: new Date('2022-01-01T20:00:00Z'),
 						paId: '4482835',
 						homeTeam: {
 							name: 'Las Palmas',
@@ -86,13 +86,13 @@ const initialDays: FootballMatches = [
 				],
 			},
 			{
-				competitionId: '650',
+				competitionId: '651',
 				name: 'FA Cup',
 				nation: 'European',
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2025-01-25T20:00:00Z'),
+						dateTime: new Date('2022-01-01T20:00:00Z'),
 						paId: '4482836',
 						homeTeam: {
 							name: 'Brighton & Hove Albion Women',
@@ -111,11 +111,33 @@ const initialDays: FootballMatches = [
 	},
 ];
 
+const moreDays: FootballMatches = [
+	{
+		date: new Date('2022-01-05T00:00:00Z'),
+		competitions: [
+			{
+				competitionId: '635',
+				name: 'Serie A',
+				nation: 'European',
+				matches: [
+					{
+						kind: 'Fixture',
+						dateTime: new Date('2022-01-05T19:45:00Z'),
+						paId: '4482890',
+						homeTeam: 'Juventus',
+						awayTeam: 'Roma',
+					},
+				],
+			},
+		],
+	},
+];
+
 export const Default = {
 	args: {
 		edition: 'UK',
 		initialDays,
-		getMoreDays: () => Promise.resolve(ok(initialDays)),
+		getMoreDays: () => Promise.resolve(ok(moreDays)),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -156,36 +156,79 @@ const MatchStatus = ({
 	}
 };
 
+function shouldRenderMatchLink(match: FootballMatch, now: Date) {
+	return match.dateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
+}
+
+const matchListItemStyles = css`
+	background-color: ${palette('--football-match-list-background')};
+	border: 1px solid ${palette('--football-match-list-border')};
+
+	${from.leftCol} {
+		&:first-of-type {
+			border-top-color: ${palette('--football-match-list-top-border')};
+		}
+	}
+`;
+
+const matchStyles = (matchKind: FootballMatch['kind']) => css`
+	${textSans14}
+
+	${matchKind === 'Live' ? 'font-weight: bold;' : undefined}
+
+	display: flex;
+	flex-wrap: wrap;
+	text-decoration: none;
+	padding: ${space[2]}px;
+`;
+
+const MatchWrapper = ({
+	match,
+	now,
+	children,
+}: {
+	match: FootballMatch;
+	now: Date;
+	children: ReactNode;
+}) => {
+	if (shouldRenderMatchLink(match, now)) {
+		return (
+			<li css={matchListItemStyles}>
+				<a
+					href={`https://football.theguardian.com/match-redirect/${match.paId}`}
+					css={[
+						matchStyles(match.kind),
+						css`
+							color: inherit;
+							:hover {
+								background-color: ${palette(
+									'--football-match-hover',
+								)};
+							}
+						`,
+					]}
+				>
+					{children}
+				</a>
+			</li>
+		);
+	}
+
+	return (
+		<li css={[matchListItemStyles, matchStyles(match.kind)]}>{children}</li>
+	);
+};
+
 const Match = ({
 	match,
 	timeFormatter,
+	now,
 }: {
 	match: FootballMatch;
 	timeFormatter: Intl.DateTimeFormat;
+	now: Date;
 }) => (
-	<li
-		css={[
-			css`
-				${textSans14}
-				background-color: ${palette(
-					'--football-match-list-background',
-				)};
-				padding: ${space[2]}px;
-				display: flex;
-				border: 1px solid ${palette('--football-match-list-border')};
-				flex-wrap: wrap;
-				${match.kind === 'Live' ? 'font-weight: bold;' : undefined}
-
-				${from.leftCol} {
-					&:first-of-type {
-						border-top-color: ${palette(
-							'--football-match-list-top-border',
-						)};
-					}
-				}
-			`,
-		]}
-	>
+	<MatchWrapper match={match} now={now}>
 		<MatchStatus match={match} timeFormatter={timeFormatter} />
 		{match.kind === 'Fixture' ? (
 			<>
@@ -220,7 +263,7 @@ const Match = ({
 				)}
 			</>
 		)}
-	</li>
+	</MatchWrapper>
 );
 
 const HomeTeam = (props: { children: ReactNode }) => (
@@ -315,6 +358,7 @@ export const FootballMatchList = ({
 
 	const [days, setDays] = useState(initialDays);
 	const [isError, setIsError] = useState<boolean>(false);
+	const now = new Date();
 
 	return (
 		<>
@@ -332,6 +376,7 @@ export const FootballMatchList = ({
 										key={match.paId}
 										match={match}
 										timeFormatter={timeFormatter}
+										now={now}
 									/>
 								))}
 							</Matches>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6497,8 +6497,8 @@ const paletteColours = {
 		dark: followTextDark,
 	},
 	'--football-match-hover': {
-		light: () => sourcePalette.neutral[86],
-		dark: () => sourcePalette.neutral[86],
+		light: () => sourcePalette.neutral[93],
+		dark: () => sourcePalette.neutral[38],
 	},
 	'--football-match-list-background': {
 		light: () => sourcePalette.neutral[97],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6496,6 +6496,10 @@ const paletteColours = {
 		light: followTextLight,
 		dark: followTextDark,
 	},
+	'--football-match-hover': {
+		light: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--football-match-list-background': {
 		light: () => sourcePalette.neutral[97],
 		dark: () => sourcePalette.neutral[20],


### PR DESCRIPTION
## What does this change?
Adds links to football matches, using a smart redirect URL. If the match is more than 72 hours in the future we do not render the link

See frontend implementation [here](https://github.com/guardian/frontend/blob/main/sport/app/football/model/TeamMap.scala#L157) 