### PR TITLE
signin gates edit: remove the privacy settings sentence in both legacy and auxia gates

### DIFF
--- a/dotcom-rendering/playwright/tests/sign-in-gate.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/sign-in-gate.e2e.spec.ts
@@ -8,9 +8,8 @@ import {
 	SIGN_IN_PROMPT,
 	SUBSCRIPTION_HEADER,
 } from '../../src/lib/signInAfterCheckOutText';
-import { CMP_LAYER1_IFRAME, cmpAcceptAll, disableCMP } from '../lib/cmp';
-import { addCookie, clearCookie } from '../lib/cookies';
-import { getIframeBody } from '../lib/iframe';
+import { disableCMP } from '../lib/cmp';
+import { addCookie } from '../lib/cookies';
 import { loadPageWithOverrides } from '../lib/load-page';
 import { expectToBeVisible, expectToNotExist } from '../lib/locators';
 
@@ -224,35 +223,6 @@ test.describe('Sign In Gate Tests', () => {
 				.getAttribute('href');
 
 			expect(signInHref).toContain('profile.theguardian.com/signin');
-		});
-
-		test('show cmp ui when privacy settings link is clicked', async ({
-			context,
-			page,
-		}) => {
-			// For this test remove the gu-cmp-disabled cookie to ensure cmp is shown
-			await clearCookie(context, 'gu-cmp-disabled');
-
-			await loadPageWithOverrides(page, standardArticle);
-
-			await cmpAcceptAll(page);
-
-			// set article count to be min number to view gate
-			await setArticleCount(page, 3);
-
-			await scrollToGateForLazyLoading(page);
-
-			await expectToBeVisible(page, SIGN_IN_GATE_MAIN_SELECTOR);
-
-			await page
-				.locator('[data-testid=sign-in-gate-main_privacy]')
-				.click();
-
-			await expectToBeVisible(page, CMP_LAYER1_IFRAME);
-
-			await expect(
-				await getIframeBody(page, CMP_LAYER1_IFRAME),
-			).toContainText('Privacy settings');
 		});
 	});
 

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -1,4 +1,3 @@
-import { cmp } from '@guardian/libs';
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
@@ -13,7 +12,6 @@ import {
 	headingStyles,
 	hideElementsCss,
 	laterButton,
-	privacyLink,
 	registerButton,
 	signInGateContainer,
 	signInHeader,
@@ -39,13 +37,11 @@ export const SignInGateAuxia = ({
 	The component must be written to gracefully handle empty values for the following field:
 		- subtitle
 		- body
-		- privacy_button_name
 	*/
 
 	const title = treatmentContent.title;
 	const subtitle = treatmentContent.subtitle;
 	const body = treatmentContent.body;
-	const privacy_button_name = treatmentContent.privacy_button_name;
 	const firstCtaName = treatmentContent.first_cta_name;
 	const firstCtaLink = treatmentContent.first_cta_link;
 	const secondCtaName = treatmentContent.second_cta_name;
@@ -60,32 +56,7 @@ export const SignInGateAuxia = ({
 			<div css={firstParagraphOverlay} />
 			<h1 css={headingStyles}>{title}</h1>
 			{hasContent(subtitle) && <p css={bodyBold}>{subtitle}</p>}
-			{hasContent(body) && (
-				<p css={bodyText}>
-					{body}{' '}
-					{hasContent(privacy_button_name) && (
-						<button
-							data-testid="sign-in-gate-main_privacy"
-							css={privacyLink}
-							onClick={async () => {
-								cmp.showPrivacyManager();
-								trackLink(
-									ophanComponentId,
-									'privacy',
-									renderingTarget,
-									abTest,
-								);
-								await logTreatmentInteractionCall(
-									'CLICKED',
-									'PRIVACY-BUTTON',
-								);
-							}}
-						>
-							privacy settings
-						</button>
-					)}
-				</p>
-			)}
+			{hasContent(body) && <p css={bodyText}>{body}</p>}
 			<div css={actionButtons}>
 				<LinkButton
 					data-testid="sign-in-gate-main_register"

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { cmp } from '@guardian/libs';
 import {
 	from,
 	headlineBold28,
@@ -21,7 +20,6 @@ import {
 	firstParagraphOverlay,
 	hideElementsCss,
 	laterButton,
-	privacyLink,
 	registerButton,
 	signInGateContainer,
 	signInLink,
@@ -310,25 +308,6 @@ export const SignInGateFakeSocial = ({
 				registering and providing us with insight into your preferences,
 				you’re helping us to engage with you more deeply, and that allow
 				us to keep our journalism free for all.
-			</p>
-			<p css={[bodyText, bodyPadding]}>
-				You’ll always be able to control your own&nbsp;
-				<button
-					data-testid="sign-in-gate-fake-social_privacy"
-					css={privacyLink}
-					onClick={() => {
-						cmp.showPrivacyManager();
-						trackLink(
-							ophanComponentId,
-							'privacy',
-							renderingTarget,
-							abTest,
-						);
-					}}
-				>
-					privacy settings
-				</button>{' '}
-				and every article will remain free.
 			</p>
 			<div css={[actionButtons, buttonMargin, bodyPadding]}>
 				<LinkButton

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateMain.tsx
@@ -1,4 +1,3 @@
-import { cmp } from '@guardian/libs';
 import { Button, Link, LinkButton } from '@guardian/source/react-components';
 import { useConfig } from '../../ConfigContext';
 import { trackLink } from '../componentEventTracking';
@@ -13,7 +12,6 @@ import {
 	headingStyles,
 	hideElementsCss,
 	laterButton,
-	privacyLink,
 	registerButton,
 	signInGateContainer,
 	signInHeader,
@@ -43,24 +41,7 @@ export const SignInGateMain = ({
 				We’re committed to keeping our quality reporting open. By
 				registering and providing us with insight into your preferences,
 				you’re helping us to engage with you more deeply, and that
-				allows us to keep our journalism free for all. You’ll always be
-				able to control your own{' '}
-				<button
-					data-testid="sign-in-gate-main_privacy"
-					css={privacyLink}
-					onClick={() => {
-						cmp.showPrivacyManager();
-						trackLink(
-							ophanComponentId,
-							'privacy',
-							renderingTarget,
-							abTest,
-						);
-					}}
-				>
-					privacy settings
-				</button>
-				.
+				allows us to keep our journalism free for all.
 			</p>
 			<div css={actionButtons}>
 				<LinkButton

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -93,7 +93,6 @@ export interface TreatmentContentDecoded {
 	title: string;
 	subtitle: string;
 	body: string;
-	privacy_button_name: string;
 	first_cta_name: string;
 	first_cta_link: string;
 	second_cta_name: string;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -486,7 +486,7 @@ const decideDailyArticleCount = (): number => {
 const decideAuxiaProxyReaderPersonalData =
 	async (): Promise<AuxiaGateReaderPersonalData> => {
 		const browserId =
-			getCookie({ name: 'bwid', shouldMemoize: true }) ?? '';
+			getCookie({ name: 'bwid', shouldMemoize: true }) ?? undefined;
 		const dailyArticleCount = decideDailyArticleCount();
 		const hasConsent = await hasCmpConsentForBrowserId();
 		const isSupporter = decideIsSupporter();


### PR DESCRIPTION
Here:
- We remove the privacy settings sentence from the legacy and auxia gates (including the default one served from SDC). 
- Correct a small bug by which we were sending an empty string for the browserId, when it should be undefined (key not appearing in the JSON payload)