### PR TITLE
Auxia Experiment: call components as components, not functions

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -376,25 +376,29 @@ export const SignInGateSelector = ({
 	);
 
 	if (!userIsInAuxiaExperiment) {
-		return SignInGateSelectorDefault({
-			contentType,
-			sectionId,
-			tags,
-			isPaidContent,
-			isPreview,
-			host,
-			pageId,
-			idUrl,
-			switches,
-			contributionsServiceUrl,
-		});
+		return (
+			<SignInGateSelectorDefault
+				contentType={contentType}
+				sectionId={sectionId}
+				tags={tags}
+				isPaidContent={isPaidContent}
+				isPreview={isPreview}
+				host={host}
+				pageId={pageId}
+				idUrl={idUrl}
+				switches={switches}
+				contributionsServiceUrl={contributionsServiceUrl}
+			/>
+		);
 	} else {
-		return SignInGateSelectorAuxia({
-			host,
-			pageId,
-			idUrl,
-			contributionsServiceUrl,
-		});
+		return (
+			<SignInGateSelectorAuxia
+				host={host}
+				pageId={pageId}
+				idUrl={idUrl}
+				contributionsServiceUrl={contributionsServiceUrl}
+			/>
+		);
 	}
 };
 


### PR DESCRIPTION
Here we correct the fact that we had been calling components as functions, which is discouraged by the documentation: https://react.dev/reference/rules/react-calls-components-and-hooks#never-call-component-functions-directly 