### PR TITLE
Crosswords: improved print layout

### DIFF
--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -181,6 +181,12 @@ const Layout: CrosswordProps['Layout'] = ({
 							background-image: none;
 						}
 					}
+					@media print {
+						max-height: none;
+						::after {
+							background-image: none;
+						}
+					}
 				`}
 			>
 				<div

--- a/dotcom-rendering/src/components/ElementContainer.tsx
+++ b/dotcom-rendering/src/components/ElementContainer.tsx
@@ -57,6 +57,7 @@ type Props = {
 	containerName?: string;
 	hasPageSkin?: boolean;
 	hasPageSkinContentSelfConstrain?: boolean;
+	hideFromPrintLayout?: boolean;
 };
 
 /**
@@ -83,12 +84,14 @@ export const ElementContainer = ({
 	containerName,
 	hasPageSkin = false,
 	hasPageSkinContentSelfConstrain = false,
+	hideFromPrintLayout = false,
 }: Props) =>
 	jsx(element, {
 		id: ophanComponentName,
 		'data-link-name': ophanComponentLink,
 		'data-component': ophanComponentName,
 		'data-container-name': containerName,
+		'data-print-layout': hideFromPrintLayout ? 'hide' : undefined,
 		style: {
 			backgroundColor: backgroundColour,
 		},

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -107,6 +107,8 @@ type Props = {
 	/** When there is a page skin in some special cases we still want the container to take full
 	 * width but the content to constrain itself e.g. Header */
 	hasPageSkinContentSelfConstrain?: boolean;
+	/** Defaults to `false`. Indicates section should be hidden when printed */
+	hideFromPrintLayout?: boolean;
 	/**
 	 * @deprecated Do not use
 	 *
@@ -254,6 +256,7 @@ export const Section = ({
 	shouldCenter,
 	hasPageSkin = false,
 	hasPageSkinContentSelfConstrain = false,
+	hideFromPrintLayout = false,
 	className,
 }: Props) => {
 	if (fullWidth) {
@@ -279,6 +282,7 @@ export const Section = ({
 				hasPageSkinContentSelfConstrain={
 					hasPageSkinContentSelfConstrain
 				}
+				hideFromPrintLayout={hideFromPrintLayout}
 			>
 				{children}
 			</ElementContainer>
@@ -302,6 +306,7 @@ export const Section = ({
 			innerBackgroundColour={innerBackgroundColour}
 			hasPageSkin={hasPageSkin}
 			hasPageSkinContentSelfConstrain={hasPageSkinContentSelfConstrain}
+			hideFromPrintLayout={hideFromPrintLayout}
 		>
 			<Flex>
 				<LeftColumn

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -165,7 +165,6 @@ export const CrosswordLayout = (props: Props) => {
 			<main data-layout="InteractiveLayout">
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					showTopBorder={false}
 					backgroundColour={themePalette('--article-background')}
 					borderColour={themePalette('--article-border')}
@@ -359,6 +358,7 @@ export const CrosswordLayout = (props: Props) => {
 					showTopBorder={false}
 					padSides={false}
 					backgroundColour={themePalette('--article-background')}
+					hideFromPrintLayout={true}
 				>
 					<StraightLines
 						count={4}
@@ -407,13 +407,13 @@ export const CrosswordLayout = (props: Props) => {
 					<Section
 						fullWidth={true}
 						sectionId="comments"
-						data-print-layout="hide"
 						element="section"
 						backgroundColour={themePalette(
 							'--discussion-section-background',
 						)}
 						borderColour={themePalette('--article-border')}
 						fontColour={themePalette('--discussion-text')}
+						hideFromPrintLayout={true}
 					>
 						<DiscussionLayout
 							discussionApiUrl={article.config.discussionApiUrl}
@@ -436,7 +436,6 @@ export const CrosswordLayout = (props: Props) => {
 				{renderAds && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -452,12 +451,7 @@ export const CrosswordLayout = (props: Props) => {
 			</main>
 
 			{props.NAV.subNavSections && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					element="aside"
-				>
+				<Section fullWidth={true} padSides={false} element="aside">
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
@@ -470,7 +464,6 @@ export const CrosswordLayout = (props: Props) => {
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				backgroundColour={sourcePalette.brand[400]}
 				borderColour={sourcePalette.brand[600]}

--- a/dotcom-rendering/src/static/css/print.css
+++ b/dotcom-rendering/src/static/css/print.css
@@ -3,6 +3,11 @@
 	color: #000000;
 }
 
+/**
+ * Hide scroll depth markers when printing as these are absolutely positioned
+ * based on the initial content height and are still present when content has
+ * been hidden in the print layout, causing blank pages to be printed.
+ */
 .scroll-depth-marker {
 	display: none;
 }

--- a/dotcom-rendering/src/static/css/print.css
+++ b/dotcom-rendering/src/static/css/print.css
@@ -2,3 +2,7 @@
 	display: none !important;
 	color: #000000;
 }
+
+.scroll-depth-marker {
+	display: none;
+}


### PR DESCRIPTION
## What does this change?

- Adds `hideFromPrintLayout` prop to `Section` and `ElementContainer` components. This allows section to be hidden entirely from the crossword print layout. `data-print-layout="hide"` was already being applied to `Section` in the crossword (and other) layouts, but this does not get passed through and applied to the underlying HTML element so has no effect.
- Hides the clue list gradient overlay. (Only visible when printing background images is enabled.)
- Hides scroll depth marker elements when printing as these are absolutely positioned based on the initial height of the page, but are still present when printing causing blank pages to be generated.

## Why?

So crosswords can be printed on a single page and don't include unnecessary elements or additional blank pages.

## Screenshots

<img width="524" alt="Screenshot 2025-03-17 at 16 55 20" src="https://github.com/user-attachments/assets/dc6a3be2-dd85-4a53-a02c-af9bd175b586" />
