### PR TITLE
Make sure slot containers have correct class applied

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -385,14 +385,14 @@ const crosswordBannerMobileAdStyles = css`
 const AdSlotWrapper = ({
 	children,
 	css: additionalCss,
-	className = 'ad-slot-container',
+	className,
 }: {
 	children: React.ReactNode;
 	css?: Interpolation;
 	className?: string;
 }) => {
 	return (
-		<aside className={className} css={additionalCss}>
+		<aside className={`ad-slot-container ${className}`} css={additionalCss}>
 			{children}
 		</aside>
 	);
@@ -719,7 +719,7 @@ export const AdSlot = ({
 			const advertId = `inline${index + 1}`;
 			return (
 				<AdSlotWrapper
-					className="ad-slot-container ad-slot-desktop"
+					className="ad-slot-desktop"
 					css={liveblogInlineContainerStyles}
 				>
 					<div


### PR DESCRIPTION
## What does this change?
Make sure that the `AdSlotWrapper` component always applies the `ad-slot-container` class to the aside element.

## Why?
The client side commercial code relies on the `ad-slot-container` class to be able to find and remove the slot. At the moment, when we pass in css to the `AdSlotWrapper` component, the default `ad-slot-container` class isn't being applied, and empty ad slots are not being removed from the DOM.

## Screenshots
### Before
<img width="477" alt="Screenshot 2025-03-14 at 09 58 22" src="https://github.com/user-attachments/assets/e45796c5-0931-4243-91fb-edd2102d2f68" />

When slot isn't populated with an ad:

<img width="1225" alt="Screenshot 2025-03-14 at 08 42 02" src="https://github.com/user-attachments/assets/a516d04e-b1c9-45d0-a673-15cd8a36808c" />


### After
<img width="574" alt="Screenshot 2025-03-14 at 08 31 22" src="https://github.com/user-attachments/assets/46b0c9af-8b7c-46ed-8a2e-7687faab0f91" />

When slot isn't populated with an ad:

<img width="1512" alt="Screenshot 2025-03-14 at 10 31 08" src="https://github.com/user-attachments/assets/05b75f63-f302-4e11-b0f8-4fb120c23fa3" />
