### PR TITLE
Update e2e lib `loadPage` to enforce adtest query param

### DIFF
--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -14,12 +14,15 @@ const BASE_URL = `http://localhost:${PORT}`;
 const loadPage = async ({
 	page,
 	path,
+	queryParams: searchParams = {},
+	fragment,
 	waitUntil = 'domcontentloaded',
 	region = 'GB',
 	preventSupportBanner = true,
 }: {
 	page: Page;
 	path: string;
+	queryParams?: Record<string, string>;
 	waitUntil?: 'domcontentloaded' | 'load';
 	region?: 'GB' | 'US' | 'AU' | 'INT';
 	preventSupportBanner?: boolean;
@@ -43,9 +46,16 @@ const loadPage = async ({
 			preventSupportBanner,
 		},
 	);
+	const params = new URLSearchParams({
+		adtest: 'fixed-puppies-ci',
+		...searchParams,
+	});
+	const paramsString = `?${params.toString()}`;
 	// The default Playwright waitUntil: 'load' ensures all requests have completed
 	// Use 'domcontentloaded' to speed up tests and prevent hanging requests from timing out tests
-	await page.goto(`${BASE_URL}${path}`, { waitUntil });
+	await page.goto(`${BASE_URL}${path}${paramsString}`, {
+		waitUntil,
+	});
 };
 
 /**

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -23,6 +23,7 @@ const loadPage = async ({
 	page: Page;
 	path: string;
 	queryParams?: Record<string, string>;
+	fragment?: `#${string}`;
 	waitUntil?: 'domcontentloaded' | 'load';
 	region?: 'GB' | 'US' | 'AU' | 'INT';
 	preventSupportBanner?: boolean;
@@ -53,7 +54,7 @@ const loadPage = async ({
 	const paramsString = `?${params.toString()}`;
 	// The default Playwright waitUntil: 'load' ensures all requests have completed
 	// Use 'domcontentloaded' to speed up tests and prevent hanging requests from timing out tests
-	await page.goto(`${BASE_URL}${path}${paramsString}`, {
+	await page.goto(`${BASE_URL}${path}${paramsString}${fragment ?? ''}`, {
 		waitUntil,
 	});
 };

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -10,11 +10,12 @@ const BASE_URL = `http://localhost:${PORT}`;
  * - default the base url and port
  * - default the geo region to GB
  * - prevent the support banner from showing
+ * - pass an adtest param to ensure we get a fixed test ad
  */
 const loadPage = async ({
 	page,
 	path,
-	queryParams: searchParams = {},
+	queryParams = {},
 	fragment,
 	waitUntil = 'domcontentloaded',
 	region = 'GB',
@@ -49,7 +50,7 @@ const loadPage = async ({
 	);
 	const params = new URLSearchParams({
 		adtest: 'fixed-puppies-ci',
-		...searchParams,
+		...queryParams,
 	});
 	const paramsString = `?${params.toString()}`;
 	// The default Playwright waitUntil: 'load' ensures all requests have completed

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -6,11 +6,7 @@ import type { FEArticleType } from '../../src/types/frontend';
 const BASE_URL = `http://localhost:${PORT}`;
 
 /**
- * Loads a page and centralises setup:
- * - default the base url and port
- * - default the geo region to GB
- * - prevent the support banner from showing
- * - pass an adtest param to ensure we get a fixed test ad
+ * Loads a page in Playwright and centralises setup
  */
 const loadPage = async ({
 	page,
@@ -33,11 +29,12 @@ const loadPage = async ({
 }): Promise<void> => {
 	await page.addInitScript(
 		(args) => {
-			// force geo region
+			// Set the geo region, defaults to GB
 			window.localStorage.setItem(
 				'gu.geo.override',
 				JSON.stringify({ value: args.region }),
 			);
+			// Prevent the support banner from showing
 			if (args.preventSupportBanner) {
 				window.localStorage.setItem(
 					'gu.prefs.engagementBannerLastClosedAt',
@@ -50,6 +47,7 @@ const loadPage = async ({
 			preventSupportBanner,
 		},
 	);
+	// Add an adtest query param to ensure we get a fixed test ad
 	const paramsString = queryParamsOn
 		? `?${new URLSearchParams({
 				adtest: 'fixed-puppies-ci',

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -11,13 +11,19 @@ const BASE_URL = `http://localhost:${PORT}`;
  * - default the geo region to GB
  * - prevent the support banner from showing
  */
-const loadPage = async (
-	page: Page,
-	path: string,
-	waitUntil: 'load' | 'domcontentloaded' = 'domcontentloaded',
+const loadPage = async ({
+	page,
+	path,
+	waitUntil = 'domcontentloaded',
 	region = 'GB',
 	preventSupportBanner = true,
-): Promise<void> => {
+}: {
+	page: Page;
+	path: string;
+	waitUntil?: 'domcontentloaded' | 'load';
+	region?: 'GB' | 'US' | 'AU' | 'INT';
+	preventSupportBanner?: boolean;
+}): Promise<void> => {
 	await page.addInitScript(
 		(args) => {
 			// force geo region
@@ -32,7 +38,10 @@ const loadPage = async (
 				);
 			}
 		},
-		{ region, preventSupportBanner },
+		{
+			region,
+			preventSupportBanner,
+		},
 	);
 	// The default Playwright waitUntil: 'load' ensures all requests have completed
 	// Use 'domcontentloaded' to speed up tests and prevent hanging requests from timing out tests
@@ -72,7 +81,7 @@ const loadPageWithOverrides = async (
 			postData,
 		});
 	});
-	await loadPage(page, path);
+	await loadPage({ page, path });
 };
 
 /**

--- a/dotcom-rendering/playwright/lib/load-page.ts
+++ b/dotcom-rendering/playwright/lib/load-page.ts
@@ -16,6 +16,7 @@ const loadPage = async ({
 	page,
 	path,
 	queryParams = {},
+	queryParamsOn = true,
 	fragment,
 	waitUntil = 'domcontentloaded',
 	region = 'GB',
@@ -24,6 +25,7 @@ const loadPage = async ({
 	page: Page;
 	path: string;
 	queryParams?: Record<string, string>;
+	queryParamsOn?: boolean;
 	fragment?: `#${string}`;
 	waitUntil?: 'domcontentloaded' | 'load';
 	region?: 'GB' | 'US' | 'AU' | 'INT';
@@ -48,11 +50,13 @@ const loadPage = async ({
 			preventSupportBanner,
 		},
 	);
-	const params = new URLSearchParams({
-		adtest: 'fixed-puppies-ci',
-		...queryParams,
-	});
-	const paramsString = `?${params.toString()}`;
+	const paramsString = queryParamsOn
+		? `?${new URLSearchParams({
+				adtest: 'fixed-puppies-ci',
+				...queryParams,
+		  }).toString()}`
+		: '';
+
 	// The default Playwright waitUntil: 'load' ensures all requests have completed
 	// Use 'domcontentloaded' to speed up tests and prevent hanging requests from timing out tests
 	await page.goto(`${BASE_URL}${path}${paramsString}${fragment ?? ''}`, {
@@ -93,7 +97,7 @@ const loadPageWithOverrides = async (
 			postData,
 		});
 	});
-	await loadPage({ page, path });
+	await loadPage({ page, path, queryParamsOn: false });
 };
 
 /**

--- a/dotcom-rendering/playwright/tests/article.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.e2e.spec.ts
@@ -55,10 +55,10 @@ test.describe('E2E Page rendering', () => {
 					),
 			);
 
-			await loadPage(
+			await loadPage({
 				page,
-				`/Article/https://www.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness`,
-			);
+				path: `/Article/https://www.theguardian.com/commentisfree/2019/oct/16/impostor-syndrome-class-unfairness`,
+			});
 
 			await expect(page.locator('[data-gu-name="title"]')).toContainText(
 				'Opinion',

--- a/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
@@ -12,7 +12,7 @@ test.describe('Embeds', () => {
 		}) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries',
 			});
 			await cmpAcceptAll(page);
 
@@ -37,7 +37,7 @@ test.describe('Embeds', () => {
 		test('should render the interactive 1', async ({ page }) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem',
 			});
 			await cmpAcceptAll(page);
 
@@ -53,7 +53,7 @@ test.describe('Embeds', () => {
 		test('should render the interactive 2', async ({ page }) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania',
 			});
 			await cmpAcceptAll(page);
 
@@ -69,7 +69,7 @@ test.describe('Embeds', () => {
 		test('should render the soundcloud embed', async ({ page }) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe',
 			});
 			await cmpAcceptAll(page);
 
@@ -85,7 +85,7 @@ test.describe('Embeds', () => {
 		test('should render the football embed', async ({ page }) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley',
 			});
 			await cmpAcceptAll(page);
 
@@ -103,7 +103,7 @@ test.describe('Embeds', () => {
 		}) => {
 			await loadPage({
 				page,
-				path: '/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue?adtest=fixed-puppies-ci',
+				path: '/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
 			});
 			await cmpAcceptAll(page);
 

--- a/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
@@ -10,10 +10,10 @@ test.describe('Embeds', () => {
 		test('should render the click to view overlay revealing the embed when clicked', async ({
 			page,
 		}) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/sport/blog/2015/dec/02/the-joy-of-six-sports-radio-documentaries?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			await waitForIsland(page, 'EmbedBlockComponent');
@@ -35,10 +35,10 @@ test.describe('Embeds', () => {
 		});
 
 		test('should render the interactive 1', async ({ page }) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/sport/2019/nov/15/forget-a-super-bowl-slump-the-la-rams-have-a-jared-goff-problem?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			await waitForIsland(page, 'InteractiveBlockComponent');
@@ -51,10 +51,10 @@ test.describe('Embeds', () => {
 		});
 
 		test('should render the interactive 2', async ({ page }) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/us-news/2017/jan/17/donald-trump-america-great-again-northampton-county-pennsylvania?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			await waitForIsland(page, 'InteractiveBlockComponent', { nth: 1 });
@@ -67,10 +67,10 @@ test.describe('Embeds', () => {
 		});
 
 		test('should render the soundcloud embed', async ({ page }) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/music/2020/jan/31/elon-musk-edm-artist-first-track-dont-doubt-ur-vibe?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			await page
@@ -83,10 +83,10 @@ test.describe('Embeds', () => {
 		});
 
 		test('should render the football embed', async ({ page }) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/football/2020/jun/10/premier-league-restart-preview-no-5-burnley?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			const embedSelector = 'div[data-testid="football-table-embed"]';
@@ -101,10 +101,10 @@ test.describe('Embeds', () => {
 		test.skip('should render the affiliate disclaimer block', async ({
 			page,
 		}) => {
-			await loadPage(
+			await loadPage({
 				page,
-				'/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue?adtest=fixed-puppies-ci',
-			);
+				path: '/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue?adtest=fixed-puppies-ci',
+			});
 			await cmpAcceptAll(page);
 
 			const selector = '[data-testid="affiliate-disclaimer"]';

--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -19,7 +19,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 
 			// Open it
 			await page.locator('[data-testid=dropdown-button]').click();
@@ -40,10 +40,10 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(
+			await loadPage({
 				page,
-				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
-			);
+				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
+			});
 
 			await expectToBeVisible(page, '[data-testid=comment-counts]');
 			// The discusion is not yet loaded
@@ -59,10 +59,10 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(
+			await loadPage({
 				page,
-				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
-			);
+				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
+			});
 			await expectToExist(page, '[data-testid=discussion]');
 		});
 
@@ -71,10 +71,10 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(
+			await loadPage({
 				page,
-				`/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
-			);
+				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
+			});
 			await waitForIsland(page, 'DiscussionWeb', {});
 			await expectToBeVisible(page, '[id=comment-154433663]');
 		});
@@ -84,7 +84,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 			await expectToNotExist(page, '[data-component=geo-most-popular]');
 			await waitForIsland(page, 'MostViewedRightWithAd', {});
 			await expectToExist(page, '[data-component=geo-most-popular]');
@@ -95,7 +95,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 			// Verify two rich links were server rendered
 			await expect(
 				page.locator('[data-component=rich-link]'),
@@ -118,7 +118,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 			await waitForIsland(page, 'TopBar');
 			await expect(
 				page.locator('header').filter({ hasText: 'Support' }),
@@ -132,7 +132,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 
 			// Make sure most viewed footer isn't in the dom yet
 			await expect(
@@ -168,7 +168,7 @@ test.describe('Interactivity', () => {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${articleUrl}`);
+			await loadPage({ page, path: `/Article/${articleUrl}` });
 
 			// Open pillar menu
 			await page.locator('[data-testid=veggie-burger]').click();
@@ -196,7 +196,7 @@ test.describe('Interactivity', () => {
 			}) => {
 				await page.setViewportSize(devices['iPhone X'].viewport);
 				await disableCMP(context);
-				await loadPage(page, `/Article/${articleUrl}`);
+				await loadPage({ page, path: `/Article/${articleUrl}` });
 
 				await page.locator('[data-testid=veggie-burger]').click();
 				await expect(
@@ -222,7 +222,7 @@ test.describe('Interactivity', () => {
 			}) => {
 				await page.setViewportSize(devices['iPhone X'].viewport);
 				await disableCMP(context);
-				await loadPage(page, `/Article/${articleUrl}`);
+				await loadPage({ page, path: `/Article/${articleUrl}` });
 
 				await page.locator('[data-testid=veggie-burger]').focus();
 				await page.locator('[data-testid=veggie-burger]').press('Tab');
@@ -237,7 +237,7 @@ test.describe('Interactivity', () => {
 			}) => {
 				await page.setViewportSize(devices['iPhone X'].viewport);
 				await disableCMP(context);
-				await loadPage(page, `/Article/${articleUrl}`);
+				await loadPage({ page, path: `/Article/${articleUrl}` });
 
 				await page.locator('[data-testid=veggie-burger]').click();
 				await expect(
@@ -251,7 +251,7 @@ test.describe('Interactivity', () => {
 			}) => {
 				await page.setViewportSize(devices['iPhone X'].viewport);
 				await disableCMP(context);
-				await loadPage(page, `/Article/${articleUrl}`);
+				await loadPage({ page, path: `/Article/${articleUrl}` });
 
 				// tab to the first sub menu item
 				await page.locator('[data-testid=veggie-burger]').click();
@@ -272,7 +272,7 @@ test.describe('Interactivity', () => {
 			}) => {
 				await page.setViewportSize(devices['iPhone X'].viewport);
 				await disableCMP(context);
-				await loadPage(page, `/Article/${articleUrl}`);
+				await loadPage({ page, path: `/Article/${articleUrl}` });
 
 				await page
 					.locator('[data-testid=veggie-burger]')

--- a/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.interactivity.e2e.spec.ts
@@ -61,7 +61,8 @@ test.describe('Interactivity', () => {
 			await disableCMP(context);
 			await loadPage({
 				page,
-				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comments`,
+				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
+				fragment: '#comments',
 			});
 			await expectToExist(page, '[data-testid=discussion]');
 		});
@@ -73,7 +74,8 @@ test.describe('Interactivity', () => {
 			await disableCMP(context);
 			await loadPage({
 				page,
-				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster#comment-154433663`,
+				path: `/Article/https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster`,
+				fragment: '#comment-154433663',
 			});
 			await waitForIsland(page, 'DiscussionWeb', {});
 			await expectToBeVisible(page, '[id=comment-154433663]');

--- a/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.metaAndOphan.e2e.spec.ts
@@ -15,10 +15,10 @@ const expectMetaContentValue = async (
 
 test.describe('The web document renders with the correct meta and analytics elements and attributes', () => {
 	test(`The page is structured as expected`, async ({ page }) => {
-		await loadPage(
+		await loadPage({
 			page,
-			'/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked',
-		);
+			path: '/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked',
+		});
 
 		await expect(page.locator('head')).toHaveCount(1);
 
@@ -51,10 +51,10 @@ test.describe('The web document renders with the correct meta and analytics elem
 	});
 
 	test('Subnav links exists with correct values', async ({ page }) => {
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
-		);
+			path: `/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+		});
 
 		// Pillar ophan data-link-name exists with correct value
 		await expectToExist(
@@ -72,10 +72,10 @@ test.describe('The web document renders with the correct meta and analytics elem
 	test('Meta ophan data-attributes exist, content and attributes are correct', async ({
 		page,
 	}) => {
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
-		);
+			path: `/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+		});
 
 		await expectToExist(page, `address[data-component="meta-byline"]`);
 		await expectToExist(page, `address[data-link-name="byline"]`);
@@ -92,10 +92,10 @@ test.describe('The web document renders with the correct meta and analytics elem
 	test('Section, Footer and Series ophan data-attributes exist', async ({
 		page,
 	}) => {
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
-		);
+			path: `/Article/https://www.theguardian.com/lifeandstyle/2021/jan/21/never-conduct-any-business-naked-how-to-work-from-bed-without-getting-sacked`,
+		});
 		await expectToExist(page, `[data-component="section"]`);
 		await expectToExist(page, `[data-link-name="article section"]`);
 		await expectToExist(page, `a[data-component="series"]`);

--- a/dotcom-rendering/playwright/tests/atom.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/atom.interactivity.e2e.spec.ts
@@ -41,7 +41,7 @@ for (const { type, url } of expandableTests) {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${url}`);
+			await loadPage({ page, path: `/Article/${url}` });
 
 			await expectToBeVisible(page, `[data-snippet-type=${type}]`);
 			await expect(
@@ -92,7 +92,7 @@ for (const { type, url } of expandableTests) {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${url}`);
+			await loadPage({ page, path: `/Article/${url}` });
 			await page.locator(`[data-snippet-type=${type}]`).click();
 			await page.locator('[data-testid="like"]').click();
 			await expectToBeVisible(page, '[data-testid="feedback"]');
@@ -103,7 +103,7 @@ for (const { type, url } of expandableTests) {
 			page,
 		}) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${url}`);
+			await loadPage({ page, path: `/Article/${url}` });
 			await page.locator(`[data-snippet-type=${type}]`).click();
 			await page.locator('[data-testid="dislike"]').click();
 			await expectToBeVisible(page, '[data-testid="feedback"]');
@@ -115,7 +115,7 @@ for (const { type, url } of genericTests) {
 	test.describe(type, () => {
 		test('should render', async ({ context, page }) => {
 			await disableCMP(context);
-			await loadPage(page, `/Article/${url}`);
+			await loadPage({ page, path: `/Article/${url}` });
 			await expectToBeVisible(page, `[data-snippet-type=${type}]`);
 		});
 	});
@@ -127,7 +127,7 @@ test.describe('Why do wombats do square poos?', () => {
 		page,
 	}) => {
 		await disableCMP(context);
-		await loadPage(page, `/Article/${quizAtomUrl}`);
+		await loadPage({ page, path: `/Article/${quizAtomUrl}` });
 
 		await waitForIsland(page, 'KnowledgeQuizAtom');
 
@@ -178,7 +178,7 @@ test.describe('Why do wombats do square poos?', () => {
 		page,
 	}) => {
 		await disableCMP(context);
-		await loadPage(page, `/Article/${quizAtomUrl}`);
+		await loadPage({ page, path: `/Article/${quizAtomUrl}` });
 
 		await waitForIsland(page, 'KnowledgeQuizAtom');
 

--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -37,13 +37,13 @@ test.describe('The banner', function () {
 			requestBodyHasProperties(request, rrBannerUrl, ['targeting']),
 		);
 
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people`,
-			'domcontentloaded',
-			'GB',
-			false,
-		);
+			path: `/Article/https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people`,
+			waitUntil: 'domcontentloaded',
+			region: 'GB',
+			preventSupportBanner: false,
+		});
 		await cmpAcceptAll(page);
 
 		await rrBannerRequestPromise;

--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -5,10 +5,10 @@ import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
 	test(`It should load the expected number of ad slots`, async ({ page }) => {
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
-		);
+			path: `/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
+		});
 
 		await cmpAcceptAll(page);
 

--- a/dotcom-rendering/playwright/tests/edition-switcher-banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/edition-switcher-banner.e2e.spec.ts
@@ -25,10 +25,10 @@ test.describe('Edition Switcher Banner', () => {
 				});
 
 				await disableCMP(context);
-				await loadPage(
+				await loadPage({
 					page,
-					`/Front/https://www.theguardian.com/${pageId}`,
-				);
+					path: `/Front/https://www.theguardian.com/${pageId}`,
+				});
 
 				await expect(
 					page.locator('[data-component="edition-switcher-banner"]'),
@@ -51,10 +51,10 @@ test.describe('Edition Switcher Banner', () => {
 				});
 
 				await disableCMP(context);
-				await loadPage(
+				await loadPage({
 					page,
-					`/Front/https://www.theguardian.com/${pageId}`,
-				);
+					path: `/Front/https://www.theguardian.com/${pageId}`,
+				});
 
 				await expect(
 					page.locator('[data-component="edition-switcher-banner"]'),
@@ -74,7 +74,10 @@ test.describe('Edition Switcher Banner', () => {
 			});
 
 			await disableCMP(context);
-			await loadPage(page, `/Front/https://www.theguardian.com/uk/sport`);
+			await loadPage({
+				page,
+				path: `/Front/https://www.theguardian.com/uk/sport`,
+			});
 
 			await expect(
 				page.locator('[data-component="edition-switcher-banner"]'),
@@ -91,10 +94,10 @@ test.describe('Edition Switcher Banner', () => {
 			});
 
 			await disableCMP(context);
-			await loadPage(
+			await loadPage({
 				page,
-				`/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
-			);
+				path: `/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
+			});
 
 			await expect(
 				page.locator('[data-component="edition-switcher-banner"]'),

--- a/dotcom-rendering/playwright/tests/epic.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/epic.interactivity.e2e.spec.ts
@@ -13,10 +13,10 @@ test.describe('Epics', () => {
 		page,
 	}) => {
 		await disableCMP(context);
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/${blogUrl}?live=true&force-liveblog-epic=true`,
-		);
+			path: `/Article/${blogUrl}?live=true&force-liveblog-epic=true`,
+		});
 
 		// Wait for hydration of the Epic
 		// The LiveBlogEpic island does not become visible so we wait for it to be attached

--- a/dotcom-rendering/playwright/tests/epic.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/epic.interactivity.e2e.spec.ts
@@ -15,7 +15,11 @@ test.describe('Epics', () => {
 		await disableCMP(context);
 		await loadPage({
 			page,
-			path: `/Article/${blogUrl}?live=true&force-liveblog-epic=true`,
+			path: `/Article/${blogUrl}`,
+			queryParams: {
+				live: 'true',
+				'force-liveblog-epic': 'true',
+			},
 		});
 
 		// Wait for hydration of the Epic

--- a/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
@@ -24,7 +24,7 @@ test.describe('Liveblogs', () => {
 	test('should show the toast, incrementing the count as new updates are sent', async ({
 		page,
 	}) => {
-		await loadPage(page, `/Article/${blogUrl}?live=true`);
+		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await expectToNotExist(page, `[data-testid="toast"]`);
@@ -63,7 +63,7 @@ test.describe('Liveblogs', () => {
 	});
 
 	test('should insert the html from the update call', async ({ page }) => {
-		await loadPage(page, `/Article/${blogUrl}?live=true`);
+		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate(() => {
@@ -82,7 +82,7 @@ test.describe('Liveblogs', () => {
 	test('should scroll the page to the top and reveal content when the toast is clicked', async ({
 		page,
 	}) => {
-		await loadPage(page, `/Article/${blogUrl}?live=true`);
+		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await expectToNotExist(page, `[data-testid="toast"]`);
@@ -110,7 +110,7 @@ test.describe('Liveblogs', () => {
 	test('should enhance tweets after they have been inserted', async ({
 		page,
 	}) => {
-		await loadPage(page, `/Article/${blogUrl}?live=true`);
+		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate((block) => {
@@ -168,10 +168,10 @@ test.describe('Liveblogs', () => {
 			['filterKeyEvents', 'false'],
 		]);
 
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
-		);
+			path: `/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
+		});
 
 		await lastUpdateRequestPromise;
 	});
@@ -185,10 +185,10 @@ test.describe('Liveblogs', () => {
 			['filterKeyEvents', 'false'],
 		]);
 
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
-		);
+			path: `/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
+		});
 
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
@@ -233,7 +233,7 @@ test.describe('Liveblogs', () => {
 	test('should initially hide new blocks, only revealing them when the top of blog is in view', async ({
 		page,
 	}) => {
-		await loadPage(page, `/Article/${blogUrl}?live=true`);
+		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate(() =>
@@ -284,10 +284,10 @@ test.describe('Liveblogs', () => {
 			},
 		);
 
-		await loadPage(
+		await loadPage({
 			page,
-			`/Article/https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live=true`,
-		);
+			path: `/Article/https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live=true`,
+		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await update1ResponsePromise;

--- a/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/liveblog.interactivity.e2e.spec.ts
@@ -24,7 +24,11 @@ test.describe('Liveblogs', () => {
 	test('should show the toast, incrementing the count as new updates are sent', async ({
 		page,
 	}) => {
-		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
+		await loadPage({
+			page,
+			path: `/Article/${blogUrl}`,
+			queryParams: { live: 'true' },
+		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await expectToNotExist(page, `[data-testid="toast"]`);
@@ -63,7 +67,11 @@ test.describe('Liveblogs', () => {
 	});
 
 	test('should insert the html from the update call', async ({ page }) => {
-		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
+		await loadPage({
+			page,
+			path: `/Article/${blogUrl}`,
+			queryParams: { live: 'true' },
+		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate(() => {
@@ -82,7 +90,12 @@ test.describe('Liveblogs', () => {
 	test('should scroll the page to the top and reveal content when the toast is clicked', async ({
 		page,
 	}) => {
-		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
+		await loadPage({
+			page,
+			path: `/Article/${blogUrl}`,
+			queryParams: { live: 'true' },
+		});
+
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await expectToNotExist(page, `[data-testid="toast"]`);
@@ -110,7 +123,11 @@ test.describe('Liveblogs', () => {
 	test('should enhance tweets after they have been inserted', async ({
 		page,
 	}) => {
-		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
+		await loadPage({
+			page,
+			path: `/Article/${blogUrl}`,
+			queryParams: { live: 'true' },
+		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate((block) => {
@@ -162,15 +179,15 @@ test.describe('Liveblogs', () => {
 			return matchLastUpdate;
 		});
 
-		const searchParams = new URLSearchParams([
-			['live', 'true'],
-			['page', 'with:block-6214732b8f08f86d89ef68d6'],
-			['filterKeyEvents', 'false'],
-		]);
-
 		await loadPage({
 			page,
-			path: `/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
+			path: `/Article/${blogUrl}`,
+			queryParams: {
+				live: 'true',
+				page: 'with:block-6214732b8f08f86d89ef68d6',
+				filterKeyEvents: 'false',
+			},
+			fragment: '#liveblog-navigation',
 		});
 
 		await lastUpdateRequestPromise;
@@ -179,15 +196,15 @@ test.describe('Liveblogs', () => {
 	test('should handle when the toast is clicked from the second page', async ({
 		page,
 	}) => {
-		const searchParams = new URLSearchParams([
-			['live', 'true'],
-			['page', 'with:block-6214732b8f08f86d89ef68d6'],
-			['filterKeyEvents', 'false'],
-		]);
-
 		await loadPage({
 			page,
-			path: `/Article/${blogUrl}?${searchParams.toString()}#liveblog-navigation`,
+			path: `/Article/${blogUrl}`,
+			queryParams: {
+				live: 'true',
+				page: 'with:block-6214732b8f08f86d89ef68d6',
+				filterKeyEvents: 'false',
+			},
+			fragment: '#liveblog-navigation',
 		});
 
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
@@ -233,7 +250,13 @@ test.describe('Liveblogs', () => {
 	test('should initially hide new blocks, only revealing them when the top of blog is in view', async ({
 		page,
 	}) => {
-		await loadPage({ page, path: `/Article/${blogUrl}?live=true` });
+		await loadPage({
+			page,
+			path: `/Article/${blogUrl}`,
+			queryParams: {
+				live: 'true',
+			},
+		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 
 		await page.evaluate(() =>
@@ -286,7 +309,10 @@ test.describe('Liveblogs', () => {
 
 		await loadPage({
 			page,
-			path: `/Article/https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live?live=true`,
+			path: `/Article/https://theguardian.com/sport/live/2022/mar/27/west-indies-v-england-third-test-day-four-live`,
+			queryParams: {
+				live: 'true',
+			},
 		});
 		await waitForIsland(page, 'Liveness', { waitFor: 'attached' });
 

--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -31,7 +31,7 @@ test.describe('Ophan requests', () => {
 				);
 			},
 		});
-		await loadPage(page, `/Article/${articleUrl}`);
+		await loadPage({ page, path: `/Article/${articleUrl}` });
 		await cmpRejectAll(page);
 		await ophanImpressionRequestPromise;
 	});
@@ -53,7 +53,7 @@ test.describe('Ophan requests', () => {
 				);
 			},
 		});
-		await loadPage(page, `/Article/${articleUrl}`);
+		await loadPage({ page, path: `/Article/${articleUrl}` });
 		await cmpAcceptAll(page);
 		await ophanImpressionRequestPromise;
 	});
@@ -71,7 +71,7 @@ test.describe('Ophan requests', () => {
 				return experiences === 'dotcom-rendering';
 			},
 		});
-		await loadPage(page, `/Article/${articleUrl}`);
+		await loadPage({ page, path: `/Article/${articleUrl}` });
 		await ophanExperienceRequestPromise;
 	});
 
@@ -94,7 +94,7 @@ test.describe('Ophan requests', () => {
 				);
 			},
 		});
-		await loadPage(page, `/Front/${frontUrl}`);
+		await loadPage({ page, path: `/Front/${frontUrl}` });
 		await ophanImpressionRequestPromise;
 	});
 
@@ -111,7 +111,7 @@ test.describe('Ophan requests', () => {
 				return experiences === 'dotcom-rendering';
 			},
 		});
-		await loadPage(page, `/Front/${frontUrl}`);
+		await loadPage({ page, path: `/Front/${frontUrl}` });
 		await ophanExperienceRequestPromise;
 	});
 });

--- a/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/paid.content.e2e.spec.ts
@@ -36,7 +36,7 @@ test.describe('Paid content tests', () => {
 	test('should send Ophan component event on click of sponsor logo in article meta and related content section', async ({
 		page,
 	}) => {
-		await loadPage(page, `/Article/${paidContentPage}`);
+		await loadPage({ page, path: `/Article/${paidContentPage}` });
 		await cmpAcceptAll(page);
 
 		// meta logo


### PR DESCRIPTION
## What does this change?

As a follow up to #13405 update e2e lib loadPage to:

- accept object of options
- centrally enforce test ads

## Why?

Allows default query params to be enforced e.g. `adtest`.
A more user friendly and descriptive way to pass options to `loadPage`

## Screenshots

Behold puppies 🐶 

<img width="1374" alt="Screenshot 2025-02-18 at 16 41 47" src="https://github.com/user-attachments/assets/088a52c4-d5bf-4c1c-bffb-aaf448bec97e" />
