### PR TITLE
Improve and clean up crossword layout

### DIFF
--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -46,8 +46,7 @@ const Layout: CrosswordProps['Layout'] = ({
 				display: flex;
 				flex-direction: column;
 				gap: ${space[4]}px;
-
-				${from.leftCol} {
+				${from.phablet} {
 					flex-direction: row;
 				}
 			`}
@@ -57,8 +56,7 @@ const Layout: CrosswordProps['Layout'] = ({
 				css={css`
 					flex-basis: ${gridWidth}px;
 
-					${from.leftCol} {
-						position: sticky;
+					${from.phablet} {
 						top: ${space[4]}px;
 						align-self: flex-start;
 					}
@@ -66,16 +64,22 @@ const Layout: CrosswordProps['Layout'] = ({
 			>
 				<FocusedClue
 					additionalCss={css`
-						${from.leftCol} {
+						max-width: ${gridWidth}px;
+						${from.phablet} {
 							display: none;
 						}
 					`}
 				/>
 				<Grid />
-				<div data-print-layout="hide">
+				<div
+					data-print-layout="hide"
+					css={css`
+						max-width: ${gridWidth}px;
+					`}
+				>
 					<FocusedClue
 						additionalCss={css`
-							${from.leftCol} {
+							${from.phablet} {
 								display: none;
 							}
 						`}
@@ -99,7 +103,9 @@ const Layout: CrosswordProps['Layout'] = ({
 					flex-direction: column;
 					gap: ${space[4]}px;
 					align-items: flex-start;
-
+					min-width: 200px;
+					max-height: ${gridWidth + 100}px;
+					overflow: auto;
 					> * {
 						flex: 1;
 					}

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -109,7 +109,6 @@ const Layout: CrosswordProps['Layout'] = ({
 						overflow: auto;
 					}
 					${from.desktop} {
-						// set back to default
 						max-height: none;
 						overflow: visible;
 					}

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -55,11 +55,6 @@ const Layout: CrosswordProps['Layout'] = ({
 			<div
 				css={css`
 					flex-basis: ${gridWidth}px;
-
-					${from.phablet} {
-						top: ${space[4]}px;
-						align-self: flex-start;
-					}
 				`}
 			>
 				<FocusedClue

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -98,21 +98,11 @@ const Layout: CrosswordProps['Layout'] = ({
 					flex-direction: column;
 					gap: ${space[4]}px;
 					align-items: flex-start;
-					min-width: 200px;
-					${from.phablet} {
-						max-height: ${gridWidth + 100}px;
-						overflow: auto;
-					}
 					${from.desktop} {
-						max-height: none;
-						overflow: visible;
+						flex-direction: row;
 					}
 					> * {
 						flex: 1;
-					}
-
-					${from.wide} {
-						flex-direction: row;
 					}
 				`}
 			>

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -104,8 +104,15 @@ const Layout: CrosswordProps['Layout'] = ({
 					gap: ${space[4]}px;
 					align-items: flex-start;
 					min-width: 200px;
-					max-height: ${gridWidth + 100}px;
-					overflow: auto;
+					${from.phablet} {
+						max-height: ${gridWidth + 100}px;
+						overflow: auto;
+					}
+					${from.desktop} {
+						// set back to default
+						max-height: none;
+						overflow: visible;
+					}
 					> * {
 						flex: 1;
 					}

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -13,7 +13,6 @@ import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
-import { Carousel } from '../components/Carousel.importable';
 import { CrosswordInstructions } from '../components/CrosswordInstructions';
 import { CrosswordLinks } from '../components/CrosswordLinks';
 import { DecideLines } from '../components/DecideLines';
@@ -23,9 +22,6 @@ import { GridItem } from '../components/GridItem';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { Masthead } from '../components/Masthead/Masthead';
-import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
-import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
-import { OnwardsUpper } from '../components/OnwardsUpper.importable';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
@@ -36,11 +32,9 @@ import { SubNav } from '../components/SubNav.importable';
 import { type ArticleFormat, ArticleSpecial } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { ArticleDeprecated } from '../types/article';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 const CrosswordGrid = ({ children }: { children: React.ReactNode }) => (
@@ -100,19 +94,14 @@ const stretchLines = css`
 	}
 `;
 
-interface CommonProps {
+interface Props {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
-	renderingTarget: RenderingTarget;
-}
-
-interface WebProps extends CommonProps {
 	NAV: NavType;
-	renderingTarget: 'Web';
 }
 
-export const CrosswordLayout = (props: WebProps) => {
-	const { article, format, renderingTarget } = props;
+export const CrosswordLayout = (props: Props) => {
+	const { article, format } = props;
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
 	} = article;
@@ -122,8 +111,6 @@ export const CrosswordLayout = (props: WebProps) => {
 	const { branding } = article.commercialProperties[article.editionId];
 
 	const contributionsServiceUrl = getContributionsServiceUrl(article);
-
-	const { absoluteServerTimes = false } = article.config.switches;
 
 	/**
 	 * This property currently only applies to the header and merchandising slots
@@ -428,56 +415,6 @@ export const CrosswordLayout = (props: WebProps) => {
 					</Section>
 				)}
 
-				{article.storyPackage && (
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<Carousel
-								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
-								)}
-								onwardsSource="more-on-this-story"
-								format={format}
-								leftColSize={'compact'}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-								absoluteServerTimes={absoluteServerTimes}
-								renderingTarget={renderingTarget}
-							/>
-						</Island>
-					</Section>
-				)}
-
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<OnwardsUpper
-						ajaxUrl={article.config.ajaxUrl}
-						hasRelated={article.hasRelated}
-						hasStoryPackage={article.hasStoryPackage}
-						isAdFreeUser={article.isAdFreeUser}
-						pageId={article.pageId}
-						isPaidContent={!!article.config.isPaidContent}
-						showRelatedContent={article.config.showRelatedContent}
-						keywordIds={article.config.keywordIds}
-						contentType={article.contentType}
-						tags={article.tags}
-						format={format}
-						pillar={format.theme}
-						editionId={article.editionId}
-						shortUrlId={article.config.shortUrlId}
-						discussionApiUrl={article.config.discussionApiUrl}
-						absoluteServerTimes={absoluteServerTimes}
-						renderingTarget={renderingTarget}
-					/>
-				</Island>
-
 				{showComments && (
 					<Section
 						fullWidth={true}
@@ -505,36 +442,6 @@ export const CrosswordLayout = (props: WebProps) => {
 							shouldHideAds={article.shouldHideAds}
 							idApiUrl={article.config.idApiUrl}
 						/>
-					</Section>
-				)}
-
-				{!isPaidContent && (
-					<Section
-						title="Most viewed"
-						padContent={false}
-						verticalMargins={false}
-						element="aside"
-						data-print-layout="hide"
-						data-link-name="most-popular"
-						data-component="most-popular"
-						backgroundColour={themePalette(
-							'--article-section-background',
-						)}
-						borderColour={themePalette('--article-border')}
-						fontColour={themePalette('--article-section-title')}
-					>
-						<MostViewedFooterLayout renderAds={renderAds}>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<MostViewedFooterData
-									sectionId={article.config.section}
-									ajaxUrl={article.config.ajaxUrl}
-									edition={article.editionId}
-								/>
-							</Island>
-						</MostViewedFooterLayout>
 					</Section>
 				)}
 

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -46,93 +46,36 @@ import { BannerWrapper, Stuck } from './lib/stickiness';
 const CrosswordGrid = ({ children }: { children: React.ReactNode }) => (
 	<div
 		css={css`
-			/* IE Fallback */
-			display: flex;
-			flex-direction: column;
-			${until.leftCol} {
-				margin-left: 0px;
-			}
+			display: grid;
+			width: 100%;
+			margin-left: 0;
+			grid-column-gap: 0px;
+			grid-template-columns: minmax(0, 1fr);
+			grid-template-areas:
+				'title'
+				'headline'
+				'standfirst'
+				'meta'
+				'instructions'
+				'body';
+
 			${from.leftCol} {
-				margin-left: 151px;
-			}
-			${from.wide} {
-				margin-left: 230px;
-			}
-
-			@supports (display: grid) {
-				display: grid;
-				width: 100%;
-				margin-left: 0;
 				grid-column-gap: 20px;
+				grid-template-columns: 140px 1fr;
+				grid-template-areas:
+					'title  headline    '
+					'meta   standfirst  '
+					'meta   instructions'
+					'body   body        ';
+			}
 
-				/*
-					Explanation of each unit of grid-template-columns
-
-					Left Column
-					Main content
-					Right Column
-				*/
-				${from.wide} {
-					grid-template-columns: 220px 1fr 300px;
-
-					grid-template-areas:
-						'title  headline      right-column'
-						'meta   standfirst    right-column'
-						'meta   instructions  right-column'
-						'body   body          right-column';
-				}
-
-				/*
-					Explanation of each unit of grid-template-columns
-
-					Left Column
-					Main content
-					Right Column
-				*/
-				${until.wide} {
-					grid-template-columns: 140px 1fr 300px;
-
-					grid-template-areas:
-						'title  headline      right-column'
-						'meta   standfirst    right-column'
-						'meta   instructions  right-column'
-						'body   body          right-column';
-				}
-
-				${until.leftCol} {
-					grid-template-columns: 1fr 300px;
-					grid-template-areas:
-						'title         right-column'
-						'headline      right-column'
-						'standfirst    right-column'
-						'meta          right-column'
-						'instructions  right-column'
-						'body          right-column';
-				}
-
-				${until.desktop} {
-					grid-column-gap: 0px;
-					grid-template-columns: minmax(0, 1fr); /* Main content */
-					grid-template-areas:
-						'title'
-						'headline'
-						'standfirst'
-						'meta'
-						'instructions'
-						'body';
-				}
-
-				${until.tablet} {
-					grid-column-gap: 0px;
-					grid-template-columns: minmax(0, 1fr); /* Main content */
-					grid-template-areas:
-						'title'
-						'headline'
-						'standfirst'
-						'meta'
-						'instructions'
-						'body';
-				}
+			${from.wide} {
+				grid-template-columns: 220px 1fr 300px;
+				grid-template-areas:
+					'title  headline      right-column'
+					'meta   standfirst    right-column'
+					'meta   instructions  right-column'
+					'body   body          right-column';
 			}
 		`}
 	>
@@ -378,7 +321,7 @@ export const CrosswordLayout = (props: WebProps) => {
 								</ArticleContainer>
 							</GridItem>
 							<GridItem area="right-column">
-								<RightColumn>
+								<RightColumn showFrom="wide">
 									{renderAds ? (
 										<AdSlot
 											position="right"

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -282,7 +282,6 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
-							renderingTarget={renderingTarget}
 						/>
 					);
 				default:


### PR DESCRIPTION
## What does this change?

- Updates layout so clues are show beside the grid from `phablet` upwards
- Right column (and associated ad slot) is now only shown at `wide` breakpoint (matching existing behaviour on `frontend`)
- Removes onward journey carousels and most read container
- Refactors and simplified grid layout styles

## Screenshots

| Breakpoint | Before      | After      |
| ----------- | ----------- | ---------- |
| Mobile | ![mobilebefore][] | ![mobileafter][] |
| Phablet | ![phabletbefore][] | ![phabletafter][] |
| Desktop | ![desktopbefore][] | ![desktopafter][] |
| LeftCol | ![leftcolbefore][] | ![leftcolafter][] |
| Wide | ![widebefore][] | ![wideafter][] |

[mobilebefore]: https://github.com/user-attachments/assets/26b46929-bc26-4c10-a7de-c41188805d24
[mobileafter]: https://github.com/user-attachments/assets/52b73965-d55a-41e0-b4b0-402537ec87ed
[phabletbefore]: https://github.com/user-attachments/assets/19ac1e00-b3c7-465a-9923-73b60b0e567b
[phabletafter]: https://github.com/user-attachments/assets/79ee9684-c325-4e17-aa30-f85a535a4036
[desktopbefore]: https://github.com/user-attachments/assets/8b38ee49-2882-450d-95f0-7803a5691081
[desktopafter]: https://github.com/user-attachments/assets/69c35aec-bcc0-40ee-819a-a706a0e4a04f
[leftcolbefore]: https://github.com/user-attachments/assets/bc11287a-67ef-4c95-b539-8ed625c45cc7
[leftcolafter]: https://github.com/user-attachments/assets/3a138467-70d8-4ca4-a0e8-37002700f45f
[widebefore]: https://github.com/user-attachments/assets/36dae7c2-9f8f-4ca3-92cf-bf389becb543
[wideafter]: https://github.com/user-attachments/assets/40f0e922-7d8e-47e7-9267-350a1445e888

