### PR TITLE
Make score optional in football matches

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -46,6 +46,21 @@ export const initialDays: FootballMatches = [
 						status: '1st',
 					},
 					{
+						kind: 'Live',
+						dateTimeISOString: new Date(
+							'2022-01-01T11:11:00Z',
+						).toISOString(),
+						paId: '12345',
+						homeTeam: {
+							name: 'Fiorentina',
+						},
+						awayTeam: {
+							name: 'Bologna',
+						},
+						status: 'S',
+						comment: 'Awaiting officials decision',
+					},
+					{
 						kind: 'Fixture',
 						dateTimeISOString: new Date(
 							'2022-01-01T19:45:00Z',

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -352,8 +352,8 @@ const Scores = ({
 	homeScore,
 	awayScore,
 }: {
-	homeScore: number;
-	awayScore: number;
+	homeScore?: number;
+	awayScore?: number;
 }) => (
 	<span
 		css={css`

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -10,7 +10,6 @@ import {
 import type {
 	FEFootballMatch,
 	FEMatchByDateAndCompetition,
-	FEMatchDay,
 	FEResult,
 } from './feFootballDataPage';
 import { parse } from './footballMatches';
@@ -100,67 +99,6 @@ describe('footballMatches', () => {
 		}
 
 		expect(resultThree.errors[0]!.kind).toBe('FootballMatchInvalidDate');
-	});
-
-	it('should return an error when football matches are missing a score', () => {
-		const matchResultMissingHomeScore: FEResult = {
-			...matchResult,
-			homeTeam: {
-				...matchResult.homeTeam,
-				score: undefined,
-			},
-		};
-		const matchResultMissingAwayScore: FEResult = {
-			...matchResult,
-			homeTeam: {
-				...matchResult.awayTeam,
-				score: undefined,
-			},
-		};
-		const liveMatchMissingHomeScore: FEMatchDay = {
-			...matchDayLive,
-			homeTeam: {
-				...matchDayLive.homeTeam,
-				score: undefined,
-			},
-		};
-		const liveMatchMissingAwayScore: FEMatchDay = {
-			...matchDayLive,
-			homeTeam: {
-				...matchDayLive.awayTeam,
-				score: undefined,
-			},
-		};
-
-		const resultHome = errorOrThrow(
-			parse(withMatches([matchResultMissingHomeScore])),
-			'Expected football match parsing to fail',
-		);
-		const resultAway = errorOrThrow(
-			parse(withMatches([matchResultMissingAwayScore])),
-			'Expected football match parsing to fail',
-		);
-		const liveHome = errorOrThrow(
-			parse(withMatches([liveMatchMissingHomeScore])),
-			'Expected football match parsing to fail',
-		);
-		const liveAway = errorOrThrow(
-			parse(withMatches([liveMatchMissingAwayScore])),
-			'Expected football match parsing to fail',
-		);
-
-		expect(resultHome.kind).toBe('FootballMatchMissingScore');
-		expect(resultAway.kind).toBe('FootballMatchMissingScore');
-
-		if (
-			liveHome.kind !== 'InvalidMatchDay' ||
-			liveAway.kind !== 'InvalidMatchDay'
-		) {
-			throw new Error('Expected an invalid match day error');
-		}
-
-		expect(liveHome.errors[0]?.kind).toBe('FootballMatchMissingScore');
-		expect(liveAway.errors[0]?.kind).toBe('FootballMatchMissingScore');
 	});
 
 	it('should return an error when it receives a live match', () => {

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -6,7 +6,6 @@ import type {
 	FEFootballPageConfig,
 	FEMatchByDateAndCompetition,
 	FEMatchDay,
-	FEMatchDayTeam,
 	FEResult,
 } from './feFootballDataPage';
 import type { EditionId } from './lib/edition';
@@ -16,7 +15,7 @@ import type { FooterType } from './types/footer';
 
 type TeamScore = {
 	name: string;
-	score: number;
+	score?: number;
 };
 
 type MatchData = {
@@ -172,22 +171,6 @@ const parseDate = (a: string): Result<string, string> => {
 	return ok(d.toISOString());
 };
 
-const parseScore = (
-	team: FEMatchDayTeam,
-	matchKind: 'Result' | 'Live',
-): Result<ParserError, number> => {
-	if (team.score === undefined) {
-		const prefix = matchKind === 'Result' ? 'Results' : 'Live matches';
-
-		return error({
-			kind: 'FootballMatchMissingScore',
-			message: `${prefix} must have scores, but the score for ${team.name} is missing`,
-		});
-	}
-
-	return ok(team.score);
-};
-
 const parseMatchDate = (date: string): Result<string, string> => {
 	// Frontend appends a timezone in square brackets
 	const isoDate = date.split('[')[0];
@@ -245,27 +228,15 @@ const parseMatchResult = (
 		return error({ kind: 'FootballMatchInvalidDate', message: date.error });
 	}
 
-	const homeScore = parseScore(feResult.homeTeam, 'Result');
-
-	if (homeScore.kind === 'error') {
-		return homeScore;
-	}
-
-	const awayScore = parseScore(feResult.awayTeam, 'Result');
-
-	if (awayScore.kind === 'error') {
-		return awayScore;
-	}
-
 	return ok({
 		kind: 'Result',
 		homeTeam: {
 			name: cleanTeamName(feResult.homeTeam.name),
-			score: homeScore.value,
+			score: feResult.homeTeam.score,
 		},
 		awayTeam: {
 			name: cleanTeamName(feResult.awayTeam.name),
-			score: awayScore.value,
+			score: feResult.awayTeam.score,
 		},
 		dateTimeISOString: date.value,
 		paId: feResult.id,
@@ -289,27 +260,15 @@ const parseLiveMatch = (
 		return error({ kind: 'FootballMatchInvalidDate', message: date.error });
 	}
 
-	const homeScore = parseScore(feMatchDay.homeTeam, 'Live');
-
-	if (homeScore.kind === 'error') {
-		return homeScore;
-	}
-
-	const awayScore = parseScore(feMatchDay.awayTeam, 'Live');
-
-	if (awayScore.kind === 'error') {
-		return awayScore;
-	}
-
 	return ok({
 		kind: 'Live',
 		homeTeam: {
 			name: cleanTeamName(feMatchDay.homeTeam.name),
-			score: homeScore.value,
+			score: feMatchDay.homeTeam.score,
 		},
 		awayTeam: {
 			name: cleanTeamName(feMatchDay.awayTeam.name),
-			score: awayScore.value,
+			score: feMatchDay.awayTeam.score,
 		},
 		dateTimeISOString: date.value,
 		paId: feMatchDay.id,


### PR DESCRIPTION
## What does this change?

Makes the `score` property optional in football live matches and results

## Why?

Over the weekend we had a live match with no score, tracked in -> https://github.com/guardian/dotcom-rendering/issues/13628. The score property is also an `Option` in frontend

<img width="296" alt="image" src="https://github.com/user-attachments/assets/5a37bbe4-168a-4340-a894-b9201796df08" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
