### PR TITLE
Reduce AdLabel size and remove adSlot padding bottom

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { remSpace, textSans14, until } from '@guardian/source/foundations';
+import {
+	from,
+	remSpace,
+	textSans12,
+	textSans14,
+	until,
+} from '@guardian/source/foundations';
 import { forwardRef } from 'react';
 import { palette } from '../palette';
 
@@ -8,7 +14,7 @@ export interface Props {
 	isFirstAdSlot: boolean;
 }
 
-const adHeightPx = 258;
+const adHeightPx = 250;
 
 const styles = css`
 	clear: both;
@@ -25,8 +31,8 @@ const styles = css`
 `;
 
 const adLabelsStyles = css`
-	${textSans14}
-	padding: ${remSpace[3]};
+	${textSans12}
+	padding: ${remSpace[0]} ${remSpace[3]};
 	float: left;
 	display: flex;
 	justify-content: center;
@@ -40,6 +46,11 @@ const adLabelsStyles = css`
 		font-size: 16px;
 		font-weight: 400;
 		color: ${palette('--ad-labels-text')};
+	}
+
+	${from.phablet} {
+		${textSans14}
+		padding: ${remSpace[1]} ${remSpace[3]};
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
