### PR TITLE
Auxia Integration (Experiement) Part 9: clarify the difference between interactionType(s) and actionName(s)

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -77,14 +77,15 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall('CLICKED').catch(
-							(error) => {
-								console.error(
-									'Failed to log treatment interaction:',
-									error,
-								);
-							},
-						);
+						logTreatmentInteractionCall(
+							'CLICKED',
+							'REGISTER-LINK',
+						).catch((error) => {
+							console.error(
+								'Failed to log treatment interaction:',
+								error,
+							);
+						});
 					}}
 				>
 					{firstCtaName}
@@ -104,7 +105,7 @@ export const SignInGateAuxia = ({
 								renderingTarget,
 								abTest,
 							);
-							logTreatmentInteractionCall('DISMISSED').catch(
+							logTreatmentInteractionCall('DISMISSED', '').catch(
 								(error) => {
 									console.error(
 										'Failed to log treatment interaction:',
@@ -135,7 +136,10 @@ export const SignInGateAuxia = ({
 						renderingTarget,
 						abTest,
 					);
-					logTreatmentInteractionCall('CLICKED').catch((error) => {
+					logTreatmentInteractionCall(
+						'CLICKED',
+						'SIGN-IN-LINK',
+					).catch((error) => {
 						console.error(
 							'Failed to log treatment interaction:',
 							error,
@@ -157,6 +161,15 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
+						logTreatmentInteractionCall(
+							'CLICKED',
+							'HOW-TO-LINK',
+						).catch((error) => {
+							console.error(
+								'Failed to log treatment interaction:',
+								error,
+							);
+						});
 					}}
 				>
 					Why register & how does it help?
@@ -172,6 +185,15 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
+						logTreatmentInteractionCall(
+							'CLICKED',
+							'WHY-LINK',
+						).catch((error) => {
+							console.error(
+								'Failed to log treatment interaction:',
+								error,
+							);
+						});
 					}}
 				>
 					How will my information & data be used?
@@ -187,6 +209,15 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
+						logTreatmentInteractionCall(
+							'CLICKED',
+							'HELP-LINK',
+						).catch((error) => {
+							console.error(
+								'Failed to log treatment interaction:',
+								error,
+							);
+						});
 					}}
 				>
 					Get help with registering or signing in

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -120,7 +120,7 @@ export type AuxiaInteractionActionName =
 	| 'HOW-TO-LINK'
 	| 'WHY-LINK'
 	| 'HELP-LINK'
-	| '';
+	| ''; // used for 'VIEWED' and 'DISMISSED' interactions
 
 export type SignInGatePropsAuxia = {
 	guUrl: string;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -114,6 +114,14 @@ export type AuxiaInteractionInteractionType =
 	| 'CLICKED'
 	| 'DISMISSED';
 
+export type AuxiaInteractionActionName =
+	| 'REGISTER-LINK'
+	| 'SIGN-IN-LINK'
+	| 'HOW-TO-LINK'
+	| 'WHY-LINK'
+	| 'HELP-LINK'
+	| '';
+
 export type SignInGatePropsAuxia = {
 	guUrl: string;
 	dismissGate: () => void;
@@ -125,5 +133,6 @@ export type SignInGatePropsAuxia = {
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 	logTreatmentInteractionCall: (
 		interactionType: AuxiaInteractionInteractionType,
+		actionName: AuxiaInteractionActionName,
 	) => Promise<void>;
 };

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -109,7 +109,10 @@ export interface SDCAuxiaProxyResponseData {
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
-export type AuxiaInteractionActionName = 'VIEWED' | 'CLICKED' | 'DISMISSED';
+export type AuxiaInteractionInteractionType =
+	| 'VIEWED'
+	| 'CLICKED'
+	| 'DISMISSED';
 
 export type SignInGatePropsAuxia = {
 	guUrl: string;
@@ -121,6 +124,6 @@ export type SignInGatePropsAuxia = {
 	personaliseSignInGateAfterCheckoutSwitch?: boolean;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 	logTreatmentInteractionCall: (
-		actionName: AuxiaInteractionActionName,
+		interactionType: AuxiaInteractionInteractionType,
 	) => Promise<void>;
 };

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -24,7 +24,7 @@ import { SignInGateAuxia } from './SignInGate/gateDesigns/SignInGateAuxia';
 import { signInGateTestIdToComponentId } from './SignInGate/signInGateMappings';
 import type {
 	AuxiaAPIResponseDataUserTreatment,
-	AuxiaInteractionActionName,
+	AuxiaInteractionInteractionType,
 	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
 	SDCAuxiaProxyResponseData,
@@ -424,7 +424,7 @@ interface ShowSignInGateAuxiaProps {
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 	contributionsServiceUrl: string;
 	logTreatmentInteractionCall: (
-		actionName: AuxiaInteractionActionName,
+		interactionType: AuxiaInteractionInteractionType,
 	) => Promise<void>;
 }
 
@@ -458,7 +458,7 @@ const fetchProxyGetTreatments = async (
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,
-	actionName: AuxiaInteractionActionName,
+	interactionType: AuxiaInteractionInteractionType,
 ): Promise<void> => {
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
@@ -469,9 +469,9 @@ const auxiaLogTreatmentInteraction = async (
 		treatmentTrackingId: userTreatment.treatmentTrackingId,
 		treatmentId: userTreatment.treatmentId,
 		surface: userTreatment.surface,
-		interactionType: 'CLICKED',
+		interactionType,
 		interactionTimeMicros: microTime,
-		actionName,
+		actionName: '',
 	};
 	const params = {
 		method: 'POST',
@@ -546,12 +546,12 @@ const SignInGateSelectorAuxia = ({
 						userTreatment={auxiaGetTreatmentsData.userTreatment}
 						contributionsServiceUrl={contributionsServiceUrl}
 						logTreatmentInteractionCall={async (
-							actionName: AuxiaInteractionActionName,
+							interactionType: AuxiaInteractionInteractionType,
 						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
 								auxiaGetTreatmentsData.userTreatment!,
-								actionName,
+								interactionType,
 							);
 						}}
 					/>

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -24,6 +24,7 @@ import { SignInGateAuxia } from './SignInGate/gateDesigns/SignInGateAuxia';
 import { signInGateTestIdToComponentId } from './SignInGate/signInGateMappings';
 import type {
 	AuxiaAPIResponseDataUserTreatment,
+	AuxiaInteractionActionName,
 	AuxiaInteractionInteractionType,
 	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
@@ -425,6 +426,7 @@ interface ShowSignInGateAuxiaProps {
 	contributionsServiceUrl: string;
 	logTreatmentInteractionCall: (
 		interactionType: AuxiaInteractionInteractionType,
+		actionName: AuxiaInteractionActionName,
 	) => Promise<void>;
 }
 
@@ -459,6 +461,7 @@ const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,
 	interactionType: AuxiaInteractionInteractionType,
+	actionName: AuxiaInteractionActionName,
 ): Promise<void> => {
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
@@ -471,7 +474,7 @@ const auxiaLogTreatmentInteraction = async (
 		surface: userTreatment.surface,
 		interactionType,
 		interactionTimeMicros: microTime,
-		actionName: '',
+		actionName,
 	};
 	const params = {
 		method: 'POST',
@@ -547,11 +550,13 @@ const SignInGateSelectorAuxia = ({
 						contributionsServiceUrl={contributionsServiceUrl}
 						logTreatmentInteractionCall={async (
 							interactionType: AuxiaInteractionInteractionType,
+							actionName: AuxiaInteractionActionName,
 						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
 								auxiaGetTreatmentsData.userTreatment!,
 								interactionType,
+								actionName,
 							);
 						}}
 					/>
@@ -578,6 +583,7 @@ const ShowSignInGateAuxia = ({
 				contributionsServiceUrl,
 				userTreatment,
 				'VIEWED',
+				'',
 			);
 		})().catch((error) => {
 			console.error('Failed to log treatment interaction:', error);


### PR DESCRIPTION
Here we clarify the difference between interactionType(s) and actionName(s). 

The interaction type are now taking values `'VIEWED' | 'CLICKED' | 'DISMISSED'` as specified by Auxia, and the action names, although defined from a specific set are actually user defined strings (aka I made them up). 