### PR TITLE
Fix image override field name for multi-bylines

### DIFF
--- a/dotcom-rendering/src/model/article-schema.json
+++ b/dotcom-rendering/src/model/article-schema.json
@@ -2547,7 +2547,7 @@
                 "endNote": {
                     "type": "string"
                 },
-                "imageOverrideUrl": {
+                "contributorImageOverrideUrl": {
                     "type": "string"
                 },
                 "contributorIds": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2034,7 +2034,7 @@
                 "endNote": {
                     "type": "string"
                 },
-                "imageOverrideUrl": {
+                "contributorImageOverrideUrl": {
                     "type": "string"
                 },
                 "contributorIds": {

--- a/dotcom-rendering/src/model/enhanceLists.test.ts
+++ b/dotcom-rendering/src/model/enhanceLists.test.ts
@@ -26,7 +26,7 @@ describe('Enhance lists', () => {
 					elements: [],
 					bio: 'bio 1',
 					endNote: 'endNote 1',
-					imageOverrideUrl: '',
+					contributorImageOverrideUrl: '',
 					contributorIds: ['profile/richard-hillgrove'],
 					byline: 'byline 1',
 					bylineHtml: 'bylineHtml 1',
@@ -36,7 +36,7 @@ describe('Enhance lists', () => {
 					elements: [],
 					bio: 'bio 2',
 					endNote: 'endNote 2',
-					imageOverrideUrl: '',
+					contributorImageOverrideUrl: '',
 					contributorIds: [],
 					byline: 'byline 2',
 					bylineHtml: 'bylineHtml 2',
@@ -46,7 +46,7 @@ describe('Enhance lists', () => {
 					elements: [],
 					bio: 'bio 3',
 					endNote: 'endNote 3',
-					imageOverrideUrl:
+					contributorImageOverrideUrl:
 						'https://i.guim.co.uk/image-override-url.jpg',
 					contributorIds: [],
 					byline: 'byline 3',

--- a/dotcom-rendering/src/model/enhanceLists.ts
+++ b/dotcom-rendering/src/model/enhanceLists.ts
@@ -73,7 +73,7 @@ const constructMultiByline =
 		elements,
 		bio,
 		endNote,
-		imageOverrideUrl,
+		contributorImageOverrideUrl,
 		contributorIds,
 		byline,
 		bylineHtml,
@@ -81,8 +81,8 @@ const constructMultiByline =
 		const contributorIdsArray = contributorIds ?? [];
 
 		let imageUrl;
-		if (imageOverrideUrl) {
-			imageUrl = imageOverrideUrl;
+		if (contributorImageOverrideUrl) {
+			imageUrl = contributorImageOverrideUrl;
 		} else if (tags) {
 			imageUrl = tags.find((tag) => tag.id === contributorIdsArray[0])
 				?.bylineImageUrl;

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -387,7 +387,7 @@ export interface ListItem {
 	elements: FEElement[];
 	bio?: string;
 	endNote?: string;
-	imageOverrideUrl?: string;
+	contributorImageOverrideUrl?: string;
 	contributorIds?: string[];
 	byline?: string;
 	bylineHtml?: string;


### PR DESCRIPTION
## What does this change?

We need to rename the field `imageOverrideUrl` to `contributorImageOverrideUrl` to match what [CAPI sends](https://github.com/guardian/content-api-models/blob/86752f2d1af7607d0b662939ddbec58aa94eba9f/models/src/main/thrift/content/v1.thrift#L906).

## Why?

So that the image override functionality in multi-byline articles works correctly. 

I am mystified this wasn't picked up during testing!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|  <img width="642" alt="Screenshot 2025-02-06 at 12 18 00" src="https://github.com/user-attachments/assets/65584a73-0ee2-407e-a367-ddbce7b1a01a" /> |  <img width="643" alt="Screenshot 2025-02-06 at 12 17 41" src="https://github.com/user-attachments/assets/f270635b-d6f3-4436-b1e1-5d1fa0370c5f" /> |
