### PR TITLE
Update dependencies for auxia request hook

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -711,7 +711,7 @@ const SignInGateSelectorAuxia = ({
 		})().catch((error) => {
 			console.error('Error fetching Auxia display data:', error);
 		});
-	}, [abTest]);
+	}, [abTest, isSignedIn, isPaidContent, isPreview]);
 
 	// We are not showing the gate if we are in preview, it's a paid contents
 	// or the user is signed in or if for some reasons we could not determine the


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/dotcom-rendering/pull/13526) fixed an issue where we were making reqests to Auxia for signed-in users.

The `useOnce` hook takes a list of dependencies which must all be defined before it is called, and `isSignedIn` in particular should be a dependency.
I'm not sure this will make much difference.