### PR TITLE
Remove old group support for flexible general

### DIFF
--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -106,35 +106,46 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const splash = curated.filter(({ card }) => card.group === '1');
+			const splash = curated.filter(({ card }) => card.group === '3');
+
+			// Backfilled cards will always be treated as 'standard' cards
+			const standard = [
+				...curated.filter(({ card }) => card.group !== '3'),
+				...backfill,
+			];
+
+			const enhanceOptions = (offset = 0) => ({
+				cardInTagPage: false,
+				editionId,
+				discussionApiUrl,
+				offset,
+			});
 
 			return {
 				snap: [],
 				huge: [],
 				veryBig: [],
 				big: [],
-				splash: enhanceCards(splash, {
-					cardInTagPage: false,
-					editionId,
-					discussionApiUrl,
-				}),
-				standard: enhanceCards(
-					// Backfilled cards will always be treated as 'standard' cards
-					curated
-						.filter(({ card }) => card.group === '0')
-						.concat(backfill),
-					{
-						cardInTagPage: false,
-						offset: splash.length,
-						editionId,
-						discussionApiUrl,
-					},
-				),
+				splash: enhanceCards(splash, enhanceOptions()),
+				standard: enhanceCards(standard, enhanceOptions(splash.length)),
 			};
 		}
 		case 'flexible/special':
 		case 'dynamic/package': {
 			const snap = curated.filter(({ card }) => card.group === '1');
+
+			// Backfilled cards will always be treated as 'standard' cards
+			const standard = [
+				...curated.filter(({ card }) => card.group === '0'),
+				...backfill,
+			];
+			const enhanceOptions = (offset = 0) => ({
+				cardInTagPage: false,
+				editionId,
+				discussionApiUrl,
+				offset,
+			});
+
 			return {
 				// Splash is not supported on these container types
 				splash: [],
@@ -142,23 +153,8 @@ export const groupCards = (
 				veryBig: [],
 				big: [],
 				// Only 'snap' and 'standard' are supported by dynamic/package
-				snap: enhanceCards(snap, {
-					cardInTagPage: false,
-					editionId,
-					discussionApiUrl,
-				}),
-				standard: enhanceCards(
-					// Backfilled cards will always be treated as 'standard' cards
-					curated
-						.filter(({ card }) => card.group === '0')
-						.concat(backfill),
-					{
-						cardInTagPage: false,
-						offset: snap.length,
-						editionId,
-						discussionApiUrl,
-					},
-				),
+				snap: enhanceCards(snap, enhanceOptions()),
+				standard: enhanceCards(standard, enhanceOptions(snap.length)),
 			};
 		}
 		default:

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -106,11 +106,17 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const splash = curated.filter(({ card }) => card.group === '3');
+			const hasv2Grouping = curated.some(
+				({ card }) => card.group === '3',
+			);
+			const splashGroup = hasv2Grouping ? '3' : '1';
+			const splash = curated.filter(
+				({ card }) => card.group === splashGroup,
+			);
 
 			// Backfilled cards will always be treated as 'standard' cards
 			const standard = [
-				...curated.filter(({ card }) => card.group !== '3'),
+				...curated.filter(({ card }) => card.group !== splashGroup),
 				...backfill,
 			];
 

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -106,17 +106,11 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const hasv2Grouping = curated.some(
-				({ card }) => card.group === '3',
-			);
-			const splashGroup = hasv2Grouping ? '3' : '1';
-			const splash = curated.filter(
-				({ card }) => card.group === splashGroup,
-			);
+			const splash = curated.filter(({ card }) => card.group === '3');
 
 			// Backfilled cards will always be treated as 'standard' cards
 			const standard = [
-				...curated.filter(({ card }) => card.group !== splashGroup),
+				...curated.filter(({ card }) => card.group !== '3'),
 				...backfill,
 			];
 


### PR DESCRIPTION
## What does this change?
remove support for flexible/general containers with the old 2 group config. 
This will "break" old config containers as all cards will be considered standard cards.

## Why?
These containers only exist in code and we dont want to support this outdated config in perpetuity so its safest to remove it now before we go to production.
