### PR TITLE
Add caption to video atoms

### DIFF
--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { VideoAtom } from './VideoAtom';
 
 const meta = {
@@ -25,6 +26,11 @@ export const Default = {
 				mimeType: 'video/mp4',
 			},
 		],
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Standard,
+			theme: Pillar.News,
+		},
 	},
 	decorators: [
 		(Story) => (

--- a/dotcom-rendering/src/components/VideoAtom.stories.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.stories.tsx
@@ -62,3 +62,11 @@ export const NoPoster = {
 		poster: undefined,
 	},
 } satisfies Story;
+
+export const WithCaption = {
+	...Default,
+	args: {
+		...Default.args,
+		caption: 'An example caption to display beneath the content',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/VideoAtom.tsx
+++ b/dotcom-rendering/src/components/VideoAtom.tsx
@@ -1,3 +1,5 @@
+import type { ArticleFormat } from '../lib/articleFormat';
+import { Caption } from './Caption';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 
 type AssetType = {
@@ -7,9 +9,12 @@ type AssetType = {
 
 interface Props {
 	assets: AssetType[];
+	format: ArticleFormat;
+	caption?: string;
 	poster?: string;
 	height?: number;
 	width?: number;
+	isMainMedia?: boolean;
 }
 
 export const VideoAtom = ({
@@ -17,30 +22,48 @@ export const VideoAtom = ({
 	poster,
 	height = 259,
 	width = 460,
+	format,
+	caption,
+	isMainMedia,
 }: Props) => {
 	if (assets.length === 0) return null; // Handle empty assets array
 	return (
-		<MaintainAspectRatio
-			height={height}
-			width={width}
-			data-spacefinder-role="inline"
-		>
-			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
-			<video
-				controls={true}
-				preload="metadata"
-				width={width}
+		<div>
+			<MaintainAspectRatio
 				height={height}
-				poster={poster}
+				width={width}
+				data-spacefinder-role="inline"
 			>
-				{assets.map((asset, index) => (
-					<source key={index} src={asset.url} type={asset.mimeType} />
-				))}
-				<p>
-					{`Your browser doesn't support HTML5 video. Here is a `}
-					<a href={assets[0]?.url}>link to the video</a> instead.
-				</p>
-			</video>
-		</MaintainAspectRatio>
+				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
+				<video
+					controls={true}
+					preload="metadata"
+					width={width}
+					height={height}
+					poster={poster}
+				>
+					{assets.map((asset) => (
+						<source
+							key={asset.url}
+							src={asset.url}
+							type={asset.mimeType}
+						/>
+					))}
+					<p>
+						{`Your browser doesn't support HTML5 video. Here is a `}
+						<a href={assets[0]?.url}>link to the video</a> instead.
+					</p>
+				</video>
+			</MaintainAspectRatio>
+			{!!caption && (
+				<Caption
+					captionText={caption}
+					format={format}
+					displayCredit={false}
+					mediaType="Video"
+					isMainMedia={isMainMedia}
+				/>
+			)}
+		</div>
 	);
 };

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -474,6 +474,9 @@ export const renderElement = ({
 				<VideoAtom
 					assets={element.assets}
 					poster={element.posterImage?.[0]?.url}
+					caption={element.title}
+					format={format}
+					isMainMedia={isMainMedia}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.MiniProfilesBlockElement':


### PR DESCRIPTION
## What does this change?

Adds a caption to video atoms, after feedback from editorial that captions were not appearing as expected. Captions do appear in frontend, e.g. in [this piece:](https://www.theguardian.com/politics/article/2024/jul/04/ukpolitics-how-the-2024-general-election-has-played-out-on-tiktok?dcr=false)

<img width="633" alt="Screenshot 2025-02-26 at 13 57 39" src="https://github.com/user-attachments/assets/18ab8a47-581e-4f46-b9fb-52f8445b1921" />

The [PR that originally implemented video atoms](https://github.com/guardian/dotcom-rendering/pull/9107) appears to have dropped captions, possibly unintentionally: the comparison shot in that PR seems to be of an atom that contains a [YouTube video](https://video.gutools.co.uk/videos/436ebac7-3175-4dc1-bd8b-9a2a231dbac8), which might be why this was missed.

## Why?

Editorial resorted to using YouTube for video content in this case, which wasn't ideal, as the content was related to an exclusive piece and shouldn't have been publicly available until the story broke.

Self-hosted content is less commonly used than YouTube hosted content, but IIUC it's more likely to be used for content that is sensitive, and so it'd be good to have parity with e.g. YouTube content here.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|<img width="633" alt="Screenshot 2025-02-26 at 13 56 29" src="https://github.com/user-attachments/assets/9f763617-af51-4eaf-8d3e-9fe190682874" />|<img width="633" alt="Screenshot 2025-02-26 at 13 56 43" src="https://github.com/user-attachments/assets/7f9472cd-8332-4b92-ad2a-c93c5c0dd87a" />|

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
