### PR TITLE
Add mobile crossword banner slot until phablet breakpoint

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
 		"@guardian/libs": "21.2.0",
 		"@guardian/ophan-tracker-js": "2.2.5",
 		"@guardian/react-crossword": "2.0.2",
-		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250220133624",
+		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250226111729",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { SlotName } from '@guardian/commercial';
-import { adSizes } from '@guardian/commercial';
+import { adSizes, constants } from '@guardian/commercial';
 import {
 	between,
 	breakpoints,
@@ -33,7 +33,6 @@ type ServerRenderedSlot = Exclude<
 	| 'carrot'
 	| 'comments-expanded'
 	| 'crossword-banner'
-	| 'crossword-banner-mobile'
 	| 'exclusion'
 	| 'external'
 	| 'inline'
@@ -368,6 +367,10 @@ const mobileStickyAdStylesFullWidth = css`
 		padding-left: calc((100% - ${adSizes.mobilesticky.width}px) / 2);
 		padding-right: calc((100% - ${adSizes.mobilesticky.width}px) / 2);
 	}
+`;
+
+const crosswordBannerMobileAdStyles = css`
+	min-height: ${adSizes.mobilesticky.height + constants.AD_LABEL_HEIGHT}px;
 `;
 
 export const AdSlot = ({
@@ -795,6 +798,26 @@ export const AdSlot = ({
 						css={[articleEndAdStyles]}
 						data-link-name="ad slot article-end"
 						data-name="article-end"
+						data-testid="slot"
+						aria-hidden="true"
+					/>
+				</div>
+			);
+		}
+		case 'crossword-banner-mobile': {
+			return (
+				<div className="ad-slot-container">
+					<div
+						id="dfp-ad--crossword-banner-mobile"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--crossword-banner-mobile',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={[crosswordBannerMobileAdStyles]}
+						data-link-name="ad slot crossword-banner-mobile"
+						data-name="crossword-banner-mobile"
 						data-testid="slot"
 						aria-hidden="true"
 					/>

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -8,9 +8,11 @@ import {
 	textSans14,
 	textSansItalic12,
 } from '@guardian/source/foundations';
-import type { ComponentType, ReactNode } from 'react';
+import { Hide } from '@guardian/source/react-components';
+import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
 
 const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 	return (
@@ -30,6 +32,14 @@ const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 		</div>
 	);
 });
+
+const MobileBannerAdComponent = () => {
+	return (
+		<Hide from="phablet">
+			<AdSlot position="crossword-banner-mobile" />
+		</Hide>
+	);
+};
 
 const Layout: CrosswordProps['Layout'] = ({
 	Grid,
@@ -119,14 +129,14 @@ const Layout: CrosswordProps['Layout'] = ({
 
 export const CrosswordComponent = ({
 	data,
-	MobileBannerAd,
+	canRenderAds,
 }: {
 	data: CrosswordProps['data'];
-	MobileBannerAd?: ComponentType | undefined;
+	canRenderAds?: boolean;
 }) => (
 	<ReactCrossword
 		data={data}
 		Layout={Layout}
-		MobileBannerAd={MobileBannerAd}
+		MobileBannerAd={canRenderAds ? MobileBannerAdComponent : undefined}
 	/>
 );

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -8,11 +8,9 @@ import {
 	textSans14,
 	textSansItalic12,
 } from '@guardian/source/foundations';
-import { Hide } from '@guardian/source/react-components';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { memo } from 'react';
 import { palette } from '../palette';
-import { AdSlot } from './AdSlot.web';
 
 const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 	return (
@@ -41,6 +39,7 @@ const Layout: CrosswordProps['Layout'] = ({
 	AnagramHelper,
 	FocusedClue,
 	gridWidth,
+	MobileBannerAd,
 }) => {
 	return (
 		<div
@@ -81,9 +80,9 @@ const Layout: CrosswordProps['Layout'] = ({
 							}
 						`}
 					/>
-					<Hide from="phablet">
-						<AdSlot position="crossword-banner-mobile" />
-					</Hide>
+					{typeof MobileBannerAd !== 'undefined' && (
+						<MobileBannerAd />
+					)}
 					<Controls />
 					<div
 						css={css`
@@ -120,6 +119,14 @@ const Layout: CrosswordProps['Layout'] = ({
 
 export const CrosswordComponent = ({
 	data,
+	MobileBannerAd,
 }: {
 	data: CrosswordProps['data'];
-}) => <ReactCrossword data={data} Layout={Layout} />;
+	MobileBannerAd?: ComponentType | undefined;
+}) => (
+	<ReactCrossword
+		data={data}
+		Layout={Layout}
+		MobileBannerAd={MobileBannerAd}
+	/>
+);

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -8,9 +8,11 @@ import {
 	textSans14,
 	textSansItalic12,
 } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
 
 const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 	return (
@@ -79,6 +81,9 @@ const Layout: CrosswordProps['Layout'] = ({
 							}
 						`}
 					/>
+					<Hide from="phablet">
+						<AdSlot position="crossword-banner-mobile" />
+					</Hide>
 					<Controls />
 					<div
 						css={css`

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -1,4 +1,6 @@
+import { Hide } from '@guardian/source/react-components';
 import { AdPlaceholder } from '../components/AdPlaceholder.apps';
+import { AdSlot } from '../components/AdSlot.web';
 import { AffiliateDisclaimerInline } from '../components/AffiliateDisclaimer';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
@@ -124,6 +126,14 @@ const updateRole = (el: FEElement, format: ArticleFormat): FEElement => {
 
 			return el;
 	}
+};
+
+const MobileBannerAd = () => {
+	return (
+		<Hide from="phablet">
+			<AdSlot position="crossword-banner-mobile" />
+		</Hide>
+	);
 };
 
 // renderElement converts a Frontend element to JSX. A boolean 'ok' flag is returned
@@ -868,7 +878,10 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.CrosswordElement':
 			return (
 				<Island priority="critical" defer={{ until: 'visible' }}>
-					<CrosswordComponent data={element.crossword} />
+					<CrosswordComponent
+						data={element.crossword}
+						MobileBannerAd={MobileBannerAd}
+					/>
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.AudioBlockElement':

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -1,6 +1,4 @@
-import { Hide } from '@guardian/source/react-components';
 import { AdPlaceholder } from '../components/AdPlaceholder.apps';
-import { AdSlot } from '../components/AdSlot.web';
 import { AffiliateDisclaimerInline } from '../components/AffiliateDisclaimer';
 import { AudioAtomWrapper } from '../components/AudioAtomWrapper.importable';
 import { BlockquoteBlockComponent } from '../components/BlockquoteBlockComponent';
@@ -126,14 +124,6 @@ const updateRole = (el: FEElement, format: ArticleFormat): FEElement => {
 
 			return el;
 	}
-};
-
-const MobileBannerAd = () => {
-	return (
-		<Hide from="phablet">
-			<AdSlot position="crossword-banner-mobile" />
-		</Hide>
-	);
 };
 
 // renderElement converts a Frontend element to JSX. A boolean 'ok' flag is returned
@@ -880,7 +870,7 @@ export const renderElement = ({
 				<Island priority="critical" defer={{ until: 'visible' }}>
 					<CrosswordComponent
 						data={element.crossword}
-						MobileBannerAd={MobileBannerAd}
+						canRenderAds={!isAdFreeUser && !isSensitive}
 					/>
 				</Island>
 			);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,8 +365,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@guardian/react-crossword-next':
-        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250220133624
-        version: /@guardian/react-crossword@0.0.0-canary-20250220133624(@emotion/react@11.11.3)(@guardian/libs@21.2.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250226111729
+        version: /@guardian/react-crossword@0.0.0-canary-20250226111729(@emotion/react@11.11.3)(@guardian/libs@21.1.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4336,8 +4336,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@guardian/react-crossword@0.0.0-canary-20250220133624(@emotion/react@11.11.3)(@guardian/libs@21.2.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
-    resolution: {integrity: sha512-htyyyu4dZyw1c6IO18/HjRvx9Fn7IKYS2t0eWRMFfllWiuFAhGpzE12vGaeLlqYskA0aYvnCdGp+Mq9aC8ZOOw==}
+  /@guardian/react-crossword@0.0.0-canary-20250226111729(@emotion/react@11.11.3)(@guardian/libs@21.1.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+    resolution: {integrity: sha512-yswR802qHkKuNxkrYk0WXzgNu+UsjWb5WYkYSq5EXmli9dVidFYLfdpZluxoxtyIvMtXRsTasuXbtIXDBtM1MA==}
     peerDependencies:
       '@emotion/react': ^11.11.3
       '@guardian/libs': ^21.0.0


### PR DESCRIPTION
## What does this change?
Adds the mobile crossword banner ad between the crossword focused clue and controls below the phablet breakpoint. Bumps the react-crossword canary to bring in the type changes that allow us to pass in the `MobileBannerAd` component.

We needed to pass the component conditionally depending on whether or not the user should see ads. If they shouldn't see ads, we don't want to render the slot as it has reserved height, and will cause CLS when collapsed.

## Why?
To ensure ad revenue parity with frontend.

## Screenshots
### Before - Frontend
<img width="317" alt="Screenshot 2025-02-26 at 12 12 22" src="https://github.com/user-attachments/assets/fbad82a3-292c-4643-b36c-4f47a7592e8b" />

### Before - DCR
<img width="324" alt="Screenshot 2025-02-26 at 12 11 38" src="https://github.com/user-attachments/assets/b1350124-27ba-4069-b7b6-b9f99dbf4880" />

### After - DCR - not signed in
<img width="329" alt="Screenshot 2025-02-26 at 12 11 09" src="https://github.com/user-attachments/assets/e7afd0a6-aa72-48f7-b8af-0d80ebafff73" />

### After - DCR - signed in as a subscriber
<img width="320" alt="Screenshot 2025-02-26 at 12 27 54" src="https://github.com/user-attachments/assets/5f65386e-75e0-4c96-bf9c-7869c99ea706" />
