### PR TITLE
Prioritise image hide over other image settings

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -87,14 +87,13 @@ const decideUrl = (trail: FESupportingContent | FEFrontCard) => {
 };
 
 const decideImage = (trail: FEFrontCard) => {
+	if (trail.display.imageHide) return undefined;
 	if (
 		trail.type === 'LinkSnap' ||
 		trail.properties.image?.type === 'Replace'
 	) {
 		return trail.properties.image?.item.imageSrc;
 	}
-
-	if (trail.display.imageHide) return undefined;
 
 	if (trail.properties.isCrossword && trail.properties.maybeContentId) {
 		return `https://api.nextgen.guardianapps.co.uk/${trail.properties.maybeContentId}.svg`;


### PR DESCRIPTION
## What does this change?
DCR should prioritise the image hide setting above other image settings such as replace images.

## Why?
If image hide is set, we should not enhance the card with an image. Previously replace image was above this logic and so took precedent.

Its interesting that image hide is managed in DCR and feels like a property that should be managed further back in the pipeline but this is outside of the scope of this ticket. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/dd30b122-1be1-4669-9eb9-423208a132ee
[after]: https://github.com/user-attachments/assets/e41707d9-7d1c-4742-966e-1f99541ab74b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
