### PR TITLE
Reduce font size on Edition Switcher Banner

### DIFF
--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette, space, textSans20 } from '@guardian/source/foundations';
+import { from, palette, space, textSans14 } from '@guardian/source/foundations';
 import { Link, SvgInfoRound } from '@guardian/source/react-components';
 import { center } from '../lib/center';
 import {
@@ -26,28 +26,24 @@ const content = css`
 	display: flex;
 	justify-content: space-between;
 	padding: 10px;
-	align-items: flex-start;
+	align-items: center;
 	${center};
 
 	${from.mobileLandscape} {
 		padding: 10px ${space[5]}px;
-	}
-
-	${from.phablet} {
-		align-items: center;
 	}
 `;
 
 const textAndLink = css`
 	display: flex;
 	flex-direction: row;
-	align-items: flex-start;
+	align-items: center;
 	gap: ${space[3]}px;
-	${textSans20};
+	${textSans14};
 
 	/* Override Source Link font styles */
 	a {
-		${textSans20};
+		${textSans14};
 	}
 `;
 
@@ -93,12 +89,10 @@ export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
 		<aside data-component="edition-switcher-banner" css={container}>
 			<div css={content}>
 				<div css={textAndLink}>
-					<div>
-						<SvgInfoRound
-							size="small"
-							theme={{ fill: palette.brand[400] }}
-						/>
-					</div>
+					<SvgInfoRound
+						size="medium"
+						theme={{ fill: palette.brand[400] }}
+					/>
 					<p>
 						You are viewing the {defaultEditionName} homepage&nbsp;
 						<Link


### PR DESCRIPTION
## What does this change?

Make visual improvements to the Edition Switcher Banner:

- Reduce font size of text
- Fixup the alignment of icons

## Why?

Consistency with [design](https://www.figma.com/design/OBiUI7dJkso1GXfsovfzaY/%E2%97%88-Web-library?m=auto&node-id=4068-1180&t=Z38loGgQLGP3lVPG-1)

Fixes guardian/design-system-advocates#33

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cd3781d4-3344-4471-ab43-610c411f7462
[after]: https://github.com/user-attachments/assets/bde865a2-e176-4cc9-92b5-9368902e7eb0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
