### PR TITLE
Changes to hide the support revenue messages in info pages

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -54,7 +54,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",
-		"@guardian/support-dotcom-components": "6.0.1",
+		"@guardian/support-dotcom-components": "6.1.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.45.3",
 		"@sentry/browser": "7.75.1",

--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -128,6 +128,7 @@ const usePayload = ({
 			hasOptedOutOfArticleCount,
 			url: window.location.origin + window.location.pathname,
 			isSignedIn,
+			pageId,
 		},
 	};
 };

--- a/dotcom-rendering/src/components/LiveblogGutterAskWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogGutterAskWrapper.importable.tsx
@@ -4,11 +4,13 @@ import { getCookie, isUndefined } from '@guardian/libs';
 import { palette, space } from '@guardian/source/foundations';
 import { getGutterLiveblog } from '@guardian/support-dotcom-components';
 import type {
-	GutterPayload,
 	ModuleData,
 	ModuleDataResponse,
 } from '@guardian/support-dotcom-components/dist/dotcom/types';
-import type { GutterProps } from '@guardian/support-dotcom-components/dist/shared/types';
+import type {
+	GutterPayload,
+	GutterProps,
+} from '@guardian/support-dotcom-components/dist/shared/types';
 import type { Tracking } from '@guardian/support-dotcom-components/dist/shared/types/props/shared';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
