### PR TITLE
wip: feat: google one tap poc

### DIFF
--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -1,0 +1,55 @@
+import { loadScript } from '@guardian/libs';
+import { useEffect } from 'react';
+import { useIsSignedIn } from '../lib/useAuthStatus';
+
+export const GoogleOneTap = () => {
+	const isSignedIn = useIsSignedIn();
+	console.log('GoogleOneTap component');
+	useEffect(() => {
+		console.log('isSignedIn', isSignedIn);
+		console.log('window.location.origin', window.location.origin);
+		if (
+			window.location.origin !== 'https://r.thegulocal.com' ||
+			// Only show the Google One Tap prompt if the user is not signed in and isSignedIn is not 'Pending'
+			isSignedIn !== false
+		) {
+			return;
+		}
+
+		console.log('loading google one tap');
+
+		loadScript('https://accounts.google.com/gsi/client')
+			.then(() => {
+				if (window.google) {
+					window.google.accounts.id.initialize({
+						client_id:
+							'774465807556-pkevncqpfs9486ms0bo5q1f2g9vhpior.apps.googleusercontent.com',
+						login_uri: 'https://r.thegulocal.com/',
+						callback: (response: { credential: string }) => {
+							console.log('callback', response);
+							const { credential } = response;
+							const queryParams = new URLSearchParams();
+							queryParams.append('got', credential);
+							queryParams.append(
+								'returnUrl',
+								window.location.href,
+							);
+							console.log(
+								`https://profile.thegulocal.com/signin/google?${queryParams.toString()}`,
+							);
+							window.location.replace(
+								`https://profile.thegulocal.com/signin/google?${queryParams.toString()}`,
+							);
+						},
+						auto_select: false,
+						cancel_on_tap_outside: false,
+						use_fedcm_for_prompt: true,
+					});
+					window.google.accounts.id.prompt();
+				}
+			})
+			.catch((e) => console.log(e));
+	}, [isSignedIn]);
+
+	return <></>;
+};

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -26,6 +26,7 @@ import { Footer } from '../components/Footer';
 import { GetMatchNav } from '../components/GetMatchNav.importable';
 import { GetMatchStats } from '../components/GetMatchStats.importable';
 import { GetMatchTabs } from '../components/GetMatchTabs.importable';
+import { GoogleOneTap } from '../components/GoogleOneTap.importable';
 import { GridItem } from '../components/GridItem';
 import { GuardianLabsLines } from '../components/GuardianLabsLines';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -450,6 +451,12 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			{renderAds && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
+			)}
+
+			{isWeb && (
+				<Island priority="enhancement" defer={{ until: 'idle' }}>
+					<GoogleOneTap />
+				</Island>
 			)}
 
 			<main data-layout="StandardLayout">

--- a/dotcom-rendering/window.guardian.ts
+++ b/dotcom-rendering/window.guardian.ts
@@ -67,7 +67,22 @@ declare global {
 			) => boolean;
 		};
 		mockLiveUpdate: (data: LiveUpdateType) => void;
-		google?: typeof google;
+		google?: typeof google & {
+			// Google One Tap
+			accounts: {
+				id: {
+					initialize: (config: {
+						client_id: string;
+						login_uri: string;
+						callback: (response: { credential: string }) => void;
+						auto_select: boolean;
+						cancel_on_tap_outside: boolean;
+						use_fedcm_for_prompt: boolean;
+					}) => void;
+					prompt: () => void;
+				};
+			};
+		};
 		YT?: typeof YT;
 		onYouTubeIframeAPIReady?: () => void;
 	}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
