### PR TITLE
auxia experiment: upgrade payload of GetTreatments

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/dismissGate.ts
+++ b/dotcom-rendering/src/components/SignInGate/dismissGate.ts
@@ -100,7 +100,10 @@ export const hasUserDismissedGate = (
 	return !(pref == null);
 };
 
-const retrieveDismissedCount = (variant: string, name: string): number => {
+export const retrieveDismissedCount = (
+	variant: string,
+	name: string,
+): number => {
 	const prefs = getSigninGatePrefsSafely();
 	const dismissed = prefs[localStorageDismissedCountKey(variant, name)];
 

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -114,6 +114,10 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	dailyArticleCount: number;
 	articleIdentifier: string;
 	editionId: EditionId;
+	contentType: string;
+	sectionId: string;
+	tagIds: string[];
+	gateDismissCount: number;
 }
 
 export interface AuxiaProxyGetTreatmentsResponse {


### PR DESCRIPTION
This is the first of two PRs (the next one is going to be in SDC), to move to SDC, the logic of deciding whether or not to display the gate (auxia or gu-default) based on policies which had not yet been enforced.

The aim is to re-implement this function:

https://github.com/guardian/dotcom-rendering/blob/7161183540c8f80714b32d29087d2fa7c37147fa/dotcom-rendering/src/components/SignInGate/displayRule.ts#L62

on SDC. 

We are adding 
```
contentType: string
sectionId: string
tagIds: string[]
gateDismissCount: number
```

This is part of an architectural policy to move (some) gate logic from the client side to SDC. 