### PR TITLE
Crosswords: scrollable clue list

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
 		"@guardian/libs": "21.6.0",
 		"@guardian/ophan-tracker-js": "2.2.5",
 		"@guardian/react-crossword": "2.0.2",
-		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250226111729",
+		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@0.0.0-canary-20250303163323",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "8.0.0",
 		"@guardian/source-development-kitchen": "12.0.0",

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -53,8 +53,8 @@ const Layout: CrosswordProps['Layout'] = ({
 	gridWidth,
 	MobileBannerAd,
 }) => {
-	const betweenTabletAndDesktop = useMatchMedia(
-		removeMediaRulePrefix(between.tablet.and.desktop),
+	const betweenTabletAndLeftCol = useMatchMedia(
+		removeMediaRulePrefix(between.tablet.and.leftCol),
 	);
 
 	return (
@@ -117,15 +117,16 @@ const Layout: CrosswordProps['Layout'] = ({
 					display: flex;
 					flex-direction: column;
 					gap: ${space[4]}px;
-					align-items: flex-start;
 					${from.tablet} {
 						max-height: ${gridWidth}px;
 						overflow-y: scroll;
 					}
 					${from.desktop} {
+						flex-direction: row;
+					}
+					${from.leftCol} {
 						max-height: none;
 						overflow: visible;
-						flex-direction: row;
 					}
 					> * {
 						flex: 1;
@@ -135,12 +136,12 @@ const Layout: CrosswordProps['Layout'] = ({
 				<Clues
 					direction="across"
 					Header={CluesHeader}
-					scrollToSelected={betweenTabletAndDesktop}
+					scrollToSelected={betweenTabletAndLeftCol}
 				/>
 				<Clues
 					direction="down"
 					Header={CluesHeader}
-					scrollToSelected={betweenTabletAndDesktop}
+					scrollToSelected={betweenTabletAndLeftCol}
 				/>
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { Crossword as ReactCrossword } from '@guardian/react-crossword-next';
 import type { CrosswordProps } from '@guardian/react-crossword-next';
 import {
+	between,
 	from,
 	headlineBold17,
 	space,
@@ -11,6 +12,7 @@ import {
 import { Hide } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
+import { removeMediaRulePrefix, useMatchMedia } from '../lib/useMatchMedia';
 import { palette } from '../palette';
 import { AdSlot } from './AdSlot.web';
 
@@ -51,13 +53,17 @@ const Layout: CrosswordProps['Layout'] = ({
 	gridWidth,
 	MobileBannerAd,
 }) => {
+	const betweenTabletAndDesktop = useMatchMedia(
+		removeMediaRulePrefix(between.tablet.and.desktop),
+	);
+
 	return (
 		<div
 			css={css`
 				display: flex;
 				flex-direction: column;
 				gap: ${space[4]}px;
-				${from.phablet} {
+				${from.tablet} {
 					flex-direction: row;
 				}
 			`}
@@ -71,7 +77,7 @@ const Layout: CrosswordProps['Layout'] = ({
 				<FocusedClue
 					additionalCss={css`
 						max-width: ${gridWidth}px;
-						${from.phablet} {
+						${from.tablet} {
 							display: none;
 						}
 					`}
@@ -85,7 +91,7 @@ const Layout: CrosswordProps['Layout'] = ({
 				>
 					<FocusedClue
 						additionalCss={css`
-							${from.phablet} {
+							${from.tablet} {
 								display: none;
 							}
 						`}
@@ -112,7 +118,13 @@ const Layout: CrosswordProps['Layout'] = ({
 					flex-direction: column;
 					gap: ${space[4]}px;
 					align-items: flex-start;
+					${from.tablet} {
+						max-height: ${gridWidth}px;
+						overflow-y: scroll;
+					}
 					${from.desktop} {
+						max-height: none;
+						overflow: visible;
 						flex-direction: row;
 					}
 					> * {
@@ -120,8 +132,16 @@ const Layout: CrosswordProps['Layout'] = ({
 					}
 				`}
 			>
-				<Clues direction="across" Header={CluesHeader} />
-				<Clues direction="down" Header={CluesHeader} />
+				<Clues
+					direction="across"
+					Header={CluesHeader}
+					scrollToSelected={betweenTabletAndDesktop}
+				/>
+				<Clues
+					direction="down"
+					Header={CluesHeader}
+					scrollToSelected={betweenTabletAndDesktop}
+				/>
 			</div>
 		</div>
 	);

--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -55,13 +55,13 @@ const Layout: CrosswordProps['Layout'] = ({
 	MobileBannerAd,
 }) => {
 	const cluesRef = useRef<HTMLDivElement>(null);
-	const [showGradient, setShowGradient] = useState(true);
+	const [showGradient, setShowGradient] = useState(false);
 
 	const betweenTabletAndLeftCol = useMatchMedia(
 		removeMediaRulePrefix(between.tablet.and.leftCol),
 	);
 
-	const updateGradientVisibilityOnScroll = () => {
+	const updateGradientVisibility = () => {
 		const clueList = cluesRef.current;
 		if (!clueList) return;
 		const scrollPos = clueList.scrollTop;
@@ -73,15 +73,25 @@ const Layout: CrosswordProps['Layout'] = ({
 		const clueList = cluesRef.current;
 		if (!clueList) return;
 
+		updateGradientVisibility();
+
 		clueList.addEventListener(
 			'scroll',
-			libDebounce(updateGradientVisibilityOnScroll, 100),
+			libDebounce(updateGradientVisibility, 100),
+		);
+		window.addEventListener(
+			'resize',
+			libDebounce(updateGradientVisibility, 100),
 		);
 
 		return () => {
 			clueList.removeEventListener(
 				'scroll',
-				libDebounce(updateGradientVisibilityOnScroll, 100),
+				libDebounce(updateGradientVisibility, 100),
+			);
+			window.removeEventListener(
+				'resize',
+				libDebounce(updateGradientVisibility, 100),
 			);
 		};
 	}, []);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,8 +365,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@guardian/react-crossword-next':
-        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250226111729
-        version: /@guardian/react-crossword@0.0.0-canary-20250226111729(@emotion/react@11.11.3)(@guardian/libs@21.6.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        specifier: npm:@guardian/react-crossword@0.0.0-canary-20250303163323
+        version: /@guardian/react-crossword@0.0.0-canary-20250303163323(@emotion/react@11.11.3)(@guardian/libs@21.6.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4336,8 +4336,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@guardian/react-crossword@0.0.0-canary-20250226111729(@emotion/react@11.11.3)(@guardian/libs@21.6.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
-    resolution: {integrity: sha512-yswR802qHkKuNxkrYk0WXzgNu+UsjWb5WYkYSq5EXmli9dVidFYLfdpZluxoxtyIvMtXRsTasuXbtIXDBtM1MA==}
+  /@guardian/react-crossword@0.0.0-canary-20250303163323(@emotion/react@11.11.3)(@guardian/libs@21.6.0)(@guardian/source@8.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+    resolution: {integrity: sha512-dl6OxpUiXv3pWwMjZXYf0hb5gZt9J6NXDIxbgmucTtoZvs6sLIva+27sTg72kmHwWodtw46F9DfsO32A3cS+VA==}
     peerDependencies:
       '@emotion/react': ^11.11.3
       '@guardian/libs': ^21.0.0


### PR DESCRIPTION
## What does this change?

- Updates to latest version of `@guardian/react-crossword` package:
  - [Fixes _Clear Word_ function](https://github.com/guardian/csnx/pull/1979) so that letters from completed intersecting answers are not cleared
  - [Adds `scrollToSelected` prop to `Clue` component](https://github.com/guardian/csnx/pull/1980) to support automatically scrolling clues into view when selected
- Updates page layout to introduce second column from `tablet` upwards
- Makes clue list scrollable between `tablet` and `leftCol`
- Adds gradient overlay to bottom of clue list to indicate it is scrollable

## Why?

This makes better use of space on smaller screens and allows readers to keep the crossword grid in view whilst scrolling through the clue list.

## Screenshots

<img width="734" alt="Screenshot 2025-03-04 at 18 10 15" src="https://github.com/user-attachments/assets/ea1ae4e2-1266-4f8a-aebd-aaba828a4d96" />
<img width="971" alt="Screenshot 2025-03-04 at 18 10 54" src="https://github.com/user-attachments/assets/83d31ef0-89bc-4c74-9b0e-4213034a2b34" />
