### PR TITLE
Add bottom padding to fronts ads

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -1,6 +1,6 @@
 import { css, type Interpolation } from '@emotion/react';
 import type { SlotName } from '@guardian/commercial';
-import { adSizes, constants } from '@guardian/commercial';
+import { adSizes } from '@guardian/commercial';
 import {
 	between,
 	breakpoints,
@@ -92,6 +92,10 @@ type Props = DefaultProps &
 
 const halfPageAdHeight = adSizes.halfPage.height;
 
+/** Calculates the minimum height for an ad slot. Used to avoid CLS */
+const getMinHeight = (adHeight: number, padding?: number): number =>
+	adHeight + labelHeight + (padding ?? 0);
+
 const outOfPageStyles = css`
 	height: 0;
 `;
@@ -111,7 +115,7 @@ const topAboveNavContainerStyles = css`
  * render first, we need to reserve space for the ad to avoid CLS.
  */
 const showcaseRightColumnContainerStyles = css`
-	min-height: ${halfPageAdHeight + labelHeight}px;
+	min-height: ${getMinHeight(halfPageAdHeight)}px;
 `;
 
 const showcaseRightColumnStyles = css`
@@ -131,7 +135,7 @@ const merchandisingAdContainerStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.billboard.height + labelHeight + space[3]}px;
+	min-height: ${getMinHeight(adSizes.billboard.height, space[3])}px;
 	margin: ${space[3]}px auto;
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
@@ -140,7 +144,7 @@ const merchandisingAdStyles = css`
 	${from.desktop} {
 		margin: 0;
 		padding-bottom: ${space[5]}px;
-		min-height: ${adSizes.billboard.height + labelHeight + space[5]}px;
+		min-height: ${getMinHeight(adSizes.billboard.height, space[5])}px;
 	}
 
 	&:not(.ad-slot--fluid).ad-slot--rendered {
@@ -173,7 +177,7 @@ const liveblogInlineContainerStyles = css`
 
 const liveblogInlineAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 	background-color: ${schemedPalette('--ad-background-article-inner')};
 
 	${until.tablet} {
@@ -183,7 +187,7 @@ const liveblogInlineAdStyles = css`
 
 const liveblogInlineMobileAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.outstreamMobile.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.outstreamMobile.height)}px;
 
 	${from.tablet} {
 		display: none;
@@ -192,7 +196,7 @@ const liveblogInlineMobileAdStyles = css`
 
 const mobileFrontAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.mpu.height + labelHeight + space[3]}px;
+	min-height: ${getMinHeight(adSizes.mpu.height, space[3])}px;
 	min-width: 300px;
 	width: 300px;
 	margin: ${space[3]}px auto;
@@ -203,22 +207,16 @@ const mobileFrontAdStyles = css`
 	}
 `;
 
-const frontsBannerPaddingHeight = space[6];
-const frontsBannerMinHeightTablet =
-	adSizes.leaderboard.height + labelHeight + frontsBannerPaddingHeight;
-const frontsBannerMinHeight =
-	adSizes.billboard.height + labelHeight + frontsBannerPaddingHeight;
-
 const frontsBannerAdTopContainerStyles = css`
 	display: none;
 	${from.tablet} {
 		display: flex;
 		justify-content: center;
-		min-height: ${frontsBannerMinHeightTablet}px;
+		min-height: ${getMinHeight(adSizes.leaderboard.height, space[6])}px;
 		background-color: ${schemedPalette('--ad-background')};
 	}
 	${from.desktop} {
-		min-height: ${frontsBannerMinHeight}px;
+		min-height: ${getMinHeight(adSizes.billboard.height, space[6])}px;
 	}
 `;
 
@@ -243,11 +241,10 @@ const frontsBannerCollapseStyles = css`
 
 const frontsBannerAdStyles = css`
 	position: relative;
-	min-height: ${frontsBannerMinHeightTablet}px;
+	min-height: ${getMinHeight(adSizes.leaderboard.height, space[6])}px;
 	max-width: ${adSizes.leaderboard.width}px;
-	max-height: ${adSizes.leaderboard.height + labelHeight}px;
 	overflow: hidden;
-	padding-bottom: ${frontsBannerPaddingHeight}px;
+	padding-bottom: ${space[6]}px;
 
 	${from.desktop} {
 		/* No banner should be taller than 600px */
@@ -258,7 +255,7 @@ const frontsBannerAdStyles = css`
 
 const articleEndAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.outstreamDesktop.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.outstreamDesktop.height)}px;
 
 	&.ad-slot--fluid {
 		min-height: 450px;
@@ -267,7 +264,7 @@ const articleEndAdStyles = css`
 
 const mostPopAdStyles = css`
 	position: relative;
-	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	max-width: ${adSizes.mpu.width}px;
 	text-align: center;
@@ -281,7 +278,7 @@ const mostPopAdStyles = css`
 `;
 
 const mostPopContainerStyles = css`
-	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	width: fit-content;
 	max-width: ${adSizes.mpu.width}px;
@@ -295,7 +292,7 @@ const mostPopContainerStyles = css`
 `;
 
 const liveBlogTopAdStyles = css`
-	min-height: ${adSizes.mpu.height + labelHeight}px;
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	width: fit-content;
 	max-width: ${adSizes.mpu.width}px;
@@ -383,7 +380,7 @@ const mobileStickyAdStylesFullWidth = css`
 `;
 
 const crosswordBannerMobileAdStyles = css`
-	min-height: ${adSizes.mobilesticky.height + constants.AD_LABEL_HEIGHT}px;
+	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
 const AdSlotWrapper = ({


### PR DESCRIPTION
## What does this change?

Adds `padding-bottom` to the following ad slots used on fronts: `fronts-banner`, `mobile-front`, `merchandising-high`, `merchandising` to reach an approximate 24px underneath each ad. This is 12px margin and 12px padding for mobile slots and 24px alone for `fronts-banner`.


## Why?

@guardian/fronts-and-curation requested updates to ad spacing to match the spacing for containers on the fronts for the homepage redesign.


## Screenshots

| Before       | After      |
| -----------  | ---------- |
| **mobile-front** : _before_ | **mobile-front** : _after_       |
| ![before][]  | ![after][] |
| **fronts-banner** : _before_ | **fronts-banner** _after_       |
| ![before2][]  | ![after2][] |
| **merchandising-high** :  _before_ | **merchandising-high** : _after_       |
| ![before3][]  | ![after3][] |
| **merchandising** : _before_ | **merchandising** : _after_       |
| ![before4][]  | ![after4][] |



[before]: https://github.com/user-attachments/assets/33d5279f-60d5-4bc0-90a4-4bbe2fb6df75
[after]: https://github.com/user-attachments/assets/4371e779-74a1-4e0c-b145-2bdc9364b964
[before2]: https://github.com/user-attachments/assets/5af68e35-5860-465d-9ee7-df187aab8627
[after2]: https://github.com/user-attachments/assets/9b9bb559-49ce-41ae-860b-582505a5feca
[before3]: https://github.com/user-attachments/assets/3b2ae6fd-7330-4d74-bd12-a90bd3207dbd
[after3]: https://github.com/user-attachments/assets/3c84112f-c639-4465-9c4e-0e92bd408624
[before4]: https://github.com/user-attachments/assets/4e20676d-e956-4e0e-9019-b17b2a2c499e
[after4]: https://github.com/user-attachments/assets/0b73ac11-7414-4435-8e4d-ddd620434c22

