### PR TITLE
Crossword dark mode support

### DIFF
--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -235,5 +235,9 @@ export const CrosswordComponent = ({
 		data={data}
 		Layout={Layout}
 		MobileBannerAd={canRenderAds ? MobileBannerAdComponent : undefined}
+		textColor={palette('--crossword-text')}
+		anagramHelperBackgroundColor={palette(
+			'--crossword-anagram-helper-background',
+		)}
 	/>
 );

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5770,10 +5770,16 @@ const pillDivider: PaletteFunction = () =>
 	transparentColour(sourcePalette.neutral[100], 0.5);
 const pillLiveBullet: PaletteFunction = () => sourcePalette.news[500];
 
+const crosswordAnagramHelperBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const crosswordAnagramHelperBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
 const crosswordCluesHeaderBorderTop: PaletteFunction = () =>
 	sourcePalette.lifestyle[400];
 const crosswordCluesHeaderBorderBottom: PaletteFunction = () =>
 	sourcePalette.neutral[86];
+const crosswordTextLight: PaletteFunction = () => sourcePalette.neutral[7];
+const crosswordTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
 // ----- Palette ----- //
 
@@ -6248,6 +6254,10 @@ const paletteColours = {
 		light: cricketScoreboardLinkText,
 		dark: cricketScoreboardLinkText,
 	},
+	'--crossword-anagram-helper-background': {
+		light: crosswordAnagramHelperBackgroundLight,
+		dark: crosswordAnagramHelperBackgroundDark,
+	},
 	'--crossword-clues-header-border-bottom': {
 		light: crosswordCluesHeaderBorderBottom,
 		dark: crosswordCluesHeaderBorderBottom,
@@ -6255,6 +6265,10 @@ const paletteColours = {
 	'--crossword-clues-header-border-top': {
 		light: crosswordCluesHeaderBorderTop,
 		dark: crosswordCluesHeaderBorderTop,
+	},
+	'--crossword-text': {
+		light: crosswordTextLight,
+		dark: crosswordTextDark,
 	},
 	'--dateline': {
 		light: datelineLight,


### PR DESCRIPTION
## What does this change?

Adds light and dark mode colours for crossword text and anagram helper. This uses the [extended theming support added in `@guardian/react-crossword@4.0.0`](https://github.com/guardian/csnx/pull/2005).

## Why?

So crosswords are usable in dark mode

_NB._ Whilst this ensures the principle elements are readable and usable in dark mode there are further elements that would benefit from updating such as the anagram helper's text field and buttons.

## Screenshots

| Light      | Dark      |
| ----------- | ---------- |
| ![light1][] | ![dark1][] |
| ![light2][] | ![dark2][] |

[light1]: https://github.com/user-attachments/assets/0bb91c72-e860-4406-861e-7207961506a8
[dark1]: https://github.com/user-attachments/assets/2899d965-00d7-4f43-ad1a-38ed206960c7
[light2]: https://github.com/user-attachments/assets/e92cdbf6-8fd5-4065-b5cb-7caaecf24fe6
[dark2]: https://github.com/user-attachments/assets/88c3148d-404d-4b96-abaa-c217370b4281
