### PR TITLE
Allow Different Crops In Lightbox

### DIFF
--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -40,8 +40,8 @@ const decideImageId = ({
 		case 'media.guim.co.uk': {
 			// E.g.
 			// https://media.guim.co.uk/be634f340e477a975c7352f289c4353105ba9e67/288_121_3702_2221/140.jpg
-			// This bit                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-			return url.pathname.split('/').at(1);
+			// This bit                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			return url.pathname.split('/').slice(1, 3).join('');
 		}
 		case 'i.guim.co.uk':
 		case 'uploads.guim.co.uk':


### PR DESCRIPTION
The lightbox code has some de-duplicating logic that is meant to prevent two or more of the same image appearing in the lightbox. This was designed to handle cases where galleries repeat the main media image in the body of the article. Currently the assumption is that two images are the same if they have the same image id, and can therefore be de-duped.

However, some articles intentionally display the same image multiple times, but with different crops. As these will all have the same image id they will be de-duped, and all but the last image will be dropped from the lightbox. Example here: https://www.theguardian.com/film/2025/feb/26/oscars-group-photo-timothee-chalamet-zoe-saldana-ariana-grande-cynthia-erivo

The solution is to use both the id and the crop of an image to determine whether it is unique in the article, so that different crops of the same image will not be considered identical. However, with this change, if a gallery uses different crops of the same image in the main media and the body then these will no longer be considered duplicates, and will both appear in the lightbox. Example of this here: https://www.theguardian.com/artanddesign/gallery/2025/feb/26/spain-in-pictures-ricardo-cases
