### PR TITLE
On card hover, stop background colour covering padding of image

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -42,11 +42,8 @@ const baseCardStyles = css`
 
 const hoverStyles = css`
 	:hover .image-overlay {
-		position: absolute;
-		top: 0;
 		width: 100%;
 		height: 100%;
-		left: 0;
 		background-color: ${palette('--card-background-hover')};
 	}
 

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -44,10 +44,17 @@ type Props = {
 	padImage?: boolean;
 };
 
+const imageOverlayContainerStyles = css`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+`;
+
 /**
  * This function works in partnership with its sibling in `ContentWrapper`. If you
  * change any values here be sure to update that file as well.
- *
  */
 const flexBasisStyles = ({
 	imageSize,
@@ -179,7 +186,18 @@ export const ImageWrapper = ({
 				{children}
 				{/* This image overlay is styled when the CardLink is hovered */}
 				{(imageType === 'picture' || imageType === 'slideshow') &&
-					!hideImageOverlay && <div className="image-overlay" />}
+					!hideImageOverlay && (
+						<div
+							css={[
+								imageOverlayContainerStyles,
+								padImage && imagePadding,
+							]}
+						>
+							{/* This child div is needed as the hover background colour covers the padded
+							    area around the image when the hover styles are applied to the top-level div */}
+							<div className="image-overlay" />
+						</div>
+					)}
 			</>
 		</div>
 	);

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -66,9 +66,9 @@ const hoverStyles = css`
 	:hover .image-overlay {
 		position: absolute;
 		top: 0;
+		left: 0;
 		width: 100%;
 		height: 100%;
-		left: 0;
 		background-color: ${palette('--card-background-hover')};
 	}
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -182,7 +182,6 @@ export const TwoSublinkSplash: Story = {
 		groupedTrails: {
 			...defaultGroupedTrails,
 			splash: [{ ...splashCard, supportingContent: getSublinks(2) }],
-			standard: standardCards,
 		},
 	},
 };
@@ -198,7 +197,6 @@ export const FourSublinkSplash: Story = {
 		groupedTrails: {
 			...defaultGroupedTrails,
 			splash: [splashWithFourSublinks],
-			standard: standardCards,
 		},
 	},
 };
@@ -273,7 +271,6 @@ export const FourSublinkSplashWithLiveUpdates: Story = {
 		groupedTrails: {
 			...defaultGroupedTrails,
 			splash: [liveUpdatesCard],
-			standard: standardCards,
 		},
 	},
 	render: ({ frontSectionTitle, ...args }) => {
@@ -303,7 +300,6 @@ export const BoostedSplash: Story = {
 					boostLevel: 'boost',
 				},
 			],
-			standard: standardCards,
 		},
 	},
 };
@@ -320,7 +316,6 @@ export const MegaBoostedSplash: Story = {
 					boostLevel: 'megaboost',
 				},
 			],
-			standard: standardCards,
 		},
 	},
 };
@@ -337,7 +332,6 @@ export const GigaBoostedSplash: Story = {
 					boostLevel: 'gigaboost',
 				},
 			],
-			standard: standardCards,
 		},
 	},
 };


### PR DESCRIPTION
## What does this change?

When a user hovers over a card, the background colour now only covers the image, not the image + padding.

Removes duplicated cards from stories.

## Why?

Design fix. It's currently not that noticeable given the symmetry.  However, there are changes coming soon that will remove the padding from one side of the image in certain scenarios, which would make this bug much more noticeable.

## Screenshots

The card on hover (mouse isn't visible)

| Before      | After      |
| ---------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f9626d1e-7a7a-46b5-ba9e-e2fc4c831060
[after]: https://github.com/user-attachments/assets/88ed9825-42ec-4665-87aa-99b15824685e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
