### PR TITLE
Disable chromatic for interactive block component

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
@@ -15,7 +15,7 @@ export default {
 	title: 'Components/InteractiveBlockComponent',
 	parameters: {
 		chromatic: {
-			disable: true,
+			disableSnapshot: true,
 		},
 	},
 };

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.stories.tsx
@@ -13,6 +13,11 @@ import { TextBlockComponent } from './TextBlockComponent';
 export default {
 	component: InteractiveBlockComponent,
 	title: 'Components/InteractiveBlockComponent',
+	parameters: {
+		chromatic: {
+			disable: true,
+		},
+	},
 };
 const textHtml =
 	'<p>US and British intelligence agencies have successfully cracked much of the online encryption relied upon by hundreds of millions of people to protect the privacy of their personal data, online transactions and emails, according to top-secret documents revealed by former contractor Edward Snowden.</p>';


### PR DESCRIPTION
## What does this change?

Disable Chromatic for InteractiveBlockComponent stories

## Why?

These stories occasionally cause false negatives as they rely on the availability of external embeds, which might not be available in time for the snapshot.

(example [canvas](https://www.chromatic.com/component?appId=63e251470cfbe61776b0ef19&csfId=components-interactiveblockcomponent--datawrapper-inline&buildNumber=11210&k=67bf22856672067e37dfad5c-1200px-interactive-true&h=1&b=10) vs [snapshot](https://www.chromatic.com/component?appId=63e251470cfbe61776b0ef19&csfId=components-interactiveblockcomponent--datawrapper-inline&buildNumber=11210&k=67bf22856672067e37dfad5c-1200px-snapshot-true&h=2&b=9))
