### PR TITLE
Stop sending browserId to SDC

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@guardian/braze-components/logic';
 import { adSizes, type SizeMapping } from '@guardian/commercial';
 import type { CountryCode } from '@guardian/libs';
-import { getCookie, isString, isUndefined } from '@guardian/libs';
+import { isUndefined } from '@guardian/libs';
 import { palette } from '@guardian/source/foundations';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/dotcom/types';
 import type { ModuleData } from '@guardian/support-dotcom-components/dist/dotcom/types';
@@ -99,20 +99,6 @@ const buildBrazeEpicConfig = (
 	};
 };
 
-const useBrowserId = () => {
-	const [browserId, setBrowserId] = useState<string>();
-
-	useEffect(() => {
-		const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
-
-		const id = isString(cookie) ? cookie : 'no-browser-id-available';
-
-		setBrowserId(id);
-	}, []);
-
-	return browserId;
-};
-
 export const SlotBodyEnd = ({
 	contentType,
 	sectionId,
@@ -131,7 +117,6 @@ export const SlotBodyEnd = ({
 	const { brazeMessages } = useBraze(idApiUrl, renderingTarget);
 	const countryCode = useCountryCode('slot-body-end');
 	const isSignedIn = useIsSignedIn();
-	const browserId = useBrowserId();
 	const ophanPageViewId = usePageViewId(renderingTarget);
 	const [SelectedEpic, setSelectedEpic] = useState<
 		React.ElementType | null | undefined
@@ -168,7 +153,6 @@ export const SlotBodyEnd = ({
 			isUndefined(countryCode) ||
 			isUndefined(brazeMessages) ||
 			isUndefined(asyncArticleCount) ||
-			isUndefined(browserId) ||
 			isUndefined(ophanPageViewId) ||
 			isSignedIn === 'Pending'
 		) {
@@ -187,7 +171,6 @@ export const SlotBodyEnd = ({
 			contributionsServiceUrl,
 			idApiUrl,
 			asyncArticleCount,
-			browserId,
 			renderingTarget,
 			ophanPageViewId,
 			pageId,
@@ -218,7 +201,6 @@ export const SlotBodyEnd = ({
 		countryCode,
 		brazeMessages,
 		asyncArticleCount,
-		browserId,
 		contentType,
 		contributionsServiceUrl,
 		idApiUrl,

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -20,7 +20,6 @@ import type {
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import {
-	hasCmpConsentForBrowserId,
 	hasCmpConsentForWeeklyArticleCount,
 	hasOptedOutOfArticleCount,
 	shouldHideSupportMessaging,
@@ -48,7 +47,6 @@ export type CanShowData = {
 	contributionsServiceUrl: string;
 	idApiUrl: string;
 	asyncArticleCount: Promise<WeeklyArticleHistory | undefined>;
-	browserId?: string;
 	renderingTarget: RenderingTarget;
 	ophanPageViewId: string;
 	pageId?: string;
@@ -72,9 +70,6 @@ const buildPayload = async (
 		mvtId: Number(getCookie({ name: 'GU_mvt_id', shouldMemoize: true })),
 		countryCode: data.countryCode,
 		url: window.location.origin + window.location.pathname,
-		browserId: (await hasCmpConsentForBrowserId())
-			? data.browserId
-			: undefined,
 		isSignedIn: data.isSignedIn,
 		pageId: data.pageId,
 	},

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -24,7 +24,6 @@ import { submitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
 import {
 	getPurchaseInfo,
-	hasCmpConsentForBrowserId,
 	hasOptedOutOfArticleCount,
 	recentlyClosedBanner,
 	setLocalNoBannerCachePeriod,
@@ -139,8 +138,6 @@ const buildPayload = async ({
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
 	const articleCountToday = getArticleCountToday(articleCounts);
 
-	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
-
 	return {
 		targeting: {
 			shouldHideReaderRevenue,
@@ -160,9 +157,6 @@ const buildPayload = async ({
 			sectionId,
 			tagIds: tags.map((tag) => tag.id),
 			contentType,
-			browserId: (await hasCmpConsentForBrowserId())
-				? browserId ?? undefined
-				: undefined,
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn,
 			hasConsented: userConsent,


### PR DESCRIPTION
In the past we ran experiments with targeting by browserId on epic + banner.
This hasn't been used in a long time, and it's best to send as little data as possible. 
This PR removes the browserId field from the payload to SDC. The field is optional on the SDC side.