### PR TITLE
Add date deserialization for football match list Island props

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -153,16 +153,21 @@ const MatchStatus = ({
 			return (
 				<time
 					css={matchStatusStyles}
-					dateTime={match.dateTime.toISOString()}
+					dateTime={maybeDeserializeDateString(
+						match.dateTime,
+					).toISOString()}
 				>
-					{timeFormatter.format(match.dateTime)}
+					{timeFormatter.format(
+						maybeDeserializeDateString(match.dateTime),
+					)}
 				</time>
 			);
 	}
 };
 
 export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
-	matchDateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
+	maybeDeserializeDateString(matchDateTime).getTime() - now.getTime() <=
+	72 * 60 * 60 * 1000;
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
@@ -352,6 +357,19 @@ const Scores = ({
 	</span>
 );
 
+/*
+	This component is used in an Island - and because part of the props are Date objects
+	they will be serialized into strings. This converts them back into a Date before using
+	Date functions
+*/
+const maybeDeserializeDateString = (date: Date): Date => {
+	if (typeof date === 'string') {
+		return new Date(date);
+	}
+
+	return date;
+};
+
 export const FootballMatchList = ({
 	edition,
 	guardianBaseUrl,
@@ -388,9 +406,13 @@ export const FootballMatchList = ({
 							}
 						}
 					`}
-					key={day.date.toISOString()}
+					key={maybeDeserializeDateString(day.date).toISOString()}
 				>
-					<Day>{dateFormatter.format(day.date)}</Day>
+					<Day>
+						{dateFormatter.format(
+							maybeDeserializeDateString(day.date),
+						)}
+					</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.id}>
 							<CompetitionName>


### PR DESCRIPTION
## What does this change?

Adds a function deserializing any `Date` props that have been serialized into strings in `FootballMatchList`. This component is called from an `Island`

## Why?

While implementing the "More" button functionality I noticed a console error that also broke any interactivity

<img width="589" alt="image" src="https://github.com/user-attachments/assets/5412e808-3146-4e46-ad97-ea74ed45cdb0" />

This was happening because the component takes props including dates - which are serialized by the island and therefore we cannot call methods like `toISOString` because it is not a `Date` object on the client
<img width="356" alt="image" src="https://github.com/user-attachments/assets/9be39d6a-bd70-4633-b139-2727f3293534" />

