### PR TITLE
Test updating to c8g with reduced ASG sizes

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 27,
-		maximumInstances: 270,
+		minimumInstances: 24,
+		maximumInstances: 240,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -52,7 +52,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Facia */
@@ -68,8 +68,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 30,
-		maximumInstances: 180,
+		minimumInstances: 21,
+		maximumInstances: 210,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -92,7 +92,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Tag pages */
@@ -108,8 +108,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 15,
-		maximumInstances: 150,
+		minimumInstances: 9,
+		maximumInstances: 90,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -132,7 +132,7 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -172,5 +172,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });


### PR DESCRIPTION
## What does this change?

Following [analysis](https://docs.google.com/spreadsheets/d/1a-coA9LF9wTzN4CnNq7NOPZ_RwS984xZBdGNJfBF9Cw/edit?gid=0#gid=0) of #13620 we are confident c8g instances provide a ~30% performance improvement to latency metrics. This PR tests updating all stacks to c8g but with a reduced number of minimum instances to replicate our current performance profile but with hopefully reduced cost.

