### PR TITLE
Fix tracking in epic + banner props

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -151,7 +151,7 @@ export const canShowReaderRevenueEpic = async (
 	};
 	const enrichedProps: EpicProps = {
 		...props,
-		...tracking,
+		tracking,
 		hasConsentForArticleCount,
 		fetchEmail,
 		submitComponentEvent: (componentEvent: OphanComponentEvent) =>

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -297,7 +297,7 @@ export const canShowRRBanner: CanShowFunctionType<
 	};
 	const enrichedProps: BannerProps = {
 		...props,
-		...tracking,
+		tracking,
 		fetchEmail,
 		submitComponentEvent: (componentEvent: OphanComponentEvent) =>
 			void submitComponentEvent(componentEvent, renderingTarget),


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/dotcom-rendering/pull/13292) changed DCR to pass the page tracking data into marketing components. This was in preparation for removing this data from the response from the API (SDC).
But for the epic + banner it incorrectly flattens the tracking object into the props, when it should be nested under the `tracking` field.
This isn't causing any issues yet, but will when we remove this data from the SDC response.
This PR fixes this.