### PR TITLE
Splash card headline sizing 

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -203,7 +203,7 @@ export const FourSublinkSplash: Story = {
 	},
 };
 
-const liveUpdatesCard = {
+export const liveUpdatesCard = {
 	url: '/football/live/2023/aug/20/spain-v-england-womens-world-cup-final-live',
 	headline:
 		'Spain 1-0 England: Women’s World Cup 2023 final – as it happened',
@@ -338,6 +338,126 @@ export const GigaBoostedSplash: Story = {
 				},
 			],
 			standard: standardCards,
+		},
+	},
+};
+export const DefaultSplashWithImageSupression: Story = {
+	name: 'Standard splash with image supression',
+	args: {
+		frontSectionTitle: 'Standard splash with image supression',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [{ ...splashCard, image: undefined }],
+		},
+	},
+};
+
+export const BoostedSplashWithImageSupression: Story = {
+	name: 'Boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...splashCard,
+					boostLevel: 'boost',
+					image: undefined,
+				},
+			],
+		},
+	},
+};
+
+export const MegaBoostedSplashWithImageSupression: Story = {
+	name: 'Mega boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Mega boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...splashCard,
+					boostLevel: 'megaboost',
+					image: undefined,
+				},
+			],
+		},
+	},
+};
+
+export const GigaBoostedSplashWithImageSupression: Story = {
+	name: 'Giga boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Giga boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...splashCard,
+					boostLevel: 'gigaboost',
+					image: undefined,
+				},
+			],
+		},
+	},
+};
+
+export const DefaultSplashWithLiveUpdates: Story = {
+	name: 'Standard splash with live updates',
+	args: {
+		frontSectionTitle: 'Standard splash with live updates',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [{ ...liveUpdatesCard }],
+		},
+	},
+};
+
+export const BoostedSplashWithLiveUpdates: Story = {
+	name: 'Boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...liveUpdatesCard,
+					boostLevel: 'boost',
+				},
+			],
+		},
+	},
+};
+
+export const MegaBoostedSplashWithLiveUpdates: Story = {
+	name: 'Mega boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Mega boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...liveUpdatesCard,
+					boostLevel: 'megaboost',
+				},
+			],
+		},
+	},
+};
+
+export const GigaBoostedSplashWithLiveUpdates: Story = {
+	name: 'Giga boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Giga boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{
+					...liveUpdatesCard,
+					boostLevel: 'gigaboost',
+				},
+			],
 		},
 	},
 };

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -203,7 +203,7 @@ export const FourSublinkSplash: Story = {
 	},
 };
 
