### PR TITLE
Update react-crossword version

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
 		"@guardian/libs": "20.0.0",
 		"@guardian/ophan-tracker-js": "2.2.5",
 		"@guardian/react-crossword": "2.0.2",
-		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250218102215",
+		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250220133624",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,8 +365,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@guardian/react-crossword-next':
-        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250218102215
-        version: /@guardian/react-crossword@0.0.0-canary-20250218102215(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250220133624
+        version: /@guardian/react-crossword@0.0.0-canary-20250220133624(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4336,11 +4336,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@guardian/react-crossword@0.0.0-canary-20250218102215(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
-    resolution: {integrity: sha512-JWqXsxCWhxCnumtcS+l4JKrcAMdrW/cW6Tkqy7UMKoqxyi2BP4urLGlo7smblRdPJ/ddBWAsWtPytIFynloi4Q==}
+  /@guardian/react-crossword@0.0.0-canary-20250220133624(@emotion/react@11.11.3)(@guardian/libs@20.0.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+    resolution: {integrity: sha512-htyyyu4dZyw1c6IO18/HjRvx9Fn7IKYS2t0eWRMFfllWiuFAhGpzE12vGaeLlqYskA0aYvnCdGp+Mq9aC8ZOOw==}
     peerDependencies:
       '@emotion/react': ^11.11.3
-      '@guardian/libs': 0.0.0-canary-20250218102215
+      '@guardian/libs': ^21.0.0
       '@guardian/source': ^8.0.0
       '@types/react': ^18.2.79
       react: ^18.2.0


### PR DESCRIPTION
## What does this change?

- Updates the version of react crossword

## Why?

- New version has A11y improvements with less verbose labels on the grid.
https://github.com/guardian/csnx/pull/1966