### PR TITLE
port/rewrite of the `sIndicator` browser extension, as DCR feature

### DIFF
--- a/dotcom-rendering/src/client/main.web.ts
+++ b/dotcom-rendering/src/client/main.web.ts
@@ -1,6 +1,7 @@
 import './webpackPublicPath';
 import { adaptSite, shouldAdapt } from './adaptiveSite';
 import { startup } from './startup';
+import { maybeSIndicatorCapiKey } from './userFeatures/cookies/sIndicatorCapiKey';
 
 void (async () => {
 	if (await shouldAdapt()) {
@@ -142,4 +143,16 @@ void (async () => {
 			).then(({ discussion }) => discussion()),
 		{ priority: 'feature' },
 	);
+
+	if (maybeSIndicatorCapiKey) {
+		void startup(
+			'sIndicator',
+			() =>
+				import(
+					/* webpackMode: 'lazy' */
+					'./sIndicator'
+				).then(({ sIndicator }) => sIndicator()),
+			{ priority: 'feature' },
+		);
+	}
 })();

--- a/dotcom-rendering/src/client/sIndicator.ts
+++ b/dotcom-rendering/src/client/sIndicator.ts
@@ -1,0 +1,252 @@
+import { maybeSIndicatorCapiKey } from './userFeatures/cookies/sIndicatorCapiKey';
+
+type Content = { id: string; rights: { syndicatable: string } };
+
+const DOTCOM = 'https://www.theguardian.com/';
+
+/**
+ * This is a port/rewrite of the sIndicator browser extension (https://github.com/guardian/sIndicator)
+ * which aims to display the syndication status of content.
+ *
+ * If the 'GU_SINDICATOR_CAPI_KEY' cookie is defined, via syndication subdomain (see https://github.com/guardian/reuse-content)
+ * then this script is loaded and uses the key defined in that cookie to visually augment pages with syndication status
+ * of the piece and any onward journeys (including fronts etc.).
+ */
+
+const overallRoundelElementId = 'gu-sindicator-roundel';
+
+const displaySIndicatorRoundel = (
+	status: 'hide' | 'loading' | 'syndicatable' | 'not-syndicatable' | 'error',
+): void => {
+	const roundelElement =
+		document.getElementById(overallRoundelElementId) ??
+		(() => {
+			const newElem = document.createElement('div');
+			newElem.id = overallRoundelElementId;
+			document.body.appendChild(newElem);
+			return newElem;
+		})();
+
+	if (status === 'hide') {
+		roundelElement.remove();
+		return;
+	}
+
+	roundelElement.style.position = 'fixed';
+	roundelElement.style.bottom = '20px';
+	roundelElement.style.left = '20px';
+	roundelElement.style.zIndex = '79999';
+	roundelElement.style.overflow = 'hidden';
+	roundelElement.style.padding = '10px';
+	roundelElement.style.fontSize = '18px';
+	roundelElement.style.lineHeight = '23px';
+	roundelElement.style.textAlign = 'center';
+	roundelElement.style.borderRadius = '7px';
+	roundelElement.style.width = '40px';
+	roundelElement.style.height = '40px';
+
+	switch (status) {
+		case 'loading':
+			roundelElement.title = 'Checking syndication status...';
+			roundelElement.style.backgroundColor = 'lightblue';
+			roundelElement.textContent = '⏳';
+			break;
+		case 'syndicatable':
+			roundelElement.title = 'This content is syndicatable';
+			roundelElement.style.backgroundColor = 'green';
+			roundelElement.textContent = '✅';
+			break;
+		case 'not-syndicatable':
+			roundelElement.title = 'This content is NOT syndicatable';
+			roundelElement.style.backgroundColor = 'red';
+			roundelElement.textContent = '⛔';
+			break;
+		case 'error':
+			roundelElement.title =
+				'There was an error checking syndication status. Click to check your CAPI key...';
+			roundelElement.style.backgroundColor = 'yellow';
+			roundelElement.textContent = '⚠️';
+			roundelElement.style.cursor = 'pointer';
+			roundelElement.addEventListener(
+				'click',
+				() =>
+					(window.location.href =
+						window.location.hostname === 'localhost'
+							? 'http://localhost:4200/sIndicator'
+							: `https://syndication.${window.location.hostname}/sIndicator`),
+			);
+			break;
+	}
+};
+
+const augmentOnwardAnchor =
+	(syndicatable: boolean) => (element: HTMLElement) => {
+		const shadowColour = syndicatable ? 'green' : 'red';
+		const shadowPosition =
+			element.parentElement &&
+			getComputedStyle(element.parentElement).getPropertyValue(
+				'overflow',
+			) === 'hidden'
+				? 'inset'
+				: '';
+		element.style.boxShadow = `${shadowPosition} 0 0 4px 3px ${shadowColour}`;
+		if (
+			getComputedStyle(element).getPropertyValue('display') === 'inline'
+		) {
+			element.style.display = 'inline-block';
+		}
+	};
+
+export const sIndicator = async (): Promise<void> => {
+	console.log('sIndicator running!');
+
+	if (!maybeSIndicatorCapiKey) {
+		console.error(
+			"sIndicator: no CAPI key found - sIndicator shouldn't be running",
+		);
+		return;
+	}
+
+	displaySIndicatorRoundel('loading');
+
+	const capiKey = maybeSIndicatorCapiKey;
+
+	const pathname = window.location.pathname;
+
+	const capiIdFromPath = pathname.includes(DOTCOM) // when running locally (i.e. proxying)
+		? pathname.substring(pathname.indexOf(DOTCOM) + DOTCOM.length)
+		: pathname;
+
+	const capiUrl = `https://content.guardianapis.com/${capiIdFromPath}?show-rights=all&api-key=${capiKey}`;
+
+	const capiOverallResponse = await fetch(capiUrl).catch(console.error);
+
+	if (capiOverallResponse?.status === 403) {
+		console.log(
+			'sIndicator: item is not available at this tier (403 response)',
+		);
+		displaySIndicatorRoundel('not-syndicatable');
+		return;
+	}
+
+	if (!capiOverallResponse || !capiOverallResponse.ok) {
+		console.error(
+			`sIndicator: error accessing CAPI ${capiOverallResponse?.status}`,
+		);
+		displaySIndicatorRoundel('error');
+		return;
+	}
+
+	const capiOverallJson: { response?: { content?: Content } } =
+		await capiOverallResponse.json();
+
+	const capiContent: Content | undefined = capiOverallJson.response?.content;
+
+	if (capiContent) {
+		// results for fronts etc. won't have content - so no need to display overall roundel
+		const isSyndicatableOverall =
+			capiContent.rights.syndicatable === 'true'
+				? 'syndicatable'
+				: 'not-syndicatable';
+		displaySIndicatorRoundel(isSyndicatableOverall);
+	}
+
+	const idToSyndicatableLookup: Record<string, boolean> = {}; // built with mutation, in response to DOM changes
+
+	async function findAndProcessOnwardLinks() {
+		// all anchors with hrefs starting with a forward slash
+		const allOnwardAnchorElements = Array.from(
+			document.querySelectorAll<HTMLElement>(
+				`a[href^='/'],a[href^='${DOTCOM}']`,
+			),
+		);
+
+		const onwardIdToElementsLookup = allOnwardAnchorElements.reduce<
+			Record<string, HTMLElement[]>
+		>((acc, anchorElem) => {
+			const href = anchorElem.getAttribute('href');
+
+			if (
+				!href?.match(/\/.+\/\d+\/\w+\/\d+\/.+/gi) ||
+				href.endsWith('#comments')
+			) {
+				// links to a piece rather than other front etc.
+				return acc;
+			}
+
+			// CAPI ID doesn't have preceding forward slash
+			const capiId = href.startsWith(DOTCOM)
+				? href.substring(DOTCOM.length)
+				: href.substring(1);
+
+			return {
+				...acc,
+				[capiId]: [...(acc[capiId] ?? []), anchorElem],
+			};
+		}, {});
+
+		const idsAlreadyLookedUp = Object.keys(idToSyndicatableLookup);
+		const idsToRequest = Object.keys(onwardIdToElementsLookup).filter(
+			(id) => !idsAlreadyLookedUp.includes(id),
+		);
+
+		const batchSize = 10;
+
+		for (let i = 0; i < idsToRequest.length; i += batchSize) {
+			const ids = idsToRequest.slice(i, i + batchSize);
+
+			const idsParam = encodeURIComponent(ids.join(','));
+
+			const capiOnwardsResponse = await fetch(
+				`https://content.guardianapis.com/search?show-rights=all&api-key=${capiKey}&ids=${idsParam}`,
+			).catch(console.error);
+
+			if (!capiOnwardsResponse?.ok) {
+				console.error(
+					'sIndicator: problem looking up onward links in capi',
+					capiOnwardsResponse,
+				);
+				return;
+			}
+
+			const capiOnwardsJson: { response: { results: Content[] } } =
+				await capiOnwardsResponse.json();
+
+			for (const lookupId of ids) {
+				idToSyndicatableLookup[lookupId] =
+					capiOnwardsJson.response.results.find(
+						({ id }) => lookupId === id,
+					)?.rights.syndicatable === 'true';
+			}
+
+			for (const [id, isSyndicatable] of Object.entries(
+				idToSyndicatableLookup,
+			)) {
+				const elements = onwardIdToElementsLookup[id];
+				if (!elements) {
+					console.warn('No elements found for id', id);
+				}
+				for (const element of elements ?? []) {
+					augmentOnwardAnchor(isSyndicatable)(element);
+				}
+			}
+		}
+	}
+
+	await findAndProcessOnwardLinks();
+
+	if (!capiContent) {
+		displaySIndicatorRoundel('hide');
+	}
+
+	// begin watching for any DOM changes (since some onward links are added asynchronously, e.g. Most viewed)
+	new MutationObserver(findAndProcessOnwardLinks).observe(document.body, {
+		characterData: false,
+		childList: true,
+		subtree: true,
+		characterDataOldValue: false,
+		attributes: true,
+		attributeOldValue: false,
+		attributeFilter: ['href'],
+	});
+};

--- a/dotcom-rendering/src/client/userFeatures/cookies/sIndicatorCapiKey.ts
+++ b/dotcom-rendering/src/client/userFeatures/cookies/sIndicatorCapiKey.ts
@@ -1,0 +1,15 @@
+import { getCookie } from '@guardian/libs';
+
+/**
+ * This cookie is used to store a CAPI key for the sIndicator feature, its presence also causes the
+ * dotcom-rendering/src/client/sIndicator.ts script to be loaded, which then uses the key to query CAPI for the
+ * rights.syndication status of the current article and onward links.
+ *
+ * The cookie is set via the syndication. subdomain of the guardian, defined in https://github.com/guardian/reuse-content
+ */
+
+const SINDICATOR_CAPI_KEY_COOKIE = 'GU_SINDICATOR_CAPI_KEY';
+
+export const maybeSIndicatorCapiKey: string | null = getCookie({
+	name: SINDICATOR_CAPI_KEY_COOKIE,
+});


### PR DESCRIPTION
This is a port/rewrite of the sIndicator browser extension (https://github.com/guardian/sIndicator) which aims to display the syndication status of content. This DCR version checks for the `GU_SINDICATOR_CAPI_KEY` cookie (see https://github.com/guardian/reuse-content/pull/129) and only if present will it load the new sIndicator.ts script, which adds some overlays to content and fronts (using value of the cookie as the api key for its requests to CAPI).

## What does this change?

- ADD `dotcom-rendering/src/client/sIndicator.ts`
   The main script which makes a call to CAPI using the path as the ID to get the syndication status of the content and displays a little roundel/indicator in the bottom left (✅ for syndicatable, ⛔ for not-syndicatable, ⚠️ for any error and ⏳ 
 whilst loading). The script also attempts to find all onward links to guardian content and uses the `ids` query param for a series of subsequent calls to CAPI and adds a green/red border accordingly based on syndication status (this is particularly powerful for fronts, but works for onward links within content too). 
   It also uses [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to watch for changes (e.g. from react islands, such as Most Viewed) and then looks up any outstanding IDs, overlaying accordingly.

- ADD `dotcom-rendering/src/client/userFeatures/cookies/sIndicatorCapiKey.ts`
   This defines the associated cookie `GU_SINDICATOR_CAPI_KEY`, consistent with how other cookies are defined in the same directory. The cookie is set via https://github.com/guardian/reuse-content/pull/129.

- UPDATE `dotcom-rendering/src/client/main.web.ts`
   This loads the `sIndicator.ts` script asynchronously, ONLY if the cookie is present.



## Why?
Various partners who syndicate our content, browse the website and check a third party to check syndicatable status - that third party is no more, and so we need our own solution. The first attempt at our own solution for this was a browser extension (https://github.com/guardian/sIndicator) - we've decided to move away from the browser extension approach given the maintenance burden of releasing for various browsers and since it augments the website, DCR seems the logical home.

## Screenshots
### Front
<img width="659" alt="image" src="https://github.com/user-attachments/assets/5ef23e66-1d20-4343-baa8-d85e5121d7cc" />

### Content IS syndicatable
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/e28a27a3-7a45-4804-8b57-76219d7f14a1" />


### Content NOT syndicatable
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/e3f6d63d-db90-4136-8abc-34c2a3f04d52" />

### Onward links within content
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/c2bd9b8f-bdda-4754-bf97-4affbd40bcb6" />

<img width="985" alt="image" src="https://github.com/user-attachments/assets/2dc55a93-ae9f-464a-89c5-f84dfbed933a" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
