### PR TITLE
Do not await auxia tracking events

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -711,7 +711,7 @@ const SignInGateSelectorAuxia = ({
 						data.auxiaData.userTreatment?.treatmentId;
 					if (treatmentId) {
 						// Record the fact that Auxia has returned a treatment. This is not a VIEW event, so we use the RETURN action here
-						await submitComponentEventTracking(
+						void submitComponentEventTracking(
 							{
 								component: {
 									componentType: 'SIGN_IN_GATE',
@@ -811,28 +811,27 @@ const ShowSignInGateAuxia = ({
 	const personaliseSignInGateAfterCheckoutSwitch = undefined;
 
 	useOnce(() => {
-		void (async () => {
-			await auxiaLogTreatmentInteraction(
-				contributionsServiceUrl,
-				userTreatment,
-				'VIEWED',
-				'',
-				browserId,
-			);
-			await submitComponentEventTracking(
-				{
-					component: {
-						componentType: 'SIGN_IN_GATE',
-						id: treatmentId,
-					},
-					action: 'VIEW',
-					abTest: buildAbTestTrackingAuxiaVariant(treatmentId),
-				},
-				renderingTarget,
-			);
-		})().catch((error) => {
+		void auxiaLogTreatmentInteraction(
+			contributionsServiceUrl,
+			userTreatment,
+			'VIEWED',
+			'',
+			browserId,
+		).catch((error) => {
 			console.error('Failed to log treatment interaction:', error);
 		});
+
+		void submitComponentEventTracking(
+			{
+				component: {
+					componentType: 'SIGN_IN_GATE',
+					id: treatmentId,
+				},
+				action: 'VIEW',
+				abTest: buildAbTestTrackingAuxiaVariant(treatmentId),
+			},
+			renderingTarget,
+		);
 	}, [componentId]);
 
 	return (


### PR DESCRIPTION
For the auxia sign-in gate we send tracking events to both ophan and auxia (via SDC).
Currently these have an `await` before them, but actually this is unnecessary.
It's particularly undesirable for the VIEW event, where currently the ophan call is not made until the response from SDC is received.
Replacing `await` with `void` indicates that we do not depend on the result.

Tested locally to confirm these events are still sent when a sign-in gate is returned.