### PR TITLE
auxia experiment: send api gate variant to Ophan

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
+++ b/dotcom-rendering/src/components/SignInGate/componentEventTracking.tsx
@@ -14,7 +14,7 @@ export type ComponentEventParams = {
 };
 
 // ophan helper methods
-const submitComponentEventTracking = async (
+export const submitComponentEventTracking = async (
 	componentEvent: ComponentEvent,
 	renderingTarget: RenderingTarget,
 ) => {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -18,6 +18,7 @@ import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
 import type { ComponentEventParams } from './SignInGate/componentEventTracking';
 import {
+	submitComponentEventTracking,
 	submitViewEventTracking,
 	withComponentId,
 } from './SignInGate/componentEventTracking';
@@ -635,6 +636,19 @@ const SignInGateSelectorAuxia = ({
 			);
 			if (data !== undefined) {
 				setAuxiaGateDisplayData(data);
+				if (data.auxiaData.userTreatment !== undefined) {
+					await submitComponentEventTracking(
+						{
+							component: {
+								componentType: 'SIGN_IN_GATE',
+								id: data.auxiaData.userTreatment.treatmentId,
+							},
+							action: 'VIEW',
+							abTest,
+						},
+						renderingTarget,
+					);
+				}
 			}
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);


### PR DESCRIPTION
Here we ensure that the Auxia API answer's `treatmentId` (essentially the id of the variant they are sending us), is logged in Ophan

![Screenshot 2025-02-13 at 10 52 49](https://github.com/user-attachments/assets/a0b6cc79-60ae-4282-8e8d-fef56d5d4ab1)


