### PR TITLE
Create Football match page component

### DIFF
--- a/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
@@ -38,6 +38,7 @@ export const FootballCompetitionSelect = {
 				],
 			},
 		],
+		kind: 'Result',
 		onChange: fn(),
 	},
 	play: async ({ args, canvasElement }) => {

--- a/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
@@ -1,17 +1,32 @@
 import { Option, Select } from '@guardian/source/react-components';
+import type { FootballMatchKind } from '../footballMatches';
 import { palette } from '../palette';
 
-type Nations = Array<{
+export type Nations = Array<{
 	name: string;
 	competitions: Array<{ tag: string; name: string }>;
 }>;
 
 type Props = {
 	nations: Nations;
+	kind: Exclude<FootballMatchKind, 'Live'>;
 	onChange: (competitionTag: string) => void;
 };
 
-export const FootballCompetitionSelect = ({ nations, onChange }: Props) => (
+const allLabel = (kind: Exclude<FootballMatchKind, 'Live'>): string => {
+	switch (kind) {
+		case 'Fixture':
+			return 'All fixtures';
+		case 'Result':
+			return 'All results';
+	}
+};
+
+export const FootballCompetitionSelect = ({
+	nations,
+	kind,
+	onChange,
+}: Props) => (
 	<Select
 		label="Choose league:"
 		onChange={(e) => onChange(e.target.value)}
@@ -21,7 +36,7 @@ export const FootballCompetitionSelect = ({ nations, onChange }: Props) => (
 			backgroundInput: palette('--article-background'),
 		}}
 	>
-		<Option value="All">All results</Option>
+		<Option value="All">{allLabel(kind)}</Option>
 		{nations.map((nation) => (
 			<optgroup label={nation.name} key={nation.name}>
 				{nation.competitions.map((competition) => (

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -14,7 +14,11 @@ import {
 	SvgPlus,
 } from '@guardian/source/react-components';
 import { Fragment, type ReactNode, useState } from 'react';
-import type { FootballMatch, FootballMatches } from '../footballMatches';
+import type {
+	FootballMatch,
+	FootballMatches,
+	FootballMatchKind,
+} from '../footballMatches';
 import { grid } from '../grid';
 import {
 	type EditionId,
@@ -171,7 +175,7 @@ const matchListItemStyles = css`
 	}
 `;
 
-const matchStyles = (matchKind: FootballMatch['kind']) => css`
+const matchStyles = (matchKind: FootballMatchKind) => css`
 	${textSans14}
 
 	${matchKind === 'Live' ? 'font-weight: bold;' : undefined}

--- a/dotcom-rendering/src/components/FootballMatchesPage.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.importable.tsx
@@ -10,7 +10,6 @@ import { FootballMatchList } from './FootballMatchList';
 
 type Props = {
 	nations: Nations;
-	title: string;
 	guardianBaseUrl: string;
 	kind: FootballMatchKind;
 	goToCompetitionSpecificPage: (tag: string) => void;
@@ -19,9 +18,23 @@ type Props = {
 	getMoreDays?: () => Promise<Result<'failed', FootballMatches>>;
 };
 
+const createTitle = (kind: FootballMatchKind, edition: EditionId) => {
+	if (edition === 'US' && kind === 'Fixture') {
+		return 'Soccer schedules';
+	}
+
+	switch (kind) {
+		case 'Fixture':
+			return 'Football fixtures';
+		case 'Live':
+			return 'Live football scores';
+		case 'Result':
+			return 'Football results';
+	}
+};
+
 export const FootballMatchesPage = ({
 	nations,
-	title,
 	guardianBaseUrl,
 	kind,
 	goToCompetitionSpecificPage,
@@ -34,9 +47,8 @@ export const FootballMatchesPage = ({
 			<h1
 				css={css`
 					${headlineBold20}
-					padding-top: 6px;
-					padding-bottom: ${space[3]}px;
-					${grid.between('centre-column-start', 'centre-column-end')}
+					padding: ${space[1]}px 0 ${space[3]}px;
+					${grid.column.centre}
 					${from.leftCol} {
 						${grid.between(
 							'left-column-start',
@@ -45,7 +57,7 @@ export const FootballMatchesPage = ({
 					}
 				`}
 			>
-				{title}
+				{createTitle(kind, edition)}
 			</h1>
 			{kind !== 'Live' && (
 				<div

--- a/dotcom-rendering/src/components/FootballMatchesPage.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.importable.tsx
@@ -1,0 +1,73 @@
+import { css } from '@emotion/react';
+import { from, headlineBold20, space } from '@guardian/source/foundations';
+import type { FootballMatches, FootballMatchKind } from '../footballMatches';
+import { grid } from '../grid';
+import type { EditionId } from '../lib/edition';
+import type { Result } from '../lib/result';
+import type { Nations } from './FootballCompetitionSelect';
+import { FootballCompetitionSelect } from './FootballCompetitionSelect';
+import { FootballMatchList } from './FootballMatchList';
+
+type Props = {
+	nations: Nations;
+	title: string;
+	guardianBaseUrl: string;
+	kind: FootballMatchKind;
+	goToCompetitionSpecificPage: (tag: string) => void;
+	initialDays: FootballMatches;
+	edition: EditionId;
+	getMoreDays?: () => Promise<Result<'failed', FootballMatches>>;
+};
+
+export const FootballMatchesPage = ({
+	nations,
+	title,
+	guardianBaseUrl,
+	kind,
+	goToCompetitionSpecificPage,
+	initialDays,
+	edition,
+	getMoreDays,
+}: Props) => (
+	<>
+		<section css={css(grid.container)}>
+			<h1
+				css={css`
+					${headlineBold20}
+					padding-top: 6px;
+					padding-bottom: ${space[3]}px;
+					${grid.between('centre-column-start', 'centre-column-end')}
+					${from.leftCol} {
+						${grid.between(
+							'left-column-start',
+							'centre-column-end',
+						)}
+					}
+				`}
+			>
+				{title}
+			</h1>
+			{kind !== 'Live' && (
+				<div
+					css={css`
+						margin-top: ${space[3]}px;
+						margin-bottom: ${space[6]}px;
+						${grid.column.centre}
+					`}
+				>
+					<FootballCompetitionSelect
+						nations={nations}
+						kind={kind}
+						onChange={goToCompetitionSpecificPage}
+					/>
+				</div>
+			)}
+		</section>
+		<FootballMatchList
+			initialDays={initialDays}
+			edition={edition}
+			getMoreDays={getMoreDays}
+			guardianBaseUrl={guardianBaseUrl}
+		/>
+	</>
+);

--- a/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
@@ -1,0 +1,72 @@
+import type { StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { FootballMatchesPage as FootballMatchesPageComponent } from './FootballMatchesPage.importable';
+import { Default as MatchListDefault } from './FootballMatchList.stories';
+
+const meta = {
+	title: 'Components/Football Matches Page',
+	component: FootballMatchesPageComponent,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		title: 'Football results',
+		nations: [
+			{
+				name: 'England',
+				competitions: [
+					{ tag: 'football/premierleague', name: 'Premier League' },
+					{ tag: 'football/championship', name: 'Championship' },
+				],
+			},
+		],
+		guardianBaseUrl: 'https://www.theguardian.com',
+		kind: 'Fixture',
+		initialDays: MatchListDefault.args.initialDays,
+		edition: 'UK',
+		goToCompetitionSpecificPage: fn(),
+	},
+} satisfies Story;
+
+export const LiveScores = {
+	args: {
+		title: 'Live football scores',
+		nations: [
+			{
+				name: 'England',
+				competitions: [
+					{ tag: 'football/premierleague', name: 'Premier League' },
+					{ tag: 'football/championship', name: 'Championship' },
+				],
+			},
+		],
+		guardianBaseUrl: 'https://www.theguardian.com',
+		kind: 'Live',
+		initialDays: MatchListDefault.args.initialDays,
+		edition: 'UK',
+		goToCompetitionSpecificPage: fn(),
+	},
+} satisfies Story;
+
+export const Fixtures = {
+	args: {
+		title: 'Football fixtures',
+		nations: [
+			{
+				name: 'England',
+				competitions: [
+					{ tag: 'football/premierleague', name: 'Premier League' },
+					{ tag: 'football/championship', name: 'Championship' },
+				],
+			},
+		],
+		guardianBaseUrl: 'https://www.theguardian.com',
+		kind: 'Fixture',
+		initialDays: MatchListDefault.args.initialDays,
+		edition: 'UK',
+		goToCompetitionSpecificPage: fn(),
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
@@ -1,19 +1,18 @@
 import type { StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { FootballMatchesPage as FootballMatchesPageComponent } from './FootballMatchesPage.importable';
+import { FootballMatchesPage } from './FootballMatchesPage.importable';
 import { Default as MatchListDefault } from './FootballMatchList.stories';
 
 const meta = {
 	title: 'Components/Football Matches Page',
-	component: FootballMatchesPageComponent,
+	component: FootballMatchesPage,
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const Results = {
 	args: {
-		title: 'Football results',
 		nations: [
 			{
 				name: 'England',
@@ -24,7 +23,7 @@ export const Default = {
 			},
 		],
 		guardianBaseUrl: 'https://www.theguardian.com',
-		kind: 'Fixture',
+		kind: 'Result',
 		initialDays: MatchListDefault.args.initialDays,
 		edition: 'UK',
 		goToCompetitionSpecificPage: fn(),
@@ -33,40 +32,14 @@ export const Default = {
 
 export const LiveScores = {
 	args: {
-		title: 'Live football scores',
-		nations: [
-			{
-				name: 'England',
-				competitions: [
-					{ tag: 'football/premierleague', name: 'Premier League' },
-					{ tag: 'football/championship', name: 'Championship' },
-				],
-			},
-		],
-		guardianBaseUrl: 'https://www.theguardian.com',
+		...Results.args,
 		kind: 'Live',
-		initialDays: MatchListDefault.args.initialDays,
-		edition: 'UK',
-		goToCompetitionSpecificPage: fn(),
 	},
 } satisfies Story;
 
 export const Fixtures = {
 	args: {
-		title: 'Football fixtures',
-		nations: [
-			{
-				name: 'England',
-				competitions: [
-					{ tag: 'football/premierleague', name: 'Premier League' },
-					{ tag: 'football/championship', name: 'Championship' },
-				],
-			},
-		],
-		guardianBaseUrl: 'https://www.theguardian.com',
+		...Results.args,
 		kind: 'Fixture',
-		initialDays: MatchListDefault.args.initialDays,
-		edition: 'UK',
-		goToCompetitionSpecificPage: fn(),
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -30,6 +30,7 @@ export type LiveMatch = MatchData & {
 };
 
 export type FootballMatch = MatchResult | MatchFixture | LiveMatch;
+export type FootballMatchKind = FootballMatch['kind'];
 
 type Competition = {
 	competitionId: string;


### PR DESCRIPTION
## What does this change?
Creates a component that stitches together the components we've built so far, `FootballMatchList` and `FootballCompetitionSelect`, plus the page's title into a component that will be hydrated in an island

