### PR TITLE
Clean up highlight test tracking

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -7,7 +7,6 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
-import { submitComponentEvent } from '../client/ophan/ophan';
 import { ophanComponentId } from '../lib/ophan-helpers';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
@@ -230,22 +229,6 @@ export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 				updateButtonVisibilityOnScroll,
 			);
 		};
-	}, []);
-	useEffect(() => {
-		void submitComponentEvent(
-			{
-				abTest: {
-					name: 'masthead-with-highlights',
-					variant: 'inTest',
-				},
-				component: {
-					componentType: 'CAROUSEL',
-					id: 'home-highlights',
-				},
-				action: 'INSERT',
-			},
-			'Web',
-		);
 	}, []);
 
 	const { ophanComponentLink, ophanComponentName, ophanFrontName } =


### PR DESCRIPTION
## What does this change?
Removes component tracking from the highlights container test 🧹 

## Why?
The test ended last year and so this tracking is no longer needed.
