### PR TITLE
Football Fixtures/Results Pages - Get More!

### DIFF
--- a/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
@@ -23,11 +23,11 @@ const allLabel = (kind: FootballMatchKind): string => {
 const getPagePath = (kind: FootballMatchKind) => {
 	switch (kind) {
 		case 'Fixture':
-			return 'football/fixtures';
+			return '/football/fixtures';
 		case 'Live':
-			return 'football/live';
+			return '/football/live';
 		case 'Result':
-			return 'football/results';
+			return '/football/results';
 	}
 };
 

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -443,6 +443,9 @@ export const FootballMatchList = ({
 							grid-column: centre-column-start / centre-column-end;
 
 							padding-top: ${space[10]}px;
+							${until.leftCol} {
+								padding-top: ${space[10]}px;
+							}
 							padding-bottom: ${space[9]}px;
 						`}
 					>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -442,11 +442,9 @@ export const FootballMatchList = ({
 						css={css`
 							grid-column: centre-column-start / centre-column-end;
 
-							padding-top: ${space[10]}px;
 							${until.leftCol} {
 								padding-top: ${space[10]}px;
 							}
-							padding-bottom: ${space[9]}px;
 						`}
 					>
 						<Button

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -192,7 +192,8 @@ const MatchStatus = ({
 };
 
 export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
-	matchDateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
+	maybeDeserializeDateString(matchDateTime).getTime() - now.getTime() <=
+	72 * 60 * 60 * 1000;
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
@@ -381,6 +382,19 @@ const Scores = ({
 		</span>
 	</span>
 );
+
+/*
+	This component is used in an Island - and because part of the props are Date objects
+	they will be serialized into strings. This converts them back into a Date before using
+	Date functions
+*/
+const maybeDeserializeDateString = (date: Date): Date => {
+	if (typeof date === 'string') {
+		return new Date(date);
+	}
+
+	return date;
+};
 
 export const FootballMatchList = ({
 	edition,

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -443,6 +443,7 @@ export const FootballMatchList = ({
 							grid-column: centre-column-start / centre-column-end;
 
 							padding-top: ${space[10]}px;
+							padding-bottom: ${space[9]}px;
 						`}
 					>
 						<Button

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -192,8 +192,7 @@ const MatchStatus = ({
 };
 
 export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
-	maybeDeserializeDateString(matchDateTime).getTime() - now.getTime() <=
-	72 * 60 * 60 * 1000;
+	matchDateTime.getTime() - now.getTime() <= 72 * 60 * 60 * 1000;
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
@@ -382,19 +381,6 @@ const Scores = ({
 		</span>
 	</span>
 );
-
-/*
-	This component is used in an Island - and because part of the props are Date objects
-	they will be serialized into strings. This converts them back into a Date before using
-	Date functions
-*/
-const maybeDeserializeDateString = (date: Date): Date => {
-	if (typeof date === 'string') {
-		return new Date(date);
-	}
-
-	return date;
-};
 
 export const FootballMatchList = ({
 	edition,

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -76,6 +76,10 @@ export const FootballMatchesPage = ({
 					right: 0;
 				}
 			}
+
+			${until.leftCol} {
+				padding-bottom: ${space[9]}px;
+			}
 		`}
 	>
 		<h1

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -77,9 +77,7 @@ export const FootballMatchesPage = ({
 				}
 			}
 
-			${until.leftCol} {
-				padding-bottom: ${space[9]}px;
-			}
+			padding-bottom: ${space[9]}px;
 		`}
 	>
 		<h1

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -1,4 +1,4 @@
-import { isObject, isString, isUndefined } from '@guardian/libs';
+import { isObject, isUndefined } from '@guardian/libs';
 import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
 import type { FEFootballDataPage } from '../feFootballDataPage';
@@ -26,7 +26,7 @@ export const getMoreDays =
 
 			const responseJson: unknown = await fetchResponse.json();
 
-			if (isObject(responseJson) && isString(responseJson.nextPage)) {
+			if (isObject(responseJson)) {
 				const feFootballData = responseJson as FEFootballDataPage;
 				const parsedFootballMatches = parse(feFootballData.matchesList);
 
@@ -39,12 +39,10 @@ export const getMoreDays =
 				}
 
 				setNextPage(feFootballData.nextPage);
+
 				return ok(parsedFootballMatches.value);
 			}
-
-			throw new Error(
-				'Failed to parse response JSON as an object with `nextPage`',
-			);
+			throw new Error('Failed to parse response JSON as an object');
 		} catch (e) {
 			if (e instanceof Error) {
 				window.guardian.modules.sentry.reportError(

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -1,10 +1,62 @@
-import type {
-	FootballMatches,
-	FootballMatchKind,
-	Regions,
+import { isObject, isString, isUndefined } from '@guardian/libs';
+import type { Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
+import type { FEFootballDataPage } from '../feFootballDataPage';
+import {
+	type FootballMatches,
+	type FootballMatchKind,
+	getParserErrorMessage,
+	parse,
+	type Regions,
 } from '../footballMatches';
 import type { EditionId } from '../lib/edition';
+import type { Result } from '../lib/result';
+import { error, ok } from '../lib/result';
 import { FootballMatchesPage } from './FootballMatchesPage';
+
+export const getMoreDays =
+	(
+		nextPage: string,
+		setNextPage: Dispatch<SetStateAction<string | undefined>>,
+	) =>
+	async (): Promise<Result<'failed', FootballMatches>> => {
+		try {
+			const fetchResponse = await fetch(
+				'/MoreFootballData?nextPage=' + nextPage,
+			);
+
+			const responseJson: unknown = await fetchResponse.json();
+
+			if (isObject(responseJson) && isString(responseJson.nextPage)) {
+				const feFootballData = responseJson as FEFootballDataPage;
+				const parsedFootballMatches = parse(feFootballData.matchesList);
+
+				if (parsedFootballMatches.kind === 'error') {
+					throw new Error(
+						`Failed to parse matches: ${getParserErrorMessage(
+							parsedFootballMatches.error,
+						)}`,
+					);
+				}
+
+				setNextPage(feFootballData.nextPage);
+				return ok(parsedFootballMatches.value);
+			}
+
+			throw new Error(
+				'Failed to parse response JSON as an object with `nextPage`',
+			);
+		} catch (e) {
+			if (e instanceof Error) {
+				window.guardian.modules.sentry.reportError(
+					e,
+					'get-more-football-matches-button',
+				);
+			}
+
+			return error('failed');
+		}
+	};
 
 const goToCompetitionSpecificPage =
 	(guardianBaseUrl: string) => (path: string) => {
@@ -17,6 +69,7 @@ type Props = {
 	guardianBaseUrl: string;
 	kind: FootballMatchKind;
 	initialDays: FootballMatches;
+	secondPage?: string;
 	edition: EditionId;
 	renderAds: boolean;
 	pageId: string;
@@ -27,20 +80,30 @@ export const FootballMatchesPageWrapper = ({
 	guardianBaseUrl,
 	kind,
 	initialDays,
+	secondPage,
 	edition,
 	renderAds,
 	pageId,
-}: Props) => (
-	<FootballMatchesPage
-		regions={nations}
-		guardianBaseUrl={guardianBaseUrl}
-		kind={kind}
-		initialDays={initialDays}
-		edition={edition}
-		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
-			guardianBaseUrl,
-		)}
-		renderAds={renderAds}
-		pageId={pageId}
-	/>
-);
+}: Props) => {
+	const [nextPage, setNextPage] = useState(secondPage);
+
+	return (
+		<FootballMatchesPage
+			regions={nations}
+			guardianBaseUrl={guardianBaseUrl}
+			kind={kind}
+			initialDays={initialDays}
+			edition={edition}
+			goToCompetitionSpecificPage={goToCompetitionSpecificPage(
+				guardianBaseUrl,
+			)}
+			getMoreDays={
+				isUndefined(nextPage)
+					? undefined
+					: getMoreDays(nextPage, setNextPage)
+			}
+			renderAds={renderAds}
+			pageId={pageId}
+		/>
+	);
+};

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -16,14 +16,13 @@ import { FootballMatchesPage } from './FootballMatchesPage';
 
 export const getMoreDays =
 	(
+		ajaxUrl: string,
 		nextPage: string,
 		setNextPage: Dispatch<SetStateAction<string | undefined>>,
 	) =>
 	async (): Promise<Result<'failed', FootballMatches>> => {
 		try {
-			const fetchResponse = await fetch(
-				`https://api.nextgen.guardianapps.co.uk${nextPage}.json?dcr`,
-			);
+			const fetchResponse = await fetch(`${ajaxUrl}${nextPage}.json?dcr`);
 
 			const responseJson: unknown = await fetchResponse.json();
 
@@ -67,6 +66,7 @@ const goToCompetitionSpecificPage =
 type Props = {
 	nations: Regions;
 	guardianBaseUrl: string;
+	ajaxUrl: string;
 	kind: FootballMatchKind;
 	initialDays: FootballMatches;
 	secondPage?: string;
@@ -78,6 +78,7 @@ type Props = {
 export const FootballMatchesPageWrapper = ({
 	nations,
 	guardianBaseUrl,
+	ajaxUrl,
 	kind,
 	initialDays,
 	secondPage,
@@ -100,7 +101,7 @@ export const FootballMatchesPageWrapper = ({
 			getMoreDays={
 				isUndefined(nextPage)
 					? undefined
-					: getMoreDays(nextPage, setNextPage)
+					: getMoreDays(ajaxUrl, nextPage, setNextPage)
 			}
 			renderAds={renderAds}
 			pageId={pageId}

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -22,7 +22,7 @@ export const getMoreDays =
 	async (): Promise<Result<'failed', FootballMatches>> => {
 		try {
 			const fetchResponse = await fetch(
-				'/MoreFootballData?nextPage=' + nextPage,
+				`https://api.nextgen.guardianapps.co.uk${nextPage}.json?dcr`,
 			);
 
 			const responseJson: unknown = await fetchResponse.json();

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -398,6 +398,17 @@ const parseFootballDay = (
 	});
 };
 
+export const getParserErrorMessage = (parserError: ParserError): string => {
+	switch (parserError.kind) {
+		case 'InvalidMatchDay':
+			return parserError.errors
+				.map((e) => getParserErrorMessage(e))
+				.join(', ');
+		default:
+			return `${parserError.kind}: ${parserError.message}`;
+	}
+};
+
 export const parse: (
 	frontendData: FEMatchByDateAndCompetition[],
 ) => Result<ParserError, FootballMatches> = listParse(parseFootballDay);

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -64,6 +64,7 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 				<FootballMatchesPageWrapper
 					nations={footballData.regions}
 					guardianBaseUrl={footballData.guardianBaseURL}
+					ajaxUrl={footballData.config.ajaxUrl}
 					kind={footballData.kind}
 					initialDays={footballData.matchesList}
 					secondPage={footballData.nextPage}

--- a/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/FootballDataPageLayout.tsx
@@ -66,6 +66,7 @@ export const FootballDataPageLayout = ({ footballData }: Props) => {
 					guardianBaseUrl={footballData.guardianBaseURL}
 					kind={footballData.kind}
 					initialDays={footballData.matchesList}
+					secondPage={footballData.nextPage}
 					edition={footballData.editionId}
 					renderAds={renderAds}
 					pageId={footballData.config.pageId}

--- a/dotcom-rendering/src/server/handler.footballDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.footballDataPage.web.ts
@@ -1,4 +1,4 @@
-import type { Request, RequestHandler, Response } from 'express';
+import type { RequestHandler } from 'express';
 import type {
 	FEFootballCompetition,
 	FEFootballDataPage,
@@ -17,15 +17,15 @@ import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderFootballDataPage } from './render.footballDataPage.web';
 
 const decidePageKind = (pageId: string): FootballMatchKind => {
-	if (pageId?.includes('live')) {
+	if (pageId.includes('live')) {
 		return 'Live';
 	}
 
-	if (pageId?.includes('results')) {
+	if (pageId.includes('results')) {
 		return 'Result';
 	}
 
-	if (pageId?.includes('fixtures')) {
+	if (pageId.includes('fixtures')) {
 		return 'Fixture';
 	}
 
@@ -86,21 +86,4 @@ export const handleFootballDataPage: RequestHandler = ({ body }, res) => {
 	const { html, prefetchScripts } =
 		renderFootballDataPage(parsedFootballData);
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
-};
-
-export const handleGetMoreFootballData: RequestHandler = (
-	req: Request,
-	res: Response,
-): void => {
-	const nextPagePath = new URLSearchParams(
-		req.url.split('/MoreFootballData')[1],
-	).get('nextPage');
-	const url = `https://www.theguardian.com/${nextPagePath}.json?dcr=true`;
-
-	fetch(url)
-		.then((response) => response.json())
-		.then((json) => {
-			res.status(200).send(json);
-		})
-		.catch((err) => res.status(500).send(err));
 };

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -13,7 +13,10 @@ import {
 	handleInteractive,
 } from './handler.article.web';
 import { handleEditionsCrossword } from './handler.editionsCrossword';
-import { handleFootballDataPage } from './handler.footballDataPage.web';
+import {
+	handleFootballDataPage,
+	handleGetMoreFootballData,
+} from './handler.footballDataPage.web';
 import {
 	handleFront,
 	handleFrontJson,
@@ -94,6 +97,8 @@ export const devServer = (): Handler => {
 				return handleEditionsCrossword(req, res, next);
 			case 'FootballDataPage':
 				return handleFootballDataPage(req, res, next);
+			case 'MoreFootballData':
+				return handleGetMoreFootballData(req, res, next);
 			default: {
 				// Do not redirect assets urls
 				if (req.url.match(ASSETS_URL)) return next();

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -13,10 +13,7 @@ import {
 	handleInteractive,
 } from './handler.article.web';
 import { handleEditionsCrossword } from './handler.editionsCrossword';
-import {
-	handleFootballDataPage,
-	handleGetMoreFootballData,
-} from './handler.footballDataPage.web';
+import { handleFootballDataPage } from './handler.footballDataPage.web';
 import {
 	handleFront,
 	handleFrontJson,
@@ -97,8 +94,6 @@ export const devServer = (): Handler => {
 				return handleEditionsCrossword(req, res, next);
 			case 'FootballDataPage':
 				return handleFootballDataPage(req, res, next);
-			case 'MoreFootballData':
-				return handleGetMoreFootballData(req, res, next);
 			default: {
 				// Do not redirect assets urls
 				if (req.url.match(ASSETS_URL)) return next();


### PR DESCRIPTION
## What does this change?

Implements a function to fetch more fixtures or results from the server. The client requests the next page of data. (eg visible at https://www.theguardian.com/football/fixtures/more/2025/Mar/08.json?dcr=true). This returns the JSON that the client will parse into a DCR model (just the matches and the URL for the next page) and render the extra matches on the page.

Also tweaks the styling of the More button to give it appropriate borders and padding.

## Why?

We need to dynamically fetch more fixtures when a user hits the More button 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/12e52c40-c6ed-40c8-b6d9-8919382aad2b
[after]: https://github.com/user-attachments/assets/5ee47fc1-6623-4fff-b878-40c3e4fda136
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.
<img width="729" alt="image" src="" />

[before2]: https://github.com/user-attachments/assets/12e52c40-c6ed-40c8-b6d9-8919382aad2b
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
