### PR TITLE
Relocate print style to avoid caching

### DIFF
--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -50,5 +50,17 @@ export const rootStyles = (
 		color: ${sourcePalette.neutral[7]};
 	}
 
+	/**
+	* Hide scroll depth markers when printing as these are absolutely positioned
+	* based on the initial content height. These will still be present in the
+	* document at their original location when printing, even if other page
+	* elements have been hidden, leading to blank pages being produced.
+	*/
+	@media print {
+		.scroll-depth-marker {
+			display: none;
+		}
+	}
+
 	${rootAdStyles}
 `;

--- a/dotcom-rendering/src/static/css/print.css
+++ b/dotcom-rendering/src/static/css/print.css
@@ -2,12 +2,3 @@
 	display: none !important;
 	color: #000000;
 }
-
-/**
- * Hide scroll depth markers when printing as these are absolutely positioned
- * based on the initial content height and are still present when content has
- * been hidden in the print layout, causing blank pages to be printed.
- */
-.scroll-depth-marker {
-	display: none;
-}


### PR DESCRIPTION
## What does this change?

Relocates the print style added in #13632 to hide scroll depth marker elements from `print.css` to `rootStyles.ts`.

## Why?

The print stylesheet is cached for a year, so the new style will be not be served to all readers.

<img width="623" alt="Screenshot 2025-03-19 at 10 28 24" src="https://github.com/user-attachments/assets/50f1f9d9-75b4-4303-9654-2de473081311" />

It _might_ make sense to remove `print.css` entirely and move the remaining `[data-print-layout='hide']` rule to `rootStyles.ts` as well. (This file is currently included by a number of interactive projects in their test harnesses, although this is likely due to the page template being copied over from DCR rather the print styles being necessary.)