### PR TITLE
Refactor card gap sizing logic

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -638,6 +638,13 @@ export const Card = ({
 			};
 		}
 
+		if (isFlexSplash) {
+			return {
+				row: 'small',
+				column: 'none',
+			};
+		}
+
 		/**
 		 * Media cards have 4px padding around the content so we have a
 		 * tiny (4px) gap to account for this and make it 8px total
@@ -1061,7 +1068,10 @@ export const Card = ({
 							isBetaContainer,
 							isOnwardContent,
 						)}
-						isFlexibleContainer={isFlexibleContainer}
+						padRight={
+							isFlexSplash ||
+							(isFlexibleContainer && imageSize === 'jumbo')
+						}
 					>
 						{/* This div is needed to keep the headline and trail text justified at the start */}
 						<div

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1069,7 +1069,7 @@ export const Card = ({
 							isOnwardContent,
 						)}
 						padRight={
-							isFlexSplash ||
+							!!isFlexSplash ||
 							(isFlexibleContainer && imageSize === 'jumbo')
 						}
 					>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -626,7 +626,10 @@ export const Card = ({
 		}
 	};
 
-	/** Determines the gap of between card components based on card properties */
+	/**
+	 * Determines the gap of between card components based on card properties
+	 * Order matters here as the logic is based on the card properties
+	 */
 	const getGapSizes = (): GapSizes => {
 		if (isOnwardContent) {
 			return {
@@ -634,43 +637,43 @@ export const Card = ({
 				column: 'none',
 			};
 		}
-		if (isMediaCardOrNewsletter && !isFlexibleContainer) {
+
+		/**
+		 * Media cards have 4px padding around the content so we have a
+		 * tiny (4px) gap to account for this and make it 8px total
+		 */
+		if (!isBetaContainer && isMediaCardOrNewsletter) {
 			return {
 				row: 'tiny',
 				column: 'tiny',
 			};
 		}
-		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
-			return {
-				row: 'small',
-				column: 'small',
-			};
+
+		// Current cards have small padding for everything
+		if (!isBetaContainer) {
+			return { row: 'small', column: 'small' };
 		}
+
 		if (isSmallCard) {
 			return {
 				row: 'medium',
 				column: 'medium',
 			};
 		}
-		if (isBetaContainer && media?.type === 'avatar') {
-			return {
-				row: 'small',
-				column: 'small',
-			};
-		}
+
 		if (
-			isFlexibleContainer &&
-			(imagePositionOnDesktop === 'left' ||
-				imagePositionOnDesktop === 'right')
+			imagePositionOnDesktop === 'bottom' ||
+			imagePositionOnMobile === 'bottom'
 		) {
 			return {
-				row: 'large',
+				row: 'tiny',
 				column: 'large',
 			};
 		}
+
 		return {
-			row: isBetaContainer ? 'tiny' : 'small',
-			column: 'small',
+			row: 'small',
+			column: 'large',
 		};
 	};
 

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -176,7 +176,7 @@ const decideColumnGap = (gapSize: GapSize) => css`
 	column-gap: ${decideGap(gapSize)};
 
 	${until.tablet} {
-		column-gap: ${gapSize === 'large' ? `10px` : decideGap(gapSize)}px;
+		column-gap: ${gapSize === 'large' ? '10px' : decideGap(gapSize)};
 	}
 `;
 

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -172,6 +172,14 @@ const decideGap = (gapSize: GapSize) => {
 	}
 };
 
+const decideColumnGap = (gapSize: GapSize) => css`
+	column-gap: ${decideGap(gapSize)};
+
+	${until.tablet} {
+		column-gap: ${gapSize === 'large' ? `10px` : decideGap(gapSize)}px;
+	}
+`;
+
 export const CardLayout = ({
 	children,
 	cardBackgroundColour,
@@ -196,11 +204,11 @@ export const CardLayout = ({
 					isBetaContainer,
 					imageType === 'avatar',
 				),
+				decideColumnGap(gapSizes.column),
 			]}
 			style={{
 				backgroundColor: cardBackgroundColour,
 				rowGap: decideGap(gapSizes.row),
-				columnGap: decideGap(gapSizes.column),
 			}}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -61,30 +61,7 @@ const flexBasisStyles = ({
 	}
 };
 
-const paddingStyles = (
-	imagePosition: ImagePositionType,
-	isFlexibleContainer: boolean,
-	paddingWidth: 1 | 2,
-) => {
-	/**
-	 * If we're in a flexible container there is a 20px gap between the image
-	 * and content. We don't apply padding to the content on the same edge as
-	 * the image so the content is aligned with the grid.
-	 */
-	if (isFlexibleContainer && imagePosition === 'left') {
-		return css`
-			padding: ${space[paddingWidth]}px ${space[paddingWidth]}px
-				${space[paddingWidth]}px 0;
-		`;
-	}
-
-	if (isFlexibleContainer && imagePosition === 'right') {
-		return css`
-			padding: ${space[paddingWidth]}px 0 ${space[paddingWidth]}px
-				${space[paddingWidth]}px;
-		`;
-	}
-
+const paddingStyles = (paddingWidth: 1 | 2) => {
 	return css`
 		padding: ${space[paddingWidth]}px;
 	`;
@@ -96,7 +73,7 @@ type Props = {
 	imageSize: ImageSizeType;
 	imagePositionOnDesktop: ImagePositionType;
 	padContent?: 'small' | 'large';
-	isFlexibleContainer?: boolean;
+	padRight?: boolean;
 };
 
 export const ContentWrapper = ({
@@ -105,7 +82,7 @@ export const ContentWrapper = ({
 	imageSize,
 	imagePositionOnDesktop,
 	padContent,
-	isFlexibleContainer = false,
+	padRight = false,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -116,12 +93,11 @@ export const ContentWrapper = ({
 				sizingStyles,
 				isHorizontalOnDesktop &&
 					flexBasisStyles({ imageSize, imageType }),
-				padContent &&
-					paddingStyles(
-						imagePositionOnDesktop,
-						isFlexibleContainer,
-						padContent === 'small' ? 1 : 2,
-					),
+				padContent && paddingStyles(padContent === 'small' ? 1 : 2),
+				padRight &&
+					css`
+						padding-right: ${space[5]}px;
+					`,
 			]}
 		>
 			{children}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
