### PR TITLE
Media card pills - updated designs

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -506,15 +506,14 @@ export const Card = ({
 				<>
 					{mainMedia.duration === 0 ? (
 						<Pill
-							content={'Live'}
+							content="Live"
 							icon={<div css={liveBulletStyles} />}
-							iconSize="small"
 						/>
 					) : (
 						<Pill
 							content={secondsToDuration(mainMedia.duration)}
-							icon={<SvgMediaControlsPlay />}
-							iconSize="small"
+							icon={<SvgMediaControlsPlay width={18} />}
+							prefix="Video"
 						/>
 					)}
 				</>
@@ -523,16 +522,15 @@ export const Card = ({
 			{mainMedia?.type === 'Audio' && (
 				<Pill
 					content={mainMedia.duration}
-					icon={<SvgMediaControlsPlay />}
-					iconSize="small"
+					icon={<SvgMediaControlsPlay width={18} />}
+					prefix="Podcast"
 				/>
 			)}
 			{mainMedia?.type === 'Gallery' && (
 				<Pill
-					prefix="Gallery"
 					content={mainMedia.count}
 					icon={<SvgCamera />}
-					iconSide="right"
+					prefix="Gallery"
 				/>
 			)}
 			{isNewsletter && <Pill content="Newsletter" />}
@@ -1021,8 +1019,11 @@ export const Card = ({
 												content={secondsToDuration(
 													mainMedia.duration,
 												)}
-												icon={<SvgMediaControlsPlay />}
-												iconSize={'small'}
+												icon={
+													<SvgMediaControlsPlay
+														width={18}
+													/>
+												}
 											/>
 										</div>
 									)}

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -5,17 +5,6 @@ import { palette } from '../../../palette';
 import ClockIcon from '../../../static/icons/clock.svg';
 import { DateTime } from '../../DateTime';
 
-type Props = {
-	absoluteServerTimes: boolean;
-	webPublication: {
-		date: string;
-		isWithinTwelveHours: boolean;
-	};
-	showClock?: boolean;
-	isTagPage: boolean;
-	colour?: string;
-};
-
 const ageStyles = (colour: string) => {
 	return css`
 		${textSansBold12};
@@ -32,11 +21,22 @@ const ageStyles = (colour: string) => {
 	`;
 };
 
+type Props = {
+	absoluteServerTimes: boolean;
+	webPublication: {
+		date: string;
+		isWithinTwelveHours: boolean;
+	};
+	isTagPage: boolean;
+	showClock?: boolean;
+	colour?: string;
+};
+
 export const CardAge = ({
-	webPublication,
-	showClock,
 	absoluteServerTimes,
+	webPublication,
 	isTagPage,
+	showClock,
 	colour = palette('--card-footer-text'),
 }: Props) => {
 	if (timeAgo(new Date(webPublication.date).getTime()) === false) {

--- a/dotcom-rendering/src/components/Card/components/CardFooter.stories.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+	Pillar,
+} from '../../../lib/articleFormat';
+import { CardFooter as CardFooterComponent } from './CardFooter';
+
+const meta = {
+	component: CardFooterComponent,
+	title: 'Components/Card Footer',
+} satisfies Meta<typeof CardFooterComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithAge = {
+	args: {
+		format: {
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Comment,
+			theme: Pillar.Opinion,
+		},
+		showLivePlayable: false,
+		age: <p>19h ago</p>,
+	},
+} satisfies Story;
+
+export const WithGallery = {
+	...WithAge,
+	args: {
+		...WithAge.args,
+		mainMedia: {
+			type: 'Gallery',
+			count: '14',
+		},
+	},
+} satisfies Story;
+
+export const WithAudio = {
+	...WithAge,
+	args: {
+		...WithAge.args,
+		mainMedia: {
+			type: 'Audio',
+			duration: '12:34',
+		},
+	},
+} satisfies Story;
+
+export const WithVideo = {
+	...WithAge,
+	args: {
+		...WithAge.args,
+		mainMedia: {
+			type: 'Video',
+			duration: 972,
+		},
+	},
+} satisfies Story;
+
+export const WithNewsletter = {
+	...WithAge,
+	args: {
+		...WithAge.args,
+		isNewsletter: true,
+	},
+} satisfies Story;
+
+export const WithBranding = {
+	...WithAge,
+	args: {
+		...WithAge.args,
+		format: {
+			...WithAge.args.format,
+			theme: ArticleSpecial.Labs,
+		},
+		cardBranding: <p>Card branding</p>,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -75,7 +75,7 @@ export const CardFooter = ({
 	commentCount,
 	cardBranding,
 	mainMedia,
-	isNewsletter = false,
+	isNewsletter,
 	shouldReserveSpace,
 }: Props) => {
 	if (showLivePlayable) return null;
@@ -91,7 +91,8 @@ export const CardFooter = ({
 					content={
 						<time>{secondsToDuration(mainMedia.duration)}</time>
 					}
-					icon={<SvgMediaControlsPlay />}
+					prefix="Video"
+					icon={<SvgMediaControlsPlay width={18} />}
 				/>
 			</footer>
 		);
@@ -102,7 +103,8 @@ export const CardFooter = ({
 			<footer css={contentStyles}>
 				<Pill
 					content={<time>{mainMedia.duration}</time>}
-					icon={<SvgMediaControlsPlay />}
+					prefix="Podcast"
+					icon={<SvgMediaControlsPlay width={18} />}
 				/>
 			</footer>
 		);
@@ -115,7 +117,6 @@ export const CardFooter = ({
 					content={mainMedia.count}
 					prefix="Gallery"
 					icon={<SvgCamera />}
-					iconSide="right"
 				/>
 			</footer>
 		);

--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -54,6 +54,9 @@ const narrowStyles = css`
 	left: calc(50% - ${narrowPlayIconWidth / 2}px);
 	width: ${narrowPlayIconWidth}px;
 	height: ${narrowPlayIconWidth}px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	background-color: ${palette('--feature-card-play-icon-background')};
 	opacity: 0.7;
 	border-radius: 50%;
@@ -92,7 +95,7 @@ export const PlayIcon = ({
 			]}
 		>
 			{iconWidth === 'narrow' ? (
-				<NarrowPlayIcon theme={theme} />
+				<NarrowPlayIcon width={40} theme={theme} />
 			) : (
 				<WidePlayIcon theme={theme} />
 			)}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -172,7 +172,7 @@ const decideSplashCardProperties = (
 	}
 };
 
-export const SplashCardLayout = ({
+const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -347,7 +347,7 @@ const decideCardProperties = (
 	}
 };
 
-export const BoostedCardLayout = ({
+const BoostedCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -431,7 +431,7 @@ export const BoostedCardLayout = ({
 	);
 };
 
-export const StandardCardLayout = ({
+const StandardCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.stories.tsx
@@ -116,7 +116,7 @@ export const WithPodcastSeriesImage: Story = {
 		},
 		mainMedia: {
 			type: 'Audio',
-			duration: '31.76',
+			duration: '31:16',
 			podcastImage: {
 				src: 'https://uploads.guim.co.uk/2024/08/01/FootballWeekly_FINAL_3000_(1).jpg',
 				altText: 'Football Weekly',

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -195,23 +195,22 @@ const MediaPill = ({ mainMedia }: { mainMedia: MainMedia }) => (
 		{mainMedia.type === 'Video' && (
 			<Pill
 				content={secondsToDuration(mainMedia.duration)}
-				icon={<SvgMediaControlsPlay />}
-				iconSize="small"
+				prefix="Video"
+				icon={<SvgMediaControlsPlay width={18} />}
 			/>
 		)}
 		{mainMedia.type === 'Audio' && (
 			<Pill
 				content={mainMedia.duration}
-				icon={<SvgMediaControlsPlay />}
-				iconSize="small"
+				prefix="Podcast"
+				icon={<SvgMediaControlsPlay width={18} />}
 			/>
 		)}
 		{mainMedia.type === 'Gallery' && (
 			<Pill
-				prefix="Gallery"
 				content={mainMedia.count}
+				prefix="Gallery"
 				icon={<SvgCamera />}
-				iconSide="right"
 			/>
 		)}
 	</div>

--- a/dotcom-rendering/src/components/Pill.stories.tsx
+++ b/dotcom-rendering/src/components/Pill.stories.tsx
@@ -20,7 +20,7 @@ export const Default = {} satisfies Story;
 export const WithVideoIcon = {
 	args: {
 		content: <time>3:35</time>,
-		icon: <SvgMediaControlsPlay />,
+		icon: <SvgMediaControlsPlay width={18} />,
 	},
 } satisfies Story;
 
@@ -32,9 +32,17 @@ export const WithGalleryIcon = {
 	},
 } satisfies Story;
 
+export const WithVideoIconAndPrefix = {
+	args: {
+		...WithVideoIcon.args,
+		prefix: 'Video',
+	},
+} satisfies Story;
+
 export const WithGalleryIconAndPrefix = {
 	args: {
 		...WithGalleryIcon.args,
 		prefix: 'Gallery',
+		iconSide: 'left',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/Pill.tsx
+++ b/dotcom-rendering/src/components/Pill.tsx
@@ -3,9 +3,7 @@ import { space, textSansBold12 } from '@guardian/source/foundations';
 import { cloneElement, type ReactElement } from 'react';
 import { palette } from '../palette';
 
-type IconSide = 'left' | 'right';
-
-interface Props {
+type Props = {
 	/**
 	 * Main content of pill. This can be a string or an element. eg.
 	 * <time>2:35</time>
@@ -16,61 +14,53 @@ interface Props {
 	/** Optional icon displayed before or after content */
 	icon?: ReactElement;
 	/** Optional icon position (icon is on the left by default) */
-	iconSide?: IconSide;
-	/** Optional icon size */
-	iconSize?: 'xsmall' | 'small' | 'medium' | 'large';
-}
+	iconSide?: 'left' | 'right';
+};
 
 const pillStyles = css`
+	height: ${space[6]}px;
 	display: inline-flex;
-	align-items: center;
+	align-items: stretch;
 	gap: ${space[1]}px;
-	padding: 0 10px;
+	padding: 0 ${space[2]}px;
 	border-radius: ${space[10]}px;
 	${textSansBold12};
 	color: ${palette('--pill-text')};
 	background-color: ${palette('--pill-background')};
+
 	svg {
 		flex: none;
-		margin: 0 -3px; /* Compensate for whitespace around icon */
 	}
 `;
 
-const pillContentStyles = css`
-	padding: ${space[1]}px 0;
+const contentStyles = css`
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	line-height: 1;
+`;
+
+const prefixStyles = css`
+	padding: ${space[1]}px 6px ${space[1]}px 0;
 	display: flex;
 	align-items: center;
 	gap: ${space[1]}px;
-`;
-
-const pillPrefixStyles = css`
-	margin-right: 2px;
-	padding-right: 6px;
 	border-right: 1px solid ${palette('--pill-divider')};
 `;
-export const Pill = ({
-	content,
-	prefix,
-	icon,
-	iconSide = 'left',
-	iconSize = 'xsmall',
-}: Props) => {
+
+export const Pill = ({ content, prefix, icon, iconSide = 'left' }: Props) => {
 	const renderedIcon =
 		icon &&
 		cloneElement(icon, {
-			size: iconSize,
+			size: 'xsmall',
 			theme: { fill: 'currentColor' },
 		});
 
 	return (
 		<div css={pillStyles}>
-			{iconSide === 'left' && renderedIcon}
-			{!!prefix && (
-				<span css={[pillContentStyles, pillPrefixStyles]}>
-					{prefix}
-				</span>
-			)}
-			<span css={pillContentStyles}>
+			{!!prefix && <span css={prefixStyles}>{prefix}</span>}
+			<span css={contentStyles}>
+				{iconSide === 'left' && renderedIcon}
 				{content}
 				{iconSide === 'right' && renderedIcon}
 			</span>

--- a/dotcom-rendering/src/components/SvgMediaControlsPlay.tsx
+++ b/dotcom-rendering/src/components/SvgMediaControlsPlay.tsx
@@ -4,14 +4,14 @@
  * icon library has been updated and published.
  */
 import { css } from '@emotion/react';
-import { iconSize, visuallyHidden } from '@guardian/source/foundations';
+import { visuallyHidden } from '@guardian/source/foundations';
 import { type IconProps } from '@guardian/source/react-components';
 
-const Svg = ({ size, theme }: IconProps) => (
+const Svg = ({ width, theme }: Props) => (
 	<svg
-		width={size ? iconSize[size] : undefined}
-		height={undefined}
-		viewBox="-3 -3 30 30"
+		width={width}
+		height={width}
+		viewBox="0 0 18 18"
 		xmlns="http://www.w3.org/2000/svg"
 		focusable={false}
 		aria-hidden={true}
@@ -19,19 +19,23 @@ const Svg = ({ size, theme }: IconProps) => (
 		<path
 			fillRule="evenodd"
 			clipRule="evenodd"
-			d="M19.2 12.39v-.72L8.59 5 8 5.36v13.23l.59.41z"
+			d="M14.4 9.2925V8.7525L6.4425 3.75L6 4.02V13.9425L6.4425 14.25L14.4 9.2925Z"
 			fill={theme?.fill}
 		/>
 	</svg>
 );
 
+type Props = {
+	width: 18 | 40;
+} & IconProps;
+
 export const SvgMediaControlsPlay = ({
-	size,
+	width,
 	theme,
 	isAnnouncedByScreenReader = false,
-}: IconProps) => (
+}: Props) => (
 	<>
-		<Svg size={size} theme={theme} />
+		<Svg width={width} theme={theme} />
 		{isAnnouncedByScreenReader ? (
 			<span
 				css={css`

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -159,7 +159,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 					<div css={videoPillStyles}>
 						<Pill
 							content={secondsToDuration(duration)}
-							icon={<SvgMediaControlsPlay />}
+							icon={<SvgMediaControlsPlay width={18} />}
 						/>
 					</div>
 				) : null}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -161,7 +161,6 @@ export const YoutubeAtomOverlay = ({
 						<Pill
 							content="Live"
 							icon={<div css={[liveBulletStyles]} />}
-							iconSize="small"
 						/>
 					</div>
 				) : hasDuration ? (
@@ -176,8 +175,7 @@ export const YoutubeAtomOverlay = ({
 					>
 						<Pill
 							content={secondsToDuration(duration)}
-							icon={<SvgMediaControlsPlay />}
-							iconSize="small"
+							icon={<SvgMediaControlsPlay width={18} />}
 						/>
 					</div>
 				) : null}


### PR DESCRIPTION
## What does this change?

Updates the Media Card pill across all cards in beta containers to display the text as well as the icon.

## Why?

[Updated designs](https://www.figma.com/design/b2qv2OMLoNCYnP01ipfrP7/%E2%97%88-Core-library?node-id=8780-47168&t=IPqgI6BYVHUCSFGO-0)

## Screenshots

| Before | After |
| - | - |
| ![a-before] | ![a-after] |
| ![b-before] | ![b-after] |
| ![c-before] | ![c-after] |
| ![d-before] | ![d-after] |
| ![e-before] | ![e-after] |
| ![f-before] | ![f-after] |

[a-before]: https://github.com/user-attachments/assets/352e45db-3a58-41d8-b6fd-cbfe3e1ee5b5
[b-before]: https://github.com/user-attachments/assets/b263bdd9-fb31-4215-b1dd-bb7c8109d61c
[c-before]: https://github.com/user-attachments/assets/afa0eea2-2851-40ef-b5cd-8d36f71b0d0d
[d-before]:  https://github.com/user-attachments/assets/3e217a3a-8cdb-41eb-b70a-e69fe03f522f
[e-before]: https://github.com/user-attachments/assets/b67cb93d-26d7-4a23-89af-67692c508b06
[f-before]: https://github.com/user-attachments/assets/39ef3133-92b4-4b3a-9f82-e667198d1b74
[a-after]: https://github.com/user-attachments/assets/b04b65a1-9150-4ac4-ae10-0eda8b3b0cea
[b-after]: https://github.com/user-attachments/assets/f8b23cf2-a6f2-450e-bf8e-18e9b26d9ef0
[c-after]: https://github.com/user-attachments/assets/3784321d-53fb-42ca-9928-19a577d39f93
[d-after]: https://github.com/user-attachments/assets/a224101e-a367-4885-ab74-625c6ff3a318
[e-after]: https://github.com/user-attachments/assets/51ef17ed-fd53-4b26-baca-656450519818
[f-after]: https://github.com/user-attachments/assets/9094d067-ec86-49a1-94b2-b82301dfdf52

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
