### PR TITLE
Create Football table list components

### DIFF
--- a/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionSelect.tsx
@@ -2,14 +2,16 @@ import { Option, Select } from '@guardian/source/react-components';
 import type { FootballMatchKind, Region } from '../footballMatches';
 import { palette } from '../palette';
 
+type FootballSelectKind = FootballMatchKind | 'Tables';
+
 type Props = {
 	regions: Region[];
-	kind: FootballMatchKind;
+	kind: FootballSelectKind;
 	pageId: string;
 	onChange: (competitionTag: string) => void;
 };
 
-const allLabel = (kind: FootballMatchKind): string => {
+const allLabel = (kind: FootballSelectKind): string => {
 	switch (kind) {
 		case 'Fixture':
 			return 'All fixtures';
@@ -17,10 +19,12 @@ const allLabel = (kind: FootballMatchKind): string => {
 			return 'All results';
 		case 'Live':
 			return 'All live';
+		case 'Tables':
+			return 'All tables';
 	}
 };
 
-const getPagePath = (kind: FootballMatchKind) => {
+const getPagePath = (kind: FootballSelectKind) => {
 	switch (kind) {
 		case 'Fixture':
 			return '/football/fixtures';
@@ -28,6 +32,8 @@ const getPagePath = (kind: FootballMatchKind) => {
 			return '/football/live';
 		case 'Result':
 			return '/football/results';
+		case 'Tables':
+			return '/football/tables';
 	}
 };
 

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -94,7 +94,7 @@ const Day = (props: { children: ReactNode }) => (
 		css={css`
 			${textSansBold14}
 			grid-column: centre-column-start / centre-column-end;
-			border-top: 1px solid ${palette('--football-match-list-border')};
+			border-top: 1px solid ${palette('--football-list-border')};
 			padding-top: ${space[2]}px;
 
 			${from.leftCol} {
@@ -119,7 +119,7 @@ const CompetitionName = (props: { children: ReactNode }) => (
 			margin-top: ${space[9]}px;
 
 			${from.leftCol} {
-				border-top-color: ${palette('--football-match-list-border')};
+				border-top-color: ${palette('--football-list-border')};
 				background-color: transparent;
 				margin-top: 0;
 				padding: ${space[1]}px 0 0;
@@ -196,7 +196,7 @@ export const shouldRenderMatchLink = (matchDateTime: Date, now: Date) =>
 
 const matchListItemStyles = css`
 	background-color: ${palette('--football-match-list-background')};
-	border: 1px solid ${palette('--football-match-list-border')};
+	border: 1px solid ${palette('--football-list-border')};
 
 	${from.leftCol} {
 		&:first-of-type {

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -31,6 +31,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
 	args: {
+		guardianBaseUrl: 'https://www.theguardian.com',
 		table: {
 			competition: {
 				name: 'Premier League',

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -36,8 +36,6 @@ export const Default = {
 			competition: {
 				name: 'Premier League',
 				url: 'https://www.theguardian.com/football/premierleague',
-				tableUrl:
-					'https://www.theguardian.com/football/premierleague/table',
 			},
 			linkToFullTable: true,
 			dividers: [1],

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -31,141 +31,143 @@ type Story = StoryObj<typeof meta>;
 
 export const Default = {
 	args: {
-		competition: {
-			name: 'Premier League',
-			url: 'https://www.theguardian.com/football/premierleague',
-			tableUrl:
-				'https://www.theguardian.com/football/premierleague/table',
+		table: {
+			competition: {
+				name: 'Premier League',
+				url: 'https://www.theguardian.com/football/premierleague',
+				tableUrl:
+					'https://www.theguardian.com/football/premierleague/table',
+			},
+			linkToFullTable: true,
+			dividers: [1],
+			entries: [
+				{
+					position: 1,
+					team: {
+						name: 'Liverpool',
+						id: '9',
+						url: 'https://www.theguardian.com/football/arsenal',
+					},
+					gamesPlayed: 29,
+					won: 21,
+					drawn: 7,
+					lost: 1,
+					goalsFor: 69,
+					goalsAgainst: 27,
+					goalDifference: 42,
+					points: 70,
+					results: [
+						{
+							self: { name: 'Liverpool', score: 1 },
+							foe: { name: 'Chelsea', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 3 },
+							foe: { name: 'Arsenal', score: 5 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'West Ham', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 8 },
+							foe: { name: 'Tottenham', score: 10 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'Brighton', score: 0 },
+						},
+						{
+							self: { name: 'Liverpool', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+				{
+					position: 2,
+					team: {
+						name: 'Arsenal',
+						id: '1006',
+						url: 'https://www.theguardian.com/football/arsenal',
+					},
+					gamesPlayed: 29,
+					won: 21,
+					drawn: 10,
+					lost: 3,
+					goalsFor: 53,
+					goalsAgainst: 24,
+					goalDifference: 29,
+					points: 58,
+					results: [
+						{
+							self: { name: 'Arsenal', score: 4 },
+							foe: { name: 'Brighton', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 3 },
+							foe: { name: 'Manchester United', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 5 },
+							foe: { name: 'West Ham', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 9 },
+							foe: { name: 'Manchester City', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 0 },
+							foe: { name: 'Tottenham', score: 0 },
+						},
+						{
+							self: { name: 'Arsenal', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+				{
+					position: 3,
+					team: {
+						name: 'Nottm Forest',
+						id: '15',
+						url: 'https://www.theguardian.com/football/nottinghamforest',
+					},
+					gamesPlayed: 29,
+					won: 16,
+					drawn: 6,
+					lost: 7,
+					goalsFor: 49,
+					goalsAgainst: 35,
+					goalDifference: 14,
+					points: 54,
+					results: [
+						{
+							self: { name: 'Nottm Forest', score: 4 },
+							foe: { name: 'Brighton', score: 4 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'Manchester United', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'West Ham', score: 7 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 9 },
+							foe: { name: 'Manchester City', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 10 },
+							foe: { name: 'Tottenham', score: 0 },
+						},
+						{
+							self: { name: 'Nottm Forest', score: 0 },
+							foe: { name: 'Blackburn', score: 0 },
+						},
+					],
+				},
+			],
 		},
-		linkToFullTable: true,
-		dividers: [1],
-		data: [
-			{
-				position: 1,
-				team: {
-					name: 'Liverpool',
-					id: '9',
-					url: 'https://www.theguardian.com/football/arsenal',
-				},
-				gamesPlayed: 29,
-				won: 21,
-				drawn: 7,
-				lost: 1,
-				goalsFor: 69,
-				goalsAgainst: 27,
-				goalDifference: 42,
-				points: 70,
-				results: [
-					{
-						self: { name: 'Liverpool', score: 1 },
-						foe: { name: 'Chelsea', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 3 },
-						foe: { name: 'Arsenal', score: 5 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'West Ham', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 8 },
-						foe: { name: 'Tottenham', score: 10 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'Brighton', score: 0 },
-					},
-					{
-						self: { name: 'Liverpool', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-			{
-				position: 2,
-				team: {
-					name: 'Arsenal',
-					id: '1006',
-					url: 'https://www.theguardian.com/football/arsenal',
-				},
-				gamesPlayed: 29,
-				won: 21,
-				drawn: 10,
-				lost: 3,
-				goalsFor: 53,
-				goalsAgainst: 24,
-				goalDifference: 29,
-				points: 58,
-				results: [
-					{
-						self: { name: 'Arsenal', score: 4 },
-						foe: { name: 'Brighton', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 3 },
-						foe: { name: 'Manchester United', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 5 },
-						foe: { name: 'West Ham', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 9 },
-						foe: { name: 'Manchester City', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 0 },
-						foe: { name: 'Tottenham', score: 0 },
-					},
-					{
-						self: { name: 'Arsenal', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-			{
-				position: 3,
-				team: {
-					name: 'Nottm Forest',
-					id: '15',
-					url: 'https://www.theguardian.com/football/nottinghamforest',
-				},
-				gamesPlayed: 29,
-				won: 16,
-				drawn: 6,
-				lost: 7,
-				goalsFor: 49,
-				goalsAgainst: 35,
-				goalDifference: 14,
-				points: 54,
-				results: [
-					{
-						self: { name: 'Nottm Forest', score: 4 },
-						foe: { name: 'Brighton', score: 4 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'Manchester United', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'West Ham', score: 7 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 9 },
-						foe: { name: 'Manchester City', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 10 },
-						foe: { name: 'Tottenham', score: 0 },
-					},
-					{
-						self: { name: 'Nottm Forest', score: 0 },
-						foe: { name: 'Blackburn', score: 0 },
-					},
-				],
-			},
-		],
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -5,8 +5,8 @@ import {
 	textSansBold14,
 	until,
 } from '@guardian/source/foundations';
+import type { FootballTableData } from '../footballTables';
 import { palette } from '../palette';
-import type { TeamResult } from './FootballTableForm';
 import { FootballTableForm } from './FootballTableForm';
 
 const tableStyles = css`
@@ -63,26 +63,7 @@ const linkStyles = css`
 `;
 
 type Props = {
-	competition: {
-		url: string;
-		tableUrl: string;
-		name: string;
-	};
-	dividers: number[];
-	data: {
-		position: number;
-		team: { name: string; id: string; url: string };
-		gamesPlayed: number;
-		won: number;
-		drawn: number;
-		lost: number;
-		goalsFor: number;
-		goalsAgainst: number;
-		goalDifference: number;
-		points: number;
-		results: TeamResult[];
-	}[];
-	linkToFullTable: boolean;
+	table: FootballTableData;
 };
 
 function getFootballCrestImageUrl(teamId: string) {
@@ -141,128 +122,121 @@ const TeamWithCrest = ({
 	</div>
 );
 
-export const FootballTable = ({
-	competition,
-	data,
-	dividers,
-	linkToFullTable,
-}: Props) => {
-	return (
-		<table css={tableStyles}>
-			<caption
-				css={css`
-					${from.leftCol} {
-						display: none;
-					}
-					text-align: left;
-					border-top: 0.0625rem solid
-						${palette('--football-top-border')};
-					padding: 0.5rem;
-					${textSansBold14};
-					background: ${palette('--table-block-background')};
-				`}
-			>
-				<a css={linkStyles} href={competition.url}>
-					{competition.name}
-				</a>
-			</caption>
-			<thead css={headStyles}>
-				<tr css={rowStyles}>
-					<th
+export const FootballTable = ({ table }: Props) => (
+	<table css={tableStyles}>
+		<caption
+			css={css`
+				${from.leftCol} {
+					display: none;
+				}
+				text-align: left;
+				border-top: 0.0625rem solid ${palette('--football-top-border')};
+				padding: 0.5rem;
+				${textSansBold14};
+				background: ${palette('--table-block-background')};
+			`}
+		>
+			<a css={linkStyles} href={table.competition.url}>
+				{table.competition.name}
+			</a>
+		</caption>
+		<thead css={headStyles}>
+			<tr css={rowStyles}>
+				<th
+					css={css`
+						color: ${palette('--football-sub-text')};
+					`}
+				>
+					<abbr title="Position">P</abbr>
+				</th>
+				<th>Team</th>
+				<th>
+					<abbr title="Games played">GP</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Won">W</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Drawn">D</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Lost">L</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Goals for">F</abbr>
+				</th>
+				<th css={hideUntilTabletStyle}>
+					<abbr title="Goals against">A</abbr>
+				</th>
+				<th>
+					<abbr title="Goal difference">GD</abbr>
+				</th>
+				<th>
+					<abbr title="Points">Pts</abbr>
+				</th>
+				<th>
+					<abbr title="Results of previous games">Form</abbr>
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			{table.entries.map((row) => (
+				<tr
+					key={row.position}
+					css={[
+						rowStyles,
+						table.dividers.includes(row.position - 1) &&
+							dividerStyle,
+					]}
+				>
+					<td
 						css={css`
 							color: ${palette('--football-sub-text')};
 						`}
 					>
-						<abbr title="Position">P</abbr>
-					</th>
-					<th>Team</th>
-					<th>
-						<abbr title="Games played">GP</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Won">W</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Drawn">D</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Lost">L</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Goals for">F</abbr>
-					</th>
-					<th css={hideUntilTabletStyle}>
-						<abbr title="Goals against">A</abbr>
-					</th>
-					<th>
-						<abbr title="Goal difference">GD</abbr>
-					</th>
-					<th>
-						<abbr title="Points">Pts</abbr>
-					</th>
-					<th>
-						<abbr title="Results of previous games">Form</abbr>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				{data.map((row) => (
-					<tr
-						key={row.position}
-						css={[
-							rowStyles,
-							dividers.includes(row.position - 1) && dividerStyle,
-						]}
-					>
-						<td
+						{row.position}
+					</td>
+					<td>
+						<TeamWithCrest
+							team={row.team.name}
+							id={row.team.id}
+							url={row.team.url}
+						/>
+					</td>
+					<td>{row.gamesPlayed}</td>
+					<td css={hideUntilTabletStyle}>{row.won}</td>
+					<td css={hideUntilTabletStyle}>{row.drawn}</td>
+					<td css={hideUntilTabletStyle}>{row.lost}</td>
+					<td css={hideUntilTabletStyle}>{row.goalsFor}</td>
+					<td css={hideUntilTabletStyle}>{row.goalsAgainst}</td>
+					<td>{row.goalDifference}</td>
+					<td>
+						<b
 							css={css`
-								color: ${palette('--football-sub-text')};
+								font-weight: 800;
 							`}
 						>
-							{row.position}
-						</td>
-						<td>
-							<TeamWithCrest
-								team={row.team.name}
-								id={row.team.id}
-								url={row.team.url}
-							/>
-						</td>
-						<td>{row.gamesPlayed}</td>
-						<td css={hideUntilTabletStyle}>{row.won}</td>
-						<td css={hideUntilTabletStyle}>{row.drawn}</td>
-						<td css={hideUntilTabletStyle}>{row.lost}</td>
-						<td css={hideUntilTabletStyle}>{row.goalsFor}</td>
-						<td css={hideUntilTabletStyle}>{row.goalsAgainst}</td>
-						<td>{row.goalDifference}</td>
-						<td>
-							<b
-								css={css`
-									font-weight: 800;
-								`}
-							>
-								{row.points}
-							</b>
-						</td>
-						<td>
-							<FootballTableForm
-								teamResults={row.results.slice(0, 5)}
-							/>
-						</td>
-					</tr>
-				))}
-			</tbody>
-			{linkToFullTable && (
-				<tfoot>
-					<tr css={rowStyles}>
-						<td colSpan={11}>
-							<a href={competition.tableUrl} css={linkStyles}>
-								View full {competition.name} table
-							</a>
-						</td>
-					</tr>
-				</tfoot>
-			)}
-		</table>
-	);
-};
+							{row.points}
+						</b>
+					</td>
+					<td>
+						<FootballTableForm
+							teamResults={row.results.slice(0, 5)}
+						/>
+					</td>
+				</tr>
+			))}
+		</tbody>
+		{table.linkToFullTable && (
+			<tfoot>
+				<tr css={rowStyles}>
+					<td colSpan={11}>
+						<a href={table.competition.tableUrl} css={linkStyles}>
+							View full {table.competition.name} table
+						</a>
+					</td>
+				</tr>
+			</tfoot>
+		)}
+	</table>
+);

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -236,7 +236,7 @@ export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 				<tr css={rowStyles}>
 					<td colSpan={11}>
 						<a
-							href={`${guardianBaseUrl}${table.competition.tableUrl}`}
+							href={`${guardianBaseUrl}${table.competition.url}/table`}
 							css={linkStyles}
 						>
 							View full {table.competition.name} table

--- a/dotcom-rendering/src/components/FootballTable.tsx
+++ b/dotcom-rendering/src/components/FootballTable.tsx
@@ -64,6 +64,7 @@ const linkStyles = css`
 
 type Props = {
 	table: FootballTableData;
+	guardianBaseUrl: string;
 };
 
 function getFootballCrestImageUrl(teamId: string) {
@@ -122,7 +123,7 @@ const TeamWithCrest = ({
 	</div>
 );
 
-export const FootballTable = ({ table }: Props) => (
+export const FootballTable = ({ table, guardianBaseUrl }: Props) => (
 	<table css={tableStyles}>
 		<caption
 			css={css`
@@ -136,7 +137,10 @@ export const FootballTable = ({ table }: Props) => (
 				background: ${palette('--table-block-background')};
 			`}
 		>
-			<a css={linkStyles} href={table.competition.url}>
+			<a
+				css={linkStyles}
+				href={`${guardianBaseUrl}${table.competition.url}`}
+			>
 				{table.competition.name}
 			</a>
 		</caption>
@@ -231,7 +235,10 @@ export const FootballTable = ({ table }: Props) => (
 			<tfoot>
 				<tr css={rowStyles}>
 					<td colSpan={11}>
-						<a href={table.competition.tableUrl} css={linkStyles}>
+						<a
+							href={`${guardianBaseUrl}${table.competition.tableUrl}`}
+							css={linkStyles}
+						>
 							View full {table.competition.name} table
 						</a>
 					</td>

--- a/dotcom-rendering/src/components/FootballTableForm.tsx
+++ b/dotcom-rendering/src/components/FootballTableForm.tsx
@@ -1,12 +1,7 @@
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source/foundations';
-import type { TeamScore } from '../footballMatches';
+import type { TeamResult } from '../footballTables';
 import { palette } from '../palette';
-
-export type TeamResult = {
-	self: TeamScore;
-	foe: TeamScore;
-};
 
 const formBlockStyles = css`
 	display: inline-block;

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react/*';
+import { FootballTableList } from './FootballTableList';
+
+const meta = {
+	title: 'Components/Football Table List',
+	component: FootballTableList,
+} satisfies Meta<typeof FootballTableList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -26,5 +26,6 @@ export const Default = {
 			{ ...TableDefault.args.table },
 			{ ...TableDefault.args.table },
 		],
+		guardianBaseUrl: 'https://www.theguardian.com',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -1,13 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
+import { Default as TableDefault } from './FootballTable.stories';
 import { FootballTableList } from './FootballTableList';
 
 const meta = {
 	title: 'Components/Football Table List',
 	component: FootballTableList,
+	decorators: [
+		// To make it easier to see the top border
+		(Story) => (
+			<>
+				<div css={{ padding: 4 }}></div>
+				<Story />
+			</>
+		),
+	],
 } satisfies Meta<typeof FootballTableList>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default = {} satisfies Story;
+export const Default = {
+	args: {
+		tables: [
+			{ ...TableDefault.args.table },
+			{ ...TableDefault.args.table },
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -1,3 +1,101 @@
-export const FootballTableList = () => {
-	return <></>;
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold17,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import { Stack } from '@guardian/source/react-components';
+import type { ReactNode } from 'react';
+import type { FootballTableData } from '../footballTables';
+import { palette } from '../palette';
+import { FootballTable } from './FootballTable';
+
+const footballTablesGridStyles = css`
+	display: grid;
+	grid-template-columns: [centre-column-start] repeat(4, 1fr) [centre-column-end];
+	column-gap: 10px;
+	${from.mobileLandscape} {
+		column-gap: 20px;
+	}
+
+	${from.tablet} {
+		grid-template-columns: [centre-column-start] repeat(12, 40px) [centre-column-end];
+	}
+
+	${from.desktop} {
+		grid-template-columns: [centre-column-start] repeat(8, 60px) [centre-column-end];
+	}
+
+	${from.leftCol} {
+		grid-template-columns:
+			[left-column-start] repeat(2, 60px)
+			[left-column-end centre-column-start] repeat(8, 60px)
+			[centre-column-end];
+	}
+
+	${from.wide} {
+		grid-template-columns:
+			[left-column-start] repeat(3, 60px)
+			[left-column-end centre-column-start] repeat(8, 60px)
+			[centre-column-end];
+	}
+`;
+
+const CompetitionName = ({ children }: { children: ReactNode }) => (
+	<h3
+		css={css`
+			${until.leftCol} {
+				display: none;
+			}
+			${from.leftCol} {
+				color: ${palette('--football-competition-text')};
+				border-top: 1px solid ${palette('--football-list-border')};
+				background-color: transparent;
+				margin-top: 0;
+				padding: ${space[1]}px 0 0;
+				grid-column: left-column-start / left-column-end;
+				${headlineBold17}
+			}
+		`}
+	>
+		{children}
+	</h3>
+);
+
+type Props = {
+	tables: FootballTableData[];
 };
+
+export const FootballTableList = ({ tables }: Props) => (
+	<Stack space={9}>
+		{tables.map((table) => (
+			<section
+				key={table.competition.name}
+				css={footballTablesGridStyles}
+			>
+				<CompetitionName>
+					<a
+						href={table.competition.url}
+						css={css`
+							text-decoration: none;
+							color: inherit;
+							:hover {
+								text-decoration: underline;
+							}
+						`}
+					>
+						{table.competition.name}
+					</a>
+				</CompetitionName>
+				<div
+					css={css`
+						grid-column: centre-column-start / centre-column-end;
+					`}
+				>
+					<FootballTable table={table} />
+				</div>
+			</section>
+		))}
+	</Stack>
+);

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -1,0 +1,3 @@
+export const FootballTableList = () => {
+	return <></>;
+};

--- a/dotcom-rendering/src/components/FootballTableList.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.tsx
@@ -65,9 +65,10 @@ const CompetitionName = ({ children }: { children: ReactNode }) => (
 
 type Props = {
 	tables: FootballTableData[];
+	guardianBaseUrl: string;
 };
 
-export const FootballTableList = ({ tables }: Props) => (
+export const FootballTableList = ({ tables, guardianBaseUrl }: Props) => (
 	<Stack space={9}>
 		{tables.map((table) => (
 			<section
@@ -76,7 +77,7 @@ export const FootballTableList = ({ tables }: Props) => (
 			>
 				<CompetitionName>
 					<a
-						href={table.competition.url}
+						href={`${guardianBaseUrl}${table.competition.url}`}
 						css={css`
 							text-decoration: none;
 							color: inherit;
@@ -93,7 +94,10 @@ export const FootballTableList = ({ tables }: Props) => (
 						grid-column: centre-column-start / centre-column-end;
 					`}
 				>
-					<FootballTable table={table} />
+					<FootballTable
+						table={table}
+						guardianBaseUrl={guardianBaseUrl}
+					/>
 				</div>
 			</section>
 		))}

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -23,5 +23,6 @@ export const Default = {
 			{ ...TableDefault.args.table },
 		],
 		renderAds: true,
+		guardianBaseUrl: 'https://www.theguardian.com',
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react/*';
+import { fn } from '@storybook/test';
+import { regions } from '../../fixtures/manual/footballData';
+import { Default as TableDefault } from './FootballTable.stories';
+import { FootballTablesPage } from './FootballTablesPage';
+
+const meta = {
+	title: 'Components/Football Tables Page',
+	component: FootballTablesPage,
+} satisfies Meta<typeof FootballTablesPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		regions,
+		goToCompetitionSpecificPage: fn(),
+		pageId: 'football/tables',
+		tables: [
+			{ ...TableDefault.args.table },
+			{ ...TableDefault.args.table },
+		],
+		renderAds: true,
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold20,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import type { Region } from '../footballMatches';
+import type { FootballTableData } from '../footballTables';
+import { grid } from '../grid';
+import { palette } from '../palette';
+import { AdSlot } from './AdSlot.web';
+import { FootballCompetitionSelect } from './FootballCompetitionSelect';
+import { FootballTableList } from './FootballTableList';
+
+type Props = {
+	regions: Region[];
+	pageId: string;
+	goToCompetitionSpecificPage: (tag: string) => void;
+	tables: FootballTableData[];
+	renderAds: boolean;
+};
+
+export const FootballTablesPage = ({
+	regions,
+	pageId,
+	goToCompetitionSpecificPage,
+	tables,
+	renderAds,
+}: Props) => (
+	<main
+		id="maincontent"
+		data-layout="FootballDataPageLayout"
+		css={css`
+			${grid.paddedContainer}
+			position: relative;
+			${from.tablet} {
+				&::before,
+				&::after {
+					content: '';
+					position: absolute;
+					border-left: 1px solid ${palette('--article-border')};
+					top: 0;
+					bottom: 0;
+				}
+
+				&::after {
+					right: 0;
+				}
+			}
+
+			padding-bottom: ${space[9]}px;
+		`}
+	>
+		<h1
+			css={css`
+				${headlineBold20}
+				padding: ${space[2]}px 0 ${space[3]}px;
+				${grid.column.centre}
+				grid-row: 1;
+				${from.leftCol} {
+					${grid.between('left-column-start', 'centre-column-end')}
+				}
+			`}
+		>
+			Football tables
+		</h1>
+		<div
+			css={css`
+				margin-top: ${space[3]}px;
+				margin-bottom: ${space[6]}px;
+				${grid.column.centre}
+				grid-row: 2;
+			`}
+		>
+			<FootballCompetitionSelect
+				regions={regions}
+				kind="Tables"
+				pageId={pageId}
+				onChange={goToCompetitionSpecificPage}
+			/>
+		</div>
+		<div
+			css={css`
+				${grid.column.centre}
+				grid-row: 3;
+				${from.leftCol} {
+					${grid.between('left-column-start', 'centre-column-end')}
+				}
+				position: relative;
+			`}
+		>
+			<FootballTableList tables={tables} />
+		</div>
+		{renderAds && (
+			<div
+				css={css`
+					${grid.column.right}
+					// ToDo: review what line to grow the ad to
+					/** This allows the ad to grow beyond the third row content (up to line 5) */
+					grid-row: 1 / 5;
+					${until.desktop} {
+						display: none;
+					}
+				`}
+			>
+				<AdSlot position="right-football" />
+			</div>
+		)}
+	</main>
+);

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -19,6 +19,7 @@ type Props = {
 	goToCompetitionSpecificPage: (tag: string) => void;
 	tables: FootballTableData[];
 	renderAds: boolean;
+	guardianBaseUrl: string;
 };
 
 export const FootballTablesPage = ({
@@ -27,6 +28,7 @@ export const FootballTablesPage = ({
 	goToCompetitionSpecificPage,
 	tables,
 	renderAds,
+	guardianBaseUrl,
 }: Props) => (
 	<main
 		id="maincontent"
@@ -90,13 +92,16 @@ export const FootballTablesPage = ({
 				position: relative;
 			`}
 		>
-			<FootballTableList tables={tables} />
+			<FootballTableList
+				tables={tables}
+				guardianBaseUrl={guardianBaseUrl}
+			/>
 		</div>
 		{renderAds && (
 			<div
 				css={css`
 					${grid.column.right}
-					// ToDo: review what line to grow the ad to
+					/**  ToDo: review what line to grow the ad to */
 					/** This allows the ad to grow beyond the third row content (up to line 5) */
 					grid-row: 1 / 5;
 					${until.desktop} {

--- a/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPageWrapper.importable.tsx
@@ -1,0 +1,36 @@
+import type { Region } from '../footballMatches';
+import type { FootballTableData } from '../footballTables';
+import { FootballTablesPage } from './FootballTablesPage';
+
+const goToCompetitionSpecificPage =
+	(guardianBaseUrl: string) => (path: string) => {
+		const url = `${guardianBaseUrl}${path}`;
+		window.location.assign(url);
+	};
+
+type Props = {
+	regions: Region[];
+	pageId: string;
+	tables: FootballTableData[];
+	renderAds: boolean;
+	guardianBaseUrl: string;
+};
+
+export const FootballTablesPageWrapper = ({
+	regions,
+	pageId,
+	tables,
+	renderAds,
+	guardianBaseUrl,
+}: Props) => (
+	<FootballTablesPage
+		regions={regions}
+		pageId={pageId}
+		tables={tables}
+		renderAds={renderAds}
+		goToCompetitionSpecificPage={goToCompetitionSpecificPage(
+			guardianBaseUrl,
+		)}
+		guardianBaseUrl={guardianBaseUrl}
+	/>
+);

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -8,7 +8,6 @@ export type TeamResult = {
 export type FootballTableData = {
 	competition: {
 		url: string;
-		tableUrl: string;
 		name: string;
 	};
 	dividers: number[];

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -1,0 +1,29 @@
+import type { TeamScore } from './footballMatches';
+
+export type TeamResult = {
+	self: TeamScore;
+	foe: TeamScore;
+};
+
+export type FootballTableData = {
+	competition: {
+		url: string;
+		tableUrl: string;
+		name: string;
+	};
+	dividers: number[];
+	entries: {
+		position: number;
+		team: { name: string; id: string; url: string };
+		gamesPlayed: number;
+		won: number;
+		drawn: number;
+		lost: number;
+		goalsFor: number;
+		goalsAgainst: number;
+		goalDifference: number;
+		points: number;
+		results: TeamResult[];
+	}[];
+	linkToFullTable: boolean;
+};

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6560,6 +6560,10 @@ const paletteColours = {
 		light: () => '#3DB540',
 		dark: () => '#3DB540',
 	},
+	'--football-list-border': {
+		light: () => sourcePalette.neutral[93],
+		dark: () => sourcePalette.neutral[38],
+	},
 	'--football-match-hover': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],
@@ -6567,10 +6571,6 @@ const paletteColours = {
 	'--football-match-list-background': {
 		light: () => sourcePalette.neutral[97],
 		dark: () => sourcePalette.neutral[20],
-	},
-	'--football-match-list-border': {
-		light: () => sourcePalette.neutral[93],
-		dark: () => sourcePalette.neutral[38],
 	},
 	'--football-match-list-error': {
 		light: () => sourcePalette.error[400],


### PR DESCRIPTION
## What does this change?

Adds components that render a list of football tables, the surrounding page furniture (title and dropdown) and the importable wrapper for the page

## Screenshots

<img width="320" alt="image" src="https://github.com/user-attachments/assets/f1f7b6d9-fc6d-452a-8e3a-6d305fb632d4" />

<img width="903" alt="image" src="https://github.com/user-attachments/assets/472791c2-57e5-4b29-b25f-432f1d3eea33" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
