### PR TITLE
auxia experiment: Use default GU data in case of non consenting reader

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -67,13 +67,17 @@ export const SignInGateAuxia = ({
 						<button
 							data-testid="sign-in-gate-main_privacy"
 							css={privacyLink}
-							onClick={() => {
+							onClick={async () => {
 								cmp.showPrivacyManager();
 								trackLink(
 									ophanComponentId,
 									'privacy',
 									renderingTarget,
 									abTest,
+								);
+								await logTreatmentInteractionCall(
+									'CLICKED',
+									'PRIVACY-BUTTON',
 								);
 							}}
 						>
@@ -90,22 +94,17 @@ export const SignInGateAuxia = ({
 					priority="primary"
 					size="small"
 					href={firstCtaLink}
-					onClick={() => {
+					onClick={async () => {
 						trackLink(
 							ophanComponentId,
 							'register-link',
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall(
+						await logTreatmentInteractionCall(
 							'CLICKED',
 							'REGISTER-LINK',
-						).catch((error) => {
-							console.error(
-								'Failed to log treatment interaction:',
-								error,
-							);
-						});
+						);
 					}}
 				>
 					{firstCtaName}
@@ -116,7 +115,7 @@ export const SignInGateAuxia = ({
 					cssOverrides={laterButton}
 					priority="subdued"
 					size="small"
-					onClick={() => {
+					onClick={async () => {
 						dismissGate();
 						trackLink(
 							ophanComponentId,
@@ -124,14 +123,7 @@ export const SignInGateAuxia = ({
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall('DISMISSED', '').catch(
-							(error) => {
-								console.error(
-									'Failed to log treatment interaction:',
-									error,
-								);
-							},
-						);
+						await logTreatmentInteractionCall('DISMISSED', '');
 					}}
 				>
 					{secondCtaName}
@@ -147,22 +139,17 @@ export const SignInGateAuxia = ({
 				data-ignore="global-link-styling"
 				cssOverrides={signInLink}
 				href={signInUrl}
-				onClick={() => {
+				onClick={async () => {
 					trackLink(
 						ophanComponentId,
 						'sign-in-link',
 						renderingTarget,
 						abTest,
 					);
-					logTreatmentInteractionCall(
+					await logTreatmentInteractionCall(
 						'CLICKED',
 						'SIGN-IN-LINK',
-					).catch((error) => {
-						console.error(
-							'Failed to log treatment interaction:',
-							error,
-						);
-					});
+					);
 				}}
 			>
 				Sign In
@@ -172,22 +159,17 @@ export const SignInGateAuxia = ({
 				<Link
 					data-ignore="global-link-styling"
 					href={`${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian`}
-					onClick={() => {
+					onClick={async () => {
 						trackLink(
 							ophanComponentId,
 							'how-link',
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall(
+						await logTreatmentInteractionCall(
 							'CLICKED',
 							'HOW-TO-LINK',
-						).catch((error) => {
-							console.error(
-								'Failed to log treatment interaction:',
-								error,
-							);
-						});
+						);
 					}}
 				>
 					Why register & how does it help?
@@ -196,22 +178,17 @@ export const SignInGateAuxia = ({
 				<Link
 					data-ignore="global-link-styling"
 					href={`${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text`}
-					onClick={() => {
+					onClick={async () => {
 						trackLink(
 							ophanComponentId,
 							'why-link',
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall(
+						await logTreatmentInteractionCall(
 							'CLICKED',
 							'WHY-LINK',
-						).catch((error) => {
-							console.error(
-								'Failed to log treatment interaction:',
-								error,
-							);
-						});
+						);
 					}}
 				>
 					How will my information & data be used?
@@ -220,22 +197,17 @@ export const SignInGateAuxia = ({
 				<Link
 					data-ignore="global-link-styling"
 					href={`${guUrl}/help/identity-faq`}
-					onClick={() => {
+					onClick={async () => {
 						trackLink(
 							ophanComponentId,
 							'help-link',
 							renderingTarget,
 							abTest,
 						);
-						logTreatmentInteractionCall(
+						await logTreatmentInteractionCall(
 							'CLICKED',
 							'HELP-LINK',
-						).catch((error) => {
-							console.error(
-								'Failed to log treatment interaction:',
-								error,
-							);
-						});
+						);
 					}}
 				>
 					Get help with registering or signing in

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -125,6 +125,7 @@ export type AuxiaInteractionInteractionType =
 	| 'DISMISSED';
 
 export type AuxiaInteractionActionName =
+	| 'PRIVACY-BUTTON'
 	| 'REGISTER-LINK'
 	| 'SIGN-IN-LINK'
 	| 'HOW-TO-LINK'

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -110,9 +110,9 @@ export interface AuxiaAPIResponseDataUserTreatment {
 
 export interface AuxiaProxyGetTreatmentsPayload {
 	browserId: string | undefined;
-	is_supporter: boolean;
-	daily_article_count: number;
-	article_identifier: string;
+	isSupporter: boolean;
+	dailyArticleCount: number;
+	articleIdentifier: string;
 }
 
 export interface AuxiaProxyGetTreatmentsResponse {
@@ -155,8 +155,8 @@ export interface AuxiaProxyLogTreatmentInteractionPayload {
 
 export interface AuxiaGateReaderPersonalData {
 	browserId: string | undefined;
-	daily_article_count: number;
-	is_supporter: boolean;
+	dailyArticleCount: number;
+	isSupporter: boolean;
 }
 
 export interface AuxiaGateDisplayData {

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -155,11 +155,10 @@ export interface AuxiaProxyLogTreatmentInteractionPayload {
 
 // DCR Types
 
-// Encapsulate all the data considered personal required for the gate to function
-// (currently limited to browserId) with the indication of whether the
-// reader has consented or not for targettting based on personal data.
 export interface AuxiaGateReaderPersonalData {
 	browserId: string;
+	daily_article_count: number;
+	is_supporter: boolean;
 	user_has_consented_to_personal_data_use: boolean;
 }
 

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -84,6 +84,9 @@ export type SignInGateTestMap = { [name: string]: SignInGateComponent };
 	comment group: auxia-prototype-e55a86ef
 */
 
+// convention: In the naming of these types, we maintain the distinction between "AuxiaAPI" and "AuxiaProxy"
+// The latter refering to the support-dotcom-components proxy for the Auxia API
+
 export interface TreatmentContentDecoded {
 	title: string;
 	subtitle: string;
@@ -104,7 +107,7 @@ export interface AuxiaAPIResponseDataUserTreatment {
 	surface: string;
 }
 
-export interface SDCAuxiaGetTreatmentsProxyResponse {
+export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;
 	data?: SDCAuxiaGetTreatmentsProxyResponseData;
 }

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -157,7 +157,6 @@ export interface AuxiaGateReaderPersonalData {
 	browserId: string | undefined;
 	daily_article_count: number;
 	is_supporter: boolean;
-	user_has_consented_to_personal_data_use: boolean;
 }
 
 export interface AuxiaGateDisplayData {

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -109,17 +109,17 @@ export interface AuxiaAPIResponseDataUserTreatment {
 
 export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;
-	data?: SDCAuxiaGetTreatmentsProxyResponseData;
+	data?: AuxiaProxyGetTreatmentsProxyResponseData;
 }
 
-export interface SDCAuxiaGetTreatmentsProxyResponseData {
+export interface AuxiaProxyGetTreatmentsProxyResponseData {
 	responseId: string;
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
 export interface AuxiaGateDisplayData {
 	browserId: string;
-	auxiaData: SDCAuxiaGetTreatmentsProxyResponseData;
+	auxiaData: AuxiaProxyGetTreatmentsProxyResponseData;
 }
 
 export type AuxiaInteractionInteractionType =

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -87,6 +87,8 @@ export type SignInGateTestMap = { [name: string]: SignInGateComponent };
 // convention: In the naming of these types, we maintain the distinction between "AuxiaAPI" and "AuxiaProxy"
 // The latter refering to the support-dotcom-components proxy for the Auxia API
 
+// Get Treatments
+
 export interface TreatmentContentDecoded {
 	title: string;
 	subtitle: string;
@@ -107,6 +109,14 @@ export interface AuxiaAPIResponseDataUserTreatment {
 	surface: string;
 }
 
+export interface AuxiaProxyGetTreatmentsPayload {
+	user_has_consented_to_personal_data_use: boolean;
+	browserId: string;
+	is_supporter: boolean;
+	daily_article_count: number;
+	article_identifier: string;
+}
+
 export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;
 	data?: AuxiaProxyGetTreatmentsProxyResponseData;
@@ -117,10 +127,7 @@ export interface AuxiaProxyGetTreatmentsProxyResponseData {
 	userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
-export interface AuxiaGateDisplayData {
-	browserId: string;
-	auxiaData: AuxiaProxyGetTreatmentsProxyResponseData;
-}
+// Log Treatment Interaction
 
 export type AuxiaInteractionInteractionType =
 	| 'VIEWED'
@@ -135,6 +142,24 @@ export type AuxiaInteractionActionName =
 	| 'WHY-LINK'
 	| 'HELP-LINK'
 	| ''; // used for 'VIEWED' and 'DISMISSED' interactions
+
+export interface AuxiaProxyLogTreatmentInteractionPayload {
+	user_has_consented_to_personal_data_use: boolean;
+	browserId: string;
+	treatmentTrackingId: string;
+	treatmentId: string;
+	surface: string;
+	interactionType: AuxiaInteractionInteractionType;
+	interactionTimeMicros: number;
+	actionName: AuxiaInteractionActionName;
+}
+
+// DCR Types
+
+export interface AuxiaGateDisplayData {
+	browserId: string;
+	auxiaData: AuxiaProxyGetTreatmentsProxyResponseData;
+}
 
 export type SignInGatePropsAuxia = {
 	guUrl: string;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -84,8 +84,7 @@ export type SignInGateTestMap = { [name: string]: SignInGateComponent };
 	comment group: auxia-prototype-e55a86ef
 */
 
-// convention: In the naming of these types, we maintain the distinction between "AuxiaAPI" and "AuxiaProxy"
-// The latter refering to the support-dotcom-components proxy for the Auxia API
+// Convention: In the naming of these types, we maintain the distinction between "AuxiaAPI", "AuxiaProxy" and "AuxiaGate".
 
 // Get Treatments
 
@@ -155,6 +154,14 @@ export interface AuxiaProxyLogTreatmentInteractionPayload {
 }
 
 // DCR Types
+
+// Encapsulate all the data considered personal required for the gate to function
+// (currently limited to browserId) with the indication of whether the
+// reader has consented or not for targettting based on personal data.
+export interface AuxiaGateReaderPersonalData {
+	browserId: string;
+	user_has_consented_to_personal_data_use: boolean;
+}
 
 export interface AuxiaGateDisplayData {
 	browserId: string;

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -109,8 +109,7 @@ export interface AuxiaAPIResponseDataUserTreatment {
 }
 
 export interface AuxiaProxyGetTreatmentsPayload {
-	user_has_consented_to_personal_data_use: boolean;
-	browserId: string;
+	browserId: string | undefined;
 	is_supporter: boolean;
 	daily_article_count: number;
 	article_identifier: string;
@@ -143,8 +142,7 @@ export type AuxiaInteractionActionName =
 	| ''; // used for 'VIEWED' and 'DISMISSED' interactions
 
 export interface AuxiaProxyLogTreatmentInteractionPayload {
-	user_has_consented_to_personal_data_use: boolean;
-	browserId: string;
+	browserId: string | undefined;
 	treatmentTrackingId: string;
 	treatmentId: string;
 	surface: string;
@@ -156,14 +154,14 @@ export interface AuxiaProxyLogTreatmentInteractionPayload {
 // DCR Types
 
 export interface AuxiaGateReaderPersonalData {
-	browserId: string;
+	browserId: string | undefined;
 	daily_article_count: number;
 	is_supporter: boolean;
 	user_has_consented_to_personal_data_use: boolean;
 }
 
 export interface AuxiaGateDisplayData {
-	browserId: string;
+	browserId: string | undefined;
 	auxiaData: AuxiaProxyGetTreatmentsProxyResponseData;
 }
 

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -35,7 +35,7 @@ import type {
 	AuxiaInteractionInteractionType,
 	CheckoutCompleteCookieData,
 	CurrentSignInGateABTest,
-	SDCAuxiaGetTreatmentsProxyResponse,
+	AuxiaProxyGetTreatmentsResponse,
 	SignInGateComponent,
 } from './SignInGate/types';
 
@@ -484,7 +484,7 @@ const fetchProxyGetTreatments = async (
 	browserId: string,
 	is_supporter: boolean,
 	daily_article_count: number,
-): Promise<SDCAuxiaGetTreatmentsProxyResponse> => {
+): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const article_identifier = `www.theguardian.com/${pageId}`;
 
@@ -507,7 +507,7 @@ const fetchProxyGetTreatments = async (
 
 	const response_raw = await fetch(url, params);
 	const response =
-		(await response_raw.json()) as SDCAuxiaGetTreatmentsProxyResponse;
+		(await response_raw.json()) as AuxiaProxyGetTreatmentsResponse;
 
 	return Promise.resolve(response);
 };

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -443,7 +443,7 @@ interface ShowSignInGateAuxiaProps {
 	abTest: CurrentSignInGateABTest;
 	userTreatment: AuxiaAPIResponseDataUserTreatment;
 	contributionsServiceUrl: string;
-	browserId: string;
+	browserId: string | undefined;
 	logTreatmentInteractionCall: (
 		interactionType: AuxiaInteractionInteractionType,
 		actionName: AuxiaInteractionActionName,
@@ -482,7 +482,7 @@ const decideAuxiaProxyReaderPersonalData =
 		const hasConsent = await hasCmpConsentForBrowserId();
 		const is_supporter = decideIsSupporter();
 		const data = {
-			browserId,
+			browserId: hasConsent ? browserId : undefined,
 			daily_article_count,
 			is_supporter,
 			user_has_consented_to_personal_data_use: hasConsent,
@@ -493,8 +493,7 @@ const decideAuxiaProxyReaderPersonalData =
 const fetchProxyGetTreatments = async (
 	contributionsServiceUrl: string,
 	pageId: string,
-	user_has_consented_to_personal_data_use: boolean,
-	browserId: string,
+	browserId: string | undefined,
 	is_supporter: boolean,
 	daily_article_count: number,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
@@ -506,7 +505,6 @@ const fetchProxyGetTreatments = async (
 		'Content-Type': 'application/json',
 	};
 	const payload: AuxiaProxyGetTreatmentsPayload = {
-		user_has_consented_to_personal_data_use,
 		browserId,
 		is_supporter,
 		daily_article_count,
@@ -533,7 +531,6 @@ const buildAuxiaGateDisplayData = async (
 	const response = await fetchProxyGetTreatments(
 		contributionsServiceUrl,
 		pageId,
-		readerPersonalData.user_has_consented_to_personal_data_use,
 		readerPersonalData.browserId,
 		readerPersonalData.is_supporter,
 		readerPersonalData.daily_article_count,
@@ -551,11 +548,10 @@ const buildAuxiaGateDisplayData = async (
 
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
-	user_has_consented_to_personal_data_use: boolean,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,
 	interactionType: AuxiaInteractionInteractionType,
 	actionName: AuxiaInteractionActionName,
-	browserId: string,
+	browserId: string | undefined,
 ): Promise<void> => {
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
@@ -564,7 +560,6 @@ const auxiaLogTreatmentInteraction = async (
 	const microTime = Date.now() * 1000;
 
 	const payload: AuxiaProxyLogTreatmentInteractionPayload = {
-		user_has_consented_to_personal_data_use,
 		browserId,
 		treatmentTrackingId: userTreatment.treatmentTrackingId,
 		treatmentId: userTreatment.treatmentId,
@@ -693,7 +688,6 @@ const SignInGateSelectorAuxia = ({
 						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
-								true, // TODO: compute value
 								auxiaGateDisplayData.auxiaData.userTreatment!,
 								interactionType,
 								actionName,
@@ -724,7 +718,6 @@ const ShowSignInGateAuxia = ({
 		void (async () => {
 			await auxiaLogTreatmentInteraction(
 				contributionsServiceUrl,
-				true, // TODO: compute value
 				userTreatment,
 				'VIEWED',
 				'',

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -450,16 +450,7 @@ interface ShowSignInGateAuxiaProps {
 const decideBrowserIdWithConsentCheck = async (): Promise<
 	string | undefined
 > => {
-	const hasConsent = await hasCmpConsentForBrowserId();
-	if (!hasConsent) {
-		return Promise.resolve(undefined);
-	}
-
-	const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
-	if (cookie === null) {
-		return Promise.resolve(undefined);
-	}
-	return Promise.resolve(cookie);
+	return Promise.resolve('294375422b48');
 };
 
 const decideIsSupporter = (): boolean => {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -37,6 +37,8 @@ import type {
 	CurrentSignInGateABTest,
 	AuxiaProxyGetTreatmentsResponse,
 	SignInGateComponent,
+	AuxiaProxyGetTreatmentsPayload,
+	AuxiaProxyLogTreatmentInteractionPayload,
 } from './SignInGate/types';
 
 // ------------------------------------------------------------------------------------------
@@ -492,7 +494,7 @@ const fetchProxyGetTreatments = async (
 	const headers = {
 		'Content-Type': 'application/json',
 	};
-	const payload = {
+	const payload: AuxiaProxyGetTreatmentsPayload = {
 		user_has_consented_to_personal_data_use,
 		browserId,
 		is_supporter,
@@ -557,7 +559,8 @@ const auxiaLogTreatmentInteraction = async (
 		'Content-Type': 'application/json',
 	};
 	const microTime = Date.now() * 1000;
-	const payload = {
+
+	const payload: AuxiaProxyLogTreatmentInteractionPayload = {
 		user_has_consented_to_personal_data_use,
 		browserId,
 		treatmentTrackingId: userTreatment.treatmentTrackingId,

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -546,6 +546,7 @@ const buildAuxiaGateDisplayData = async (
 
 const auxiaLogTreatmentInteraction = async (
 	contributionsServiceUrl: string,
+	user_has_consented_to_personal_data_use: boolean,
 	userTreatment: AuxiaAPIResponseDataUserTreatment,
 	interactionType: AuxiaInteractionInteractionType,
 	actionName: AuxiaInteractionActionName,
@@ -557,6 +558,7 @@ const auxiaLogTreatmentInteraction = async (
 	};
 	const microTime = Date.now() * 1000;
 	const payload = {
+		user_has_consented_to_personal_data_use,
 		browserId,
 		treatmentTrackingId: userTreatment.treatmentTrackingId,
 		treatmentId: userTreatment.treatmentId,
@@ -685,6 +687,7 @@ const SignInGateSelectorAuxia = ({
 						) => {
 							await auxiaLogTreatmentInteraction(
 								contributionsServiceUrl,
+								true, // TODO: compute value
 								auxiaGateDisplayData.auxiaData.userTreatment!,
 								interactionType,
 								actionName,
@@ -715,6 +718,7 @@ const ShowSignInGateAuxia = ({
 		void (async () => {
 			await auxiaLogTreatmentInteraction(
 				contributionsServiceUrl,
+				true, // TODO: compute value
 				userTreatment,
 				'VIEWED',
 				'',

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -480,6 +480,7 @@ const decideDailyArticleCount = (): number => {
 const fetchProxyGetTreatments = async (
 	contributionsServiceUrl: string,
 	pageId: string,
+	user_has_consented_to_personal_data_use: boolean,
 	browserId: string,
 	is_supporter: boolean,
 	daily_article_count: number,
@@ -492,6 +493,7 @@ const fetchProxyGetTreatments = async (
 		'Content-Type': 'application/json',
 	};
 	const payload = {
+		user_has_consented_to_personal_data_use,
 		browserId,
 		is_supporter,
 		daily_article_count,
@@ -525,6 +527,7 @@ const buildAuxiaGateDisplayData = async (
 	const response = await fetchProxyGetTreatments(
 		contributionsServiceUrl,
 		pageId,
+		true, // TODO: compute value
 		browserId,
 		is_supporter,
 		daily_article_count,

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -453,11 +453,11 @@ interface ShowSignInGateAuxiaProps {
 const decideIsSupporter = (): boolean => {
 	// nb: We will not be calling the Auxia API if the user is signed in, so we can set isSignedIn to false.
 	const isSignedIn = false;
-	const is_supporter = shouldHideSupportMessaging(isSignedIn);
-	if (is_supporter === 'Pending') {
+	const isSupporter = shouldHideSupportMessaging(isSignedIn);
+	if (isSupporter === 'Pending') {
 		return true;
 	}
-	return is_supporter;
+	return isSupporter;
 };
 
 const decideDailyArticleCount = (): number => {
@@ -478,13 +478,13 @@ const decideAuxiaProxyReaderPersonalData =
 	async (): Promise<AuxiaGateReaderPersonalData> => {
 		const browserId =
 			getCookie({ name: 'bwid', shouldMemoize: true }) ?? '';
-		const daily_article_count = decideDailyArticleCount();
+		const dailyArticleCount = decideDailyArticleCount();
 		const hasConsent = await hasCmpConsentForBrowserId();
-		const is_supporter = decideIsSupporter();
+		const isSupporter = decideIsSupporter();
 		const data = {
 			browserId: hasConsent ? browserId : undefined,
-			daily_article_count,
-			is_supporter,
+			dailyArticleCount,
+			isSupporter,
 		};
 		return Promise.resolve(data);
 	};
@@ -493,11 +493,11 @@ const fetchProxyGetTreatments = async (
 	contributionsServiceUrl: string,
 	pageId: string,
 	browserId: string | undefined,
-	is_supporter: boolean,
-	daily_article_count: number,
+	isSupporter: boolean,
+	dailyArticleCount: number,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
-	const article_identifier = `www.theguardian.com/${pageId}`;
+	const articleIdentifier = `www.theguardian.com/${pageId}`;
 
 	const url = `${contributionsServiceUrl}/auxia/get-treatments`;
 	const headers = {
@@ -505,9 +505,9 @@ const fetchProxyGetTreatments = async (
 	};
 	const payload: AuxiaProxyGetTreatmentsPayload = {
 		browserId,
-		is_supporter,
-		daily_article_count,
-		article_identifier,
+		isSupporter,
+		dailyArticleCount,
+		articleIdentifier,
 	};
 	const params = {
 		method: 'POST',
@@ -531,8 +531,8 @@ const buildAuxiaGateDisplayData = async (
 		contributionsServiceUrl,
 		pageId,
 		readerPersonalData.browserId,
-		readerPersonalData.is_supporter,
-		readerPersonalData.daily_article_count,
+		readerPersonalData.isSupporter,
+		readerPersonalData.dailyArticleCount,
 	);
 	if (response.status && response.data) {
 		const answer = {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -485,7 +485,6 @@ const decideAuxiaProxyReaderPersonalData =
 			browserId: hasConsent ? browserId : undefined,
 			daily_article_count,
 			is_supporter,
-			user_has_consented_to_personal_data_use: hasConsent,
 		};
 		return Promise.resolve(data);
 	};


### PR DESCRIPTION
Here we adapt the Auxia Gate logic rendering to handle the case of non consenting users finding themselves in the Auxia experiment. In this case the SDC Proxy will not call the Auxia API, and will return GU data. 

Sister PR: https://github.com/guardian/support-dotcom-components/pull/1288