### PR TITLE
Move highlights carousel buttons above card links

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -7,6 +7,7 @@ import {
 	SvgChevronRightSingle,
 } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
+import { getZIndex } from '../lib/getZIndex';
 import { ophanComponentId } from '../lib/ophan-helpers';
 import { palette } from '../palette';
 import type { DCRFrontCard } from '../types/front';
@@ -100,7 +101,7 @@ const verticalLineStyles = css`
 `;
 
 const buttonStyles = css`
-	z-index: 1;
+	z-index: ${getZIndex('highlights-carousel-buttons')};
 `;
 
 const buttonOverlayStyles = css`
@@ -276,7 +277,7 @@ export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 				})}
 			</ol>
 
-			<Hide until={'tablet'}>
+			<Hide until="tablet">
 				{showPreviousButton && (
 					<div css={[buttonOverlayStyles, previousButtonFadeStyles]}>
 						<Button

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -88,6 +88,10 @@ const indices = [
 	// Main media
 	'mainMedia',
 
+	// The carousel buttons of the highlights container that sits above the header.
+	// Needs to be above 'card-link'.
+	'highlights-carousel-buttons',
+
 	// Nested links in cards should sit above the main card link
 	// See: https://www.sarasoueidan.com/blog/nested-links/
 	'card-nested-link',


### PR DESCRIPTION
## What does this change?

Makes the carousel right chevron button in the highlights container clickable.

## Why?

This was not functioning correctly. The card link was above the chevron button by z-index, so users were unable to click the chevron.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1d58efe5-5bed-4e9e-9347-bdb2aa56e43f
[after]: https://github.com/user-attachments/assets/ea40f040-6657-4f38-aa6b-4a900b93caf1

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
