### PR TITLE
Don't show Card grey bounding box when no image

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1714,3 +1714,51 @@ export const WithAVerticalGapWhenScrollableSmallContainer = () => {
 		</>
 	);
 };
+
+export const WithBetaContainerAndSublinks = () => {
+	return (
+		<CardGroup>
+			{/* With an image */}
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					image={undefined}
+					containerType="flexible/general"
+					imagePositionOnMobile="bottom"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline: 'Headline 1',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline: 'Headline 2',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+			{/* Without an image */}
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					containerType="flexible/general"
+					imagePositionOnMobile="bottom"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline: 'Headline 1',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline: 'Headline 2',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -693,7 +693,9 @@ export const Card = ({
 				isDynamo={isDynamo}
 				fillBackgroundOnMobile={
 					!!isFlexSplash ||
-					(isBetaContainer && imagePositionOnMobile === 'bottom')
+					(isBetaContainer &&
+						!!image &&
+						imagePositionOnMobile === 'bottom')
 				}
 			/>
 		);


### PR DESCRIPTION
## What does this change?

In the new beta containers, when there are sublinks and the image is placed below the content, the sublinks are surrounded with a grey box. We no longer show the grey box if there is not a card image

## Why?

Better UI

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/b0299006-45b3-4b67-af72-21e5a89ec102
[after]: https://github.com/user-attachments/assets/3039aa9e-821a-48df-b2d9-ad5ac0bb8b7b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
