### PR TITLE
Revert back to using default SSM parameter

### DIFF
--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -36,8 +36,6 @@ deployments:
       cloudFormationStackByTags: false
       cloudFormationStackName: article-rendering
       amiParameter: AMIArticlerendering
-      templateParameters:
-        articlerenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # article-rendering autoscaling
   article-rendering:
     type: autoscaling
@@ -58,8 +56,6 @@ deployments:
       cloudFormationStackByTags: false
       cloudFormationStackName: facia-rendering
       amiParameter: AMIFaciarendering
-      templateParameters:
-        faciarenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # facia-rendering autoscaling
   facia-rendering:
     type: autoscaling
@@ -80,8 +76,6 @@ deployments:
       cloudFormationStackByTags: false
       cloudFormationStackName: tag-page-rendering
       amiParameter: AMITagpagerendering
-      templateParameters:
-        tagpagerenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # tag-page-rendering autoscaling
   tag-page-rendering:
     type: autoscaling
@@ -102,8 +96,6 @@ deployments:
       cloudFormationStackByTags: false
       cloudFormationStackName: interactive-rendering
       amiParameter: AMIInteractiverendering
-      templateParameters:
-        interactiverenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # interactive-rendering autoscaling
   interactive-rendering:
     type: autoscaling

--- a/dotcom-rendering/scripts/deploy/riff-raff.yaml
+++ b/dotcom-rendering/scripts/deploy/riff-raff.yaml
@@ -37,7 +37,7 @@ deployments:
       cloudFormationStackName: article-rendering
       amiParameter: AMIArticlerendering
       templateParameters:
-        articlerenderingPrivateSubnets: /devx/bigger/private/subnets
+        articlerenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # article-rendering autoscaling
   article-rendering:
     type: autoscaling
@@ -59,7 +59,7 @@ deployments:
       cloudFormationStackName: facia-rendering
       amiParameter: AMIFaciarendering
       templateParameters:
-        faciarenderingPrivateSubnets: /devx/bigger/private/subnets
+        faciarenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # facia-rendering autoscaling
   facia-rendering:
     type: autoscaling
@@ -81,7 +81,7 @@ deployments:
       cloudFormationStackName: tag-page-rendering
       amiParameter: AMITagpagerendering
       templateParameters:
-        tagpagerenderingPrivateSubnets: /devx/bigger/private/subnets
+        tagpagerenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # tag-page-rendering autoscaling
   tag-page-rendering:
     type: autoscaling
@@ -103,7 +103,7 @@ deployments:
       cloudFormationStackName: interactive-rendering
       amiParameter: AMIInteractiverendering
       templateParameters:
-        interactiverenderingPrivateSubnets: /devx/bigger/private/subnets
+        interactiverenderingPrivateSubnets: /account/vpc/primary/subnets/private
   # interactive-rendering autoscaling
   interactive-rendering:
     type: autoscaling


### PR DESCRIPTION
## What does this change?

We've now set the bigger subnets as the [default for the account](https://github.com/guardian/aws-account-setup/pull/300), so we can go back to relying on defaults.

This reverts https://github.com/guardian/dotcom-rendering/pull/13403  https://github.com/guardian/dotcom-rendering/pull/13521 https://github.com/guardian/dotcom-rendering/pull/13519 and https://github.com/guardian/dotcom-rendering/pull/13517

This is expected to be a no op, as the SSM parameter should resolve to the same same value as before this change.
