### PR TITLE
Added Schema For `FEFootballDataPage`

### DIFF
--- a/dotcom-rendering/scripts/jsonSchema/schema.mjs
+++ b/dotcom-rendering/scripts/jsonSchema/schema.mjs
@@ -14,6 +14,7 @@ const program = TJS.getProgramFromFiles(
 		path.resolve(`${root}/src/types/tagPage.ts`),
 		path.resolve(`${root}/src/types/newslettersPage.ts`),
 		path.resolve(`${root}/src/types/editionsCrossword.ts`),
+		path.resolve(`${root}/src/feFootballDataPage.ts`),
 	],
 	{
 		skipLibCheck: true,
@@ -55,6 +56,10 @@ const schemas = [
 	{
 		typeName: 'FEEditionsCrosswords',
 		file: `${root}/src/model/editions-crossword-schema.json`,
+	},
+	{
+		typeName: 'FEFootballDataPage',
+		file: `${root}/src/model/fe-football-data-page-schema.json`,
 	},
 ];
 

--- a/dotcom-rendering/src/feFootballDataPage.ts
+++ b/dotcom-rendering/src/feFootballDataPage.ts
@@ -40,7 +40,7 @@ type FEMatchDayTeam = {
 
 type FEFootballMatchData = {
 	id: string;
-	date: Date;
+	date: string;
 	stage: FEStage;
 	round: FERound;
 	leg: string;

--- a/dotcom-rendering/src/model/fe-football-data-page-schema.json
+++ b/dotcom-rendering/src/model/fe-football-data-page-schema.json
@@ -1,0 +1,1290 @@
+{
+    "type": "object",
+    "properties": {
+        "matchesList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string"
+                    },
+                    "competitionMatches": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "competitionSummary": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "type": "string"
+                                        },
+                                        "fullName": {
+                                            "type": "string"
+                                        },
+                                        "nation": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "fullName",
+                                        "id",
+                                        "nation",
+                                        "url"
+                                    ]
+                                },
+                                "matches": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/FEFootballMatch"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "competitionSummary",
+                                "matches"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "competitionMatches",
+                    "date"
+                ]
+            }
+        },
+        "nextPage": {
+            "type": "string"
+        },
+        "previousPage": {
+            "type": "string"
+        },
+        "nav": {
+            "$ref": "#/definitions/FENavType"
+        },
+        "editionId": {
+            "$ref": "#/definitions/EditionId"
+        },
+        "guardianBaseURL": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "keywords": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "keywordIds": {
+                    "type": "string"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "$ref": "#/definitions/SharedAdTargeting"
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "isFront": {
+                    "type": "boolean",
+                    "const": true
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "buildNumber",
+                "calloutsUrl",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isFront",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "keywordIds",
+                "keywords",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "webTitle"
+            ]
+        },
+        "pageFooter": {
+            "$ref": "#/definitions/FooterType"
+        },
+        "isAdFreeUser": {
+            "type": "boolean"
+        },
+        "canonicalUrl": {
+            "type": "string"
+        },
+        "contributionsServiceUrl": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "config",
+        "contributionsServiceUrl",
+        "editionId",
+        "guardianBaseURL",
+        "isAdFreeUser",
+        "matchesList",
+        "nav",
+        "pageFooter"
+    ],
+    "definitions": {
+        "FEFootballMatch": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/FELive"
+                },
+                {
+                    "$ref": "#/definitions/FEFixture"
+                },
+                {
+                    "$ref": "#/definitions/FEMatchDay"
+                },
+                {
+                    "$ref": "#/definitions/FEResult"
+                }
+            ]
+        },
+        "FELive": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "date": {
+                            "type": "string"
+                        },
+                        "stage": {
+                            "type": "object",
+                            "properties": {
+                                "stageNumber": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "stageNumber"
+                            ]
+                        },
+                        "round": {
+                            "type": "object",
+                            "properties": {
+                                "roundNumber": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "roundNumber"
+                            ]
+                        },
+                        "leg": {
+                            "type": "string"
+                        },
+                        "homeTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "awayTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "venue": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "comments": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "awayTeam",
+                        "date",
+                        "homeTeam",
+                        "id",
+                        "leg",
+                        "round",
+                        "stage"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "LiveMatch"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "attendance": {
+                            "type": "string"
+                        },
+                        "referee": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "status",
+                        "type"
+                    ]
+                }
+            ]
+        },
+        "FEFixture": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "date": {
+                            "type": "string"
+                        },
+                        "stage": {
+                            "type": "object",
+                            "properties": {
+                                "stageNumber": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "stageNumber"
+                            ]
+                        },
+                        "round": {
+                            "type": "object",
+                            "properties": {
+                                "roundNumber": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "roundNumber"
+                            ]
+                        },
+                        "leg": {
+                            "type": "string"
+                        },
+                        "homeTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "awayTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "venue": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "comments": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "awayTeam",
+                        "date",
+                        "homeTeam",
+                        "id",
+                        "leg",
+                        "round",
+                        "stage"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "Fixture"
+                        },
+                        "competition": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                }
+            ]
+        },
+        "FEMatchDay": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "date": {
+                            "type": "string"
+                        },
+                        "stage": {
+                            "type": "object",
+                            "properties": {
+                                "stageNumber": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "stageNumber"
+                            ]
+                        },
+                        "round": {
+                            "type": "object",
+                            "properties": {
+                                "roundNumber": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "roundNumber"
+                            ]
+                        },
+                        "leg": {
+                            "type": "string"
+                        },
+                        "homeTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "awayTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "venue": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "comments": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "awayTeam",
+                        "date",
+                        "homeTeam",
+                        "id",
+                        "leg",
+                        "round",
+                        "stage"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "MatchDay"
+                        },
+                        "liveMatch": {
+                            "type": "boolean"
+                        },
+                        "result": {
+                            "type": "boolean"
+                        },
+                        "previewAvailable": {
+                            "type": "boolean"
+                        },
+                        "reportAvailable": {
+                            "type": "boolean"
+                        },
+                        "lineupsAvailable": {
+                            "type": "boolean"
+                        },
+                        "matchStatus": {
+                            "type": "string"
+                        },
+                        "attendance": {
+                            "type": "string"
+                        },
+                        "referee": {
+                            "type": "string"
+                        },
+                        "competition": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "lineupsAvailable",
+                        "liveMatch",
+                        "matchStatus",
+                        "previewAvailable",
+                        "reportAvailable",
+                        "result",
+                        "type"
+                    ]
+                }
+            ]
+        },
+        "FEResult": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "date": {
+                            "type": "string"
+                        },
+                        "stage": {
+                            "type": "object",
+                            "properties": {
+                                "stageNumber": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "stageNumber"
+                            ]
+                        },
+                        "round": {
+                            "type": "object",
+                            "properties": {
+                                "roundNumber": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "roundNumber"
+                            ]
+                        },
+                        "leg": {
+                            "type": "string"
+                        },
+                        "homeTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "awayTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "htScore": {
+                                    "type": "number"
+                                },
+                                "aggregateScore": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "venue": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "comments": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "awayTeam",
+                        "date",
+                        "homeTeam",
+                        "id",
+                        "leg",
+                        "round",
+                        "stage"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "Result"
+                        },
+                        "reportAvailable": {
+                            "type": "boolean"
+                        },
+                        "attendance": {
+                            "type": "string"
+                        },
+                        "referee": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "reportAvailable",
+                        "type"
+                    ]
+                }
+            ]
+        },
+        "FENavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/FELinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/FELinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FELinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "FELinkType": {
+            "description": "Data types for the API request bodies from clients that require transformation before internal use.\nWhere data types are coming from Frontend we try to use the 'FE' prefix.\nPrior to this we used 'CAPI' as a prefix which wasn't entirely accurate, and some data structures never received the prefix, meaning some are still missing it.",
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "SharedAdTargeting": {
+            "type": "object"
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
+        },
+        "FooterType": {
+            "type": "object",
+            "properties": {
+                "footerLinks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/FooterLink"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "footerLinks"
+            ]
+        },
+        "FooterLink": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "dataLinkName": {
+                    "type": "string"
+                },
+                "extraClasses": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}


### PR DESCRIPTION
This will be used to validate requests from frontend to render the football data pages.

Changed a `Date` type to a `string`, as `Date`s are not a supported JSON type.
