### PR TITLE
Auxia Experiment: hand over full gate control to the Auxia API

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -510,7 +510,6 @@ const fetchProxyGetTreatments = async (
 	const response_raw = await fetch(url, params);
 	const response =
 		(await response_raw.json()) as SDCAuxiaGetTreatmentsProxyResponse;
-
 	return Promise.resolve(response);
 };
 
@@ -631,6 +630,7 @@ const SignInGateSelectorAuxia = ({
 			);
 			if (data !== undefined) {
 				setAuxiaGateDisplayData(data);
+				setIsGateDismissed(false);
 			}
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);


### PR DESCRIPTION
Here we allow for the auxia gate to display by default and always be driven by the Auxia API. 

The prerequisites essentially are
- not being signed-in
- having consented to the use of the browserId.

With the prerequisites true, if the user is in the Auxia experiment, a single call is going to be made to Auxia and the gate will be made in a state to be displayed and will show up if AuxiaGateDisplayData has the correct information.