### PR TITLE
auxia experiment: prevent calling Auxia in the case of SignedIn users

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -656,13 +656,15 @@ const SignInGateSelectorAuxia = ({
 
 	useOnce(() => {
 		void (async () => {
-			const data = await buildAuxiaGateDisplayData(
-				contributionsServiceUrl,
-				pageId,
-				editionId,
-			);
-			if (data !== undefined) {
-				setAuxiaGateDisplayData(data);
+			if (!isSignedIn) {
+				const data = await buildAuxiaGateDisplayData(
+					contributionsServiceUrl,
+					pageId,
+					editionId,
+				);
+				if (data !== undefined) {
+					setAuxiaGateDisplayData(data);
+				}
 			}
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);


### PR DESCRIPTION
This fix a bug in the rendering of the Auxia gate by which we were calling Auxia in the case of signed in users but then not showing the gate because they were signed in. 

The change ensures that the API is not called if the user was signed in.

Another find by @tomrf1  ✨ 🙏