### PR TITLE
Football Data Page Ads

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -60,10 +60,17 @@ type IndexedSlotProps = {
 };
 
 type RightProps = {
-	position: 'right' | 'football-data-page';
+	position: 'right';
 	colourScheme?: ColourScheme;
 	index?: never;
 	shouldHideReaderRevenue: boolean;
+};
+
+type RightFootballProps = {
+	position: 'right-football';
+	colourScheme?: ColourScheme;
+	index?: never;
+	shouldHideReaderRevenue?: never;
 };
 
 type RemainingProps = {
@@ -80,7 +87,8 @@ type RemainingProps = {
  * - If `position` is `right` then we expect the `shouldHideReaderRevenue` prop
  * - If not, then we explicitly refuse these properties
  */
-type Props = DefaultProps & (RightProps | IndexedSlotProps | RemainingProps);
+type Props = DefaultProps &
+	(RightProps | IndexedSlotProps | RemainingProps | RightFootballProps);
 
 const halfPageAdHeight = adSizes.halfPage.height;
 
@@ -492,11 +500,10 @@ export const AdSlot = ({
 				default:
 					return null;
 			}
-		case 'football-data-page': {
-			const slotId = 'dfp-ad--right'; // TODO: check if this is what we want for slot id
+		case 'right-football': {
+			const slotId = 'dfp-ad--right';
 			return (
 				<div
-					id="top-right-ad-slot" // TODO: not sure what this should be
 					className="ad-slot-container"
 					css={[
 						css`
@@ -505,7 +512,7 @@ export const AdSlot = ({
 							max-height: 100%;
 						`,
 						labelStyles,
-						// rightAdLabelStyles,
+						rightAdLabelStyles,
 					]}
 				>
 					<div
@@ -513,7 +520,7 @@ export const AdSlot = ({
 						className={[
 							'js-ad-slot',
 							'ad-slot',
-							'ad-slot--football-data-page', // TODO: check if this class needs to be added in commercial
+							'ad-slot--right',
 							'ad-slot--mpu-banner-ad',
 							'ad-slot--rendered',
 							'js-sticky-mpu',
@@ -525,8 +532,8 @@ export const AdSlot = ({
 							`,
 							labelStyles,
 						]}
-						data-link-name="ad slot football-data-page" // TODO: check if this needs to be added in commercial
-						data-name="football-data-page" // TODO: check if this needs to be added in commercial
+						data-link-name="ad slot right"
+						data-name="right"
 						data-testid="slot"
 						aria-hidden="true"
 					/>

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -6,9 +6,11 @@ import {
 	breakpoints,
 	from,
 	palette,
+	space,
 	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
+import { grid } from '../grid';
 import { labelBoxStyles, labelHeight, labelStyles } from '../lib/adStyles';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
@@ -510,6 +512,13 @@ export const AdSlot = ({
 							position: static;
 							height: 100%;
 							max-height: 100%;
+							${grid.column.right}
+							grid-row: 1;
+							position: relative;
+							padding-top: ${space[2]}px;
+							${until.desktop} {
+								display: none;
+							}
 						`,
 						labelStyles,
 						rightAdLabelStyles,
@@ -528,7 +537,7 @@ export const AdSlot = ({
 						css={[
 							rightAdStyles,
 							css`
-								position: sticky;
+								position: absolute;
 							`,
 							labelStyles,
 						]}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -60,7 +60,7 @@ type IndexedSlotProps = {
 };
 
 type RightProps = {
-	position: 'right';
+	position: 'right' | 'football-data-page';
 	colourScheme?: ColourScheme;
 	index?: never;
 	shouldHideReaderRevenue: boolean;
@@ -492,6 +492,47 @@ export const AdSlot = ({
 				default:
 					return null;
 			}
+		case 'football-data-page': {
+			const slotId = 'dfp-ad--right'; // TODO: check if this is what we want for slot id
+			return (
+				<div
+					id="top-right-ad-slot" // TODO: not sure what this should be
+					className="ad-slot-container"
+					css={[
+						css`
+							position: static;
+							height: 100%;
+							max-height: 100%;
+						`,
+						labelStyles,
+						// rightAdLabelStyles,
+					]}
+				>
+					<div
+						id={slotId}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--football-data-page', // TODO: check if this class needs to be added in commercial
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+							'js-sticky-mpu',
+						].join(' ')}
+						css={[
+							rightAdStyles,
+							css`
+								position: sticky;
+							`,
+							labelStyles,
+						]}
+						data-link-name="ad slot football-data-page" // TODO: check if this needs to be added in commercial
+						data-name="football-data-page" // TODO: check if this needs to be added in commercial
+						data-testid="slot"
+						aria-hidden="true"
+					/>
+				</div>
+			);
+		}
 		case 'comments': {
 			return (
 				<div className="ad-slot-container">

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -509,12 +509,11 @@ export const AdSlot = ({
 					className="ad-slot-container"
 					css={[
 						css`
-							position: static;
+							position: relative;
 							height: 100%;
 							max-height: 100%;
 							${grid.column.right}
 							grid-row: 1;
-							position: relative;
 							padding-top: ${space[2]}px;
 							${until.desktop} {
 								display: none;

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -64,7 +64,7 @@ const Day = (props: { children: ReactNode }) => (
 		css={css`
 			${textSansBold14}
 			${grid.column.centre}
-				border-top: 1px solid ${palette('--football-match-list-border')};
+			border-top: 1px solid ${palette('--football-match-list-border')};
 			padding-top: ${space[2]}px;
 
 			${from.leftCol} {
@@ -368,7 +368,28 @@ export const FootballMatchList = ({
 	return (
 		<>
 			{days.map((day) => (
-				<section css={css(grid.container)} key={day.date.toISOString()}>
+				<section
+					css={css`
+						${grid.paddedContainer}
+						position: relative;
+						${from.tablet} {
+							&::before,
+							&::after {
+								content: '';
+								position: absolute;
+								border-left: 1px solid
+									${palette('--article-border')};
+								top: 0;
+								bottom: 0;
+							}
+
+							&::after {
+								right: 0;
+							}
+						}
+					`}
+					key={day.date.toISOString()}
+				>
 					<Day>{dateFormatter.format(day.date)}</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.competitionId}>
@@ -402,7 +423,7 @@ export const FootballMatchList = ({
 			))}
 
 			{getMoreDays === undefined ? null : (
-				<div css={css(grid.container)}>
+				<div css={css(grid.paddedContainer)}>
 					<div
 						css={css`
 							${grid.column.centre}

--- a/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
@@ -19,6 +19,7 @@ export const Results = {
 		initialDays,
 		edition: 'UK',
 		goToCompetitionSpecificPage: fn(),
+		renderAds: true,
 	},
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -4,6 +4,8 @@ import type { FootballMatches, FootballMatchKind } from '../footballMatches';
 import { grid } from '../grid';
 import type { EditionId } from '../lib/edition';
 import type { Result } from '../lib/result';
+import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
 import type { Nations } from './FootballCompetitionSelect';
 import { FootballCompetitionSelect } from './FootballCompetitionSelect';
 import { FootballMatchList } from './FootballMatchList';
@@ -16,6 +18,7 @@ type Props = {
 	edition: EditionId;
 	goToCompetitionSpecificPage: (tag: string) => void;
 	getMoreDays?: () => Promise<Result<'failed', FootballMatches>>;
+	renderAds: boolean;
 };
 
 const createTitle = (kind: FootballMatchKind, edition: EditionId) => {
@@ -41,9 +44,29 @@ export const FootballMatchesPage = ({
 	edition,
 	goToCompetitionSpecificPage,
 	getMoreDays,
+	renderAds,
 }: Props) => (
-	<>
-		<section css={css(grid.container)}>
+	<main id="maincontent" data-layout="FootballDataPageLayout">
+		<div
+			css={css`
+				${grid.paddedContainer}
+				position: relative;
+				${from.tablet} {
+					&::before,
+					&::after {
+						content: '';
+						position: absolute;
+						border-left: 1px solid ${palette('--article-border')};
+						top: 0;
+						bottom: 0;
+					}
+
+					&::after {
+						right: 0;
+					}
+				}
+			`}
+		>
 			<h1
 				css={css`
 					${headlineBold20}
@@ -74,12 +97,13 @@ export const FootballMatchesPage = ({
 					/>
 				</div>
 			)}
-		</section>
+			{renderAds && <AdSlot position="right-football" />}
+		</div>
 		<FootballMatchList
 			initialDays={initialDays}
 			edition={edition}
 			getMoreDays={getMoreDays}
 			guardianBaseUrl={guardianBaseUrl}
 		/>
-	</>
+	</main>
 );

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -29,6 +29,7 @@ type Props = {
 	kind: FootballMatchKind;
 	initialDays: FootballMatches;
 	edition: EditionId;
+	renderAds: boolean;
 };
 
 export const FootballMatchesPageWrapper = ({
@@ -37,6 +38,7 @@ export const FootballMatchesPageWrapper = ({
 	kind,
 	initialDays,
 	edition,
+	renderAds,
 }: Props) => (
 	<FootballMatchesPage
 		nations={nations}
@@ -48,5 +50,6 @@ export const FootballMatchesPageWrapper = ({
 			guardianBaseUrl,
 			kind,
 		)}
+		renderAds={renderAds}
 	/>
 );

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -1,6 +1,9 @@
 // ----- Imports ----- //
 
-import { from as fromBreakpoint } from '@guardian/source/foundations';
+import {
+	breakpoints,
+	from as fromBreakpoint,
+} from '@guardian/source/foundations';
 
 // ----- Columns & Lines ----- //
 
@@ -9,25 +12,25 @@ import { from as fromBreakpoint } from '@guardian/source/foundations';
  * layouts.
  */
 type Line =
-	| 'viewport-start'
+	| 'grid-start'
 	| 'left-column-start'
 	| 'left-column-end'
 	| 'centre-column-start'
 	| 'centre-column-end'
 	| 'right-column-start'
 	| 'right-column-end'
-	| 'viewport-end';
+	| 'grid-end';
 
 const mobileColumns =
-	'[viewport-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [viewport-end]';
+	'[grid-start] 0px [centre-column-start] repeat(4, 1fr) [centre-column-end] 0px [grid-end]';
 const tabletColumns =
-	'[viewport-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [viewport-end]';
+	'[grid-start] 1fr [centre-column-start] repeat(12, 40px) [centre-column-end] 1fr [grid-end]';
 const desktopColumns =
-	'[viewport-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+	'[grid-start] 1fr [centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end]';
 const leftColColumns =
-	'[viewport-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+	'[grid-start] 1fr [left-column-start] repeat(2, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end]';
 const wideColumns =
-	'[viewport-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [viewport-end]';
+	'[grid-start] 1fr [left-column-start] repeat(3, 60px) [left-column-end centre-column-start] repeat(8, 60px) [centre-column-end] 60px [right-column-start] repeat(4, 60px) [right-column-end] 1fr [grid-end]';
 const mobileColumnGap = '10px';
 const columnGap = '20px';
 
@@ -56,6 +59,27 @@ const container = `
 
     ${fromBreakpoint.wide} {
         grid-template-columns: ${wideColumns};
+    }
+`;
+
+const paddedContainer = `
+	${container}
+
+	${fromBreakpoint.tablet} {
+		width: ${breakpoints.tablet}px;
+		margin: 0 auto;
+	}
+
+	${fromBreakpoint.desktop} {
+		width: ${breakpoints.desktop}px;
+    }
+
+    ${fromBreakpoint.leftCol} {
+		width: ${breakpoints.leftCol}px;
+    }
+
+    ${fromBreakpoint.wide} {
+		width: ${breakpoints.wide}px;
     }
 `;
 
@@ -114,6 +138,7 @@ const grid = {
 	 *   </div>
 	 */
 	container,
+	paddedContainer,
 	/**
 	 * Place the element into one of the common Guardian layout columns. The
 	 * breakpoints at which they're available are as follows:
@@ -141,10 +166,10 @@ const grid = {
 		 */
 		right: between('right-column-start', 'right-column-end'),
 		/**
-		 * Ask the element to take up the entire width of the viewport.
+		 * Ask the element to take up the entire width of the grid.
 		 * Available for all breakpoints.
 		 */
-		all: between('viewport-start', 'viewport-end'),
+		all: between('grid-start', 'grid-end'),
 	},
 	between,
 	span,

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -9,10 +9,9 @@ import { Section } from '../components/Section';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubNav } from '../components/SubNav.importable';
 import type { FEFootballDataPage } from '../feFootballDataPage';
+import { canRenderAds } from '../lib/canRenderAds';
 import { extractNAV } from '../model/extract-nav';
 import { BannerWrapper, Stuck } from './lib/stickiness';
-import { canRenderAds } from '../lib/canRenderAds';
-import { AdSlot } from '../components/AdSlot.web';
 
 interface Props {
 	footballData: FEFootballDataPage;
@@ -71,20 +70,17 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 				/>
 			</div>
 
-			{renderAds && <AdSlot position="right-football" />}
-
-			<main id="maincontent" data-layout="FootballDataPageLayout">
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<FootballMatchesPageWrapper
-						nations={nationsHardcoded}
-						guardianBaseUrl={footballData.guardianBaseURL}
-						// ToDo: determine based on URL
-						kind={'Fixture'}
-						initialDays={initialDaysHardcoded}
-						edition={footballData.editionId}
-					/>
-				</Island>
-			</main>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<FootballMatchesPageWrapper
+					nations={nationsHardcoded}
+					guardianBaseUrl={footballData.guardianBaseURL}
+					// ToDo: determine based on URL
+					kind={'Fixture'}
+					initialDays={initialDaysHardcoded}
+					edition={footballData.editionId}
+					renderAds={renderAds}
+				/>
+			</Island>
 
 			{NAV.subNavSections && (
 				<Section

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -11,6 +11,8 @@ import { SubNav } from '../components/SubNav.importable';
 import type { FEFootballDataPage } from '../feFootballDataPage';
 import { extractNAV } from '../model/extract-nav';
 import { BannerWrapper, Stuck } from './lib/stickiness';
+import { canRenderAds } from '../lib/canRenderAds';
+import { AdSlot } from '../components/AdSlot.web';
 
 interface Props {
 	footballData: FEFootballDataPage;
@@ -25,8 +27,8 @@ const initialDaysHardcoded = initialDays;
 export const FootballDataPageLayout = ({ footballData }: Props) => {
 	const NAV = extractNAV(footballData.nav);
 	const pageFooter = footballData.pageFooter;
-	// ToDo: call canRenderAds with matching type
-	const renderAds = true;
+	// TODO: Ask commercial, do we need to use the config shouldHideAdverts?
+	const renderAds = canRenderAds(footballData);
 
 	// ToDo: use getContributionsServiceUrl
 	//const contributionsServiceUrl = getContributionsServiceUrl(footballData);
@@ -68,6 +70,8 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 					pageId={footballData.config.pageId}
 				/>
 			</div>
+
+			{renderAds && <AdSlot position="right-football" />}
 
 			<main id="maincontent" data-layout="FootballDataPageLayout">
 				<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.ts
@@ -1,4 +1,4 @@
-import { FEFootballDataPage } from '../feFootballDataPage';
+import type { FEFootballDataPage } from '../feFootballDataPage';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { RenderingTarget } from '../types/renderingTarget';

--- a/dotcom-rendering/src/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.ts
@@ -1,3 +1,4 @@
+import { FEFootballDataPage } from '../feFootballDataPage';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -8,7 +9,7 @@ import type { TagPage } from '../types/tagPage';
  * prevent ads from being displayed.
  */
 export const canRenderAds = (
-	pageData: ArticleDeprecated | DCRFrontType | TagPage,
+	pageData: ArticleDeprecated | DCRFrontType | TagPage | FEFootballDataPage, // TODO: we need to use DCR type instead of FEFootballDataPage
 	renderingTarget?: RenderingTarget,
 ): boolean => {
 	if (renderingTarget === 'Apps') {

--- a/dotcom-rendering/src/server/render.footballDataPage.web.tsx
+++ b/dotcom-rendering/src/server/render.footballDataPage.web.tsx
@@ -83,6 +83,7 @@ export const renderFootballDataPage = (footballData: FEFootballDataPage) => {
 			isPaidContent: footballData.config.isPaidContent,
 			contentType: footballData.config.contentType,
 			googleRecaptchaSiteKey: footballData.config.googleRecaptchaSiteKey,
+			unknownConfig: footballData.config,
 		}),
 		keywords: '', // TODO: we need to make this field optional in createGuardian
 		renderingTarget: 'Web',


### PR DESCRIPTION
Added a variant of the web `AdSlot` component to appear on football data pages.

The ad must be positioned in the right column whenever that column is available. This can be done using the `grid` module, but CSS grid only works when elements are direct children of the grid container, so the structure of some of the components has been refactored to make this the case.

In addition, the `grid` module has been extended to include a `paddedContainer`, which automatically handles the side margins that are common to many page designs. This makes it easier to apply borders, which has also been done in this change.
