### PR TITLE
Parse Football Matches From Frontend Data

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -25,7 +25,7 @@ export const initialDays: FootballMatches = [
 		date: new Date('2022-01-01T00:00:00Z'),
 		competitions: [
 			{
-				competitionId: '635',
+				id: '635',
 				tag: 'football/serieafootball',
 				name: 'Serie A',
 				nation: 'European',
@@ -54,7 +54,7 @@ export const initialDays: FootballMatches = [
 				],
 			},
 			{
-				competitionId: '650',
+				id: '650',
 				tag: 'football/laligafootball',
 				name: 'La Liga',
 				nation: 'European',
@@ -76,7 +76,7 @@ export const initialDays: FootballMatches = [
 				],
 			},
 			{
-				competitionId: '651',
+				id: '651',
 				tag: 'football/fa-cup',
 				name: 'FA Cup',
 				nation: 'European',
@@ -107,7 +107,7 @@ export const moreDays: FootballMatches = [
 		date: new Date('2022-01-05T00:00:00Z'),
 		competitions: [
 			{
-				competitionId: '635',
+				id: '635',
 				tag: 'football/serieafootball',
 				name: 'Serie A',
 				nation: 'European',

--- a/dotcom-rendering/fixtures/manual/footballMatches.ts
+++ b/dotcom-rendering/fixtures/manual/footballMatches.ts
@@ -1,0 +1,94 @@
+import type {
+	FEFixture,
+	FELive,
+	FEMatchByDateAndCompetition,
+	FEMatchDay,
+	FEResult,
+} from '../../src/feFootballDataPage';
+
+const matchData = {
+	id: '1',
+	date: '2025-02-18T12:00:00Z[Europe/London]',
+	stage: {
+		stageNumber: '1',
+	},
+	round: {
+		roundNumber: '1',
+	},
+	leg: '1',
+	homeTeam: {
+		id: '1',
+		name: 'Home Team',
+	},
+	awayTeam: {
+		id: '2',
+		name: 'Away Team',
+	},
+};
+
+export const matchResult: FEResult = {
+	...matchData,
+	type: 'Result',
+	reportAvailable: false,
+	homeTeam: {
+		...matchData.homeTeam,
+		score: 3,
+	},
+	awayTeam: {
+		...matchData.awayTeam,
+		score: 3,
+	},
+};
+
+export const matchFixture: FEFixture = {
+	...matchData,
+	type: 'Fixture',
+};
+
+export const matchDayFixture: FEMatchDay = {
+	...matchData,
+	type: 'MatchDay',
+	lineupsAvailable: true,
+	liveMatch: false,
+	matchStatus: 'HT',
+	previewAvailable: true,
+	reportAvailable: true,
+	result: false,
+};
+
+export const matchDayLive: FEMatchDay = {
+	...matchDayFixture,
+	matchStatus: 'HT',
+	liveMatch: true,
+	homeTeam: {
+		...matchData.homeTeam,
+		score: 3,
+	},
+	awayTeam: {
+		...matchData.awayTeam,
+		score: 3,
+	},
+};
+
+export const liveMatch: FELive = {
+	...matchData,
+	type: 'LiveMatch',
+	status: 'HT',
+};
+
+export const emptyMatches: FEMatchByDateAndCompetition[] = [
+	{
+		date: '2025-02-14',
+		competitionMatches: [
+			{
+				competitionSummary: {
+					id: '100',
+					url: '/football/premierleague',
+					fullName: 'Premier League',
+					nation: 'English',
+				},
+				matches: [],
+			},
+		],
+	},
+];

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -371,7 +371,7 @@ export const FootballMatchList = ({
 				<section css={css(grid.container)} key={day.date.toISOString()}>
 					<Day>{dateFormatter.format(day.date)}</Day>
 					{day.competitions.map((competition) => (
-						<Fragment key={competition.competitionId}>
+						<Fragment key={competition.id}>
 							<CompetitionName>
 								<a
 									href={`${guardianBaseUrl}/${competition.tag}`}

--- a/dotcom-rendering/src/feFootballDataPage.ts
+++ b/dotcom-rendering/src/feFootballDataPage.ts
@@ -29,7 +29,7 @@ type FEMatchCompetition = {
 	name: string;
 };
 
-type FEMatchDayTeam = {
+export type FEMatchDayTeam = {
 	id: string;
 	name: string;
 	score?: number;
@@ -50,19 +50,19 @@ type FEFootballMatchData = {
 	comments?: string;
 };
 
-type FELive = FEFootballMatchData & {
+export type FELive = FEFootballMatchData & {
 	type: 'LiveMatch';
 	status: string;
 	attendance?: string;
 	referee?: string;
 };
 
-type FEFixture = FEFootballMatchData & {
+export type FEFixture = FEFootballMatchData & {
 	type: 'Fixture';
 	competition?: FEMatchCompetition;
 };
 
-type FEMatchDay = FEFootballMatchData & {
+export type FEMatchDay = FEFootballMatchData & {
 	type: 'MatchDay';
 	liveMatch: boolean;
 	result: boolean;
@@ -75,21 +75,21 @@ type FEMatchDay = FEFootballMatchData & {
 	competition?: FEMatchCompetition;
 };
 
-type FEResult = FEFootballMatchData & {
+export type FEResult = FEFootballMatchData & {
 	type: 'Result';
 	reportAvailable: boolean;
 	attendance?: string;
 	referee?: string;
 };
 
-type FEFootballMatch = FEFixture | FEMatchDay | FEResult | FELive;
+export type FEFootballMatch = FEFixture | FEMatchDay | FEResult | FELive;
 
-type FECompetitionMatch = {
+export type FECompetitionMatch = {
 	competitionSummary: FECompetitionSummary;
 	matches: FEFootballMatch[];
 };
 
-type FEMatchByDateAndCompetition = {
+export type FEMatchByDateAndCompetition = {
 	date: string;
 	competitionMatches: FECompetitionMatch[];
 };

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -1,0 +1,173 @@
+import { footballData } from '../fixtures/generated/football-live';
+import {
+	emptyMatches,
+	liveMatch,
+	matchDayLive,
+	matchFixture,
+	matchResult,
+} from '../fixtures/manual/footballMatches';
+import type {
+	FEFootballMatch,
+	FEMatchByDateAndCompetition,
+	FEMatchDay,
+	FEResult,
+} from './feFootballDataPage';
+import { parse } from './footballMatches';
+import { errorOrThrow, okOrThrow } from './lib/result';
+
+const withMatches = (
+	matches: FEFootballMatch[],
+): FEMatchByDateAndCompetition[] =>
+	emptyMatches.map((day) => ({
+		...day,
+		competitionMatches: day.competitionMatches.map((competition) => ({
+			...competition,
+			matches,
+		})),
+	}));
+
+describe('footballMatches', () => {
+	it('should parse match fixtures correctly', () => {
+		const result = okOrThrow(
+			parse(footballData.matchesList),
+			'Expected football match parsing to succeed',
+		);
+
+		expect(result.length).toBe(1);
+
+		const day = result[0];
+		expect(day?.date.toISOString()).toBe('2025-02-14T00:00:00.000Z');
+		expect(day?.competitions.length).toBe(6);
+
+		const competition = day?.competitions[0];
+		expect(competition?.name).toBe('Premier League');
+		expect(competition?.matches[0]?.kind).toBe('Fixture');
+		expect(competition?.tag).toBe('football/premierleague');
+	});
+
+	it('should return an error when football days have invalid dates', () => {
+		const invalidDate: FEMatchByDateAndCompetition[] = emptyMatches.map(
+			(day) => ({
+				...day,
+				date: 'foo',
+			}),
+		);
+
+		const result = errorOrThrow(
+			parse(invalidDate),
+			'Expected football match parsing to fail',
+		);
+
+		expect(result.kind).toBe('FootballDayInvalidDate');
+	});
+
+	it('should return an error when football matches have an invalid date', () => {
+		const invalidMatchResult: FEMatchByDateAndCompetition[] = withMatches([
+			matchFixture,
+			{ ...matchResult, date: '' },
+			matchDayLive,
+		]);
+		const invalidMatchFixture: FEMatchByDateAndCompetition[] = withMatches([
+			{ ...matchFixture, date: '' },
+			matchResult,
+			matchDayLive,
+		]);
+		const invalidLiveMatch: FEMatchByDateAndCompetition[] = withMatches([
+			matchResult,
+			matchFixture,
+			{ ...matchDayLive, date: '' },
+		]);
+
+		const resultOne = errorOrThrow(
+			parse(invalidMatchResult),
+			'Expected football match parsing to fail',
+		);
+		const resultTwo = errorOrThrow(
+			parse(invalidMatchFixture),
+			'Expected football match parsing to fail',
+		);
+		const resultThree = errorOrThrow(
+			parse(invalidLiveMatch),
+			'Expected football match parsing to fail',
+		);
+
+		expect(resultOne.kind).toBe('FootballMatchInvalidDate');
+		expect(resultTwo.kind).toBe('FootballMatchInvalidDate');
+
+		if (resultThree.kind !== 'InvalidMatchDay') {
+			throw new Error('Expected an invalid match day error');
+		}
+
+		expect(resultThree.errors[0]!.kind).toBe('FootballMatchInvalidDate');
+	});
+
+	it('should return an error when football matches are missing a score', () => {
+		const matchResultMissingHomeScore: FEResult = {
+			...matchResult,
+			homeTeam: {
+				...matchResult.homeTeam,
+				score: undefined,
+			},
+		};
+		const matchResultMissingAwayScore: FEResult = {
+			...matchResult,
+			homeTeam: {
+				...matchResult.awayTeam,
+				score: undefined,
+			},
+		};
+		const liveMatchMissingHomeScore: FEMatchDay = {
+			...matchDayLive,
+			homeTeam: {
+				...matchDayLive.homeTeam,
+				score: undefined,
+			},
+		};
+		const liveMatchMissingAwayScore: FEMatchDay = {
+			...matchDayLive,
+			homeTeam: {
+				...matchDayLive.awayTeam,
+				score: undefined,
+			},
+		};
+
+		const resultHome = errorOrThrow(
+			parse(withMatches([matchResultMissingHomeScore])),
+			'Expected football match parsing to fail',
+		);
+		const resultAway = errorOrThrow(
+			parse(withMatches([matchResultMissingAwayScore])),
+			'Expected football match parsing to fail',
+		);
+		const liveHome = errorOrThrow(
+			parse(withMatches([liveMatchMissingHomeScore])),
+			'Expected football match parsing to fail',
+		);
+		const liveAway = errorOrThrow(
+			parse(withMatches([liveMatchMissingAwayScore])),
+			'Expected football match parsing to fail',
+		);
+
+		expect(resultHome.kind).toBe('FootballMatchMissingScore');
+		expect(resultAway.kind).toBe('FootballMatchMissingScore');
+
+		if (
+			liveHome.kind !== 'InvalidMatchDay' ||
+			liveAway.kind !== 'InvalidMatchDay'
+		) {
+			throw new Error('Expected an invalid match day error');
+		}
+
+		expect(liveHome.errors[0]?.kind).toBe('FootballMatchMissingScore');
+		expect(liveAway.errors[0]?.kind).toBe('FootballMatchMissingScore');
+	});
+
+	it('should return an error when it receives a live match', () => {
+		const result = errorOrThrow(
+			parse(withMatches([liveMatch])),
+			'Expected football match parsing to fail',
+		);
+
+		expect(result.kind).toBe('UnexpectedLiveMatch');
+	});
+});

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -1,3 +1,15 @@
+import { isUndefined } from '@guardian/libs';
+import type {
+	FECompetitionMatch,
+	FEFixture,
+	FEFootballMatch,
+	FEMatchByDateAndCompetition,
+	FEMatchDay,
+	FEMatchDayTeam,
+	FEResult,
+} from './feFootballDataPage';
+import { error, ok, type Result } from './lib/result';
+
 type TeamScore = {
 	name: string;
 	score: number;
@@ -33,14 +45,355 @@ export type FootballMatch = MatchResult | MatchFixture | LiveMatch;
 export type FootballMatchKind = FootballMatch['kind'];
 
 type Competition = {
-	competitionId: string;
+	id: string;
 	tag: string;
 	name: string;
 	nation: string;
 	matches: FootballMatch[];
 };
 
-export type FootballMatches = Array<{
+type FootballDay = {
 	date: Date;
 	competitions: Competition[];
-}>;
+};
+
+export type FootballMatches = FootballDay[];
+
+type FootballDayInvalidDate = {
+	kind: 'FootballDayInvalidDate';
+	message: string;
+};
+
+type FootballMatchMissingScore = {
+	kind: 'FootballMatchMissingScore';
+	message: string;
+};
+
+type FootballMatchInvalidDate = {
+	kind: 'FootballMatchInvalidDate';
+	message: string;
+};
+
+type UnexpectedLiveMatch = {
+	kind: 'UnexpectedLiveMatch';
+	message: string;
+};
+
+type ExpectedMatchDayFixture = {
+	kind: 'ExpectedMatchDayFixture';
+	message: string;
+};
+
+type ExpectedMatchDayResult = {
+	kind: 'ExpectedMatchDayResult';
+	message: string;
+};
+
+type ExpectedMatchDayLive = {
+	kind: 'ExpectedMatchDayLive';
+	message: string;
+};
+
+type InvalidMatchDay = {
+	kind: 'InvalidMatchDay';
+	errors: Array<ParserError>;
+};
+
+export type ParserError =
+	| FootballDayInvalidDate
+	| FootballMatchMissingScore
+	| FootballMatchInvalidDate
+	| UnexpectedLiveMatch
+	| InvalidMatchDay
+	| ExpectedMatchDayFixture
+	| ExpectedMatchDayResult
+	| ExpectedMatchDayLive;
+
+type Parser<E, A, B> = (a: A) => Result<E, B>;
+
+const oneOf =
+	<E, A, B>(parsers: [Parser<E, A, B>, ...Array<Parser<E, A, B>>]) =>
+	(input: A): Result<E[], B> => {
+		const f = (
+			remainingParsers: Array<Parser<E, A, B>>,
+			errs: E[],
+		): Result<E[], B> => {
+			const [head, ...tail] = remainingParsers;
+
+			if (head === undefined) {
+				return error(errs);
+			}
+
+			const result = head(input);
+
+			if (result.kind === 'error') {
+				return f(tail, [...errs, result.error]);
+			}
+
+			return result;
+		};
+
+		return f(parsers, []);
+	};
+
+const listParse =
+	<E, A, B>(parser: (a: A) => Result<E, B>) =>
+	(input: A[]): Result<E, B[]> => {
+		const f = (toParse: A[], parsed: B[]): Result<E, B[]> => {
+			const [next, ...remaining] = toParse;
+
+			if (next === undefined) {
+				return ok(parsed);
+			}
+
+			const result = parser(next);
+
+			if (result.kind === 'error') {
+				return result;
+			}
+
+			return f(remaining, parsed.concat(result.value));
+		};
+
+		return f(input, []);
+	};
+
+const parseDate = (a: string): Result<string, Date> => {
+	const d = new Date(a);
+
+	if (d.toString() === 'Invalid Date') {
+		return error(`${String(a)} isn't a valid Date`);
+	}
+
+	return ok(d);
+};
+
+const parseScore = (
+	team: FEMatchDayTeam,
+	matchKind: 'Result' | 'Live',
+): Result<ParserError, number> => {
+	if (team.score === undefined) {
+		const prefix = matchKind === 'Result' ? 'Results' : 'Live matches';
+
+		return error({
+			kind: 'FootballMatchMissingScore',
+			message: `${prefix} must have scores, but the score for ${team.name} is missing`,
+		});
+	}
+
+	return ok(team.score);
+};
+
+const parseMatchDate = (date: string): Result<string, Date> => {
+	// Frontend appends a timezone in square brackets
+	const isoDate = date.split('[')[0];
+
+	if (isUndefined(isoDate)) {
+		return error(
+			`Expected a match date with a timezone appended in square brackets at the end, but instead got ${date}`,
+		);
+	}
+
+	return parseDate(isoDate);
+};
+
+const parseFixture = (
+	feFixture: FEFixture | FEMatchDay,
+): Result<ParserError, MatchFixture> => {
+	if (
+		feFixture.type === 'MatchDay' &&
+		(feFixture.result || feFixture.liveMatch)
+	) {
+		return error({
+			kind: 'ExpectedMatchDayFixture',
+			message: `A fixture match day must not have 'liveMatch' or 'result' set to 'true', but this was not the case for ${feFixture.id}`,
+		});
+	}
+
+	const date = parseMatchDate(feFixture.date);
+
+	if (date.kind === 'error') {
+		return error({ kind: 'FootballMatchInvalidDate', message: date.error });
+	}
+
+	return ok({
+		kind: 'Fixture',
+		homeTeam: feFixture.homeTeam.name,
+		awayTeam: feFixture.awayTeam.name,
+		dateTime: date.value,
+		paId: feFixture.id,
+	});
+};
+
+const parseMatchResult = (
+	feResult: FEResult | FEMatchDay,
+): Result<ParserError, MatchResult> => {
+	if (feResult.type === 'MatchDay' && !feResult.result) {
+		return error({
+			kind: 'ExpectedMatchDayResult',
+			message: `A result match day must have 'result' set to 'true', but this was not the case for ${feResult.id}`,
+		});
+	}
+
+	const date = parseMatchDate(feResult.date);
+
+	if (date.kind === 'error') {
+		return error({ kind: 'FootballMatchInvalidDate', message: date.error });
+	}
+
+	const homeScore = parseScore(feResult.homeTeam, 'Result');
+
+	if (homeScore.kind === 'error') {
+		return homeScore;
+	}
+
+	const awayScore = parseScore(feResult.awayTeam, 'Result');
+
+	if (awayScore.kind === 'error') {
+		return awayScore;
+	}
+
+	return ok({
+		kind: 'Result',
+		homeTeam: {
+			name: feResult.homeTeam.name,
+			score: homeScore.value,
+		},
+		awayTeam: {
+			name: feResult.awayTeam.name,
+			score: awayScore.value,
+		},
+		dateTime: date.value,
+		paId: feResult.id,
+		comment: feResult.comments,
+	});
+};
+
+const parseLiveMatch = (
+	feMatchDay: FEMatchDay,
+): Result<ParserError, LiveMatch> => {
+	if (!feMatchDay.liveMatch) {
+		return error({
+			kind: 'ExpectedMatchDayLive',
+			message: `A live match day must have 'liveMatch' set to 'true', but this was not the case for ${feMatchDay.id}`,
+		});
+	}
+
+	const date = parseMatchDate(feMatchDay.date);
+
+	if (date.kind === 'error') {
+		return error({ kind: 'FootballMatchInvalidDate', message: date.error });
+	}
+
+	const homeScore = parseScore(feMatchDay.homeTeam, 'Live');
+
+	if (homeScore.kind === 'error') {
+		return homeScore;
+	}
+
+	const awayScore = parseScore(feMatchDay.awayTeam, 'Live');
+
+	if (awayScore.kind === 'error') {
+		return awayScore;
+	}
+
+	return ok({
+		kind: 'Live',
+		homeTeam: {
+			name: feMatchDay.homeTeam.name,
+			score: homeScore.value,
+		},
+		awayTeam: {
+			name: feMatchDay.awayTeam.name,
+			score: awayScore.value,
+		},
+		dateTime: date.value,
+		paId: feMatchDay.id,
+		comment: feMatchDay.comments,
+		status: feMatchDay.matchStatus,
+	});
+};
+
+const parseMatchDay = (
+	feMatchDay: FEMatchDay,
+): Result<ParserError, FootballMatch> => {
+	const result = oneOf<ParserError, FEMatchDay, FootballMatch>([
+		parseLiveMatch,
+		parseMatchResult,
+		parseFixture,
+	])(feMatchDay);
+
+	if (result.kind === 'error') {
+		return error({ kind: 'InvalidMatchDay', errors: result.error });
+	}
+
+	return result;
+};
+
+const parseMatch = (
+	feMatch: FEFootballMatch,
+): Result<ParserError, FootballMatch> => {
+	switch (feMatch.type) {
+		case 'Fixture':
+			return parseFixture(feMatch);
+		case 'Result':
+			return parseMatchResult(feMatch);
+		case 'MatchDay':
+			return parseMatchDay(feMatch);
+		case 'LiveMatch':
+			return error({
+				kind: 'UnexpectedLiveMatch',
+				message:
+					"Did not expect to get a match with type 'LiveMatch', allowed options are 'MatchDay', 'Fixture' or 'Result'",
+			});
+	}
+};
+
+const parseMatches = listParse(parseMatch);
+
+const parseCompetition = ({
+	competitionSummary,
+	matches,
+}: FECompetitionMatch): Result<ParserError, Competition> => {
+	const parsedMatches = parseMatches(matches);
+
+	if (parsedMatches.kind === 'error') {
+		return parsedMatches;
+	}
+
+	return ok({
+		id: competitionSummary.id,
+		// Frontend stores a path, which is the tag with a leading '/'.
+		tag: competitionSummary.url.slice(1),
+		name: competitionSummary.fullName,
+		nation: competitionSummary.nation,
+		matches: parsedMatches.value,
+	});
+};
+
+const parseCompetitions = listParse(parseCompetition);
+
+const parseFootballDay = (
+	day: FEMatchByDateAndCompetition,
+): Result<ParserError, FootballDay> => {
+	const date = parseDate(day.date);
+
+	if (date.kind === 'error') {
+		return error({ kind: 'FootballDayInvalidDate', message: date.error });
+	}
+
+	const competitions = parseCompetitions(day.competitionMatches);
+
+	if (competitions.kind === 'error') {
+		return competitions;
+	}
+
+	return ok({
+		date: date.value,
+		competitions: competitions.value,
+	});
+};
+
+export const parse: (
+	frontendData: FEMatchByDateAndCompetition[],
+) => Result<ParserError, FootballMatches> = listParse(parseFootballDay);

--- a/dotcom-rendering/src/lib/result.ts
+++ b/dotcom-rendering/src/lib/result.ts
@@ -18,6 +18,22 @@ const error = <Err, Value>(err: Err): Result<Err, Value> => ({
 	error: err,
 });
 
+const okOrThrow = <E, A>(result: Result<E, A>, throwMessage: string): A => {
+	if (result.kind === 'error') {
+		throw new Error(throwMessage);
+	}
+
+	return result.value;
+};
+
+const errorOrThrow = <E, A>(result: Result<E, A>, throwMessage: string): E => {
+	if (result.kind === 'ok') {
+		throw new Error(throwMessage);
+	}
+
+	return result.error;
+};
+
 export type { Result };
 
-export { ok, error };
+export { ok, error, okOrThrow, errorOrThrow };


### PR DESCRIPTION
Some of the football data pages (live, fixtures, results) render a list of matches. The model we use to represent these matches in DCAR is different to that sent as JSON from frontend. For example, it includes types like `Date` that do not exist as JSON primitives, and it structures the data in a way that primarily makes sense for rendering in DCAR but not necessarily for the agents in frontend.

This change adds a parser to transform from the frontend data to DCAR's internal model. It also generates errors when the data received is not structured as expected.

In addition, there's a small change to the `Competition` type, renaming `competitionId` to `id`. It's already a field of the `Competition` type and therefore does not need the `competition` prefix.

Note that while this parsing approach works, we may want to refine it in the future by abstracting some of the generic parsing code into another module or using a library.
