### PR TITLE
Use new video and container for loop video test

### DIFF
--- a/dotcom-rendering/src/components/LoopVideoABTest.tsx
+++ b/dotcom-rendering/src/components/LoopVideoABTest.tsx
@@ -21,7 +21,7 @@ export const LoopVideoABTest = () => (
 		Your browser does not support the video tag.
 		<source
 			type="video/mp4"
-			src="https://uploads.guim.co.uk/2024/45/14/TEST+1+FOR+ELLEN--0ee1b132-3a0d-405b-b493-aada74b259b2-2.mp4"
+			src="https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4"
 		/>
 	</video>
 );

--- a/dotcom-rendering/src/lib/loop-video-ab-test-data.ts
+++ b/dotcom-rendering/src/lib/loop-video-ab-test-data.ts
@@ -8,9 +8,9 @@ const exampleCard: DCRFrontCard = {
 	},
 	dataLinkName: 'media | group-0 | card-@1',
 	url: '/science/audio/2024/dec/12/does-googles-mindboggling-new-chip-bring-quantum-computers-any-closer-podcast',
-	headline: ' Google’s ‘mindboggling’ new quantum chip',
+	headline: 'Loop video test. This is what a looping video might look like',
 	trailText:
-		'Ian Sample speaks to Winfried Hensinger, professor of quantum technologies at the University of Sussex to find out how quantum computers work, and whether Google’s new chip is an important milestone in their development.',
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.',
 	webPublicationDate: '2024-12-12T05:00:09.000Z',
 	kickerText: 'Podcast',
 	supportingContent: [],
@@ -45,7 +45,7 @@ const exampleCard: DCRFrontCard = {
 export const testVideoCollection: DCRCollectionType = {
 	id: '2e10eba3-7836-4381-bfc0-07d71a3295f6',
 	displayName: 'video test',
-	collectionType: 'fixed/small/slow-V-third',
+	collectionType: 'fixed/small/slow-I',
 	grouped: {
 		snap: [],
 		huge: [],
@@ -54,7 +54,7 @@ export const testVideoCollection: DCRCollectionType = {
 		standard: [],
 		splash: [],
 	},
-	curated: [exampleCard, exampleCard, exampleCard, exampleCard, exampleCard],
+	curated: [exampleCard],
 	backfill: [],
 	treats: [],
 	config: {


### PR DESCRIPTION
## What does this change?

Uses a new container and video for a repeat of the [Loop Video test
](https://github.com/guardian/dotcom-rendering/pull/13344)

## Why?

To collect more data regarding performance and CWV's

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/201aa3b2-8e7a-45e7-a4fe-1c6f923a8b79
[after]: https://github.com/user-attachments/assets/c94f7c6d-11a2-499c-a403-58e266dc510b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
