### PR TITLE
Allow dual aspect ratios for card pictures

### DIFF
--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -26,7 +26,8 @@ export type ImageSizeType =
 	| 'carousel'
 	| 'podcast'
 	| 'feature'
-	| 'feature-large';
+	| 'feature-large'
+	| 'feature-immersive';
 
 type Props = {
 	children: React.ReactNode;

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -106,10 +106,20 @@ const decideImageWidths = (
 				{
 					breakpoint: breakpoints.mobile,
 					width: 325,
-					aspectRatio: aspectRatioMobile,
+					aspectRatio: aspectRatio,
 				},
 				{ breakpoint: breakpoints.tablet, width: 337, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
+			];
+		case 'feature-immersive':
+			return [
+				{
+					breakpoint: breakpoints.mobile,
+					width: 340,
+					aspectRatio: aspectRatioMobile,
+				},
+				{ breakpoint: breakpoints.tablet, width: 700, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 940, aspectRatio },
 			];
 	}
 };
@@ -129,7 +139,7 @@ const block = css`
  * Determines the padding-top percentage based on the provided aspect ratio.
  * This helps maintain the correct aspect ratio for images.
  */
-const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
+export const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 	switch (aspectRatio) {
 		case '5:4':
 			return '80%';

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { breakpoints, space } from '@guardian/source/foundations';
+import { breakpoints, space, until } from '@guardian/source/foundations';
 import type { ImgHTMLAttributes } from 'react';
 import React from 'react';
 import type { AspectRatio } from '../types/front';
@@ -18,6 +18,7 @@ type Props = {
 	roundedCorners?: boolean;
 	isCircular?: boolean;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 	isInLoopVideoTest?: boolean;
 };
 
@@ -32,7 +33,9 @@ type Props = {
 const decideImageWidths = (
 	imageSize: ImageSizeType,
 	aspectRatio?: AspectRatio,
+	mobileAspectRatio?: AspectRatio,
 ): [ImageWidthType, ...ImageWidthType[]] => {
+	const aspectRatioMobile = mobileAspectRatio ?? aspectRatio;
 	switch (imageSize) {
 		// @TODO missing image size option
 		// case 'tiny':
@@ -100,7 +103,11 @@ const decideImageWidths = (
 			];
 		case 'feature-large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 325, aspectRatio },
+				{
+					breakpoint: breakpoints.mobile,
+					width: 325,
+					aspectRatio: aspectRatioMobile,
+				},
 				{ breakpoint: breakpoints.tablet, width: 337, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
@@ -151,6 +158,15 @@ const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	`;
 };
 
