### PR TITLE
Add table of contents support to timelines

### DIFF
--- a/dotcom-rendering/src/components/Timeline.tsx
+++ b/dotcom-rendering/src/components/Timeline.tsx
@@ -14,6 +14,7 @@ import {
 } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import type { NestedArticleElement } from '../lib/renderElement';
+import { slugify } from '../model/enhance-H2s';
 import { palette } from '../palette';
 import type {
 	DCRSectionedTimelineBlockElement,
@@ -294,7 +295,11 @@ export const Timeline = ({
 				<>
 					{timeline.sections.map((section) => (
 						<section key={section.title}>
-							<Subheading format={format} topPadding={false}>
+							<Subheading
+								format={format}
+								topPadding={false}
+								id={slugify(section.title)}
+							>
 								{section.title}
 							</Subheading>
 							{section.events.map((event) => (

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -90,6 +90,16 @@ export const enhanceTableOfContents = (
 				}
 			} else if (
 				element._type ===
+				'model.dotcomrendering.pageElements.DCRSectionedTimelineBlockElement'
+			) {
+				for (const section of element.sections) {
+					tocItems.push({
+						id: slugify(section.title),
+						title: section.title,
+					});
+				}
+			} else if (
+				element._type ===
 					'model.dotcomrendering.pageElements.SubheadingBlockElement' ||
 				element._type ===
 					'model.dotcomrendering.pageElements.NumberedTitleBlockElement'


### PR DESCRIPTION
## What does this change?

Adds support for table of contents to the timeline format

## Why?

It was accidentally missed when developing the format. Last week we received the following comment from Rich:

> Also the Table of Contents does not work. I wondered why? Ideally it would pick up the section headers only (ie. h2s).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|<img width="668" alt="Screenshot 2025-03-17 at 11 13 58" src="https://github.com/user-attachments/assets/b4a31fb0-7dba-45c6-bc75-f0c722263a49" /> | <img width="659" alt="Screenshot 2025-03-17 at 11 18 05" src="https://github.com/user-attachments/assets/a68cefea-1b0a-48cf-9199-884b88dfd6a4" /> |
