### PR TITLE
Update trail text colour

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -143,8 +143,6 @@ export type Props = {
 	showTopBarDesktop?: boolean;
 	showTopBarMobile?: boolean;
 	trailTextSize?: TrailTextSize;
-	/** If specified, overrides trail text colour */
-	trailTextColour?: string;
 	/** The square podcast series image, if it exists for a card */
 	podcastImage?: PodcastSeriesImage;
 	/** A kicker image is seperate to the main media and renders as part of the kicker */
@@ -404,7 +402,6 @@ export const Card = ({
 	showTopBarDesktop = true,
 	showTopBarMobile = false,
 	trailTextSize,
-	trailTextColour,
 	podcastImage,
 	showKickerImage = false,
 	galleryCount,
@@ -1111,7 +1108,6 @@ export const Card = ({
 							{!!trailText && media?.type !== 'podcast' && (
 								<TrailText
 									trailText={trailText}
-									trailTextColour={trailTextColour}
 									trailTextSize={trailTextSize}
 									padTop={headlinePosition === 'inner'}
 									hideUntil={hideTrailTextUntil()}

--- a/dotcom-rendering/src/components/ContainerOverrides.tsx
+++ b/dotcom-rendering/src/components/ContainerOverrides.tsx
@@ -72,29 +72,29 @@ const cardTrailTextLight: ContainerFunction = (
 ) => {
 	switch (containerPalette) {
 		case 'InvestigationPalette':
-			return sourcePalette.neutral[93];
+			return sourcePalette.neutral[100];
 		case 'LongRunningPalette':
-			return sourcePalette.neutral[10];
+			return sourcePalette.neutral[7];
 		case 'SombrePalette':
-			return sourcePalette.neutral[93];
+			return sourcePalette.neutral[100];
 		case 'BreakingPalette':
-			return sourcePalette.neutral[93];
+			return sourcePalette.neutral[100];
 		case 'EventPalette':
 			return sourcePalette.brand[300];
 		case 'EventAltPalette':
 			return sourcePalette.brand[300];
 		case 'LongRunningAltPalette':
-			return sourcePalette.neutral[10];
+			return sourcePalette.neutral[7];
 		case 'SombreAltPalette':
-			return sourcePalette.neutral[86];
+			return sourcePalette.neutral[93];
 		case 'SpecialReportAltPalette':
 			return sourcePalette.specialReportAlt[100];
 		case 'PodcastPalette':
-			return sourcePalette.neutral[93];
+			return sourcePalette.neutral[100];
 		case 'Branded':
-			return sourcePalette.neutral[38];
+			return sourcePalette.neutral[20];
 		case 'MediaPalette':
-			return sourcePalette.neutral[93];
+			return sourcePalette.neutral[100];
 	}
 };
 const cardTrailTextDark: ContainerFunction = (

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -1,5 +1,4 @@
 import { shouldPadWrappableRows } from '../lib/dynamicSlices';
-import { palette } from '../palette';
 import type {
 	DCRContainerPalette,
 	DCRFrontCard,
@@ -18,7 +17,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 };
 
-/*
+/*ø
  * Note:
  * dynamic/package does not use cardWrappers as
  * most of the card configurations are custom and not used

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -62,7 +62,6 @@ const Snap100 = ({
 					trailText={snaps[0].trailText}
 					supportingContentAlignment="horizontal"
 					imageLoading={imageLoading}
-					trailTextColour={palette('--card-headline')}
 				/>
 			</LI>
 		</UL>
@@ -109,7 +108,6 @@ const Card100 = ({
 					supportingContent={limitSupportingContent(cards[0])}
 					supportingContentAlignment="horizontal"
 					imageLoading={imageLoading}
-					trailTextColour={palette('--card-headline')}
 				/>
 			</LI>
 		</UL>
@@ -149,7 +147,6 @@ const Card75_Card25 = ({
 						imageSize="medium"
 						trailText={card.trailText}
 						imageLoading={imageLoading}
-						trailTextColour={palette('--card-headline')}
 					/>
 				</LI>
 			))}
@@ -167,7 +164,6 @@ const Card75_Card25 = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						imageLoading={imageLoading}
-						trailTextColour={palette('--card-headline')}
 					/>
 				</LI>
 			))}
@@ -210,7 +206,6 @@ const Card25_Card25_Card25_Card25 = ({
 							supportingContent={limitSupportingContent(card)}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
-							trailTextColour={palette('--card-headline')}
 						/>
 					</LI>
 				);
@@ -253,7 +248,6 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
-							trailTextColour={palette('--card-headline')}
 						/>
 					</LI>
 				);
@@ -278,7 +272,6 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 									)}
 									image={undefined}
 									imageLoading={imageLoading}
-									trailTextColour={palette('--card-headline')}
 								/>
 							</LI>
 						);
@@ -323,7 +316,6 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
-							trailTextColour={palette('--card-headline')}
 						/>
 					</LI>
 				);
@@ -354,7 +346,6 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									)}
 									image={undefined}
 									imageLoading={imageLoading}
-									trailTextColour={palette('--card-headline')}
 								/>
 							</LI>
 						);
@@ -394,7 +385,6 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							absoluteServerTimes={absoluteServerTimes}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
-							trailTextColour={palette('--card-headline')}
 						/>
 					</LI>
 				);
@@ -425,7 +415,6 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									)}
 									image={undefined}
 									imageLoading={imageLoading}
-									trailTextColour={palette('--card-headline')}
 								/>
 							</LI>
 						);
@@ -469,7 +458,6 @@ const Card75_ColumnOfCards25 = ({
 						supportingContent={limitSupportingContent(card)}
 						isDynamo={true}
 						imageLoading={imageLoading}
-						trailTextColour={palette('--card-headline')}
 					/>
 				</LI>
 			))}
@@ -511,7 +499,6 @@ const Card75_ColumnOfCards25 = ({
 										card,
 									)}
 									imageLoading={imageLoading}
-									trailTextColour={palette('--card-headline')}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -59,7 +59,6 @@ export const FixedSmallSlowVThird = ({
 									imagePositionOnMobile="none"
 									imageSize="small"
 									imageLoading={imageLoading}
-									trailTextColour={palette('--card-headline')}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -1,5 +1,4 @@
 import { Card25Media25 } from '../lib/cardWrappers';
-import { palette } from '../palette';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -18,7 +18,6 @@ import { shouldPadWrappableRows } from '../lib/dynamicSlices';
 import type { EditionId } from '../lib/edition';
 import { useApi } from '../lib/useApi';
 import { enhanceCards } from '../model/enhanceCards';
-import { palette } from '../palette';
 import type { DCRContainerPalette, FEFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';

--- a/dotcom-rendering/src/components/ShowMore.importable.tsx
+++ b/dotcom-rendering/src/components/ShowMore.importable.tsx
@@ -181,9 +181,6 @@ export const ShowMore = ({
 											}}
 											imageLoading="eager"
 											absoluteServerTimes={false}
-											trailTextColour={palette(
-												'--card-headline',
-											)}
 										/>
 									</LI>
 								);

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -79,7 +79,6 @@ export const Card100Media50 = ({
 					? 'horizontal'
 					: 'vertical'
 			}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -132,7 +131,6 @@ export const Card100Media75 = ({
 					? 'horizontal'
 					: 'vertical'
 			}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -174,7 +172,6 @@ export const Card100Media100 = ({
 			isTagPage={isTagPage}
 			supportingContent={trail.supportingContent?.slice(0, 4)}
 			supportingContentAlignment="horizontal"
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -218,7 +215,6 @@ export const Card100Media100Tall = ({
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
 			trailText={trail.trailText}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -263,7 +259,6 @@ export const Card75Media50Right = ({
 			imagePositionOnMobile="top"
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
-			trailTextColour={palette('--card-headline')}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
 		/>
 	);
@@ -310,7 +305,6 @@ export const Card75Media50Left = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -352,7 +346,6 @@ export const Card25Media25 = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -394,7 +387,6 @@ export const Card25Media25SmallHeadline = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall', tablet: 'xxsmall' }}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -443,7 +435,6 @@ export const Card25Media25Tall = ({
 			}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -484,7 +475,6 @@ export const Card25Media25TallNoTrail = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -525,7 +515,6 @@ export const Card25Media25TallSmallHeadline = ({
 			headlineSizes={{ desktop: 'xxsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -566,7 +555,6 @@ export const Card50Media50 = ({
 			absoluteServerTimes={absoluteServerTimes}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -609,7 +597,6 @@ export const Card50Media50Tall = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -649,7 +636,6 @@ export const Card66Media66 = ({
 			imageSize="large"
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -688,7 +674,6 @@ export const Card33Media33 = ({
 			imagePositionOnMobile="left"
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
-			trailTextColour={palette('--card-headline')}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 		/>
 	);
@@ -729,7 +714,6 @@ export const Card33Media33Tall = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -771,7 +755,6 @@ export const Card33Media33MobileTopTall = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -807,7 +790,6 @@ export const CardDefault = ({
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
 			isTagPage={isTagPage}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -845,7 +827,6 @@ export const CardDefaultMedia = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };
@@ -883,7 +864,6 @@ export const CardDefaultMediaMobile = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
-			trailTextColour={palette('--card-headline')}
 		/>
 	);
 };

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -1,7 +1,6 @@
 import { isUndefined } from '@guardian/libs';
 import type { Loading } from '../components/CardPicture';
 import { FrontCard } from '../components/FrontCard';
-import { palette } from '../palette';
 import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
 
 type TrailProps = {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2513,7 +2513,7 @@ const cardHeadlineTextLight: PaletteFunction = () => sourcePalette.neutral[7];
 
 const cardTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
-const cardTrailTextLight: PaletteFunction = () => sourcePalette.neutral[38];
+const cardTrailTextLight: PaletteFunction = () => sourcePalette.neutral[46];
 const cardTrailTextDark: PaletteFunction = () => sourcePalette.neutral[73];
 
 const liveKickerBackgroundLight: PaletteFunction = (format) => {


### PR DESCRIPTION
## What does this change?
Updates the trail text color from neutral.38 to neutral.46. 

It also removes the overrides for the card-headline palette as it has been agreed we can update the trail text colour across all containers. As a consequence, we can remove the trail text colour override prop from the card component.

## Why?
This is a design update.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/d70aaa6b-fbe5-4756-9c4e-44cb5cbf0d80
[after]: https://github.com/user-attachments/assets/c97b9868-5623-4eb6-9b16-c52a99cd59ad


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
