### PR TITLE
Remove unused YoutubeAtomFeatureCardOverlay props

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -333,14 +333,6 @@ export const FeatureCard = ({
 										iconSizeOnDesktop="large"
 										iconSizeOnMobile="large"
 										headlineSizes={headlineSizes}
-										webPublicationDate={webPublicationDate}
-										showClock={!!showClock}
-										absoluteServerTimes={
-											absoluteServerTimes
-										}
-										linkTo={linkTo}
-										discussionId={discussionId}
-										discussionApiUrl={discussionApiUrl}
 										isFeatureCard={true}
 									/>
 								</Island>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -54,12 +54,6 @@ export type Props = {
 	trailText?: string;
 	headlineSizes?: ResponsiveFontSize;
 	isVideoArticle?: boolean;
-	webPublicationDate?: string;
-	showClock?: boolean;
-	absoluteServerTimes?: boolean;
-	linkTo?: string;
-	discussionApiUrl?: string;
-	discussionId?: string;
 	isFeatureCard?: boolean;
 };
 
@@ -106,12 +100,6 @@ export const YoutubeAtom = ({
 	trailText,
 	headlineSizes,
 	isVideoArticle,
-	webPublicationDate,
-	showClock,
-	absoluteServerTimes,
-	linkTo,
-	discussionApiUrl,
-	discussionId,
 	isFeatureCard,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
@@ -250,12 +238,6 @@ export const YoutubeAtom = ({
 								aspectRatio={aspectRatio}
 								trailText={trailText}
 								isVideoArticle={isVideoArticle}
-								webPublicationDate={webPublicationDate}
-								showClock={!!showClock}
-								absoluteServerTimes={absoluteServerTimes}
-								linkTo={linkTo}
-								discussionId={discussionId}
-								discussionApiUrl={discussionApiUrl}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -10,8 +10,6 @@ import { PlayIcon } from '../Card/components/PlayIcon';
 import { TrailText } from '../Card/components/TrailText';
 import type { ResponsiveFontSize } from '../CardHeadline';
 import { CardHeadline } from '../CardHeadline';
-import { FeatureCardCardAge } from '../FeatureCardCardAge';
-import { FeatureCardCommentCount } from '../FeatureCardCommentCount';
 import { FormatBoundary } from '../FormatBoundary';
 import { Kicker } from '../Kicker';
 import { Pill } from '../Pill';
@@ -94,12 +92,6 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	trailText?: string;
 	isVideoArticle?: boolean;
-	webPublicationDate?: string;
-	showClock?: boolean;
-	absoluteServerTimes?: boolean;
-	linkTo?: string;
-	discussionApiUrl?: string;
-	discussionId?: string;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -117,25 +109,9 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	aspectRatio,
 	trailText,
 	isVideoArticle,
-	webPublicationDate,
-	showClock,
-	absoluteServerTimes,
-	linkTo,
-	discussionId,
-	discussionApiUrl,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
-
-	const showCardAge =
-		webPublicationDate !== undefined &&
-		showClock !== undefined &&
-		absoluteServerTimes !== undefined;
-
-	const showCommentCount =
-		linkTo !== undefined &&
-		discussionId !== undefined &&
-		discussionApiUrl !== undefined;
 
 	return (
 		<FormatBoundary format={format}>
@@ -202,24 +178,6 @@ export const YoutubeAtomFeatureCardOverlay = ({
 					)}
 					<CardFooter
 						format={format}
-						age={
-							showCardAge ? (
-								<FeatureCardCardAge
-									webPublicationDate={webPublicationDate}
-									showClock={!!showClock}
-									absoluteServerTimes={absoluteServerTimes}
-								/>
-							) : undefined
-						}
-						commentCount={
-							showCommentCount ? (
-								<FeatureCardCommentCount
-									linkTo={linkTo}
-									discussionId={discussionId}
-									discussionApiUrl={discussionApiUrl}
-								/>
-							) : undefined
-						}
 						showLivePlayable={false}
 						mainMedia={{ type: 'Video', duration: duration ?? 0 }}
 					/>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -47,12 +47,6 @@ type Props = {
 	trailText?: string;
 	headlineSizes?: ResponsiveFontSize;
 	isVideoArticle?: boolean;
-	webPublicationDate?: string;
-	showClock?: boolean;
-	absoluteServerTimes?: boolean;
-	linkTo?: string;
-	discussionApiUrl?: string;
-	discussionId?: string;
 	isFeatureCard?: boolean;
 };
 
@@ -84,12 +78,6 @@ export const YoutubeBlockComponent = ({
 	trailText,
 	headlineSizes,
 	isVideoArticle,
-	webPublicationDate,
-	showClock,
-	absoluteServerTimes,
-	linkTo,
-	discussionApiUrl,
-	discussionId,
 	isFeatureCard,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
@@ -193,12 +181,6 @@ export const YoutubeBlockComponent = ({
 				trailText={trailText}
 				headlineSizes={headlineSizes}
 				isVideoArticle={isVideoArticle}
-				webPublicationDate={webPublicationDate}
-				showClock={!!showClock}
-				absoluteServerTimes={absoluteServerTimes}
-				linkTo={linkTo}
-				discussionId={discussionId}
-				discussionApiUrl={discussionApiUrl}
 				isFeatureCard={isFeatureCard}
 			/>
 			{!hideCaption && (


### PR DESCRIPTION
## What does this change?

Removes props from the `YoutubeAtomFeatureCardOverlay` component that are not used

## Why?

A Feature Card Youtube overlay displays the duration pill in the footer - it never displays the age or comment count.