@@ -26,6 +28,7 @@ interface LiveblogGutterAskBuilderProps {
 	countryCode: string;
 	pageViewId: string;
 	pageUrl: string;
+	pageId?: string;
 }
 
 const LiveblogGutterAskBuilder = ({
@@ -35,6 +38,7 @@ const LiveblogGutterAskBuilder = ({
 	countryCode,
 	pageViewId,
 	pageUrl,
+	pageId,
 }: LiveblogGutterAskBuilderProps) => {
 	const [gutterVariantResponse, setGutterVariantResponse] =
 		useState<ModuleData<GutterProps> | null>(null);
@@ -69,6 +73,7 @@ const LiveblogGutterAskBuilder = ({
 				isSignedIn,
 				tagIds,
 				sectionId,
+				pageId,
 			},
 		};
 
@@ -112,6 +117,7 @@ const LiveblogGutterAskBuilder = ({
 		pageUrl,
 		sectionId,
 		tags,
+		pageId,
 	]);
 
 	if (gutterVariantResponse && !isUndefined(GutterWrapperComponent)) {
@@ -162,6 +168,7 @@ interface LiveblogGutterAskWrapperProps {
 	tags: TagType[];
 	contributionsServiceUrl: string;
 	pageUrl: string;
+	pageId?: string;
 }
 
 export const LiveblogGutterAskWrapper = ({
@@ -170,6 +177,7 @@ export const LiveblogGutterAskWrapper = ({
 	tags,
 	contributionsServiceUrl,
 	pageUrl,
+	pageId,
 }: LiveblogGutterAskWrapperProps) => {
 	const { renderingTarget } = useConfig();
 	const countryCode = useCountryCode('liveblog-gutter-ask');
@@ -191,6 +199,7 @@ export const LiveblogGutterAskWrapper = ({
 			countryCode={countryCode}
 			pageViewId={pageViewId}
 			pageUrl={pageUrl}
+			pageId={pageId}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -190,6 +190,7 @@ export const SlotBodyEnd = ({
 			browserId,
 			renderingTarget,
 			ophanPageViewId,
+			pageId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
@@ -228,6 +229,7 @@ export const SlotBodyEnd = ({
 		shouldHideReaderRevenue,
 		tags,
 		ophanPageViewId,
+		pageId,
 	]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -51,6 +51,7 @@ export type CanShowData = {
 	browserId?: string;
 	renderingTarget: RenderingTarget;
 	ophanPageViewId: string;
+	pageId?: string;
 };
 
 const buildPayload = async (
@@ -75,6 +76,7 @@ const buildPayload = async (
 			? data.browserId
 			: undefined,
 		isSignedIn: data.isSignedIn,
+		pageId: data.pageId,
 	},
 });
 

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -103,6 +103,7 @@ const buildRRBannerConfigWith = ({
 		idApiUrl,
 		renderingTarget,
 		ophanPageViewId,
+		pageId,
 	}: {
 		isSignedIn: boolean;
 		countryCode: CountryCode;
@@ -120,6 +121,7 @@ const buildRRBannerConfigWith = ({
 		idApiUrl: string;
 		renderingTarget: RenderingTarget;
 		ophanPageViewId: string;
+		pageId?: string;
 	}): CandidateConfig<ModuleData<BannerProps>> => {
 		return {
 			candidate: {
@@ -156,6 +158,7 @@ const buildRRBannerConfigWith = ({
 						signInGateWillShow,
 						asyncArticleCounts,
 						ophanPageViewId,
+						pageId,
 					}),
 				show:
 					({ name, props }: ModuleData<BannerProps>) =>
@@ -283,6 +286,7 @@ export const StickyBottomBanner = ({
 			idApiUrl,
 			renderingTarget,
 			ophanPageViewId,
+			pageId,
 		});
 		const brazeArticleContext: BrazeArticleContext = {
 			section: sectionId,
@@ -327,6 +331,7 @@ export const StickyBottomBanner = ({
 		signInGateWillShow,
 		tags,
 		ophanPageViewId,
+		pageId,
 	]);
 
 	if (SelectedBanner) {

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -53,6 +53,7 @@ type BaseProps = {
 	subscriptionBannerLastClosedAt?: string;
 	signInBannerLastClosedAt?: string;
 	abandonedBasketBannerLastClosedAt?: string;
+	pageId?: string;
 };
 
 type BuildPayloadProps = BaseProps & {
@@ -132,6 +133,7 @@ const buildPayload = async ({
 	contentType,
 	userConsent,
 	hideSupportMessagingForUser,
+	pageId,
 }: BuildPayloadProps): Promise<BannerPayload> => {
 	const articleCounts = await asyncArticleCounts;
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
@@ -167,6 +169,7 @@ const buildPayload = async ({
 			abandonedBasket: parseAbandonedBasket(
 				getCookie({ name: 'GU_CO_INCOMPLETE', shouldMemoize: true }),
 			),
+			pageId,
 		},
 	};
 };
@@ -195,6 +198,7 @@ export const canShowRRBanner: CanShowFunctionType<
 	signInGateWillShow,
 	asyncArticleCounts,
 	ophanPageViewId,
+	pageId,
 }) => {
 	if (!remoteBannerConfig) return { show: false };
 
@@ -261,6 +265,7 @@ export const canShowRRBanner: CanShowFunctionType<
 		asyncArticleCounts,
 		userConsent,
 		hideSupportMessagingForUser,
+		pageId,
 	});
 
 	const response: ModuleDataResponse<BannerProps> = await getBanner(

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -853,7 +853,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						isPaidContent={!!front.config.isPaidContent}
 						isPreview={front.config.isPreview}
 						isSensitive={front.config.isSensitive}
-						pageId={front.config.pageId ?? front.pressedPage.id}
+						pageId={front.pressedPage.id}
 						sectionId={front.config.section}
 						shouldHideReaderRevenue={false} // never defined for fronts
 						remoteBannerSwitch={

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -853,7 +853,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 						isPaidContent={!!front.config.isPaidContent}
 						isPreview={front.config.isPreview}
 						isSensitive={front.config.isSensitive}
-						pageId={front.pressedPage.id}
+						pageId={front.config.pageId ?? front.pressedPage.id}
 						sectionId={front.config.section}
 						shouldHideReaderRevenue={false} // never defined for fronts
 						remoteBannerSwitch={

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -733,6 +733,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 													contributionsServiceUrl
 												}
 												pageUrl={article.webURL}
+												pageId={article.pageId}
 											/>
 										</Island>
 									</Hide>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 12.0.0
         version: 12.0.0(@emotion/react@11.11.3)(@guardian/libs@21.4.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 6.0.1
-        version: 6.0.1(@guardian/libs@21.2.0)(zod@3.22.4)
+        specifier: 6.1.0
+        version: 6.1.0(@guardian/libs@21.4.0)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4485,8 +4485,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@6.0.1(@guardian/libs@21.2.0)(zod@3.22.4):
-    resolution: {integrity: sha512-PxM0CcXZB0WGLj++l/6meEMW4odCoEd0Jbc9bvGeCyyU3qj1NEf2I55ed4VI+fGSl2q31HyGI/wlbrsoByVR7g==}
+  /@guardian/support-dotcom-components@6.1.0(@guardian/libs@21.4.0)(zod@3.22.4):
+    resolution: {integrity: sha512-2BSL8AkhGN4NMuYrpJysguI3VgbXanYz+BrSQKQOy61AdzCb4UEVUZ/HcwnALSu+hyGEl/mfW8Kc4s1CfeHEMQ==}
     peerDependencies:
       '@guardian/libs': ^17.0.0
       zod: ^3.22.4


### PR DESCRIPTION
## What does this change?

We need to disable RRCP support messages on pages like [Privacy | The Guardian](https://www.theguardian.com/info/privacy) like [Privacy | The Guardian](https://www.theguardian.com/info/privacy)

See green section here for full list: https://docs.google.com/spreadsheets/d/1KdwxnOecrV-2j3X-mX_kkvLgupPH8DvBgvEH-D-cRWg/edit?gid=0#gid=0Connect your Google account

[Trello card](https://trello.com/c/xeqIF1aP/944-do-not-show-epic-banner-on-info-pages)

Out of the list we are making this change for the below pageIds

'info/privacy'
'info/complaints-and-corrections'
'about'

The related Support-dotcom-component  changes are in the [SDC PR](https://github.com/guardian/support-dotcom-components/pull/1298)


## Screenshots

## Before Change
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/a18b253e-c307-461d-860d-b5157bb4ea0f" />

##After Change


## How to test

Tested locally (Run SDC and DCR locally) 
1.Take any article/liveblog with epic/banner/gutter ask (Here I have used a Liveblog Article)
Eg:https://www.theguardian.com/politics/live/2025/feb/27/keir-starmer-donald-trump-white-house-ukraine-uk-politics-live-news 
In local machine -use http://localhost:3030/Article/https://www.theguardian.com/politics/live/2025/feb/27/keir-starmer-donald-trump-white-house-ukraine-uk-politics-live-news
2.Note the pageId
3.Add it to the list of pageIds in SDC pageIdsOfInterest in [here](https://github.com/guardian/support-dotcom-components/blob/main/src/shared/types/targeting/shared.ts#L35)
4.Reload the page
5..Check if the  response for banner , epic and gutter ask is empty for this pageId

Requests

### Request
### Banner
<img width="760" alt="image" src="https://github.com/user-attachments/assets/5bd975aa-3b52-490f-9eb2-35ba775085dd" />

### Epic/Liveblog Epic
<img width="856" alt="image" src="https://github.com/user-attachments/assets/f250ffd1-af54-4f4f-be96-b64ae64eb368" />

### Gutter Ask
<img width="797" alt="image" src="https://github.com/user-attachments/assets/e3d9a292-6853-4b62-8954-415113d5f335" />

### Response
<img width="725" alt="image" src="https://github.com/user-attachments/assets/b580f39a-ec1a-4765-8375-ee6a5b763f10" />

