### PR TITLE
Only add background colour to passback ads

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -166,7 +166,6 @@ const spacefinderAdSlotStyles = css`
     Let the ad slot take control of its height once rendered. */
 	.ad-slot--inline {
 		min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
-		background-color: ${palette('--ad-background')};
 	}
 
 	/* Give inline1 ad slot a different placeholder height comparing to subsequent-inlines to reduce CLS.
@@ -184,6 +183,12 @@ const spacefinderAdSlotStyles = css`
 	.ad-slot--top-above-nav {
 		${until.tablet} {
 			min-height: ${adSizes.mpu.height + constants.AD_LABEL_HEIGHT}px;
+		}
+	}
+
+	#dfp-ad--top-above-nav--passback {
+		${until.tablet} {
+			background-color: ${palette('--ad-background')};
 		}
 	}
 


### PR DESCRIPTION
## What does this change?
Only adds the ad slot background colour to mobile top-above-nav passback ads.

## Why?
Some outstream ads are serving in PROD not through passback, which I couldn't replicate when developing locally or on CODE. This means the grey background added in https://github.com/guardian/dotcom-rendering/pull/13241 looks ugly on them, because they're lacking the vertical centering added by the passback code. By only adding the grey background for passback ads, we can improve the formatting of the mobile inlines.

We should look to vertically centre the ads as a follow up, but just removing the background colour is an improvement for now. I tried adding some vertical centering locally but it was creating CLS with the ad label, so we can do this as a follow up.

## Screenshots
### Passback ad before & after
<img width="317" alt="Screenshot 2025-02-10 at 13 22 44" src="https://github.com/user-attachments/assets/d70f80f6-a521-4d33-8ae0-23ce2772ed73" />

### Outstream ad before
<img width="321" alt="Screenshot 2025-02-10 at 13 39 13" src="https://github.com/user-attachments/assets/cb9175d6-0233-4ce2-a538-7f98a1829389" />

### Outstream ad after
<img width="327" alt="Screenshot 2025-02-10 at 13 45 44" src="https://github.com/user-attachments/assets/932df924-3f74-487a-a6d5-649d0ee9e7de" />

