### PR TITLE
Football Data Pages - Selected Nav Pillar

### DIFF
--- a/dotcom-rendering/src/server/handler.footballDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.footballDataPage.web.ts
@@ -10,6 +10,7 @@ import type {
 	Regions,
 } from '../footballMatches';
 import { parse } from '../footballMatches';
+import { getCurrentPillar } from '../lib/layoutHelpers';
 import { extractNAV } from '../model/extract-nav';
 import { validateAsFootballDataPageType } from '../model/validate';
 import { makePrefetchHeader } from './lib/header';
@@ -74,7 +75,10 @@ const parseFEFootballData = (data: FEFootballDataPage): DCRFootballDataPage => {
 		nextPage: data.nextPage,
 		previousPage: data.previousPage,
 		regions: parseFEFootballCompetitionRegions(data.filters),
-		nav: extractNAV(data.nav),
+		nav: {
+			...extractNAV(data.nav),
+			selectedPillar: getCurrentPillar(data),
+		},
 		editionId: data.editionId,
 		guardianBaseURL: data.guardianBaseURL,
 		config: data.config,

--- a/dotcom-rendering/src/server/handler.footballDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.footballDataPage.web.ts
@@ -10,7 +10,7 @@ import type {
 	Regions,
 } from '../footballMatches';
 import { parse } from '../footballMatches';
-import { getCurrentPillar } from '../lib/layoutHelpers';
+import { Pillar } from '../lib/articleFormat';
 import { extractNAV } from '../model/extract-nav';
 import { validateAsFootballDataPageType } from '../model/validate';
 import { makePrefetchHeader } from './lib/header';
@@ -77,7 +77,7 @@ const parseFEFootballData = (data: FEFootballDataPage): DCRFootballDataPage => {
 		regions: parseFEFootballCompetitionRegions(data.filters),
 		nav: {
 			...extractNAV(data.nav),
-			selectedPillar: getCurrentPillar(data),
+			selectedPillar: Pillar.Sport,
 		},
 		editionId: data.editionId,
 		guardianBaseURL: data.guardianBaseURL,


### PR DESCRIPTION
## What does this change?
Selects "Sport" as the selected nav pillar for football data pages

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1ebe75ce-a525-4c3f-b066-7ac8e6a55c0b
[after]: https://github.com/user-attachments/assets/36074711-31dc-40ac-94d8-db4055ad4f92

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
