### PR TITLE
Align Opinion Card Avatars

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -51,7 +51,11 @@ import { AvatarContainer } from './components/AvatarContainer';
 import { CardAge } from './components/CardAge';
 import { CardBranding } from './components/CardBranding';
 import { CardFooter } from './components/CardFooter';
-import { CardLayout, type GapSizes } from './components/CardLayout';
+import {
+	CardLayout,
+	decideAvatarPosition,
+	type GapSizes,
+} from './components/CardLayout';
 import { CardLink } from './components/CardLink';
 import { CardWrapper } from './components/CardWrapper';
 import { ContentWrapper } from './components/ContentWrapper';
@@ -553,10 +557,21 @@ export const Card = ({
 		isBetaContainer,
 	});
 
-	// For opinion type cards with avatars (which aren't onwards content)
-	// we render the footer in a different location
-	const showCommentFooter =
+	/**
+	 * For opinion type cards with avatars (which aren't onwards content)
+	 * we render the footer in a different location
+	 */
+	const isOpinionCardWithAvatar =
 		isOpinion && !isOnwardContent && media?.type === 'avatar';
+
+	/**
+	 * The avatar position is not always the same as the image position.
+	 */
+	const avatarPosition = decideAvatarPosition(
+		imagePositionOnMobile,
+		imagePositionOnDesktop,
+		isBetaContainer,
+	);
 
 	/**
 -	 * Media cards have contrasting background colours. We add additional
@@ -1107,7 +1122,7 @@ export const Card = ({
 								/>
 							)}
 
-							{!showCommentFooter && (
+							{!isOpinionCardWithAvatar && (
 								<>
 									{showPill ? (
 										<>
@@ -1231,7 +1246,7 @@ export const Card = ({
 				)}
 				{decideOuterSublinks()}
 
-				{showCommentFooter && (
+				{isOpinionCardWithAvatar && (
 					<CardFooter
 						format={format}
 						age={decideAge()}
@@ -1245,6 +1260,10 @@ export const Card = ({
 							) : undefined
 						}
 						showLivePlayable={showLivePlayable}
+						shouldReserveSpace={{
+							mobile: avatarPosition.mobile === 'bottom',
+							desktop: avatarPosition.desktop === 'bottom',
+						}}
 					/>
 				)}
 			</div>

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { palette, space, textSansBold12 } from '@guardian/source/foundations';
+import {
+	from,
+	palette,
+	space,
+	textSansBold12,
+} from '@guardian/source/foundations';
 import { SvgCamera } from '@guardian/source/react-components';
 import { Pill } from '../../../components/Pill';
 import { SvgMediaControlsPlay } from '../../../components/SvgMediaControlsPlay';
@@ -35,6 +40,14 @@ const contentStyles = css`
 	}
 `;
 
+const reserveSpaceStyles = (mobile: boolean, desktop: boolean) => css`
+	min-height: ${mobile ? '14px' : 0};
+
+	${from.tablet} {
+		min-height: ${desktop ? '14px' : 0};
+	}
+`;
+
 const labStyles = css`
 	margin-top: ${space[1]}px;
 `;
@@ -51,6 +64,7 @@ type Props = {
 	commentCount?: JSX.Element;
 	cardBranding?: JSX.Element;
 	mainMedia?: MainMedia;
+	shouldReserveSpace?: { mobile: boolean; desktop: boolean };
 };
 
 export const CardFooter = ({
@@ -60,6 +74,7 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	mainMedia,
+	shouldReserveSpace,
 }: Props) => {
 	if (showLivePlayable) return null;
 
@@ -104,12 +119,17 @@ export const CardFooter = ({
 		);
 	}
 
-	if (age === undefined && commentCount === undefined) {
-		return null;
-	}
-
 	return (
-		<footer css={contentStyles}>
+		<footer
+			css={[
+				contentStyles,
+				shouldReserveSpace &&
+					reserveSpaceStyles(
+						shouldReserveSpace.mobile,
+						shouldReserveSpace.desktop,
+					),
+			]}
+		>
 			{age}
 			{commentCount}
 		</footer>

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -65,70 +65,86 @@ const minWidth = (minWidthInPixels?: number) => {
  * position for desktop and mobile are both set to `bottom` to avoid affecting
  * existing layouts where the default position values are relied upon.
  */
