### PR TITLE
Stop sending tracking data to SDC

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -54,7 +54,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",
-		"@guardian/support-dotcom-components": "4.0.0",
+		"@guardian/support-dotcom-components": "6.0.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.45.3",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -34,10 +34,7 @@ test.describe('The banner', function () {
 		const rrBannerUrl = 'https://contributions.guardianapis.com/banner';
 
 		const rrBannerRequestPromise = page.waitForRequest((request) =>
-			requestBodyHasProperties(request, rrBannerUrl, [
-				'targeting',
-				'tracking',
-			]),
+			requestBodyHasProperties(request, rrBannerUrl, ['targeting']),
 		);
 
 		await loadPage(

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -89,7 +89,6 @@ const usePayload = ({
 	isPaidContent,
 	tags,
 	pageId,
-	ophanPageViewId,
 }: {
 	shouldHideReaderRevenue: boolean;
 	sectionId: string;
@@ -97,7 +96,6 @@ const usePayload = ({
 	tags: TagType[];
 	pageId: string;
 	keywordIds: string;
-	ophanPageViewId?: string;
 }): EpicPayload | undefined => {
 	const articleCounts = useArticleCounts(pageId, tags, 'LiveBlog');
 	const hasOptedOutOfArticleCount = useHasOptedOutOfArticleCount();
@@ -105,7 +103,6 @@ const usePayload = ({
 	const mvtId = useMvtId();
 	const isSignedIn = useIsSignedIn();
 
-	if (!ophanPageViewId) return;
 	if (isSignedIn === 'Pending') return;
 	const hideSupportMessagingForUser = shouldHideSupportMessaging(isSignedIn);
 	if (hideSupportMessagingForUser === 'Pending') return;
@@ -116,12 +113,6 @@ const usePayload = ({
 	log('dotcom', 'LiveBlogEpic has countryCode');
 
 	return {
-		tracking: {
-			ophanPageId: ophanPageViewId,
-			platformId: 'GUARDIAN_WEB',
-			clientName: 'dcr',
-			referrerUrl: window.location.origin + window.location.pathname,
-		},
 		targeting: {
 			contentType: 'LiveBlog',
 			sectionId,
@@ -201,7 +192,6 @@ const Fetch = ({
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: pageUrl,
-		clientName: 'dcr',
 	};
 
 	// Add submitComponentEvent function to props to enable Ophan tracking in the component
@@ -266,7 +256,6 @@ export const LiveBlogEpic = ({
 		tags,
 		pageId,
 		keywordIds,
-		ophanPageViewId,
 	});
 	if (!ophanPageViewId || !payload || !pageUrl) return null;
 

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -56,12 +56,6 @@ export type CanShowData = {
 const buildPayload = async (
 	data: CanShowData & { hideSupportMessagingForUser: boolean },
 ): Promise<EpicPayload> => ({
-	tracking: {
-		ophanPageId: window.guardian.config.ophan.pageViewId,
-		platformId: 'GUARDIAN_WEB',
-		clientName: 'dcr',
-		referrerUrl: window.location.origin + window.location.pathname,
-	},
 	targeting: {
 		contentType: data.contentType,
 		sectionId: data.sectionId,
@@ -147,7 +141,6 @@ export const canShowReaderRevenueEpic = async (
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: window.location.origin + window.location.pathname,
-		clientName: 'dcr',
 	};
 	const enrichedProps: EpicProps = {
 		...props,

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -140,12 +140,6 @@ const buildPayload = async ({
 	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
 
 	return {
-		tracking: {
-			ophanPageId: window.guardian.config.ophan.pageViewId,
-			platformId: 'GUARDIAN_WEB',
-			clientName: 'dcr',
-			referrerUrl: window.location.origin + window.location.pathname,
-		},
 		targeting: {
 			shouldHideReaderRevenue,
 			isPaidContent,
@@ -293,7 +287,6 @@ export const canShowRRBanner: CanShowFunctionType<
 		ophanPageId: ophanPageViewId,
 		platformId: 'GUARDIAN_WEB',
 		referrerUrl: window.location.origin + window.location.pathname,
-		clientName: 'dcr',
 	};
 	const enrichedProps: BannerProps = {
 		...props,

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -75,12 +75,6 @@ const ReaderRevenueLinksRemote = ({
 		setAutomat();
 
 		const requestData: HeaderPayload = {
-			tracking: {
-				ophanPageId: pageViewId,
-				platformId: 'GUARDIAN_WEB',
-				referrerUrl: pageUrl,
-				clientName: 'dcr',
-			},
 			targeting: {
 				showSupportMessaging: !hideSupportMessagingForUser,
 				countryCode,
@@ -135,7 +129,6 @@ const ReaderRevenueLinksRemote = ({
 			ophanPageId: pageViewId,
 			platformId: 'GUARDIAN_WEB',
 			referrerUrl: pageUrl,
-			clientName: 'dcr',
 		};
 		const enrichedProps: HeaderProps = {
 			...props,

--- a/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/banners/utils/storybook.ts
@@ -15,7 +15,6 @@ export const tracking: Tracking = {
 	ophanPageId: 'kbluzw2csbf83eabedel',
 	componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 	platformId: 'GUARDIAN_WEB',
-	clientName: 'dcr',
 	referrerUrl: 'http://localhost:3030/Article',
 	abTestName: 'UsEoyAppealBannerSupporters',
 	abTestVariant: 'control',

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -17,10 +17,7 @@ import {
 	containsNonArticleCountPlaceholder,
 	replaceNonArticleCountPlaceholders,
 } from '@guardian/support-dotcom-components';
-import type {
-	EpicProps,
-	Tracking,
-} from '@guardian/support-dotcom-components/dist/shared/types';
+import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types';
 import { useEffect } from 'react';
 import { useIsInView } from '../../../lib/useIsInView';
 import type { ReactComponent } from '../lib/ReactComponent';
@@ -33,7 +30,7 @@ import { logEpicView } from '../lib/viewLog';
 import { ContributionsEpicNewsletterSignup } from './ContributionsEpicNewsletterSignup';
 import { ContributionsEpicCtasContainer } from './ctas/ContributionsEpicCtasContainer';
 
-const container = (tracking: Tracking) => css`
+const container = css`
 	padding: 6px 10px 28px 10px;
 	border-top: 1px solid ${palette.brandAlt[400]};
 	border-bottom: 1px solid ${palette.neutral[86]};
@@ -49,7 +46,7 @@ const container = (tracking: Tracking) => css`
 	}
 
 	${from.tablet} {
-		padding-left: ${tracking.clientName === 'dcr' ? '60px' : '80px'};
+		padding-left: 60px;
 		padding-right: 20px;
 	}
 `;
@@ -74,7 +71,7 @@ const textContainer = css`
 	}
 `;
 
-const yellowHeading = (tracking: Tracking) => css`
+const yellowHeading = css`
 	${headlineBold34};
 	font-size: 28px;
 	color: ${palette.neutral[7]};
@@ -85,7 +82,7 @@ const yellowHeading = (tracking: Tracking) => css`
 
 	padding: 8px 10px 12px 10px;
 	${from.tablet} {
-		padding-left: ${tracking.clientName === 'dcr' ? '60px' : '80px'};
+		padding-left: 60px;
 		padding-right: 20px;
 	}
 `;
@@ -193,10 +190,8 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 
 	return (
 		<div data-testid="contributions-liveblog-epic" ref={setNode}>
-			{!!cleanHeading && (
-				<div css={yellowHeading(tracking)}>{cleanHeading}</div>
-			)}
-			<section css={container(tracking)}>
+			{!!cleanHeading && <div css={yellowHeading}>{cleanHeading}</div>}
+			<section css={container}>
 				<LiveblogEpicBody
 					paragraphs={cleanParagraphs}
 					numArticles={articleCounts.forTargetedWeeks}

--- a/dotcom-rendering/src/components/marketing/epics/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/epics/utils/storybook.ts
@@ -46,7 +46,6 @@ const articleCounts = {
 const pageTracking: PageTracking = {
 	ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
 	platformId: 'GUARDIAN_WEB',
-	clientName: 'dcr',
 	referrerUrl:
 		'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 12.0.0
         version: 12.0.0(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 4.0.0
-        version: 4.0.0(@guardian/libs@20.0.0)(zod@3.22.4)
+        specifier: 6.0.0
+        version: 6.0.0(@guardian/libs@20.0.0)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4408,8 +4408,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@4.0.0(@guardian/libs@20.0.0)(zod@3.22.4):
-    resolution: {integrity: sha512-MJlL2ToCHUXTe0pwZv/9xVftpzOXNuOPa0lm014qpn978Mue8wFBYYjfZjooW8e8qaIR6eYW3NRx4kpSl76b5A==}
+  /@guardian/support-dotcom-components@6.0.0(@guardian/libs@20.0.0)(zod@3.22.4):
+    resolution: {integrity: sha512-jGsUNAMD6gESbWm6wQ7f5cUxaRYmacBNNmBw/UPTeSRUuGfe8XQNsLi9nbtJtwpU3rEljuqa6PG9zDnCTa7jaw==}
     peerDependencies:
       '@guardian/libs': ^17.0.0
       zod: ^3.22.4


### PR DESCRIPTION
We no longer need to send page tracking data to the marketing API (SDC). Instead, we pass the tracking data directly into the components that use it.
Previous PRs:
- DCR change to pass the tracking data to the components: https://github.com/guardian/dotcom-rendering/pull/13292
- SDC change to stop expecting page tracking data: https://github.com/guardian/support-dotcom-components/pull/1278

This PR:
1. updates the version of the SDC dependency
2. changes the marketing slots to stop sending `tracking` to SDC
3. removes the `clientName` field, because all relevant pages are now rendered by DCR and nothing expects this field anymore