### PR TITLE
Football Data Pages: Add mappings for live match status

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballMatches.ts
+++ b/dotcom-rendering/fixtures/manual/footballMatches.ts
@@ -70,6 +70,11 @@ export const matchDayLive: FEMatchDay = {
 	},
 };
 
+export const matchDayLiveSecondHalf: FEMatchDay = {
+	...matchDayLive,
+	matchStatus: 'SHS',
+};
+
 export const liveMatch: FELive = {
 	...matchData,
 	type: 'LiveMatch',

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -3,6 +3,7 @@ import {
 	emptyMatches,
 	liveMatch,
 	matchDayLive,
+	matchDayLiveSecondHalf,
 	matchFixture,
 	matchResult,
 } from '../fixtures/manual/footballMatches';
@@ -12,7 +13,7 @@ import type {
 	FEMatchDay,
 	FEResult,
 } from './feFootballDataPage';
-import { parse, parseMatchResult } from './footballMatches';
+import { parse, parseLiveMatch, parseMatchResult } from './footballMatches';
 import { errorOrThrow, okOrThrow } from './lib/result';
 
 const withMatches = (
@@ -196,5 +197,26 @@ describe('footballMatches', () => {
 			);
 			expect(match.homeTeam.name).toBe(cleanName);
 		}
+	});
+	it('should replace known live match status with our status', () => {
+		const matchDay = okOrThrow(
+			parseLiveMatch(matchDayLiveSecondHalf),
+			'Expected football live match parsing to succeed',
+		);
+
+		expect(matchDay.status).toBe('2nd');
+	});
+	it('should replace unknown live match status with first two characters', () => {
+		const matchDayLiveUnknownStatus = {
+			...matchDayLiveSecondHalf,
+			matchStatus: 'Something odd',
+		};
+
+		const matchDay = okOrThrow(
+			parseLiveMatch(matchDayLiveUnknownStatus),
+			'Expected football live match parsing to succeed',
+		);
+
+		expect(matchDay.status).toBe('So');
 	});
 });

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -273,7 +273,7 @@ export const parseMatchResult = (
 	});
 };
 
-const parseLiveMatch = (
+export const parseLiveMatch = (
 	feMatchDay: FEMatchDay,
 ): Result<ParserError, LiveMatch> => {
 	if (!feMatchDay.liveMatch) {
@@ -314,7 +314,7 @@ const parseLiveMatch = (
 		dateTimeISOString: date.value,
 		paId: feMatchDay.id,
 		comment: feMatchDay.comments,
-		status: feMatchDay.matchStatus,
+		status: replaceLiveMatchStatus(feMatchDay.matchStatus),
 	});
 };
 
@@ -440,4 +440,36 @@ const cleanTeamName = (teamName: string): string => {
 		.replace('Holland', 'The Netherlands')
 		.replace('Bialystock', 'Białystok')
 		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
+};
+
+// This comes from Frontend
+const paStatusToMatchStatus: Record<string, string> = {
+	KO: '1st', // The Match has started Kicked Off.
+	HT: 'HT', // The Referee has blown the whistle for Half Time.
+	SHS: '2nd', // The Second Half of the Match has Started.
+	FT: 'FT', // The Referee has blown the whistle for Full Time.
+	PTFT: 'FT', // Penalty Shootout Full Time.
+	Result: 'FT', // The Result is official.
+	ETFT: 'FT', // Extra Time, Full Time has been blown.
+	MC: 'FT', // Match has been Completed.
+	FTET: 'ET', // Full Time, Extra Time it to be played.
+	ETS: 'ET', // Extra Time has Started.
+	ETHT: 'ET', // Extra Time Half Time has been called.
+	ETSHS: 'ET', // Extra Time, Second Half has Started.
+	FTPT: 'PT', // Full Time, Penalties are To be played.
+	PT: 'PT', // Penalty Shootout has started.
+	ETFTPT: 'PT', // Extra Time, Full Time, Penalties are To be played.
+	Suspended: 'S', // Match has been Suspended.
+
+	// We don't really expect to see these the way we handle data in frontend
+	Resumed: 'R', // Match has been Resumed.
+	Abandoned: 'A', // Match has been Abandoned.
+	Fixture: 'F', // Created Fixture is available and had been Created by us.
+	'-': 'F', // this sneaky one is not in the docs
+	New: 'N', // Match A New Match has been added to our data.
+	Cancelled: 'C', // A Match has been Cancelled.
+};
+
+const replaceLiveMatchStatus = (status: string): string => {
+	return paStatusToMatchStatus[status] ?? status.slice(0, 2);
 };


### PR DESCRIPTION
## What does this change?

Adds a mapping to rename live match statuses from what PA gives us to the form we want 

## Why?
In [frontend](https://github.com/guardian/frontend/blob/main/sport/app/football/views/support.scala#L11) there is a mapping of PA status to our own set of statuses. This does not come through in the data to DCR, as it was called in the Twirl template

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
