### PR TITLE
Refactor Youtube overlay out of YoutubeAtom

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -47,6 +47,7 @@ import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
+import { YoutubeAtomCardOverlay } from '../YoutubeAtom/YoutubeAtomCardOverlay';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -906,32 +907,54 @@ export const Card = ({
 												isMainMedia={true}
 												hideCaption={true}
 												stickyVideos={false}
-												kickerText={kickerText}
 												pauseOffscreenVideo={
 													pauseOffscreenVideo
 												}
-												showTextOverlay={
-													containerType ===
-													'fixed/video'
-												}
-												imagePositionOnMobile={
-													imagePositionOnMobile
-												}
-												//** TODO: IMPROVE THIS MAPPING */
-												// image size defaults to small if not provided. However, if the headline size is large or greater, we want to assume the image is also large so that the play icon is correctly sized.
-												imageSize={
-													[
-														'small',
-														'medium',
-														'large',
-														'xlarge',
-														'xxlarge',
-													].includes(
-														headlineSizes?.desktop ??
-															'',
-													)
-														? 'large'
-														: imageSize
+												YoutubeAtomOverlay={
+													<YoutubeAtomCardOverlay
+														alt={headlineText}
+														kicker={kickerText}
+														format={format}
+														showTextOverlay={
+															containerType ===
+															'fixed/video'
+														}
+														//** TODO: IMPROVE THIS MAPPING */
+														// image size defaults to small if not provided. However, if the headline size is large or greater, we want to assume the image is also large so that the play icon is correctly sized.
+														iconSizeOnDesktop={
+															[
+																'small',
+																'medium',
+																'large',
+																'xlarge',
+																'xxlarge',
+															].includes(
+																headlineSizes?.desktop ??
+																	'',
+															) ||
+															imageSize !==
+																'small'
+																? 'large'
+																: 'small'
+														}
+														iconSizeOnMobile={
+															imagePositionOnMobile ===
+																'left' ||
+															imagePositionOnMobile ===
+																'right'
+																? 'small'
+																: 'large'
+														}
+														aspectRatio={
+															aspectRatio
+														}
+														hidePillOnMobile={
+															imagePositionOnMobile ===
+																'left' ||
+															imagePositionOnMobile ===
+																'right'
+														}
+													/>
 												}
 												enableAds={false}
 												aspectRatio={aspectRatio}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -910,7 +910,14 @@ export const Card = ({
 												pauseOffscreenVideo={
 													pauseOffscreenVideo
 												}
-												YoutubeAtomOverlay={
+												renderOverlay={({
+													uniqueId,
+													posterImage,
+													title,
+													height,
+													width,
+													onClick,
+												}) => (
 													<YoutubeAtomCardOverlay
 														alt={headlineText}
 														kicker={kickerText}
@@ -954,8 +961,16 @@ export const Card = ({
 															imagePositionOnMobile ===
 																'right'
 														}
+														uniqueId={uniqueId}
+														posterImage={
+															posterImage
+														}
+														title={title}
+														height={height}
+														width={width}
+														onClick={onClick}
 													/>
-												}
+												)}
 												enableAds={false}
 												aspectRatio={aspectRatio}
 											/>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -913,12 +913,18 @@ export const Card = ({
 												renderOverlay={({
 													uniqueId,
 													posterImage,
-													title,
 													height,
 													width,
 													onClick,
 												}) => (
 													<YoutubeAtomCardOverlay
+														uniqueId={uniqueId}
+														posterImage={
+															posterImage
+														}
+														height={height}
+														width={width}
+														onClick={onClick}
 														alt={headlineText}
 														kicker={kickerText}
 														format={format}
@@ -961,14 +967,7 @@ export const Card = ({
 															imagePositionOnMobile ===
 																'right'
 														}
-														uniqueId={uniqueId}
-														posterImage={
-															posterImage
-														}
-														title={title}
-														height={height}
-														width={width}
-														onClick={onClick}
+														title={headlineText}
 													/>
 												)}
 												enableAds={false}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -47,7 +47,7 @@ import { StarRating } from '../StarRating/StarRating';
 import type { Alignment } from '../SupportingContent';
 import { SupportingContent } from '../SupportingContent';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
-import { YoutubeAtomCardOverlay } from '../YoutubeAtom/YoutubeAtomCardOverlay';
+import { YoutubeAtomOverlayCard } from '../YoutubeAtom/YoutubeAtomOverlayCard';
 import { YoutubeBlockComponent } from '../YoutubeBlockComponent.importable';
 import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
@@ -912,16 +912,14 @@ export const Card = ({
 												}
 												renderOverlay={({
 													uniqueId,
-													posterImage,
+													image: overlayImage,
 													height,
 													width,
 													onClick,
 												}) => (
-													<YoutubeAtomCardOverlay
+													<YoutubeAtomOverlayCard
 														uniqueId={uniqueId}
-														posterImage={
-															posterImage
-														}
+														image={overlayImage}
 														height={height}
 														width={width}
 														onClick={onClick}

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -2,9 +2,8 @@ import { css } from '@emotion/react';
 import { from, palette } from '@guardian/source/foundations';
 import type { ThemeIcon } from '@guardian/source/react-components';
 import { SvgMediaControlsPlay } from '@guardian/source/react-components';
-import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 
-type PlayButtonSize = keyof typeof sizes;
+export type PlayButtonSize = keyof typeof sizes;
 
 const sizes = {
 	small: { button: 40, icon: 32 },
@@ -46,42 +45,19 @@ const theme = {
 	fill: palette.neutral[100],
 } satisfies Partial<ThemeIcon>;
 
-const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
-	switch (imageSize) {
-		case 'jumbo':
-		case 'large':
-		case 'podcast':
-		case 'carousel':
-		case 'medium':
-		case 'feature':
-		case 'feature-large':
-			return 'large';
-		case 'small':
-			return 'small';
-	}
+type Props = {
+	iconSizeOnDesktop?: PlayButtonSize;
+	iconSizeOnMobile?: PlayButtonSize;
 };
 
-const getIconSizeOnMobile = (imagePositionOnMobile: ImagePositionType) =>
-	imagePositionOnMobile === 'left' || imagePositionOnMobile === 'right'
-		? 'small'
-		: 'large';
-
 export const PlayIcon = ({
-	imageSize,
-	imagePositionOnMobile,
-}: {
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
-}) => {
+	iconSizeOnDesktop = 'large',
+	iconSizeOnMobile = 'large',
+}: Props) => {
 	return (
 		<div
 			className="play-icon"
-			css={[
-				iconStyles(
-					getIconSizeOnDesktop(imageSize),
-					getIconSizeOnMobile(imagePositionOnMobile),
-				),
-			]}
+			css={[iconStyles(iconSizeOnDesktop, iconSizeOnMobile)]}
 		>
 			<SvgMediaControlsPlay theme={theme} />
 		</div>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -4,12 +4,9 @@ import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
 import type { AdTargeting } from '../../types/commercial';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
 import type { Props } from './YoutubeAtom';
 import { YoutubeAtom } from './YoutubeAtom';
+import { YoutubeAtomCardOverlay } from './YoutubeAtomCardOverlay';
 
 const meta = {
 	title: 'Components/Youtube Atom',
@@ -129,34 +126,33 @@ const adTargetingAndConsentGiven = {
 	...consentGiven,
 } satisfies AdTargeting & ConsentState;
 
-const imagePositionOnMobile: ImagePositionType = 'none';
-const imageSize: ImageSizeType = 'large';
-
 const baseConfiguration = {
 	atomId: 'a2502abd-1373-45a2-b508-3e5a2ec050be',
 	videoId: '-ZCvZmYlQD8',
 	uniqueId: '-ZCvZmYlQD8-1',
-	alt: '',
 	eventEmitters: [
 		// eslint-disable-next-line no-console -- check event emitters are called
 		(e: unknown) => console.log(`event emitter ${String(e)} called`),
 	],
-	duration: 252,
-	format: {
-		theme: Pillar.Culture,
-		design: ArticleDesign.Standard,
-		display: ArticleDisplay.Standard,
-	},
 	height: 450,
 	width: 800,
 	shouldStick: false,
 	isMainMedia: false,
 	abTestParticipations: {},
 	adTargeting: disableAds,
-	imagePositionOnMobile,
-	imageSize,
 	consentState: consentGiven,
 	renderingTarget: 'Web',
+	YoutubeAtomOverlay: (
+		<YoutubeAtomCardOverlay
+			format={{
+				theme: Pillar.News,
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+			}}
+			hidePillOnMobile={false}
+			duration={252}
+		/>
+	),
 } satisfies Partial<Props>;
 
 const NoConsent = {
@@ -178,56 +174,25 @@ export const NoOverlay = {
 	},
 } satisfies Story;
 
-export const WithOverrideImage = {
-	args: {
-		...baseConfiguration,
-		videoId: '3jpXAMwRSu4',
-		alt: 'Microscopic image of COVID',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		overrideImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
-		height: undefined,
-		width: undefined,
-		title: 'How to stop the spread of coronavirus',
-	},
-	decorators: [OverlayAutoplayExplainer, Container],
-} satisfies Story;
-
 export const WithPosterImage = {
 	args: {
 		...baseConfiguration,
 		videoId: 'N9Cgy-ke5-s',
-		format: {
-			theme: Pillar.Sport,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		posterImage:
 			'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
 		title: 'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington',
-	},
-	decorators: [OverlayAutoplayExplainer, Container],
-} satisfies Story;
-
-export const WithOverlayAndPosterImage = {
-	args: {
-		...baseConfiguration,
-		videoId: WithPosterImage.args.videoId,
-		format: {
-			theme: Pillar.Opinion,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		posterImage: WithPosterImage.args.posterImage,
-		overrideImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg',
-		title: 'How Donald Trump’s broken promises failed Ohio',
-		kicker: 'Breaking News',
-		showTextOverlay: true,
+		YoutubeAtomOverlay: (
+			<YoutubeAtomCardOverlay
+				alt="Microscopic image of COVID"
+				format={{
+					theme: Pillar.Sport,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				duration={252}
+				hidePillOnMobile={false}
+			/>
+		),
 	},
 	decorators: [OverlayAutoplayExplainer, Container],
 } satisfies Story;
@@ -236,11 +201,21 @@ export const GiveConsent = {
 	args: {
 		...baseConfiguration,
 		...consentNotGiven,
-		videoId: WithOverrideImage.args.videoId,
-		alt: WithOverrideImage.args.alt,
-		format: WithOverrideImage.args.format,
-		title: WithOverrideImage.args.title,
-		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
+		videoId: WithPosterImage.args.videoId,
+		title: WithPosterImage.args.title,
+		posterImage: WithPosterImage.args.posterImage,
+		YoutubeAtomOverlay: (
+			<YoutubeAtomCardOverlay
+				duration={252}
+				alt="Microscopic image of COVID"
+				format={{
+					theme: Pillar.News,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				hidePillOnMobile={false}
+			/>
+		),
 	},
 	render: function Render(args) {
 		const [consented, setConsented] = useState(false);
@@ -385,7 +360,6 @@ export const PausesOffscreen = {
  * The ad enabled tests are a convenience for manual testing.
  *
  */
-
 export const NoConsentWithAds = {
 	args: {
 		...NoConsent.args,
@@ -407,35 +381,10 @@ export const NoOverlayWithAds = {
 	},
 } satisfies Story;
 
-export const WithOverrideImageWithAds = {
-	args: {
-		...WithOverrideImage.args,
-		...adTargetingAndConsentGiven,
-		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
-	},
-	decorators: [Container],
-	parameters: {
-		chromatic: { disableSnapshot: true },
-	},
-} satisfies Story;
-
 export const WithPosterImageWithAds = {
 	args: {
 		...WithPosterImage.args,
 		...adTargetingAndConsentGiven,
-	},
-	decorators: [Container],
-	parameters: {
-		chromatic: { disableSnapshot: true },
-	},
-} satisfies Story;
-
-export const WithOverlayAndPosterImageWithAds = {
-	args: {
-		...WithOverlayAndPosterImage.args,
-		...adTargetingAndConsentGiven,
-		kicker: undefined,
-		showTextOverlay: undefined,
 	},
 	decorators: [Container],
 	parameters: {
@@ -504,18 +453,23 @@ export const LiveStream = {
 	args: {
 		...baseConfiguration,
 		videoId: '3jpXAMwRSu4',
-		alt: 'Microscopic image of COVID',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		overrideImage:
+		posterImage:
 			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
 		height: undefined,
 		width: undefined,
 		title: 'How to stop the spread of coronavirus',
-		duration: 0,
+		YoutubeAtomOverlay: (
+			<YoutubeAtomCardOverlay
+				format={{
+					theme: Pillar.News,
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+				}}
+				hidePillOnMobile={false}
+				alt="Microscopic image of COVID"
+				duration={0}
+			/>
+		),
 	},
 	decorators: [OverlayAutoplayExplainer, Container],
 } satisfies Story;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -142,14 +142,7 @@ const baseConfiguration = {
 	adTargeting: disableAds,
 	consentState: consentGiven,
 	renderingTarget: 'Web',
-	renderOverlay: ({
-		uniqueId,
-		posterImage,
-		title,
-		height,
-		width,
-		onClick,
-	}) => (
+	renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
 		<YoutubeAtomCardOverlay
 			format={{
 				theme: Pillar.News,
@@ -161,7 +154,7 @@ const baseConfiguration = {
 			alt="Microscopic image of COVID"
 			uniqueId={uniqueId}
 			posterImage={posterImage}
-			title={title}
+			title=""
 			height={height}
 			width={width}
 			onClick={onClick}
@@ -195,14 +188,7 @@ export const WithPosterImage = {
 		posterImage:
 			'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
 		title: 'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington',
-		renderOverlay: ({
-			uniqueId,
-			posterImage,
-			title,
-			height,
-			width,
-			onClick,
-		}) => (
+		renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
 			<YoutubeAtomCardOverlay
 				format={{
 					theme: Pillar.Sport,
@@ -213,7 +199,9 @@ export const WithPosterImage = {
 				duration={252}
 				uniqueId={uniqueId}
 				posterImage={posterImage}
-				title={title}
+				title={
+					'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington'
+				}
 				height={height}
 				width={width}
 				onClick={onClick}
@@ -472,14 +460,7 @@ export const LiveStream = {
 		height: undefined,
 		width: undefined,
 		title: 'How to stop the spread of coronavirus',
-		renderOverlay: ({
-			uniqueId,
-			posterImage,
-			title,
-			height,
-			width,
-			onClick,
-		}) => (
+		renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
 			<YoutubeAtomCardOverlay
 				format={{
 					theme: Pillar.News,
@@ -491,7 +472,7 @@ export const LiveStream = {
 				alt="Microscopic image of COVID"
 				uniqueId={uniqueId}
 				posterImage={posterImage}
-				title={title}
+				title={'How to stop the spread of coronavirus'}
 				height={height}
 				width={width}
 				onClick={onClick}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -6,7 +6,7 @@ import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
 import type { AdTargeting } from '../../types/commercial';
 import type { Props } from './YoutubeAtom';
 import { YoutubeAtom } from './YoutubeAtom';
-import { YoutubeAtomCardOverlay } from './YoutubeAtomCardOverlay';
+import { YoutubeAtomOverlayCard } from './YoutubeAtomOverlayCard';
 
 const meta = {
 	title: 'Components/Youtube Atom',
@@ -142,8 +142,8 @@ const baseConfiguration = {
 	adTargeting: disableAds,
 	consentState: consentGiven,
 	renderingTarget: 'Web',
-	renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
-		<YoutubeAtomCardOverlay
+	renderOverlay: ({ uniqueId, image, height, width, onClick }) => (
+		<YoutubeAtomOverlayCard
 			format={{
 				theme: Pillar.News,
 				design: ArticleDesign.Standard,
@@ -153,7 +153,7 @@ const baseConfiguration = {
 			duration={252}
 			alt="Microscopic image of COVID"
 			uniqueId={uniqueId}
-			posterImage={posterImage}
+			image={image}
 			title=""
 			height={height}
 			width={width}
@@ -181,15 +181,14 @@ export const NoOverlay = {
 	},
 } satisfies Story;
 
-export const WithPosterImage = {
+export const Withimage = {
 	args: {
 		...baseConfiguration,
 		videoId: 'N9Cgy-ke5-s',
-		posterImage:
-			'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
+		image: 'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
 		title: 'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington',
-		renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
-			<YoutubeAtomCardOverlay
+		renderOverlay: ({ uniqueId, image, height, width, onClick }) => (
+			<YoutubeAtomOverlayCard
 				format={{
 					theme: Pillar.Sport,
 					design: ArticleDesign.Standard,
@@ -198,7 +197,7 @@ export const WithPosterImage = {
 				hidePillOnMobile={false}
 				duration={252}
 				uniqueId={uniqueId}
-				posterImage={posterImage}
+				image={image}
 				title={
 					'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington'
 				}
@@ -215,9 +214,9 @@ export const GiveConsent = {
 	args: {
 		...baseConfiguration,
 		...consentNotGiven,
-		videoId: WithPosterImage.args.videoId,
-		title: WithPosterImage.args.title,
-		posterImage: WithPosterImage.args.posterImage,
+		videoId: Withimage.args.videoId,
+		title: Withimage.args.title,
+		image: Withimage.args.image,
 	},
 	render: function Render(args) {
 		const [consented, setConsented] = useState(false);
@@ -383,9 +382,9 @@ export const NoOverlayWithAds = {
 	},
 } satisfies Story;
 
-export const WithPosterImageWithAds = {
+export const WithimageWithAds = {
 	args: {
-		...WithPosterImage.args,
+		...Withimage.args,
 		...adTargetingAndConsentGiven,
 	},
 	decorators: [Container],
@@ -455,13 +454,12 @@ export const LiveStream = {
 	args: {
 		...baseConfiguration,
 		videoId: '3jpXAMwRSu4',
-		posterImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
+		image: 'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
 		height: undefined,
 		width: undefined,
 		title: 'How to stop the spread of coronavirus',
-		renderOverlay: ({ uniqueId, posterImage, height, width, onClick }) => (
-			<YoutubeAtomCardOverlay
+		renderOverlay: ({ uniqueId, image, height, width, onClick }) => (
+			<YoutubeAtomOverlayCard
 				format={{
 					theme: Pillar.News,
 					design: ArticleDesign.Standard,
@@ -471,7 +469,7 @@ export const LiveStream = {
 				duration={0}
 				alt="Microscopic image of COVID"
 				uniqueId={uniqueId}
-				posterImage={posterImage}
+				image={image}
 				title={'How to stop the spread of coronavirus'}
 				height={height}
 				width={width}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -142,7 +142,14 @@ const baseConfiguration = {
 	adTargeting: disableAds,
 	consentState: consentGiven,
 	renderingTarget: 'Web',
-	YoutubeAtomOverlay: (
+	renderOverlay: ({
+		uniqueId,
+		posterImage,
+		title,
+		height,
+		width,
+		onClick,
+	}) => (
 		<YoutubeAtomCardOverlay
 			format={{
 				theme: Pillar.News,
@@ -151,6 +158,13 @@ const baseConfiguration = {
 			}}
 			hidePillOnMobile={false}
 			duration={252}
+			alt="Microscopic image of COVID"
+			uniqueId={uniqueId}
+			posterImage={posterImage}
+			title={title}
+			height={height}
+			width={width}
+			onClick={onClick}
 		/>
 	),
 } satisfies Partial<Props>;
@@ -181,16 +195,28 @@ export const WithPosterImage = {
 		posterImage:
 			'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
 		title: 'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington',
-		YoutubeAtomOverlay: (
+		renderOverlay: ({
+			uniqueId,
+			posterImage,
+			title,
+			height,
+			width,
+			onClick,
+		}) => (
 			<YoutubeAtomCardOverlay
-				alt="Microscopic image of COVID"
 				format={{
 					theme: Pillar.Sport,
 					design: ArticleDesign.Standard,
 					display: ArticleDisplay.Standard,
 				}}
-				duration={252}
 				hidePillOnMobile={false}
+				duration={252}
+				uniqueId={uniqueId}
+				posterImage={posterImage}
+				title={title}
+				height={height}
+				width={width}
+				onClick={onClick}
 			/>
 		),
 	},
@@ -204,18 +230,6 @@ export const GiveConsent = {
 		videoId: WithPosterImage.args.videoId,
 		title: WithPosterImage.args.title,
 		posterImage: WithPosterImage.args.posterImage,
-		YoutubeAtomOverlay: (
-			<YoutubeAtomCardOverlay
-				duration={252}
-				alt="Microscopic image of COVID"
-				format={{
-					theme: Pillar.News,
-					design: ArticleDesign.Standard,
-					display: ArticleDisplay.Standard,
-				}}
-				hidePillOnMobile={false}
-			/>
-		),
 	},
 	render: function Render(args) {
 		const [consented, setConsented] = useState(false);
@@ -458,7 +472,14 @@ export const LiveStream = {
 		height: undefined,
 		width: undefined,
 		title: 'How to stop the spread of coronavirus',
-		YoutubeAtomOverlay: (
+		renderOverlay: ({
+			uniqueId,
+			posterImage,
+			title,
+			height,
+			width,
+			onClick,
+		}) => (
 			<YoutubeAtomCardOverlay
 				format={{
 					theme: Pillar.News,
@@ -466,8 +487,14 @@ export const LiveStream = {
 					display: ArticleDisplay.Standard,
 				}}
 				hidePillOnMobile={false}
-				alt="Microscopic image of COVID"
 				duration={0}
+				alt="Microscopic image of COVID"
+				uniqueId={uniqueId}
+				posterImage={posterImage}
+				title={title}
+				height={height}
+				width={width}
+				onClick={onClick}
 			/>
 		),
 	},

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
 import { ConfigProvider } from '../ConfigContext';
 import { YoutubeAtom } from './YoutubeAtom';
-import { YoutubeAtomCardOverlay } from './YoutubeAtomCardOverlay';
+import { YoutubeAtomOverlayCard } from './YoutubeAtomOverlayCard';
 
 const overlayImage =
 	'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac';
@@ -22,11 +22,11 @@ const consentStateCanTarget: ConsentState = {
 	framework: 'tcfv2',
 };
 
+const uniqueId = 'c_xtiZNDgGc-1';
+const title = 'My Youtube video!';
+
 describe('YoutubeAtom', () => {
 	it('Player initialises when no overlay and has consent state', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -48,13 +48,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -62,7 +57,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -78,9 +73,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('Player initialises when overlay clicked and has consent state', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -98,18 +90,13 @@ describe('YoutubeAtom', () => {
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
-					posterImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -117,7 +104,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -139,9 +126,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('player div has correct title', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -163,13 +147,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -177,7 +156,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -193,9 +172,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('overlay has correct aria-label', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -213,18 +189,13 @@ describe('YoutubeAtom', () => {
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
-					posterImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -232,7 +203,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -250,9 +221,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('shows a placeholder if overlay is missing', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -273,13 +241,8 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -287,7 +250,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -305,9 +268,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('shows an overlay if present', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -324,18 +284,13 @@ describe('YoutubeAtom', () => {
 					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					posterImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -343,7 +298,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -359,9 +314,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('hides an overlay once it is clicked', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -378,18 +330,13 @@ describe('YoutubeAtom', () => {
 					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					posterImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					renderOverlay={({
-						posterImage,
-						height,
-						width,
-						onClick,
-					}) => (
-						<YoutubeAtomCardOverlay
+					renderOverlay={({ image, height, width, onClick }) => (
+						<YoutubeAtomOverlayCard
 							format={{
 								display: ArticleDisplay.Standard,
 								design: ArticleDesign.Standard,
@@ -397,7 +344,7 @@ describe('YoutubeAtom', () => {
 							}}
 							hidePillOnMobile={false}
 							uniqueId={uniqueId}
-							posterImage={posterImage}
+							image={image}
 							title={title}
 							height={height}
 							width={width}
@@ -416,9 +363,6 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('when two Atoms - hides the overlay of the correct player if clicked', () => {
-		const uniqueId = 'c_xtiZNDgGc-1';
-		const title = 'My Youtube video!';
-
 		const atom = (
 			<>
 				<ConfigProvider
@@ -436,18 +380,13 @@ describe('YoutubeAtom', () => {
 						title={title}
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
-						posterImage={overlayImage}
+						image={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
 						renderingTarget="Web"
-						renderOverlay={({
-							posterImage,
-							height,
-							width,
-							onClick,
-						}) => (
-							<YoutubeAtomCardOverlay
+						renderOverlay={({ image, height, width, onClick }) => (
+							<YoutubeAtomOverlayCard
 								format={{
 									display: ArticleDisplay.Standard,
 									design: ArticleDesign.Standard,
@@ -455,7 +394,7 @@ describe('YoutubeAtom', () => {
 								}}
 								hidePillOnMobile={false}
 								uniqueId={uniqueId}
-								posterImage={posterImage}
+								image={image}
 								title={title}
 								height={height}
 								width={width}
@@ -470,18 +409,13 @@ describe('YoutubeAtom', () => {
 						title="My Youtube video 2!"
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
-						posterImage={overlayImage}
+						image={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
 						renderingTarget="Web"
-						renderOverlay={({
-							posterImage,
-							height,
-							width,
-							onClick,
-						}) => (
-							<YoutubeAtomCardOverlay
+						renderOverlay={({ image, height, width, onClick }) => (
+							<YoutubeAtomOverlayCard
 								format={{
 									display: ArticleDisplay.Standard,
 									design: ArticleDesign.Standard,
@@ -489,7 +423,7 @@ describe('YoutubeAtom', () => {
 								}}
 								hidePillOnMobile={false}
 								uniqueId={uniqueId}
-								posterImage={posterImage}
+								image={image}
 								title={title}
 								height={height}
 								width={width}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
 import { ConfigProvider } from '../ConfigContext';
 import { YoutubeAtom } from './YoutubeAtom';
+import { YoutubeAtomCardOverlay } from './YoutubeAtomCardOverlay';
 
 const overlayImage =
 	'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac';
@@ -37,21 +38,23 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
 					consentState={consentStateCanTarget}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -75,22 +78,24 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
 					consentState={consentStateCanTarget}
-					overrideImage={overlayImage}
+					posterImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -122,21 +127,23 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
 					consentState={consentStateCanTarget}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -161,22 +168,24 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
 					consentState={consentStateCanTarget}
-					overrideImage={overlayImage}
+					posterImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -202,20 +211,22 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -241,21 +252,23 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
-					overrideImage={overlayImage}
+					posterImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -279,21 +292,23 @@ describe('YoutubeAtom', () => {
 					videoId="c_xtiZNDgGc"
 					uniqueId="c_xtiZNDgGc-1"
 					title="My Youtube video!"
-					alt=""
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
-					format={{
-						theme: Pillar.News,
-						design: ArticleDesign.Standard,
-						display: ArticleDisplay.Standard,
-					}}
-					overrideImage={overlayImage}
+					posterImage={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
 					renderingTarget="Web"
+					YoutubeAtomOverlay={
+						<YoutubeAtomCardOverlay
+							format={{
+								theme: Pillar.News,
+								design: ArticleDesign.Standard,
+								display: ArticleDisplay.Standard,
+							}}
+							hidePillOnMobile={false}
+						/>
+					}
 				/>
 			</ConfigProvider>
 		);
@@ -321,42 +336,46 @@ describe('YoutubeAtom', () => {
 						videoId="c_xtiZNDgGc"
 						uniqueId="c_xtiZNDgGc-1"
 						title="My Youtube video!"
-						alt=""
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
-						format={{
-							theme: Pillar.News,
-							design: ArticleDesign.Standard,
-							display: ArticleDisplay.Standard,
-						}}
-						overrideImage={overlayImage}
+						posterImage={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
-						imagePositionOnMobile="left"
-						imageSize="small"
 						renderingTarget="Web"
+						YoutubeAtomOverlay={
+							<YoutubeAtomCardOverlay
+								format={{
+									theme: Pillar.News,
+									design: ArticleDesign.Standard,
+									display: ArticleDisplay.Standard,
+								}}
+								hidePillOnMobile={false}
+							/>
+						}
 					/>
 					<YoutubeAtom
 						atomId="atom1"
 						videoId="c_xtiZNDgGc"
 						uniqueId="c_xtiZNDgGc-2"
 						title="My Youtube video 2!"
-						alt=""
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
-						format={{
-							theme: Pillar.News,
-							design: ArticleDesign.Standard,
-							display: ArticleDisplay.Standard,
-						}}
-						overrideImage={overlayImage}
+						posterImage={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
-						imagePositionOnMobile="left"
-						imageSize="small"
 						renderingTarget="Web"
+						YoutubeAtomOverlay={
+							<YoutubeAtomCardOverlay
+								format={{
+									theme: Pillar.News,
+									design: ArticleDesign.Standard,
+									display: ArticleDisplay.Standard,
+								}}
+								hidePillOnMobile={false}
+							/>
+						}
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -24,6 +24,9 @@ const consentStateCanTarget: ConsentState = {
 
 describe('YoutubeAtom', () => {
 	it('Player initialises when no overlay and has consent state', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -36,8 +39,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
@@ -45,16 +48,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -64,6 +78,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('Player initialises when overlay clicked and has consent state', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -76,8 +93,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
@@ -86,16 +103,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -111,6 +139,7 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('player div has correct title', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
 		const title = 'My Youtube video!';
 
 		const atom = (
@@ -125,8 +154,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
@@ -134,16 +163,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -153,7 +193,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('overlay has correct aria-label', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
 		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -166,8 +208,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					consentState={consentStateCanTarget}
@@ -176,16 +218,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -197,6 +250,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('shows a placeholder if overlay is missing', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -209,24 +265,35 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -238,6 +305,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('shows an overlay if present', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -250,8 +320,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					posterImage={overlayImage}
@@ -259,16 +329,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -278,6 +359,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('hides an overlay once it is clicked', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -290,8 +374,8 @@ describe('YoutubeAtom', () => {
 				<YoutubeAtom
 					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
 					videoId="c_xtiZNDgGc"
-					uniqueId="c_xtiZNDgGc-1"
-					title="My Youtube video!"
+					uniqueId={uniqueId}
+					title={title}
 					adTargeting={{ disableAds: true }}
 					eventEmitters={[]}
 					posterImage={overlayImage}
@@ -299,16 +383,27 @@ describe('YoutubeAtom', () => {
 					isMainMedia={false}
 					abTestParticipations={{}}
 					renderingTarget="Web"
-					YoutubeAtomOverlay={
+					renderOverlay={({
+						posterImage,
+						height,
+						width,
+						onClick,
+					}) => (
 						<YoutubeAtomCardOverlay
 							format={{
-								theme: Pillar.News,
-								design: ArticleDesign.Standard,
 								display: ArticleDisplay.Standard,
+								design: ArticleDesign.Standard,
+								theme: Pillar.News,
 							}}
 							hidePillOnMobile={false}
+							uniqueId={uniqueId}
+							posterImage={posterImage}
+							title={title}
+							height={height}
+							width={width}
+							onClick={onClick}
 						/>
-					}
+					)}
 				/>
 			</ConfigProvider>
 		);
@@ -321,6 +416,9 @@ describe('YoutubeAtom', () => {
 	});
 
 	it('when two Atoms - hides the overlay of the correct player if clicked', () => {
+		const uniqueId = 'c_xtiZNDgGc-1';
+		const title = 'My Youtube video!';
+
 		const atom = (
 			<>
 				<ConfigProvider
@@ -334,8 +432,8 @@ describe('YoutubeAtom', () => {
 					<YoutubeAtom
 						atomId="atom1"
 						videoId="c_xtiZNDgGc"
-						uniqueId="c_xtiZNDgGc-1"
-						title="My Youtube video!"
+						uniqueId={uniqueId}
+						title={title}
 						adTargeting={{ disableAds: true }}
 						eventEmitters={[]}
 						posterImage={overlayImage}
@@ -343,16 +441,27 @@ describe('YoutubeAtom', () => {
 						isMainMedia={false}
 						abTestParticipations={{}}
 						renderingTarget="Web"
-						YoutubeAtomOverlay={
+						renderOverlay={({
+							posterImage,
+							height,
+							width,
+							onClick,
+						}) => (
 							<YoutubeAtomCardOverlay
 								format={{
-									theme: Pillar.News,
-									design: ArticleDesign.Standard,
 									display: ArticleDisplay.Standard,
+									design: ArticleDesign.Standard,
+									theme: Pillar.News,
 								}}
 								hidePillOnMobile={false}
+								uniqueId={uniqueId}
+								posterImage={posterImage}
+								title={title}
+								height={height}
+								width={width}
+								onClick={onClick}
 							/>
-						}
+						)}
 					/>
 					<YoutubeAtom
 						atomId="atom1"
@@ -366,16 +475,27 @@ describe('YoutubeAtom', () => {
 						isMainMedia={false}
 						abTestParticipations={{}}
 						renderingTarget="Web"
-						YoutubeAtomOverlay={
+						renderOverlay={({
+							posterImage,
+							height,
+							width,
+							onClick,
+						}) => (
 							<YoutubeAtomCardOverlay
 								format={{
-									theme: Pillar.News,
-									design: ArticleDesign.Standard,
 									display: ArticleDisplay.Standard,
+									design: ArticleDesign.Standard,
+									theme: Pillar.News,
 								}}
 								hidePillOnMobile={false}
+								uniqueId={uniqueId}
+								posterImage={posterImage}
+								title={title}
+								height={height}
+								width={width}
+								onClick={onClick}
 							/>
-						}
+						)}
 					/>
 				</ConfigProvider>
 			</>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,7 +1,7 @@
 import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/libs';
 import type { ReactElement } from 'react';
-import { cloneElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { AdTargeting } from '../../types/commercial';
 import type { AspectRatio } from '../../types/front';
 import type { RenderingTarget } from '../../types/renderingTarget';
@@ -39,7 +39,21 @@ export type Props = {
 	shouldPauseOutOfView?: boolean;
 	renderingTarget: RenderingTarget;
 	aspectRatio?: AspectRatio;
-	YoutubeAtomOverlay: ReactElement;
+	renderOverlay: ({
+		uniqueId,
+		posterImage,
+		title,
+		height,
+		width,
+		onClick,
+	}: {
+		uniqueId: string;
+		posterImage: string | undefined;
+		title: string | undefined;
+		height: number;
+		width: number;
+		onClick: () => void;
+	}) => ReactElement;
 };
 
 export const YoutubeAtom = ({
@@ -60,7 +74,7 @@ export const YoutubeAtom = ({
 	shouldPauseOutOfView = false,
 	renderingTarget,
 	aspectRatio,
-	YoutubeAtomOverlay,
+	renderOverlay,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -140,15 +154,6 @@ export const YoutubeAtom = ({
 	 */
 	const playerReadyCallback = useCallback(() => setPlayerReady(true), []);
 
-	const YoutubeAtomOverlayWithCommonProps = cloneElement(YoutubeAtomOverlay, {
-		uniqueId,
-		posterImage,
-		title,
-		height,
-		width,
-		onClick: () => setOverlayClicked(true),
-	});
-
 	return (
 		<div
 			data-component="youtube-atom"
@@ -205,7 +210,15 @@ export const YoutubeAtom = ({
 							/>
 						)
 					}
-					{showOverlay && YoutubeAtomOverlayWithCommonProps}
+					{showOverlay &&
+						renderOverlay({
+							uniqueId,
+							posterImage,
+							title,
+							height,
+							width,
+							onClick: () => setOverlayClicked(true),
+						})}
 					{showPlaceholder && (
 						<YoutubeAtomPlaceholder uniqueId={uniqueId} />
 					)}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,16 +1,11 @@
 import type { Participations } from '@guardian/ab-core';
 import type { ConsentState } from '@guardian/libs';
-import { useCallback, useState } from 'react';
-import type { ArticleFormat } from '../../lib/articleFormat';
+import type { ReactElement } from 'react';
+import { cloneElement, useCallback, useState } from 'react';
 import type { AdTargeting } from '../../types/commercial';
 import type { AspectRatio } from '../../types/front';
 import type { RenderingTarget } from '../../types/renderingTarget';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
 import { MaintainAspectRatio } from '../MaintainAspectRatio';
-import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';
 import { YoutubeAtomPlaceholder } from './YoutubeAtomPlaceholder';
 import { YoutubeAtomPlayer } from './YoutubeAtomPlayer';
 import { YoutubeAtomSticky } from './YoutubeAtomSticky';
@@ -30,56 +25,42 @@ export type Props = {
 	atomId: string;
 	videoId: string;
 	uniqueId: string;
-	overrideImage?: string | undefined;
 	posterImage?: string | undefined;
 	adTargeting?: AdTargeting;
 	consentState?: ConsentState;
 	height?: number;
 	width?: number;
 	title?: string;
-	alt: string;
-	duration?: number; // in seconds
 	origin?: string;
 	eventEmitters: Array<(event: VideoEventKey) => void>;
-	format: ArticleFormat;
 	shouldStick?: boolean;
 	isMainMedia?: boolean;
 	abTestParticipations: Participations;
-	kicker?: string;
 	shouldPauseOutOfView?: boolean;
-	showTextOverlay?: boolean;
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
 	renderingTarget: RenderingTarget;
 	aspectRatio?: AspectRatio;
+	YoutubeAtomOverlay: ReactElement;
 };
 
 export const YoutubeAtom = ({
 	atomId,
 	videoId,
 	uniqueId,
-	overrideImage,
 	posterImage,
 	adTargeting,
 	consentState,
 	height = 259,
 	width = 460,
-	alt,
 	title,
-	duration,
 	origin,
 	eventEmitters,
 	shouldStick,
 	isMainMedia,
 	abTestParticipations,
-	kicker,
-	format,
 	shouldPauseOutOfView = false,
-	showTextOverlay = false,
-	imageSize,
-	imagePositionOnMobile,
 	renderingTarget,
 	aspectRatio,
+	YoutubeAtomOverlay,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -137,29 +118,10 @@ export const YoutubeAtom = ({
 	 * 3. When consent and ad targeting is available render the player to initiate loading of the YouTube player
 	 * 4. When the player is ready the placeholder is removed and the YouTube player is shown
 	 */
+	const hasOverlay = !!posterImage;
 
-	const hasOverlay = !!(overrideImage ?? posterImage);
-
-	/**
-	 * Show an overlay if:
-	 *
-	 * - It exists
-	 *
-	 * AND
-	 *
-	 * - It hasn't been clicked
-	 */
 	const showOverlay = hasOverlay && !overlayClicked;
 
-	/**
-	 * Show a placeholder if:
-	 *
-	 * - We don't have an overlay OR the user has clicked the overlay
-	 *
-	 * AND
-	 *
-	 * - The player is not ready
-	 */
 	const showPlaceholder = (!hasOverlay || overlayClicked) && !playerReady;
 
 	let loadPlayer;
@@ -177,6 +139,15 @@ export const YoutubeAtom = ({
 	 * Create a stable callback as it will be a useEffect dependency in YoutubeAtomPlayer
 	 */
 	const playerReadyCallback = useCallback(() => setPlayerReady(true), []);
+
+	const YoutubeAtomOverlayWithCommonProps = cloneElement(YoutubeAtomOverlay, {
+		uniqueId,
+		posterImage,
+		title,
+		height,
+		width,
+		onClick: () => setOverlayClicked(true),
+	});
 
 	return (
 		<div
@@ -234,25 +205,7 @@ export const YoutubeAtom = ({
 							/>
 						)
 					}
-					{showOverlay && (
-						<YoutubeAtomOverlay
-							uniqueId={uniqueId}
-							overrideImage={overrideImage}
-							posterImage={posterImage}
-							height={height}
-							width={width}
-							alt={alt}
-							duration={duration}
-							title={title}
-							onClick={() => setOverlayClicked(true)}
-							kicker={kicker}
-							format={format}
-							showTextOverlay={showTextOverlay}
-							imageSize={imageSize}
-							imagePositionOnMobile={imagePositionOnMobile}
-							aspectRatio={aspectRatio}
-						/>
-					)}
+					{showOverlay && YoutubeAtomOverlayWithCommonProps}
 					{showPlaceholder && (
 						<YoutubeAtomPlaceholder uniqueId={uniqueId} />
 					)}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -25,7 +25,7 @@ export type Props = {
 	atomId: string;
 	videoId: string;
 	uniqueId: string;
-	posterImage?: string | undefined;
+	image?: string;
 	adTargeting?: AdTargeting;
 	consentState?: ConsentState;
 	height?: number;
@@ -41,13 +41,13 @@ export type Props = {
 	aspectRatio?: AspectRatio;
 	renderOverlay: ({
 		uniqueId,
-		posterImage,
+		image,
 		height,
 		width,
 		onClick,
 	}: {
 		uniqueId: string;
-		posterImage: string;
+		image: string;
 		height: number;
 		width: number;
 		onClick: () => void;
@@ -58,7 +58,7 @@ export const YoutubeAtom = ({
 	atomId,
 	videoId,
 	uniqueId,
-	posterImage,
+	image,
 	adTargeting,
 	consentState,
 	height = 259,
@@ -130,7 +130,7 @@ export const YoutubeAtom = ({
 	 * 3. When consent and ad targeting is available render the player to initiate loading of the YouTube player
 	 * 4. When the player is ready the placeholder is removed and the YouTube player is shown
 	 */
-	const hasOverlay = !!posterImage;
+	const hasOverlay = !!image;
 
 	const showOverlay = hasOverlay && !overlayClicked;
 
@@ -211,7 +211,7 @@ export const YoutubeAtom = ({
 					{showOverlay &&
 						renderOverlay({
 							uniqueId,
-							posterImage,
+							image,
 							height,
 							width,
 							onClick: () => setOverlayClicked(true),

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -42,14 +42,12 @@ export type Props = {
 	renderOverlay: ({
 		uniqueId,
 		posterImage,
-		title,
 		height,
 		width,
 		onClick,
 	}: {
 		uniqueId: string;
-		posterImage: string | undefined;
-		title: string | undefined;
+		posterImage: string;
 		height: number;
 		width: number;
 		onClick: () => void;
@@ -214,7 +212,6 @@ export const YoutubeAtom = ({
 						renderOverlay({
 							uniqueId,
 							posterImage,
-							title,
 							height,
 							width,
 							onClick: () => setOverlayClicked(true),

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomCardOverlay.tsx
@@ -11,34 +11,13 @@ import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
 import type { AspectRatio } from '../../types/front';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
+import type { PlayButtonSize } from '../Card/components/PlayIcon';
 import { PlayIcon } from '../Card/components/PlayIcon';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { Pill } from '../Pill';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
-
-type Props = {
-	uniqueId: string;
-	overrideImage?: string;
-	posterImage?: string;
-	height: number;
-	width: number;
-	alt: string;
-	duration?: number; // in seconds
-	title?: string;
-	onClick: () => void;
-	kicker?: string;
-	format: ArticleFormat;
-	showTextOverlay?: boolean;
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
-	aspectRatio?: AspectRatio;
-};
 
 const overlayStyles = css`
 	background-size: cover;
@@ -108,9 +87,28 @@ const titleStyles = css`
 	}
 `;
 
-export const YoutubeAtomOverlay = ({
+type Props = {
+	format: ArticleFormat;
+	hidePillOnMobile: boolean;
+	uniqueId?: string;
+	posterImage?: string;
+	height?: number;
+	width?: number;
+	alt?: string;
+	duration?: number; // in seconds
+	title?: string;
+	onClick?: () => void;
+	kicker?: string;
+	showTextOverlay?: boolean;
+	aspectRatio?: AspectRatio;
+	iconSizeOnDesktop?: PlayButtonSize;
+	iconSizeOnMobile?: PlayButtonSize;
+};
+
+export const YoutubeAtomCardOverlay = ({
+	format,
+	hidePillOnMobile,
 	uniqueId,
-	overrideImage,
 	posterImage,
 	height,
 	width,
@@ -119,19 +117,18 @@ export const YoutubeAtomOverlay = ({
 	title,
 	onClick,
 	kicker,
-	format,
 	showTextOverlay,
-	imageSize,
-	imagePositionOnMobile,
 	aspectRatio,
+	iconSizeOnDesktop,
+	iconSizeOnMobile,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
-	//** We infer that a video is a livestream if the duration is set to 0. This is a soft contract with Editorial who manual set the duration of videos   */
+	/**
+	 * We infer that a video is a livestream if the duration is set to 0. This is
+	 * a soft contract with Editorial who manual set the duration of videos
+	 */
 	const isLiveStream = !isUndefined(duration) && duration === 0;
-	const image = overrideImage ?? posterImage;
-	const hidePillOnMobile =
-		imagePositionOnMobile === 'right' || imagePositionOnMobile === 'left';
 
 	return (
 		<FormatBoundary format={format}>
@@ -142,16 +139,18 @@ export const YoutubeAtomOverlay = ({
 				aria-label={title ? `Play video: ${title}` : `Play video`}
 				type="button"
 			>
-				{!!image && (
-					<YoutubeAtomPicture
-						image={image}
-						alt={alt}
-						height={height}
-						width={width}
-						aspectRatio={aspectRatio}
-					/>
-				)}
-				{isLiveStream && (
+				{!!posterImage &&
+					height !== undefined &&
+					width !== undefined && (
+						<YoutubeAtomPicture
+							image={posterImage}
+							alt={alt ?? ''}
+							height={height}
+							width={width}
+							aspectRatio={aspectRatio}
+						/>
+					)}
+				{isLiveStream ? (
 					<div
 						css={
 							hidePillOnMobile
@@ -162,13 +161,12 @@ export const YoutubeAtomOverlay = ({
 						}
 					>
 						<Pill
-							content={'Live'}
+							content="Live"
 							icon={<div css={[liveBulletStyles]} />}
-							iconSize={'small'}
+							iconSize="small"
 						/>
 					</div>
-				)}
-				{hasDuration && (
+				) : hasDuration ? (
 					<div
 						css={
 							hidePillOnMobile
@@ -181,13 +179,13 @@ export const YoutubeAtomOverlay = ({
 						<Pill
 							content={secondsToDuration(duration)}
 							icon={<SvgMediaControlsPlay />}
-							iconSize={'small'}
+							iconSize="small"
 						/>
 					</div>
-				)}
+				) : null}
 				<PlayIcon
-					imageSize={imageSize}
-					imagePositionOnMobile={imagePositionOnMobile}
+					iconSizeOnDesktop={iconSizeOnDesktop}
+					iconSizeOnMobile={iconSizeOnMobile}
 				/>
 				{showTextOverlay && (
 					<div css={textOverlayStyles}>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomCardOverlay.tsx
@@ -88,16 +88,16 @@ const titleStyles = css`
 `;
 
 type Props = {
+	uniqueId: string;
+	height: number;
+	width: number;
+	title: string;
+	onClick: () => void;
 	format: ArticleFormat;
 	hidePillOnMobile: boolean;
-	uniqueId?: string;
-	posterImage?: string;
-	height?: number;
-	width?: number;
 	alt?: string;
+	posterImage?: string;
 	duration?: number; // in seconds
-	title?: string;
-	onClick?: () => void;
 	kicker?: string;
 	showTextOverlay?: boolean;
 	aspectRatio?: AspectRatio;
@@ -112,7 +112,7 @@ export const YoutubeAtomCardOverlay = ({
 	posterImage,
 	height,
 	width,
-	alt,
+	alt = '',
 	duration,
 	title,
 	onClick,
@@ -139,17 +139,15 @@ export const YoutubeAtomCardOverlay = ({
 				aria-label={title ? `Play video: ${title}` : `Play video`}
 				type="button"
 			>
-				{!!posterImage &&
-					height !== undefined &&
-					width !== undefined && (
-						<YoutubeAtomPicture
-							image={posterImage}
-							alt={alt ?? ''}
-							height={height}
-							width={width}
-							aspectRatio={aspectRatio}
-						/>
-					)}
+				{!!posterImage && !!height && !!width && (
+					<YoutubeAtomPicture
+						image={posterImage}
+						alt={alt}
+						height={height}
+						width={width}
+						aspectRatio={aspectRatio}
+					/>
+				)}
 				{isLiveStream ? (
 					<div
 						css={

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayArticle.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayArticle.tsx
@@ -92,11 +92,11 @@ type Props = {
 	height: number;
 	width: number;
 	title: string;
-	onClick: () => void;
 	format: ArticleFormat;
+	onClick: () => void;
 	hidePillOnMobile: boolean;
 	alt?: string;
-	posterImage?: string;
+	image?: string;
 	duration?: number; // in seconds
 	kicker?: string;
 	showTextOverlay?: boolean;
@@ -105,11 +105,11 @@ type Props = {
 	iconSizeOnMobile?: PlayButtonSize;
 };
 
-export const YoutubeAtomCardOverlay = ({
+export const YoutubeAtomOverlayArticle = ({
 	format,
 	hidePillOnMobile,
 	uniqueId,
-	posterImage,
+	image,
 	height,
 	width,
 	alt = '',
@@ -139,9 +139,9 @@ export const YoutubeAtomCardOverlay = ({
 				aria-label={title ? `Play video: ${title}` : `Play video`}
 				type="button"
 			>
-				{!!posterImage && !!height && !!width && (
+				{!!image && (
 					<YoutubeAtomPicture
-						image={posterImage}
+						image={image}
 						alt={alt}
 						height={height}
 						width={width}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayArticle.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayArticle.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import {
-	from,
-	headlineMedium17,
-	headlineMedium20,
-	palette as sourcePalette,
-	space,
-} from '@guardian/source/foundations';
+import { space } from '@guardian/source/foundations';
 import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
@@ -14,7 +8,6 @@ import type { AspectRatio } from '../../types/front';
 import type { PlayButtonSize } from '../Card/components/PlayIcon';
 import { PlayIcon } from '../Card/components/PlayIcon';
 import { FormatBoundary } from '../FormatBoundary';
-import { Kicker } from '../Kicker';
 import { Pill } from '../Pill';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
@@ -62,44 +55,16 @@ const liveBulletStyles = css`
 	margin-right: ${space[1]}px;
 `;
 
-const textOverlayStyles = css`
-	position: absolute;
-	background: linear-gradient(
-		180deg,
-		rgba(0, 0, 0, 0) 0%,
-		rgba(0, 0, 0, 0.7) 25%
-	);
-	width: 100%;
-	bottom: 0;
-	color: ${sourcePalette.neutral[100]};
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	text-align: start;
-	padding: ${space[2]}px;
-	padding-top: ${space[9]}px;
-`;
-
-const titleStyles = css`
-	${headlineMedium17};
-	${from.tablet} {
-		${headlineMedium20};
-	}
-`;
-
 type Props = {
 	uniqueId: string;
 	height: number;
 	width: number;
-	title: string;
 	format: ArticleFormat;
 	onClick: () => void;
-	hidePillOnMobile: boolean;
+	title?: string;
 	alt?: string;
 	image?: string;
 	duration?: number; // in seconds
-	kicker?: string;
-	showTextOverlay?: boolean;
 	aspectRatio?: AspectRatio;
 	iconSizeOnDesktop?: PlayButtonSize;
 	iconSizeOnMobile?: PlayButtonSize;
@@ -107,7 +72,6 @@ type Props = {
 
 export const YoutubeAtomOverlayArticle = ({
 	format,
-	hidePillOnMobile,
 	uniqueId,
 	image,
 	height,
@@ -116,8 +80,6 @@ export const YoutubeAtomOverlayArticle = ({
 	duration,
 	title,
 	onClick,
-	kicker,
-	showTextOverlay,
 	aspectRatio,
 	iconSizeOnDesktop,
 	iconSizeOnMobile,
@@ -149,15 +111,7 @@ export const YoutubeAtomOverlayArticle = ({
 					/>
 				)}
 				{isLiveStream ? (
-					<div
-						css={
-							hidePillOnMobile
-								? css`
-										display: none;
-								  `
-								: pillStyles
-						}
-					>
+					<div css={pillStyles}>
 						<Pill
 							content="Live"
 							icon={<div css={[liveBulletStyles]} />}
@@ -165,15 +119,7 @@ export const YoutubeAtomOverlayArticle = ({
 						/>
 					</div>
 				) : hasDuration ? (
-					<div
-						css={
-							hidePillOnMobile
-								? css`
-										display: none;
-								  `
-								: pillStyles
-						}
-					>
+					<div css={pillStyles}>
 						<Pill
 							content={secondsToDuration(duration)}
 							icon={<SvgMediaControlsPlay />}
@@ -185,18 +131,6 @@ export const YoutubeAtomOverlayArticle = ({
 					iconSizeOnDesktop={iconSizeOnDesktop}
 					iconSizeOnMobile={iconSizeOnMobile}
 				/>
-				{showTextOverlay && (
-					<div css={textOverlayStyles}>
-						{!!kicker && (
-							<Kicker
-								text={kicker}
-								color={palette('--youtube-overlay-kicker')}
-								fontWeight="bold"
-							/>
-						)}
-						<div css={titleStyles}>{title}</div>
-					</div>
-				)}
 			</button>
 		</FormatBoundary>
 	);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayCard.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayCard.tsx
@@ -1,0 +1,203 @@
+import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
+import {
+	from,
+	headlineMedium17,
+	headlineMedium20,
+	palette as sourcePalette,
+	space,
+} from '@guardian/source/foundations';
+import type { ArticleFormat } from '../../lib/articleFormat';
+import { secondsToDuration } from '../../lib/formatTime';
+import { palette } from '../../palette';
+import type { AspectRatio } from '../../types/front';
+import type { PlayButtonSize } from '../Card/components/PlayIcon';
+import { PlayIcon } from '../Card/components/PlayIcon';
+import { FormatBoundary } from '../FormatBoundary';
+import { Kicker } from '../Kicker';
+import { Pill } from '../Pill';
+import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
+import { YoutubeAtomPicture } from './YoutubeAtomPicture';
+
+const overlayStyles = css`
+	background-size: cover;
+	background-position: 49% 49%;
+	background-repeat: no-repeat;
+	text-align: center;
+	height: 100%;
+	width: 100%;
+	position: absolute;
+	max-height: 100vh;
+	cursor: pointer;
+	border: 0;
+	padding: 0;
+
+	img {
+		width: 100%;
+		height: 100%;
+	}
+
+	.play-icon {
+		transition: transform 300ms;
+	}
+
+	/* We scale the play icon on hover and focus to indicate it's playable content. */
+	:focus .play-icon,
+	:hover .play-icon {
+		transform: translate(-50%, -50%) scale(1.15);
+	}
+`;
+
+const pillStyles = css`
+	position: absolute;
+	top: ${space[2]}px;
+	right: ${space[2]}px;
+`;
+
+const liveBulletStyles = css`
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	background-color: ${palette('--pill-bullet')};
+	margin-right: ${space[1]}px;
+`;
+
+const textOverlayStyles = css`
+	position: absolute;
+	background: linear-gradient(
+		180deg,
+		rgba(0, 0, 0, 0) 0%,
+		rgba(0, 0, 0, 0.7) 25%
+	);
+	width: 100%;
+	bottom: 0;
+	color: ${sourcePalette.neutral[100]};
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	text-align: start;
+	padding: ${space[2]}px;
+	padding-top: ${space[9]}px;
+`;
+
+const titleStyles = css`
+	${headlineMedium17};
+	${from.tablet} {
+		${headlineMedium20};
+	}
+`;
+
+type Props = {
+	uniqueId: string;
+	height: number;
+	width: number;
+	title: string;
+	onClick: () => void;
+	format: ArticleFormat;
+	hidePillOnMobile: boolean;
+	alt?: string;
+	image?: string;
+	duration?: number; // in seconds
+	kicker?: string;
+	showTextOverlay?: boolean;
+	aspectRatio?: AspectRatio;
+	iconSizeOnDesktop?: PlayButtonSize;
+	iconSizeOnMobile?: PlayButtonSize;
+};
+
+export const YoutubeAtomOverlayCard = ({
+	format,
+	hidePillOnMobile,
+	uniqueId,
+	image,
+	height,
+	width,
+	alt = '',
+	duration,
+	title,
+	onClick,
+	kicker,
+	showTextOverlay,
+	aspectRatio,
+	iconSizeOnDesktop,
+	iconSizeOnMobile,
+}: Props) => {
+	const id = `youtube-overlay-${uniqueId}`;
+	const hasDuration = !isUndefined(duration) && duration > 0;
+	/**
+	 * We infer that a video is a livestream if the duration is set to 0. This is
+	 * a soft contract with Editorial who manual set the duration of videos
+	 */
+	const isLiveStream = !isUndefined(duration) && duration === 0;
+
+	return (
+		<FormatBoundary format={format}>
+			<button
+				data-testid={id}
+				onClick={onClick}
+				css={overlayStyles}
+				aria-label={title ? `Play video: ${title}` : `Play video`}
+				type="button"
+			>
+				{!!image && (
+					<YoutubeAtomPicture
+						image={image}
+						alt={alt}
+						height={height}
+						width={width}
+						aspectRatio={aspectRatio}
+					/>
+				)}
+				{isLiveStream ? (
+					<div
+						css={
+							hidePillOnMobile
+								? css`
+										display: none;
+								  `
+								: pillStyles
+						}
+					>
+						<Pill
+							content="Live"
+							icon={<div css={[liveBulletStyles]} />}
+							iconSize="small"
+						/>
+					</div>
+				) : hasDuration ? (
+					<div
+						css={
+							hidePillOnMobile
+								? css`
+										display: none;
+								  `
+								: pillStyles
+						}
+					>
+						<Pill
+							content={secondsToDuration(duration)}
+							icon={<SvgMediaControlsPlay />}
+							iconSize="small"
+						/>
+					</div>
+				) : null}
+				<PlayIcon
+					iconSizeOnDesktop={iconSizeOnDesktop}
+					iconSizeOnMobile={iconSizeOnMobile}
+				/>
+				{showTextOverlay && (
+					<div css={textOverlayStyles}>
+						{!!kicker && (
+							<Kicker
+								text={kicker}
+								color={palette('--youtube-overlay-kicker')}
+								fontWeight="bold"
+							/>
+						)}
+						<div css={titleStyles}>{title}</div>
+					</div>
+				)}
+			</button>
+		</FormatBoundary>
+	);
+};

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayCard.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlayCard.tsx
@@ -91,10 +91,10 @@ type Props = {
 	uniqueId: string;
 	height: number;
 	width: number;
-	title: string;
 	onClick: () => void;
 	format: ArticleFormat;
 	hidePillOnMobile: boolean;
+	title?: string;
 	alt?: string;
 	image?: string;
 	duration?: number; // in seconds

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -23,13 +23,13 @@ type Props = {
 	enableAds: boolean;
 	renderOverlay: ({
 		uniqueId,
-		posterImage,
+		image,
 		height,
 		width,
 		onClick,
 	}: {
 		uniqueId: string;
-		posterImage: string | undefined;
+		image: string | undefined;
 		height: number;
 		width: number;
 		onClick: () => void;
@@ -141,7 +141,7 @@ export const YoutubeBlockComponent = ({
 				atomId={id}
 				videoId={assetId}
 				uniqueId={uniqueId}
-				posterImage={overrideImage ?? overlayImage}
+				image={overrideImage ?? overlayImage}
 				adTargeting={
 					enableAds && renderingTarget === 'Web'
 						? adTargeting
@@ -156,7 +156,7 @@ export const YoutubeBlockComponent = ({
 						? [ophanTrackerWeb(id)]
 						: [ophanTrackerApps(id)]
 				}
-				origin={origin}
+				origin={process.env.NODE_ENV === 'development' ? '' : origin}
 				shouldStick={renderingTarget === 'Web' ? stickyVideos : false}
 				isMainMedia={isMainMedia}
 				abTestParticipations={abTestParticipations}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -21,7 +21,14 @@ type Props = {
 	format: ArticleFormat;
 	stickyVideos: boolean;
 	enableAds: boolean;
-	YoutubeAtomOverlay: ReactElement;
+	renderOverlay: (settings: {
+		uniqueId: string;
+		posterImage: string | undefined;
+		title: string | undefined;
+		height: number;
+		width: number;
+		onClick: () => void;
+	}) => ReactElement;
 	mediaTitle?: string;
 	hideCaption?: boolean;
 	overrideImage?: string;
@@ -48,7 +55,7 @@ export const YoutubeBlockComponent = ({
 	format,
 	stickyVideos,
 	enableAds,
-	YoutubeAtomOverlay,
+	renderOverlay,
 	mediaTitle,
 	hideCaption,
 	overrideImage,
@@ -151,7 +158,7 @@ export const YoutubeBlockComponent = ({
 				shouldPauseOutOfView={pauseOffscreenVideo}
 				renderingTarget={renderingTarget}
 				aspectRatio={aspectRatio}
-				YoutubeAtomOverlay={YoutubeAtomOverlay}
+				renderOverlay={renderOverlay}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -21,10 +21,15 @@ type Props = {
 	format: ArticleFormat;
 	stickyVideos: boolean;
 	enableAds: boolean;
-	renderOverlay: (settings: {
+	renderOverlay: ({
+		uniqueId,
+		posterImage,
+		height,
+		width,
+		onClick,
+	}: {
 		uniqueId: string;
 		posterImage: string | undefined;
-		title: string | undefined;
 		height: number;
 		width: number;
 		onClick: () => void;

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -55,7 +55,14 @@ export const Default = () => {
 				expired={false}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -63,8 +70,14 @@ export const Default = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -101,7 +114,14 @@ export const Vertical = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -109,8 +129,14 @@ export const Vertical = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -148,7 +174,14 @@ export const Expired = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -156,8 +189,14 @@ export const Expired = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -196,7 +235,14 @@ export const WithOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -204,8 +250,14 @@ export const WithOverlayImage = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -265,7 +317,14 @@ export const WithPosterImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -273,8 +332,14 @@ export const WithPosterImage = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -335,7 +400,14 @@ export const WithPosterAndOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -343,8 +415,14 @@ export const WithPosterAndOverlayImage = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -405,7 +483,14 @@ export const WithShowMainVideoFlagOff = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				YoutubeAtomOverlay={
+				renderOverlay={({
+					uniqueId,
+					posterImage,
+					title,
+					height,
+					width,
+					onClick,
+				}) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,
@@ -413,8 +498,14 @@ export const WithShowMainVideoFlagOff = () => {
 							theme: Pillar.News,
 						}}
 						hidePillOnMobile={false}
+						uniqueId={uniqueId}
+						posterImage={posterImage}
+						title={title}
+						height={height}
+						width={width}
+						onClick={onClick}
 					/>
-				}
+				)}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -4,6 +4,7 @@ import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { RightColumn } from './RightColumn';
 import { Section } from './Section';
+import { YoutubeAtomCardOverlay } from './YoutubeAtom/YoutubeAtomCardOverlay';
 import { YoutubeBlockComponent } from './YoutubeBlockComponent.importable';
 
 export default {
@@ -54,6 +55,16 @@ export const Default = () => {
 				expired={false}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -90,6 +101,16 @@ export const Vertical = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -127,6 +148,16 @@ export const Expired = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -165,6 +196,16 @@ export const WithOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -224,6 +265,16 @@ export const WithPosterImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -284,6 +335,16 @@ export const WithPosterAndOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -344,12 +405,22 @@ export const WithShowMainVideoFlagOff = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				YoutubeAtomOverlay={
+					<YoutubeAtomCardOverlay
+						format={{
+							display: ArticleDisplay.Standard,
+							design: ArticleDesign.Standard,
+							theme: Pillar.News,
+						}}
+						hidePillOnMobile={false}
+					/>
+				}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -58,7 +58,6 @@ export const Default = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -72,7 +71,9 @@ export const Default = () => {
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
 						posterImage={posterImage}
-						title={title}
+						title={
+							"Prince Harry and Meghan's 'bombshell' plans explained – video"
+						}
 						height={height}
 						width={width}
 						onClick={onClick}
@@ -117,7 +118,6 @@ export const Vertical = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -131,7 +131,9 @@ export const Vertical = () => {
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
 						posterImage={posterImage}
-						title={title}
+						title={
+							"Prince Harry and Meghan's 'bombshell' plans explained – video"
+						}
 						height={height}
 						width={width}
 						onClick={onClick}
@@ -177,7 +179,6 @@ export const Expired = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -191,7 +192,9 @@ export const Expired = () => {
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
 						posterImage={posterImage}
-						title={title}
+						title={
+							"Prince Harry and Meghan's 'bombshell' plans explained – video"
+						}
 						height={height}
 						width={width}
 						onClick={onClick}
@@ -238,7 +241,6 @@ export const WithOverlayImage = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -252,7 +254,9 @@ export const WithOverlayImage = () => {
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
 						posterImage={posterImage}
-						title={title}
+						title={
+							"Prince Harry and Meghan's 'bombshell' plans explained – video"
+						}
 						height={height}
 						width={width}
 						onClick={onClick}
@@ -320,7 +324,6 @@ export const WithPosterImage = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -334,7 +337,9 @@ export const WithPosterImage = () => {
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
 						posterImage={posterImage}
-						title={title}
+						title={
+							"Prince Harry and Meghan's 'bombshell' plans explained – video"
+						}
 						height={height}
 						width={width}
 						onClick={onClick}
@@ -353,6 +358,8 @@ export const WithPosterImage = () => {
 WithPosterImage.storyName = 'with poster image';
 
 export const WithPosterAndOverlayImage = () => {
+	const title =
+		"Prince Harry and Meghan's 'bombshell' plans explained – video";
 	return (
 		<Wrapper>
 			<p>
@@ -368,7 +375,7 @@ export const WithPosterAndOverlayImage = () => {
 					theme: Pillar.News,
 				}}
 				assetId="d2Q5bXvEgMg"
-				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+				mediaTitle={title}
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
 				index={0}
 				expired={false}
@@ -403,7 +410,6 @@ export const WithPosterAndOverlayImage = () => {
 				renderOverlay={({
 					uniqueId,
 					posterImage,
-					title,
 					height,
 					width,
 					onClick,
@@ -436,6 +442,11 @@ export const WithPosterAndOverlayImage = () => {
 WithPosterAndOverlayImage.storyName = 'with poster and overlay image';
 
 export const WithShowMainVideoFlagOff = () => {
+	const title =
+		"Prince Harry and Meghan's 'bombshell' plans explained – video";
+	const height = 259;
+	const width = 460;
+
 	return (
 		<Wrapper>
 			<p>
@@ -451,7 +462,7 @@ export const WithShowMainVideoFlagOff = () => {
 					theme: Pillar.News,
 				}}
 				assetId="d2Q5bXvEgMg"
-				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+				mediaTitle={title}
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
 				index={0}
 				expired={false}
@@ -483,14 +494,7 @@ export const WithShowMainVideoFlagOff = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				renderOverlay={({
-					uniqueId,
-					posterImage,
-					title,
-					height,
-					width,
-					onClick,
-				}) => (
+				renderOverlay={({ uniqueId, posterImage, onClick }) => (
 					<YoutubeAtomCardOverlay
 						format={{
 							display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -4,7 +4,7 @@ import { Flex } from './Flex';
 import { LeftColumn } from './LeftColumn';
 import { RightColumn } from './RightColumn';
 import { Section } from './Section';
-import { YoutubeAtomCardOverlay } from './YoutubeAtom/YoutubeAtomCardOverlay';
+import { YoutubeAtomOverlayCard } from './YoutubeAtom/YoutubeAtomOverlayCard';
 import { YoutubeBlockComponent } from './YoutubeBlockComponent.importable';
 
 export default {
@@ -57,12 +57,12 @@ export const Default = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -70,7 +70,7 @@ export const Default = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={
 							"Prince Harry and Meghan's 'bombshell' plans explained – video"
 						}
@@ -117,12 +117,12 @@ export const Vertical = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -130,7 +130,7 @@ export const Vertical = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={
 							"Prince Harry and Meghan's 'bombshell' plans explained – video"
 						}
@@ -178,12 +178,12 @@ export const Expired = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -191,7 +191,7 @@ export const Expired = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={
 							"Prince Harry and Meghan's 'bombshell' plans explained – video"
 						}
@@ -240,12 +240,12 @@ export const WithOverlayImage = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -253,7 +253,7 @@ export const WithOverlayImage = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={
 							"Prince Harry and Meghan's 'bombshell' plans explained – video"
 						}
@@ -274,7 +274,7 @@ export const WithOverlayImage = () => {
 };
 WithOverlayImage.storyName = 'with overlay image';
 
-export const WithPosterImage = () => {
+export const Withimage = () => {
 	return (
 		<Wrapper>
 			<p>
@@ -323,12 +323,12 @@ export const WithPosterImage = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -336,7 +336,7 @@ export const WithPosterImage = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={
 							"Prince Harry and Meghan's 'bombshell' plans explained – video"
 						}
@@ -355,7 +355,7 @@ export const WithPosterImage = () => {
 		</Wrapper>
 	);
 };
-WithPosterImage.storyName = 'with poster image';
+Withimage.storyName = 'with poster image';
 
 export const WithPosterAndOverlayImage = () => {
 	const title =
@@ -409,12 +409,12 @@ export const WithPosterAndOverlayImage = () => {
 				enableAds={false}
 				renderOverlay={({
 					uniqueId,
-					posterImage,
+					image,
 					height,
 					width,
 					onClick,
 				}) => (
-					<YoutubeAtomCardOverlay
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -422,7 +422,7 @@ export const WithPosterAndOverlayImage = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={title}
 						height={height}
 						width={width}
@@ -444,8 +444,6 @@ WithPosterAndOverlayImage.storyName = 'with poster and overlay image';
 export const WithShowMainVideoFlagOff = () => {
 	const title =
 		"Prince Harry and Meghan's 'bombshell' plans explained – video";
-	const height = 259;
-	const width = 460;
 
 	return (
 		<Wrapper>
@@ -494,8 +492,14 @@ export const WithShowMainVideoFlagOff = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
-				renderOverlay={({ uniqueId, posterImage, onClick }) => (
-					<YoutubeAtomCardOverlay
+				renderOverlay={({
+					uniqueId,
+					image,
+					height,
+					width,
+					onClick,
+				}) => (
+					<YoutubeAtomOverlayCard
 						format={{
 							display: ArticleDisplay.Standard,
 							design: ArticleDesign.Standard,
@@ -503,7 +507,7 @@ export const WithShowMainVideoFlagOff = () => {
 						}}
 						hidePillOnMobile={false}
 						uniqueId={uniqueId}
-						posterImage={posterImage}
+						image={image}
 						title={title}
 						height={height}
 						width={width}

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -12,6 +12,17 @@ export const getLargest = (images: Image[]): Image | undefined => {
 	return images.slice().sort(descendingByWidthComparator)[0];
 };
 
+/**
+ * Finds the largest image by width in an array of images
+ */
+export const getLargestImageSize = (
+	images: {
+		url: string;
+		width: number;
+	}[],
+): { url: string; width: number } | undefined =>
+	[...images].sort((a, b) => a.width - b.width).pop();
+
 const getServiceFromUrl = (url: URL): string => {
 	const serviceName = url.hostname.split('.')[0] ?? '';
 	switch (serviceName) {

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -858,21 +858,20 @@ export const renderElement = ({
 						renderOverlay={({
 							uniqueId,
 							posterImage,
-							title,
 							height,
 							width,
 							onClick,
 						}) => (
 							<YoutubeAtomCardOverlay
-								alt={element.altText}
-								format={format}
-								hidePillOnMobile={false}
 								uniqueId={uniqueId}
 								posterImage={posterImage}
-								title={title}
 								height={height}
 								width={width}
 								onClick={onClick}
+								alt={element.altText}
+								format={format}
+								hidePillOnMobile={false}
+								title={element.mediaTitle}
 							/>
 						)}
 					/>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -60,6 +60,7 @@ import {
 	WitnessTextBlockComponent,
 	WitnessVideoBlockComponent,
 } from '../components/WitnessBlockComponent';
+import { YoutubeAtomCardOverlay } from '../components/YoutubeAtom/YoutubeAtomCardOverlay';
 import { YoutubeBlockComponent } from '../components/YoutubeBlockComponent.importable';
 import { YoutubeEmbedBlockComponent } from '../components/YoutubeEmbedBlockComponent';
 import {
@@ -851,10 +852,16 @@ export const renderElement = ({
 						posterImage={element.posterImage}
 						duration={element.duration}
 						mediaTitle={element.mediaTitle}
-						altText={element.altText}
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
 						enableAds={true}
+						YoutubeAtomOverlay={
+							<YoutubeAtomCardOverlay
+								alt={element.altText}
+								format={format}
+								hidePillOnMobile={false}
+							/>
+						}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -870,7 +870,6 @@ export const renderElement = ({
 								title={element.mediaTitle}
 								format={format}
 								onClick={onClick}
-								hidePillOnMobile={false}
 								alt={element.altText}
 								duration={element.duration}
 							/>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -60,7 +60,7 @@ import {
 	WitnessTextBlockComponent,
 	WitnessVideoBlockComponent,
 } from '../components/WitnessBlockComponent';
-import { YoutubeAtomCardOverlay } from '../components/YoutubeAtom/YoutubeAtomCardOverlay';
+import { YoutubeAtomOverlayArticle } from '../components/YoutubeAtom/YoutubeAtomOverlayArticle';
 import { YoutubeBlockComponent } from '../components/YoutubeBlockComponent.importable';
 import { YoutubeEmbedBlockComponent } from '../components/YoutubeEmbedBlockComponent';
 import {
@@ -857,21 +857,22 @@ export const renderElement = ({
 						enableAds={true}
 						renderOverlay={({
 							uniqueId,
-							posterImage,
+							image,
 							height,
 							width,
 							onClick,
 						}) => (
-							<YoutubeAtomCardOverlay
+							<YoutubeAtomOverlayArticle
 								uniqueId={uniqueId}
-								posterImage={posterImage}
 								height={height}
 								width={width}
-								onClick={onClick}
-								alt={element.altText}
-								format={format}
-								hidePillOnMobile={false}
+								image={image}
 								title={element.mediaTitle}
+								format={format}
+								onClick={onClick}
+								hidePillOnMobile={false}
+								alt={element.altText}
+								duration={element.duration}
 							/>
 						)}
 					/>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -855,13 +855,26 @@ export const renderElement = ({
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
 						enableAds={true}
-						YoutubeAtomOverlay={
+						renderOverlay={({
+							uniqueId,
+							posterImage,
+							title,
+							height,
+							width,
+							onClick,
+						}) => (
 							<YoutubeAtomCardOverlay
 								alt={element.altText}
 								format={format}
 								hidePillOnMobile={false}
+								uniqueId={uniqueId}
+								posterImage={posterImage}
+								title={title}
+								height={height}
+								width={width}
+								onClick={onClick}
 							/>
-						}
+						)}
 					/>
 				</Island>
 			);


### PR DESCRIPTION
## What does this change?

Refactors the YoutubeOverlay component out of the YoutubeAtom.

Refactors the Card Play Icon to accept props that makes sense for the component.

## Why?

The overlay for the YouTube atom is tightly coupled with the YouTube overlay, which is configured for the Card component. For the new Fronts pages, we would like to use the YouTube player within our new FeatureCard component. See [this PR](https://github.com/guardian/dotcom-rendering/pull/13318) for details. The existing functionality within `YoutubeBlockComponent` and `YoutubeAtom` is exactly what we need for our `FeatureCard`, however, the overlay will be completely different.

## Screenshots

No visual changes.
