### PR TITLE
Fix multi-byline contributor links

### DIFF
--- a/dotcom-rendering/src/components/MultiByline.tsx
+++ b/dotcom-rendering/src/components/MultiByline.tsx
@@ -203,7 +203,7 @@ const Byline = ({
 		allowedAttributes: {
 			...defaults.allowedAttributes,
 			span: ['data-contributor-rel'],
-			a: ['data-ignore'],
+			a: ['data-ignore', 'data-contributor-rel', 'href'],
 		},
 	});
 


### PR DESCRIPTION
## What does this change?

The `href` attribute of the byline link is being stripped out when santising the field, so we need to explicitly allow it.

I've also allowed `data-contributor-rel` while in the area.

## Why?

Contributor links are currently broken on multi-byline articles. See:

https://www.theguardian.com/commentisfree/2025/feb/18/trump-vance-smashed-old-order-realignment-europe-response

Try clicking on "Nathalie Tocci" under the first heading and note it doesn't work.