-const decideDirection = (
+export const decideAvatarPosition = (
+	imagePositionOnMobile: ImagePositionType,
+	imagePositionOnDesktop: ImagePositionType,
+	isBetaContainer: boolean,
+): { mobile: ImagePositionType; desktop: ImagePositionType } => {
+	if (
+		imagePositionOnMobile === 'bottom' &&
+		imagePositionOnDesktop === 'bottom'
+	) {
+		return {
+			mobile: 'bottom',
+			desktop: 'bottom',
+		};
+	}
+
+	if (
+		imagePositionOnDesktop === 'left' ||
+		imagePositionOnDesktop === 'right'
+	) {
+		if (isBetaContainer && imagePositionOnMobile === 'bottom') {
+			return {
+				mobile: 'bottom',
+				desktop: 'right',
+			};
+		}
+		return {
+			mobile: 'right',
+			desktop: 'right',
+		};
+	}
+
+	return {
+		mobile: 'right',
+		desktop: 'bottom',
+	};
+};
+
+const imagePositionMap = {
+	top: 'column',
+	bottom: 'column-reverse',
+	left: 'row',
+	right: 'row-reverse',
+	none: 'column',
+};
+
+const decideFlexDirection = (
 	imagePositionOnMobile: ImagePositionType,
 	imagePositionOnDesktop: ImagePositionType,
 	isBetaContainer: boolean,
 	hasAvatar?: boolean,
 ) => {
-	const imagePosition = {
-		top: 'column',
-		bottom: 'column-reverse',
-		left: 'row',
-		right: 'row-reverse',
-		none: 'column',
-	};
-	if (hasAvatar) {
-		if (
-			imagePositionOnMobile === 'bottom' &&
-			imagePositionOnDesktop === 'bottom'
-		) {
-			return {
-				mobile: imagePosition['bottom'],
-				desktop: imagePosition['bottom'],
-			};
-		}
-
-		if (
-			imagePositionOnDesktop === 'left' ||
-			imagePositionOnDesktop === 'right'
-		) {
-			if (isBetaContainer && imagePositionOnMobile === 'bottom') {
-				return {
-					mobile: imagePosition['bottom'],
-					desktop: imagePosition['right'],
-				};
-			}
-			return {
-				mobile: imagePosition['right'],
-				desktop: imagePosition['right'],
-			};
-		}
-
-		// Default case for avatar: Mobile right, Desktop bottom
+	if (!hasAvatar) {
 		return {
-			mobile: imagePosition['right'],
-			desktop: imagePosition['bottom'],
+			mobile: imagePositionMap[imagePositionOnMobile],
+			desktop: imagePositionMap[imagePositionOnDesktop],
 		};
 	}
 
-	// Handle cases without an avatar
+	const { mobile, desktop } = decideAvatarPosition(
+		imagePositionOnMobile,
+		imagePositionOnDesktop,
+		isBetaContainer,
+	);
+
 	return {
-		mobile: imagePosition[imagePositionOnMobile],
-		desktop: imagePosition[imagePositionOnDesktop],
+		mobile: imagePositionMap[mobile],
+		desktop: imagePositionMap[desktop],
 	};
 };
 
 const decidePosition = (
 	imagePositionOnMobile: ImagePositionType,
 	imagePositionOnDesktop: ImagePositionType,
-	isFairgroundContainer: boolean,
+	isBetaContainer: boolean,
 	hasAvatar?: boolean,
 ) => {
-	const { mobile, desktop } = decideDirection(
+	const { mobile, desktop } = decideFlexDirection(
 		imagePositionOnMobile,
 		imagePositionOnDesktop,
-		isFairgroundContainer,
+		isBetaContainer,
 		hasAvatar,
 	);
 


### PR DESCRIPTION
## What does this change?

Give the footer in Opinion cards a minimum height when the avatar sits below the text.

Includes a refactor of the avatar position calculation in `CardLayout.tsx` so that we can know about the avatar position in `Card.tsx`, pass this information down to `CardFooter.tsx` and reserve space if we need to.

## Why?

So that avatars align when we have a row of Opinion cards.

Two options I considered but turned down, were:
- Always reserve space for the footer on Opinion cards with avatars. However, this means that many card types would unnecessarily by reserving space when avatar position is not taken into account. For example, the [DynamicSlow](https://guardian.github.io/storybooks/?path=/story/dotcom-rendering_components-dynamicslow--avatar) container which has cards with avatars on the right.
- Only reserve space when the Card is Opinion, has an Avatar and at least one of the other cards in the row has a footer. This would add a lot of complexity and would not scale well. Each container would likely need to be taken into account.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/33324af9-56f8-41cf-8b16-592ee457683d
[after]: https://github.com/user-attachments/assets/218d2ca1-8e94-4637-88df-d88220112a2f

### What's changed?

The avatars are now aligned.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
