### PR TITLE
Add storybook for the Football data page layout

### DIFF
--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj } from '@storybook/react/*';
+import type { StoryObj } from '@storybook/react';
 import { footballData } from '../../fixtures/generated/football-live';
 import { initialDays, regions } from '../../fixtures/manual/footballData';
 import { extractNAV } from '../model/extract-nav';

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.stories.tsx
@@ -1,0 +1,48 @@
+import type { StoryObj } from '@storybook/react/*';
+import { footballData } from '../../fixtures/generated/football-live';
+import { initialDays, regions } from '../../fixtures/manual/footballData';
+import { extractNAV } from '../model/extract-nav';
+import { FootballDataPageLayout } from './FootballDataPageLayout';
+
+const meta = {
+	title: 'Components/Football Data Page Layout',
+	component: FootballDataPageLayout,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Results = {
+	args: {
+		footballData: {
+			matchesList: initialDays,
+			regions,
+			kind: 'Result',
+			guardianBaseURL: 'https://www.theguardian.com',
+			editionId: 'UK',
+			config: footballData.config,
+			nav: extractNAV(footballData.nav),
+			pageFooter: footballData.pageFooter,
+			contributionsServiceUrl: 'https://contributions.guardianapis.com',
+			isAdFreeUser: false,
+		},
+	},
+} satisfies Story;
+
+export const Live = {
+	args: {
+		footballData: {
+			...Results.args.footballData,
+			kind: 'Live',
+		},
+	},
+} satisfies Story;
+
+export const Fixtures = {
+	args: {
+		footballData: {
+			...Results.args.footballData,
+			kind: 'Fixture',
+		},
+	},
+} satisfies Story;


### PR DESCRIPTION
## What does this change?

Adds a storybook story for the layout component for football data pages, that encompasses the whole page layout (ie header, main content and footer)