+const decideMobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
+	const paddingRatio = getAspectRatioPadding(aspectRatio);
+	return css`
+		${until.tablet} {
+			padding-top: ${paddingRatio};
+		}
+	`;
+};
+
 const borderRadius = css`
 	& > * {
 		border-radius: ${space[2]}px;
@@ -172,11 +188,12 @@ export const CardPicture = ({
 	roundedCorners,
 	isCircular,
 	aspectRatio,
+	mobileAspectRatio,
 	isInLoopVideoTest = false,
 }: Props) => {
 	const sources = generateSources(
 		mainImage,
-		decideImageWidths(imageSize, aspectRatio),
+		decideImageWidths(imageSize, aspectRatio, mobileAspectRatio),
 	);
 
 	const fallbackSource = getFallbackSource(sources);
@@ -191,6 +208,8 @@ export const CardPicture = ({
 			css={[
 				block,
 				decideAspectRatioStyles(aspectRatio),
+				mobileAspectRatio &&
+					decideMobileAspectRatioStyles(mobileAspectRatio),
 				roundedCorners && borderRadius,
 				isCircular && circularStyles,
 			]}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -125,6 +125,10 @@ const block = css`
 	display: block;
 `;
 
+/**
+ * Determines the padding-top percentage based on the provided aspect ratio.
+ * This helps maintain the correct aspect ratio for images.
+ */
 const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 	switch (aspectRatio) {
 		case '5:4':
@@ -138,11 +142,7 @@ const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 			return '60%';
 	}
 };
-/**
- * On fronts, Fairground cards have an image ration of 5:4.
- * This is due to replace the existing card ratio of 5:3
- * For now, we are keeping both ratios.
- */
+
 const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	const paddingRatio = getAspectRatioPadding(aspectRatio);
 	return css`

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -31,6 +31,7 @@ type Props = {
  */
 const decideImageWidths = (
 	imageSize: ImageSizeType,
+	aspectRatio?: AspectRatio,
 ): [ImageWidthType, ...ImageWidthType[]] => {
 	switch (imageSize) {
 		// @TODO missing image size option
@@ -42,52 +43,66 @@ const decideImageWidths = (
 		// 	];
 
 		case 'podcast':
-			return [{ breakpoint: breakpoints.mobile, width: 80 }];
+			return [{ breakpoint: breakpoints.mobile, width: 80, aspectRatio }];
 
 		case 'carousel':
-			return [{ breakpoint: breakpoints.mobile, width: 220 }];
+			return [
+				{
+					breakpoint: breakpoints.mobile,
+					width: 220,
+					aspectRatio,
+				},
+			];
 
 		case 'small':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 120 },
-				{ breakpoint: breakpoints.tablet, width: 160 },
-				{ breakpoint: breakpoints.desktop, width: 220 },
+				{ breakpoint: breakpoints.mobile, width: 120, aspectRatio },
+				{ breakpoint: breakpoints.tablet, width: 160, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 220, aspectRatio },
 			];
 
 		case 'medium':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 240 },
-				{ breakpoint: breakpoints.tablet, width: 330 },
-				{ breakpoint: breakpoints.desktop, width: 460 },
+				{ breakpoint: breakpoints.mobile, width: 240, aspectRatio },
+				{ breakpoint: breakpoints.tablet, width: 330, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
 
 		case 'large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 360 },
-				{ breakpoint: breakpoints.mobileLandscape, width: 480 },
-				{ breakpoint: breakpoints.tablet, width: 500 },
-				{ breakpoint: breakpoints.desktop, width: 700 },
+				{ breakpoint: breakpoints.mobile, width: 360, aspectRatio },
+				{
+					breakpoint: breakpoints.mobileLandscape,
+					width: 480,
+					aspectRatio,
+				},
+				{ breakpoint: breakpoints.tablet, width: 500, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 700, aspectRatio },
 			];
 
 		case 'jumbo':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 360 },
-				{ breakpoint: breakpoints.mobileLandscape, width: 480 },
-				{ breakpoint: breakpoints.tablet, width: 680 },
-				{ breakpoint: breakpoints.desktop, width: 940 },
+				{ breakpoint: breakpoints.mobile, width: 360, aspectRatio },
+				{
+					breakpoint: breakpoints.mobileLandscape,
+					width: 480,
+					aspectRatio,
+				},
+				{ breakpoint: breakpoints.tablet, width: 680, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 940, aspectRatio },
 			];
 
 		case 'feature':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 325 },
-				{ breakpoint: breakpoints.tablet, width: 220 },
-				{ breakpoint: breakpoints.desktop, width: 300 },
+				{ breakpoint: breakpoints.mobile, width: 325, aspectRatio },
+				{ breakpoint: breakpoints.tablet, width: 220, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 300, aspectRatio },
 			];
 		case 'feature-large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 325 },
-				{ breakpoint: breakpoints.tablet, width: 337 },
-				{ breakpoint: breakpoints.desktop, width: 460 },
+				{ breakpoint: breakpoints.mobile, width: 325, aspectRatio },
+				{ breakpoint: breakpoints.tablet, width: 337, aspectRatio },
+				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
 	}
 };
