### PR TITLE
Update secondary section title colour to neutral 20

### DIFF
--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -1155,6 +1155,10 @@ const containerColours = {
 		light: sectionTitleLight,
 		dark: sectionTitleDark,
 	},
+	'--article-section-secondary-title': {
+		light: sectionTitleLight,
+		dark: sectionTitleDark,
+	},
 	'--section-date': {
 		light: sectionDateLight,
 		dark: sectionDateDark,

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -610,9 +610,15 @@ export const FrontSection = ({
 								title={title}
 								lightweightHeader={isTagPage}
 								description={description}
-								fontColour={schemePalette(
-									'--article-section-title',
-								)}
+								fontColour={
+									containerLevel === 'Secondary'
+										? schemePalette(
+												'--article-section-secondary-title',
+										  )
+										: schemePalette(
+												'--article-section-title',
+										  )
+								}
 								// On paid fronts the title is not treated as a link
 								url={!isOnPaidContentFront ? url : undefined}
 								showDateHeader={showDateHeader}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5926,13 +5926,13 @@ const paletteColours = {
 		light: articleSectionBackgroundLight,
 		dark: articleSectionBackgroundDark,
 	},
-	'--article-section-title': {
-		light: articleSectionTitleLight,
-		dark: articleSectionTitleDark,
-	},
 	'--article-section-secondary-title': {
 		light: articleSectionSecondaryTitleLight,
 		dark: articleSectionSecondaryTitleDark,
+	},
+	'--article-section-title': {
+		light: articleSectionTitleLight,
+		dark: articleSectionTitleDark,
 	},
 	'--article-text': {
 		light: articleTextLight,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -3031,6 +3031,12 @@ const articleSectionTitleLight: PaletteFunction = () =>
 const articleSectionTitleDark: PaletteFunction = () =>
 	sourcePalette.neutral[86];
 
+const articleSectionSecondaryTitleLight: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+
+const articleSectionSecondaryTitleDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
 const articleLinkTextLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.Audio) {
 		return sourcePalette.neutral[86];
@@ -5923,6 +5929,10 @@ const paletteColours = {
 	'--article-section-title': {
 		light: articleSectionTitleLight,
 		dark: articleSectionTitleDark,
+	},
+	'--article-section-secondary-title': {
+		light: articleSectionSecondaryTitleLight,
+		dark: articleSectionSecondaryTitleDark,
 	},
 	'--article-text': {
 		light: articleTextLight,


### PR DESCRIPTION
## What does this change?
Adds and implements a colour declaration for a secondary section title. It uses neutral 20.

## Why?
This was requested by design to help visually differentiate between primary and secondary containers. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/47cbadfe-226c-4793-b125-909d134613c6
[after]: https://github.com/user-attachments/assets/66c7c2e8-bc03-4b0f-bc6b-0a0a0ea4c0a2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