-export const liveUpdatesCard = {
+const liveUpdatesCard = {
 	url: '/football/live/2023/aug/20/spain-v-england-womens-world-cup-final-live',
 	headline:
 		'Spain 1-0 England: Women’s World Cup 2023 final – as it happened',

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -90,7 +90,9 @@ const decideSplashCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
 	mediaCard: boolean,
-	avatarUrl?: string,
+	hasLivePlayable: boolean,
+	imageSuppressed: boolean,
+	avatarUrl: boolean,
 ): BoostedSplashProperties => {
 	switch (boostLevel) {
 		// boostedfont sizing
@@ -98,7 +100,8 @@ const decideSplashCardProperties = (
 		case 'default':
 			return {
 				headlineSizes: {
-					desktop: 'medium',
+					desktop:
+						imageSuppressed || hasLivePlayable ? 'large' : 'medium',
 					tablet: 'medium',
 					mobile: 'medium',
 				},
@@ -113,7 +116,8 @@ const decideSplashCardProperties = (
 		case 'boost':
 			return {
 				headlineSizes: {
-					desktop: 'large',
+					desktop:
+						imageSuppressed || hasLivePlayable ? 'xlarge' : 'large',
 					tablet: 'large',
 					mobile: 'large',
 				},
@@ -128,7 +132,10 @@ const decideSplashCardProperties = (
 		case 'megaboost':
 			return {
 				headlineSizes: {
-					desktop: 'xlarge',
+					desktop:
+						imageSuppressed || hasLivePlayable
+							? 'xxlarge'
+							: 'xlarge',
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
@@ -142,7 +149,10 @@ const decideSplashCardProperties = (
 		case 'gigaboost':
 			return {
 				headlineSizes: {
-					desktop: 'xxlarge',
+					desktop:
+						imageSuppressed || hasLivePlayable
+							? 'xxxlarge'
+							: 'xxlarge',
 					tablet: 'xlarge',
 					mobile: 'xxlarge',
 				},
@@ -188,7 +198,9 @@ export const SplashCardLayout = ({
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
 		isMediaCard(card.format),
-		card.avatarUrl,
+		card.showLivePlayable,
+		!card.image,
+		!!card.avatarUrl,
 	);
 
 	return (

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -2,8 +2,12 @@ import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
-import type { DCRContainerPalette, DCRGroupedTrails } from '../types/front';
-import { liveUpdatesCard } from './FlexibleGeneral.stories';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import type {
+	DCRContainerPalette,
+	DCRFrontCard,
+	DCRGroupedTrails,
+} from '../types/front';
 import { FlexibleSpecial } from './FlexibleSpecial';
 import { FrontSection } from './FrontSection';
 
@@ -19,6 +23,64 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 	snap: [],
 	splash: [],
 };
+
+const liveUpdatesCard = {
+	url: '/football/live/2023/aug/20/spain-v-england-womens-world-cup-final-live',
+	headline:
+		'Spain 1-0 England: Women’s World Cup 2023 final – as it happened',
+	showByline: false,
+	byline: 'Sarah Rendell (the match) and James Wallace (reaction)',
+	trailText:
+		'<p>La Roja won their first Women’s World Cup after Olga Carmona’s first-half strike, with Mary Earps’ penalty save proving to be in vain</p>',
+	image: {
+		src: 'https://i.guim.co.uk/img/media/d7b100ce3d052d66bfc6c0de8f777901c774fede/0_214_5118_3072/master/5118.jpg',
+		altText: 'Spain celebrate with the trophy.',
+	},
+	webPublicationDate: '2023-08-20T16:09:23.000Z',
+	format: {
+		theme: Pillar.Sport,
+		design: ArticleDesign.LiveBlog,
+		display: ArticleDisplay.Standard,
+	},
+	showQuotedHeadline: false,
+	dataLinkName: 'news | group-0 | card-@1',
+	mainMedia: {
+		type: 'Video',
+		id: 'fd00c892-407f-4d99-adfb-a8d12eada25f',
+		videoId: '04lLgC1NioA',
+		height: 300,
+		width: 500,
+		origin: '',
+		title: 'Spain fans celebrate at final whistle as England fans left heartbroken – video',
+		duration: 0,
+		expired: false,
+		images: [
+			{
+				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/2000.jpg',
+				width: 2000,
+			},
+			{
+				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/1000.jpg',
+				width: 1000,
+			},
+			{
+				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/500.jpg',
+				width: 500,
+			},
+			{
+				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/140.jpg',
+				width: 140,
+			},
+			{
+				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/4791.jpg',
+				width: 4791,
+			},
+		],
+	},
+	isExternalLink: false,
+	discussionApiUrl,
+	showLivePlayable: true,
+} satisfies DCRFrontCard;
 
 const meta = {
 	component: FlexibleSpecial,

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -3,8 +3,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import { trails } from '../../fixtures/manual/trails';
 import type { DCRContainerPalette, DCRGroupedTrails } from '../types/front';
+import { liveUpdatesCard } from './FlexibleGeneral.stories';
 import { FlexibleSpecial } from './FlexibleSpecial';
 import { FrontSection } from './FrontSection';
+
+type FlexibleSpecialArgsAndCustomArgs = React.ComponentProps<
+	typeof FlexibleSpecial
+> & { frontSectionTitle: string };
 
 const defaultGroupedTrails: DCRGroupedTrails = {
 	huge: [],
@@ -33,9 +38,11 @@ const meta = {
 		absoluteServerTimes: true,
 		imageLoading: 'eager',
 		aspectRatio: '5:4',
+		frontSectionTitle: 'Flexible general',
 	},
-	render: (args) => (
+	render: ({ frontSectionTitle, ...args }) => (
 		<FrontSection
+			title={frontSectionTitle}
 			discussionApiUrl={discussionApiUrl}
 			editionId={'UK'}
 			showTopBorder={true}
@@ -43,7 +50,7 @@ const meta = {
 			<FlexibleSpecial {...args} />
 		</FrontSection>
 	),
-} satisfies Meta<typeof FlexibleSpecial>;
+} satisfies Meta<FlexibleSpecialArgsAndCustomArgs>;
 
 export default meta;
 
@@ -96,6 +103,105 @@ export const Five: Story = {
 			...defaultGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 5),
+		},
+	},
+};
+export const DefaultSplashWithImageSupression: Story = {
+	name: 'Standard splash with image supression',
+	args: {
+		frontSectionTitle: 'Standard splash with image supression',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...trails[0], image: undefined }],
+		},
+	},
+};
+
+export const BoostedSplashWithImageSupression: Story = {
+	name: 'Boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...trails[0], boostLevel: 'boost', image: undefined }],
+		},
+	},
+};
+
+export const MegaBoostedSplashWithImageSupression: Story = {
+	name: 'Mega boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Mega boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [
+				{ ...trails[0], boostLevel: 'megaboost', image: undefined },
+			],
+		},
+	},
+};
+
+export const GigaBoostedSplashWithImageSupression: Story = {
+	name: 'Giga boosted splash with image supression',
+	args: {
+		frontSectionTitle: 'Giga boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [
+				{ ...trails[0], boostLevel: 'gigaboost', image: undefined },
+			],
+		},
+	},
+};
+
+export const DefaultSplashWithLiveUpdates: Story = {
+	name: 'Standard splash with live updates',
+	args: {
+		frontSectionTitle: 'Standard splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...liveUpdatesCard }],
+		},
+	},
+};
+
+export const BoostedSplashWithLiveUpdates: Story = {
+	name: 'Boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...liveUpdatesCard, boostLevel: 'boost' }],
+		},
+	},
+};
+
+export const MegaBoostedSplashWithLiveUpdates: Story = {
+	name: 'Mega boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Mega boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...liveUpdatesCard, boostLevel: 'megaboost' }],
+		},
+	},
+};
+
+export const GigaBoostedSplashWithLiveUpdates: Story = {
+	name: 'Giga boosted splash with live updates',
+	args: {
+		frontSectionTitle: 'Giga boosted splash',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			snap: [],
+			standard: [{ ...liveUpdatesCard, boostLevel: 'gigaboost' }],
 		},
 	},
 };

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -45,13 +45,18 @@ const determineCardProperties = (
 	boostLevel: BoostLevel,
 	supportingContentLength: number,
 	mediaCard: boolean,
+	imageSuppressed: boolean,
+	hasLivePlayable: boolean,
 ): BoostProperties => {
 	switch (boostLevel) {
 		// The default boost level is equal to no boost. It is the same as the default card layout.
 		case 'default':
 			return {
 				headlineSizes: {
-					desktop: 'xlarge',
+					desktop:
+						imageSuppressed || hasLivePlayable
+							? 'xxlarge'
+							: 'xlarge',
 					tablet: 'large',
 					mobile: 'medium',
 				},
@@ -67,7 +72,10 @@ const determineCardProperties = (
 		case 'boost':
 			return {
 				headlineSizes: {
-					desktop: 'xxlarge',
+					desktop:
+						imageSuppressed || hasLivePlayable
+							? 'xxxlarge'
+							: 'xxlarge',
 					tablet: 'xlarge',
 					mobile: 'large',
 				},
@@ -82,7 +90,10 @@ const determineCardProperties = (
 		case 'megaboost':
 			return {
 				headlineSizes: {
-					desktop: 'xxlarge',
+					desktop:
+						imageSuppressed || hasLivePlayable
+							? 'xxxlarge'
+							: 'xxlarge',
 					tablet: 'xlarge',
 					mobile: 'xlarge',
 				},
@@ -141,6 +152,8 @@ export const OneCardLayout = ({
 		card.boostLevel ?? 'default',
 		card.supportingContent?.length ?? 0,
 		isMediaCard(card.format),
+		!card.image,
+		card.showLivePlayable,
 	);
 	return (
 		<UL padBottom={!isLastRow} hasLargeSpacing={!isLastRow}>


### PR DESCRIPTION
## What does this change?
Increase the headline size of any splash card that meets either of the following criteria:

- Suppressed images
- Live blog updates (referred to in the model as "live playable")

Exception: Do not increase the headline size for a gigaboosted splash card in a flexible/special, as it is already at the highest available font size.

## Why?
This has been requested by design.

## Screenshots
Sample of screenshots below. Additional screenshots can be found in storybook. 

| Before      | After      |
| ----------- | ---------- |
| ![defaultbefore][] | ![defaultafter][] |
| ![boostbefore][] | ![boostafter][] |
| ![megabefore][] | ![megaafter][] |
| ![gigabefore][] | ![gigaafter][] |

[defaultbefore]: https://github.com/user-attachments/assets/e7c1f27e-3775-40ca-bf74-4cee22f021dd
[defaultafter]: https://github.com/user-attachments/assets/1d31267a-6805-4f34-b782-0bab042b6af5

[boostbefore]: https://github.com/user-attachments/assets/1287610c-8814-4d59-b440-7fa4e343380e
[boostafter]: https://github.com/user-attachments/assets/fb2e318c-e7b0-4193-ab71-9c8e594156e1

[megabefore]: https://github.com/user-attachments/assets/ceeb047e-b79f-4168-8b0d-fbdb0f0facee
[megaafter]: https://github.com/user-attachments/assets/475b8bc2-82b4-4532-b55e-bb0938154d61

[gigabefore]: https://github.com/user-attachments/assets/43915cee-e5e9-4fb7-b925-79cae334dcda
[gigaafter]: https://github.com/user-attachments/assets/91d2c8cd-b20a-4455-8bc6-2a8a4e81bbf6


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
