### PR TITLE
Parsing Football data - wire up to the component on page

### DIFF
--- a/dotcom-rendering/src/components/FootballDataPage.tsx
+++ b/dotcom-rendering/src/components/FootballDataPage.tsx
@@ -1,6 +1,6 @@
 import { Global } from '@emotion/react';
 import { StrictMode } from 'react';
-import type { FEFootballDataPage } from '../feFootballDataPage';
+import type { DCRFootballDataPage } from '../footballMatches';
 import { FootballDataPageLayout } from '../layouts/FootballDataPageLayout';
 import { buildAdTargeting } from '../lib/ad-targeting';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
@@ -17,7 +17,7 @@ import { SetAdTargeting } from './SetAdTargeting.importable';
 import { SkipTo } from './SkipTo';
 
 type Props = {
-	footballData: FEFootballDataPage;
+	footballData: DCRFootballDataPage;
 };
 
 /**

--- a/dotcom-rendering/src/feFootballDataPage.ts
+++ b/dotcom-rendering/src/feFootballDataPage.ts
@@ -94,7 +94,7 @@ export type FEMatchByDateAndCompetition = {
 	competitionMatches: FECompetitionMatch[];
 };
 
-type FEFootballPageConfig = Omit<
+export type FEFootballPageConfig = Omit<
 	FEFrontConfigType,
 	'keywordIds' | 'keywords' | 'isFront'
 > & {

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -3,12 +3,16 @@ import type {
 	FECompetitionMatch,
 	FEFixture,
 	FEFootballMatch,
+	FEFootballPageConfig,
 	FEMatchByDateAndCompetition,
 	FEMatchDay,
 	FEMatchDayTeam,
 	FEResult,
 } from './feFootballDataPage';
+import type { EditionId } from './lib/edition';
 import { error, ok, type Result } from './lib/result';
+import type { NavType } from './model/extract-nav';
+import type { FooterType } from './types/footer';
 
 type TeamScore = {
 	name: string;
@@ -397,3 +401,18 @@ const parseFootballDay = (
 export const parse: (
 	frontendData: FEMatchByDateAndCompetition[],
 ) => Result<ParserError, FootballMatches> = listParse(parseFootballDay);
+
+export type DCRFootballDataPage = {
+	matchesList: FootballMatches;
+	kind: FootballMatchKind;
+	nextPage?: string;
+	previousPage?: string;
+	nav: NavType;
+	editionId: EditionId;
+	guardianBaseURL: string;
+	config: FEFootballPageConfig;
+	pageFooter: FooterType;
+	isAdFreeUser: boolean;
+	canonicalUrl?: string;
+	contributionsServiceUrl: string;
+};

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -1,5 +1,5 @@
 import { palette } from '@guardian/source/foundations';
-import { initialDays, nations } from '../../fixtures/manual/footballData';
+import { nations } from '../../fixtures/manual/footballData';
 import { FootballMatchesPageWrapper } from '../components/FootballMatchesPageWrapper.importable';
 import { Footer } from '../components/Footer';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
@@ -8,23 +8,21 @@ import { Masthead } from '../components/Masthead/Masthead';
 import { Section } from '../components/Section';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubNav } from '../components/SubNav.importable';
-import type { FEFootballDataPage } from '../feFootballDataPage';
+import type { DCRFootballDataPage } from '../footballMatches';
 import { canRenderAds } from '../lib/canRenderAds';
-import { extractNAV } from '../model/extract-nav';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
-	footballData: FEFootballDataPage;
+	footballData: DCRFootballDataPage;
 }
 
 /*
 	Hardcoded data to test layout
 */
 const nationsHardcoded = nations;
-const initialDaysHardcoded = initialDays;
 
 export const FootballDataPageLayout = ({ footballData }: Props) => {
-	const NAV = extractNAV(footballData.nav);
+	const { nav } = footballData;
 	const pageFooter = footballData.pageFooter;
 	// TODO: Ask commercial, do we need to use the config shouldHideAdverts?
 	const renderAds = canRenderAds(footballData);
@@ -56,7 +54,7 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 				)}
 
 				<Masthead
-					nav={NAV}
+					nav={nav}
 					editionId={footballData.editionId}
 					idUrl={footballData.config.idUrl}
 					mmaUrl={footballData.config.mmaUrl}
