### PR TITLE
Disable dark mode for Datawrapper embeds on web

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -15,6 +15,7 @@ import { useOnce } from '../lib/useOnce';
 import { palette as themePalette } from '../palette';
 import type { RoleType } from '../types/content';
 import { Caption } from './Caption';
+import { useConfig } from './ConfigContext';
 import { defaultRoleStyles } from './Figure';
 import { Placeholder } from './Placeholder';
 
@@ -324,6 +325,7 @@ export const InteractiveBlockComponent = ({
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
+	const { darkModeAvailable } = useConfig();
 	useOnce(() => {
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
 		if (
@@ -346,15 +348,21 @@ export const InteractiveBlockComponent = ({
 			// Datawrapper-specific fix to suppress scrollbars appearing
 			if (url.includes('datawrapper')) {
 				iframe.scrolling = 'no';
-				iframe.scrolling = 'no';
 				// Turn off dark mode for Datawrapper embeds on web
 				// This should be removed if/when dark mode is implements on the website
 				if (
-					!document.querySelector('.ios') ||
+					!document.querySelector('.ios') &&
 					!document.querySelector('.android')
 				) {
-					iframe.src +=
-						(iframe.src.includes('?') ? '&' : '?') + 'dark=false';
+					const prefersDarkScheme = window.matchMedia(
+						'(prefers-color-scheme: dark)',
+					).matches;
+					const darkMode = darkModeAvailable && prefersDarkScheme;
+					if (!darkMode) {
+						iframe.src +=
+							(iframe.src.includes('?') ? '&' : '?') +
+							'dark=false';
+					}
 				}
 			}
 

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -346,6 +346,16 @@ export const InteractiveBlockComponent = ({
 			// Datawrapper-specific fix to suppress scrollbars appearing
 			if (url.includes('datawrapper')) {
 				iframe.scrolling = 'no';
+				iframe.scrolling = 'no';
+				// Turn off dark mode for Datawrapper embeds on web
+				// This should be removed if/when dark mode is implements on the website
+				if (
+					!document.querySelector('.ios') ||
+					!document.querySelector('.android')
+				) {
+					iframe.src +=
+						(iframe.src.includes('?') ? '&' : '?') + 'dark=false';
+				}
 			}
 
 			setupWindowListeners(iframe);


### PR DESCRIPTION
## What does this change?

This adds an additional check on Datawrapper embeds and adds a rendering flag ([Datawrapper documentation here](https://developer.datawrapper.de/docs/render-flags#:~:text=Description-,dark,true%2C%20false%2C%20%22auto%22,-For%20enforcing/disabling)) to turn off dark mode for charts appearing on the web.

A companion task to this would be turning on auto dark mode on Datawrapper as the default.

## Why?

The Guardian website has not rolled out dark mode in full yet, so having auto dark mode turned on for Datawrapper embeds has led to some visual clashes, i.e. the site appears 'light' because unless people opt in that's what they see, and the Datawrapper graphic appears dark.

This implementation would mean those who have opted in would get the visual clash - perhaps there's a way to weave that in too? - but a vast majority of browsers will get parity between site and Datawrapper palettes.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | <img width="1343" alt="image" src="https://github.com/user-attachments/assets/99152ecf-cc00-4a57-a010-0bfab2fd0f9d" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
