### PR TITLE
Sublinks Grey Bounding Box

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -691,7 +691,10 @@ export const Card = ({
 				containerPalette={containerPalette}
 				alignment={supportingContentAlignment}
 				isDynamo={isDynamo}
-				fillBackgroundOnMobile={isFlexSplash}
+				fillBackgroundOnMobile={
+					!!isFlexSplash ||
+					(isBetaContainer && imagePositionOnMobile === 'bottom')
+				}
 			/>
 		);
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -684,26 +684,24 @@ export const Card = ({
 	const decideOuterSublinks = () => {
 		if (!hasSublinks) return null;
 		if (sublinkPosition === 'none') return null;
+
+		const OuterSublinks = () => (
+			<SupportingContent
+				supportingContent={supportingContent}
+				containerPalette={containerPalette}
+				alignment={supportingContentAlignment}
+				isDynamo={isDynamo}
+				fillBackgroundOnMobile={isFlexSplash}
+			/>
+		);
+
 		if (sublinkPosition === 'outer') {
-			return (
-				<SupportingContent
-					supportingContent={supportingContent}
-					containerPalette={containerPalette}
-					alignment={supportingContentAlignment}
-					isDynamo={isDynamo}
-					fillBackgroundOnMobile={isFlexSplash}
-				/>
-			);
+			return <OuterSublinks />;
 		}
+
 		return (
 			<Hide from={isFlexSplash ? 'desktop' : 'tablet'}>
-				<SupportingContent
-					supportingContent={supportingContent}
-					containerPalette={containerPalette}
-					alignment={supportingContentAlignment}
-					isDynamo={isDynamo}
-					fillBackgroundOnMobile={isFlexSplash}
-				/>
+				<OuterSublinks />
 			</Hide>
 		);
 	};

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -67,7 +67,8 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 		// We change the row layout to 'twoCard' to indicate that it is now full
 		if (row && row.layout === 'oneCard') {
 			return [...acc.slice(0, acc.length - 1), addCardToRow(row, card)];
-		} // Otherwise we consider the row to be 'full' and start a new row
+		}
+		// Otherwise we consider the row to be 'full' and start a new row
 		else {
 			return [...acc, createNewRow('oneCard', card)];
 		}
@@ -86,7 +87,8 @@ type BoostedSplashProperties = {
 };
 
 /**
- * Boosting a splash card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ * Boosting a splash card will affect the layout and style of the card.
+ * This function will determine the properties of the card based on the boost level.
  */
 const decideSplashCardProperties = (
 	boostLevel: BoostLevel,
@@ -262,11 +264,12 @@ type BoostedCardProperties = {
 };
 
 /**
- * Boosting a standard card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ * Boosting a standard card will affect the layout and style of the card.
+ * This function will determine the properties of the card based on the boost level.
  */
 const decideCardProperties = (
-	boostLevel: Omit<BoostLevel, 'default' | 'gigaboost'> = 'boost',
 	supportingContentLength: number,
+	boostLevel: Omit<BoostLevel, 'default' | 'gigaboost'> = 'boost',
 	avatarUrl?: string,
 ): BoostedCardProperties => {
 	switch (boostLevel) {
@@ -328,10 +331,11 @@ export const BoostedCardLayout = ({
 		supportingContentAlignment,
 		liveUpdatesPosition,
 	} = decideCardProperties(
-		card.boostLevel,
 		card.supportingContent?.length ?? 0,
+		card.boostLevel,
 		card.avatarUrl,
 	);
+
 	return (
 		<UL
 			showTopBar={!isFirstRow}
@@ -421,7 +425,7 @@ export const StandardCardLayout = ({
 				return (
 					<LI
 						stretch={false}
-						percentage={'50%'}
+						percentage="50%"
 						key={card.url}
 						padSides={true}
 						showDivider={cardIndex > 0}
@@ -437,7 +441,7 @@ export const StandardCardLayout = ({
 							absoluteServerTimes={absoluteServerTimes}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
-							imagePositionOnDesktop={'left'}
+							imagePositionOnDesktop="left"
 							supportingContent={card.supportingContent?.slice(
 								0,
 								2,

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -42,7 +42,8 @@ type BoostProperties = {
 };
 
 /**
- * Boosting a card will affect the layout and style of the card. This function will determine the properties of the card based on the boost level.
+ * Boosting a card will affect the layout and style of the card. This function
+ * will determine the properties of the card based on the boost level.
  */
 const determineCardProperties = (
 	boostLevel: BoostLevel,
@@ -71,7 +72,6 @@ const determineCardProperties = (
 				liveUpdatesAlignment: 'vertical',
 				trailTextSize: 'regular',
 			};
-
 		case 'boost':
 			return {
 				headlineSizes: {
@@ -123,6 +123,7 @@ const determineCardProperties = (
 			};
 	}
 };
+
 export const OneCardLayout = ({
 	cards,
 	containerPalette,
@@ -233,6 +234,7 @@ const TwoCardOrFourCardLayout = ({
 }) => {
 	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
+
 	return (
 		<UL direction="row" showTopBar={true}>
 			{cards.map((card, cardIndex) => {
@@ -258,7 +260,7 @@ const TwoCardOrFourCardLayout = ({
 							)}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
-							imageSize={'medium'}
+							imageSize="medium"
 							aspectRatio={aspectRatio}
 							kickerText={card.kickerText}
 							showLivePlayable={false}

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -149,6 +149,7 @@ export const SupportingContent = ({
 	fillBackgroundOnDesktop = false,
 }: Props) => {
 	const columnSpan = getColumnSpan(supportingContent.length);
+
 	return (
 		<ul
 			className="sublinks"
@@ -161,8 +162,7 @@ export const SupportingContent = ({
 			]}
 		>
 			{supportingContent.map((subLink, index) => {
-				// The model has this property as optional but it is very likely
-				// to exist
+				// The model has this property as optional but it is very likely to exist
 				if (!subLink.headline) return null;
 
 				/** Force the format design to be Standard if sublink format


### PR DESCRIPTION
## What does this change?

Show Sublinks in grey bounding box when it's in a beta container and the image is full width.

## Why?

Design tweaks.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1fa95178-0a99-416d-8d44-581fec2461e9
[after]: https://github.com/user-attachments/assets/a519de12-228a-4ab6-88c9-bc1c5791b123

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
