### PR TITLE
Football match list: Add dark mode styling for More button

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -393,6 +393,15 @@ export const FootballMatchList = ({
 						`}
 					>
 						<Button
+							theme={{
+								textPrimary: palette('--button-text-primary'),
+								backgroundPrimary: palette(
+									'--button-background-primary',
+								),
+								backgroundPrimaryHover: palette(
+									'--button-background-primary-hover',
+								),
+							}}
 							icon={<SvgPlus />}
 							size="xsmall"
 							onClick={() => {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7,6 +7,7 @@ import { palette as sourcePalette } from '@guardian/source/foundations';
 import {
 	buttonThemeBrand,
 	buttonThemeDefault,
+	themeButton,
 } from '@guardian/source/react-components';
 import {
 	expandingWrapperDarkTheme,
@@ -5997,6 +5998,18 @@ const paletteColours = {
 	'--bullet-fill': {
 		light: bulletFillLight,
 		dark: bulletFillDark,
+	},
+	'--button-background-primary': {
+		light: () => themeButton.backgroundPrimary,
+		dark: () => sourcePalette.neutral[86],
+	},
+	'--button-background-primary-hover': {
+		light: () => themeButton.backgroundPrimaryHover,
+		dark: () => '#CACACA',
+	},
+	'--button-text-primary': {
+		light: () => themeButton.textPrimary,
+		dark: () => sourcePalette.brand[400],
 	},
 	'--byline': {
 		light: bylineLight,


### PR DESCRIPTION
## What does this change?

Adds colours for dark mode to the More button on football match lists

## Screenshots

| Hover      | Focus      |
| ----------- | ---------- |
| <img width="285" alt="image" src="https://github.com/user-attachments/assets/a118798f-c949-4a9e-b6c7-0559a9f18ebd" />|<img width="323" alt="image" src="https://github.com/user-attachments/assets/7fc35212-8b84-4b0a-94b8-b9fa3e7e70e1" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

