### PR TITLE
Enrich RRCP component tracking client-side

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -257,8 +257,10 @@ describe('Island: server-side rendering', () => {
 					isPaidContent={false}
 					tags={[]}
 					contributionsServiceUrl={''}
+					host={''}
 					pageId={''}
 					keywordIds={''}
+					renderingTarget={'Web'}
 				/>,
 			),
 		).not.toThrow();

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -257,7 +257,6 @@ describe('Island: server-side rendering', () => {
 					isPaidContent={false}
 					tags={[]}
 					contributionsServiceUrl={''}
-					host={''}
 					pageId={''}
 					keywordIds={''}
 					renderingTarget={'Web'}

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -95,7 +95,6 @@ const usePayload = ({
 	sectionId: string;
 	isPaidContent: boolean;
 	tags: TagType[];
-	host?: string;
 	pageId: string;
 	keywordIds: string;
 	ophanPageViewId?: string;

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -90,7 +90,6 @@ const usePayload = ({
 	tags,
 	pageId,
 	ophanPageViewId,
-	pageUrl,
 }: {
 	shouldHideReaderRevenue: boolean;
 	sectionId: string;
@@ -100,7 +99,6 @@ const usePayload = ({
 	pageId: string;
 	keywordIds: string;
 	ophanPageViewId?: string;
-	pageUrl: string;
 }): EpicPayload | undefined => {
 	const articleCounts = useArticleCounts(pageId, tags, 'LiveBlog');
 	const hasOptedOutOfArticleCount = useHasOptedOutOfArticleCount();
@@ -123,7 +121,7 @@ const usePayload = ({
 			ophanPageId: ophanPageViewId,
 			platformId: 'GUARDIAN_WEB',
 			clientName: 'dcr',
-			referrerUrl: pageUrl,
+			referrerUrl: window.location.origin + window.location.pathname,
 		},
 		targeting: {
 			contentType: 'LiveBlog',
@@ -138,7 +136,7 @@ const usePayload = ({
 			epicViewLog: getEpicViewLog(storage.local),
 			weeklyArticleHistory: articleCounts?.weeklyArticleHistory,
 			hasOptedOutOfArticleCount,
-			url: pageUrl,
+			url: window.location.origin + window.location.pathname,
 			isSignedIn,
 		},
 	};
@@ -269,7 +267,6 @@ export const LiveBlogEpic = ({
 		pageId,
 		keywordIds,
 		ophanPageViewId,
-		pageUrl,
 	});
 	if (!ophanPageViewId || !payload || !pageUrl) return null;
 

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -4,7 +4,10 @@ import { getCookie, isUndefined, log, storage } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
 import { getEpicViewLog } from '@guardian/support-dotcom-components';
 import type { EpicPayload } from '@guardian/support-dotcom-components/dist/dotcom/types';
-import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
+import type {
+	EpicProps,
+	Tracking,
+} from '@guardian/support-dotcom-components/dist/shared/types';
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { submitComponentEvent } from '../client/ophan/ophan';
@@ -200,7 +203,7 @@ const Fetch = ({
 
 	const { props } = response.data.module;
 
-	const tracking = {
+	const tracking: Tracking = {
 		...props.tracking,
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -148,7 +148,6 @@ export const LiveBlogRenderer = ({
 						tags={tags}
 						isPaidContent={isPaidContent}
 						contributionsServiceUrl={contributionsServiceUrl}
-						host={host}
 						pageId={pageId}
 						keywordIds={keywordIds}
 						renderingTarget={renderingTarget}

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -148,8 +148,10 @@ export const LiveBlogRenderer = ({
 						tags={tags}
 						isPaidContent={isPaidContent}
 						contributionsServiceUrl={contributionsServiceUrl}
+						host={host}
 						pageId={pageId}
 						keywordIds={keywordIds}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 			)}

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -22,6 +22,7 @@ import { useAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
+import { usePageViewId } from '../lib/usePageViewId';
 import type { TagType } from '../types/tag';
 import { AdSlot } from './AdSlot.web';
 import { useConfig } from './ConfigContext';
@@ -131,6 +132,7 @@ export const SlotBodyEnd = ({
 	const countryCode = useCountryCode('slot-body-end');
 	const isSignedIn = useIsSignedIn();
 	const browserId = useBrowserId();
+	const ophanPageViewId = usePageViewId(renderingTarget);
 	const [SelectedEpic, setSelectedEpic] = useState<
 		React.ElementType | null | undefined
 	>();
@@ -167,6 +169,7 @@ export const SlotBodyEnd = ({
 			isUndefined(brazeMessages) ||
 			isUndefined(asyncArticleCount) ||
 			isUndefined(browserId) ||
+			isUndefined(ophanPageViewId) ||
 			isSignedIn === 'Pending'
 		) {
 			return;
@@ -186,6 +189,7 @@ export const SlotBodyEnd = ({
 			asyncArticleCount,
 			browserId,
 			renderingTarget,
+			ophanPageViewId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
@@ -223,6 +227,7 @@ export const SlotBodyEnd = ({
 		sectionId,
 		shouldHideReaderRevenue,
 		tags,
+		ophanPageViewId,
 	]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -13,7 +13,10 @@ import type {
 	ModuleDataResponse,
 	WeeklyArticleHistory,
 } from '@guardian/support-dotcom-components/dist/dotcom/types';
-import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
+import type {
+	EpicProps,
+	Tracking,
+} from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import {
@@ -47,6 +50,7 @@ export type CanShowData = {
 	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
 	browserId?: string;
 	renderingTarget: RenderingTarget;
+	ophanPageViewId: string;
 };
 
 const buildPayload = async (
@@ -90,6 +94,7 @@ export const canShowReaderRevenueEpic = async (
 		contributionsServiceUrl,
 		idApiUrl,
 		renderingTarget,
+		ophanPageViewId,
 	} = data;
 
 	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
@@ -136,17 +141,29 @@ export const canShowReaderRevenueEpic = async (
 		cmp.showPrivacyManager();
 	};
 
+	const { props, name } = module;
+	const tracking: Tracking = {
+		...props.tracking,
+		ophanPageId: ophanPageViewId,
+		platformId: 'GUARDIAN_WEB',
+		referrerUrl: window.location.origin + window.location.pathname,
+	};
+	const enrichedProps: EpicProps = {
+		...props,
+		...tracking,
+		hasConsentForArticleCount,
+		fetchEmail,
+		submitComponentEvent: (componentEvent: OphanComponentEvent) =>
+			void submitComponentEvent(componentEvent, renderingTarget),
+		openCmp,
+	};
+
 	return {
 		show: true,
 		meta: {
-			name: module.name,
+			name,
 			props: {
-				...module.props,
-				hasConsentForArticleCount,
-				fetchEmail,
-				submitComponentEvent: (componentEvent: OphanComponentEvent) =>
-					void submitComponentEvent(componentEvent, renderingTarget),
-				openCmp,
+				...enrichedProps,
 			},
 		},
 	};

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -162,9 +162,7 @@ export const canShowReaderRevenueEpic = async (
 		show: true,
 		meta: {
 			name,
-			props: {
-				...enrichedProps,
-			},
+			props: enrichedProps,
 		},
 	};
 };

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -18,6 +18,7 @@ import { pickMessage } from '../lib/messagePicker';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
+import { usePageViewId } from '../lib/usePageViewId';
 import { useSignInGateWillShow } from '../lib/useSignInGateWillShow';
 import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
@@ -101,6 +102,7 @@ const buildRRBannerConfigWith = ({
 		contributionsServiceUrl,
 		idApiUrl,
 		renderingTarget,
+		ophanPageViewId,
 	}: {
 		isSignedIn: boolean;
 		countryCode: CountryCode;
@@ -117,6 +119,7 @@ const buildRRBannerConfigWith = ({
 		contributionsServiceUrl: string;
 		idApiUrl: string;
 		renderingTarget: RenderingTarget;
+		ophanPageViewId: string;
 	}): CandidateConfig<ModuleData<BannerProps>> => {
 		return {
 			candidate: {
@@ -152,6 +155,7 @@ const buildRRBannerConfigWith = ({
 						renderingTarget,
 						signInGateWillShow,
 						asyncArticleCounts,
+						ophanPageViewId,
 					}),
 				show:
 					({ name, props }: ModuleData<BannerProps>) =>
@@ -226,6 +230,7 @@ export const StickyBottomBanner = ({
 
 	const countryCode = useCountryCode('sticky-bottom-banner');
 	const isSignedIn = useIsSignedIn();
+	const ophanPageViewId = usePageViewId(renderingTarget);
 
 	const [SelectedBanner, setSelectedBanner] = useState<MaybeFC | null>(null);
 	const [asyncArticleCounts, setAsyncArticleCounts] =
@@ -252,6 +257,7 @@ export const StickyBottomBanner = ({
 			isUndefined(brazeMessages) ||
 			isUndefined(asyncArticleCounts) ||
 			isUndefined(signInGateWillShow) ||
+			isUndefined(ophanPageViewId) ||
 			isSignedIn === 'Pending'
 		) {
 			return;
@@ -276,6 +282,7 @@ export const StickyBottomBanner = ({
 			contributionsServiceUrl,
 			idApiUrl,
 			renderingTarget,
+			ophanPageViewId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
@@ -319,6 +326,7 @@ export const StickyBottomBanner = ({
 		shouldHideReaderRevenue,
 		signInGateWillShow,
 		tags,
+		ophanPageViewId,
 	]);
 
 	if (SelectedBanner) {

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -17,6 +17,7 @@ import type {
 import type {
 	AbandonedBasket,
 	BannerProps,
+	Tracking,
 } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
@@ -70,6 +71,7 @@ type CanShowProps = BaseProps & {
 	signInGateWillShow: boolean;
 	asyncArticleCounts: Promise<ArticleCounts | undefined>;
 	renderingTarget: RenderingTarget;
+	ophanPageViewId: string;
 };
 
 export type CanShowFunctionType<T> = (
@@ -198,6 +200,7 @@ export const canShowRRBanner: CanShowFunctionType<
 	renderingTarget,
 	signInGateWillShow,
 	asyncArticleCounts,
+	ophanPageViewId,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
 
@@ -285,15 +288,24 @@ export const canShowRRBanner: CanShowFunctionType<
 		? lazyFetchEmailWithTimeout(idApiUrl)
 		: undefined;
 
+	const tracking: Tracking = {
+		...props.tracking,
+		ophanPageId: ophanPageViewId,
+		platformId: 'GUARDIAN_WEB',
+		referrerUrl: window.location.origin + window.location.pathname,
+	};
+	const enrichedProps: BannerProps = {
+		...props,
+		...tracking,
+		fetchEmail,
+		submitComponentEvent: (componentEvent: OphanComponentEvent) =>
+			void submitComponentEvent(componentEvent, renderingTarget),
+	};
+
 	return {
 		show: true,
 		meta: {
-			props: {
-				...props,
-				fetchEmail,
-				submitComponentEvent: (componentEvent: OphanComponentEvent) =>
-					void submitComponentEvent(componentEvent, renderingTarget),
-			},
+			props: enrichedProps,
 			name,
 		},
 	};

--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -143,6 +143,7 @@ export const TopBar = ({
 				>
 					<TopBarSupport
 						contributionsServiceUrl={contributionsServiceUrl}
+						pageUrl={referrerUrl}
 					/>
 				</TopBarLinkContainer>
 


### PR DESCRIPTION
Currently when a DCR page makes a request to support-dotcom-components (SDC) it includes a `tracking` field in the payload:
![Screenshot 2025-02-06 at 13 35 30](https://github.com/user-attachments/assets/d85d92e2-81ca-44be-a769-65cb671c5437)

SDC does not need this tracking data. It returns a `tracking` field in the response, and adds to this the fields that were sent by the client.

This PR is the first step towards not sending the `tracking` field to SDC.
The fields are still needed by the DCR marketing components, but the client can just pass them in directly instead of sending them to SDC.

This involves merging the tracking data received from SDC with the fields that the client has.
In general this looks like:
```
const { props } = response.data.module;
const tracking: Tracking = {
	...props.tracking,
	ophanPageId: ophanPageViewId,
	platformId: 'GUARDIAN_WEB',
	referrerUrl: pageUrl,
};
const enrichedProps: EpicProps = {
	...props,
	tracking,
};
```

As part of this I've also migrated to getting the ophan pageViewId using the `usePageViewId` hook, which is the standard way of doing this.
Also, `clientName` is not used anywhere so I've dropped this (everything is dcr now!).