### PR TITLE
WIP

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -914,12 +914,9 @@ export const Card = ({
 													containerType ===
 													'fixed/video'
 												}
-												imagePositionOnMobile={
-													imagePositionOnMobile
-												}
 												//** TODO: IMPROVE THIS MAPPING */
 												// image size defaults to small if not provided. However, if the headline size is large or greater, we want to assume the image is also large so that the play icon is correctly sized.
-												imageSize={
+												iconSizeOnDesktop={
 													[
 														'small',
 														'medium',
@@ -929,9 +926,23 @@ export const Card = ({
 													].includes(
 														headlineSizes?.desktop ??
 															'',
-													)
+													) || imageSize !== 'small'
 														? 'large'
-														: imageSize
+														: 'small'
+												}
+												iconSizeOnMobile={
+													imagePositionOnMobile ===
+														'left' ||
+													imagePositionOnMobile ===
+														'right'
+														? 'small'
+														: 'large'
+												}
+												hidePillOnMobile={
+													imagePositionOnMobile ===
+														'left' ||
+													imagePositionOnMobile ===
+														'right'
 												}
 												enableAds={false}
 												aspectRatio={aspectRatio}

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -2,9 +2,8 @@ import { css } from '@emotion/react';
 import { from, palette } from '@guardian/source/foundations';
 import type { ThemeIcon } from '@guardian/source/react-components';
 import { SvgMediaControlsPlay } from '@guardian/source/react-components';
-import type { ImagePositionType, ImageSizeType } from './ImageWrapper';
 
-type PlayButtonSize = keyof typeof sizes;
+export type PlayButtonSize = keyof typeof sizes;
 
 const sizes = {
 	small: { button: 40, icon: 32 },
@@ -46,42 +45,16 @@ const theme = {
 	fill: palette.neutral[100],
 } satisfies Partial<ThemeIcon>;
 
-const getIconSizeOnDesktop = (imageSize: ImageSizeType) => {
-	switch (imageSize) {
-		case 'jumbo':
-		case 'large':
-		case 'podcast':
-		case 'carousel':
-		case 'medium':
-		case 'feature':
-		case 'feature-large':
-			return 'large';
-		case 'small':
-			return 'small';
-	}
+type Props = {
+	iconSizeOnDesktop: PlayButtonSize;
+	iconSizeOnMobile: PlayButtonSize;
 };
 
-const getIconSizeOnMobile = (imagePositionOnMobile: ImagePositionType) =>
-	imagePositionOnMobile === 'left' || imagePositionOnMobile === 'right'
-		? 'small'
-		: 'large';
-
-export const PlayIcon = ({
-	imageSize,
-	imagePositionOnMobile,
-}: {
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
-}) => {
+export const PlayIcon = ({ iconSizeOnDesktop, iconSizeOnMobile }: Props) => {
 	return (
 		<div
 			className="play-icon"
-			css={[
-				iconStyles(
-					getIconSizeOnDesktop(imageSize),
-					getIconSizeOnMobile(imagePositionOnMobile),
-				),
-			]}
+			css={[iconStyles(iconSizeOnDesktop, iconSizeOnMobile)]}
 		>
 			<SvgMediaControlsPlay theme={theme} />
 		</div>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.stories.tsx
@@ -4,10 +4,6 @@ import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../../lib/articleFormat';
 import type { AdTargeting } from '../../types/commercial';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
 import type { Props } from './YoutubeAtom';
 import { YoutubeAtom } from './YoutubeAtom';
 
@@ -129,9 +125,6 @@ const adTargetingAndConsentGiven = {
 	...consentGiven,
 } satisfies AdTargeting & ConsentState;
 
-const imagePositionOnMobile: ImagePositionType = 'none';
-const imageSize: ImageSizeType = 'large';
-
 const baseConfiguration = {
 	atomId: 'a2502abd-1373-45a2-b508-3e5a2ec050be',
 	videoId: '-ZCvZmYlQD8',
@@ -153,8 +146,10 @@ const baseConfiguration = {
 	isMainMedia: false,
 	abTestParticipations: {},
 	adTargeting: disableAds,
-	imagePositionOnMobile,
-	imageSize,
+	iconSizeOnDesktop: 'large',
+	iconSizeOnMobile: 'large',
+	hidePillOnMobile: false,
+	showTextOverlay: false,
 	consentState: consentGiven,
 	renderingTarget: 'Web',
 } satisfies Partial<Props>;
@@ -178,26 +173,7 @@ export const NoOverlay = {
 	},
 } satisfies Story;
 
-export const WithOverrideImage = {
-	args: {
-		...baseConfiguration,
-		videoId: '3jpXAMwRSu4',
-		alt: 'Microscopic image of COVID',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		overrideImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
-		height: undefined,
-		width: undefined,
-		title: 'How to stop the spread of coronavirus',
-	},
-	decorators: [OverlayAutoplayExplainer, Container],
-} satisfies Story;
-
-export const WithPosterImage = {
+export const WithImage = {
 	args: {
 		...baseConfiguration,
 		videoId: 'N9Cgy-ke5-s',
@@ -206,28 +182,8 @@ export const WithPosterImage = {
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
 		},
-		posterImage:
-			'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
+		image: 'https://media.guim.co.uk/757dd4db5818984fd600b41cdaf687668497051d/0_0_1920_1080/1920.jpg',
 		title: 'How Donald Trump’s broken promises failed Ohio | Anywhere but Washington',
-	},
-	decorators: [OverlayAutoplayExplainer, Container],
-} satisfies Story;
-
-export const WithOverlayAndPosterImage = {
-	args: {
-		...baseConfiguration,
-		videoId: WithPosterImage.args.videoId,
-		format: {
-			theme: Pillar.Opinion,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
-		posterImage: WithPosterImage.args.posterImage,
-		overrideImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg',
-		title: 'How Donald Trump’s broken promises failed Ohio',
-		kicker: 'Breaking News',
-		showTextOverlay: true,
 	},
 	decorators: [OverlayAutoplayExplainer, Container],
 } satisfies Story;
@@ -236,11 +192,11 @@ export const GiveConsent = {
 	args: {
 		...baseConfiguration,
 		...consentNotGiven,
-		videoId: WithOverrideImage.args.videoId,
-		alt: WithOverrideImage.args.alt,
-		format: WithOverrideImage.args.format,
-		title: WithOverrideImage.args.title,
-		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
+		videoId: WithImage.args.videoId,
+		alt: WithImage.args.alt,
+		format: WithImage.args.format,
+		title: WithImage.args.title,
+		image: WithImage.args.image,
 	},
 	render: function Render(args) {
 		const [consented, setConsented] = useState(false);
@@ -385,7 +341,6 @@ export const PausesOffscreen = {
  * The ad enabled tests are a convenience for manual testing.
  *
  */
-
 export const NoConsentWithAds = {
 	args: {
 		...NoConsent.args,
@@ -407,35 +362,10 @@ export const NoOverlayWithAds = {
 	},
 } satisfies Story;
 
-export const WithOverrideImageWithAds = {
+export const WithimageWithAds = {
 	args: {
-		...WithOverrideImage.args,
+		...WithImage.args,
 		...adTargetingAndConsentGiven,
-		overrideImage: WithOverlayAndPosterImage.args.overrideImage,
-	},
-	decorators: [Container],
-	parameters: {
-		chromatic: { disableSnapshot: true },
-	},
-} satisfies Story;
-
-export const WithPosterImageWithAds = {
-	args: {
-		...WithPosterImage.args,
-		...adTargetingAndConsentGiven,
-	},
-	decorators: [Container],
-	parameters: {
-		chromatic: { disableSnapshot: true },
-	},
-} satisfies Story;
-
-export const WithOverlayAndPosterImageWithAds = {
-	args: {
-		...WithOverlayAndPosterImage.args,
-		...adTargetingAndConsentGiven,
-		kicker: undefined,
-		showTextOverlay: undefined,
 	},
 	decorators: [Container],
 	parameters: {
@@ -510,8 +440,7 @@ export const LiveStream = {
 			design: ArticleDesign.Standard,
 			display: ArticleDisplay.Standard,
 		},
-		overrideImage:
-			'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
+		image: 'https://i.guim.co.uk/img/media/4b3808707ec341629932a9d443ff5a812cf4df14/0_309_1800_1081/master/1800.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=aff4b8255693eb449f13070df88e9cac',
 		height: undefined,
 		width: undefined,
 		title: 'How to stop the spread of coronavirus',

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -49,8 +49,10 @@ describe('YoutubeAtom', () => {
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -84,12 +86,14 @@ describe('YoutubeAtom', () => {
 						display: ArticleDisplay.Standard,
 					}}
 					consentState={consentStateCanTarget}
-					overrideImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -134,8 +138,10 @@ describe('YoutubeAtom', () => {
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -147,6 +153,7 @@ describe('YoutubeAtom', () => {
 
 	it('overlay has correct aria-label', () => {
 		const title = 'My Youtube video!';
+
 		const atom = (
 			<ConfigProvider
 				value={{
@@ -170,12 +177,14 @@ describe('YoutubeAtom', () => {
 						display: ArticleDisplay.Standard,
 					}}
 					consentState={consentStateCanTarget}
-					overrideImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -213,8 +222,10 @@ describe('YoutubeAtom', () => {
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -249,12 +260,14 @@ describe('YoutubeAtom', () => {
 						design: ArticleDesign.Standard,
 						display: ArticleDisplay.Standard,
 					}}
-					overrideImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -287,12 +300,14 @@ describe('YoutubeAtom', () => {
 						design: ArticleDesign.Standard,
 						display: ArticleDisplay.Standard,
 					}}
-					overrideImage={overlayImage}
+					image={overlayImage}
 					shouldStick={false}
 					isMainMedia={false}
 					abTestParticipations={{}}
-					imagePositionOnMobile="none"
-					imageSize="large"
+					iconSizeOnDesktop="large"
+					iconSizeOnMobile="large"
+					hidePillOnMobile={false}
+					showTextOverlay={false}
 					renderingTarget="Web"
 				/>
 			</ConfigProvider>
@@ -329,12 +344,14 @@ describe('YoutubeAtom', () => {
 							design: ArticleDesign.Standard,
 							display: ArticleDisplay.Standard,
 						}}
-						overrideImage={overlayImage}
+						image={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
-						imagePositionOnMobile="left"
-						imageSize="small"
+						iconSizeOnDesktop="large"
+						iconSizeOnMobile="large"
+						hidePillOnMobile={false}
+						showTextOverlay={false}
 						renderingTarget="Web"
 					/>
 					<YoutubeAtom
@@ -350,12 +367,14 @@ describe('YoutubeAtom', () => {
 							design: ArticleDesign.Standard,
 							display: ArticleDisplay.Standard,
 						}}
-						overrideImage={overlayImage}
+						image={overlayImage}
 						shouldStick={false}
 						isMainMedia={false}
 						abTestParticipations={{}}
-						imagePositionOnMobile="left"
-						imageSize="small"
+						iconSizeOnDesktop="large"
+						iconSizeOnMobile="large"
+						hidePillOnMobile={false}
+						showTextOverlay={false}
 						renderingTarget="Web"
 					/>
 				</ConfigProvider>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -5,10 +5,7 @@ import type { ArticleFormat } from '../../lib/articleFormat';
 import type { AdTargeting } from '../../types/commercial';
 import type { AspectRatio } from '../../types/front';
 import type { RenderingTarget } from '../../types/renderingTarget';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
+import type { PlayButtonSize } from '../Card/components/PlayIcon';
 import { MaintainAspectRatio } from '../MaintainAspectRatio';
 import { YoutubeAtomOverlay } from './YoutubeAtomOverlay';
 import { YoutubeAtomPlaceholder } from './YoutubeAtomPlaceholder';
@@ -30,8 +27,7 @@ export type Props = {
 	atomId: string;
 	videoId: string;
 	uniqueId: string;
-	overrideImage?: string | undefined;
-	posterImage?: string | undefined;
+	image?: string;
 	adTargeting?: AdTargeting;
 	consentState?: ConsentState;
 	height?: number;
@@ -47,19 +43,33 @@ export type Props = {
 	abTestParticipations: Participations;
 	kicker?: string;
 	shouldPauseOutOfView?: boolean;
-	showTextOverlay?: boolean;
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
+	showTextOverlay: boolean;
+	iconSizeOnDesktop: PlayButtonSize;
+	iconSizeOnMobile: PlayButtonSize;
+	hidePillOnMobile: boolean;
 	renderingTarget: RenderingTarget;
 	aspectRatio?: AspectRatio;
 };
 
+/**
+ * The loading sequence of the YoutubeAtom is as follows:
+ *
+ * Overlay -> Placeholder -> Player
+ *
+ * In detail:
+ *
+ * 1. Initially show the overlay if it exists
+ * 2. When the overlay is clicked
+ *     2.1 Remove the overlay
+ *     2.2 Show the placeholder until the player is ready
+ * 3. When consent and ad targeting is available render the player to initiate loading of the YouTube player
+ * 4. When the player is ready the placeholder is removed and the YouTube player is shown
+ */
 export const YoutubeAtom = ({
 	atomId,
 	videoId,
 	uniqueId,
-	overrideImage,
-	posterImage,
+	image,
 	adTargeting,
 	consentState,
 	height = 259,
@@ -75,9 +85,10 @@ export const YoutubeAtom = ({
 	kicker,
 	format,
 	shouldPauseOutOfView = false,
-	showTextOverlay = false,
-	imageSize,
-	imagePositionOnMobile,
+	showTextOverlay,
+	iconSizeOnDesktop,
+	iconSizeOnMobile,
+	hidePillOnMobile,
 	renderingTarget,
 	aspectRatio,
 }: Props): JSX.Element => {
@@ -122,44 +133,10 @@ export const YoutubeAtom = ({
 	 * Combine the videoState and tracking event emitters
 	 */
 	const compositeEventEmitters = [playerState, ...eventEmitters];
+	const hasOverlay = !!image;
 
-	/**
-	 * The loading sequence of the YoutubeAtom is as follows:
-	 *
-	 * Overlay -> Placeholder -> Player
-	 *
-	 * In detail:
-	 *
-	 * 1. Initially show the overlay if it exists
-	 * 2. When the overlay is clicked
-	 *     2.1 Remove the overlay
-	 *     2.2 Show the placeholder until the player is ready
-	 * 3. When consent and ad targeting is available render the player to initiate loading of the YouTube player
-	 * 4. When the player is ready the placeholder is removed and the YouTube player is shown
-	 */
-
-	const hasOverlay = !!(overrideImage ?? posterImage);
-
-	/**
-	 * Show an overlay if:
-	 *
-	 * - It exists
-	 *
-	 * AND
-	 *
-	 * - It hasn't been clicked
-	 */
 	const showOverlay = hasOverlay && !overlayClicked;
 
-	/**
-	 * Show a placeholder if:
-	 *
-	 * - We don't have an overlay OR the user has clicked the overlay
-	 *
-	 * AND
-	 *
-	 * - The player is not ready
-	 */
 	const showPlaceholder = (!hasOverlay || overlayClicked) && !playerReady;
 
 	let loadPlayer;
@@ -237,8 +214,7 @@ export const YoutubeAtom = ({
 					{showOverlay && (
 						<YoutubeAtomOverlay
 							uniqueId={uniqueId}
-							overrideImage={overrideImage}
-							posterImage={posterImage}
+							image={image}
 							height={height}
 							width={width}
 							alt={alt}
@@ -248,8 +224,9 @@ export const YoutubeAtom = ({
 							kicker={kicker}
 							format={format}
 							showTextOverlay={showTextOverlay}
-							imageSize={imageSize}
-							imagePositionOnMobile={imagePositionOnMobile}
+							iconSizeOnDesktop={iconSizeOnDesktop}
+							iconSizeOnMobile={iconSizeOnMobile}
+							hidePillOnMobile={hidePillOnMobile}
 							aspectRatio={aspectRatio}
 						/>
 					)}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -11,34 +11,13 @@ import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
 import type { AspectRatio } from '../../types/front';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from '../Card/components/ImageWrapper';
+import type { PlayButtonSize } from '../Card/components/PlayIcon';
 import { PlayIcon } from '../Card/components/PlayIcon';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { Pill } from '../Pill';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
 import { YoutubeAtomPicture } from './YoutubeAtomPicture';
-
-type Props = {
-	uniqueId: string;
-	overrideImage?: string;
-	posterImage?: string;
-	height: number;
-	width: number;
-	alt: string;
-	duration?: number; // in seconds
-	title?: string;
-	onClick: () => void;
-	kicker?: string;
-	format: ArticleFormat;
-	showTextOverlay?: boolean;
-	imageSize: ImageSizeType;
-	imagePositionOnMobile: ImagePositionType;
-	aspectRatio?: AspectRatio;
-};
 
 const overlayStyles = css`
 	background-size: cover;
@@ -108,30 +87,48 @@ const titleStyles = css`
 	}
 `;
 
+type Props = {
+	uniqueId: string;
+	height: number;
+	width: number;
+	onClick: () => void;
+	format: ArticleFormat;
+	alt: string;
+	hidePillOnMobile: boolean;
+	showTextOverlay: boolean;
+	iconSizeOnDesktop: PlayButtonSize;
+	iconSizeOnMobile: PlayButtonSize;
+	title?: string;
+	image?: string;
+	duration?: number; // in seconds
+	kicker?: string;
+	aspectRatio?: AspectRatio;
+};
+
 export const YoutubeAtomOverlay = ({
 	uniqueId,
-	overrideImage,
-	posterImage,
 	height,
 	width,
-	alt,
-	duration,
-	title,
 	onClick,
-	kicker,
 	format,
+	alt,
+	hidePillOnMobile,
 	showTextOverlay,
-	imageSize,
-	imagePositionOnMobile,
+	iconSizeOnDesktop,
+	iconSizeOnMobile,
+	title,
+	image,
+	duration,
+	kicker,
 	aspectRatio,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
-	//** We infer that a video is a livestream if the duration is set to 0. This is a soft contract with Editorial who manual set the duration of videos   */
+	/**
+	 * We infer that a video is a livestream if the duration is set to 0. This is
+	 * a soft contract with Editorial who manual set the duration of videos
+	 */
 	const isLiveStream = !isUndefined(duration) && duration === 0;
-	const image = overrideImage ?? posterImage;
-	const hidePillOnMobile =
-		imagePositionOnMobile === 'right' || imagePositionOnMobile === 'left';
 
 	return (
 		<FormatBoundary format={format}>
@@ -151,7 +148,7 @@ export const YoutubeAtomOverlay = ({
 						aspectRatio={aspectRatio}
 					/>
 				)}
-				{isLiveStream && (
+				{isLiveStream ? (
 					<div
 						css={
 							hidePillOnMobile
@@ -162,13 +159,12 @@ export const YoutubeAtomOverlay = ({
 						}
 					>
 						<Pill
-							content={'Live'}
+							content="Live"
 							icon={<div css={[liveBulletStyles]} />}
-							iconSize={'small'}
+							iconSize="small"
 						/>
 					</div>
-				)}
-				{hasDuration && (
+				) : hasDuration ? (
 					<div
 						css={
 							hidePillOnMobile
@@ -181,13 +177,13 @@ export const YoutubeAtomOverlay = ({
 						<Pill
 							content={secondsToDuration(duration)}
 							icon={<SvgMediaControlsPlay />}
-							iconSize={'small'}
+							iconSize="small"
 						/>
 					</div>
-				)}
+				) : null}
 				<PlayIcon
-					imageSize={imageSize}
-					imagePositionOnMobile={imagePositionOnMobile}
+					iconSizeOnDesktop={iconSizeOnDesktop}
+					iconSizeOnMobile={iconSizeOnMobile}
 				/>
 				{showTextOverlay && (
 					<div css={textOverlayStyles}>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -1,15 +1,13 @@
 import type { ConsentState } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
+import { getLargestImageSize } from '../lib/image';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import type { AdTargeting } from '../types/commercial';
 import type { AspectRatio } from '../types/front';
 import { Caption } from './Caption';
-import type {
-	ImagePositionType,
-	ImageSizeType,
-} from './Card/components/ImageWrapper';
+import type { PlayButtonSize } from './Card/components/PlayIcon';
 import { useConfig } from './ConfigContext';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import { YoutubeAtom } from './YoutubeAtom/YoutubeAtom';
@@ -37,27 +35,13 @@ type Props = {
 	stickyVideos: boolean;
 	kickerText?: string;
 	pauseOffscreenVideo?: boolean;
-	showTextOverlay?: boolean;
-	// If the youtube block component is used on a card, we can pass in the image size and position on mobile to get the correct styling for the play icon. If it's not used on a card, we can just pass default values to get the standard large play icon.
-	imageSize?: ImageSizeType;
-	imagePositionOnMobile?: ImagePositionType;
+	showTextOverlay: boolean;
+	iconSizeOnDesktop: PlayButtonSize;
+	iconSizeOnMobile: PlayButtonSize;
+	hidePillOnMobile: boolean;
 	enableAds: boolean;
 	aspectRatio?: AspectRatio;
 };
-
-/**
- * We do our own image optimization in DCR and only need 1 image. Pick the largest image available to
- * us to avoid up-scaling later.
- *
- * @param images an array of the same image at different resolutions
- * @returns largest image from images
- */
-const getLargestImageSize = (
-	images: {
-		url: string;
-		width: number;
-	}[],
-) => [...images].sort((a, b) => a.width - b.width).pop();
 
 const adTargetingDisabled: AdTargeting = { disableAds: true };
 
@@ -81,8 +65,9 @@ export const YoutubeBlockComponent = ({
 	kickerText,
 	pauseOffscreenVideo = false,
 	showTextOverlay,
-	imageSize = 'large',
-	imagePositionOnMobile = 'none',
+	iconSizeOnDesktop,
+	iconSizeOnMobile,
+	hidePillOnMobile,
 	enableAds,
 	aspectRatio,
 }: Props) => {
@@ -102,6 +87,12 @@ export const YoutubeBlockComponent = ({
 	 * We need to ensure a unique id for each YouTube player on the page.
 	 */
 	const uniqueId = `${assetId}-${index}`;
+
+	/**
+	 * We do our own image optimization in DCR and only need 1 image.
+	 * Pick the largest image available to us to avoid up-scaling later.
+	 */
+	const largestPosterImage = getLargestImageSize(posterImage)?.url;
 
 	useEffect(() => {
 		if (renderingTarget === 'Web') {
@@ -148,8 +139,7 @@ export const YoutubeBlockComponent = ({
 				atomId={id}
 				videoId={assetId}
 				uniqueId={uniqueId}
-				overrideImage={overrideImage}
-				posterImage={getLargestImageSize(posterImage)?.url}
+				image={overrideImage ?? largestPosterImage}
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={
 					enableAds && renderingTarget === 'Web'
@@ -174,8 +164,9 @@ export const YoutubeBlockComponent = ({
 				kicker={kickerText}
 				shouldPauseOutOfView={pauseOffscreenVideo}
 				showTextOverlay={showTextOverlay}
-				imageSize={imageSize}
-				imagePositionOnMobile={imagePositionOnMobile}
+				iconSizeOnDesktop={iconSizeOnDesktop}
+				iconSizeOnMobile={iconSizeOnMobile}
+				hidePillOnMobile={hidePillOnMobile}
 				renderingTarget={renderingTarget}
 				aspectRatio={aspectRatio}
 			/>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -39,7 +39,7 @@ export const Default = () => {
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -54,12 +54,16 @@ export const Default = () => {
 				expired={false}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
@@ -73,7 +77,7 @@ export const Vertical = () => {
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -90,12 +94,16 @@ export const Vertical = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
@@ -109,7 +117,7 @@ export const Expired = () => {
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -127,12 +135,16 @@ export const Expired = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
@@ -146,7 +158,7 @@ export const WithOverlayImage = () => {
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -165,26 +177,30 @@ export const WithOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
 };
 WithOverlayImage.storyName = 'with overlay image';
 
-export const WithPosterImage = () => {
+export const Withimage = () => {
 	return (
 		<Wrapper>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -224,26 +240,32 @@ export const WithPosterImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
 };
-WithPosterImage.storyName = 'with poster image';
+Withimage.storyName = 'with poster image';
 
 export const WithPosterAndOverlayImage = () => {
+	const title =
+		"Prince Harry and Meghan's 'bombshell' plans explained – video";
 	return (
 		<Wrapper>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -252,7 +274,7 @@ export const WithPosterAndOverlayImage = () => {
 					theme: Pillar.News,
 				}}
 				assetId="d2Q5bXvEgMg"
-				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+				mediaTitle={title}
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
 				index={0}
 				expired={false}
@@ -284,12 +306,16 @@ export const WithPosterAndOverlayImage = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);
@@ -297,13 +323,16 @@ export const WithPosterAndOverlayImage = () => {
 WithPosterAndOverlayImage.storyName = 'with poster and overlay image';
 
 export const WithShowMainVideoFlagOff = () => {
+	const title =
+		"Prince Harry and Meghan's 'bombshell' plans explained – video";
+
 	return (
 		<Wrapper>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<YoutubeBlockComponent
 				format={{
@@ -312,7 +341,7 @@ export const WithShowMainVideoFlagOff = () => {
 					theme: Pillar.News,
 				}}
 				assetId="d2Q5bXvEgMg"
-				mediaTitle="Prince Harry and Meghan's 'bombshell' plans explained – video"
+				mediaTitle={title}
 				id="c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28"
 				index={0}
 				expired={false}
@@ -344,12 +373,16 @@ export const WithShowMainVideoFlagOff = () => {
 				width={460}
 				stickyVideos={false}
 				enableAds={false}
+				showTextOverlay={false}
+				iconSizeOnDesktop="large"
+				iconSizeOnMobile="large"
+				hidePillOnMobile={false}
 			/>
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
 				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.{' '}
+				nisi ut aliquip ex ea commodo consequat.
 			</p>
 		</Wrapper>
 	);

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -12,6 +12,17 @@ export const getLargest = (images: Image[]): Image | undefined => {
 	return images.slice().sort(descendingByWidthComparator)[0];
 };
 
+/**
+ * Finds the largest image by width in an array of images
+ */
+export const getLargestImageSize = (
+	images: {
+		url: string;
+		width: number;
+	}[],
+): { url: string; width: number } | undefined =>
+	[...images].sort((a, b) => a.width - b.width).pop();
+
 const getServiceFromUrl = (url: URL): string => {
 	const serviceName = url.hostname.split('.')[0] ?? '';
 	switch (serviceName) {

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -855,6 +855,10 @@ export const renderElement = ({
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
 						enableAds={true}
+						iconSizeOnDesktop="large"
+						iconSizeOnMobile="large"
+						showTextOverlay={false}
+						hidePillOnMobile={false}
 					/>
 				</Island>
 			);


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
