### PR TITLE
Football data pages: also clean team name in comments

### DIFF
--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -269,7 +269,7 @@ const parseMatchResult = (
 		},
 		dateTimeISOString: date.value,
 		paId: feResult.id,
-		comment: feResult.comments,
+		comment: cleanTeamName(feResult.comments ?? ''),
 	});
 };
 
@@ -313,7 +313,7 @@ const parseLiveMatch = (
 		},
 		dateTimeISOString: date.value,
 		paId: feMatchDay.id,
-		comment: feMatchDay.comments,
+		comment: cleanTeamName(feMatchDay.comments ?? ''),
 		status: replaceLiveMatchStatus(feMatchDay.matchStatus),
 	});
 };


### PR DESCRIPTION
## What does this change?

Applies the `cleanTeamName` replacement to match comments too. For example we're removing the word "Ladies" from PA data

## Why?

It creates an inconsistency to have two different names (especially if one is considered wrong)

## Screenshots


| Before      | 
| ----------- | 
| ![before][] |
| After      |
| ![after][] |

[before]: https://github.com/user-attachments/assets/ef3f977d-cf21-46d4-b5e6-72d24b91dcb4
[after]: https://github.com/user-attachments/assets/33315d82-2612-441b-aea4-4f452bb720ed

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
