### PR TITLE
Make right ad sticky in football pages

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -516,7 +516,8 @@ export const AdSlot = ({
 							height: 100%;
 							max-height: 100%;
 							${grid.column.right}
-							grid-row: 1;
+							// TODO: this grid row solution is hacky
+							grid-row: 1 / 500;
 							padding-top: ${space[2]}px;
 							${until.desktop} {
 								display: none;
@@ -539,7 +540,8 @@ export const AdSlot = ({
 						css={[
 							rightAdStyles,
 							css`
-								position: absolute;
+								position: sticky;
+								top: 0;
 							`,
 							labelStyles,
 						]}

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -368,28 +368,7 @@ export const FootballMatchList = ({
 	return (
 		<>
 			{days.map((day) => (
-				<section
-					css={css`
-						${grid.paddedContainer}
-						position: relative;
-						${from.tablet} {
-							&::before,
-							&::after {
-								content: '';
-								position: absolute;
-								border-left: 1px solid
-									${palette('--article-border')};
-								top: 0;
-								bottom: 0;
-							}
-
-							&::after {
-								right: 0;
-							}
-						}
-					`}
-					key={day.date.toISOString()}
-				>
+				<Fragment key={day.date.toISOString()}>
 					<Day>{dateFormatter.format(day.date)}</Day>
 					{day.competitions.map((competition) => (
 						<Fragment key={competition.id}>
@@ -419,11 +398,11 @@ export const FootballMatchList = ({
 							</Matches>
 						</Fragment>
 					))}
-				</section>
+				</Fragment>
 			))}
 
 			{getMoreDays === undefined ? null : (
-				<div css={css(grid.paddedContainer)}>
+				<div>
 					<div
 						css={css`
 							${grid.column.centre}

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -49,57 +49,54 @@ export const FootballMatchesPage = ({
 	getMoreDays,
 	renderAds,
 }: Props) => (
-	<main id="maincontent" data-layout="FootballDataPageLayout">
-		<div
-			css={css`
-				${grid.paddedContainer}
-				position: relative;
-				${from.tablet} {
-					&::before,
-					&::after {
-						content: '';
-						position: absolute;
-						border-left: 1px solid ${palette('--article-border')};
-						top: 0;
-						bottom: 0;
-					}
+	<main
+		id="maincontent"
+		data-layout="FootballDataPageLayout"
+		css={css`
+			${grid.paddedContainer}
+			position: relative;
+			${from.tablet} {
+				&::before,
+				&::after {
+					content: '';
+					position: absolute;
+					border-left: 1px solid ${palette('--article-border')};
+					top: 0;
+					bottom: 0;
+				}
 
-					&::after {
-						right: 0;
-					}
+				&::after {
+					right: 0;
+				}
+			}
+		`}
+	>
+		<h1
+			css={css`
+				${headlineBold20}
+				padding: ${space[2]}px 0 ${space[3]}px;
+				${grid.column.centre}
+				${from.leftCol} {
+					${grid.between('left-column-start', 'centre-column-end')}
 				}
 			`}
 		>
-			<h1
-				css={css`
-					${headlineBold20}
-					padding: ${space[2]}px 0 ${space[3]}px;
-					${grid.column.centre}
-					${from.leftCol} {
-						${grid.between(
-							'left-column-start',
-							'centre-column-end',
-						)}
-					}
-				`}
-			>
-				{createTitle(kind, edition)}
-			</h1>
-			<div
-				css={css`
-					margin-top: ${space[3]}px;
-					margin-bottom: ${space[6]}px;
-					${grid.column.centre}
-				`}
-			>
-				<FootballCompetitionSelect
-					nations={nations}
-					kind={kind}
-					onChange={goToCompetitionSpecificPage}
-				/>
-			</div>
-			{renderAds && <AdSlot position="right-football" />}
+			{createTitle(kind, edition)}
+		</h1>
+		<div
+			css={css`
+				margin-top: ${space[3]}px;
+				margin-bottom: ${space[6]}px;
+				${grid.column.centre}
+			`}
+		>
+			<FootballCompetitionSelect
+				nations={nations}
+				kind={kind}
+				onChange={goToCompetitionSpecificPage}
+			/>
 		</div>
+		{renderAds && <AdSlot position="right-football" />}
 		<FootballMatchList
 			initialDays={initialDays}
 			edition={edition}


### PR DESCRIPTION
- one grid instead of two
- position sticky
- hacky grid row

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
