### PR TITLE
Auxia Experiment (Part 12): better fake browserId

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -448,7 +448,7 @@ const decideBrowserId = (): string => {
 	// getCookie({ name: 'bwid', shouldMemoize: true })
 	// but we are not calling it for the moment until we have guidance on
 	// how to handle the bwid cookie in the context of this experiment.
-	return '2598326e-7c';
+	return '2598326e7c';
 };
 
 const decideIsSupporter = (): boolean => {


### PR DESCRIPTION
Turns out that Auxia does validation and my original fake `browserId` causes them to answer something we are not handling well, which caused sdc to 500 🎉 (This will be followed by a sdc PR to try catch parsing the Auxia answer).

Avoid:

![Screenshot 2025-02-10 at 17 00 12](https://github.com/user-attachments/assets/2afb557e-216f-4b28-bcd7-de58d4348cc5)


