### PR TITLE
Football Data Pages - Use ISO string instead of dates

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -21,7 +21,7 @@ export const regions: Regions = [
 
 export const initialDays: FootballMatches = [
 	{
-		date: new Date('2022-01-01T00:00:00Z'),
+		date: new Date('2022-01-01T00:00:00Z').getTime(),
 		competitions: [
 			{
 				id: '635',
@@ -31,7 +31,7 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Live',
-						dateTime: new Date('2022-01-01T11:11:00Z'),
+						dateTime: new Date('2022-01-01T11:11:00Z').getTime(),
 						paId: '4482093',
 						homeTeam: {
 							name: 'Torino',
@@ -45,7 +45,7 @@ export const initialDays: FootballMatches = [
 					},
 					{
 						kind: 'Fixture',
-						dateTime: new Date('2022-01-01T19:45:00Z'),
+						dateTime: new Date('2022-01-01T19:45:00Z').getTime(),
 						paId: '4482890',
 						homeTeam: 'Auxerre',
 						awayTeam: 'St Etienne',
@@ -60,7 +60,7 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2022-01-01T20:00:00Z'),
+						dateTime: new Date('2022-01-01T20:00:00Z').getTime(),
 						paId: '4482835',
 						homeTeam: {
 							name: 'Las Palmas',
@@ -82,7 +82,7 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2022-01-01T20:00:00Z'),
+						dateTime: new Date('2022-01-01T20:00:00Z').getTime(),
 						paId: '4482836',
 						homeTeam: {
 							name: 'Brighton & Hove Albion Women',
@@ -103,7 +103,7 @@ export const initialDays: FootballMatches = [
 
 export const moreDays: FootballMatches = [
 	{
-		date: new Date('2022-01-05T00:00:00Z'),
+		date: new Date('2022-01-05T00:00:00Z').getTime(),
 		competitions: [
 			{
 				id: '635',
@@ -113,7 +113,7 @@ export const moreDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Fixture',
-						dateTime: new Date('2022-01-05T19:45:00Z'),
+						dateTime: new Date('2022-01-05T19:45:00Z').getTime(),
 						paId: '4482890',
 						homeTeam: 'Juventus',
 						awayTeam: 'Roma',

--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -21,7 +21,7 @@ export const regions: Regions = [
 
 export const initialDays: FootballMatches = [
 	{
-		date: new Date('2022-01-01T00:00:00Z').getTime(),
+		dateISOString: new Date('2022-01-01T00:00:00Z').toISOString(),
 		competitions: [
 			{
 				id: '635',
@@ -31,7 +31,9 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Live',
-						dateTime: new Date('2022-01-01T11:11:00Z').getTime(),
+						dateTimeISOString: new Date(
+							'2022-01-01T11:11:00Z',
+						).toISOString(),
 						paId: '4482093',
 						homeTeam: {
 							name: 'Torino',
@@ -45,7 +47,9 @@ export const initialDays: FootballMatches = [
 					},
 					{
 						kind: 'Fixture',
-						dateTime: new Date('2022-01-01T19:45:00Z').getTime(),
+						dateTimeISOString: new Date(
+							'2022-01-01T19:45:00Z',
+						).toISOString(),
 						paId: '4482890',
 						homeTeam: 'Auxerre',
 						awayTeam: 'St Etienne',
@@ -60,7 +64,9 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2022-01-01T20:00:00Z').getTime(),
+						dateTimeISOString: new Date(
+							'2022-01-01T20:00:00Z',
+						).toISOString(),
 						paId: '4482835',
 						homeTeam: {
 							name: 'Las Palmas',
@@ -82,7 +88,9 @@ export const initialDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Result',
-						dateTime: new Date('2022-01-01T20:00:00Z').getTime(),
+						dateTimeISOString: new Date(
+							'2022-01-01T20:00:00Z',
+						).toISOString(),
 						paId: '4482836',
 						homeTeam: {
 							name: 'Brighton & Hove Albion Women',
@@ -103,7 +111,7 @@ export const initialDays: FootballMatches = [
 
 export const moreDays: FootballMatches = [
 	{
-		date: new Date('2022-01-05T00:00:00Z').getTime(),
+		dateISOString: new Date('2022-01-05T00:00:00Z').toISOString(),
 		competitions: [
 			{
 				id: '635',
@@ -113,7 +121,9 @@ export const moreDays: FootballMatches = [
 				matches: [
 					{
 						kind: 'Fixture',
-						dateTime: new Date('2022-01-05T19:45:00Z').getTime(),
+						dateTimeISOString: new Date(
+							'2022-01-05T19:45:00Z',
+						).toISOString(),
 						paId: '4482890',
 						homeTeam: 'Juventus',
 						awayTeam: 'Roma',

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -153,21 +153,16 @@ const MatchStatus = ({
 			return (
 				<time
 					css={matchStatusStyles}
-					dateTime={maybeDeserializeDateString(
-						match.dateTime,
-					).toISOString()}
+					dateTime={epochToDate(match.dateTime).toISOString()}
 				>
-					{timeFormatter.format(
-						maybeDeserializeDateString(match.dateTime),
-					)}
+					{timeFormatter.format(epochToDate(match.dateTime))}
 				</time>
 			);
 	}
 };
 
 export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
-	maybeDeserializeDateString(matchDateTime).getTime() - now.getTime() <=
-	72 * 60 * 60 * 1000;
+	matchDateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
@@ -199,7 +194,7 @@ const MatchWrapper = ({
 	now: Date;
 	children: ReactNode;
 }) => {
-	if (shouldRenderMatchLink(match.dateTime, now)) {
+	if (shouldRenderMatchLink(epochToDate(match.dateTime), now)) {
 		return (
 			<li css={matchListItemStyles}>
 				<a
@@ -358,16 +353,11 @@ const Scores = ({
 );
 
 /*
-	This component is used in an Island - and because part of the props are Date objects
-	they will be serialized into strings. This converts them back into a Date before using
-	Date functions
+	This component is used in an Island - we cannot use a Date object, since props are serialized.
+	We use the time since epoch and convert back to Date on the client.
 */
-const maybeDeserializeDateString = (date: Date): Date => {
-	if (typeof date === 'string') {
-		return new Date(date);
-	}
-
-	return date;
+const epochToDate = (dateEpoch: number): Date => {
+	return new Date(dateEpoch);
 };
 
 export const FootballMatchList = ({
@@ -406,13 +396,9 @@ export const FootballMatchList = ({
 							}
 						}
 					`}
-					key={maybeDeserializeDateString(day.date).toISOString()}
+					key={epochToDate(day.date).toISOString()}
 				>
-					<Day>
-						{dateFormatter.format(
-							maybeDeserializeDateString(day.date),
-						)}
-					</Day>
+					<Day>{dateFormatter.format(epochToDate(day.date))}</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.id}>
 							<CompetitionName>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -153,9 +153,9 @@ const MatchStatus = ({
 			return (
 				<time
 					css={matchStatusStyles}
-					dateTime={epochToDate(match.dateTime).toISOString()}
+					dateTime={match.dateTimeISOString}
 				>
-					{timeFormatter.format(epochToDate(match.dateTime))}
+					{timeFormatter.format(new Date(match.dateTimeISOString))}
 				</time>
 			);
 	}
@@ -194,7 +194,7 @@ const MatchWrapper = ({
 	now: Date;
 	children: ReactNode;
 }) => {
-	if (shouldRenderMatchLink(epochToDate(match.dateTime), now)) {
+	if (shouldRenderMatchLink(new Date(match.dateTimeISOString), now)) {
 		return (
 			<li css={matchListItemStyles}>
 				<a
@@ -352,14 +352,6 @@ const Scores = ({
 	</span>
 );
 
-/*
-	This component is used in an Island - we cannot use a Date object, since props are serialized.
-	We use the time since epoch and convert back to Date on the client.
-*/
-const epochToDate = (dateEpoch: number): Date => {
-	return new Date(dateEpoch);
-};
-
 export const FootballMatchList = ({
 	edition,
 	guardianBaseUrl,
@@ -396,9 +388,11 @@ export const FootballMatchList = ({
 							}
 						}
 					`}
-					key={epochToDate(day.date).toISOString()}
+					key={day.dateISOString}
 				>
-					<Day>{dateFormatter.format(epochToDate(day.date))}</Day>
+					<Day>
+						{dateFormatter.format(new Date(day.dateISOString))}
+					</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.id}>
 							<CompetitionName>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -153,16 +153,21 @@ const MatchStatus = ({
 			return (
 				<time
 					css={matchStatusStyles}
-					dateTime={match.dateTime.toISOString()}
+					dateTime={maybeDeserializeDateString(
+						match.dateTime,
+					).toISOString()}
 				>
-					{timeFormatter.format(match.dateTime)}
+					{timeFormatter.format(
+						maybeDeserializeDateString(match.dateTime),
+					)}
 				</time>
 			);
 	}
 };
 
 export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
-	matchDateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
+	maybeDeserializeDateString(matchDateTime).getTime() - now.getTime() <=
+	72 * 60 * 60 * 1000;
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
@@ -352,6 +357,19 @@ const Scores = ({
 	</span>
 );
 
+/*
+	This component is used in an Island - and because part of the props are Date objects
+	they will be serialized into strings. This converts them back into a Date before using
+	Date functions
+*/
+const maybeDeserializeDateString = (date: Date): Date => {
+	if (typeof date === 'string') {
+		return new Date(date);
+	}
+
+	return date;
+};
+
 export const FootballMatchList = ({
 	edition,
 	guardianBaseUrl,
@@ -388,9 +406,13 @@ export const FootballMatchList = ({
 							}
 						}
 					`}
-					key={day.date.toISOString()}
+					key={maybeDeserializeDateString(day.date).toISOString()}
 				>
-					<Day>{dateFormatter.format(day.date)}</Day>
+					<Day>
+						{dateFormatter.format(
+							maybeDeserializeDateString(day.date),
+						)}
+					</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.id}>
 							<CompetitionName>

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -36,8 +36,7 @@ describe('footballMatches', () => {
 		expect(result.length).toBe(1);
 
 		const day = result[0];
-		const date = day?.date ?? 0;
-		expect(new Date(date).toISOString()).toBe('2025-03-03T00:00:00.000Z');
+		expect(day?.dateISOString).toBe('2025-03-03T00:00:00.000Z');
 		expect(day?.competitions.length).toBe(3);
 
 		const competition = day?.competitions[0];

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -36,7 +36,8 @@ describe('footballMatches', () => {
 		expect(result.length).toBe(1);
 
 		const day = result[0];
-		expect(day?.date.toISOString()).toBe('2025-03-03T00:00:00.000Z');
+		const date = day?.date ?? 0;
+		expect(new Date(date).toISOString()).toBe('2025-03-03T00:00:00.000Z');
 		expect(day?.competitions.length).toBe(3);
 
 		const competition = day?.competitions[0];

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -21,7 +21,7 @@ type TeamScore = {
 
 type MatchData = {
 	paId: string;
-	dateTime: Date;
+	dateTime: number;
 };
 
 export type MatchResult = MatchData & {
@@ -57,7 +57,7 @@ type Competition = {
 };
 
 type FootballDay = {
-	date: Date;
+	date: number;
 	competitions: Competition[];
 };
 
@@ -162,14 +162,14 @@ const listParse =
 		return f(input, []);
 	};
 
-const parseDate = (a: string): Result<string, Date> => {
+const parseDate = (a: string): Result<string, number> => {
 	const d = new Date(a);
 
 	if (d.toString() === 'Invalid Date') {
 		return error(`${String(a)} isn't a valid Date`);
 	}
 
-	return ok(d);
+	return ok(d.getTime());
 };
 
 const parseScore = (
@@ -188,7 +188,7 @@ const parseScore = (
 	return ok(team.score);
 };
 
-const parseMatchDate = (date: string): Result<string, Date> => {
+const parseMatchDate = (date: string): Result<string, number> => {
 	// Frontend appends a timezone in square brackets
 	const isoDate = date.split('[')[0];
 

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -21,7 +21,7 @@ type TeamScore = {
 
 type MatchData = {
 	paId: string;
-	dateTime: number;
+	dateTimeISOString: string;
 };
 
 export type MatchResult = MatchData & {
@@ -57,7 +57,7 @@ type Competition = {
 };
 
 type FootballDay = {
-	date: number;
+	dateISOString: string;
 	competitions: Competition[];
 };
 
@@ -162,14 +162,14 @@ const listParse =
 		return f(input, []);
 	};
 
-const parseDate = (a: string): Result<string, number> => {
+const parseDate = (a: string): Result<string, string> => {
 	const d = new Date(a);
 
 	if (d.toString() === 'Invalid Date') {
 		return error(`${String(a)} isn't a valid Date`);
 	}
 
-	return ok(d.getTime());
+	return ok(d.toISOString());
 };
 
 const parseScore = (
@@ -188,7 +188,7 @@ const parseScore = (
 	return ok(team.score);
 };
 
-const parseMatchDate = (date: string): Result<string, number> => {
+const parseMatchDate = (date: string): Result<string, string> => {
 	// Frontend appends a timezone in square brackets
 	const isoDate = date.split('[')[0];
 
@@ -224,7 +224,7 @@ const parseFixture = (
 		kind: 'Fixture',
 		homeTeam: cleanTeamName(feFixture.homeTeam.name),
 		awayTeam: cleanTeamName(feFixture.awayTeam.name),
-		dateTime: date.value,
+		dateTimeISOString: date.value,
 		paId: feFixture.id,
 	});
 };
@@ -267,7 +267,7 @@ export const parseMatchResult = (
 			name: cleanTeamName(feResult.awayTeam.name),
 			score: awayScore.value,
 		},
-		dateTime: date.value,
+		dateTimeISOString: date.value,
 		paId: feResult.id,
 		comment: feResult.comments,
 	});
@@ -311,7 +311,7 @@ const parseLiveMatch = (
 			name: cleanTeamName(feMatchDay.awayTeam.name),
 			score: awayScore.value,
 		},
-		dateTime: date.value,
+		dateTimeISOString: date.value,
 		paId: feMatchDay.id,
 		comment: feMatchDay.comments,
 		status: feMatchDay.matchStatus,
@@ -393,7 +393,7 @@ const parseFootballDay = (
 	}
 
 	return ok({
-		date: date.value,
+		dateISOString: date.value,
 		competitions: competitions.value,
 	});
 };


### PR DESCRIPTION
## What does this change?

This changes all the dates used in football data page components to use the ~time since epoch as a number~ ISO date string instead of a Date object

## Why?

The components exist inside an Island in order to interactively get more fixtures/results. Therefore the props are serialized and any dates cannot be passed as an object

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/8e9d7b84-2983-4544-8c83-6ac0a6f5d78e) | No console error |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
