### PR TITLE
Epic choice card US only Test 2025

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -474,6 +474,20 @@ export const WithThreeTierChoiceCardsForUS: Story = {
 	},
 };
 
+export const WithThreeTierChoiceCardsSimplifiedForUS: Story = {
+	name: 'ContributionsEpic with three tier choice cards for US (Simplified third choice)',
+	args: {
+		...meta.args,
+		countryCode: 'US',
+		variant: {
+			...props.variant,
+			name: 'TEST_EPIC_SIMPLIFIED_THIRD_CHOICE_CARD',
+			secondaryCta: undefined,
+			showChoiceCards: true,
+		},
+	},
+};
+
 export const WithThreeTierDiscountChoiceCards: Story = {
 	name: 'ContributionsEpic with discounted three tier choice cards',
 	args: {

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -323,8 +323,9 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 		tracking.abTestVariant === 'VARIANT';
 
 	const isSimpleThirdChoiceCardInTestVariant: boolean =
-		showChoiceCards &&
-		variant.name.includes('EPIC_SIMPLIFIED_THIRD_CHOICE_CARD');
+		(showChoiceCards &&
+			variant.name.includes('EPIC_SIMPLIFIED_THIRD_CHOICE_CARD')) ??
+		false;
 
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -310,12 +310,21 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	openCmp,
 	hasConsentForArticleCount,
 }: EpicProps) => {
-	const { image, tickerSettings, choiceCardAmounts, newsletterSignup } =
-		variant;
+	const {
+		image,
+		showChoiceCards,
+		tickerSettings,
+		choiceCardAmounts,
+		newsletterSignup,
+	} = variant;
 
 	const isColourInTestVariant: boolean =
 		tracking.abTestName.includes('_ARTICLE_EPIC_BG_COLOUR') &&
 		tracking.abTestVariant === 'VARIANT';
+
+	const isSimpleThirdChoiceCardInTestVariant: boolean =
+		showChoiceCards &&
+		variant.name.includes('EPIC_SIMPLIFIED_THIRD_CHOICE_CARD');
 
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();
@@ -479,6 +488,9 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 					amountsTestName={choiceCardAmounts?.testName}
 					amountsVariantName={choiceCardAmounts?.variantName}
 					isColourInTestVariant={isColourInTestVariant}
+					isSimpleThirdChoiceCardInTestVariant={
+						isSimpleThirdChoiceCardInTestVariant
+					}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -91,6 +91,42 @@ export const ChoiceCardTestData_US: ChoiceInfo[] = [
 	},
 ];
 
+export const ChoiceCardTestData_US_SIMPLIFIED: ChoiceInfo[] = [
+	{
+		supportTier: 'Contribution',
+		label: (amount: number, currencySymbol: string): string =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'Support',
+		benefits: () => [
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+		],
+		recommended: false,
+	},
+	{
+		supportTier: 'SupporterPlus',
+		label: (amount: number, currencySymbol: string): string =>
+			`Support ${currencySymbol}${amount}/month`,
+		benefitsLabel: 'All-access digital',
+		benefits: () => [
+			'Unlimited access to the Guardian app',
+			'Unlimited access to our new Feast App',
+			'Ad-free reading on all your devices',
+			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
+			'Far fewer asks for support',
+		],
+		recommended: true,
+	},
+	{
+		supportTier: 'OneOff',
+		label: (): string => `Support with another amount`,
+		benefitsLabel: undefined,
+		benefits: () => [
+			`We welcome all support, whether big or small, one-time or recurring`,
+		],
+		recommended: false,
+	},
+];
+
 export const ChoiceCardTestData_TwoTier_REGULAR: ChoiceInfo[] = [
 	{
 		supportTier: 'SupporterPlus',

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -24,6 +24,7 @@ import {
 	ChoiceCardTestData_REGULAR,
 	ChoiceCardTestData_TwoTier_REGULAR,
 	ChoiceCardTestData_US,
+	ChoiceCardTestData_US_SIMPLIFIED,
 } from './ThreeTierChoiceCardData';
 import type {
 	SupportRatePlan,
@@ -184,8 +185,8 @@ const getChoiceCardData = (choiceCardVariant: string): ChoiceInfo[] => {
 	switch (choiceCardVariant) {
 		case 'US_THREE_TIER_CHOICE_CARDS':
 			return ChoiceCardTestData_US;
-		case 'US_CHECKOUT_THREE_TIER_CHOICE_CARDS':
-			return ChoiceCardTestData_US;
+		case 'US_SIMPLIFY_THIRD_CHOICE_CARD':
+			return ChoiceCardTestData_US_SIMPLIFIED;
 		case 'TWO_TIER_CHOICE_CARDS':
 			return ChoiceCardTestData_TwoTier_REGULAR;
 		default:

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -14,6 +14,7 @@ type Props = EpicProps & {
 	amountsTestName?: string;
 	amountsVariantName?: string;
 	isColourInTestVariant?: boolean;
+	isSimpleThirdChoiceCardInTestVariant?: boolean;
 };
 
 export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
@@ -27,6 +28,7 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 	amountsTestName,
 	amountsVariantName,
 	isColourInTestVariant,
+	isSimpleThirdChoiceCardInTestVariant,
 }: Props): JSX.Element => {
 	// reminders
 	const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(
@@ -54,15 +56,12 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 		setThreeTierChoiceCardSelectedProduct,
 	] = useState<SupportTier>('SupporterPlus');
 
-	const showUSSupportCheckout =
-		showChoiceCards && variant.name.includes('US_CHECKOUT_PAGE');
-
 	const hasSupporterPlusPromoCode =
 		variant.cta?.baseUrl.includes('BLACK_FRIDAY_DISCOUNT_2024') ?? false;
 
 	const variantOfChoiceCard =
-		countryCode === 'US' && showUSSupportCheckout
-			? 'US_CHECKOUT_THREE_TIER_CHOICE_CARDS'
+		countryCode === 'US' && isSimpleThirdChoiceCardInTestVariant
+			? 'US_SIMPLIFY_THIRD_CHOICE_CARD'
 			: countryCode === 'US'
 			? 'US_THREE_TIER_CHOICE_CARDS'
 			: 'THREE_TIER_CHOICE_CARDS';


### PR DESCRIPTION
## What does this change?

Epic choice card US only Test 2025 Feb 
[Trello card](https://trello.com/c/x6dtCfFU/918-epic-choice-card-us-only-test)

## Why?

US are interested in whether changing the copy in the 3rd epic choice card to remove the $1 anchor will improve LTV3.

Changes
1.  change the 3rd epic choice card from “ Support once from just $1” to “Support with another amount”
2. sub-text to read: “We welcome all support, whether big or small, one-time or recurring”

This will be an AB test- US only

## Screenshots

## How to test 
1. Deploy the changes to CODE 
2. Create a new test
3. Create a control 
4. Create a variant with name that includes "EPIC_SIMPLIFIED_THIRD_CHOICE_CARD" 

## Control
<img width="312" alt="image" src="https://github.com/user-attachments/assets/89f019f4-42bc-4af5-b4e8-c9c4e780bfe3" />

## EPIC_SIMPLIFIED_THIRD_CHOICE_CARD(Variant)

<img width="312" alt="image" src="https://github.com/user-attachments/assets/c89bae48-15be-410b-a48c-a94be8e14a3e" />

