### PR TITLE
Card gap sizing amendments

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1062,7 +1062,6 @@ export const Card = ({
 						imageType={media?.type}
 						imageSize={imageSize}
 						isBetaContainer={isBetaContainer}
-						isFlexibleContainer={isFlexibleContainer}
 						imagePositionOnDesktop={imagePositionOnDesktop}
 						imagePositionOnMobile={imagePositionOnMobile}
 						padContent={determinePadContent(

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -499,6 +499,7 @@ export const Card = ({
 		<div
 			css={css`
 				margin-top: auto;
+				display: flex;
 			`}
 		>
 			{isVideoArticle && (
@@ -626,7 +627,10 @@ export const Card = ({
 		}
 	};
 
-	/** Determines the gap of between card components based on card properties */
+	/**
+	 * Determines the gap of between card components based on card properties
+	 * Order matters here as the logic is based on the card properties
+	 */
 	const getGapSizes = (): GapSizes => {
 		if (isOnwardContent) {
 			return {
@@ -634,43 +638,50 @@ export const Card = ({
 				column: 'none',
 			};
 		}
-		if (isMediaCardOrNewsletter && !isFlexibleContainer) {
-			return {
-				row: 'tiny',
-				column: 'tiny',
-			};
-		}
-		if (!!isFlexSplash || (isFlexibleContainer && imageSize === 'jumbo')) {
+
+		if (isFlexSplash) {
 			return {
 				row: 'small',
-				column: 'small',
+				column: 'none',
 			};
 		}
+
+		if (!isBetaContainer) {
+			/**
+			 * Media cards have 4px padding around the content so we have a
+			 * tiny (4px) gap to account for this and make it 8px total
+			 */
+			if (isMediaCardOrNewsletter) {
+				return {
+					row: 'tiny',
+					column: 'tiny',
+				};
+			}
+
+			// Current cards have small padding for everything
+			return { row: 'small', column: 'small' };
+		}
+
 		if (isSmallCard) {
 			return {
 				row: 'medium',
 				column: 'medium',
 			};
 		}
-		if (isBetaContainer && media?.type === 'avatar') {
-			return {
-				row: 'small',
-				column: 'small',
-			};
-		}
+
 		if (
-			isFlexibleContainer &&
-			(imagePositionOnDesktop === 'left' ||
-				imagePositionOnDesktop === 'right')
+			imagePositionOnDesktop === 'bottom' ||
+			imagePositionOnMobile === 'bottom'
 		) {
 			return {
-				row: 'large',
+				row: 'tiny',
 				column: 'large',
 			};
 		}
+
 		return {
-			row: isBetaContainer ? 'tiny' : 'small',
-			column: 'small',
+			row: 'small',
+			column: 'large',
 		};
 	};
 
@@ -1050,13 +1061,20 @@ export const Card = ({
 					<ContentWrapper
 						imageType={media?.type}
 						imageSize={imageSize}
+						isBetaContainer={isBetaContainer}
+						isFlexibleContainer={isFlexibleContainer}
 						imagePositionOnDesktop={imagePositionOnDesktop}
+						imagePositionOnMobile={imagePositionOnMobile}
 						padContent={determinePadContent(
 							isMediaCardOrNewsletter,
 							isBetaContainer,
 							isOnwardContent,
 						)}
-						isFlexibleContainer={isFlexibleContainer}
+						padRight={
+							!!isFlexSplash &&
+							image &&
+							imagePositionOnDesktop === 'right'
+						}
 					>
 						{/* This div is needed to keep the headline and trail text justified at the start */}
 						<div

--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -156,7 +156,7 @@ const decidePosition = (
 	`;
 };
 
-/** Detemines the gap size between components in card layout */
+/** Determines the gap size between components in card layout */
 const decideGap = (gapSize: GapSize) => {
 	switch (gapSize) {
 		case 'none':
@@ -171,6 +171,14 @@ const decideGap = (gapSize: GapSize) => {
 			return `${space[5]}px`;
 	}
 };
+
+const decideColumnGap = (gapSize: GapSize) => css`
+	column-gap: ${gapSize === 'large' ? '10px' : decideGap(gapSize)};
+
+	${from.tablet} {
+		column-gap: ${decideGap(gapSize)};
+	}
+`;
 
 export const CardLayout = ({
 	children,
@@ -196,11 +204,11 @@ export const CardLayout = ({
 					isBetaContainer,
 					imageType === 'avatar',
 				),
+				decideColumnGap(gapSizes.column),
 			]}
 			style={{
 				backgroundColor: cardBackgroundColour,
 				rowGap: decideGap(gapSizes.row),
-				columnGap: decideGap(gapSizes.column),
 			}}
 		>
 			{children}

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -62,33 +62,31 @@ const flexBasisStyles = ({
 
 type ImageDirection = 'vertical' | 'horizontal' | 'none';
 
+/**
+ * There is no padding on the side of the image where the text is.
+ */
 const paddingBetaContainerStyles = (
-	imageDirectionMobile: ImageDirection,
-	imageDirectionDesktop: ImageDirection,
-	imagePositionOnDesktop: ImagePositionType,
-	paddingWidth: 1 | 2,
-	isFlexibleContainer: boolean,
+	imagePositionMobile: ImagePositionType,
+	imagePositionDesktop: ImagePositionType,
+	padding: 1 | 2,
 ) => css`
 	${until.tablet} {
-		padding-left: ${imageDirectionMobile !== 'horizontal' &&
-		`${space[paddingWidth]}px`};
-		padding-right: ${imageDirectionMobile !== 'horizontal' &&
-		`${space[paddingWidth]}px`};
-		padding-top: ${imageDirectionMobile !== 'vertical' &&
-		`${space[paddingWidth]}px`};
-		padding-bottom: ${imageDirectionMobile !== 'vertical' &&
-		`${space[paddingWidth]}px`};
+		padding-left: ${imagePositionMobile !== 'left' &&
+		`${space[padding]}px`};
+		padding-right: ${imagePositionMobile !== 'right' &&
+		`${space[padding]}px`};
+		padding-top: ${imagePositionMobile !== 'top' && `${space[padding]}px`};
+		padding-bottom: ${imagePositionMobile !== 'bottom' &&
+		`${space[padding]}px`};
 	}
 	${from.tablet} {
-		padding-left: ${imageDirectionDesktop !== 'horizontal' &&
-		`${space[paddingWidth]}px`};
-		padding-right: ${imageDirectionDesktop !== 'horizontal' &&
-		`${space[paddingWidth]}px`};
-		padding-top: ${imageDirectionDesktop !== 'vertical' &&
-		`${space[paddingWidth]}px`};
-		padding-bottom: ${(imageDirectionDesktop !== 'vertical' ||
-			(!isFlexibleContainer && imagePositionOnDesktop === 'top')) &&
-		`${space[paddingWidth]}px`};
+		padding-left: ${imagePositionDesktop !== 'left' &&
+		`${space[padding]}px`};
+		padding-right: ${imagePositionDesktop !== 'right' &&
+		`${space[padding]}px`};
+		padding-top: ${imagePositionDesktop !== 'top' && `${space[padding]}px`};
+		padding-bottom: ${imagePositionDesktop !== 'bottom' &&
+		`${space[padding]}px`};
 	}
 `;
 
@@ -117,7 +115,6 @@ type Props = {
 	imageType?: CardImageType;
 	imageSize: ImageSizeType;
 	isBetaContainer: boolean;
-	isFlexibleContainer: boolean;
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	padContent?: 'small' | 'large';
@@ -129,14 +126,12 @@ export const ContentWrapper = ({
 	imageType,
 	imageSize,
 	isBetaContainer,
-	isFlexibleContainer,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	padContent,
 	padRight = false,
 }: Props) => {
 	const imageDirectionDesktop = getImageDirection(imagePositionOnDesktop);
-	const imageDirectionMobile = getImageDirection(imagePositionOnMobile);
 	const paddingSpace = padContent === 'small' ? 1 : 2;
 
 	return (
@@ -153,11 +148,9 @@ export const ContentWrapper = ({
 				padContent &&
 					isBetaContainer &&
 					paddingBetaContainerStyles(
-						imageDirectionMobile,
-						imageDirectionDesktop,
+						imagePositionOnMobile,
 						imagePositionOnDesktop,
 						paddingSpace,
-						isFlexibleContainer,
 					),
 				padRight && padRightStyles,
 			]}

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -53,6 +53,27 @@ const imageOverlayContainerStyles = css`
 `;
 
 /**
+ * There is no padding on the side of the image where the text is.
+ */
+const imagePaddingStyles = (
+	imagePositionOnDesktop: ImagePositionType,
+	imagePositionOnMobile: ImagePositionType,
+) => css`
+	${until.tablet} {
+		padding-left: ${imagePositionOnMobile !== 'right' && `${space[2]}px`};
+		padding-right: ${imagePositionOnMobile !== 'left' && `${space[2]}px`};
+		padding-top: ${imagePositionOnMobile !== 'bottom' && `${space[2]}px`};
+		padding-bottom: ${imagePositionOnMobile !== 'top' && `${space[2]}px`};
+	}
+	${from.tablet} {
+		padding-left: ${imagePositionOnDesktop !== 'right' && `${space[2]}px`};
+		padding-right: ${imagePositionOnDesktop !== 'left' && `${space[2]}px`};
+		padding-top: ${imagePositionOnDesktop !== 'bottom' && `${space[2]}px`};
+		padding-bottom: ${imagePositionOnDesktop !== 'top' && `${space[2]}px`};
+	}
+`;
+
+/**
  * This function works in partnership with its sibling in `ContentWrapper`. If you
  * change any values here be sure to update that file as well.
  */
@@ -122,10 +143,6 @@ const fixImageWidth = ({
 	`}
 `;
 
-const imagePadding = css`
-	padding: ${space[2]}px;
-`;
-
 export const ImageWrapper = ({
 	children,
 	imageSize,
@@ -179,7 +196,11 @@ export const ImageWrapper = ({
 						display: block;
 					}
 				`,
-				padImage && imagePadding,
+				padImage &&
+					imagePaddingStyles(
+						imagePositionOnDesktop,
+						imagePositionOnMobile,
+					),
 			]}
 		>
 			<>
@@ -190,7 +211,11 @@ export const ImageWrapper = ({
 						<div
 							css={[
 								imageOverlayContainerStyles,
-								padImage && imagePadding,
+								padImage &&
+									imagePaddingStyles(
+										imagePositionOnDesktop,
+										imagePositionOnMobile,
+									),
 							]}
 						>
 							{/* This child div is needed as the hover background colour covers the padded


### PR DESCRIPTION
## What does this change?

Amends the amount of space between content and image on cards in beta containers.

## Why?

To [match](https://www.figma.com/design/uNL0UL65eoC80JPrglYrAx/Fairground---Flexible-Containers?node-id=11-3&p=f&t=BEj1NCOh9YYr4jI4-0) [designs](https://www.figma.com/design/OBiUI7dJkso1GXfsovfzaY/%E2%97%88-Web-library?node-id=3835-1089&t=eW7WHTScSlwANrhg-0).

## Screenshots

Flex splash: space between text and image is increased from 8px to 20px

| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before2]: https://github.com/user-attachments/assets/e76a3c8a-c4ec-4df3-921f-19f0ee4348bf
[after2]: https://github.com/user-attachments/assets/10f996db-46c9-44cb-8c7e-182e1db407b0

Space between image and text on mobile is reduced from 20px to 10px

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5b4eccb9-94b6-4599-844f-1dc2d3d9cf60
[after]: https://github.com/user-attachments/assets/5604252e-7404-44e3-be5f-3a21a90a2054

Vertical cards: space between image and text on desktop is reduced

| Before      | After      |
| ----------- | ---------- |
| ![before3][] | ![after3][] |

[before3]: https://github.com/user-attachments/assets/283a8704-74f7-4c1f-8136-39c9560b11f4
[after3]: https://github.com/user-attachments/assets/b2b53760-6551-46a0-893a-5364abd90fbe

Media pill aligns with bottom of image.

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |

[before1]: https://github.com/user-attachments/assets/ef26049f-a510-44c1-be7a-fc20a890602b
[after1]: https://github.com/user-attachments/assets/cdc00bea-7388-4489-b1dc-e19cba2c70bd

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
