### PR TITLE
Update braze.e2e.spec.ts

### DIFF
--- a/dotcom-rendering/playwright/tests/braze.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/braze.e2e.spec.ts
@@ -13,6 +13,9 @@ const idapiIdentifiersResponse = {
 	googleTagId: 'aaaaaaaaaaaa',
 };
 
+const userBenefitsApiUrl =
+	'https://user-benefits.code.dev-guardianapis.com/benefits/me';
+
 const expectLocalStorageItem = (
 	page: Page,
 	key: string,
@@ -33,7 +36,7 @@ const expectLocalStorageItem = (
 };
 
 test.describe('Braze messaging', () => {
-	test.skip('records in local storage that the Braze SDK was loaded', async ({
+	test('records in local storage that the Braze SDK was loaded', async ({
 		context,
 		page,
 	}) => {
@@ -60,7 +63,11 @@ test.describe('Braze messaging', () => {
 		const choiceGdprRequestPromise =
 			page.waitForRequest('**/choice/gdpr/**');
 
-		await loadPageNoOkta(page, standardArticle);
+		await loadPageNoOkta(page, standardArticle, {
+			configOverrides: {
+				userBenefitsApiUrl,
+			},
+		});
 
 		await cmpAcceptAll(page);
 
@@ -73,7 +80,7 @@ test.describe('Braze messaging', () => {
 		await expectLocalStorageItem(page, 'gu.brazeUserSet', 'true');
 	});
 
-	test.skip('clears Braze data when a user logs out', async ({
+	test('clears Braze data when a user logs out', async ({
 		context,
 		page,
 	}) => {
@@ -100,7 +107,11 @@ test.describe('Braze messaging', () => {
 		const choiceGdprRequestPromise =
 			page.waitForRequest('**/choice/gdpr/**');
 
-		await loadPageNoOkta(page, standardArticle);
+		await loadPageNoOkta(page, standardArticle, {
+			configOverrides: {
+				userBenefitsApiUrl,
+			},
+		});
 
 		await cmpAcceptAll(page);
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
