### PR TITLE
correct the link on the sIndicator roundel

### DIFF
--- a/dotcom-rendering/src/client/sIndicator.ts
+++ b/dotcom-rendering/src/client/sIndicator.ts
@@ -21,7 +21,7 @@ const displaySIndicatorRoundel = (
 	const roundelElement =
 		document.getElementById(overallRoundelElementId) ??
 		(() => {
-			const newElem = document.createElement('div');
+			const newElem = document.createElement('a');
 			newElem.id = overallRoundelElementId;
 			document.body.appendChild(newElem);
 			return newElem;
@@ -45,6 +45,16 @@ const displaySIndicatorRoundel = (
 	roundelElement.style.width = '40px';
 	roundelElement.style.height = '40px';
 
+	roundelElement.style.cursor = 'pointer';
+	roundelElement.setAttribute(
+		'href',
+		window.location.hostname === 'localhost'
+			? 'http://localhost:4200/sIndicator'
+			: `https://syndication.${window.location.hostname
+					.replace('m.', '')
+					.replace('www.', '')}/sIndicator`,
+	);
+
 	switch (status) {
 		case 'loading':
 			roundelElement.title = 'Checking syndication status...';
@@ -66,15 +76,6 @@ const displaySIndicatorRoundel = (
 				'There was an error checking syndication status. Click to check your CAPI key...';
 			roundelElement.style.backgroundColor = 'yellow';
 			roundelElement.textContent = '⚠️';
-			roundelElement.style.cursor = 'pointer';
-			roundelElement.addEventListener(
-				'click',
-				() =>
-					(window.location.href =
-						window.location.hostname === 'localhost'
-							? 'http://localhost:4200/sIndicator'
-							: `https://syndication.${window.location.hostname}/sIndicator`),
-			);
 			break;
 	}
 };

--- a/dotcom-rendering/src/client/sIndicator.ts
+++ b/dotcom-rendering/src/client/sIndicator.ts
@@ -50,9 +50,10 @@ const displaySIndicatorRoundel = (
 		'href',
 		window.location.hostname === 'localhost'
 			? 'http://localhost:4200/sIndicator'
-			: `https://syndication.${window.location.hostname
-					.replace('m.', '')
-					.replace('www.', '')}/sIndicator`,
+			: `https://syndication.${window.location.hostname.replace(
+					/^(m\.|www\.)/i,
+					'',
+			  )}/sIndicator`,
 	);
 
 	switch (status) {


### PR DESCRIPTION
## What does this change?
Tweaks/corrects the url for the sIndicator roundel 

## Why?
It was wrong before and only showed for errors, better if the roundel is always clickable, so users can get easily to the place to turn it off.


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
