### PR TITLE
Use frontend filters for competition selector

### DIFF
--- a/dotcom-rendering/fixtures/generated/football-live.ts
+++ b/dotcom-rendering/fixtures/generated/football-live.ts
@@ -16,78 +16,8 @@ import type { FEFootballDataPage } from '../../src/feFootballDataPage';
 export const footballData: FEFootballDataPage = {
 	matchesList: [
 		{
-			date: '2025-02-14',
+			date: '2025-03-03',
 			competitionMatches: [
-				{
-					competitionSummary: {
-						id: '100',
-						url: '/football/premierleague',
-						fullName: 'Premier League',
-						nation: 'English',
-					},
-					matches: [
-						{
-							id: '4478426',
-							date: '2025-02-14T20:00:00Z[Europe/London]',
-							stage: {
-								stageNumber: '1',
-							},
-							round: {
-								roundNumber: '1',
-								name: 'League',
-							},
-							leg: '1',
-							homeTeam: {
-								id: '6795',
-								name: 'Brighton',
-							},
-							awayTeam: {
-								id: '4',
-								name: 'Chelsea',
-							},
-							venue: {
-								id: '1536',
-								name: 'The American Express Community Stadium',
-							},
-							type: 'Fixture',
-						},
-					],
-				},
-				{
-					competitionSummary: {
-						id: '625',
-						url: '/football/bundesligafootball',
-						fullName: 'Bundesliga',
-						nation: 'European',
-					},
-					matches: [
-						{
-							id: '4484272',
-							date: '2025-02-14T19:30:00Z[Europe/London]',
-							stage: {
-								stageNumber: '1',
-							},
-							round: {
-								roundNumber: '1',
-								name: 'League',
-							},
-							leg: '1',
-							homeTeam: {
-								id: '32656',
-								name: 'Augsburg',
-							},
-							awayTeam: {
-								id: '61019',
-								name: 'RB Leipzig',
-							},
-							venue: {
-								id: '1371',
-								name: 'WWK Arena',
-							},
-							type: 'Fixture',
-						},
-					],
-				},
 				{
 					competitionSummary: {
 						id: '635',
@@ -97,8 +27,8 @@ export const footballData: FEFootballDataPage = {
 					},
 					matches: [
 						{
-							id: '4486775',
-							date: '2025-02-14T19:45:00Z[Europe/London]',
+							id: '4489318',
+							date: '2025-03-03T19:45:00Z[Europe/London]',
 							stage: {
 								stageNumber: '1',
 							},
@@ -108,16 +38,16 @@ export const footballData: FEFootballDataPage = {
 							},
 							leg: '1',
 							homeTeam: {
-								id: '26371',
-								name: 'Bologna',
+								id: '26359',
+								name: 'Juventus',
 							},
 							awayTeam: {
-								id: '27038',
-								name: 'Torino',
+								id: '27648',
+								name: 'Verona',
 							},
 							venue: {
-								id: '419',
-								name: "Renato Dall'Ara",
+								id: '1704',
+								name: 'Juventus Stadium',
 							},
 							type: 'Fixture',
 						},
@@ -132,8 +62,8 @@ export const footballData: FEFootballDataPage = {
 					},
 					matches: [
 						{
-							id: '4486653',
-							date: '2025-02-14T20:00:00Z[Europe/London]',
+							id: '4488456',
+							date: '2025-03-03T20:00:00Z[Europe/London]',
 							stage: {
 								stageNumber: '1',
 							},
@@ -143,16 +73,16 @@ export const footballData: FEFootballDataPage = {
 							},
 							leg: '1',
 							homeTeam: {
-								id: '27832',
-								name: 'Girona',
+								id: '38295',
+								name: 'Villarreal',
 							},
 							awayTeam: {
-								id: '37459',
-								name: 'Getafe',
+								id: '26306',
+								name: 'Espanyol',
 							},
 							venue: {
-								id: '236',
-								name: 'Montilivi',
+								id: '466',
+								name: 'Estadio de la Ceramica',
 							},
 							type: 'Fixture',
 						},
@@ -160,77 +90,70 @@ export const footballData: FEFootballDataPage = {
 				},
 				{
 					competitionSummary: {
-						id: '620',
-						url: '/football/ligue1football',
-						fullName: 'Ligue 1',
-						nation: 'European',
-					},
-					matches: [
-						{
-							id: '4487176',
-							date: '2025-02-14T19:45:00Z[Europe/London]',
-							stage: {
-								stageNumber: '1',
-							},
-							round: {
-								roundNumber: '1',
-								name: 'League',
-							},
-							leg: '1',
-							homeTeam: {
-								id: '27099',
-								name: 'Brest',
-							},
-							awayTeam: {
-								id: '26348',
-								name: 'Auxerre',
-							},
-							venue: {
-								id: '143',
-								name: 'Stade Francis-Le Ble',
-							},
-							type: 'Fixture',
-						},
-					],
-				},
-				{
-					competitionSummary: {
-						id: '101',
-						url: '/football/championship',
-						fullName: 'Championship',
+						id: '300',
+						url: '/football/fa-cup',
+						fullName: 'FA Cup',
 						nation: 'English',
 					},
 					matches: [
 						{
-							id: '4475296',
-							date: '2025-02-14T20:00:00Z[Europe/London]',
+							id: '4488116',
+							date: '2025-03-03T19:30:00Z[Europe/London]',
+							competition: {
+								id: '300',
+								name: 'The Emirates FA Cup 24/25',
+							},
 							stage: {
 								stageNumber: '1',
 							},
 							round: {
-								roundNumber: '1',
-								name: 'League',
+								roundNumber: '5',
+								name: 'Fifth Round',
 							},
 							leg: '1',
+							liveMatch: false,
+							result: false,
+							previewAvailable: false,
+							reportAvailable: false,
+							lineupsAvailable: false,
+							matchStatus: '-',
 							homeTeam: {
-								id: '16',
-								name: 'QPR',
+								id: '15',
+								name: 'Nottm Forest',
 							},
 							awayTeam: {
-								id: '7',
-								name: 'Derby',
+								id: '27',
+								name: 'Ipswich',
 							},
 							venue: {
-								id: '48',
-								name: 'Loftus Road',
+								id: '2020',
+								name: 'The City Ground',
 							},
-							type: 'Fixture',
+							type: 'MatchDay',
 						},
 					],
 				},
 			],
 		},
 	],
+	filters: {
+		English: [
+			{
+				name: 'FA Cup',
+				url: '/football/fa-cup/live',
+			},
+		],
+		European: [
+			{
+				name: 'Serie A',
+				url: '/football/serieafootball/live',
+			},
+			{
+				name: 'La Liga',
+				url: '/football/laligafootball/live',
+			},
+		],
+	},
 	nav: {
 		currentUrl: '/football/live',
 		pillars: [
@@ -359,6 +282,10 @@ export const footballData: FEFootballDataPage = {
 						url: '/world/ukraine',
 					},
 					{
+						title: 'Oscars',
+						url: '/film/oscars',
+					},
+					{
 						title: 'Football',
 						url: '/football',
 						children: [
@@ -479,10 +406,6 @@ export const footballData: FEFootballDataPage = {
 					{
 						title: 'UK politics',
 						url: '/politics',
-					},
-					{
-						title: 'Society',
-						url: '/society',
 					},
 					{
 						title: 'Science',
@@ -1055,7 +978,7 @@ export const footballData: FEFootballDataPage = {
 	config: {
 		switches: {
 			lightbox: true,
-			abPrebidKeywords: true,
+			externalVideoEmbeds: true,
 			personaliseSignInGateAfterCheckout: true,
 			abSignInGateMainVariant: true,
 			prebidAppnexusUkRow: true,
@@ -1089,8 +1012,8 @@ export const footballData: FEFootballDataPage = {
 			imrWorldwide: true,
 			acast: true,
 			twitterUwt: true,
-			abAuxiaSignInGate: false,
-			abDeferPermutiveLoad: false,
+			abAuxiaSignInGate: true,
+			abDeferPermutiveLoad: true,
 			prebidAppnexusInvcode: true,
 			ampPrebidPubmatic: false,
 			a9HeaderBidding: true,
@@ -1102,9 +1025,8 @@ export const footballData: FEFootballDataPage = {
 			discussionAllPageSize: true,
 			prebidUserSync: true,
 			audioOnwardJourneySwitch: true,
+			abMovePermutiveSegmentation: false,
 			brazeTaylorReport: false,
-			externalVideoEmbeds: true,
-			abTheTradeDesk: true,
 			callouts: true,
 			sentinelLogger: true,
 			geoMostPopular: true,
@@ -1119,7 +1041,6 @@ export const footballData: FEFootballDataPage = {
 			optOutAdvertising: true,
 			abSignInGateMainControl: true,
 			googleSearch: true,
-			abOptOutFrequencyCap: true,
 			brazeSwitch: true,
 			prebidKargo: true,
 			consentManagement: true,
@@ -1137,7 +1058,6 @@ export const footballData: FEFootballDataPage = {
 			youtubeIma: true,
 			webFonts: true,
 			liveBlogTopSponsorship: true,
-			abAdBlockAsk: false,
 			ophan: true,
 			crosswordSvgThumbnails: true,
 			prebidTriplelift: true,
@@ -1150,6 +1070,7 @@ export const footballData: FEFootballDataPage = {
 			prebidHeaderBidding: true,
 			idCookieRefresh: true,
 			discussionPageSize: true,
+			abFiveFourImages: false,
 			smartAppBanner: false,
 			historyTags: true,
 			brazeContentCards: true,
@@ -1159,8 +1080,11 @@ export const footballData: FEFootballDataPage = {
 			shouldLoadGoogletag: true,
 			inizio: true,
 			europeBetaFront: true,
+			dcrFootballLive: false,
 		},
-		abTests: {},
+		abTests: {
+			dcrCrosswordsControl: 'control',
+		},
 		googletagUrl: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
 		stage: 'PROD',
 		frontendAssetsFullURL: 'https://assets.guim.co.uk/',
@@ -1180,7 +1104,7 @@ export const footballData: FEFootballDataPage = {
 		forecastsapiurl: '/weatherapi/forecast',
 		supportUrl: 'https://support.theguardian.com',
 		commercialBundleUrl:
-			'https://assets.guim.co.uk/commercial/47e59a6f2531251d895a/graun.standalone.commercial.js',
+			'https://assets.guim.co.uk/commercial/1ceb3579215c79c2231f/graun.standalone.commercial.js',
 		idOAuthUrl: 'https://oauth.theguardian.com',
 		webTitle: 'Live matches',
 		isFront: false,

--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -1,7 +1,7 @@
 import type { Nations } from '../../src/components/FootballCompetitionSelect';
 import type { FootballMatches } from '../../src/footballMatches';
 
-export const nations: Nations = [
+export const regions: Nations = [
 	{
 		name: 'England',
 		competitions: [

--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -1,19 +1,18 @@
-import type { Nations } from '../../src/components/FootballCompetitionSelect';
-import type { FootballMatches } from '../../src/footballMatches';
+import type { FootballMatches, Regions } from '../../src/footballMatches';
 
-export const regions: Nations = [
+export const regions: Regions = [
 	{
 		name: 'England',
 		competitions: [
-			{ tag: 'football/premierleague', name: 'Premier League' },
-			{ tag: 'football/championship', name: 'Championship' },
+			{ url: '/football/premierleague/live', name: 'Premier League' },
+			{ url: 'football/championship/live', name: 'Championship' },
 		],
 	},
 	{
 		name: 'Scotland',
 		competitions: [
 			{
-				tag: 'football/scottish-premiership',
+				url: 'football/scottish-premiership/live',
 				name: 'Scottish Premiership',
 			},
 		],

--- a/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
@@ -31,10 +31,13 @@ export const FootballCompetitionSelect = {
 		const selects = canvas.getAllByLabelText('Choose league:');
 
 		for (const select of selects) {
-			await userEvent.selectOptions(select, 'football/premierleague');
+			await userEvent.selectOptions(
+				select,
+				'/football/premierleague/live',
+			);
 			await waitFor(() =>
 				expect(args.onChange).toHaveBeenLastCalledWith(
-					'football/premierleague',
+					'/football/premierleague/live',
 				),
 			);
 		}

--- a/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
 import { allModes } from '../../.storybook/modes';
-import { nations } from '../../fixtures/manual/footballData';
+import { regions } from '../../fixtures/manual/footballData';
 import { FootballCompetitionSelect as FootballCompetitionSelectComponent } from './FootballCompetitionSelect';
 
 const meta = {
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 export const FootballCompetitionSelect = {
 	args: {
-		nations,
+		nations: regions,
 		kind: 'Result',
 		onChange: fn(),
 	},

--- a/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
@@ -1,24 +1,32 @@
 import { Option, Select } from '@guardian/source/react-components';
-import type { FootballMatchKind } from '../footballMatches';
+import type { FootballMatchKind, Regions } from '../footballMatches';
 import { palette } from '../palette';
 
-export type Nations = Array<{
-	name: string;
-	competitions: Array<{ tag: string; name: string }>;
-}>;
-
 type Props = {
-	nations: Nations;
-	kind: Exclude<FootballMatchKind, 'Live'>;
+	nations: Regions;
+	kind: FootballMatchKind;
 	onChange: (competitionTag: string) => void;
 };
 
-const allLabel = (kind: Exclude<FootballMatchKind, 'Live'>): string => {
+const allLabel = (kind: FootballMatchKind): string => {
 	switch (kind) {
 		case 'Fixture':
 			return 'All fixtures';
 		case 'Result':
 			return 'All results';
+		case 'Live':
+			return 'All live';
+	}
+};
+
+const getPagePath = (kind: FootballMatchKind) => {
+	switch (kind) {
+		case 'Fixture':
+			return 'football/fixtures';
+		case 'Live':
+			return 'football/live';
+		case 'Result':
+			return 'football/results';
 	}
 };
 
@@ -36,11 +44,11 @@ export const FootballCompetitionSelect = ({
 			backgroundInput: palette('--article-background'),
 		}}
 	>
-		<Option value="All">{allLabel(kind)}</Option>
+		<Option value={getPagePath(kind)}>{allLabel(kind)}</Option>
 		{nations.map((nation) => (
 			<optgroup label={nation.name} key={nation.name}>
 				{nation.competitions.map((competition) => (
-					<Option key={competition.tag} value={competition.tag}>
+					<Option key={competition.name} value={competition.url}>
 						{competition.name}
 					</Option>
 				))}

--- a/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { initialDays, nations } from '../../fixtures/manual/footballData';
+import { initialDays, regions } from '../../fixtures/manual/footballData';
 import { FootballMatchesPage } from './FootballMatchesPage';
 
 const meta = {
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Results = {
 	args: {
-		nations,
+		regions,
 		guardianBaseUrl: 'https://www.theguardian.com',
 		kind: 'Result',
 		initialDays,

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -82,21 +82,19 @@ export const FootballMatchesPage = ({
 			>
 				{createTitle(kind, edition)}
 			</h1>
-			{kind !== 'Live' && (
-				<div
-					css={css`
-						margin-top: ${space[3]}px;
-						margin-bottom: ${space[6]}px;
-						${grid.column.centre}
-					`}
-				>
-					<FootballCompetitionSelect
-						nations={nations}
-						kind={kind}
-						onChange={goToCompetitionSpecificPage}
-					/>
-				</div>
-			)}
+			<div
+				css={css`
+					margin-top: ${space[3]}px;
+					margin-bottom: ${space[6]}px;
+					${grid.column.centre}
+				`}
+			>
+				<FootballCompetitionSelect
+					nations={nations}
+					kind={kind}
+					onChange={goToCompetitionSpecificPage}
+				/>
+			</div>
 			{renderAds && <AdSlot position="right-football" />}
 		</div>
 		<FootballMatchList

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -1,17 +1,20 @@
 import { css } from '@emotion/react';
 import { from, headlineBold20, space } from '@guardian/source/foundations';
-import type { FootballMatches, FootballMatchKind } from '../footballMatches';
+import type {
+	FootballMatches,
+	FootballMatchKind,
+	Regions,
+} from '../footballMatches';
 import { grid } from '../grid';
 import type { EditionId } from '../lib/edition';
 import type { Result } from '../lib/result';
 import { palette } from '../palette';
 import { AdSlot } from './AdSlot.web';
-import type { Nations } from './FootballCompetitionSelect';
 import { FootballCompetitionSelect } from './FootballCompetitionSelect';
 import { FootballMatchList } from './FootballMatchList';
 
 type Props = {
-	nations: Nations;
+	regions: Regions;
 	guardianBaseUrl: string;
 	kind: FootballMatchKind;
 	initialDays: FootballMatches;
@@ -37,7 +40,7 @@ const createTitle = (kind: FootballMatchKind, edition: EditionId) => {
 };
 
 export const FootballMatchesPage = ({
-	nations,
+	regions: nations,
 	guardianBaseUrl,
 	kind,
 	initialDays,

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -30,7 +30,7 @@ export const FootballMatchesPageWrapper = ({
 	renderAds,
 }: Props) => (
 	<FootballMatchesPage
-		nations={nations}
+		regions={nations}
 		guardianBaseUrl={guardianBaseUrl}
 		kind={kind}
 		initialDays={initialDays}

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -1,30 +1,19 @@
-import type { FootballMatches, FootballMatchKind } from '../footballMatches';
+import type {
+	FootballMatches,
+	FootballMatchKind,
+	Regions,
+} from '../footballMatches';
 import type { EditionId } from '../lib/edition';
-import type { Nations } from './FootballCompetitionSelect';
 import { FootballMatchesPage } from './FootballMatchesPage';
 
-const getPagePath = (kind: FootballMatchKind) => {
-	switch (kind) {
-		case 'Fixture':
-			return 'fixtures';
-		case 'Live':
-			return 'live';
-		case 'Result':
-			return 'results';
-	}
-};
-
 const goToCompetitionSpecificPage =
-	(guardianBaseUrl: string, kind: FootballMatchKind) => (tag: string) => {
-		const url =
-			tag === 'All'
-				? `${guardianBaseUrl}/football/${getPagePath(kind)}`
-				: `${guardianBaseUrl}/${tag}/${getPagePath(kind)}`;
+	(guardianBaseUrl: string) => (path: string) => {
+		const url = `${guardianBaseUrl}/${path}`;
 		window.location.assign(url);
 	};
 
 type Props = {
-	nations: Nations;
+	nations: Regions;
 	guardianBaseUrl: string;
 	kind: FootballMatchKind;
 	initialDays: FootballMatches;
@@ -48,7 +37,6 @@ export const FootballMatchesPageWrapper = ({
 		edition={edition}
 		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
 			guardianBaseUrl,
-			kind,
 		)}
 		renderAds={renderAds}
 	/>

--- a/dotcom-rendering/src/feFootballDataPage.ts
+++ b/dotcom-rendering/src/feFootballDataPage.ts
@@ -102,10 +102,16 @@ export type FEFootballPageConfig = Omit<
 	hasSurveyAd: boolean;
 };
 
+export type FEFootballCompetition = {
+	name: string;
+	url: string;
+};
+
 export type FEFootballDataPage = {
 	matchesList: FEMatchByDateAndCompetition[];
 	nextPage?: string;
 	previousPage?: string;
+	filters: Record<string, FEFootballCompetition[]>;
 	nav: FENavType;
 	editionId: EditionId;
 	guardianBaseURL: string;

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -36,13 +36,13 @@ describe('footballMatches', () => {
 		expect(result.length).toBe(1);
 
 		const day = result[0];
-		expect(day?.date.toISOString()).toBe('2025-02-14T00:00:00.000Z');
-		expect(day?.competitions.length).toBe(6);
+		expect(day?.date.toISOString()).toBe('2025-03-03T00:00:00.000Z');
+		expect(day?.competitions.length).toBe(3);
 
 		const competition = day?.competitions[0];
-		expect(competition?.name).toBe('Premier League');
+		expect(competition?.name).toBe('Serie A');
 		expect(competition?.matches[0]?.kind).toBe('Fixture');
-		expect(competition?.tag).toBe('football/premierleague');
+		expect(competition?.tag).toBe('football/serieafootball');
 	});
 
 	it('should return an error when football days have invalid dates', () => {

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -402,11 +402,17 @@ export const parse: (
 	frontendData: FEMatchByDateAndCompetition[],
 ) => Result<ParserError, FootballMatches> = listParse(parseFootballDay);
 
+export type Regions = Array<{
+	name: string;
+	competitions: Array<{ url: string; name: string }>;
+}>;
+
 export type DCRFootballDataPage = {
 	matchesList: FootballMatches;
 	kind: FootballMatchKind;
 	nextPage?: string;
 	previousPage?: string;
+	regions: Regions;
 	nav: NavType;
 	editionId: EditionId;
 	guardianBaseURL: string;

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -1,5 +1,4 @@
 import { palette } from '@guardian/source/foundations';
-import { nations } from '../../fixtures/manual/footballData';
 import { FootballMatchesPageWrapper } from '../components/FootballMatchesPageWrapper.importable';
 import { Footer } from '../components/Footer';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -17,11 +17,6 @@ interface Props {
 	footballData: DCRFootballDataPage;
 }
 
-/*
-	Hardcoded data to test layout
-*/
-const nationsHardcoded = nations;
-
 export const FootballDataPageLayout = ({ footballData }: Props) => {
 	const { nav } = footballData;
 	const pageFooter = footballData.pageFooter;
@@ -69,7 +64,7 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 
 			<Island priority="feature" defer={{ until: 'visible' }}>
 				<FootballMatchesPageWrapper
-					nations={nationsHardcoded}
+					nations={footballData.regions}
 					guardianBaseUrl={footballData.guardianBaseURL}
 					kind={footballData.kind}
 					initialDays={footballData.matchesList}

--- a/dotcom-rendering/src/model/fe-football-data-page-schema.json
+++ b/dotcom-rendering/src/model/fe-football-data-page-schema.json
@@ -63,6 +63,9 @@
         "previousPage": {
             "type": "string"
         },
+        "filters": {
+            "$ref": "#/definitions/Record<string,FEFootballCompetition[]>"
+        },
         "nav": {
             "$ref": "#/definitions/FENavType"
         },
@@ -92,6 +95,7 @@
         "config",
         "contributionsServiceUrl",
         "editionId",
+        "filters",
         "guardianBaseURL",
         "isAdFreeUser",
         "matchesList",
@@ -738,6 +742,9 @@
                     ]
                 }
             ]
+        },
+        "Record<string,FEFootballCompetition[]>": {
+            "type": "object"
         },
         "FENavType": {
             "type": "object",

--- a/dotcom-rendering/src/server/handler.footballDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.footballDataPage.web.ts
@@ -1,9 +1,13 @@
 import type { RequestHandler } from 'express';
-import type { FEFootballDataPage } from '../feFootballDataPage';
+import type {
+	FEFootballCompetition,
+	FEFootballDataPage,
+} from '../feFootballDataPage';
 import type {
 	DCRFootballDataPage,
 	FootballMatchKind,
 	ParserError,
+	Regions,
 } from '../footballMatches';
 import { parse } from '../footballMatches';
 import { extractNAV } from '../model/extract-nav';
@@ -39,6 +43,20 @@ const getParserErrorMessage = (error: ParserError): string => {
 	}
 };
 
+const parseFEFootballCompetitionRegions = (
+	competitionRegions: Record<string, FEFootballCompetition[]>,
+): Regions => {
+	return Object.entries(competitionRegions).map(([key, competition]) => {
+		return {
+			name: key,
+			competitions: competition.map((comp) => ({
+				url: comp.url,
+				name: comp.name,
+			})),
+		};
+	});
+};
+
 const parseFEFootballData = (data: FEFootballDataPage): DCRFootballDataPage => {
 	const parsedMatchesResult = parse(data.matchesList);
 
@@ -55,6 +73,7 @@ const parseFEFootballData = (data: FEFootballDataPage): DCRFootballDataPage => {
 		kind: decidePageKind(data.canonicalUrl),
 		nextPage: data.nextPage,
 		previousPage: data.previousPage,
+		regions: parseFEFootballCompetitionRegions(data.filters),
 		nav: extractNAV(data.nav),
 		editionId: data.editionId,
 		guardianBaseURL: data.guardianBaseURL,


### PR DESCRIPTION
Paired with @andrewHEguardian 

## What does this change?
This PR adds the filters to the frontend football data model. This is used for the competition selector on football pages. 