### PR TITLE
Reduce PROD article-rendering stack from 30 to 27 instances

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 30,
-		maximumInstances: 300,
+		minimumInstances: 27,
+		maximumInstances: 270,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
## What does this change?

Reduce PROD article-rendering stack from 30 to 27 instances

## Why?

Test if we can reduce the stack size and hence lower cost

