### PR TITLE
Add football competition links to tag pages

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -38,6 +38,7 @@ const initialDays: FootballMatches = [
 		competitions: [
 			{
 				competitionId: '635',
+				tag: 'serieafootball',
 				name: 'Serie A',
 				nation: 'European',
 				matches: [
@@ -66,6 +67,7 @@ const initialDays: FootballMatches = [
 			},
 			{
 				competitionId: '650',
+				tag: 'laligafootball',
 				name: 'La Liga',
 				nation: 'European',
 				matches: [
@@ -87,6 +89,7 @@ const initialDays: FootballMatches = [
 			},
 			{
 				competitionId: '651',
+				tag: 'fa-cup',
 				name: 'FA Cup',
 				nation: 'European',
 				matches: [
@@ -117,6 +120,7 @@ const moreDays: FootballMatches = [
 		competitions: [
 			{
 				competitionId: '635',
+				tag: 'serieafootball',
 				name: 'Serie A',
 				nation: 'European',
 				matches: [

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -177,7 +177,6 @@ const matchStyles = (matchKind: FootballMatch['kind']) => css`
 
 	display: flex;
 	flex-wrap: wrap;
-	text-decoration: none;
 	padding: ${space[2]}px;
 `;
 
@@ -198,6 +197,7 @@ const MatchWrapper = ({
 					css={[
 						matchStyles(match.kind),
 						css`
+							text-decoration: none;
 							color: inherit;
 							:hover {
 								background-color: ${palette(
@@ -367,7 +367,18 @@ export const FootballMatchList = ({
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.competitionId}>
 							<CompetitionName>
-								{competition.name}
+								<a
+									href={`https://www.theguardian.com/football/${competition.tag}`}
+									css={css`
+										text-decoration: none;
+										color: inherit;
+										:hover {
+											text-decoration: underline;
+										}
+									`}
+								>
+									{competition.name}
+								</a>
 							</CompetitionName>
 							<Matches>
 								{competition.matches.map((match) => (

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -33,6 +33,7 @@ export type FootballMatch = MatchResult | MatchFixture | LiveMatch;
 
 type Competition = {
 	competitionId: string;
+	tag: string;
 	name: string;
 	nation: string;
 	matches: FootballMatch[];


### PR DESCRIPTION
## What does this change?

Adds the links that go out to tag page from the football results/fixtures/live scores pages