@@ -161,8 +176,7 @@ export const CardPicture = ({
 }: Props) => {
 	const sources = generateSources(
 		mainImage,
-		decideImageWidths(imageSize),
-		aspectRatio,
+		decideImageWidths(imageSize, aspectRatio),
 	);
 
 	const fallbackSource = getFallbackSource(sources);

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -168,7 +168,7 @@ const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	`;
 };
 
-const decideMobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
+export const decideMobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	const paddingRatio = getAspectRatioPadding(aspectRatio);
 	return css`
 		${until.tablet} {

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
@@ -85,6 +85,26 @@ const contentStyles = css`
 	flex-direction: column;
 `;
 
+const immersiveOverlayStyles = css`
+	${from.tablet} {
+		height: 100%;
+		top: 0;
+		width: 260px;
+		padding-top: ${space[2]}px;
+		mask-image: linear-gradient(
+			270deg,
+			transparent 0px,
+			rgba(0, 0, 0, 0.0381) 8px,
+			rgba(0, 0, 0, 0.1464) 16px,
+			rgba(0, 0, 0, 0.3087) 24px,
+			rgba(0, 0, 0, 0.5) 32px,
+			rgba(0, 0, 0, 0.6913) 40px,
+			rgba(0, 0, 0, 0.8536) 48px,
+			rgba(0, 0, 0, 0.9619) 56px,
+			rgb(0, 0, 0) 64px
+		);
+	}
+`;
 /**
  * Image mask gradient has additional colour stops to emulate a non-linear
  * ease in / ease out curve to make the transition smoother. Values were
@@ -220,6 +240,8 @@ export type Props = {
 	 * The highlights container above the header is 0, the first container below the header is 1, etc.
 	 */
 	collectionId: number;
+	/** Immersive cards have a seperate aspect ratio for mobile and tablet/desktop */
+	isImmersive?: boolean;
 };
 
 export const FeatureCard = ({
@@ -253,6 +275,7 @@ export const FeatureCard = ({
 	starRating,
 	showQuotes,
 	collectionId,
+	isImmersive = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -342,6 +365,7 @@ export const FeatureCard = ({
 										discussionId={discussionId}
 										discussionApiUrl={discussionApiUrl}
 										isFeatureCard={true}
+										isImmersive={isImmersive}
 									/>
 								</Island>
 							</div>
@@ -373,7 +397,14 @@ export const FeatureCard = ({
 											alt={headlineText}
 											loading={imageLoading}
 											roundedCorners={false}
-											aspectRatio={aspectRatio}
+											aspectRatio={
+												isImmersive
+													? '5:3'
+													: aspectRatio
+											}
+											mobileAspectRatio={
+												isImmersive ? '4:5' : undefined
+											}
 										/>
 									</div>
 								)}
@@ -386,7 +417,14 @@ export const FeatureCard = ({
 											alt={media.imageAltText}
 											loading={imageLoading}
 											roundedCorners={false}
-											aspectRatio={aspectRatio}
+											aspectRatio={
+												isImmersive
+													? '5:3'
+													: aspectRatio
+											}
+											mobileAspectRatio={
+												isImmersive ? '4:5' : undefined
+											}
 										/>
 										{isVideoMainMedia &&
 											mainMedia.duration > 0 && (
@@ -443,7 +481,13 @@ export const FeatureCard = ({
 												</div>
 											</div>
 										)}
-									<div css={overlayStyles}>
+									<div
+										css={[
+											overlayStyles,
+											isImmersive &&
+												immersiveOverlayStyles,
+										]}
+									>
 										{/**
 										 * Without the wrapping div the headline and byline would have space
 										 * inserted between them due to being direct children of the flex container

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -18,6 +18,7 @@ import type { TrailTextSize } from './Card/components/TrailText';
 import { UL } from './Card/components/UL';
 import type { ResponsiveFontSize } from './CardHeadline';
 import type { Loading } from './CardPicture';
+import { FeatureCard } from './FeatureCard';
 import { FrontCard } from './FrontCard';
 import type { Alignment } from './SupportingContent';
 
@@ -203,6 +204,44 @@ export const SplashCardLayout = ({
 		!!card.avatarUrl,
 	);
 
+	if (card.format.design === ArticleDesign.Video) {
+		return (
+			<UL>
+				<LI key={card.url} padSides={true}>
+					<FeatureCard
+						linkTo={card.url}
+						format={card.format}
+						headlineText={card.headline}
+						byline={card.byline}
+						showByline={card.showByline}
+						webPublicationDate={card.webPublicationDate}
+						kickerText={card.kickerText}
+						showClock={false}
+						image={card.image}
+						canPlayInline={true}
+						starRating={card.starRating}
+						dataLinkName={card.dataLinkName}
+						discussionApiUrl={card.discussionApiUrl}
+						discussionId={card.discussionId}
+						mainMedia={card.mainMedia}
+						isExternalLink={card.isExternalLink}
+						// branding={card.branding}
+						containerPalette={containerPalette}
+						trailText={card.trailText}
+						absoluteServerTimes={absoluteServerTimes}
+						imageLoading={imageLoading}
+						aspectRatio={aspectRatio}
+						imageSize="feature-immersive"
+						headlineSizes={{ desktop: 'small' }}
+						supportingContent={card.supportingContent}
+						isImmersive={true}
+						collectionId={1}
+					/>
+				</LI>
+			</UL>
+		);
+	}
+
 	return (
 		<UL
 			padBottom={!isLastRow}
@@ -323,6 +362,44 @@ export const BoostedCardLayout = ({
 		card.supportingContent?.length ?? 0,
 		card.avatarUrl,
 	);
+
+	if (card.format.design === ArticleDesign.Video) {
+		return (
+			<UL>
+				<LI key={card.url} padSides={true}>
+					<FeatureCard
+						linkTo={card.url}
+						format={card.format}
+						headlineText={card.headline}
+						byline={card.byline}
+						showByline={card.showByline}
+						webPublicationDate={card.webPublicationDate}
+						kickerText={card.kickerText}
+						showClock={false}
+						image={card.image}
+						canPlayInline={true}
+						starRating={card.starRating}
+						dataLinkName={card.dataLinkName}
+						discussionApiUrl={card.discussionApiUrl}
+						discussionId={card.discussionId}
+						mainMedia={card.mainMedia}
+						isExternalLink={card.isExternalLink}
+						// branding={card.branding}
+						containerPalette={containerPalette}
+						trailText={card.trailText}
+						absoluteServerTimes={absoluteServerTimes}
+						imageLoading={imageLoading}
+						aspectRatio={aspectRatio}
+						imageSize="feature-immersive"
+						headlineSizes={{ desktop: 'small' }}
+						supportingContent={card.supportingContent}
+						isImmersive={true}
+						collectionId={1}
+					/>
+				</LI>
+			</UL>
+		);
+	}
 	return (
 		<UL
 			showTopBar={!isFirstRow}

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -1,10 +1,15 @@
 import { css } from '@emotion/react';
 import type { AspectRatio } from '../types/front';
+import {
+	decideMobileAspectRatioStyles,
+	getAspectRatioPadding,
+} from './CardPicture';
 
 type Props = {
 	height: number;
 	width: number;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 	children: React.ReactNode;
 };
 
@@ -12,29 +17,33 @@ export const MaintainAspectRatio = ({
 	height,
 	width,
 	aspectRatio,
+	mobileAspectRatio,
 	children,
 }: Props) => {
 	/* https://css-tricks.com/aspect-ratio-boxes/ */
-	const paddingBottom =
-		aspectRatio === '5:4'
-			? `${(4 / 5) * 100}%`
-			: `${(height / width) * 100}%`;
+	const paddingTop = aspectRatio
+		? getAspectRatioPadding(aspectRatio)
+		: `${(height / width) * 100}%`;
 
 	return (
 		<div
-			css={css`
-				/* position relative to contain the absolutely positioned iframe plus any Overlay image */
-				position: relative;
-				padding-bottom: ${paddingBottom};
-				& > iframe,
-				& > video {
-					width: 100%;
-					height: 100%;
-					position: absolute;
-					top: 0;
-					left: 0;
-				}
-			`}
+			css={[
+				css`
+					/* position relative to contain the absolutely positioned iframe plus any Overlay image */
+					position: relative;
+					padding-top: ${paddingTop};
+					& > iframe,
+					& > video {
+						width: 100%;
+						height: 100%;
+						position: absolute;
+						top: 0;
+						left: 0;
+					}
+				`,
+				mobileAspectRatio &&
+					decideMobileAspectRatioStyles(mobileAspectRatio),
+			]}
 		>
 			{children}
 		</div>

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -265,8 +265,7 @@ type ImageSource = {
  * Generate image sources for an image.
  *
  * @param mainImage source image URL
- * @param imageWidths list of image widths
- * @param aspectRatio - Aspect ratio that the image should be cropped to (e.g., 5:4). Optional.
+ * @param imageWidths list of image widths. Each "width" includes the breakpoint, width, and optional aspectratio
  */
 export const generateSources = (
 	mainImage: string,

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -8,6 +8,7 @@ import {
 } from '../lib/articleFormat';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
+import { AspectRatio } from '../types/front';
 import type { Loading } from './CardPicture';
 
 /**
@@ -36,7 +37,11 @@ type Props = {
 	aspectRatio?: string;
 };
 
-export type ImageWidthType = { breakpoint: number; width: number };
+export type ImageWidthType = {
+	breakpoint: number;
+	width: number;
+	aspectRatio?: AspectRatio;
+};
 
 /**
  * All business logic for image sizing is contained in this one function. This
@@ -267,12 +272,11 @@ type ImageSource = {
 export const generateSources = (
 	mainImage: string,
 	imageWidths: readonly [ImageWidthType, ...ImageWidthType[]],
-	aspectRatio?: string,
 ): ImageSource[] =>
 	imageWidths
 		.slice()
 		.sort(descendingByBreakpoint)
-		.map(({ width: imageWidth, breakpoint }) => {
+		.map(({ width: imageWidth, breakpoint, aspectRatio }) => {
 			return {
 				breakpoint,
 				width: imageWidth,
@@ -340,7 +344,6 @@ export const Picture = ({
 	isLightbox = false,
 	orientation = 'landscape',
 	onLoad,
-	aspectRatio,
 }: Props) => {
 	const [loaded, setLoaded] = useState(false);
 	const ref = useCallback((node: HTMLImageElement | null) => {
@@ -365,7 +368,6 @@ export const Picture = ({
 			isLightbox,
 			orientation,
 		}),
-		aspectRatio,
 	);
 
 	/** portrait if higher than 1 or landscape if lower than 1 */

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -8,7 +8,7 @@ import {
 } from '../lib/articleFormat';
 import { generateImageURL } from '../lib/image';
 import type { RoleType } from '../types/content';
-import { AspectRatio } from '../types/front';
+import type { AspectRatio } from '../types/front';
 import type { Loading } from './CardPicture';
 
 /**
@@ -34,7 +34,6 @@ type Props = {
 	isLightbox?: boolean;
 	orientation?: Orientation;
 	onLoad?: () => void;
-	aspectRatio?: string;
 };
 
 export type ImageWidthType = {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -61,6 +61,7 @@ export type Props = {
 	discussionApiUrl?: string;
 	discussionId?: string;
 	isFeatureCard?: boolean;
+	isImmersive?: boolean;
 };
 
 /**
@@ -113,6 +114,7 @@ export const YoutubeAtom = ({
 	discussionApiUrl,
 	discussionId,
 	isFeatureCard,
+	isImmersive,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -199,7 +201,8 @@ export const YoutubeAtom = ({
 				<MaintainAspectRatio
 					height={height}
 					width={width}
-					aspectRatio={aspectRatio}
+					aspectRatio={isImmersive ? '5:3' : aspectRatio}
+					mobileAspectRatio={isImmersive ? '4:5' : undefined}
 				>
 					{
 						/**
@@ -256,6 +259,7 @@ export const YoutubeAtom = ({
 								linkTo={linkTo}
 								discussionId={discussionId}
 								discussionApiUrl={discussionApiUrl}
+								isImmersive={isImmersive}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
+import { from, space } from '@guardian/source/foundations';
 import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
@@ -46,6 +46,26 @@ const hoverStyles = css`
 	/* Only underline the headline element we want to target (not kickers/sublink headlines) */
 	:hover .card-headline .show-underline {
 		text-decoration: underline;
+	}
+`;
+const immersiveOverlayStyles = css`
+	${from.tablet} {
+		height: 100%;
+		top: 0;
+		width: 260px;
+		padding-top: ${space[2]}px;
+		mask-image: linear-gradient(
+			270deg,
+			transparent 0px,
+			rgba(0, 0, 0, 0.0381) 8px,
+			rgba(0, 0, 0, 0.1464) 16px,
+			rgba(0, 0, 0, 0.3087) 24px,
+			rgba(0, 0, 0, 0.5) 32px,
+			rgba(0, 0, 0, 0.6913) 40px,
+			rgba(0, 0, 0, 0.8536) 48px,
+			rgba(0, 0, 0, 0.9619) 56px,
+			rgb(0, 0, 0) 64px
+		);
 	}
 `;
 
@@ -100,6 +120,7 @@ type Props = {
 	linkTo?: string;
 	discussionApiUrl?: string;
 	discussionId?: string;
+	isImmersive?: boolean;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -123,6 +144,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	linkTo,
 	discussionId,
 	discussionApiUrl,
+	isImmersive,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -152,7 +174,8 @@ export const YoutubeAtomFeatureCardOverlay = ({
 						alt={alt}
 						height={height}
 						width={width}
-						aspectRatio={aspectRatio}
+						aspectRatio={isImmersive ? '5:3' : aspectRatio}
+						mobileAspectRatio={isImmersive ? '4:5' : undefined}
 					/>
 				)}
 				{hasDuration && !isVideoArticle ? (
@@ -165,7 +188,12 @@ export const YoutubeAtomFeatureCardOverlay = ({
 				) : null}
 				<div className="image-overlay" />
 				<PlayIcon iconWidth="narrow" />
-				<div css={[textOverlayStyles]}>
+				<div
+					css={[
+						textOverlayStyles,
+						isImmersive && immersiveOverlayStyles,
+					]}
+				>
 					{!!kicker && (
 						<Kicker
 							text={kicker}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -10,6 +10,7 @@ type Props = {
 	height: number;
 	width: number;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 };
 
 export const YoutubeAtomPicture = ({
@@ -18,11 +19,25 @@ export const YoutubeAtomPicture = ({
 	height,
 	width,
 	aspectRatio,
+	mobileAspectRatio,
 }: Props) => {
+	const aspectRatioMobile = mobileAspectRatio ?? aspectRatio;
 	const sources = generateSources(getSourceImageUrl(image), [
-		{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
-		{ breakpoint: breakpoints.mobileLandscape, width: 645, aspectRatio },
-		{ breakpoint: breakpoints.phablet, width: 620, aspectRatio },
+		{
+			breakpoint: breakpoints.mobile,
+			width: 465,
+			aspectRatio: aspectRatioMobile,
+		},
+		{
+			breakpoint: breakpoints.mobileLandscape,
+			width: 645,
+			aspectRatio: aspectRatioMobile,
+		},
+		{
+			breakpoint: breakpoints.phablet,
+			width: 620,
+			aspectRatio: aspectRatioMobile,
+		},
 		{ breakpoint: breakpoints.tablet, width: 700, aspectRatio },
 		{ breakpoint: breakpoints.desktop, width: 620, aspectRatio },
 	]);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source/foundations';
 import { getSourceImageUrl } from '../../lib/getSourceImageUrl_temp_fix';
-import { generateSources, getFallbackSource, Sources } from '../Picture';
 import type { AspectRatio } from '../../types/front';
+import { generateSources, getFallbackSource, Sources } from '../Picture';
 
 type Props = {
 	image: string;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -2,13 +2,14 @@ import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source/foundations';
 import { getSourceImageUrl } from '../../lib/getSourceImageUrl_temp_fix';
 import { generateSources, getFallbackSource, Sources } from '../Picture';
+import type { AspectRatio } from '../../types/front';
 
 type Props = {
 	image: string;
 	alt: string;
 	height: number;
 	width: number;
-	aspectRatio?: string;
+	aspectRatio?: AspectRatio;
 };
 
 export const YoutubeAtomPicture = ({
@@ -18,17 +19,13 @@ export const YoutubeAtomPicture = ({
 	width,
 	aspectRatio,
 }: Props) => {
-	const sources = generateSources(
-		getSourceImageUrl(image),
-		[
-			{ breakpoint: breakpoints.mobile, width: 465 },
-			{ breakpoint: breakpoints.mobileLandscape, width: 645 },
-			{ breakpoint: breakpoints.phablet, width: 620 },
-			{ breakpoint: breakpoints.tablet, width: 700 },
-			{ breakpoint: breakpoints.desktop, width: 620 },
-		],
-		aspectRatio,
-	);
+	const sources = generateSources(getSourceImageUrl(image), [
+		{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
+		{ breakpoint: breakpoints.mobileLandscape, width: 645, aspectRatio },
+		{ breakpoint: breakpoints.phablet, width: 620, aspectRatio },
+		{ breakpoint: breakpoints.tablet, width: 700, aspectRatio },
+		{ breakpoint: breakpoints.desktop, width: 620, aspectRatio },
+	]);
 	const fallbackSource = getFallbackSource(sources);
 
 	return (

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -54,6 +54,7 @@ type Props = {
 	discussionApiUrl?: string;
 	discussionId?: string;
 	isFeatureCard?: boolean;
+	isImmersive?: boolean;
 };
 
 export const YoutubeBlockComponent = ({
@@ -91,6 +92,7 @@ export const YoutubeBlockComponent = ({
 	discussionApiUrl,
 	discussionId,
 	isFeatureCard,
+	isImmersive,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -200,6 +202,7 @@ export const YoutubeBlockComponent = ({
 				discussionId={discussionId}
 				discussionApiUrl={discussionApiUrl}
 				isFeatureCard={isFeatureCard}
+				isImmersive={isImmersive}
 			/>
 			{!hideCaption && (
 				<Caption


### PR DESCRIPTION
## What does this change?
Provide an additional mobileAspectRatio prop to card picture to allow us to have a seperate mobile aspect ratio for images where needed. This is required for the "immersive" feature card <LINK TO DESIGNS>. If no mobile aspect ratio is provided, it defaults to the aspect ratio. 

To incorporate this change, the prop drilling of aspect ratio has been updated so that it is explicitly coupled to the image breakpoint and width. 

This PR does not wire up the immersive feature card. The UI changes will be in a separate PR. 

## Why?

## Screenshots


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
