### PR TITLE
Reduce grey space in first slot to be the same as the other slots

### DIFF
--- a/dotcom-rendering/src/components/AdPortals.importable.tsx
+++ b/dotcom-rendering/src/components/AdPortals.importable.tsx
@@ -217,10 +217,9 @@ export const AdPortals = ({
 		return () => resizeObserver?.disconnect();
 	}, [adPlaceholders, rightAdPlaceholder, tryRightAligned]);
 
-	const renderAdSlot = (id: string, index: number) => (
+	const renderAdSlot = (id: string) => (
 		<AdSlot
 			key={id}
-			isFirstAdSlot={index === 0}
 			ref={(node) => {
 				if (node !== null) {
 					adSlots.current = [...adSlots.current, node];
@@ -231,18 +230,12 @@ export const AdPortals = ({
 
 	if (tryRightAligned && rightAdPlaceholder) {
 		return createPortal(
-			<>
-				{adPlaceholders.map((ad, index) => renderAdSlot(ad.id, index))}
-			</>,
+			<>{adPlaceholders.map((ad) => renderAdSlot(ad.id))}</>,
 			rightAdPlaceholder,
 		);
 	}
 
 	return (
-		<>
-			{adPlaceholders.map((ad, index) =>
-				createPortal(renderAdSlot(ad.id, index), ad),
-			)}
-		</>
+		<>{adPlaceholders.map((ad) => createPortal(renderAdSlot(ad.id), ad))}</>
 	);
 };

--- a/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.stories.tsx
@@ -24,14 +24,4 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const FirstSlot = {
-	args: {
-		isFirstAdSlot: true,
-	},
-} satisfies Story;
-
-export const OtherSlots = {
-	args: {
-		isFirstAdSlot: false,
-	},
-} satisfies Story;
+export const Slots = {} satisfies Story;

--- a/dotcom-rendering/src/components/AdSlot.apps.tsx
+++ b/dotcom-rendering/src/components/AdSlot.apps.tsx
@@ -3,11 +3,6 @@ import { remSpace, textSans14, until } from '@guardian/source/foundations';
 import { forwardRef } from 'react';
 import { palette } from '../palette';
 
-// Exported for Storybook use
-export interface Props {
-	isFirstAdSlot: boolean;
-}
-
 const adHeightPx = 250;
 
 const styles = css`
@@ -42,19 +37,6 @@ const adSlotStyles = css`
 	width: 100%;
 `;
 
-const adSlotSquareStyles = css`
-	${adSlotStyles}
-	${until.phablet} {
-		width: 320px;
-		margin-left: 10px;
-		margin-right: 10px;
-	}
-
-	height: 344px;
-	width: 300px;
-	padding-bottom: 0;
-`;
-
 /**
  * AdSlot component for in-article ads **on apps only**
  *
@@ -63,16 +45,11 @@ const adSlotSquareStyles = css`
  * The ref is important so that we can provide the location of the slot to
  * the native layer, for it to "paint" an advert over the top of it.
  */
-export const AdSlot = forwardRef<HTMLDivElement, Props>(
-	({ isFirstAdSlot }, ref) => (
-		<aside css={styles}>
-			<div css={adLabelsStyles}>
-				<p>Advertisement</p>
-			</div>
-			<div
-				css={isFirstAdSlot ? adSlotSquareStyles : adSlotStyles}
-				ref={ref}
-			></div>
-		</aside>
-	),
-);
+export const AdSlot = forwardRef<HTMLDivElement>((_, ref) => (
+	<aside css={styles}>
+		<div css={adLabelsStyles}>
+			<p>Advertisement</p>
+		</div>
+		<div css={adSlotStyles} ref={ref}></div>
+	</aside>
+));


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
