### PR TITLE
Expect grouped cards for flex gen

### DIFF
--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -106,35 +106,46 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const splash = curated.filter(({ card }) => card.group === '1');
+			const splash = curated.filter(({ card }) => card.group === '3');
+
+			// Backfilled cards will always be treated as 'standard' cards
+			const standard = [
+				...curated.filter(({ card }) => card.group !== '3'),
+				...backfill,
+			];
+
+			const enhanceOptions = (offset = 0) => ({
+				cardInTagPage: false,
+				editionId,
+				discussionApiUrl,
+				offset,
+			});
 
 			return {
 				snap: [],
 				huge: [],
 				veryBig: [],
 				big: [],
-				splash: enhanceCards(splash, {
-					cardInTagPage: false,
-					editionId,
-					discussionApiUrl,
-				}),
-				standard: enhanceCards(
-					// Backfilled cards will always be treated as 'standard' cards
-					curated
-						.filter(({ card }) => card.group === '0')
-						.concat(backfill),
-					{
-						cardInTagPage: false,
-						offset: splash.length,
-						editionId,
-						discussionApiUrl,
-					},
-				),
+				splash: enhanceCards(splash, enhanceOptions()),
+				standard: enhanceCards(standard, enhanceOptions(splash.length)),
 			};
 		}
 		case 'flexible/special':
 		case 'dynamic/package': {
 			const snap = curated.filter(({ card }) => card.group === '1');
+
+			// Backfilled cards will always be treated as 'standard' cards
+			const standard = [
+				...curated.filter(({ card }) => card.group === '0'),
+				...backfill,
+			];
+			const enhanceOptions = (offset = 0) => ({
+				cardInTagPage: false,
+				editionId,
+				discussionApiUrl,
+				offset,
+			});
+
 			return {
 				// Splash is not supported on these container types
 				splash: [],
@@ -142,23 +153,8 @@ export const groupCards = (
 				veryBig: [],
 				big: [],
 				// Only 'snap' and 'standard' are supported by dynamic/package
-				snap: enhanceCards(snap, {
-					cardInTagPage: false,
-					editionId,
-					discussionApiUrl,
-				}),
-				standard: enhanceCards(
-					// Backfilled cards will always be treated as 'standard' cards
-					curated
-						.filter(({ card }) => card.group === '0')
-						.concat(backfill),
-					{
-						cardInTagPage: false,
-						offset: snap.length,
-						editionId,
-						discussionApiUrl,
-					},
-				),
+				snap: enhanceCards(snap, enhanceOptions()),
+				standard: enhanceCards(standard, enhanceOptions(snap.length)),
 			};
 		}
 		default:

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -106,11 +106,17 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const splash = curated.filter(({ card }) => card.group === '3');
+			const hasv2Grouping = curated.some(
+				({ card }) => card.group === '3',
+			);
+			const splashGroup = hasv2Grouping ? '3' : '1';
+			const splash = curated.filter(
+				({ card }) => card.group === splashGroup,
+			);
 
 			// Backfilled cards will always be treated as 'standard' cards
 			const standard = [
-				...curated.filter(({ card }) => card.group !== '3'),
+				...curated.filter(({ card }) => card.group !== splashGroup),
 				...backfill,
 			];
 


### PR DESCRIPTION
## What does this change?
Updates the collection enhancer to expect extended card groups.

This PR also refactors the enhancer to improve readability.

This PR temporarily supports both config types (2 groups and 4 groups) to allow us to safely migrate the europe-beta front. Once this is achieved, we will remove support for the old (2 group) config https://github.com/guardian/dotcom-rendering/pull/13514 and expect flexible/general users to migrate their containers to the new config. 

## Why?

The fronts tool has moved from 2 card groups (splash and standard) to 4 card groups (splash, very big, big, and standard). 

These groups are an editorial enhancement and do not translate to a different card treatment by the front end. As such, We separate these cards out by splash (group 3) and standard ( all cards in any group except 3, including backfill).

## Screenshots
Fronts tool group breakdown
![Screenshot 2025-03-03 at 16 46 43](https://github.com/user-attachments/assets/6ebb78c3-0764-4518-a1ce-82292f97f7f9)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/0f270e81-dbcb-4a4e-9600-24eeb6716f56
[after]: https://github.com/user-attachments/assets/c5745c35-eea2-4412-a43e-a1deea7da00c


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
