### PR TITLE
Update `CaptionBlockComponent` Stories To Component Story Format v3

### DIFF
--- a/dotcom-rendering/src/components/CaptionBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/CaptionBlockComponent.stories.tsx
@@ -1,185 +1,111 @@
-import { css } from '@emotion/react';
-import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { allModes } from '../../.storybook/modes';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { CaptionBlockComponent } from './CaptionBlockComponent';
-import { Flex } from './Flex';
-import { LeftColumn } from './LeftColumn';
-import { RightColumn } from './RightColumn';
-import { Section } from './Section';
 
-export default {
+const meta = {
 	component: CaptionBlockComponent,
-	title: 'Components/CaptionBlockComponent',
-};
+	title: 'Components/Caption Block Component',
+	decorators: [centreColumnDecorator],
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+			},
+		},
+	},
+} satisfies Meta<typeof CaptionBlockComponent>;
 
-/*
-    type Props = {
-        display: Display;
-        design: Design;
-        captionText?: string;
-        pillar: Theme;
-        padCaption?: boolean;
-        credit?: string;
-        displayCredit?: boolean;
-        shouldLimitWidth?: boolean;
-        isOverlaid?: boolean;
-    };
- */
+export default meta;
 
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-	<Section fullWidth={true} showTopBorder={false}>
-		<Flex>
-			<LeftColumn borderType="full">
-				<></>
-			</LeftColumn>
-			<div
-				css={css`
-					width: 620px;
-					padding: 20px;
-					flex-grow: 1;
-				`}
-			>
-				{children}
-			</div>
-			<RightColumn>
-				<></>
-			</RightColumn>
-		</Flex>
-	</Section>
-);
+type Story = StoryObj<typeof meta>;
 
-const standardFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-	theme: Pillar.News,
-};
-export const StandardArticle = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption text"
-				format={standardFormat}
-			/>
-		</Wrapper>
-	);
-};
-StandardArticle.storyName = 'with defaults';
-StandardArticle.decorators = [splitTheme([standardFormat])];
+export const Default = {
+	args: {
+		captionText: 'Caption text',
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
+		padCaption: false,
+		credit: 'Credit text',
+		displayCredit: false,
+		shouldLimitWidth: false,
+		isOverlaid: false,
+	},
+} satisfies Story;
 
-const photoEssayFormat = {
-	display: ArticleDisplay.Immersive,
-	design: ArticleDesign.PhotoEssay,
-	theme: Pillar.Lifestyle,
-};
-export const PhotoEssay = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption text"
-				format={photoEssayFormat}
-				padCaption={false}
-				credit="Credit text"
-				displayCredit={false}
-				shouldLimitWidth={false}
-				isOverlaid={false}
-			/>
-		</Wrapper>
-	);
-};
-PhotoEssay.storyName = 'PhotoEssay';
-PhotoEssay.decorators = [splitTheme([photoEssayFormat])];
+export const WithDefaults = {
+	args: {
+		...Default.args,
+		padCaption: undefined,
+		credit: undefined,
+		displayCredit: undefined,
+		shouldLimitWidth: undefined,
+		isOverlaid: undefined,
+	},
+} satisfies Story;
 
-export const PhotoEssayHTML = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="<ul><li>Line 1 text</li><li>Line 2 text</li><li>Line 3 text</li></ul>"
-				format={photoEssayFormat}
-				padCaption={false}
-				credit="Credit text"
-				displayCredit={false}
-				shouldLimitWidth={false}
-				isOverlaid={false}
-			/>
-		</Wrapper>
-	);
-};
-PhotoEssayHTML.storyName = 'PhotoEssay using html';
-PhotoEssayHTML.decorators = [splitTheme([photoEssayFormat])];
+export const PhotoEssay = {
+	args: {
+		...Default.args,
+		format: {
+			display: ArticleDisplay.Immersive,
+			design: ArticleDesign.PhotoEssay,
+			theme: Pillar.Lifestyle,
+		},
+	},
+} satisfies Story;
 
