### PR TITLE
Create Football Table component

### DIFF
--- a/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
@@ -2,14 +2,16 @@ import { Option, Select } from '@guardian/source/react-components';
 import type { FootballMatchKind, Region } from '../footballMatches';
 import { palette } from '../palette';
 
+type FootballSelectKind = FootballMatchKind | 'Tables';
+
 type Props = {
 	regions: Region[];
-	kind: FootballMatchKind;
+	kind: FootballSelectKind;
 	pageId: string;
 	onChange: (competitionTag: string) => void;
 };
 
-const allLabel = (kind: FootballMatchKind): string => {
+const allLabel = (kind: FootballSelectKind): string => {
 	switch (kind) {
 		case 'Fixture':
 			return 'All fixtures';
@@ -17,10 +19,12 @@ const allLabel = (kind: FootballMatchKind): string => {
 			return 'All results';
 		case 'Live':
 			return 'All live';
+		case 'Tables':
+			return 'All tables';
 	}
 };
 
-const getPagePath = (kind: FootballMatchKind) => {
+const getPagePath = (kind: FootballSelectKind) => {
 	switch (kind) {
 		case 'Fixture':
 			return '/football/fixtures';
@@ -28,6 +32,8 @@ const getPagePath = (kind: FootballMatchKind) => {
 			return '/football/live';
 		case 'Result':
 			return '/football/results';
+		case 'Tables':
+			return '/football/tables';
 	}
 };
 

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -147,7 +147,7 @@ const Matches = (props: { children: ReactNode }) => (
 
 const matchStatusStyles = css`
 	width: 5rem;
-	color: ${palette('--football-match-list-sub-text')};
+	color: ${palette('--football-sub-text')};
 
 	${until.mobileMedium} {
 		flex-basis: 100%;
@@ -283,7 +283,7 @@ const Match = ({
 				{isUndefined(match.comment) ? null : (
 					<small
 						css={css`
-							color: ${palette('--football-match-list-sub-text')};
+							color: ${palette('--football-sub-text')};
 							flex-basis: 100%;
 							text-align: center;
 							padding-top: ${space[2]}px;
@@ -337,7 +337,7 @@ const Battleline = () => (
 const Versus = () => (
 	<span
 		css={css`
-			color: ${palette('--football-match-list-sub-text')};
+			color: ${palette('--football-sub-text')};
 			width: 3rem;
 			display: block;
 			padding: 0 4px;
@@ -359,7 +359,7 @@ const Scores = ({
 		css={css`
 			width: 3rem;
 			display: flex;
-			color: ${palette('--football-match-list-sub-text')};
+			color: ${palette('--football-sub-text')};
 		`}
 	>
 		<span

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -94,7 +94,7 @@ const Day = (props: { children: ReactNode }) => (
 		css={css`
 			${textSansBold14}
 			grid-column: centre-column-start / centre-column-end;
-			border-top: 1px solid ${palette('--football-match-list-border')};
+			border-top: 1px solid ${palette('--football-list-border')};
 			padding-top: ${space[2]}px;
 
 			${from.leftCol} {
@@ -119,7 +119,7 @@ const CompetitionName = (props: { children: ReactNode }) => (
 			margin-top: ${space[9]}px;
 
 			${from.leftCol} {
-				border-top-color: ${palette('--football-match-list-border')};
+				border-top-color: ${palette('--football-list-border')};
 				background-color: transparent;
 				margin-top: 0;
 				padding: ${space[1]}px 0 0;
@@ -196,7 +196,7 @@ export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
-	border: 1px solid ${palette('--football-match-list-border')};
+	border: 1px solid ${palette('--football-list-border')};
 
 	${from.leftCol} {
 		&:first-of-type {

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -112,7 +112,7 @@ const CompetitionName = (props: { children: ReactNode }) => (
 		css={css`
 			${textSansBold14}
 			grid-column: centre-column-start / centre-column-end;
-			color: ${palette('--football-match-list-competition-text')};
+			color: ${palette('--football-competition-text')};
 			border-top: 1px solid ${palette('--football-top-border')};
 			padding: ${space[2]}px;
 			background-color: ${palette('--football-match-list-background')};

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -113,7 +113,7 @@ const CompetitionName = (props: { children: ReactNode }) => (
 			${textSansBold14}
 			grid-column: centre-column-start / centre-column-end;
 			color: ${palette('--football-match-list-competition-text')};
-			border-top: 1px solid ${palette('--football-match-list-top-border')};
+			border-top: 1px solid ${palette('--football-top-border')};
 			padding: ${space[2]}px;
 			background-color: ${palette('--football-match-list-background')};
 			margin-top: ${space[9]}px;
@@ -200,7 +200,7 @@ const matchListItemStyles = css`
 
 	${from.leftCol} {
 		&:first-of-type {
-			border-top-color: ${palette('--football-match-list-top-border')};
+			border-top-color: ${palette('--football-top-border')};
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -31,12 +31,10 @@ type Story = StoryObj<typeof meta>;
 
 export const FootballTable = {
 	args: {
+		competitionName: 'Premier League',
+		competitionUrl: '/football/premierleague',
 		guardianBaseUrl: 'https://www.theguardian.com',
 		table: {
-			competition: {
-				name: 'Premier League',
-				url: '/football/premierleague',
-			},
 			linkToFullTable: true,
 			dividers: [1],
 			entries: [

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
+import { allModes } from '../../.storybook/modes';
 import { FootballTable } from './FootballTable';
 
 const meta = {
@@ -13,6 +14,15 @@ const meta = {
 			</>
 		),
 	],
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobile': allModes['vertical mobile'],
+				'vertical desktop': allModes['vertical desktop'],
+				'vertical wide': allModes['splitVertical'],
+			},
+		},
+	},
 } satisfies Meta<typeof FootballTable>;
 
 export default meta;

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -55,22 +55,27 @@ export const FootballTable = {
 					points: 70,
 					results: [
 						{
+							id: '1',
 							self: { name: 'Liverpool', score: 1 },
 							foe: { name: 'Chelsea', score: 0 },
 						},
 						{
+							id: '2',
 							self: { name: 'Liverpool', score: 3 },
 							foe: { name: 'Arsenal', score: 5 },
 						},
 						{
+							id: '3',
 							self: { name: 'Liverpool', score: 0 },
 							foe: { name: 'West Ham', score: 0 },
 						},
 						{
+							id: '4',
 							self: { name: 'Liverpool', score: 8 },
 							foe: { name: 'Tottenham', score: 10 },
 						},
 						{
+							id: '5',
 							self: { name: 'Liverpool', score: 0 },
 							foe: { name: 'Brighton', score: 0 },
 						},
@@ -93,22 +98,27 @@ export const FootballTable = {
 					points: 58,
 					results: [
 						{
+							id: '1',
 							self: { name: 'Arsenal', score: 4 },
 							foe: { name: 'Brighton', score: 0 },
 						},
 						{
+							id: '2',
 							self: { name: 'Arsenal', score: 3 },
 							foe: { name: 'Manchester United', score: 0 },
 						},
 						{
+							id: '3',
 							self: { name: 'Arsenal', score: 5 },
 							foe: { name: 'West Ham', score: 0 },
 						},
 						{
+							id: '4',
 							self: { name: 'Arsenal', score: 9 },
 							foe: { name: 'Manchester City', score: 0 },
 						},
 						{
+							id: '5',
 							self: { name: 'Arsenal', score: 0 },
 							foe: { name: 'Tottenham', score: 0 },
 						},
@@ -131,22 +141,27 @@ export const FootballTable = {
 					points: 54,
 					results: [
 						{
+							id: '1',
 							self: { name: 'Nottm Forest', score: 4 },
 							foe: { name: 'Brighton', score: 4 },
 						},
 						{
+							id: '2',
 							self: { name: 'Nottm Forest', score: 0 },
 							foe: { name: 'Manchester United', score: 0 },
 						},
 						{
+							id: '3',
 							self: { name: 'Nottm Forest', score: 0 },
 							foe: { name: 'West Ham', score: 7 },
 						},
 						{
+							id: '4',
 							self: { name: 'Nottm Forest', score: 9 },
 							foe: { name: 'Manchester City', score: 0 },
 						},
 						{
+							id: '5',
 							self: { name: 'Nottm Forest', score: 10 },
 							foe: { name: 'Tottenham', score: 0 },
 						},

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -31,141 +31,142 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
 	args: {
-		competition: {
-			name: 'Premier League',
-			url: 'https://www.theguardian.com/football/premierleague',
-			tableUrl:
-				'https://www.theguardian.com/football/premierleague/table',
+		guardianBaseUrl: 'https://www.theguardian.com',
+		table: {
+			competition: {
+				name: 'Premier League',
+				url: 'https://www.theguardian.com/football/premierleague',
+			},
+			linkToFullTable: true,
+			dividers: [1],
+			entries: [
+				{
+					position: 1,
+					team: {
+						name: 'Liverpool',
+						id: '9',
+						url: 'https://www.theguardian.com/football/arsenal',
+					},
+					gamesPlayed: 29,
+					won: 21,
+					drawn: 7,
+					lost: 1,
+					goalsFor: 69,
+					goalsAgainst: 27,
+					goalDifference: 42,
+					points: 70,
+					results: [
+						{
+							self: { name: 'Liverpool', score: 1 },
+							foe: { name: 'Chelsea', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 3 },
+							foe: { name: 'Arsenal', score: 5 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'West Ham', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 8 },
+							foe: { name: 'Tottenham', score: 10 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'Brighton', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+				{
+					position: 2,
+					team: {
+						name: 'Arsenal',
+						id: '1006',
+						url: 'https://www.theguardian.com/football/arsenal',
+					},
+					gamesPlayed: 29,
+					won: 21,
+					drawn: 10,
+					lost: 3,
+					goalsFor: 53,
+					goalsAgainst: 24,
+					goalDifference: 29,
+					points: 58,
+					results: [
+						{
+							self: { name: 'Arsenal', score: 4 },
+							foe: { name: 'Brighton', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 3 },
+							foe: { name: 'Manchester United', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 5 },
+							foe: { name: 'West Ham', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 9 },
+							foe: { name: 'Manchester City', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 0 },
+							foe: { name: 'Tottenham', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+				{
+					position: 3,
+					team: {
+						name: 'Nottm Forest',
+						id: '15',
+						url: 'https://www.theguardian.com/football/nottinghamforest',
+					},
+					gamesPlayed: 29,
+					won: 16,
+					drawn: 6,
+					lost: 7,
+					goalsFor: 49,
+					goalsAgainst: 35,
+					goalDifference: 14,
+					points: 54,
+					results: [
+						{
+							self: { name: 'Nottm Forest', score: 4 },
+							foe: { name: 'Brighton', score: 4 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'Manchester United', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'West Ham', score: 7 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 9 },
+							foe: { name: 'Manchester City', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 10 },
+							foe: { name: 'Tottenham', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+			],
 		},
-		linkToFullTable: true,
-		dividers: [1],
-		data: [
-			{
-				position: 1,
-				team: {
-					name: 'Liverpool',
-					id: '9',
-					url: 'https://www.theguardian.com/football/arsenal',
-				},
-				gamesPlayed: 29,
-				won: 21,
-				drawn: 7,
-				lost: 1,
-				goalsFor: 69,
-				goalsAgainst: 27,
-				goalDifference: 42,
-				points: 70,
-				results: [
-					{
-						self: { name: 'Liverpool', score: 1 },
-						foe: { name: 'Chelsea', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 3 },
-						foe: { name: 'Arsenal', score: 5 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'West Ham', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 8 },
-						foe: { name: 'Tottenham', score: 10 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'Brighton', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-			{
-				position: 2,
-				team: {
-					name: 'Arsenal',
-					id: '1006',
-					url: 'https://www.theguardian.com/football/arsenal',
-				},
-				gamesPlayed: 29,
-				won: 21,
-				drawn: 10,
-				lost: 3,
-				goalsFor: 53,
-				goalsAgainst: 24,
-				goalDifference: 29,
-				points: 58,
-				results: [
-					{
-						self: { name: 'Arsenal', score: 4 },
-						foe: { name: 'Brighton', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 3 },
-						foe: { name: 'Manchester United', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 5 },
-						foe: { name: 'West Ham', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 9 },
-						foe: { name: 'Manchester City', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 0 },
-						foe: { name: 'Tottenham', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-			{
-				position: 3,
-				team: {
-					name: 'Nottm Forest',
-					id: '15',
-					url: 'https://www.theguardian.com/football/nottinghamforest',
-				},
-				gamesPlayed: 29,
-				won: 16,
-				drawn: 6,
-				lost: 7,
-				goalsFor: 49,
-				goalsAgainst: 35,
-				goalDifference: 14,
-				points: 54,
-				results: [
-					{
-						self: { name: 'Nottm Forest', score: 4 },
-						foe: { name: 'Brighton', score: 4 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'Manchester United', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'West Ham', score: 7 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 9 },
-						foe: { name: 'Manchester City', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 10 },
-						foe: { name: 'Tottenham', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-		],
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -76,10 +76,6 @@ export const FootballTable = {
 							self: { name: 'Liverpool', score: 0 },
 							foe: { name: 'Brighton', score: 0 },
 						},
-						{
-							self: { name: 'Liverpool', score: 0 },
-							foe: { name: 'Blackburn', score: 0 },
-						},
 					],
 				},
 				{
@@ -118,10 +114,6 @@ export const FootballTable = {
 							self: { name: 'Arsenal', score: 0 },
 							foe: { name: 'Tottenham', score: 0 },
 						},
-						{
-							self: { name: 'Arsenal', score: 0 },
-							foe: { name: 'Blackburn', score: 0 },
-						},
 					],
 				},
 				{
@@ -159,10 +151,6 @@ export const FootballTable = {
 						{
 							self: { name: 'Nottm Forest', score: 10 },
 							foe: { name: 'Tottenham', score: 0 },
-						},
-						{
-							self: { name: 'Nottm Forest', score: 0 },
-							foe: { name: 'Blackburn', score: 0 },
 						},
 					],
 				},

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -45,6 +45,32 @@ export const Default = {
 				goalsAgainst: 27,
 				goalDifference: 42,
 				points: 70,
+				results: [
+					{
+						self: { name: 'Liverpool', score: 1 },
+						foe: { name: 'Chelsea', score: 0 },
+					},
+					{
+						self: { name: 'Liverpool', score: 3 },
+						foe: { name: 'Arsenal', score: 5 },
+					},
+					{
+						self: { name: 'Liverpool', score: 0 },
+						foe: { name: 'West Ham', score: 0 },
+					},
+					{
+						self: { name: 'Liverpool', score: 8 },
+						foe: { name: 'Tottenham', score: 10 },
+					},
+					{
+						self: { name: 'Liverpool', score: 0 },
+						foe: { name: 'Brighton', score: 0 },
+					},
+					{
+						self: { name: 'Liverpool', score: 0 },
+						foe: { name: 'Blackburn', score: 0 },
+					},
+				],
 			},
 			{
 				position: 2,
@@ -61,6 +87,32 @@ export const Default = {
 				goalsAgainst: 24,
 				goalDifference: 29,
 				points: 58,
+				results: [
+					{
+						self: { name: 'Arsenal', score: 4 },
+						foe: { name: 'Brighton', score: 0 },
+					},
+					{
+						self: { name: 'Arsenal', score: 3 },
+						foe: { name: 'Manchester United', score: 0 },
+					},
+					{
+						self: { name: 'Arsenal', score: 5 },
+						foe: { name: 'West Ham', score: 0 },
+					},
+					{
+						self: { name: 'Arsenal', score: 9 },
+						foe: { name: 'Manchester City', score: 0 },
+					},
+					{
+						self: { name: 'Arsenal', score: 0 },
+						foe: { name: 'Tottenham', score: 0 },
+					},
+					{
+						self: { name: 'Arsenal', score: 0 },
+						foe: { name: 'Blackburn', score: 0 },
+					},
+				],
 			},
 			{
 				position: 3,
@@ -77,6 +129,32 @@ export const Default = {
 				goalsAgainst: 35,
 				goalDifference: 14,
 				points: 54,
+				results: [
+					{
+						self: { name: 'Nottm Forest', score: 4 },
+						foe: { name: 'Brighton', score: 4 },
+					},
+					{
+						self: { name: 'Nottm Forest', score: 0 },
+						foe: { name: 'Manchester United', score: 0 },
+					},
+					{
+						self: { name: 'Nottm Forest', score: 0 },
+						foe: { name: 'West Ham', score: 7 },
+					},
+					{
+						self: { name: 'Nottm Forest', score: 9 },
+						foe: { name: 'Manchester City', score: 0 },
+					},
+					{
+						self: { name: 'Nottm Forest', score: 10 },
+						foe: { name: 'Tottenham', score: 0 },
+					},
+					{
+						self: { name: 'Nottm Forest', score: 0 },
+						foe: { name: 'Blackburn', score: 0 },
+					},
+				],
 			},
 		],
 	},

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -21,6 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
 	args: {
+		dividers: [1],
 		data: [
 			{
 				position: 1,
@@ -33,6 +34,30 @@ export const Default = {
 				goalsAgainst: 27,
 				goalDifference: 42,
 				points: 70,
+			},
+			{
+				position: 2,
+				team: 'Arsenal',
+				gamesPlayed: 29,
+				won: 21,
+				drawn: 10,
+				lost: 3,
+				goalsFor: 53,
+				goalsAgainst: 24,
+				goalDifference: 29,
+				points: 58,
+			},
+			{
+				position: 3,
+				team: 'Nottm Forest',
+				gamesPlayed: 29,
+				won: 16,
+				drawn: 6,
+				lost: 7,
+				goalsFor: 49,
+				goalsAgainst: 35,
+				goalDifference: 14,
+				points: 54,
 			},
 		],
 	},

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -30,7 +30,11 @@ export const Default = {
 		data: [
 			{
 				position: 1,
-				team: 'Liverpool',
+				team: {
+					name: 'Liverpool',
+					id: '9',
+					url: 'https://www.theguardian.com/football/arsenal',
+				},
 				gamesPlayed: 29,
 				won: 21,
 				drawn: 7,
@@ -42,7 +46,11 @@ export const Default = {
 			},
 			{
 				position: 2,
-				team: 'Arsenal',
+				team: {
+					name: 'Arsenal',
+					id: '1006',
+					url: 'https://www.theguardian.com/football/arsenal',
+				},
 				gamesPlayed: 29,
 				won: 21,
 				drawn: 10,
@@ -54,7 +62,11 @@ export const Default = {
 			},
 			{
 				position: 3,
-				team: 'Nottm Forest',
+				team: {
+					name: 'Nottm Forest',
+					id: '15',
+					url: 'https://www.theguardian.com/football/nottinghamforest',
+				},
 				gamesPlayed: 29,
 				won: 16,
 				drawn: 6,

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta<typeof FootballTableComponent >;
+} satisfies Meta<typeof FootballTableComponent>;
 
 export default meta;
 
@@ -35,7 +35,7 @@ export const FootballTable = {
 		table: {
 			competition: {
 				name: 'Premier League',
-				url: 'https://www.theguardian.com/football/premierleague',
+				url: '/football/premierleague',
 			},
 			linkToFullTable: true,
 			dividers: [1],
@@ -45,7 +45,7 @@ export const FootballTable = {
 					team: {
 						name: 'Liverpool',
 						id: '9',
-						url: 'https://www.theguardian.com/football/arsenal',
+						url: '/football/liverpool',
 					},
 					gamesPlayed: 29,
 					won: 21,
@@ -87,7 +87,7 @@ export const FootballTable = {
 					team: {
 						name: 'Arsenal',
 						id: '1006',
-						url: 'https://www.theguardian.com/football/arsenal',
+						url: '/football/arsenal',
 					},
 					gamesPlayed: 29,
 					won: 21,
@@ -129,7 +129,7 @@ export const FootballTable = {
 					team: {
 						name: 'Nottm Forest',
 						id: '15',
-						url: 'https://www.theguardian.com/football/nottinghamforest',
+						url: '/football/nottinghamforest',
 					},
 					gamesPlayed: 29,
 					won: 16,

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -23,7 +23,9 @@ export const Default = {
 	args: {
 		competition: {
 			name: 'Premier League',
-			url: 'https://www.theguardian.com/football/premierleague/table',
+			url: 'https://www.theguardian.com/football/premierleague',
+			tableUrl:
+				'https://www.theguardian.com/football/premierleague/table',
 		},
 		linkToFullTable: true,
 		dividers: [1],

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react/*';
+import { FootballTable } from './FootballTable';
+
+const meta = {
+	title: 'Components/Football Table',
+	component: FootballTable,
+	decorators: [
+		// To make it easier to see the top border above the table
+		(Story) => (
+			<>
+				<div css={{ padding: 4 }}></div>
+				<Story />
+			</>
+		),
+	],
+} satisfies Meta<typeof FootballTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		data: [
+			{
+				position: 1,
+				team: 'Liverpool',
+				gamesPlayed: 29,
+				won: 21,
+				drawn: 7,
+				lost: 1,
+				goalsFor: 69,
+				goalsAgainst: 27,
+				goalDifference: 42,
+				points: 70,
+			},
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
 import { allModes } from '../../.storybook/modes';
-import { FootballTable } from './FootballTable';
+import { FootballTable as FootballTableComponent } from './FootballTable';
 
 const meta = {
 	title: 'Components/Football Table',
-	component: FootballTable,
+	component: FootballTableComponent,
 	decorators: [
 		// To make it easier to see the top border above the table
 		(Story) => (
@@ -23,13 +23,13 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta<typeof FootballTable>;
+} satisfies Meta<typeof FootballTableComponent >;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const FootballTable = {
 	args: {
 		guardianBaseUrl: 'https://www.theguardian.com',
 		table: {

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -21,6 +21,11 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
 	args: {
+		competition: {
+			name: 'Premier League',
+			url: 'https://www.theguardian.com/football/premierleague/table',
+		},
+		linkToFullTable: true,
 		dividers: [1],
 		data: [
 			{

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -50,6 +50,10 @@ const headingAbbreviations: Record<string, string | undefined> = {
 };
 
 type Props = {
+	competition: {
+		url: string;
+		name: string;
+	};
 	dividers: number[];
 	data: {
 		position: number;
@@ -63,9 +67,15 @@ type Props = {
 		goalDifference: number;
 		points: number;
 	}[];
+	linkToFullTable: boolean;
 };
 
-export const FootballTable = ({ data, dividers }: Props) => {
+export const FootballTable = ({
+	competition,
+	data,
+	dividers,
+	linkToFullTable,
+}: Props) => {
 	return (
 		<table css={tableStyles}>
 			<thead css={headStyles}>
@@ -113,6 +123,28 @@ export const FootballTable = ({ data, dividers }: Props) => {
 					</tr>
 				))}
 			</tbody>
+			{linkToFullTable && (
+				<tfoot>
+					<tr css={rowStyles}>
+						<td colSpan={11}>
+							<a
+								href={competition.url}
+								css={css`
+									text-decoration: none;
+									color: ${palette(
+										'--football-competition-text',
+									)};
+									:hover {
+										text-decoration: underline;
+									}
+								`}
+							>
+								View full {competition.name} table
+							</a>
+						</td>
+					</tr>
+				</tfoot>
+			)}
 		</table>
 	);
 };

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -26,7 +26,8 @@ const headStyles = css`
 
 const rowStyles = css`
 	${textSans14};
-	:nth-child(odd) > td {
+	:nth-child(odd) > td,
+	:nth-child(odd) > th {
 		background-color: ${palette('--table-block-stripe')};
 	}
 
@@ -38,7 +39,8 @@ const rowStyles = css`
 `;
 
 const dividerStyle = css`
-	td {
+	td,
+	th {
 		border-top: 0.0625rem dashed ${palette('--football-table-divider')};
 	}
 `;
@@ -176,13 +178,13 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 					>
 						{row.position}
 					</td>
-					<td>
+					<th scope="row">
 						<TeamWithCrest
 							team={row.team.name}
 							id={row.team.id}
 							url={row.team.url}
 						/>
-					</td>
+					</th>
 					<td>{row.gamesPlayed}</td>
 					<td css={hideUntilTabletStyle}>{row.won}</td>
 					<td css={hideUntilTabletStyle}>{row.drawn}</td>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -69,6 +69,18 @@ function getFootballCrestImageUrl(teamId: string) {
 	return `https://sport.guim.co.uk/football/crests/60/${teamId}.png`;
 }
 
+const FullTableLink = ({
+	competition,
+	guardianBaseUrl,
+}: {
+	competition: FootballTableData['competition'];
+	guardianBaseUrl: string;
+}) => (
+	<a href={`${guardianBaseUrl}${competition.url}/table`} css={linkStyles}>
+		View full {competition.name} table
+	</a>
+);
+
 const FootballCrest = ({ teamId }: { teamId: string }) => (
 	<div
 		css={css`
@@ -212,13 +224,24 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 		{table.linkToFullTable && (
 			<tfoot>
 				<tr css={rowStyles}>
-					<td colSpan={11}>
-						<a
-							href={`${guardianBaseUrl}${table.competition.url}/table`}
-							css={linkStyles}
-						>
-							View full {table.competition.name} table
-						</a>
+					<td colSpan={11} css={hideUntilTabletStyle}>
+						<FullTableLink
+							competition={table.competition}
+							guardianBaseUrl={guardianBaseUrl}
+						/>
+					</td>
+					<td
+						colSpan={6}
+						css={css`
+							${from.tablet} {
+								display: none;
+							}
+						`}
+					>
+						<FullTableLink
+							competition={table.competition}
+							guardianBaseUrl={guardianBaseUrl}
+						/>
 					</td>
 				</tr>
 			</tfoot>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -164,7 +164,11 @@ export const FootballTable = ({
 			</caption>
 			<thead css={headStyles}>
 				<tr css={rowStyles}>
-					<th>
+					<th
+						css={css`
+							color: ${palette('--football-sub-text')};
+						`}
+					>
 						<abbr title="Position">P</abbr>
 					</th>
 					<th>Team</th>
@@ -203,7 +207,13 @@ export const FootballTable = ({
 							dividers.includes(row.position - 1) && dividerStyle,
 						]}
 					>
-						<td>{row.position}</td>
+						<td
+							css={css`
+								color: ${palette('--football-sub-text')};
+							`}
+						>
+							{row.position}
+						</td>
 						<td>
 							<TeamWithCrest
 								team={row.team.name}

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -57,7 +57,7 @@ type Props = {
 	dividers: number[];
 	data: {
 		position: number;
-		team: string;
+		team: { name: string; id: string; url: string };
 		gamesPlayed: number;
 		won: number;
 		drawn: number;
@@ -69,6 +69,62 @@ type Props = {
 	}[];
 	linkToFullTable: boolean;
 };
+
+function getFootballCrestImageUrl(teamId: string) {
+	// todo: use fastly resizer
+	return `https://sport.guim.co.uk/football/crests/60/${teamId}.png`;
+}
+
+const FootballCrest = ({ teamId }: { teamId: string }) => (
+	<div
+		css={css`
+			width: 1.25rem;
+			height: 1.25rem;
+			flex-shrink: 0;
+			display: flex;
+			justify-content: center;
+		`}
+	>
+		<img
+			css={css`
+				max-width: 100%;
+				max-height: 100%;
+				object-fit: contain;
+			`}
+			src={getFootballCrestImageUrl(teamId)}
+			alt=""
+		/>
+	</div>
+);
+
+const TeamWithCrest = ({
+	team,
+	id,
+	url,
+}: {
+	team: string;
+	id: string;
+	url: string;
+}) => (
+	<div
+		css={css`
+			display: flex;
+			align-items: center;
+			gap: 0.325rem;
+		`}
+	>
+		<FootballCrest teamId={id} />
+		<a
+			css={css`
+				color: inherit;
+				text-decoration: none;
+			`}
+			href={url}
+		>
+			{team}
+		</a>
+	</div>
+);
 
 export const FootballTable = ({
 	competition,
@@ -103,7 +159,13 @@ export const FootballTable = ({
 						]}
 					>
 						<td>{row.position}</td>
-						<td>{row.team}</td>
+						<td>
+							<TeamWithCrest
+								team={row.team.name}
+								id={row.team.id}
+								url={row.team.url}
+							/>
+						</td>
 						<td>{row.gamesPlayed}</td>
 						<td>{row.won}</td>
 						<td>{row.drawn}</td>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -5,8 +5,8 @@ import {
 	textSansBold14,
 	until,
 } from '@guardian/source/foundations';
+import type { FootballTableData } from '../footballTables';
 import { palette } from '../palette';
-import type { TeamResult } from './FootballTableForm';
 import { FootballTableForm } from './FootballTableForm';
 
 const tableStyles = css`
@@ -63,26 +63,8 @@ const linkStyles = css`
 `;
 
 type Props = {
-	competition: {
-		url: string;
-		tableUrl: string;
-		name: string;
-	};
-	dividers: number[];
-	data: {
-		position: number;
-		team: { name: string; id: string; url: string };
-		gamesPlayed: number;
-		won: number;
-		drawn: number;
-		lost: number;
-		goalsFor: number;
-		goalsAgainst: number;
-		goalDifference: number;
-		points: number;
-		results: TeamResult[];
-	}[];
-	linkToFullTable: boolean;
+	table: FootballTableData;
+	guardianBaseUrl: string;
 };
 
 function getFootballCrestImageUrl(teamId: string) {
@@ -141,128 +123,127 @@ const TeamWithCrest = ({
 	</div>
 );
 
-export const FootballTable = ({
-	competition,
-	data,
-	dividers,
-	linkToFullTable,
-}: Props) => {
-	return (
-		<table css={tableStyles}>
-			<caption
-				css={css`
-					${from.leftCol} {
-						display: none;
-					}
-					text-align: left;
-					border-top: 0.0625rem solid
-						${palette('--football-top-border')};
-					padding: 0.5rem;
-					${textSansBold14};
-					background: ${palette('--table-block-background')};
-				`}
+export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
+	<table css={tableStyles}>
+		<caption
+			css={css`
+				${from.leftCol} {
+					display: none;
+				}
+				text-align: left;
+				border-top: 0.0625rem solid ${palette('--football-top-border')};
+				padding: 0.5rem;
+				${textSansBold14};
+				background: ${palette('--table-block-background')};
+			`}
+		>
+			<a
+				css={linkStyles}
+				href={`${guardianBaseUrl}${table.competition.url}`}
 			>
-				<a css={linkStyles} href={competition.url}>
-					{competition.name}
-				</a>
-			</caption>
-			<thead css={headStyles}>
-				<tr css={rowStyles}>
-					<th
+				{table.competition.name}
+			</a>
+		</caption>
+		<thead css={headStyles}>
+			<tr css={rowStyles}>
+				<th
+					css={css`
+						color: ${palette('--football-sub-text')};
+					`}
+				>
+					<abbr title="Position">P</abbr>
+				</th>
+				<th>Team</th>
+				<th>
+					<abbr title="Games played">GP</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Won">W</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Drawn">D</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Lost">L</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Goals for">F</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Goals against">A</abbr>
+				</th>
+				<th>
+					<abbr title="Goal difference">GD</abbr>
+				</th>
+				<th>
+					<abbr title="Points">Pts</abbr>
+				</th>
+				<th>
+					<abbr title="Results of previous games">Form</abbr>
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			{table.entries.map((row) => (
+				<tr
+					key={row.position}
+					css={[
+						rowStyles,
+						table.dividers.includes(row.position - 1) &&
+							dividerStyle,
+					]}
+				>
+					<td
 						css={css`
 							color: ${palette('--football-sub-text')};
 						`}
 					>
-						<abbr title="Position">P</abbr>
-					</th>
-					<th>Team</th>
-					<th>
-						<abbr title="Games played">GP</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Won">W</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Drawn">D</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Lost">L</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Goals for">F</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Goals against">A</abbr>
-					</th>
-					<th>
-						<abbr title="Goal difference">GD</abbr>
-					</th>
-					<th>
-						<abbr title="Points">Pts</abbr>
-					</th>
-					<th>
-						<abbr title="Results of previous games">Form</abbr>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				{data.map((row) => (
-					<tr
-						key={row.position}
-						css={[
-							rowStyles,
-							dividers.includes(row.position - 1) && dividerStyle,
-						]}
-					>
-						<td
+						{row.position}
+					</td>
+					<td>
+						<TeamWithCrest
+							team={row.team.name}
+							id={row.team.id}
+							url={row.team.url}
+						/>
+					</td>
+					<td>{row.gamesPlayed}</td>
+					<td css={hideUntilTabletStyle}>{row.won}</td>
+					<td css={hideUntilTabletStyle}>{row.drawn}</td>
+					<td css={hideUntilTabletStyle}>{row.lost}</td>
+					<td css={hideUntilTabletStyle}>{row.goalsFor}</td>
+					<td css={hideUntilTabletStyle}>{row.goalsAgainst}</td>
+					<td>{row.goalDifference}</td>
+					<td>
+						<b
 							css={css`
-								color: ${palette('--football-sub-text')};
+								font-weight: 800;
 							`}
 						>
-							{row.position}
-						</td>
-						<td>
-							<TeamWithCrest
-								team={row.team.name}
-								id={row.team.id}
-								url={row.team.url}
-							/>
-						</td>
-						<td>{row.gamesPlayed}</td>
-						<td css={hideUntilTabletStyle}>{row.won}</td>
-						<td css={hideUntilTabletStyle}>{row.drawn}</td>
-						<td css={hideUntilTabletStyle}>{row.lost}</td>
-						<td css={hideUntilTabletStyle}>{row.goalsFor}</td>
-						<td css={hideUntilTabletStyle}>{row.goalsAgainst}</td>
-						<td>{row.goalDifference}</td>
-						<td>
-							<b
-								css={css`
-									font-weight: 800;
-								`}
-							>
-								{row.points}
-							</b>
-						</td>
-						<td>
-							<FootballTableForm
-								teamResults={row.results.slice(0, 5)}
-							/>
-						</td>
-					</tr>
-				))}
-			</tbody>
-			{linkToFullTable && (
-				<tfoot>
-					<tr css={rowStyles}>
-						<td colSpan={11}>
-							<a href={competition.tableUrl} css={linkStyles}>
-								View full {competition.name} table
-							</a>
-						</td>
-					</tr>
-				</tfoot>
-			)}
-		</table>
-	);
-};
+							{row.points}
+						</b>
+					</td>
+					<td>
+						<FootballTableForm
+							teamResults={row.results.slice(0, 5)}
+						/>
+					</td>
+				</tr>
+			))}
+		</tbody>
+		{table.linkToFullTable && (
+			<tfoot>
+				<tr css={rowStyles}>
+					<td colSpan={11}>
+						<a
+							href={`${guardianBaseUrl}${table.competition.url}/table`}
+							css={linkStyles}
+						>
+							View full {table.competition.name} table
+						</a>
+					</td>
+				</tr>
+			</tfoot>
+		)}
+	</table>
+);

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -214,9 +214,7 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 						</b>
 					</td>
 					<td>
-						<FootballTableForm
-							teamResults={row.results.slice(0, 5)}
-						/>
+						<FootballTableForm teamResults={row.results} />
 					</td>
 				</tr>
 			))}

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
-import { textSans14 } from '@guardian/source/foundations';
+import { textSans14, until } from '@guardian/source/foundations';
 import { palette } from '../palette';
 
 const tableStyles = css`
@@ -36,18 +35,11 @@ const dividerStyle = css`
 	}
 `;
 
-const headingAbbreviations: Record<string, string | undefined> = {
-	P: 'Position',
-	Team: undefined,
-	GP: 'Games played',
-	W: 'Won',
-	D: 'Drawn',
-	L: 'Lost',
-	F: 'Goals for',
-	A: 'Goals against',
-	GD: 'Goal difference',
-	Pts: 'Points',
-};
+const hideUntilTabletStyle = css`
+	${until.tablet} {
+		display: none;
+	}
+`;
 
 type Props = {
 	competition: {
@@ -136,17 +128,34 @@ export const FootballTable = ({
 		<table css={tableStyles}>
 			<thead css={headStyles}>
 				<tr css={rowStyles}>
-					{Object.entries(headingAbbreviations).map(
-						([key, value]) => (
-							<th key={key}>
-								{isUndefined(value) ? (
-									<>{key}</>
-								) : (
-									<abbr title={value}>{key}</abbr>
-								)}
-							</th>
-						),
-					)}
+					<th>
+						<abbr title="Position">P</abbr>
+					</th>
+					<th>Team</th>
+					<th>
+						<abbr title="Games played">GP</abbr>
+					</th>
+					<th css={hideUntilTabletStyle}>
+						<abbr title="Won">W</abbr>
+					</th>
+					<th css={hideUntilTabletStyle}>
+						<abbr title="Drawn">D</abbr>
+					</th>
+					<th css={hideUntilTabletStyle}>
+						<abbr title="Lost">L</abbr>
+					</th>
+					<th css={hideUntilTabletStyle}>
+						<abbr title="Goals for">F</abbr>
+					</th>
+					<th css={hideUntilTabletStyle}>
+						<abbr title="Goals against">A</abbr>
+					</th>
+					<th>
+						<abbr title="Goal difference">GD</abbr>
+					</th>
+					<th>
+						<abbr title="Points">Pts</abbr>
+					</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -167,11 +176,11 @@ export const FootballTable = ({
 							/>
 						</td>
 						<td>{row.gamesPlayed}</td>
-						<td>{row.won}</td>
-						<td>{row.drawn}</td>
-						<td>{row.lost}</td>
-						<td>{row.goalsFor}</td>
-						<td>{row.goalsAgainst}</td>
+						<td css={hideUntilTabletStyle}>{row.won}</td>
+						<td css={hideUntilTabletStyle}>{row.drawn}</td>
+						<td css={hideUntilTabletStyle}>{row.lost}</td>
+						<td css={hideUntilTabletStyle}>{row.goalsFor}</td>
+						<td css={hideUntilTabletStyle}>{row.goalsAgainst}</td>
 						<td>{row.goalDifference}</td>
 						<td>
 							<b

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -1,11 +1,21 @@
 import { css } from '@emotion/react';
-import { textSans14, until } from '@guardian/source/foundations';
+import {
+	from,
+	textSans14,
+	textSansBold14,
+	until,
+} from '@guardian/source/foundations';
 import { palette } from '../palette';
 
 const tableStyles = css`
 	width: 100%;
 	background: ${palette('--table-block-background')};
-	border-top: 0.0625rem solid ${palette('--football-top-border')};
+	${until.leftCol} {
+		border-top: 0.0625rem solid ${palette('--table-block-stripe')};
+	}
+	${from.leftCol} {
+		border-top: 0.0625rem solid ${palette('--football-top-border')};
+	}
 	color: ${palette('--table-block-text')};
 	border-collapse: inherit;
 `;
@@ -41,9 +51,18 @@ const hideUntilTabletStyle = css`
 	}
 `;
 
+const linkStyles = css`
+	text-decoration: none;
+	color: ${palette('--football-competition-text')};
+	:hover {
+		text-decoration: underline;
+	}
+`;
+
 type Props = {
 	competition: {
 		url: string;
+		tableUrl: string;
 		name: string;
 	};
 	dividers: number[];
@@ -126,6 +145,23 @@ export const FootballTable = ({
 }: Props) => {
 	return (
 		<table css={tableStyles}>
+			<caption
+				css={css`
+					${from.leftCol} {
+						display: none;
+					}
+					text-align: left;
+					border-top: 0.0625rem solid
+						${palette('--football-top-border')};
+					padding: 0.5rem;
+					${textSansBold14};
+					background: ${palette('--table-block-background')};
+				`}
+			>
+				<a css={linkStyles} href={competition.url}>
+					{competition.name}
+				</a>
+			</caption>
 			<thead css={headStyles}>
 				<tr css={rowStyles}>
 					<th>
@@ -198,18 +234,7 @@ export const FootballTable = ({
 				<tfoot>
 					<tr css={rowStyles}>
 						<td colSpan={11}>
-							<a
-								href={competition.url}
-								css={css`
-									text-decoration: none;
-									color: ${palette(
-										'--football-competition-text',
-									)};
-									:hover {
-										text-decoration: underline;
-									}
-								`}
-							>
+							<a href={competition.tableUrl} css={linkStyles}>
 								View full {competition.name} table
 							</a>
 						</td>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -1,0 +1,105 @@
+import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
+import { textSans14 } from '@guardian/source/foundations';
+import { palette } from '../palette';
+
+const tableStyles = css`
+	width: 100%;
+	background: ${palette('--table-block-background')};
+	border-top: 0.0625rem solid ${palette('--football-top-border')};
+	color: ${palette('--table-block-text')};
+	border-collapse: inherit;
+`;
+
+const headStyles = css`
+	tr {
+		font-weight: 800;
+		text-align: left;
+	}
+`;
+
+const rowStyles = css`
+	${textSans14};
+	:nth-child(odd) > td {
+		background-color: ${palette('--table-block-stripe')};
+	}
+
+	td,
+	th {
+		padding: 0.5rem;
+	}
+`;
+
+const headingAbbreviations: Record<string, string | undefined> = {
+	P: 'Position',
+	Team: undefined,
+	GP: 'Games played',
+	W: 'Won',
+	D: 'Drawn',
+	L: 'Lost',
+	F: 'Goals for',
+	A: 'Goals against',
+	GD: 'Goal difference',
+	Pts: 'Points',
+};
+
+type Props = {
+	data: {
+		position: number;
+		team: string;
+		gamesPlayed: number;
+		won: number;
+		drawn: number;
+		lost: number;
+		goalsFor: number;
+		goalsAgainst: number;
+		goalDifference: number;
+		points: number;
+	}[];
+};
+
+export const FootballTable = ({ data }: Props) => {
+	return (
+		<table css={tableStyles}>
+			<thead css={headStyles}>
+				<tr css={rowStyles}>
+					{Object.entries(headingAbbreviations).map(
+						([key, value]) => (
+							<th key={key}>
+								{isUndefined(value) ? (
+									<>{key}</>
+								) : (
+									<abbr title={value}>{key}</abbr>
+								)}
+							</th>
+						),
+					)}
+				</tr>
+			</thead>
+			<tbody>
+				{data.map((row) => (
+					<tr key={row.position} css={rowStyles}>
+						<td>{row.position}</td>
+						<td>{row.team}</td>
+						<td>{row.gamesPlayed}</td>
+						<td>{row.won}</td>
+						<td>{row.drawn}</td>
+						<td>{row.lost}</td>
+						<td>{row.goalsFor}</td>
+						<td>{row.goalsAgainst}</td>
+						<td>{row.goalDifference}</td>
+						<td>
+							<b
+								css={css`
+									font-weight: 800;
+								`}
+							>
+								{row.points}
+							</b>
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+};

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -60,7 +60,9 @@ const linkStyles = css`
 `;
 
 type Props = {
-	table: FootballTableData;
+	competitionName: string;
+	competitionUrl: string;
+	table: Omit<FootballTableData, 'groupName'>;
 	guardianBaseUrl: string;
 };
 
@@ -70,14 +72,16 @@ function getFootballCrestImageUrl(teamId: string) {
 }
 
 const FullTableLink = ({
-	competition,
+	competitionName,
+	competitionUrl,
 	guardianBaseUrl,
 }: {
-	competition: FootballTableData['competition'];
+	competitionName: string;
+	competitionUrl: string;
 	guardianBaseUrl: string;
 }) => (
-	<a href={`${guardianBaseUrl}${competition.url}/table`} css={linkStyles}>
-		View full {competition.name} table
+	<a href={`${guardianBaseUrl}${competitionUrl}/table`} css={linkStyles}>
+		View full {competitionName} table
 	</a>
 );
 
@@ -132,7 +136,12 @@ const TeamWithCrest = ({
 	</div>
 );
 
-export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
+export const FootballTable = ({
+	competitionName,
+	competitionUrl,
+	table,
+	guardianBaseUrl,
+}: Props) => (
 	<table css={tableStyles}>
 		<thead css={headStyles}>
 			<tr css={rowStyles}>
@@ -224,7 +233,8 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 				<tr css={rowStyles}>
 					<td colSpan={11} css={hideUntilTabletStyle}>
 						<FullTableLink
-							competition={table.competition}
+							competitionName={competitionName}
+							competitionUrl={competitionUrl}
 							guardianBaseUrl={guardianBaseUrl}
 						/>
 					</td>
@@ -237,7 +247,8 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 						`}
 					>
 						<FullTableLink
-							competition={table.competition}
+							competitionName={competitionName}
+							competitionUrl={competitionUrl}
 							guardianBaseUrl={guardianBaseUrl}
 						/>
 					</td>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -201,7 +201,7 @@ export const FootballTable = ({
 						<abbr title="Points">Pts</abbr>
 					</th>
 					<th>
-						<abbr title="Form">Form</abbr>
+						<abbr title="Results of previous games">Form</abbr>
 					</th>
 				</tr>
 			</thead>

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	textSans14,
-	textSansBold14,
-	until,
-} from '@guardian/source/foundations';
+import { from, textSans14, until } from '@guardian/source/foundations';
 import type { FootballTableData } from '../footballTables';
 import { palette } from '../palette';
 import { FootballTableForm } from './FootballTableForm';
@@ -125,25 +120,6 @@ const TeamWithCrest = ({
 
 export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 	<table css={tableStyles}>
-		<caption
-			css={css`
-				${from.leftCol} {
-					display: none;
-				}
-				text-align: left;
-				border-top: 0.0625rem solid ${palette('--football-top-border')};
-				padding: 0.5rem;
-				${textSansBold14};
-				background: ${palette('--table-block-background')};
-			`}
-		>
-			<a
-				css={linkStyles}
-				href={`${guardianBaseUrl}${table.competition.url}`}
-			>
-				{table.competition.name}
-			</a>
-		</caption>
 		<thead css={headStyles}>
 			<tr css={rowStyles}>
 				<th

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -6,6 +6,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import type { TeamResult } from './FootballTableForm';
+import { FootballTableForm } from './FootballTableForm';
 
 const tableStyles = css`
 	width: 100%;
@@ -35,6 +37,7 @@ const rowStyles = css`
 
 	td,
 	th {
+		vertical-align: middle;
 		padding: 0.5rem;
 	}
 `;
@@ -77,6 +80,7 @@ type Props = {
 		goalsAgainst: number;
 		goalDifference: number;
 		points: number;
+		results: TeamResult[];
 	}[];
 	linkToFullTable: boolean;
 };
@@ -196,6 +200,9 @@ export const FootballTable = ({
 					<th>
 						<abbr title="Points">Pts</abbr>
 					</th>
+					<th>
+						<abbr title="Form">Form</abbr>
+					</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -236,6 +243,11 @@ export const FootballTable = ({
 							>
 								{row.points}
 							</b>
+						</td>
+						<td>
+							<FootballTableForm
+								teamResults={row.results.slice(0, 5)}
+							/>
 						</td>
 					</tr>
 				))}

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -30,6 +30,12 @@ const rowStyles = css`
 	}
 `;
 
+const dividerStyle = css`
+	td {
+		border-top: 0.0625rem dashed ${palette('--football-table-divider')};
+	}
+`;
+
 const headingAbbreviations: Record<string, string | undefined> = {
 	P: 'Position',
 	Team: undefined,
@@ -44,6 +50,7 @@ const headingAbbreviations: Record<string, string | undefined> = {
 };
 
 type Props = {
+	dividers: number[];
 	data: {
 		position: number;
 		team: string;
@@ -58,7 +65,7 @@ type Props = {
 	}[];
 };
 
-export const FootballTable = ({ data }: Props) => {
+export const FootballTable = ({ data, dividers }: Props) => {
 	return (
 		<table css={tableStyles}>
 			<thead css={headStyles}>
@@ -78,7 +85,13 @@ export const FootballTable = ({ data }: Props) => {
 			</thead>
 			<tbody>
 				{data.map((row) => (
-					<tr key={row.position} css={rowStyles}>
+					<tr
+						key={row.position}
+						css={[
+							rowStyles,
+							dividers.includes(row.position - 1) && dividerStyle,
+						]}
+					>
 						<td>{row.position}</td>
 						<td>{row.team}</td>
 						<td>{row.gamesPlayed}</td>

--- a/dotcom-rendering/src/components/FootballTableForm.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.stories.tsx
@@ -24,22 +24,27 @@ export const FootballTableForm: Story = {
 	args: {
 		teamResults: [
 			{
+				id: '1',
 				self: { name: 'Torino', score: 10 },
 				foe: { name: 'Cagliari', score: 0 },
 			},
 			{
+				id: '2',
 				self: { name: 'Torino', score: 4 },
 				foe: { name: 'Inter', score: 3 },
 			},
 			{
+				id: '3',
 				self: { name: 'Torino', score: 1 },
 				foe: { name: 'Lazio', score: 3 },
 			},
 			{
+				id: '4',
 				self: { name: 'Torino', score: 0 },
 				foe: { name: 'Bologna', score: 0 },
 			},
 			{
+				id: '5',
 				self: { name: 'Torino', score: 1 },
 				foe: { name: 'Inter', score: 4 },
 			},

--- a/dotcom-rendering/src/components/FootballTableForm.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 			</>
 		),
 	],
-} satisfies Meta<typeof FootballTableFormComponent >;
+} satisfies Meta<typeof FootballTableFormComponent>;
 
 export default meta;
 

--- a/dotcom-rendering/src/components/FootballTableForm.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { FootballTableForm } from './FootballTableForm';
+import { FootballTableForm as FootballTableFormComponent } from './FootballTableForm';
 
 const meta = {
 	title: 'Components/Football Table Form',
-	component: FootballTableForm,
+	component: FootballTableFormComponent,
 	decorators: [
 		// To make the story not shoved in the corner.
 		(Story) => (
@@ -14,13 +14,13 @@ const meta = {
 			</>
 		),
 	],
-} satisfies Meta<typeof FootballTableForm>;
+} satisfies Meta<typeof FootballTableFormComponent >;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const FootballTableForm: Story = {
 	args: {
 		teamResults: [
 			{

--- a/dotcom-rendering/src/components/FootballTableForm.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FootballTableForm } from './FootballTableForm';
+
+const meta = {
+	title: 'Components/Football Table Form',
+	component: FootballTableForm,
+	decorators: [
+		// To make the story not shoved in the corner.
+		(Story) => (
+			<>
+				<div css={{ padding: 16 }}>
+					<Story />
+				</div>
+			</>
+		),
+	],
+} satisfies Meta<typeof FootballTableForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		teamResults: [
+			{
+				self: { name: 'Torino', score: 10 },
+				foe: { name: 'Cagliari', score: 0 },
+			},
+			{
+				self: { name: 'Torino', score: 4 },
+				foe: { name: 'Inter', score: 3 },
+			},
+			{
+				self: { name: 'Torino', score: 1 },
+				foe: { name: 'Lazio', score: 3 },
+			},
+			{
+				self: { name: 'Torino', score: 0 },
+				foe: { name: 'Bologna', score: 0 },
+			},
+			{
+				self: { name: 'Torino', score: 1 },
+				foe: { name: 'Inter', score: 4 },
+			},
+		],
+	},
+};

--- a/dotcom-rendering/src/components/FootballTableForm.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.tsx
@@ -1,12 +1,7 @@
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source/foundations';
-import type { TeamScore } from '../footballMatches';
+import type { TeamResult } from '../footballTables';
 import { palette } from '../palette';
-
-export type TeamResult = {
-	self: TeamScore;
-	foe: TeamScore;
-};
 
 const formBlockStyles = css`
 	display: inline-block;

--- a/dotcom-rendering/src/components/FootballTableForm.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.tsx
@@ -1,0 +1,87 @@
+import { css } from '@emotion/react';
+import { visuallyHidden } from '@guardian/source/foundations';
+import type { TeamScore } from '../footballMatches';
+import { palette } from '../palette';
+
+export type TeamResult = {
+	self: TeamScore;
+	foe: TeamScore;
+};
+
+const formBlockStyles = css`
+	display: inline-block;
+	top: 0;
+	vertical-align: middle;
+	border-radius: 0.25rem;
+	margin-left: 0.125rem;
+	height: 0.75rem;
+	width: 0.25rem;
+	cursor: help;
+	:first-child {
+		margin-left: 0;
+	}
+`;
+
+const winStyles = css`
+	background-color: ${palette('--football-form-win')};
+	margin-top: -0.375rem;
+`;
+
+const drawStyles = css`
+	background-color: ${palette('--football-form-draw')};
+	height: 0.25rem;
+`;
+const lossStyles = css`
+	background-color: ${palette('--football-form-loss')};
+	margin-top: 0.375rem;
+`;
+
+export const FootballTableForm = ({
+	teamResults,
+}: {
+	teamResults: TeamResult[];
+}) => {
+	return (
+		<div
+			css={css`
+				min-width: 1.875rem;
+				font-size: 0;
+				white-space: nowrap;
+			`}
+		>
+			{teamResults.map(({ self, foe }) => {
+				const isWin = self.score > foe.score;
+				const isLoss = self.score < foe.score;
+				const styles = isWin
+					? winStyles
+					: isLoss
+					? lossStyles
+					: drawStyles;
+				const title = isWin
+					? `Won ${self.score}-${foe.score} against ${foe.name}`
+					: isLoss
+					? `Lost ${self.score}-${foe.score} to ${foe.name}`
+					: `Drew ${self.score}-${foe.score} with ${foe.name}`;
+
+				return (
+					<span
+						css={[formBlockStyles, styles]}
+						key={`${self.name}-${foe.name}`}
+						data-foe={foe.name}
+						data-score={self.score}
+						data-score-foe={foe.score}
+						title={title}
+					>
+						<span
+							css={css`
+								${visuallyHidden}
+							`}
+						>
+							{title}
+						</span>
+					</span>
+				);
+			})}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/FootballTableForm.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.tsx
@@ -61,7 +61,7 @@ export const FootballTableForm = ({
 				return (
 					<span
 						css={[formBlockStyles, styles]}
-						key={`${id}`}
+						key={id}
 						title={title}
 					>
 						<span

--- a/dotcom-rendering/src/components/FootballTableForm.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.tsx
@@ -44,7 +44,7 @@ export const FootballTableForm = ({
 				white-space: nowrap;
 			`}
 		>
-			{teamResults.map(({ self, foe }) => {
+			{teamResults.map(({ self, foe, id }) => {
 				const isWin = self.score > foe.score;
 				const isLoss = self.score < foe.score;
 				const styles = isWin
@@ -61,10 +61,7 @@ export const FootballTableForm = ({
 				return (
 					<span
 						css={[formBlockStyles, styles]}
-						key={`${self.name}-${foe.name}`}
-						data-foe={foe.name}
-						data-score={self.score}
-						data-score-foe={foe.score}
+						key={`${id}`}
 						title={title}
 					>
 						<span

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -22,10 +22,7 @@ type Story = StoryObj<typeof meta>;
 
 export const FootballTableList = {
 	args: {
-		tables: [
-			{ ...TableDefault.args.table },
-			{ ...TableDefault.args.table },
-		],
+		tables: [TableDefault.args.table, TableDefault.args.table],
 		guardianBaseUrl: 'https://www.theguardian.com',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
-import { Default as TableDefault } from './FootballTable.stories';
-import { FootballTableList } from './FootballTableList';
+import { FootballTable as TableDefault } from './FootballTable.stories';
+import { FootballTableList as FootballTableListComponent } from './FootballTableList';
 
 const meta = {
 	title: 'Components/Football Table List',
-	component: FootballTableList,
+	component: FootballTableListComponent,
 	decorators: [
 		// To make it easier to see the top border
 		(Story) => (
@@ -14,13 +14,13 @@ const meta = {
 			</>
 		),
 	],
-} satisfies Meta<typeof FootballTableList>;
+} satisfies Meta<typeof FootballTableListComponent>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const FootballTableList = {
 	args: {
 		tables: [
 			{ ...TableDefault.args.table },

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -22,7 +22,23 @@ type Story = StoryObj<typeof meta>;
 
 export const FootballTableList = {
 	args: {
-		tables: [TableDefault.args.table, TableDefault.args.table],
+		competitions: [
+			{
+				name: 'Premier League',
+				url: '/football/premierleague',
+				tables: [{ ...TableDefault.args.table, groupName: 'League' }],
+				hasGroups: false,
+			},
+			{
+				name: 'Champions League',
+				url: '/football/championsleague',
+				tables: [
+					{ ...TableDefault.args.table, groupName: 'Group A' },
+					{ ...TableDefault.args.table, groupName: 'Group B' },
+				],
+				hasGroups: true,
+			},
+		],
 		guardianBaseUrl: 'https://www.theguardian.com',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react/*';
+import { Default as TableDefault } from './FootballTable.stories';
+import { FootballTableList } from './FootballTableList';
+
+const meta = {
+	title: 'Components/Football Table List',
+	component: FootballTableList,
+	decorators: [
+		// To make it easier to see the top border
+		(Story) => (
+			<>
+				<div css={{ padding: 4 }}></div>
+				<Story />
+			</>
+		),
+	],
+} satisfies Meta<typeof FootballTableList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		tables: [
+			{ ...TableDefault.args.table },
+			{ ...TableDefault.args.table },
+		],
+		guardianBaseUrl: 'https://www.theguardian.com',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	from,
-	headlineBold17,
-	space,
-	until,
-} from '@guardian/source/foundations';
+import { from, headlineBold17, space } from '@guardian/source/foundations';
 import { Stack } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import type { FootballTableData } from '../footballTables';

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -7,7 +7,7 @@ import {
 } from '@guardian/source/foundations';
 import { Stack } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
-import type { FootballTableData } from '../footballTables';
+import type { FootballTableCompetition } from '../footballTables';
 import { palette } from '../palette';
 import { FootballTable } from './FootballTable';
 
@@ -68,21 +68,31 @@ const CompetitionName = ({ children }: { children: ReactNode }) => (
 	</h3>
 );
 
+const GroupName = ({ children }: { children: ReactNode }) => (
+	<h4
+		css={css`
+			grid-column: centre-column-start / centre-column-end;
+			padding-top: ${space[1]}px;
+			padding-bottom: ${space[3]}px;
+			${headlineBold17}
+		`}
+	>
+		{children}
+	</h4>
+);
+
 type Props = {
-	tables: FootballTableData[];
+	competitions: FootballTableCompetition[];
 	guardianBaseUrl: string;
 };
 
-export const FootballTableList = ({ tables, guardianBaseUrl }: Props) => (
+export const FootballTableList = ({ competitions, guardianBaseUrl }: Props) => (
 	<Stack space={9}>
-		{tables.map((table) => (
-			<section
-				key={table.competition.name}
-				css={footballTablesGridStyles}
-			>
+		{competitions.map((competition) => (
+			<section key={competition.name} css={footballTablesGridStyles}>
 				<CompetitionName>
 					<a
-						href={`${guardianBaseUrl}${table.competition.url}`}
+						href={`${guardianBaseUrl}${competition.url}`}
 						css={css`
 							text-decoration: none;
 							color: inherit;
@@ -91,20 +101,30 @@ export const FootballTableList = ({ tables, guardianBaseUrl }: Props) => (
 							}
 						`}
 					>
-						{table.competition.name}
+						{competition.name}
 					</a>
 				</CompetitionName>
-				{/* ToDo: h4 for group name */}
-				<div
-					css={css`
-						grid-column: centre-column-start / centre-column-end;
-					`}
-				>
-					<FootballTable
-						table={table}
-						guardianBaseUrl={guardianBaseUrl}
-					/>
-				</div>
+				{competition.tables.map((table) => (
+					<>
+						{competition.hasGroups && (
+							<GroupName>{table.groupName}</GroupName>
+						)}
+						<div
+							css={css`
+								grid-column: centre-column-start /
+									centre-column-end;
+							`}
+							key={table.groupName}
+						>
+							<FootballTable
+								competitionName={competition.name}
+								competitionUrl={competition.url}
+								table={table}
+								guardianBaseUrl={guardianBaseUrl}
+							/>
+						</div>
+					</>
+				))}
 			</section>
 		))}
 	</Stack>

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -1,0 +1,105 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold17,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import { Stack } from '@guardian/source/react-components';
+import type { ReactNode } from 'react';
+import type { FootballTableData } from '../footballTables';
+import { palette } from '../palette';
+import { FootballTable } from './FootballTable';
+
+const footballTablesGridStyles = css`
+	display: grid;
+	grid-template-columns: [centre-column-start] repeat(4, 1fr) [centre-column-end];
+	column-gap: 10px;
+	${from.mobileLandscape} {
+		column-gap: 20px;
+	}
+
+	${from.tablet} {
+		grid-template-columns: [centre-column-start] repeat(12, 40px) [centre-column-end];
+	}
+
+	${from.desktop} {
+		grid-template-columns: [centre-column-start] repeat(8, 60px) [centre-column-end];
+	}
+
+	${from.leftCol} {
+		grid-template-columns:
+			[left-column-start] repeat(2, 60px)
+			[left-column-end centre-column-start] repeat(8, 60px)
+			[centre-column-end];
+	}
+
+	${from.wide} {
+		grid-template-columns:
+			[left-column-start] repeat(3, 60px)
+			[left-column-end centre-column-start] repeat(8, 60px)
+			[centre-column-end];
+	}
+`;
+
+const CompetitionName = ({ children }: { children: ReactNode }) => (
+	<h3
+		css={css`
+			${until.leftCol} {
+				display: none;
+			}
+			${from.leftCol} {
+				color: ${palette('--football-competition-text')};
+				border-top: 1px solid ${palette('--football-list-border')};
+				background-color: transparent;
+				margin-top: 0;
+				padding: ${space[1]}px 0 0;
+				grid-column: left-column-start / left-column-end;
+				${headlineBold17}
+			}
+		`}
+	>
+		{children}
+	</h3>
+);
+
+type Props = {
+	tables: FootballTableData[];
+	guardianBaseUrl: string;
+};
+
+export const FootballTableList = ({ tables, guardianBaseUrl }: Props) => (
+	<Stack space={9}>
+		{tables.map((table) => (
+			<section
+				key={table.competition.name}
+				css={footballTablesGridStyles}
+			>
+				<CompetitionName>
+					<a
+						href={`${guardianBaseUrl}${table.competition.url}`}
+						css={css`
+							text-decoration: none;
+							color: inherit;
+							:hover {
+								text-decoration: underline;
+							}
+						`}
+					>
+						{table.competition.name}
+					</a>
+				</CompetitionName>
+				<div
+					css={css`
+						grid-column: centre-column-start / centre-column-end;
+					`}
+				>
+					<FootballTable
+						table={table}
+						guardianBaseUrl={guardianBaseUrl}
+					/>
+				</div>
+			</section>
+		))}
+	</Stack>
+);

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { from, headlineBold17, space } from '@guardian/source/foundations';
+import {
+	from,
+	headlineBold17,
+	space,
+	textSansBold14,
+} from '@guardian/source/foundations';
 import { Stack } from '@guardian/source/react-components';
 import type { ReactNode } from 'react';
 import type { FootballTableData } from '../footballTables';
@@ -40,7 +45,12 @@ const footballTablesGridStyles = css`
 const CompetitionName = ({ children }: { children: ReactNode }) => (
 	<h3
 		css={css`
-			display: none;
+			${textSansBold14}
+			grid-column: centre-column-start / centre-column-end;
+			color: ${palette('--football-competition-text')};
+			border-top: 1px solid ${palette('--football-top-border')};
+			padding: ${space[2]}px;
+			background-color: ${palette('--football-match-list-background')};
 
 			${from.leftCol} {
 				display: block;
@@ -84,6 +94,7 @@ export const FootballTableList = ({ tables, guardianBaseUrl }: Props) => (
 						{table.competition.name}
 					</a>
 				</CompetitionName>
+				{/* ToDo: h4 for group name */}
 				<div
 					css={css`
 						grid-column: centre-column-start / centre-column-end;

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -43,7 +43,7 @@ const footballTablesGridStyles = css`
 `;
 
 const CompetitionName = ({ children }: { children: ReactNode }) => (
-	<h3
+	<h2
 		css={css`
 			${textSansBold14}
 			grid-column: centre-column-start / centre-column-end;
@@ -66,7 +66,7 @@ const CompetitionName = ({ children }: { children: ReactNode }) => (
 		`}
 	>
 		{children}
-	</h3>
+	</h2>
 );
 
 const GroupName = ({
@@ -76,7 +76,7 @@ const GroupName = ({
 	children: ReactNode;
 	index: number;
 }) => (
-	<h4
+	<h3
 		css={css`
 			grid-column: centre-column-start / centre-column-end;
 			padding-top: ${space[1]}px;
@@ -88,7 +88,7 @@ const GroupName = ({
 		`}
 	>
 		{children}
-	</h4>
+	</h3>
 );
 
 type Props = {

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -53,6 +53,7 @@ const CompetitionName = ({ children }: { children: ReactNode }) => (
 			background-color: ${palette('--football-match-list-background')};
 
 			${from.leftCol} {
+				grid-row: 1;
 				display: block;
 				color: ${palette('--football-competition-text')};
 				border-top: 1px solid ${palette('--football-list-border')};
@@ -68,13 +69,22 @@ const CompetitionName = ({ children }: { children: ReactNode }) => (
 	</h3>
 );
 
-const GroupName = ({ children }: { children: ReactNode }) => (
+const GroupName = ({
+	children,
+	index,
+}: {
+	children: ReactNode;
+	index: number;
+}) => (
 	<h4
 		css={css`
 			grid-column: centre-column-start / centre-column-end;
 			padding-top: ${space[1]}px;
 			padding-bottom: ${space[3]}px;
+			border-top: 1px solid ${palette('--football-list-border')};
 			${headlineBold17}
+
+			${index !== 0 ? `margin-top: ${space[6]}px` : ''}
 		`}
 	>
 		{children}
@@ -90,25 +100,32 @@ export const FootballTableList = ({ competitions, guardianBaseUrl }: Props) => (
 	<Stack space={9}>
 		{competitions.map((competition) => (
 			<section key={competition.name} css={footballTablesGridStyles}>
-				<CompetitionName>
-					<a
-						href={`${guardianBaseUrl}${competition.url}`}
-						css={css`
-							text-decoration: none;
-							color: inherit;
-							:hover {
-								text-decoration: underline;
-							}
-						`}
-					>
-						{competition.name}
-					</a>
-				</CompetitionName>
-				{competition.tables.map((table) => (
+				{competition.tables.map((table, groupIndex) => (
 					<>
 						{competition.hasGroups && (
-							<GroupName>{table.groupName}</GroupName>
+							<GroupName index={groupIndex}>
+								{table.groupName}
+							</GroupName>
 						)}
+						{
+							// Only show the competition name above/beside the first group
+							groupIndex === 0 && (
+								<CompetitionName>
+									<a
+										href={`${guardianBaseUrl}${competition.url}`}
+										css={css`
+											text-decoration: none;
+											color: inherit;
+											:hover {
+												text-decoration: underline;
+											}
+										`}
+									>
+										{competition.name}
+									</a>
+								</CompetitionName>
+							)
+						}
 						<div
 							css={css`
 								grid-column: centre-column-start /

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -45,10 +45,10 @@ const footballTablesGridStyles = css`
 const CompetitionName = ({ children }: { children: ReactNode }) => (
 	<h3
 		css={css`
-			${until.leftCol} {
-				display: none;
-			}
+			display: none;
+
 			${from.leftCol} {
+				display: block;
 				color: ${palette('--football-competition-text')};
 				border-top: 1px solid ${palette('--football-list-border')};
 				background-color: transparent;

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react/*';
+import { fn } from '@storybook/test';
+import { regions } from '../../fixtures/manual/footballData';
+import { Default as TableDefault } from './FootballTable.stories';
+import { FootballTablesPage } from './FootballTablesPage';
+
+const meta = {
+	title: 'Components/Football Tables Page',
+	component: FootballTablesPage,
+} satisfies Meta<typeof FootballTablesPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		regions,
+		goToCompetitionSpecificPage: fn(),
+		pageId: 'football/tables',
+		tables: [
+			{ ...TableDefault.args.table },
+			{ ...TableDefault.args.table },
+		],
+		renderAds: true,
+		guardianBaseUrl: 'https://www.theguardian.com',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
 import { fn } from '@storybook/test';
 import { regions } from '../../fixtures/manual/footballData';
-import { FootballTable as TableDefault } from './FootballTable.stories';
+import { FootballTableList as TableListDefault } from './FootballTableList.stories';
 import { FootballTablesPage as FootballTablesPageComponent } from './FootballTablesPage';
 
 const meta = {
@@ -18,7 +18,7 @@ export const FootballTablesPage = {
 		regions,
 		goToCompetitionSpecificPage: fn(),
 		pageId: 'football/tables',
-		tables: [TableDefault.args.table, TableDefault.args.table],
+		competitions: TableListDefault.args.competitions,
 		renderAds: true,
 		guardianBaseUrl: 'https://www.theguardian.com',
 	},

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,27 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
 import { fn } from '@storybook/test';
 import { regions } from '../../fixtures/manual/footballData';
-import { Default as TableDefault } from './FootballTable.stories';
-import { FootballTablesPage } from './FootballTablesPage';
+import { FootballTable as TableDefault } from './FootballTable.stories';
+import { FootballTablesPage as FootballTablesPageComponent } from './FootballTablesPage';
 
 const meta = {
 	title: 'Components/Football Tables Page',
-	component: FootballTablesPage,
-} satisfies Meta<typeof FootballTablesPage>;
+	component: FootballTablesPageComponent,
+} satisfies Meta<typeof FootballTablesPageComponent>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const FootballTablesPage = {
 	args: {
 		regions,
 		goToCompetitionSpecificPage: fn(),
 		pageId: 'football/tables',
-		tables: [
-			{ ...TableDefault.args.table },
-			{ ...TableDefault.args.table },
-		],
+		tables: [TableDefault.args.table, TableDefault.args.table],
 		renderAds: true,
 		guardianBaseUrl: 'https://www.theguardian.com',
 	},

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -6,7 +6,7 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import type { Region } from '../footballMatches';
-import type { FootballTableData } from '../footballTables';
+import type { FootballTableCompetition } from '../footballTables';
 import { grid } from '../grid';
 import { palette } from '../palette';
 import { AdSlot } from './AdSlot.web';
@@ -17,7 +17,7 @@ type Props = {
 	regions: Region[];
 	pageId: string;
 	goToCompetitionSpecificPage: (tag: string) => void;
-	tables: FootballTableData[];
+	competitions: FootballTableCompetition[];
 	renderAds: boolean;
 	guardianBaseUrl: string;
 };
@@ -26,7 +26,7 @@ export const FootballTablesPage = ({
 	regions,
 	pageId,
 	goToCompetitionSpecificPage,
-	tables,
+	competitions,
 	renderAds,
 	guardianBaseUrl,
 }: Props) => (
@@ -93,7 +93,7 @@ export const FootballTablesPage = ({
 			`}
 		>
 			<FootballTableList
-				tables={tables}
+				competitions={competitions}
 				guardianBaseUrl={guardianBaseUrl}
 			/>
 		</div>

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -1,0 +1,116 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold20,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import type { Region } from '../footballMatches';
+import type { FootballTableData } from '../footballTables';
+import { grid } from '../grid';
+import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
+import { FootballCompetitionSelect } from './FootballCompetitionSelect';
+import { FootballTableList } from './FootballTableList';
+
+type Props = {
+	regions: Region[];
+	pageId: string;
+	goToCompetitionSpecificPage: (tag: string) => void;
+	tables: FootballTableData[];
+	renderAds: boolean;
+	guardianBaseUrl: string;
+};
+
+export const FootballTablesPage = ({
+	regions,
+	pageId,
+	goToCompetitionSpecificPage,
+	tables,
+	renderAds,
+	guardianBaseUrl,
+}: Props) => (
+	<main
+		id="maincontent"
+		data-layout="FootballDataPageLayout"
+		css={css`
+			${grid.paddedContainer}
+			position: relative;
+			${from.tablet} {
+				&::before,
+				&::after {
+					content: '';
+					position: absolute;
+					border-left: 1px solid ${palette('--article-border')};
+					top: 0;
+					bottom: 0;
+				}
+
+				&::after {
+					right: 0;
+				}
+			}
+
+			padding-bottom: ${space[9]}px;
+		`}
+	>
+		<h1
+			css={css`
+				${headlineBold20}
+				padding: ${space[2]}px 0 ${space[3]}px;
+				${grid.column.centre}
+				grid-row: 1;
+				${from.leftCol} {
+					${grid.between('left-column-start', 'centre-column-end')}
+				}
+			`}
+		>
+			Football tables
+		</h1>
+		<div
+			css={css`
+				margin-top: ${space[3]}px;
+				margin-bottom: ${space[6]}px;
+				${grid.column.centre}
+				grid-row: 2;
+			`}
+		>
+			<FootballCompetitionSelect
+				regions={regions}
+				kind="Tables"
+				pageId={pageId}
+				onChange={goToCompetitionSpecificPage}
+			/>
+		</div>
+		<div
+			css={css`
+				${grid.column.centre}
+				grid-row: 3;
+				${from.leftCol} {
+					${grid.between('left-column-start', 'centre-column-end')}
+				}
+				position: relative;
+			`}
+		>
+			<FootballTableList
+				tables={tables}
+				guardianBaseUrl={guardianBaseUrl}
+			/>
+		</div>
+		{renderAds && (
+			<div
+				css={css`
+					${grid.column.right}
+					/**  ToDo: review what line to grow the ad to */
+					/** This allows the ad to grow beyond the third row content (up to line 5) */
+					grid-row: 1 / 5;
+					${until.desktop} {
+						display: none;
+					}
+				`}
+			>
+				<AdSlot position="right-football" />
+			</div>
+		)}
+	</main>
+);

--- a/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
@@ -26,7 +26,7 @@ export const FootballTablesPageWrapper = ({
 	<FootballTablesPage
 		regions={regions}
 		pageId={pageId}
-		tables={tables}
+		competitions={tables}
 		renderAds={renderAds}
 		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
 			guardianBaseUrl,

--- a/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
@@ -1,0 +1,36 @@
+import type { Region } from '../footballMatches';
+import type { FootballTableData } from '../footballTables';
+import { FootballTablesPage } from './FootballTablesPage';
+
+const goToCompetitionSpecificPage =
+	(guardianBaseUrl: string) => (path: string) => {
+		const url = `${guardianBaseUrl}${path}`;
+		window.location.assign(url);
+	};
+
+type Props = {
+	regions: Region[];
+	pageId: string;
+	tables: FootballTableData[];
+	renderAds: boolean;
+	guardianBaseUrl: string;
+};
+
+export const FootballTablesPageWrapper = ({
+	regions,
+	pageId,
+	tables,
+	renderAds,
+	guardianBaseUrl,
+}: Props) => (
+	<FootballTablesPage
+		regions={regions}
+		pageId={pageId}
+		tables={tables}
+		renderAds={renderAds}
+		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
+			guardianBaseUrl,
+		)}
+		guardianBaseUrl={guardianBaseUrl}
+	/>
+);

--- a/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
@@ -1,5 +1,5 @@
 import type { Region } from '../footballMatches';
-import type { FootballTableData } from '../footballTables';
+import type { FootballTableCompetition } from '../footballTables';
 import { FootballTablesPage } from './FootballTablesPage';
 
 const goToCompetitionSpecificPage =
@@ -11,7 +11,7 @@ const goToCompetitionSpecificPage =
 type Props = {
 	regions: Region[];
 	pageId: string;
-	tables: FootballTableData[];
+	competitions: FootballTableCompetition[];
 	renderAds: boolean;
 	guardianBaseUrl: string;
 };
@@ -19,14 +19,14 @@ type Props = {
 export const FootballTablesPageWrapper = ({
 	regions,
 	pageId,
-	tables,
+	competitions,
 	renderAds,
 	guardianBaseUrl,
 }: Props) => (
 	<FootballTablesPage
 		regions={regions}
 		pageId={pageId}
-		competitions={tables}
+		competitions={competitions}
 		renderAds={renderAds}
 		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
 			guardianBaseUrl,

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -14,7 +14,7 @@ import { error, ok, type Result } from './lib/result';
 import type { NavType } from './model/extract-nav';
 import type { FooterType } from './types/footer';
 
-type TeamScore = {
+export type TeamScore = {
 	name: string;
 	score: number;
 };

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -1,0 +1,28 @@
+import type { TeamScore } from './footballMatches';
+
+export type TeamResult = {
+	self: TeamScore;
+	foe: TeamScore;
+};
+
+export type FootballTableData = {
+	competition: {
+		url: string;
+		name: string;
+	};
+	dividers: number[];
+	entries: {
+		position: number;
+		team: { name: string; id: string; url: string };
+		gamesPlayed: number;
+		won: number;
+		drawn: number;
+		lost: number;
+		goalsFor: number;
+		goalsAgainst: number;
+		goalDifference: number;
+		points: number;
+		results: TeamResult[];
+	}[];
+	linkToFullTable: boolean;
+};

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -5,11 +5,15 @@ export type TeamResult = {
 	foe: TeamScore;
 };
 
+export type FootballTableCompetition = {
+	url: string;
+	name: string;
+	hasGroups: boolean;
+	tables: FootballTableData[];
+};
+
 export type FootballTableData = {
-	competition: {
-		url: string;
-		name: string;
-	};
+	groupName: string;
 	dividers: number[];
 	entries: {
 		position: number;

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -1,6 +1,7 @@
 import type { TeamScore } from './footballMatches';
 
 export type TeamResult = {
+	id: string;
 	self: TeamScore;
 	foe: TeamScore;
 };

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6560,6 +6560,10 @@ const paletteColours = {
 		light: () => '#3DB540',
 		dark: () => '#3DB540',
 	},
+	'--football-list-border': {
+		light: () => sourcePalette.neutral[93],
+		dark: () => sourcePalette.neutral[38],
+	},
 	'--football-match-hover': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],
@@ -6567,10 +6571,6 @@ const paletteColours = {
 	'--football-match-list-background': {
 		light: () => sourcePalette.neutral[97],
 		dark: () => sourcePalette.neutral[20],
-	},
-	'--football-match-list-border': {
-		light: () => sourcePalette.neutral[93],
-		dark: () => sourcePalette.neutral[38],
 	},
 	'--football-match-list-error': {
 		light: () => sourcePalette.error[400],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6568,7 +6568,7 @@ const paletteColours = {
 		light: () => sourcePalette.sport[500],
 		dark: () => sourcePalette.sport[500],
 	},
-	'--football-match-list-sub-text': {
+	'--football-sub-text': {
 		light: () => sourcePalette.neutral[46],
 		dark: () => sourcePalette.neutral[73],
 	},

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6548,6 +6548,18 @@ const paletteColours = {
 		light: () => sourcePalette.sport[300],
 		dark: () => sourcePalette.neutral[86],
 	},
+	'--football-form-draw': {
+		light: () => sourcePalette.neutral[46],
+		dark: () => sourcePalette.neutral[73],
+	},
+	'--football-form-loss': {
+		light: () => '#C70000',
+		dark: () => '#C70000',
+	},
+	'--football-form-win': {
+		light: () => '#3DB540',
+		dark: () => '#3DB540',
+	},
 	'--football-match-hover': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6572,6 +6572,10 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[46],
 		dark: () => sourcePalette.neutral[73],
 	},
+	'--football-table-divider': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--football-top-border': {
 		light: () => sourcePalette.sport[500],
 		dark: () => sourcePalette.neutral[60],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6544,6 +6544,10 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[7],
 		dark: () => sourcePalette.neutral[86],
 	},
+	'--football-competition-text': {
+		light: () => sourcePalette.sport[300],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--football-match-hover': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],
@@ -6555,10 +6559,6 @@ const paletteColours = {
 	'--football-match-list-border': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],
-	},
-	'--football-match-list-competition-text': {
-		light: () => sourcePalette.sport[300],
-		dark: () => sourcePalette.neutral[86],
 	},
 	'--football-match-list-error': {
 		light: () => sourcePalette.error[400],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6572,7 +6572,7 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[46],
 		dark: () => sourcePalette.neutral[73],
 	},
-	'--football-match-list-top-border': {
+	'--football-top-border': {
 		light: () => sourcePalette.sport[500],
 		dark: () => sourcePalette.neutral[60],
 	},


### PR DESCRIPTION
## What does this change?

Creates a football table component, including a form indicator, and list of tables component and accompanying Storybook stories


## Screenshots

![image](https://github.com/user-attachments/assets/c475cdd7-e573-42b4-91cc-cf079e104fb4)

![image](https://github.com/user-attachments/assets/47907c39-dd15-48f8-acb6-427a0c362624)

![image](https://github.com/user-attachments/assets/b3581a27-0fb5-42d9-a909-f81dffab4fd0)

![image](https://github.com/user-attachments/assets/8ecb393f-948a-4cba-b225-facba966d088)

![image](https://github.com/user-attachments/assets/ea3a129a-2ade-407b-8778-106898e43633)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
