### PR TITLE
Track when auxia treatment is returned

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -706,6 +706,25 @@ const SignInGateSelectorAuxia = ({
 				);
 				if (data !== undefined) {
 					setAuxiaGateDisplayData(data);
+
+					const treatmentId =
+						data.auxiaData.userTreatment?.treatmentId;
+					if (treatmentId) {
+						// Record the fact that Auxia has returned a treatment. This is not a VIEW event, so we use the RETURN action here
+						await submitComponentEventTracking(
+							{
+								component: {
+									componentType: 'SIGN_IN_GATE',
+									id: treatmentId,
+								},
+								action: 'RETURN',
+								abTest: buildAbTestTrackingAuxiaVariant(
+									treatmentId,
+								),
+							},
+							renderingTarget,
+						);
+					}
 				}
 			}
 		})().catch((error) => {


### PR DESCRIPTION
This is to aid an investigation into Auxia view event tracking.
Here we send an ophan component even when Auxia returns a "treatment", which means we should display a sign-in gate.

Here we use the `RETURN` action type. This is the closest I could find from the [available set of action types](https://github.com/guardian/csnx/blob/6a1e951e55caaa48345ef3ecdf50d9c1e5caf34f/libs/%40guardian/libs/src/ophan/%40types/index.ts#L26).
