### PR TITLE
Add caption to video atom

### DIFF
--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { VideoAtom } from './VideoAtom';
 
 const meta = {
@@ -25,6 +26,13 @@ export const Default = {
 				mimeType: 'video/mp4',
 			},
 		],
+		isMainMedia: false,
+		format: {
+			theme: Pillar.News,
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+		},
+		caption: 'This is a video caption',
 	},
 	decorators: [
 		(Story) => (

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -1,3 +1,5 @@
+import type { ArticleFormat } from '../lib/articleFormat';
+import { Caption } from './Caption';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 
 type AssetType = {
@@ -6,41 +8,61 @@ type AssetType = {
 };
 
 interface Props {
+	format: ArticleFormat;
 	assets: AssetType[];
+	isMainMedia: boolean;
 	poster?: string;
+	caption?: string;
 	height?: number;
 	width?: number;
 }
 
 export const VideoAtom = ({
+	format,
 	assets,
+	isMainMedia,
 	poster,
+	caption,
 	height = 259,
 	width = 460,
 }: Props) => {
 	if (assets.length === 0) return null; // Handle empty assets array
 	return (
-		<MaintainAspectRatio
-			height={height}
-			width={width}
-			data-spacefinder-role="inline"
-		>
-			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
-			<video
-				controls={true}
-				preload="metadata"
-				width={width}
+		<>
+			<MaintainAspectRatio
 				height={height}
-				poster={poster}
+				width={width}
+				data-spacefinder-role="inline"
 			>
-				{assets.map((asset, index) => (
-					<source key={index} src={asset.url} type={asset.mimeType} />
-				))}
-				<p>
-					{`Your browser doesn't support HTML5 video. Here is a `}
-					<a href={assets[0]?.url}>link to the video</a> instead.
-				</p>
-			</video>
-		</MaintainAspectRatio>
+				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
+				<video
+					controls={true}
+					preload="metadata"
+					width={width}
+					height={height}
+					poster={poster}
+				>
+					{assets.map((asset, index) => (
+						<source
+							key={index}
+							src={asset.url}
+							type={asset.mimeType}
+						/>
+					))}
+					<p>
+						{`Your browser doesn't support HTML5 video. Here is a `}
+						<a href={assets[0]?.url}>link to the video</a> instead.
+					</p>
+				</video>
+			</MaintainAspectRatio>
+			{!!caption && (
+				<Caption
+					captionText={caption}
+					format={format}
+					mediaType="Video"
+					isMainMedia={isMainMedia}
+				/>
+			)}
+		</>
 	);
 };

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -1,4 +1,5 @@
 import type { ArticleFormat } from '../lib/articleFormat';
+import { sanitiseHTML } from '../model/sanitise';
 import { Caption } from './Caption';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 
@@ -27,6 +28,7 @@ export const VideoAtom = ({
 	width = 460,
 }: Props) => {
 	if (assets.length === 0) return null; // Handle empty assets array
+	const santisedUrl = sanitiseHTML(assets[0]?.url ?? '');
 	return (
 		<>
 			<MaintainAspectRatio
@@ -45,13 +47,13 @@ export const VideoAtom = ({
 					{assets.map((asset, index) => (
 						<source
 							key={index}
-							src={asset.url}
+							src={santisedUrl}
 							type={asset.mimeType}
 						/>
 					))}
 					<p>
 						{`Your browser doesn't support HTML5 video. Here is a `}
-						<a href={assets[0]?.url}>link to the video</a> instead.
+						<a href={santisedUrl}>link to the video</a> instead.
 					</p>
 				</video>
 			</MaintainAspectRatio>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -472,8 +472,11 @@ export const renderElement = ({
 		case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
 			return (
 				<VideoAtom
+					format={format}
 					assets={element.assets}
 					poster={element.posterImage?.[0]?.url}
+					caption={element.title}
+					isMainMedia={isMainMedia}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MiniProfilesBlockElement':


### PR DESCRIPTION
## What does this change?

Adds the caption component to the video atom

## Why?

The Video atom implementation in DCR doesn't support captions, even though they are available in frontend. Sometimes these captions contain legally sensitive information, so they can't be omitted.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/edf4d81a-8fbd-4155-ada3-29842e3b6bf4
[after]: https://github.com/user-attachments/assets/7d659724-5199-4269-b4c4-58463459233e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
