### PR TITLE
Auxia Experiment (Part 15): put auxia behind consent check

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -114,6 +114,11 @@ export interface SDCAuxiaGetTreatmentsProxyResponseData {
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
+export interface AuxiaGateDisplayData {
+	browserId: string;
+	auxiaData: SDCAuxiaGetTreatmentsProxyResponseData;
+}
+
 export type AuxiaInteractionInteractionType =
 	| 'VIEWED'
 	| 'CLICKED'

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -456,11 +456,11 @@ const decideBrowserIdWithConsentCheck = async (): Promise<
 		return Promise.resolve(undefined);
 	}
 
-	// The way to get the browserId is:
-	// getCookie({ name: 'bwid', shouldMemoize: true })
-	// but we are not calling it for the moment until we have guidance on
-	// how to handle the bwid cookie in the context of this experiment.
-	return Promise.resolve('2598326e7c');
+	const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
+	if (cookie === null) {
+		return Promise.resolve(undefined);
+	}
+	return Promise.resolve(cookie);
 };
 
 const decideIsSupporter = (): boolean => {


### PR DESCRIPTION
Previously in Auxia Experiment: https://github.com/guardian/dotcom-rendering/pull/13345

Here we use the `hasCmpConsentForBrowserId` from the contributions library to check whether we can query GetTreatments and display the Auxia gate.