### PR TITLE
Fix name of football-right ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -67,7 +67,7 @@ type RightProps = {
 };
 
 type RightFootballProps = {
-	position: 'right-football';
+	position: 'football-right';
 	colourScheme?: ColourScheme;
 	index?: never;
 	shouldHideReaderRevenue?: never;
@@ -515,7 +515,7 @@ export const AdSlot = ({
 				default:
 					return null;
 			}
-		case 'right-football': {
+		case 'football-right': {
 			const slotId = 'dfp-ad--right';
 			return (
 				<AdSlotWrapper

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -139,7 +139,7 @@ export const FootballMatchesPage = ({
 					}
 				`}
 			>
-				<AdSlot position="right-football" />
+				<AdSlot position="football-right" />
 			</div>
 		)}
 	</main>


### PR DESCRIPTION
## What does this change?

Renames `right-football` to `football-right` because this is the name for the slot in commercial 

## Why?

Keeps naming and types consistent between commercial and DCR

See https://github.com/search?q=org%3Aguardian+right-football&type=code vs https://github.com/search?q=org%3Aguardian+football-right&type=code