@@ -74,15 +72,14 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 				<FootballMatchesPageWrapper
 					nations={nationsHardcoded}
 					guardianBaseUrl={footballData.guardianBaseURL}
-					// ToDo: determine based on URL
-					kind={'Fixture'}
-					initialDays={initialDaysHardcoded}
+					kind={footballData.kind}
+					initialDays={footballData.matchesList}
 					edition={footballData.editionId}
 					renderAds={renderAds}
 				/>
 			</Island>
 
-			{NAV.subNavSections && (
+			{nav.subNavSections && (
 				<Section
 					fullWidth={true}
 					showTopBorder={true}
@@ -92,8 +89,8 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 				>
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
+							subNavSections={nav.subNavSections}
+							currentNavLink={nav.currentNavLink}
 							position="footer"
 						/>
 					</Island>
@@ -112,9 +109,9 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 			>
 				<Footer
 					pageFooter={pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={NAV.readerRevenueLinks.footer}
+					selectedPillar={nav.selectedPillar}
+					pillars={nav.pillars}
+					urls={nav.readerRevenueLinks.footer}
 					editionId={footballData.editionId}
 				/>
 			</Section>

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -10,6 +10,7 @@ import { StickyBottomBanner } from '../components/StickyBottomBanner.importable'
 import { SubNav } from '../components/SubNav.importable';
 import type { DCRFootballDataPage } from '../footballMatches';
 import { canRenderAds } from '../lib/canRenderAds';
+import { getContributionsServiceUrl } from '../lib/contributions';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
 interface Props {
@@ -27,9 +28,7 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 	// TODO: Ask commercial, do we need to use the config shouldHideAdverts?
 	const renderAds = canRenderAds(footballData);
 
-	// ToDo: use getContributionsServiceUrl
-	//const contributionsServiceUrl = getContributionsServiceUrl(footballData);
-	const contributionsServiceUrl = footballData.contributionsServiceUrl;
+	const contributionsServiceUrl = getContributionsServiceUrl(footballData);
 
 	return (
 		<>

--- a/dotcom-rendering/src/lib/canRenderAds.ts
+++ b/dotcom-rendering/src/lib/canRenderAds.ts
@@ -1,4 +1,4 @@
-import type { FEFootballDataPage } from '../feFootballDataPage';
+import type { DCRFootballDataPage } from '../footballMatches';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -9,7 +9,7 @@ import type { TagPage } from '../types/tagPage';
  * prevent ads from being displayed.
  */
 export const canRenderAds = (
-	pageData: ArticleDeprecated | DCRFrontType | TagPage | FEFootballDataPage, // TODO: we need to use DCR type instead of FEFootballDataPage
+	pageData: ArticleDeprecated | DCRFrontType | TagPage | DCRFootballDataPage,
 	renderingTarget?: RenderingTarget,
 ): boolean => {
 	if (renderingTarget === 'Apps') {

--- a/dotcom-rendering/src/lib/contributions.ts
+++ b/dotcom-rendering/src/lib/contributions.ts
@@ -8,6 +8,7 @@ import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dot
 import { useEffect, useState } from 'react';
 import { hideSupportMessaging } from '../client/userFeatures/cookies/hideSupportMessaging';
 import { userBenefitsDataIsUpToDate } from '../client/userFeatures/cookies/userBenefitsExpiry';
+import type { DCRFootballDataPage } from '../footballMatches';
 import type { ArticleDeprecated } from '../types/article';
 import type { DCRFrontType } from '../types/front';
 import type { DCRNewslettersPageType } from '../types/newslettersPage';
@@ -195,7 +196,12 @@ export const recentlyClosedBanner = (
 };
 
 export const getContributionsServiceUrl = (
-	config: ArticleDeprecated | DCRFrontType | TagPage | DCRNewslettersPageType,
+	config:
+		| ArticleDeprecated
+		| DCRFrontType
+		| TagPage
+		| DCRNewslettersPageType
+		| DCRFootballDataPage,
 ): string => process.env.SDC_URL ?? config.contributionsServiceUrl;
 
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -92,7 +92,7 @@ export const createGuardian = ({
 	revisionNumber: string;
 	sentryPublicApiKey: string;
 	sentryHost: string;
-	keywordIds: string;
+	keywordIds?: string;
 	dfpAccountId: string;
 	adUnit: string;
 	ajaxUrl: string;
@@ -132,7 +132,7 @@ export const createGuardian = ({
 					'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
 				sentryPublicApiKey,
 				sentryHost,
-				keywordIds,
+				keywordIds: keywordIds ?? '',
 				dfpAccountId,
 				adUnit,
 				showRelatedContent: true,

--- a/dotcom-rendering/src/server/handler.footballDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.footballDataPage.web.ts
@@ -1,10 +1,78 @@
 import type { RequestHandler } from 'express';
 import type { FEFootballDataPage } from '../feFootballDataPage';
+import type {
+	DCRFootballDataPage,
+	FootballMatchKind,
+	ParserError,
+} from '../footballMatches';
+import { parse } from '../footballMatches';
+import { extractNAV } from '../model/extract-nav';
+import { validateAsFootballDataPageType } from '../model/validate';
 import { makePrefetchHeader } from './lib/header';
+import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderFootballDataPage } from './render.footballDataPage.web';
 
+const decidePageKind = (
+	canonicalUrl: string | undefined,
+): FootballMatchKind => {
+	if (canonicalUrl?.includes('live')) {
+		return 'Live';
+	}
+
+	if (canonicalUrl?.includes('results')) {
+		return 'Result';
+	}
+
+	if (canonicalUrl?.includes('fixtures')) {
+		return 'Fixture';
+	}
+
+	throw new Error('Could not determine football page kind');
+};
+
+const getParserErrorMessage = (error: ParserError): string => {
+	switch (error.kind) {
+		case 'InvalidMatchDay':
+			return error.errors.map((e) => getParserErrorMessage(e)).join(', ');
+		default:
+			return `${error.kind}: ${error.message}`;
+	}
+};
+
+const parseFEFootballData = (data: FEFootballDataPage): DCRFootballDataPage => {
+	const parsedMatchesResult = parse(data.matchesList);
+
+	if (parsedMatchesResult.kind === 'error') {
+		throw new Error(
+			`Failed to parse matches: ${getParserErrorMessage(
+				parsedMatchesResult.error,
+			)}`,
+		);
+	}
+
+	return {
+		matchesList: parsedMatchesResult.value,
+		kind: decidePageKind(data.canonicalUrl),
+		nextPage: data.nextPage,
+		previousPage: data.previousPage,
+		nav: extractNAV(data.nav),
+		editionId: data.editionId,
+		guardianBaseURL: data.guardianBaseURL,
+		config: data.config,
+		pageFooter: data.pageFooter,
+		isAdFreeUser: data.isAdFreeUser,
+		canonicalUrl: data.canonicalUrl,
+		contributionsServiceUrl: data.contributionsServiceUrl,
+	};
+};
+
 export const handleFootballDataPage: RequestHandler = ({ body }, res) => {
-	const footballData = body as FEFootballDataPage;
-	const { html, prefetchScripts } = renderFootballDataPage(footballData);
+	recordTypeAndPlatform('footballDataPage', 'web');
+	const footballDataValidated: FEFootballDataPage =
+		validateAsFootballDataPageType(body);
+
+	const parsedFootballData = parseFEFootballData(footballDataValidated);
+	const { html, prefetchScripts } =
+		renderFootballDataPage(parsedFootballData);
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -78,7 +78,6 @@ export const renderEditorialNewslettersPage = ({
 		revisionNumber: newslettersPage.config.revisionNumber,
 		sentryPublicApiKey: newslettersPage.config.sentryPublicApiKey,
 		sentryHost: newslettersPage.config.sentryHost,
-		keywordIds: '',
 		dfpAccountId: newslettersPage.config.dfpAccountId,
 		adUnit: newslettersPage.config.adUnit,
 		ajaxUrl: newslettersPage.config.ajaxUrl,

--- a/dotcom-rendering/src/server/render.footballDataPage.web.tsx
+++ b/dotcom-rendering/src/server/render.footballDataPage.web.tsx
@@ -99,7 +99,6 @@ export const renderFootballDataPage = (footballData: DCRFootballDataPage) => {
 			revisionNumber: footballData.config.revisionNumber,
 			sentryPublicApiKey: footballData.config.sentryPublicApiKey,
 			sentryHost: footballData.config.sentryHost,
-			keywordIds: '', // TODO: we need to make this field optional in createGuardian
 			dfpAccountId: footballData.config.dfpAccountId,
 			adUnit: footballData.config.adUnit,
 			ajaxUrl: footballData.config.ajaxUrl,
@@ -112,7 +111,7 @@ export const renderFootballDataPage = (footballData: DCRFootballDataPage) => {
 			googleRecaptchaSiteKey: footballData.config.googleRecaptchaSiteKey,
 			unknownConfig: footballData.config,
 		}),
-		keywords: '', // TODO: we need to make this field optional in createGuardian
+		keywords: '',
 		renderingTarget: 'Web',
 		weAreHiring: !!footballData.config.switches.weAreHiring,
 		config,

--- a/dotcom-rendering/src/server/render.footballDataPage.web.tsx
+++ b/dotcom-rendering/src/server/render.footballDataPage.web.tsx
@@ -1,7 +1,10 @@
 import { isString } from '@guardian/libs';
 import { ConfigProvider } from '../components/ConfigContext';
 import { FootballDataPage } from '../components/FootballDataPage';
-import type { FEFootballDataPage } from '../feFootballDataPage';
+import type {
+	DCRFootballDataPage,
+	FootballMatchKind,
+} from '../footballMatches';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -14,42 +17,32 @@ import { createGuardian } from '../model/guardian';
 import type { Config } from '../types/configContext';
 import { htmlPageTemplate } from './htmlPageTemplate';
 
-const decideDescription = (canonicalUrl: string | undefined) => {
-	const fromTheGuardian =
-		'from the Guardian, the world&#x27;s leading liberal voice';
+const fromTheGuardian =
+	'from the Guardian, the world&#x27;s leading liberal voice';
 
-	if (canonicalUrl?.includes('live')) {
-		return `Live football scores ${fromTheGuardian}`;
+const decideDescription = (kind: FootballMatchKind) => {
+	switch (kind) {
+		case 'Live':
+			return `Live football scores ${fromTheGuardian}`;
+		case 'Result':
+			return `Latest football results ${fromTheGuardian}`;
+		case 'Fixture':
+			return `Football fixtures ${fromTheGuardian}`;
 	}
-
-	if (canonicalUrl?.includes('results')) {
-		return `Latest football results ${fromTheGuardian}`;
-	}
-
-	if (canonicalUrl?.includes('fixtures')) {
-		return `Football fixtures ${fromTheGuardian}`;
-	}
-
-	return;
 };
 
-const decideTitle = (canonicalUrl: string | undefined) => {
-	if (canonicalUrl?.includes('live')) {
-		return 'Live matches | Football | The Guardian';
+const decideTitle = (kind: FootballMatchKind) => {
+	switch (kind) {
+		case 'Live':
+			return 'Live matches | Football | The Guardian';
+		case 'Result':
+			return 'All results | Football | The Guardian';
+		case 'Fixture':
+			return 'All fixtures | Football | The Guardian';
 	}
-
-	if (canonicalUrl?.includes('results')) {
-		return 'All results | Football | The Guardian';
-	}
-
-	if (canonicalUrl?.includes('fixtures')) {
-		return 'All fixtures | Football | The Guardian';
-	}
-
-	return;
 };
 
-export const renderFootballDataPage = (footballData: FEFootballDataPage) => {
+export const renderFootballDataPage = (footballData: DCRFootballDataPage) => {
 	const config: Config = {
 		renderingTarget: 'Web',
 		darkModeAvailable:
@@ -96,8 +89,8 @@ export const renderFootballDataPage = (footballData: FEFootballDataPage) => {
 		scriptTags,
 		css: extractedCss,
 		html,
-		title: decideTitle(footballData.canonicalUrl),
-		description: decideDescription(footballData.canonicalUrl),
+		title: decideTitle(footballData.kind),
+		description: decideDescription(footballData.kind),
 		canonicalUrl: footballData.canonicalUrl,
 		guardian: createGuardian({
 			editionId: footballData.editionId,


### PR DESCRIPTION
Paired with: @marjisound 

## What does this change?

This PR adds the step parsing the football data from frontend into the type that DCR expects (parser added in #13463) and passes that through to the component that renders the matches list
<!--

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png
-->

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
