### PR TITLE
Add crossword banner ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -32,8 +32,6 @@ type ServerRenderedSlot = Exclude<
 	SlotNamesWithPageSkin,
 	| 'carrot'
 	| 'comments-expanded'
-	| 'crossword-banner'
-	| 'crossword-banner-mobile'
 	| 'exclusion'
 	| 'external'
 	| 'inline'
@@ -251,6 +249,18 @@ const articleEndAdStyles = css`
 	&.ad-slot--fluid {
 		min-height: 450px;
 	}
+`;
+
+const mobileBannerCrosswordStyles = css`
+	width: 320px;
+	height: 74px;
+	background-color: #ffffff;
+`;
+
+const crosswordBannerStyles = css`
+	width: 728px;
+	height: 90px;
+	background-color: #ffffff;
 `;
 
 const mostPopAdStyles = css`
@@ -799,6 +809,50 @@ export const AdSlot = ({
 						aria-hidden="true"
 					/>
 				</div>
+			);
+		}
+		case 'crossword-banner-mobile': {
+			return (
+				<Hide from="tablet">
+					<div className="ad-slot-container">
+						<div
+							id="dfp-ad--crossword-banner-mobile"
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								'ad-slot--crossword-banner-mobile',
+								'ad-slot--rendered',
+							].join(' ')}
+							css={[mobileBannerCrosswordStyles]}
+							data-link-name="ad slot crossword-banner-mobile"
+							data-name="crossword-banner-mobile"
+							data-testid="slot"
+							aria-hidden="true"
+						/>
+					</div>
+				</Hide>
+			);
+		}
+		case 'crossword-banner': {
+			return (
+				<Hide from="mobile" until="tablet">
+					<div className="ad-slot-container">
+						<div
+							id="dfp-ad--crossword-banner"
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								'ad-slot--crossword-banner',
+								'ad-slot--rendered',
+							].join(' ')}
+							css={[crosswordBannerStyles]}
+							data-link-name="ad slot crossword-banner"
+							data-name="crossword-banner"
+							data-testid="slot"
+							aria-hidden="true"
+						/>
+					</div>
+				</Hide>
 			);
 		}
 	}

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -10,7 +10,9 @@ import {
 } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
+import { ArticleDisplay } from '../lib/articleFormat';
 import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
 
 const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 	return (
@@ -79,6 +81,14 @@ const Layout: CrosswordProps['Layout'] = ({
 								display: none;
 							}
 						`}
+					/>
+					<AdSlot
+						position={'crossword-banner-mobile'}
+						display={ArticleDisplay.Standard}
+					/>
+					<AdSlot
+						position={'crossword-banner'}
+						display={ArticleDisplay.Standard}
 					/>
 					<Controls />
 					<div


### PR DESCRIPTION
## What does this change?

Adds the crossword banner ad slot to the crossword layout

## Why?

Parity with frotend-rendered crossword

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
