### PR TITLE
Auxia Experiment (Part 14): gate signature and content update 

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -37,21 +37,23 @@ export const SignInGateAuxia = ({
 	/*
 	The treatmentContent object is expected to have the following structure:
 	{
-		"title": "Sign in for a personlised experience",
-		"subtitle": ""
+		"title": "Sign in for a personlised Guardian experience",
 		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
 		"first_cta_name": "Sign in",
 		"first_cta_link": "https://profile.theguardian.com/signin?",
 		"second_cta_name": "I'll do it later",
+		"subtitle": "Get less asks for support and more personalised recommendations",
+		"privacy_button_name": "privacy settings"
 	}
 	*/
 
 	const title = treatmentContent.title;
 	const body = treatmentContent.body;
+	const subtitle = treatmentContent.subtitle;
 	const firstCtaName = treatmentContent.first_cta_name;
 	const firstCtaLink = treatmentContent.first_cta_link;
 	const secondCtaName = treatmentContent.second_cta_name;
-	const subtitle = treatmentContent.subtitle;
+	const privacy_button_name = treatmentContent.privacy_button_name;
 
 	return (
 		<div css={signInGateContainer} data-testid="sign-in-gate-main">

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -42,10 +42,10 @@ export const SignInGateAuxia = ({
 		"title": "Sign in for a personlised Guardian experience",
 		"subtitle": "Get less asks for support and more personalised recommendations",
 		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
+		"privacy_button_name": "privacy settings"
 		"first_cta_name": "Sign in",
 		"first_cta_link": "https://profile.theguardian.com/signin?",
 		"second_cta_name": "I'll do it later",
-		"privacy_button_name": "privacy settings"
 	}
 
 	The component must be written to gracefully handle empty values for the following field:

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -1,3 +1,4 @@
+import { cmp } from '@guardian/libs';
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
@@ -12,6 +13,7 @@ import {
 	headingStyles,
 	hideElementsCss,
 	laterButton,
+	privacyLink,
 	registerButton,
 	signInGateContainer,
 	signInHeader,
@@ -24,7 +26,6 @@ export const SignInGateAuxia = ({
 	dismissGate,
 	abTest,
 	ophanComponentId,
-	isMandatory = false,
 	userTreatment,
 	logTreatmentInteractionCall,
 }: SignInGatePropsAuxia) => {
@@ -36,32 +37,63 @@ export const SignInGateAuxia = ({
 
 	/*
 	The treatmentContent object is expected to have the following structure:
+
 	{
 		"title": "Sign in for a personlised Guardian experience",
+		"subtitle": "Get less asks for support and more personalised recommendations",
 		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
 		"first_cta_name": "Sign in",
 		"first_cta_link": "https://profile.theguardian.com/signin?",
 		"second_cta_name": "I'll do it later",
-		"subtitle": "Get less asks for support and more personalised recommendations",
 		"privacy_button_name": "privacy settings"
 	}
+
+	The component must be written to gracefully handle empty values for the following field:
+		- subtitle
+		- body
+		- privacy_button_name
 	*/
 
 	const title = treatmentContent.title;
-	const body = treatmentContent.body;
 	const subtitle = treatmentContent.subtitle;
+	const body = treatmentContent.body;
+	const privacy_button_name = treatmentContent.privacy_button_name;
 	const firstCtaName = treatmentContent.first_cta_name;
 	const firstCtaLink = treatmentContent.first_cta_link;
 	const secondCtaName = treatmentContent.second_cta_name;
-	const privacy_button_name = treatmentContent.privacy_button_name;
+
+	const hasContent = (input: string): boolean => {
+		return input !== '';
+	};
 
 	return (
 		<div css={signInGateContainer} data-testid="sign-in-gate-main">
 			<style>{hideElementsCss}</style>
 			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>{title}</h1>
-			<p css={bodyBold}>{subtitle}</p>
-			<p css={bodyText}>{body}</p>
+			{hasContent(subtitle) && <p css={bodyBold}>{subtitle}</p>}
+			{hasContent(body) && (
+				<p css={bodyText}>
+					{body}{' '}
+					{hasContent(privacy_button_name) && (
+						<button
+							data-testid="sign-in-gate-main_privacy"
+							css={privacyLink}
+							onClick={() => {
+								cmp.showPrivacyManager();
+								trackLink(
+									ophanComponentId,
+									'privacy',
+									renderingTarget,
+									abTest,
+								);
+							}}
+						>
+							privacy settings
+						</button>
+					)}
+				</p>
+			)}
 			<div css={actionButtons}>
 				<LinkButton
 					data-testid="sign-in-gate-main_register"
@@ -90,34 +122,32 @@ export const SignInGateAuxia = ({
 				>
 					{firstCtaName}
 				</LinkButton>
-				{!isMandatory && (
-					<Button
-						data-testid="sign-in-gate-main_dismiss"
-						data-ignore="global-link-styling"
-						cssOverrides={laterButton}
-						priority="subdued"
-						size="small"
-						onClick={() => {
-							dismissGate();
-							trackLink(
-								ophanComponentId,
-								'not-now',
-								renderingTarget,
-								abTest,
-							);
-							logTreatmentInteractionCall('DISMISSED', '').catch(
-								(error) => {
-									console.error(
-										'Failed to log treatment interaction:',
-										error,
-									);
-								},
-							);
-						}}
-					>
-						{secondCtaName}
-					</Button>
-				)}
+				<Button
+					data-testid="sign-in-gate-main_dismiss"
+					data-ignore="global-link-styling"
+					cssOverrides={laterButton}
+					priority="subdued"
+					size="small"
+					onClick={() => {
+						dismissGate();
+						trackLink(
+							ophanComponentId,
+							'not-now',
+							renderingTarget,
+							abTest,
+						);
+						logTreatmentInteractionCall('DISMISSED', '').catch(
+							(error) => {
+								console.error(
+									'Failed to log treatment interaction:',
+									error,
+								);
+							},
+						);
+					}}
+				>
+					{secondCtaName}
+				</Button>
 			</div>
 
 			<p css={[bodySeparator, bodyBold, signInHeader]}>

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -36,18 +36,6 @@ export const SignInGateAuxia = ({
 	) as TreatmentContentDecoded;
 
 	/*
-	The treatmentContent object is expected to have the following structure:
-
-	{
-		"title": "Sign in for a personlised Guardian experience",
-		"subtitle": "Get less asks for support and more personalised recommendations",
-		"body": "By signing into your Guardian account you'll provide us with insights into your preferences that will result in a more personalised experience, including less frequent asks to support. You'll always be able to control your preferences in your own privacy settings.",
-		"privacy_button_name": "privacy settings"
-		"first_cta_name": "Sign in",
-		"first_cta_link": "https://profile.theguardian.com/signin?",
-		"second_cta_name": "I'll do it later",
-	}
-
 	The component must be written to gracefully handle empty values for the following field:
 		- subtitle
 		- body

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -88,10 +88,10 @@ export interface TreatmentContentDecoded {
 	title: string;
 	subtitle: string;
 	body: string;
+	privacy_button_name: string;
 	first_cta_name: string;
 	first_cta_link: string;
 	second_cta_name: string;
-	privacy_button_name: string;
 }
 
 export interface AuxiaAPIResponseDataUserTreatment {
@@ -133,7 +133,6 @@ export type SignInGatePropsAuxia = {
 	dismissGate: () => void;
 	ophanComponentId: string;
 	abTest?: CurrentSignInGateABTest;
-	isMandatory?: boolean;
 	checkoutCompleteCookieData?: CheckoutCompleteCookieData;
 	personaliseSignInGateAfterCheckoutSwitch?: boolean;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -91,6 +91,7 @@ export interface TreatmentContentDecoded {
 	first_cta_name: string;
 	first_cta_link: string;
 	second_cta_name: string;
+	privacy_button_name: string;
 }
 
 export interface AuxiaAPIResponseDataUserTreatment {


### PR DESCRIPTION
Previously in Auxia Experiment: https://github.com/guardian/dotcom-rendering/pull/13339

He we perform the following updates
- Add the newly introduced `privacy_button_name` to `TreatmentContentDecoded` 

- Remove `isMandatory?` (which was `false` in the case of Auxia) to the signature of the Auxia gate since we are not going to run the version where sign-in is mandatory. 

- Ensure that the gate gracefully handle the case of empty: 
    - subtitle
    - body
    - privacy_button_name

- Add the "privacy button", which was missing in the component. 