### PR TITLE
Pass container level for top bar decision making

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -1,6 +1,7 @@
 import type { ImgHTMLAttributes } from 'react';
 import type {
 	AspectRatio,
+	DCRContainerLevel,
 	DCRContainerPalette,
 	DCRContainerType,
 	DCRFrontCard,
@@ -46,6 +47,7 @@ type Props = {
 	sectionId: string;
 	frontId?: string;
 	collectionId: number;
+	containerLevel?: DCRContainerLevel;
 };
 
 export const DecideContainer = ({
@@ -60,6 +62,7 @@ export const DecideContainer = ({
 	sectionId,
 	frontId,
 	collectionId,
+	containerLevel,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -263,6 +266,7 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
+					containerLevel={containerLevel}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -4,6 +4,7 @@ import { palette } from '../palette';
 import type { BoostLevel } from '../types/content';
 import type {
 	AspectRatio,
+	DCRContainerLevel,
 	DCRContainerPalette,
 	DCRFrontCard,
 	DCRGroupedTrails,
@@ -28,6 +29,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	containerLevel?: DCRContainerLevel;
 };
 
 type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
@@ -174,6 +176,7 @@ export const SplashCardLayout = ({
 	imageLoading,
 	aspectRatio,
 	isLastRow,
+	containerLevel,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -182,6 +185,7 @@ export const SplashCardLayout = ({
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
+	containerLevel: DCRContainerLevel;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -237,7 +241,10 @@ export const SplashCardLayout = ({
 					liveUpdatesAlignment={liveUpdatesAlignment}
 					isFlexSplash={true}
 					showTopBarDesktop={false}
-					showTopBarMobile={true}
+					showTopBarMobile={
+						containerLevel === 'Primary' &&
+						!isMediaCard(card.format)
+					}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
@@ -300,6 +307,7 @@ export const BoostedCardLayout = ({
 	aspectRatio,
 	isFirstRow,
 	isLastRow,
+	containerLevel,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -309,6 +317,7 @@ export const BoostedCardLayout = ({
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
 	isLastRow: boolean;
+	containerLevel: DCRContainerLevel;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -358,7 +367,11 @@ export const BoostedCardLayout = ({
 					showLivePlayable={card.showLivePlayable}
 					liveUpdatesAlignment="horizontal"
 					showTopBarDesktop={false}
-					showTopBarMobile={true}
+					showTopBarMobile={
+						!isFirstRow ||
+						(containerLevel === 'Primary' &&
+							!isMediaCard(card.format))
+					}
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
@@ -379,6 +392,7 @@ export const StandardCardLayout = ({
 	isFirstStandardRow,
 	aspectRatio,
 	isLastRow,
+	containerLevel,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -390,6 +404,7 @@ export const StandardCardLayout = ({
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
+	containerLevel: DCRContainerLevel;
 }) => {
 	if (cards.length === 0) return null;
 
@@ -438,7 +453,11 @@ export const StandardCardLayout = ({
 							kickerText={card.kickerText}
 							showLivePlayable={false}
 							showTopBarDesktop={false}
-							showTopBarMobile={true}
+							showTopBarMobile={
+								!isFirstRow ||
+								(containerLevel === 'Primary' &&
+									!isMediaCard(card.format))
+							}
 							trailText={undefined}
 							// On standard cards, we increase the headline size if the trail image has been hidden
 							headlineSizes={
@@ -465,6 +484,7 @@ export const FlexibleGeneral = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	containerLevel = 'Primary',
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(0, 19);
@@ -481,6 +501,7 @@ export const FlexibleGeneral = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					isLastRow={cards.length === 0}
+					containerLevel={containerLevel}
 				/>
 			)}
 
@@ -497,6 +518,7 @@ export const FlexibleGeneral = ({
 								aspectRatio={aspectRatio}
 								isFirstRow={!splash.length && i === 0}
 								isLastRow={i === groupedCards.length - 1}
+								containerLevel={containerLevel}
 							/>
 						);
 
@@ -514,6 +536,7 @@ export const FlexibleGeneral = ({
 								isFirstStandardRow={i === 0}
 								aspectRatio={aspectRatio}
 								isLastRow={i === groupedCards.length - 1}
+								containerLevel={containerLevel}
 							/>
 						);
 				}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -3,6 +3,7 @@ import { isMediaCard } from '../lib/cardHelpers';
 import type { BoostLevel } from '../types/content';
 import type {
 	AspectRatio,
+	DCRContainerLevel,
 	DCRContainerPalette,
 	DCRFrontCard,
 	DCRGroupedTrails,
@@ -26,6 +27,7 @@ type Props = {
 	showAge?: boolean;
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
+	containerLevel?: DCRContainerLevel;
 };
 
 type BoostProperties = {
@@ -128,6 +130,8 @@ export const OneCardLayout = ({
 	imageLoading,
 	aspectRatio,
 	isLastRow,
+	isFirstRow,
+	containerLevel,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -136,6 +140,8 @@ export const OneCardLayout = ({
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
+	isFirstRow: boolean;
+	containerLevel: DCRContainerLevel;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -177,8 +183,12 @@ export const OneCardLayout = ({
 					showLivePlayable={card.showLivePlayable}
 					liveUpdatesAlignment={liveUpdatesAlignment}
 					isFlexSplash={true}
-					showTopBarDesktop={false}
-					showTopBarMobile={true}
+					showTopBarDesktop={!isFirstRow}
+					showTopBarMobile={
+						!isFirstRow ||
+						(containerLevel === 'Primary' &&
+							!isMediaCard(card.format))
+					}
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
@@ -205,6 +215,8 @@ const TwoCardOrFourCardLayout = ({
 	showImage = true,
 	imageLoading,
 	aspectRatio,
+	isFirstRow,
+	containerLevel,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -213,6 +225,8 @@ const TwoCardOrFourCardLayout = ({
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
+	isFirstRow: boolean;
+	containerLevel: DCRContainerLevel;
 }) => {
 	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
@@ -246,7 +260,11 @@ const TwoCardOrFourCardLayout = ({
 							kickerText={card.kickerText}
 							showLivePlayable={false}
 							showTopBarDesktop={false}
-							showTopBarMobile={true}
+							showTopBarMobile={
+								!isFirstRow ||
+								(containerLevel === 'Primary' &&
+									!isMediaCard(card.format))
+							}
 							canPlayInline={false}
 						/>
 					</LI>
@@ -263,6 +281,7 @@ export const FlexibleSpecial = ({
 	absoluteServerTimes,
 	imageLoading,
 	aspectRatio,
+	containerLevel = 'Primary',
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
 	const splash = [...groupedTrails.standard].slice(0, 1);
@@ -277,7 +296,9 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
+				isFirstRow={true}
 				isLastRow={splash.length === 0 && cards.length === 0}
+				containerLevel={containerLevel}
 			/>
 			<OneCardLayout
 				cards={splash}
@@ -287,6 +308,8 @@ export const FlexibleSpecial = ({
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
 				isLastRow={cards.length === 0}
+				isFirstRow={!snaps}
+				containerLevel={containerLevel}
 			/>
 			<TwoCardOrFourCardLayout
 				cards={cards}
@@ -295,6 +318,8 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
+				isFirstRow={!snaps && !splash}
+				containerLevel={containerLevel}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -1,5 +1,6 @@
 import { ArticleDesign } from '../lib/articleFormat';
 import { isMediaCard } from '../lib/cardHelpers';
+import { isNonEmptyArray } from '../lib/tuple';
 import type { BoostLevel } from '../types/content';
 import type {
 	AspectRatio,
@@ -308,7 +309,7 @@ export const FlexibleSpecial = ({
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
 				isLastRow={cards.length === 0}
-				isFirstRow={!snaps}
+				isFirstRow={!isNonEmptyArray(snaps)}
 				containerLevel={containerLevel}
 			/>
 			<TwoCardOrFourCardLayout
@@ -318,7 +319,7 @@ export const FlexibleSpecial = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
-				isFirstRow={!snaps && !splash}
+				isFirstRow={!isNonEmptyArray(snaps) && !isNonEmptyArray(splash)}
 				containerLevel={containerLevel}
 			/>
 		</>

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -63,7 +63,7 @@ export const StaticMediumFour = ({
 							showLivePlayable={false}
 							showTopBarDesktop={false}
 							showTopBarMobile={
-								cardIndex != 0 ||
+								cardIndex !== 0 ||
 								(containerLevel === 'Primary' &&
 									!isMediaCard(card.format))
 							}

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -1,6 +1,7 @@
 import { isMediaCard } from '../lib/cardHelpers';
 import type {
 	AspectRatio,
+	DCRContainerLevel,
 	DCRContainerPalette,
 	DCRFrontCard,
 } from '../types/front';
@@ -17,6 +18,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
+	containerLevel?: DCRContainerLevel;
 };
 
 export const StaticMediumFour = ({
@@ -27,6 +29,7 @@ export const StaticMediumFour = ({
 	imageLoading,
 	showImage = true,
 	aspectRatio,
+	containerLevel = 'Primary',
 }: Props) => {
 	const cards = trails.slice(0, 4);
 
@@ -59,7 +62,11 @@ export const StaticMediumFour = ({
 							kickerText={card.kickerText}
 							showLivePlayable={false}
 							showTopBarDesktop={false}
-							showTopBarMobile={true}
+							showTopBarMobile={
+								cardIndex != 0 ||
+								(containerLevel === 'Primary' &&
+									!isMediaCard(card.format))
+							}
 							canPlayInline={false}
 						/>
 					</LI>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -541,6 +541,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										}
 										sectionId={ophanName}
 										collectionId={index + 1}
+										containerLevel={
+											collection.containerLevel
+										}
 									/>
 								</LabsSection>
 								{mobileAdPositions.includes(index) && (
@@ -757,6 +760,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									}
 									sectionId={ophanName}
 									collectionId={index + 1}
+									containerLevel={collection.containerLevel}
 								/>
 							</FrontSection>
 							{mobileAdPositions.includes(index) && (


### PR DESCRIPTION
## What does this change?
This update adds logic to determine when a top border should be displayed on the first card in a container at mobile breakpoints. Since the decision depends on whether the container is primary or secondary, the container level (`Primary` / 'Secondary') has been prop-drilled to the card.

This PR ensures the following set of rules are followed (although some were already being adhered to)

### First Card Top Border Rules:

**Primary Container:**

- No top border if the card is a **media card** (media cards have coloured backgrounds and lead with an image when vertically orientated).
- No top border if the card is in a **scrollable container** (cards are not vertically stacked).
- No top border if the card is in a **feature container** (leads with an image).

**Secondary Container:**

- The first card never has a top border to maintain visual continuity with the container title.

## Why?
The top border helps visually separate stacked cards on mobile. However, different rules apply to the first card to ensure a clear distinction between the container title and the first card.

**Primary Containers:** A top border is omitted in cases where the card’s design already creates a visual distinction (e.g., media cards, scrollable layouts, feature containers).
**Secondary Containers:** The first card blends with the container title for a seamless look, so no top border is applied.
This approach ensures a clean and consistent visual hierarchy.

## Screenshots

| Primary standard card      | Primary standard card      |
| ----------- | ----------- |
| ![primary-standard][] | ![static-standard][] | 

| Primary media card          | Primary media card          |
| ----------- | ----------- |
| ![primary-media][] | ![static-media][] | 

| Primary  scrollable      |
| ----------- |
| ![scrollable][] | 

[primary-standard]: https://github.com/user-attachments/assets/b557a43c-744c-4774-9e25-79a4ab6c14b6
[primary-media]:https://github.com/user-attachments/assets/643d42cb-e86d-4003-8528-d32d92eab963
[static-standard]: https://github.com/user-attachments/assets/b892f89c-5595-4b5c-a2c2-08cb78bc79fa
[static-media]: https://github.com/user-attachments/assets/a4e6b867-6a03-482a-b7e5-e6a656890a86
[scrollable]: https://github.com/user-attachments/assets/ca034534-75db-4f85-a3e1-d14e66e41040

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
