### PR TITLE
Set aspect ratio of images in highlights card to 1:1

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -142,6 +142,7 @@ const decideImage = (
 	if (!image && !avatarUrl) {
 		return null;
 	}
+
 	if (avatarUrl) {
 		return (
 			<Avatar
@@ -152,6 +153,7 @@ const decideImage = (
 			/>
 		);
 	}
+
 	if (mainMedia?.type === 'Audio' && mainMedia.podcastImage?.src) {
 		return (
 			<>
@@ -161,15 +163,17 @@ const decideImage = (
 					alt={mainMedia.podcastImage.altText}
 					loading={imageLoading}
 					isCircular={false}
-					aspectRatio={'1:1'}
+					aspectRatio="1:1"
 				/>
 				<div className="image-overlay"> </div>
 			</>
 		);
 	}
+
 	if (!image) {
 		return null;
 	}
+
 	return (
 		<>
 			<CardPicture
@@ -178,12 +182,40 @@ const decideImage = (
 				alt={image.altText}
 				loading={imageLoading}
 				isCircular={true}
+				aspectRatio="1:1"
 			/>
 			{/* This image overlay is styled when the CardLink is hovered */}
 			<div className="image-overlay circular"> </div>
 		</>
 	);
 };
+
+const MediaPill = ({ mainMedia }: { mainMedia: MainMedia }) => (
+	<div css={mediaIcon}>
+		{mainMedia.type === 'Video' && (
+			<Pill
+				content={secondsToDuration(mainMedia.duration)}
+				icon={<SvgMediaControlsPlay />}
+				iconSize="small"
+			/>
+		)}
+		{mainMedia.type === 'Audio' && (
+			<Pill
+				content={mainMedia.duration}
+				icon={<SvgMediaControlsPlay />}
+				iconSize="small"
+			/>
+		)}
+		{mainMedia.type === 'Gallery' && (
+			<Pill
+				prefix="Gallery"
+				content={mainMedia.count}
+				icon={<SvgCamera />}
+				iconSide="right"
+			/>
+		)}
+	</div>
+);
 
 export const HighlightsCard = ({
 	linkTo,
@@ -201,32 +233,7 @@ export const HighlightsCard = ({
 	starRating,
 }: HighlightsCardProps) => {
 	const isMediaCard = isMedia(format);
-	const MediaPill = () => (
-		<div css={mediaIcon}>
-			{mainMedia?.type === 'Video' && (
-				<Pill
-					content={secondsToDuration(mainMedia.duration)}
-					icon={<SvgMediaControlsPlay />}
-					iconSize={'small'}
-				/>
-			)}
-			{mainMedia?.type === 'Audio' && (
-				<Pill
-					content={mainMedia.duration}
-					icon={<SvgMediaControlsPlay />}
-					iconSize={'small'}
-				/>
-			)}
-			{mainMedia?.type === 'Gallery' && (
-				<Pill
-					prefix="Gallery"
-					content={mainMedia.count}
-					icon={<SvgCamera />}
-					iconSide="right"
-				/>
-			)}
-		</div>
-	);
+
 	return (
 		<FormatBoundary format={format}>
 			<div css={[gridContainer, hoverStyles]}>
@@ -265,7 +272,9 @@ export const HighlightsCard = ({
 					</div>
 				) : null}
 
-				{!!mainMedia && isMediaCard && MediaPill()}
+				{!!mainMedia && isMediaCard && (
+					<MediaPill mainMedia={mainMedia} />
+				)}
 
 				<div css={[imageArea, avatarUrl && avatarAlignmentStyles]}>
 					{decideImage(


### PR DESCRIPTION
## What does this change?

Sets the aspect ratio of images in highlights cards to 1:1.

## Why?

The (incorrect) default aspect ratio cases the image to be more zoomed in than expected.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/2d24891f-f3fb-4179-915f-a99dae0bc7ad
[after]: https://github.com/user-attachments/assets/fc5f6d09-50c9-457a-9952-45469b3ba932

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
