### PR TITLE
Show horizontal line on all sublinks

### DIFF
--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -92,9 +92,7 @@ const sublinkBaseStyles = css`
 `;
 
 const verticalSublinkStyles = css`
-	:not(:first-child) {
-		${horizontalLineStyle}
-	}
+	${horizontalLineStyle}
 
 	${from.tablet} {
 		:first-child {
@@ -106,9 +104,7 @@ const verticalSublinkStyles = css`
 const horizontalSublinkStyles = (totalColumns: number) => css`
 	grid-column: span ${totalColumns};
 	${until.tablet} {
-		:not(:first-child) {
-			${horizontalLineStyle}
-		}
+		${horizontalLineStyle}
 	}
 
 	${from.tablet} {


### PR DESCRIPTION
## What does this change?

Adds a horizontal line above all sublinks. We will forward fix a removal rule if needed.

## Why?

Design tweaks.

## Screenshots

| Before | After |
| - | - |
| ![one-before] | ![one-after] |
| ![two-before] | ![two-after] |
| ![three-before] | ![three-after] |
| ![four-before] | ![four-after] |

[one-before]: https://github.com/user-attachments/assets/1b0ff2d6-7a72-4d32-b621-4990481d1b05
[two-before]: https://github.com/user-attachments/assets/7bdf81b2-7990-49c8-87e5-03ef57badf33
[three-before]: https://github.com/user-attachments/assets/8e92d4eb-5aa1-4e95-8b05-48de06c2f819
[four-before]: https://github.com/user-attachments/assets/190d34e8-8275-4af1-ad7c-e2dce78f30a8
[one-after]: https://github.com/user-attachments/assets/98a73a57-8e51-42b9-8f35-dfea81f38853
[two-after]: https://github.com/user-attachments/assets/0bb88415-2cd4-42d3-b918-f531a9ca4fa0
[three-after]: https://github.com/user-attachments/assets/0b1ec8a3-ae05-4388-99a0-20dedaa0c072
[four-after]: https://github.com/user-attachments/assets/8de2fcda-6850-458f-a20a-010e5315d48d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
