### PR TITLE
Pass clientName to marketing components

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -201,6 +201,7 @@ const Fetch = ({
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: pageUrl,
+		clientName: 'dcr',
 	};
 
 	// Add submitComponentEvent function to props to enable Ophan tracking in the component

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -147,6 +147,7 @@ export const canShowReaderRevenueEpic = async (
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: window.location.origin + window.location.pathname,
+		clientName: 'dcr',
 	};
 	const enrichedProps: EpicProps = {
 		...props,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -293,6 +293,7 @@ export const canShowRRBanner: CanShowFunctionType<
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: window.location.origin + window.location.pathname,
+		clientName: 'dcr',
 	};
 	const enrichedProps: BannerProps = {
 		...props,

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -135,6 +135,7 @@ const ReaderRevenueLinksRemote = ({
 			ophanPageId: pageViewId,
 			platformId: 'GUARDIAN_WEB',
 			referrerUrl: pageUrl,
+			clientName: 'dcr',
 		};
 		const enrichedProps: HeaderProps = {
 			...props,


### PR DESCRIPTION
A [recent PR](https://github.com/guardian/dotcom-rendering/pull/13292) made a change to pass page tracking fields directly into the marketing components. This is so that we can stop sending these fields via SDC (the API).

As part of this I'll be removing the `clientName` field as nothing uses it. However, I've realised I can't do this just yet without temporarily breaking validation of the component props, because `clientName` is still part of the model.

So this PR just adds the `clientName` field to the set of fields in the tracking object that is passed to the marketing components.