### PR TITLE
Temporarily skip Playwright reject all cookies test

### DIFF
--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -19,7 +19,12 @@ const articleUrl =
 const frontUrl = 'https://www.theguardian.com/uk';
 
 test.describe('Ophan requests', () => {
-	test('should make an IMPRESSION request on an article when consent is rejected', async ({
+	/**
+	 * Why is this test skipped?
+	 *
+	 * Since the launch of Guardian Ad Lite, rejecting all cookies takes the user to the "Consent or Pay" page.
+	 */
+	test.skip('should make an IMPRESSION request on an article when consent is rejected', async ({
 		page,
 		context,
 	}) => {

--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -22,7 +22,8 @@ test.describe('Ophan requests', () => {
 	/**
 	 * Why is this test skipped?
 	 *
-	 * Since the launch of Guardian Ad Lite, rejecting all cookies takes the user to the "Consent or Pay" page.
+	 * Since the launch of Guardian Ad Lite, rejecting all cookies takes the user to the "Consent or Pay" page,
+	 * instead of removing the cookie banner. This new behaviour is causing the below test to fail.
 	 */
 	test.skip('should make an IMPRESSION request on an article when consent is rejected', async ({
 		page,


### PR DESCRIPTION
## What does this change?

Skips the following Playwright test:

`should make an IMPRESSION request on an article when consent is rejected`

## Why?

Since the launch of Guardian Ad Lite, rejecting all cookies takes the user to the "Consent or Pay" page, failing this test. We should amend this test so that it makes sense in the new Consent or Pay environment, but for now, this failing test is blocking other development.
