### PR TITLE
Auxia Experiment (Part 13): upgrade to new get-treatments answer schema

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -103,7 +103,12 @@ export interface AuxiaAPIResponseDataUserTreatment {
 	surface: string;
 }
 
-export interface SDCAuxiaProxyResponseData {
+export interface SDCAuxiaGetTreatmentsProxyResponse {
+	status: boolean;
+	data?: SDCAuxiaGetTreatmentsProxyResponseData;
+}
+
+export interface SDCAuxiaGetTreatmentsProxyResponseData {
 	responseId: string;
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -30,7 +30,8 @@ import type {
 	AuxiaInteractionInteractionType,
 	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
-	SDCAuxiaProxyResponseData,
+	SDCAuxiaGetTreatmentsProxyResponse,
+	SDCAuxiaGetTreatmentsProxyResponseData,
 	SignInGateComponent,
 } from './SignInGate/types';
 
@@ -478,7 +479,7 @@ const decideDailyArticleCount = (): number => {
 const fetchProxyGetTreatments = async (
 	contributionsServiceUrl: string,
 	pageId: string,
-): Promise<SDCAuxiaProxyResponseData> => {
+): Promise<SDCAuxiaGetTreatmentsProxyResponseData | undefined> => {
 	// We are defaulting to empty string if the cookie is not found, because the API expects a string
 	const browserId = decideBrowserId();
 
@@ -505,11 +506,14 @@ const fetchProxyGetTreatments = async (
 		body: JSON.stringify(payload),
 	};
 
-	const response = await fetch(url, params);
+	const response_raw = await fetch(url, params);
+	const response =
+		(await response_raw.json()) as SDCAuxiaGetTreatmentsProxyResponse;
 
-	const data = (await response.json()) as SDCAuxiaProxyResponseData;
-
-	return Promise.resolve(data);
+	if (response.status && response.data) {
+		return Promise.resolve(response.data);
+	}
+	return Promise.resolve(undefined);
 };
 
 const auxiaLogTreatmentInteraction = async (
@@ -559,7 +563,7 @@ const SignInGateSelectorAuxia = ({
 	);
 
 	const [auxiaGetTreatmentsData, setAuxiaGetTreatmentsData] = useState<
-		SDCAuxiaProxyResponseData | undefined
+		SDCAuxiaGetTreatmentsProxyResponseData | undefined
 	>(undefined);
 
 	// We are using CurrentSignInGateABTest, with the details of the Auxia experiment,
@@ -591,7 +595,9 @@ const SignInGateSelectorAuxia = ({
 				contributionsServiceUrl,
 				pageId,
 			);
-			setAuxiaGetTreatmentsData(data);
+			if (data !== undefined) {
+				setAuxiaGetTreatmentsData(data);
+			}
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);
 		});


### PR DESCRIPTION
Previously, in Auxia Integration: https://github.com/guardian/dotcom-rendering/pull/13335

This is the sister PR of the SDC change we just made: https://github.com/guardian/support-dotcom-components/pull/1285
Upgrading to the new `get-treatments` answer schema.