### PR TITLE
decommission iOS9 sign-in gate check

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/displayRule.test.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRule.test.ts
@@ -1,6 +1,5 @@
 import { incrementDailyArticleCount } from '../../lib/dailyArticleCount';
 import {
-	isIOS9,
 	isNPageOrHigherPageView,
 	isValidContentType,
 	isValidSection,
@@ -58,61 +57,6 @@ describe('SignInGate - displayRule methods', () => {
 			const output = isNPageOrHigherPageView(5);
 
 			expect(output).toBe(false);
-		});
-	});
-
-	describe('isIOS9', () => {
-		// spy on user agent to mock return value
-		const userAgentGetter = jest.spyOn(
-			window.navigator,
-			'userAgent',
-			'get',
-		);
-
-		test('iphone ios9 is true', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPhone; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(true);
-		});
-
-		test('ipad ios9 is true', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(true);
-		});
-
-		test('ipod ios9 is true', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPod; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(true);
-		});
-
-		test('iphone not ios9 is false', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPhone; CPU OS 10_3 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(false);
-		});
-
-		test('ipad not ios9 is false', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(false);
-		});
-
-		test('ipod not ios9 is false', () => {
-			userAgentGetter.mockReturnValueOnce(
-				'Mozilla/5.0 (iPod; CPU OS 7_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4',
-			);
-			expect(isIOS9()).toBe(false);
-		});
-
-		test('not ios device is false', () => {
-			expect(isIOS9()).toBe(false);
 		});
 	});
 

--- a/dotcom-rendering/src/components/SignInGate/displayRule.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRule.ts
@@ -17,19 +17,6 @@ export const isNPageOrHigherPageView = (n = 2): boolean => {
 	return count >= n;
 };
 
-// determine if the useragent is running iOS 9 (known to be buggy for sign in flow)
-export const isIOS9 = (): boolean => {
-	// get the browser user agent
-	const ua = navigator.userAgent;
-	// check useragent if the device is an iOS device
-	const appleDevice = /(iPhone|iPod|iPad)/i.test(ua);
-	// check useragent if the os is version 9
-	const os = /(CPU OS 9_)/i.test(ua);
-
-	// if both true, then it's an apple ios 9 device
-	return appleDevice && os;
-};
-
 // hide the sign in gate on article types that are not supported
 export const isValidContentType = (contentType: string): boolean => {
 	// It's safer to definitively *include* types as we
@@ -95,8 +82,7 @@ export const canShowSignInGate = ({
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
-			!isPreview &&
-			!isIOS9(),
+			!isPreview,
 	);
 
 export const canShowSignInGateMandatory: ({
@@ -164,7 +150,6 @@ export const canShowSignInGateWithOffers = ({
 			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
 			!isPreview &&
-			!isIOS9() &&
 			// hide the sign in gate for AU and US readers
 			!['AU', ...US_REGION_CODES].includes(currentLocaleCode),
 	);

--- a/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
@@ -1,6 +1,5 @@
 import { hasUserDismissedGate } from '../dismissGate';
 import {
-	isIOS9,
 	isNPageOrHigherPageView,
 	isValidContentType,
 	isValidSection,
@@ -27,8 +26,7 @@ const canShow = ({
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
 			// hide the sign in gate on internal tools preview
-			!isPreview &&
-			!isIOS9(),
+			!isPreview,
 	);
 
 export const signInGateComponent: SignInGateComponent = {


### PR DESCRIPTION
This decommission the iOS9 check used during sign-in gate rendering logic. 

This check was introduced at a time the sign in process wasn't working with iOS9, but this problem has been resolved. 