### PR TITLE
Use `aside` rather than `div` for ad slot container

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, type Interpolation } from '@emotion/react';
 import type { SlotName } from '@guardian/commercial';
 import { adSizes, constants } from '@guardian/commercial';
 import {
@@ -382,6 +382,22 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${adSizes.mobilesticky.height + constants.AD_LABEL_HEIGHT}px;
 `;
 
+const AdSlotWrapper = ({
+	children,
+	css: additionalCss,
+	className = 'ad-slot-container',
+}: {
+	children: React.ReactNode;
+	css?: Interpolation;
+	className?: string;
+}) => {
+	return (
+		<aside className={className} css={additionalCss}>
+			{children}
+		</aside>
+	);
+};
+
 export const AdSlot = ({
 	position,
 	display,
@@ -395,7 +411,7 @@ export const AdSlot = ({
 			switch (display) {
 				case ArticleDisplay.Immersive: {
 					return (
-						<div className="ad-slot-container">
+						<AdSlotWrapper>
 							<div
 								id="dfp-ad--right"
 								css={rightAdStyles}
@@ -412,16 +428,13 @@ export const AdSlot = ({
 								data-testid="slot"
 								aria-hidden="true"
 							/>
-						</div>
+						</AdSlotWrapper>
 					);
 				}
 				case ArticleDisplay.Showcase:
 				case ArticleDisplay.NumberedList: {
 					return (
-						<div
-							className="ad-slot-container"
-							css={[showcaseRightColumnContainerStyles]}
-						>
+						<AdSlotWrapper css={showcaseRightColumnContainerStyles}>
 							<div
 								id="dfp-ad--right"
 								css={[rightAdStyles, showcaseRightColumnStyles]}
@@ -438,7 +451,7 @@ export const AdSlot = ({
 								data-testid="slot"
 								aria-hidden="true"
 							/>
-						</div>
+						</AdSlotWrapper>
 					);
 				}
 				case ArticleDisplay.Standard: {
@@ -458,9 +471,7 @@ export const AdSlot = ({
 									}
 								/>
 							</Island>
-							<div
-								id="top-right-ad-slot"
-								className="ad-slot-container"
+							<AdSlotWrapper
 								css={[
 									css`
 										position: static;
@@ -497,7 +508,7 @@ export const AdSlot = ({
 									data-testid="slot"
 									aria-hidden="true"
 								/>
-							</div>
+							</AdSlotWrapper>
 						</>
 					);
 				}
@@ -507,8 +518,7 @@ export const AdSlot = ({
 		case 'right-football': {
 			const slotId = 'dfp-ad--right';
 			return (
-				<div
-					className="ad-slot-container"
+				<AdSlotWrapper
 					css={[
 						css`
 							height: 100%;
@@ -545,12 +555,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'comments': {
 			return (
-				<div className="ad-slot-container">
+				<AdSlotWrapper>
 					<div
 						id="dfp-ad--comments"
 						className={[
@@ -566,15 +576,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'top-above-nav': {
 			return (
-				<div
-					css={[topAboveNavContainerStyles]}
-					className="ad-slot-container"
-				>
+				<AdSlotWrapper css={[topAboveNavContainerStyles]}>
 					<div
 						id="dfp-ad--top-above-nav"
 						className={[
@@ -589,16 +596,13 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					></div>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'mostpop': {
 			return (
 				<Hide until="tablet">
-					<div
-						className="ad-slot-container"
-						css={[mostPopContainerStyles]}
-					>
+					<AdSlotWrapper css={mostPopContainerStyles}>
 						<div
 							id="dfp-ad--mostpop"
 							className={[
@@ -614,16 +618,13 @@ export const AdSlot = ({
 							data-testid="slot"
 							aria-hidden="true"
 						/>
-					</div>
+					</AdSlotWrapper>
 				</Hide>
 			);
 		}
 		case 'merchandising-high': {
 			return (
-				<div
-					className="ad-slot-container"
-					css={[merchandisingAdContainerStyles]}
-				>
+				<AdSlotWrapper css={[merchandisingAdContainerStyles]}>
 					<div
 						id="dfp-ad--merchandising-high"
 						className={[
@@ -638,15 +639,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'merchandising': {
 			return (
-				<div
-					className="ad-slot-container"
-					css={[merchandisingAdContainerStyles]}
-				>
+				<AdSlotWrapper css={merchandisingAdContainerStyles}>
 					<div
 						id="dfp-ad--merchandising"
 						className={[
@@ -660,7 +658,7 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'fronts-banner': {
@@ -670,8 +668,7 @@ export const AdSlot = ({
 					className="top-fronts-banner-ad-container"
 					css={frontsBannerAdTopContainerStyles}
 				>
-					<div
-						className="ad-slot-container"
+					<AdSlotWrapper
 						css={[
 							frontsBannerAdContainerStyles,
 							hasPageskin && frontsBannerCollapseStyles,
@@ -692,7 +689,7 @@ export const AdSlot = ({
 							data-testid="slot"
 							aria-hidden="true"
 						/>
-					</div>
+					</AdSlotWrapper>
 				</div>
 			);
 		}
@@ -719,7 +716,7 @@ export const AdSlot = ({
 		case 'liveblog-inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div
+				<AdSlotWrapper
 					className="ad-slot-container ad-slot-desktop"
 					css={liveblogInlineContainerStyles}
 				>
@@ -738,16 +735,13 @@ export const AdSlot = ({
 						data-testid={`liveblog-inline--${advertId}`}
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'liveblog-inline-mobile': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div
-					className="ad-slot-container ad-slot-mobile"
-					css={liveblogInlineContainerStyles}
-				>
+				<AdSlotWrapper css={liveblogInlineContainerStyles}>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -763,15 +757,12 @@ export const AdSlot = ({
 						data-testid={`liveblog-inline-mobile--${advertId}`}
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'liveblog-top': {
 			return (
-				<div
-					className="ad-slot-container"
-					css={[liveBlogTopContainerStyles]}
-				>
+				<AdSlotWrapper css={liveBlogTopContainerStyles}>
 					<div
 						id="dfp-ad--liveblog-top"
 						className={[
@@ -786,13 +777,13 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'mobile-front': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div className="ad-slot-container">
+				<AdSlotWrapper>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -810,12 +801,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'pageskin': {
 			return (
-				<div className="ad-slot-container">
+				<AdSlotWrapper>
 					<div
 						id="dfp-ad--pageskin-inread"
 						className={[
@@ -834,12 +825,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'article-end': {
 			return (
-				<div className="ad-slot-container">
+				<AdSlotWrapper>
 					<div
 						id="dfp-ad--article-end"
 						className={[
@@ -854,12 +845,12 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 		case 'crossword-banner-mobile': {
 			return (
-				<div className="ad-slot-container">
+				<AdSlotWrapper>
 					<div
 						id="dfp-ad--crossword-banner-mobile"
 						className={[
@@ -874,7 +865,7 @@ export const AdSlot = ({
 						data-testid="slot"
 						aria-hidden="true"
 					/>
-				</div>
+				</AdSlotWrapper>
 			);
 		}
 	}


### PR DESCRIPTION
## What does this change?

Uses `aside` element as the containing element around ad slots. Does this by adding a new wrapper component `AdSlotWrapper`.

Maintains existing styles and classes apart from `ad-slot-mobile` [which isn't referenced anywhere else](https://github.com/search?q=org%3Aguardian+ad-slot-mobile&type=code)


## Why?

This is more semantic and as such, it should improve SEO and the accessibility experience

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/823f36bd-d4f2-4ff9-9704-209b2d14a8af
[after]: https://github.com/user-attachments/assets/729f5e1f-92b0-403a-bd4d-c2ab9b3293f5
