### PR TITLE
Use lighter font for Cartoon front cards

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -100,6 +100,7 @@ export type Props = {
 	isCrossword?: boolean;
 	isNewsletter?: boolean;
 	isOnwardContent?: boolean;
+	isCartoon?: boolean;
 	trailText?: string;
 	avatarUrl?: string;
 	showClock?: boolean;
@@ -392,6 +393,7 @@ export const Card = ({
 	isCrossword,
 	isNewsletter = false,
 	isOnwardContent = false,
+	isCartoon = false,
 	isExternalLink,
 	slideshowImages,
 	showLivePlayable = false,
@@ -1093,6 +1095,7 @@ export const Card = ({
 										showByline={showByline}
 										isExternalLink={isExternalLink}
 										isBetaContainer={isBetaContainer}
+										isCartoon={isCartoon}
 										kickerImage={
 											showKickerImage &&
 											media?.type === 'podcast'

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -64,6 +64,7 @@ type Props = {
 	kickerColour?: string;
 	isBetaContainer?: boolean;
 	kickerImage?: PodcastSeriesImage;
+	isCartoon?: boolean;
 };
 
 const sublinkStyles = css`
@@ -182,6 +183,7 @@ const getFonts = (
 	format: ArticleFormat,
 	fontSizes: ResponsiveFontSize,
 	isBetaContainer: boolean,
+	isCartoon: boolean,
 ) => {
 	if (format.theme === ArticleSpecial.Labs) {
 		return getFontSize(fontSizes, FontFamily.TextSans);
@@ -189,8 +191,9 @@ const getFonts = (
 
 	if (
 		isBetaContainer &&
-		/** Any of these designs are considered an "opinion" */
-		(format.design === ArticleDesign.Comment ||
+		(isCartoon ||
+			/** Any of these designs are considered an "opinion" */
+			format.design === ArticleDesign.Comment ||
 			format.design === ArticleDesign.Editorial ||
 			format.design === ArticleDesign.Letter)
 	) {
@@ -234,11 +237,12 @@ export const CardHeadline = ({
 	kickerColour = palette('--card-kicker-text'),
 	isBetaContainer = false,
 	kickerImage,
+	isCartoon = false,
 }: Props) => {
 	// The link is only applied directly to the headline if it is a sublink
 	const isSublink = !!linkTo;
 
-	const fontStyles = getFonts(format, fontSizes, isBetaContainer);
+	const fontStyles = getFonts(format, fontSizes, isBetaContainer, isCartoon);
 
 	return (
 		<WithLink linkTo={linkTo}>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -198,6 +198,7 @@ export type Props = {
 	 * Youtube requires a minimum width 200px.
 	 */
 	canPlayInline?: boolean;
+	isCartoon?: boolean;
 	kickerText?: string;
 	showPulsingDot?: boolean;
 	starRating?: Rating;
@@ -240,6 +241,7 @@ export const FeatureCard = ({
 	showClock,
 	mainMedia,
 	canPlayInline,
+	isCartoon,
 	kickerText,
 	showPulsingDot,
 	dataLinkName,
@@ -478,6 +480,7 @@ export const FeatureCard = ({
 													'--feature-card-kicker-text',
 												)}
 												isBetaContainer={true}
+												isCartoon={isCartoon}
 											/>
 										</div>
 

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -43,6 +43,7 @@ export const FrontCard = (props: Props) => {
 		image: trail.image,
 		isCrossword: trail.isCrossword,
 		isNewsletter: trail.isNewsletter,
+		isCartoon: trail.isCartoon,
 		canPlayInline: true,
 		starRating: trail.starRating,
 		dataLinkName: trail.dataLinkName,

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -61,6 +61,7 @@ export const ScrollableFeature = ({
 							discussionId={card.discussionId}
 							mainMedia={card.mainMedia}
 							isExternalLink={card.isExternalLink}
+							isCartoon={card.isCartoon}
 							// branding={card.branding}
 							containerPalette={containerPalette}
 							absoluteServerTimes={absoluteServerTimes}

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -66,6 +66,7 @@ export const StaticFeatureTwo = ({
 							discussionId={card.discussionId}
 							mainMedia={card.mainMedia}
 							isExternalLink={card.isExternalLink}
+							isCartoon={card.isCartoon}
 							// branding={card.branding}
 							containerPalette={containerPalette}
 							trailText={undefined}

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -269,6 +269,10 @@ export const enhanceCards = (
 				(type === 'Tone' && id === 'tone/newsletter-tone'),
 		);
 
+		const isCartoon = tags.some(
+			({ id, type }) => type === 'Tone' && id === 'tone/cartoons',
+		);
+
 		const branding = faciaCard.properties.editionBrandings.find(
 			(editionBranding) => editionBranding.edition.id === editionId,
 		)?.branding;
@@ -318,6 +322,7 @@ export const enhanceCards = (
 			boostLevel: faciaCard.display.boostLevel,
 			isCrossword: faciaCard.properties.isCrossword,
 			isNewsletter,
+			isCartoon,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
 			showLivePlayable: faciaCard.display.showLivePlayable,
 			avatarUrl:

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -341,6 +341,7 @@ export type DCRFrontCard = {
 	boostLevel?: BoostLevel;
 	isCrossword?: boolean;
 	isNewsletter?: boolean;
+	isCartoon?: boolean;
 	discussionId?: string;
 	byline?: string;
 	showByline?: boolean;


### PR DESCRIPTION
## What does this change?

Uses a lighter, Opinion-style font for Cartoon cards on fronts

## Why?

Design tweaks

## Screenshots

| Before | After |
| - | - |
| ![one-before] | ![one-after] |
| ![two-before] | ![two-after] |

[one-before]: https://github.com/user-attachments/assets/3dcda8c4-ed80-4864-8d6b-dc9899dd48d9
[two-before]: https://github.com/user-attachments/assets/9974e3f4-88e1-434b-bccb-9c7efc909e33
[one-after]: https://github.com/user-attachments/assets/2ee0523d-8316-4604-a3eb-777fc80ef4ec
[two-after]: https://github.com/user-attachments/assets/5d5f1748-b477-4253-b3fb-fb8e232c502f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
