### PR TITLE
Limit allowed ad size in football-right slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -544,6 +544,8 @@ export const AdSlot = ({
 						data-name="right"
 						data-testid="slot"
 						aria-hidden="true"
+						// Football fixtures pages cannot always support longer right column ads, so limit allowed size
+						data-desktop="300,250"
 					/>
 				</div>
 			);


### PR DESCRIPTION
## What does this change?

This adds a data attribute to the `football-right` ad slot which limits the size of ads which can be served in it, utilising [existing functionality in commercial code](https://github.com/guardian/commercial/blob/307061939b824678905ab4fdc64fd1e07faa4792/src/define/Advert.ts#L55).

## Why?

The football fixtures pages are often so short that serving a double MPU (300 x 600) significantly lengthens the page, causing CLS. While it is possible for pages to be so short that even the standard MPU (300 x 250) adds height, the impact is fairly minor, and introducing code to the commercial bundle to entirely remove the slot specifically on these pages based on page height adds significant complexity.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
