### PR TITLE
Add `navigator.canShare` check in `ShareButton.importable.tsx`

### DIFF
--- a/dotcom-rendering/src/components/ShareButton.importable.tsx
+++ b/dotcom-rendering/src/components/ShareButton.importable.tsx
@@ -210,6 +210,7 @@ export const ShareButton = ({
 		if (
 			!isLiveBlogBlockDesktop &&
 			'share' in navigator &&
+			'canShare' in navigator &&
 			navigator.canShare(shareData)
 		) {
 			setButtonKind('native');


### PR DESCRIPTION
## What does this change?

Add a defensive check for `navigator.canShare` as it is not supported by all browsers

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img src="https://github.com/user-attachments/assets/c981b3df-082c-4e6a-83ae-dfba6f69fdd0" width="460px" /> | Error not present |


