### PR TITLE
pass through quoted headline prop

### DIFF
--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -75,6 +75,7 @@ export const ScrollableFeature = ({
 							trailText={undefined}
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
+							showQuotes={card.showQuotedHeadline}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -77,6 +77,7 @@ export const StaticFeatureTwo = ({
 							supportingContent={card.supportingContent}
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
+							showQuotes={card.showQuotedHeadline}
 						/>
 					</LI>
 				);


### PR DESCRIPTION
## Why?
This change ensures that the `showQuotedHeadline` prop is passed through to feature cards in both the `scrollable/feature` and `static/feature` containers, allowing quotes to be displayed when the "show quotes" toggle is enabled in the fronts tool.

 
## Why?
This was missed in the initial implementation and is  required by editorial.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b4d58e3f-aa94-42ec-8ce5-ef319501e280
[after]: https://github.com/user-attachments/assets/43dc1c93-2e75-4e6c-96a2-05ba3d39dbee

<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
