### PR TITLE
Auxia Integration (Experiment) Part 10: signin gate component updates

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -1,7 +1,7 @@
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
-import type { SignInGatePropsAuxia, treatmentContentDecoded } from '../types';
+import type { SignInGatePropsAuxia, TreatmentContentDecoded } from '../types';
 import {
 	actionButtons,
 	bodyBold,
@@ -20,6 +20,7 @@ import {
 
 export const SignInGateAuxia = ({
 	guUrl,
+	signInUrl,
 	dismissGate,
 	abTest,
 	ophanComponentId,
@@ -31,17 +32,17 @@ export const SignInGateAuxia = ({
 
 	const treatmentContent = JSON.parse(
 		userTreatment.treatmentContent,
-	) as treatmentContentDecoded;
+	) as TreatmentContentDecoded;
 
 	/*
-	sample: {
+	The treatmentContent object is expected to have the following structure:
+	{
 		"title": "Sign in for a personlised experience",
+		"subtitle": ""
 		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
 		"first_cta_name": "Sign in",
 		"first_cta_link": "https://profile.theguardian.com/signin?",
 		"second_cta_name": "I'll do it later",
-		"second_cta_link": "https://profile.theguardian.com/signin?",
-		"subtitle": ""
 	}
 	*/
 
@@ -50,17 +51,14 @@ export const SignInGateAuxia = ({
 	const firstCtaName = treatmentContent.first_cta_name;
 	const firstCtaLink = treatmentContent.first_cta_link;
 	const secondCtaName = treatmentContent.second_cta_name;
-	const secondCtaLink = treatmentContent.second_cta_link;
-	//const subtitle = treatmentContent.subtitle;
+	const subtitle = treatmentContent.subtitle;
 
 	return (
 		<div css={signInGateContainer} data-testid="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
 			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>{title}</h1>
-			<p css={bodyBold}>
-				It’s still free to read – this is not a paywall
-			</p>
+			<p css={bodyBold}>{subtitle}</p>
 			<p css={bodyText}>{body}</p>
 			<div css={actionButtons}>
 				<LinkButton
@@ -115,7 +113,7 @@ export const SignInGateAuxia = ({
 							);
 						}}
 					>
-						I’ll do it later
+						{secondCtaName}
 					</Button>
 				)}
 			</div>
@@ -128,7 +126,7 @@ export const SignInGateAuxia = ({
 				data-testid="sign-in-gate-main_signin"
 				data-ignore="global-link-styling"
 				cssOverrides={signInLink}
-				href={secondCtaLink}
+				href={signInUrl}
 				onClick={() => {
 					trackLink(
 						ophanComponentId,
@@ -147,7 +145,7 @@ export const SignInGateAuxia = ({
 					});
 				}}
 			>
-				{secondCtaName}
+				Sign In
 			</Link>
 
 			<div css={faq}>

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -84,14 +84,13 @@ export type SignInGateTestMap = { [name: string]: SignInGateComponent };
 	comment group: auxia-prototype-e55a86ef
 */
 
-export interface treatmentContentDecoded {
+export interface TreatmentContentDecoded {
 	title: string;
+	subtitle: string;
 	body: string;
 	first_cta_name: string;
 	first_cta_link: string;
 	second_cta_name: string;
-	second_cta_link: string;
-	subtitle: string;
 }
 
 export interface AuxiaAPIResponseDataUserTreatment {
@@ -124,6 +123,7 @@ export type AuxiaInteractionActionName =
 
 export type SignInGatePropsAuxia = {
 	guUrl: string;
+	signInUrl: string;
 	dismissGate: () => void;
 	ophanComponentId: string;
 	abTest?: CurrentSignInGateABTest;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -385,6 +385,8 @@ export const SignInGateSelector = ({
 	} else {
 		return SignInGateSelectorAuxia({
 			host,
+			pageId,
+			idUrl,
 			contributionsServiceUrl,
 		});
 	}
@@ -415,11 +417,14 @@ export const SignInGateSelector = ({
 
 type PropsAuxia = {
 	host?: string;
+	pageId: string;
+	idUrl: string;
 	contributionsServiceUrl: string;
 };
 
 interface ShowSignInGateAuxiaProps {
 	host: string;
+	signInUrl: string;
 	setShowGate: React.Dispatch<React.SetStateAction<boolean>>;
 	abTest: CurrentSignInGateABTest;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
@@ -487,6 +492,8 @@ const auxiaLogTreatmentInteraction = async (
 
 const SignInGateSelectorAuxia = ({
 	host = 'https://theguardian.com/',
+	pageId,
+	idUrl,
 	contributionsServiceUrl,
 }: PropsAuxia) => {
 	/*
@@ -537,12 +544,24 @@ const SignInGateSelectorAuxia = ({
 		return null;
 	}
 
+	const ctaUrlParams = {
+		pageId,
+		host,
+		pageViewId,
+		idUrl,
+		currentTest: abTest,
+		componentId: abTest.id,
+	} satisfies Parameters<typeof generateGatewayUrl>[1];
+
+	const signInUrl = generateGatewayUrl('signin', ctaUrlParams);
+
 	return (
 		<>
 			{!isGateDismissed &&
 				auxiaGetTreatmentsData?.userTreatment !== undefined && (
 					<ShowSignInGateAuxia
 						host={host}
+						signInUrl={signInUrl}
 						// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Odd react types, should review
 						setShowGate={(show) => setIsGateDismissed(!show)}
 						abTest={abTest}
@@ -567,6 +586,7 @@ const SignInGateSelectorAuxia = ({
 
 const ShowSignInGateAuxia = ({
 	host,
+	signInUrl,
 	setShowGate,
 	abTest,
 	userTreatment,
@@ -592,6 +612,7 @@ const ShowSignInGateAuxia = ({
 
 	return SignInGateAuxia({
 		guUrl: host,
+		signInUrl,
 		dismissGate: () => {
 			dismissGateAuxia(setShowGate);
 		},


### PR DESCRIPTION
Previously, in Auxia Integration: https://github.com/guardian/dotcom-rendering/pull/13296

Here we perform the following updates:

1. Correct the capitalisation of `TreatmentContentDecoded`.

2. Remove attribute `second_cta_link` from `TreatmentContentDecoded` (decided with Auxia that the second element will only perform dismiss and threfore doesn't need an URL).

3. Correct the positioning of first_cta and second_cta inside the component. 

4. Revert the "SignIn" link after mid gate separation to be like the default gate since Auxia won't be controlling that. Incidentally, since that particular link is now back under our control, I pass the link to the component. 

Below: TreatmentContentDecoded, from the console (note that the Auxia object still contains `second_cta_link` but only because it has not yet been removed from the Auxia console), and corresponding Rendered gate.

![Screenshot 2025-02-07 at 05 27 36](https://github.com/user-attachments/assets/9bdafcf2-917f-4c16-8ec3-6f3ae9963a00)

![Screenshot 2025-02-07 at 05 27 46](https://github.com/user-attachments/assets/06c53bca-9432-449e-9948-08eed7d2609a)

We are now fully compliant with this:

![unnamed](https://github.com/user-attachments/assets/4fc2a553-f48e-4df5-a4f5-2fd89318ac55)

