### PR TITLE
Fix Storybook Build Errors And Warnings

### DIFF
--- a/dotcom-rendering/.storybook/main.ts
+++ b/dotcom-rendering/.storybook/main.ts
@@ -51,6 +51,7 @@ const config: StorybookConfig = {
 		// clean-css will try to import these packages
 		config.resolve.fallback['http'] = false;
 		config.resolve.fallback['https'] = false;
+		config.resolve.fallback['os'] = false;
 
 		// Required as otherwise 'process' will not be defined when included on its own (without .env)
 		// e.g process?.env?.SOME_VAR
@@ -103,12 +104,13 @@ const webpackConfig = (config: Configuration) => {
 
 	// log4js tries to call "fs" in storybook -- we can ignore it
 	config.resolve.alias[
-		path.resolve(__dirname, '../src/server/lib/logging.ts')
+		`${path.resolve(__dirname, '../src/server/lib/logging')}$`
 	] = path.resolve(__dirname, './mocks/log4js.ts');
 
 	// Mock BridgetApi for storybook
-	config.resolve.alias[path.resolve(__dirname, '../src/lib/bridgetApi.ts')] =
-		path.resolve(__dirname, './mocks/bridgetApi.ts');
+	config.resolve.alias[
+		`${path.resolve(__dirname, '../src/lib/bridgetApi')}$`
+	] = path.resolve(__dirname, './mocks/bridgetApi.ts');
 
 	const webpackLoaders = getLoaders('client.web');
 


### PR DESCRIPTION
There are two groups of issues with the Storybook build:

1. A "Module not found" warning related to the "os" node module.
2. A pair of "ENOTDIR" errors related to `bridgetApi.ts` and `logging.ts`.

The first is caused by `clean-css`, which attempts to import the "os" module that's built into Node.js. Storybook's Webpack is building for the browser so this module is not available, and it's not automatically polyfilled as of Webpack 5. The "os" module is not required for our usage of `clean-css`, so the solution is to instruct Webpack to provide an empty module via `resolve.fallback`[^1].

The second issue is caused by our attempt to mock the `logging.ts` and `bridgetApi.ts` modules in Storybook. Webpack is attempting to treat these as directories during the compilation process, which causes the above error. Removing the `.ts` file extensions solves this. This change also adds a `$` suffix to these paths, which makes sure an exact match is always used[^2].

[^1]: https://webpack.js.org/configuration/resolve/#resolvefallback
[^2]: https://webpack.js.org/configuration/resolve/#resolvealias
