### PR TITLE
Revert facia-rendering back to c7g

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -92,7 +92,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Tag pages */


### PR DESCRIPTION
## What does this change?

Reverts test of #13607 . Raised a new PR to keep the `aws-cdk` bump.

## Why?

Test is over
