### PR TITLE
Remove trail text from standard, non-boosted cards in flexible/genera…

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -439,8 +439,7 @@ export const StandardCardLayout = ({
 							showLivePlayable={false}
 							showTopBarDesktop={false}
 							showTopBarMobile={true}
-							// On standard cards, we only show the trail text if the trail image has been hidden
-							trailText={!card.image ? card.trailText : undefined}
+							trailText={undefined}
 							// On standard cards, we increase the headline size if the trail image has been hidden
 							headlineSizes={
 								!card.image


### PR DESCRIPTION
…l container

## What does this change?
Reverts a decision to show trail text on standard, non boosted cards when the image was hidden / supressed in a flexible general container.

The Flexible general trail text rules are now as follows:

- Standard, non-boosted card : **never** show trail text 
- Card with a boost property : **always** show trail text
- Splash card : **always** show trail text

## Why?
We want editors to be able to choose if they display trail text or not. At this point, and to cover the main aim of hiding it in most instances, Editorial are happy with the approach of no showing trail text on the frontend for a standard, default card.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4c291d34-71b7-4b60-a155-1b3f014a1862
[after]: https://github.com/user-attachments/assets/0c061bb3-e9c7-42e6-bc1f-93d1665d9b18


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