-export const Padded = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption text"
-				format={standardFormat}
-				padCaption={true}
-				credit="Credit text"
-				displayCredit={false}
-				shouldLimitWidth={false}
-				isOverlaid={false}
-			/>
-		</Wrapper>
-	);
-};
-Padded.storyName = 'when padded';
-Padded.decorators = [splitTheme([standardFormat])];
+export const PhotoEssayUsingHTML = {
+	args: {
+		...PhotoEssay.args,
+		captionText:
+			'<ul><li>Line 1 text</li><li>Line 2 text</li><li>Line 3 text</li></ul>',
+	},
+} satisfies Story;
 
-export const WidthLimited = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
-				format={standardFormat}
-				padCaption={false}
-				credit="Credit text"
-				displayCredit={false}
-				shouldLimitWidth={true}
-				isOverlaid={false}
-			/>
-		</Wrapper>
-	);
-};
-WidthLimited.storyName = 'with width limited';
-WidthLimited.decorators = [splitTheme([standardFormat])];
+export const WhenPadded = {
+	args: {
+		...Default.args,
+		padCaption: true,
+	},
+} satisfies Story;
 
-export const Credited = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
-				format={standardFormat}
-				padCaption={false}
-				credit="Credit text"
-				displayCredit={true}
-				shouldLimitWidth={false}
-				isOverlaid={false}
-			/>
-		</Wrapper>
-	);
-};
-Credited.storyName = 'with credit';
-Credited.decorators = [splitTheme([standardFormat])];
+export const WithWidthLimited = {
+	args: {
+		...Default.args,
+		captionText:
+			'Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit',
+		shouldLimitWidth: true,
+	},
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical leftCol': allModes['vertical leftCol'],
+			},
+		},
+	},
+} satisfies Story;
 
-const showcaseFormat = {
-	display: ArticleDisplay.Showcase,
-	design: ArticleDesign.Comment,
-	theme: Pillar.Sport,
-};
-export const Overlaid = () => {
-	return (
-		<Wrapper>
-			<CaptionBlockComponent
-				captionText="Caption textQuas repellat sapiente nobis vel. Expedita veniam ut officiis. Omnis tempore natus est distinctio sapiente aliquid dolores soluta. Vel facere vitae velit et non. Eveniet omnis impedit mollitia voluptas omnis sit"
-				format={showcaseFormat}
-				padCaption={false}
-				credit="Credit text"
-				displayCredit={false}
-				shouldLimitWidth={false}
-				isOverlaid={true}
-			/>
-		</Wrapper>
-	);
-};
-Overlaid.storyName = 'when overlaid';
-Overlaid.decorators = [splitTheme([showcaseFormat])];
+export const WithCredit = {
+	args: {
+		...Default.args,
+		displayCredit: true,
+	},
+} satisfies Story;
+
+export const WhenOverlaid = {
+	args: {
+		...Default.args,
+		captionText: WithWidthLimited.args.captionText,
+		isOverlaid: true,
+		format: {
+			display: ArticleDisplay.Showcase,
+			design: ArticleDesign.Comment,
+			theme: Pillar.Sport,
+		},
+	},
+} satisfies Story;


### PR DESCRIPTION
This is the default for Storybook 7+, and integrates better with some of its features[^1].

Using `satisfies` gives better type safety for args[^2]. Removed the `splitTheme` decorator, as this is now handled by the "global colour scheme" toolbar item[^3] and a Chromatic mode[^4]. Added the `centreColumnDecorator` to replace the `Wrapper` component. Added a new `Default` story, and derived the other stories from that. Changed the Chromatic snapshots to use `mobileMedium`, and added an additional mode to `WithWidthLimited` to capture the width limiting behaviour at a wider breakpoint.

[^1]: https://storybook.js.org/blog/storybook-csf3-is-here/
[^2]: https://storybook.js.org/docs/writing-stories/typescript#using-satisfies-for-better-type-safety
[^3]: https://storybook.js.org/docs/essentials/toolbars-and-globals
[^4]: https://www.chromatic.com/docs/modes/
