### PR TITLE
auxia experiment: send editionId

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -382,6 +382,7 @@ describe('Island: server-side rendering', () => {
 						pageId={''}
 						switches={{}}
 						contributionsServiceUrl={''}
+						editionId="UK"
 					/>
 				</WithConfig>,
 			),

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -1,5 +1,6 @@
 import type { CountryCode } from '@guardian/libs';
 import { isObject, isOneOf, isString } from '@guardian/libs';
+import type { EditionId } from '../../lib/edition';
 import type { TagType } from '../../types/tag';
 
 export type CanShowGateProps = {
@@ -113,6 +114,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	isSupporter: boolean;
 	dailyArticleCount: number;
 	articleIdentifier: string;
+	editionId: EditionId;
 }
 
 export interface AuxiaProxyGetTreatmentsResponse {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -5,6 +5,7 @@ import {
 	shouldHideSupportMessaging,
 } from '../lib/contributions';
 import { getDailyArticleCount, getToday } from '../lib/dailyArticleCount';
+import type { EditionId } from '../lib/edition';
 import { parseCheckoutCompleteCookieData } from '../lib/parser/parseCheckoutOutCookieData';
 import { constructQuery } from '../lib/querystring';
 import { useAB } from '../lib/useAB';
@@ -57,6 +58,19 @@ type Props = {
 	idUrl?: string;
 	switches: Switches;
 	contributionsServiceUrl: string;
+	editionId: EditionId;
+};
+
+type PropsDefault = {
+	contentType: string;
+	sectionId?: string;
+	tags: TagType[];
+	isPaidContent: boolean;
+	isPreview: boolean;
+	host?: string;
+	pageId: string;
+	idUrl?: string;
+	switches: Switches;
 };
 
 // interface for the component which shows the sign in gate
@@ -214,14 +228,7 @@ const SignInGateSelectorDefault = ({
 	pageId,
 	idUrl = 'https://profile.theguardian.com',
 	switches,
-	contributionsServiceUrl,
-}: Props) => {
-	// comment group: auxia-prototype-e55a86ef
-	// The following (useless) instruction only exists to avoid linting error
-	// so that SignInGateSelectorDefault, SignInGateSelectorAuxia and SignInGateSelector
-	// all have the same signature, while we give shape to the Auxia prototype.
-	contributionsServiceUrl;
-
+}: PropsDefault) => {
 	const authStatus = useAuthStatus();
 	const isSignedIn =
 		authStatus.kind === 'SignedInWithOkta' ||
@@ -372,6 +379,7 @@ export const SignInGateSelector = ({
 	idUrl = 'https://profile.theguardian.com',
 	switches,
 	contributionsServiceUrl,
+	editionId,
 }: Props) => {
 	const abTestAPI = useAB()?.api;
 	const userIsInAuxiaExperiment = !!abTestAPI?.isUserInVariant(
@@ -391,7 +399,6 @@ export const SignInGateSelector = ({
 				pageId={pageId}
 				idUrl={idUrl}
 				switches={switches}
-				contributionsServiceUrl={contributionsServiceUrl}
 			/>
 		);
 	} else {
@@ -401,6 +408,7 @@ export const SignInGateSelector = ({
 				pageId={pageId}
 				idUrl={idUrl}
 				contributionsServiceUrl={contributionsServiceUrl}
+				editionId={editionId}
 			/>
 		);
 	}
@@ -434,6 +442,7 @@ type PropsAuxia = {
 	pageId: string;
 	idUrl: string;
 	contributionsServiceUrl: string;
+	editionId: EditionId;
 };
 
 interface ShowSignInGateAuxiaProps {
@@ -495,10 +504,10 @@ const fetchProxyGetTreatments = async (
 	browserId: string | undefined,
 	isSupporter: boolean,
 	dailyArticleCount: number,
+	editionId: EditionId,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
-
 	const url = `${contributionsServiceUrl}/auxia/get-treatments`;
 	const headers = {
 		'Content-Type': 'application/json',
@@ -508,6 +517,7 @@ const fetchProxyGetTreatments = async (
 		isSupporter,
 		dailyArticleCount,
 		articleIdentifier,
+		editionId,
 	};
 	const params = {
 		method: 'POST',
@@ -525,6 +535,7 @@ const fetchProxyGetTreatments = async (
 const buildAuxiaGateDisplayData = async (
 	contributionsServiceUrl: string,
 	pageId: string,
+	editionId: EditionId,
 ): Promise<AuxiaGateDisplayData | undefined> => {
 	const readerPersonalData = await decideAuxiaProxyReaderPersonalData();
 	const response = await fetchProxyGetTreatments(
@@ -533,6 +544,7 @@ const buildAuxiaGateDisplayData = async (
 		readerPersonalData.browserId,
 		readerPersonalData.isSupporter,
 		readerPersonalData.dailyArticleCount,
+		editionId,
 	);
 	if (response.status && response.data) {
 		const answer = {
@@ -581,6 +593,7 @@ const SignInGateSelectorAuxia = ({
 	pageId,
 	idUrl,
 	contributionsServiceUrl,
+	editionId,
 }: PropsAuxia) => {
 	/*
 		comment group: auxia-prototype-e55a86ef
@@ -643,6 +656,7 @@ const SignInGateSelectorAuxia = ({
 			const data = await buildAuxiaGateDisplayData(
 				contributionsServiceUrl,
 				pageId,
+				editionId,
 			);
 			if (data !== undefined) {
 				setAuxiaGateDisplayData(data);

--- a/dotcom-rendering/src/lib/ArticleRenderer.tsx
+++ b/dotcom-rendering/src/lib/ArticleRenderer.tsx
@@ -132,6 +132,7 @@ export const ArticleRenderer = ({
 						isSensitive,
 						isDev,
 						contributionsServiceUrl,
+						editionId,
 				  })}
 		</div>
 	); // classname that space finder is going to target for in-body ads in DCR

--- a/dotcom-rendering/src/lib/withSignInGateSlot.tsx
+++ b/dotcom-rendering/src/lib/withSignInGateSlot.tsx
@@ -6,6 +6,7 @@ import { Island } from '../components/Island';
 import { SignInGateSelector } from '../components/SignInGateSelector.importable';
 import type { Switches } from '../types/config';
 import type { TagType } from '../types/tag';
+import type { EditionId } from './edition';
 
 type Props = {
 	renderedElements: (JSX.Element | null | undefined)[];
@@ -21,6 +22,7 @@ type Props = {
 	isSensitive?: boolean;
 	isDev?: boolean;
 	contributionsServiceUrl: string;
+	editionId: EditionId;
 };
 
 export const withSignInGateSlot = ({
@@ -35,6 +37,7 @@ export const withSignInGateSlot = ({
 	idUrl,
 	switches,
 	contributionsServiceUrl,
+	editionId,
 }: Props): React.ReactNode => {
 	return renderedElements.map((element, i) => {
 		return (
@@ -57,6 +60,7 @@ export const withSignInGateSlot = ({
 								contributionsServiceUrl={
 									contributionsServiceUrl
 								}
+								editionId={editionId}
 							/>
 						</Island>
 					</div>


### PR DESCRIPTION
Upgrade the GetTreatments call with the editionId.

(sister change: https://github.com/guardian/support-dotcom-components/pull/1289)

![Screenshot 2025-02-17 at 09 52 14](https://github.com/user-attachments/assets/2c5b92e4-c3b6-4053-b127-06a7c2f24e82)

We also rescind the convention that SignInGateSelector, SignInGateSelectorDefault and SignInGateSelectorAuxia all have the same signature.