### PR TITLE
Auxia Integration (Experimental) Part 7: send all log treatment interactions

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -77,6 +77,14 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
+						logTreatmentInteractionCall('CLICKED').catch(
+							(error) => {
+								console.error(
+									'Failed to log treatment interaction:',
+									error,
+								);
+							},
+						);
 					}}
 				>
 					{firstCtaName}
@@ -96,12 +104,14 @@ export const SignInGateAuxia = ({
 								renderingTarget,
 								abTest,
 							);
-							logTreatmentInteractionCall().catch((error) => {
-								console.error(
-									'Failed to log treatment interaction:',
-									error,
-								);
-							});
+							logTreatmentInteractionCall('DISMISSED').catch(
+								(error) => {
+									console.error(
+										'Failed to log treatment interaction:',
+										error,
+									);
+								},
+							);
 						}}
 					>
 						I’ll do it later
@@ -125,6 +135,12 @@ export const SignInGateAuxia = ({
 						renderingTarget,
 						abTest,
 					);
+					logTreatmentInteractionCall('CLICKED').catch((error) => {
+						console.error(
+							'Failed to log treatment interaction:',
+							error,
+						);
+					});
 				}}
 			>
 				{secondCtaName}

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -109,6 +109,8 @@ export interface SDCAuxiaProxyResponseData {
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
+export type AuxiaInteractionActionName = 'VIEWED' | 'CLICKED' | 'DISMISSED';
+
 export type SignInGatePropsAuxia = {
 	guUrl: string;
 	dismissGate: () => void;
@@ -118,5 +120,7 @@ export type SignInGatePropsAuxia = {
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
 	personaliseSignInGateAfterCheckoutSwitch?: boolean;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
-	logTreatmentInteractionCall: (actionName: string) => Promise<void>;
+	logTreatmentInteractionCall: (
+		actionName: AuxiaInteractionActionName,
+	) => Promise<void>;
 };

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -118,5 +118,5 @@ export type SignInGatePropsAuxia = {
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
 	personaliseSignInGateAfterCheckoutSwitch?: boolean;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
-	logTreatmentInteractionCall: () => Promise<void>;
+	logTreatmentInteractionCall: (actionName: string) => Promise<void>;
 };

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -420,7 +420,8 @@ interface ShowSignInGateAuxiaProps {
 	host: string;
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
-	logTreatmentInteractionCall: () => Promise<void>;
+	contributionsServiceUrl: string;
+	logTreatmentInteractionCall: (actionName: string) => Promise<void>;
 }
 
 const dismissGateAuxia = (
@@ -536,11 +537,14 @@ const SignInGateSelectorAuxia = ({
 						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 						setShowGate={(show) => setIsGateDismissed(!show)}
 						userTreatment={auxiaGetTreatmentsData.userTreatment}
-						logTreatmentInteractionCall={async () => {
+						contributionsServiceUrl={contributionsServiceUrl}
+						logTreatmentInteractionCall={async (
+							actionName: string,
+						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
 								auxiaGetTreatmentsData.userTreatment!,
-								'gate-dismissed',
+								actionName,
 							);
 						}}
 					/>
@@ -553,12 +557,25 @@ const ShowSignInGateAuxia = ({
 	host,
 	setShowGate,
 	userTreatment,
+	contributionsServiceUrl,
 	logTreatmentInteractionCall,
 }: ShowSignInGateAuxiaProps) => {
 	const componentId = 'main_variant_5';
 	const abTest = undefined;
 	const checkoutCompleteCookieData = undefined;
 	const personaliseSignInGateAfterCheckoutSwitch = undefined;
+
+	useOnce(() => {
+		void (async () => {
+			await auxiaLogTreatmentInteraction(
+				contributionsServiceUrl,
+				userTreatment,
+				'VIEWED',
+			);
+		})().catch((error) => {
+			console.error('Failed to log treatment interaction:', error);
+		});
+	}, [componentId]);
 
 	return SignInGateAuxia({
 		guUrl: host,

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -24,6 +24,7 @@ import { SignInGateAuxia } from './SignInGate/gateDesigns/SignInGateAuxia';
 import { signInGateTestIdToComponentId } from './SignInGate/signInGateMappings';
 import type {
 	AuxiaAPIResponseDataUserTreatment,
+	AuxiaInteractionActionName,
 	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
 	SDCAuxiaProxyResponseData,
@@ -421,7 +422,9 @@ interface ShowSignInGateAuxiaProps {
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 	contributionsServiceUrl: string;
-	logTreatmentInteractionCall: (actionName: string) => Promise<void>;
+	logTreatmentInteractionCall: (
+		actionName: AuxiaInteractionActionName,
+	) => Promise<void>;
 }
 
 const dismissGateAuxia = (
@@ -454,7 +457,7 @@ const fetchProxyGetTreatments = async (
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,
-	actionName: string,
+	actionName: AuxiaInteractionActionName,
 ): Promise<void> => {
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
@@ -539,7 +542,7 @@ const SignInGateSelectorAuxia = ({
 						userTreatment={auxiaGetTreatmentsData.userTreatment}
 						contributionsServiceUrl={contributionsServiceUrl}
 						logTreatmentInteractionCall={async (
-							actionName: string,
+							actionName: AuxiaInteractionActionName,
 						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,


### PR DESCRIPTION
Previously on Auxia Integration (Experimental) ...

- Part 1: https://github.com/guardian/dotcom-rendering/pull/13198
- Part 2: https://github.com/guardian/dotcom-rendering/pull/13237
- Part 3: https://github.com/guardian/dotcom-rendering/pull/13247
- Part 4: https://github.com/guardian/dotcom-rendering/pull/13265
- Part 5: https://github.com/guardian/dotcom-rendering/pull/13267
- Part 6: https://github.com/guardian/dotcom-rendering/pull/13267

This part is the simple follow up of Part 6. Here is ensure that all the log treatment interactions are sent, with a correct action name.

