### PR TITLE
Football Pages - Add the correct name for Jagiellonia Białystok

### DIFF
--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -427,5 +427,6 @@ const cleanTeamName = (teamName: string): string => {
 	return teamName
 		.replace('Ladies', '')
 		.replace('Holland', 'The Netherlands')
+		.replace('Bialystock', 'Białystok')
 		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
 };


### PR DESCRIPTION
## What does this change?

The name of the team Jagiellonia Białystok comes back from PA data as "Jagiellonia Bialystock", this PR adds an exception to replace this with the correct name

## Why?

Pointed out by @paperboyo in demo

### Before
<img width="635" alt="image" src="https://github.com/user-attachments/assets/c2917eab-c34b-4b71-bf94-37737a0679c1" />

### After

<img width="640" alt="image" src="https://github.com/user-attachments/assets/69de0423-8e4a-4ad4-9702-05d32da92c94" />
