### PR TITLE
Remove epic slot from crossword layout

### DIFF
--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -25,7 +25,6 @@ import { Island } from '../components/Island';
 import { Masthead } from '../components/Masthead/Masthead';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
-import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
@@ -329,47 +328,6 @@ export const CrosswordLayout = (props: Props) => {
 								</RightColumn>
 							</GridItem>
 						</CrosswordGrid>
-					</div>
-				</Section>
-
-				<Section
-					stretchRight={false}
-					showTopBorder={false}
-					backgroundColour={themePalette('--article-background')}
-					borderColour={themePalette('--article-border')}
-					fontColour={themePalette('--article-section-title')}
-					padContent={false}
-					verticalMargins={false}
-				>
-					<div
-						css={css`
-							max-width: 620px;
-						`}
-					>
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<SlotBodyEnd
-								contentType={article.contentType}
-								contributionsServiceUrl={
-									contributionsServiceUrl
-								}
-								idApiUrl={article.config.idApiUrl}
-								isMinuteArticle={
-									article.pageType.isMinuteArticle
-								}
-								isPaidContent={article.pageType.isPaidContent}
-								pageId={article.pageId}
-								sectionId={article.config.section}
-								shouldHideReaderRevenue={
-									article.shouldHideReaderRevenue
-								}
-								tags={article.tags}
-								renderAds={renderAds}
-								isLabs={false}
-								articleEndSlot={
-									!!article.config.switches.articleEndSlot
-								}
-							/>
-						</Island>
 					</div>
 				</Section>
 


### PR DESCRIPTION
## What does this change?

- Remove the epic slot from the crossword layout

## Why?

This is not present in the frontend-rendered version of crosswords. 

It looks a bit lost at desktop width, floating in a sea of empty space.

## Screenshots (pre-change)

**Mobile**

![2025-03-07 08 51 30](https://github.com/user-attachments/assets/f26820f2-8e05-4d6a-9aaa-3ce5e56adbdf)

**Desktop**

![2025-03-07 08 58 46](https://github.com/user-attachments/assets/3c79a316-b425-4b6d-a9c3-987101a8770a)

