### PR TITLE
Add `dark=false` param for in-house interactive embeds

### DIFF
--- a/dotcom-rendering/playwright/lib/iframe.ts
+++ b/dotcom-rendering/playwright/lib/iframe.ts
@@ -10,4 +10,16 @@ const getIframeBody = async (
 	return iframeBodyLocator;
 };
 
-export { getIframeBody };
+const getIframePart = async (
+	page: Page,
+	iframeSelector: string,
+	partSelector: string,
+): Promise<Locator> => {
+	const iframePartLocator = page
+		.frameLocator(iframeSelector)
+		.locator(partSelector);
+	await expect(iframePartLocator).toBeAttached({ timeout: 10_000 });
+	return iframePartLocator;
+};
+
+export { getIframeBody, getIframePart };

--- a/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { cmpAcceptAll } from '../lib/cmp';
-import { getIframeBody } from '../lib/iframe';
+import { getIframeBody, getIframePart } from '../lib/iframe';
 import { waitForIsland } from '../lib/islands';
 import { loadPage } from '../lib/load-page';
 import { expectToBeVisible } from '../lib/locators';
@@ -43,9 +43,10 @@ test.describe('Embeds', () => {
 
 			await waitForIsland(page, 'InteractiveBlockComponent');
 			await expect(
-				await getIframeBody(
+				await getIframePart(
 					page,
 					'[data-testid="interactive-element-LA%20Rams%20dead%20cap%20numbers"] > iframe',
+					'.title',
 				),
 			).toContainText('The Rams’ dead cap numbers for 2020');
 		});

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -350,11 +350,13 @@ export const InteractiveBlockComponent = ({
 
 			// Bespoke dark mode logic for Datawrapper and ai2html embeds on web
 			// This should be removed if/when dark mode is implements on the website
+			const isai2html = url.includes(
+				'interactive.guim.co.uk/uploader/embed/',
+			);
 			if (
 				!document.querySelector('.ios') &&
 				!document.querySelector('.android') &&
-				(url.includes('datawrapper') ||
-					url.includes('interactive.guim.co.uk/uploader/embed/'))
+				(url.includes('datawrapper') || isai2html)
 			) {
 				const prefersDarkScheme = window.matchMedia(
 					'(prefers-color-scheme: dark)',
@@ -362,7 +364,9 @@ export const InteractiveBlockComponent = ({
 				const darkMode = darkModeAvailable && prefersDarkScheme;
 				if (!darkMode) {
 					iframe.src +=
-						(iframe.src.includes('?') ? '&' : '?') + 'dark=false';
+						(isai2html ? '/' : '') +
+						(iframe.src.includes('?') ? '&' : '?') +
+						'dark=false';
 				}
 			}
 

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -326,52 +326,72 @@ export const InteractiveBlockComponent = ({
 	const placeholderLinkRef = useRef<HTMLAnchorElement>(null);
 	const [loaded, setLoaded] = useState(false);
 	const { darkModeAvailable } = useConfig();
+
+	// Define some one-time flags
+	const isDatawrapperGraphic =
+		url &&
+		url.substring &&
+		url.includes('interactive.guim.co.uk/datawrapper');
+
+	const isUploaderEmbedPath =
+		url &&
+		url.substring &&
+		url.includes('interactive.guim.co.uk/uploader/embed/');
+
+	const scriptUrlIsBoot =
+		scriptUrl &&
+		scriptUrl.substring &&
+		scriptUrl.includes(
+			'interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js',
+		);
+
 	useOnce(() => {
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
-		if (
-			scriptUrl ===
-				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js' &&
-			url &&
-			placeholderLinkRef.current
-		) {
+
+		// Define additional one-time flags - these depend on window/document objects
+		const isRunningInWebEnvironment =
+			!document.querySelector('.ios') &&
+			!document.querySelector('.android');
+
+		const prefersDarkScheme = window.matchMedia(
+			'(prefers-color-scheme: dark)',
+		).matches;
+		const requiresDarkMode = darkModeAvailable && prefersDarkScheme;
+
+		if (url && scriptUrlIsBoot && placeholderLinkRef.current) {
+			// Prepare for graphic url dynamic updates
+			const graphicUrl = new URL(url);
+			const graphicUrlParams = new URLSearchParams(graphicUrl.search);
+
+			// Begin creating new iframe element
 			const iframe = document.createElement('iframe');
 			iframe.style.width = '100%';
 			iframe.style.border = 'none';
 			iframe.height = decideHeight(role).toString();
 			iframe.title = caption ?? alt ?? 'Interactive Content';
-			if (url.startsWith('http:')) {
-				iframe.src = url.replace('http:', 'https:');
-			} else {
-				iframe.src = url;
+
+			// Fix for Datawrapper graphic
+			if (isDatawrapperGraphic) {
+				iframe.scrolling = 'no';
 			}
 
-			// Datawrapper-specific fix to suppress scrollbars appearing
-			if (url.includes('datawrapper')) iframe.scrolling = 'no';
-
-			// Bespoke dark mode logic for Datawrapper and ai2html embeds on web
-			// This should be removed if/when dark mode is implements on the website
-			const isai2html = url.includes(
-				'interactive.guim.co.uk/uploader/embed/',
-			);
-			if (
-				!document.querySelector('.ios') &&
-				!document.querySelector('.android') &&
-				(url.includes('datawrapper') || isai2html)
-			) {
-				const prefersDarkScheme = window.matchMedia(
-					'(prefers-color-scheme: dark)',
-				).matches;
-				const darkMode = darkModeAvailable && prefersDarkScheme;
-				if (!darkMode) {
-					iframe.src +=
-						(isai2html ? '/' : '') +
-						(iframe.src.includes('?') ? '&' : '?') +
-						'dark=false';
+			// Fix darkmode for web environment
+			if (isRunningInWebEnvironment && !requiresDarkMode) {
+				if (isDatawrapperGraphic || isUploaderEmbedPath) {
+					// Add the 'dark=false' search param
+					graphicUrlParams.set('dark', 'false');
 				}
 			}
 
-			setupWindowListeners(iframe);
+			// Always serve graphic over https, not http
+			graphicUrl.protocol = 'https:';
 
+			graphicUrl.search = graphicUrlParams.toString();
+
+			// Finalise new iframe element
+			iframe.src = graphicUrl.href;
+
+			setupWindowListeners(iframe);
 			wrapperRef.current?.prepend(iframe);
 
 			setLoaded(true);
@@ -396,17 +416,9 @@ export const InteractiveBlockComponent = ({
 					}
 				},
 			);
-
 			setLoaded(true);
 		}
 	}, [loaded]);
-
-	const isDatawrapperGraphic =
-		url == undefined
-			? false
-			: /^https?:\/\/interactive\.guim\.co\.uk\/datawrapper(-test)?\/embed/.test(
-					url,
-			  );
 
 	return (
 		<>

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -385,6 +385,14 @@ export const InteractiveBlockComponent = ({
 					if (graphicUrl.search.length) {
 						graphicUrl.search += '&dark=false';
 					} else {
+						// Embed URLs without a trailing slash are redirected and the
+						// search param is lost so we need to add it to the pathname
+						const hasTrailingSlash = graphicUrl.pathname.endsWith(
+							'/',
+						)
+							? true
+							: false;
+						graphicUrl.pathname += hasTrailingSlash ? '' : '/';
 						graphicUrl.search += '?dark=false';
 					}
 				}

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -365,7 +365,6 @@ export const InteractiveBlockComponent = ({
 		if (url && scriptUrlIsBoot && placeholderLinkRef.current) {
 			// Prepare for graphic url dynamic updates
 			const graphicUrl = new URL(url);
-			const graphicUrlParams = new URLSearchParams(graphicUrl.search);
 
 			// Begin creating new iframe element
 			const iframe = document.createElement('iframe');
@@ -383,19 +382,22 @@ export const InteractiveBlockComponent = ({
 			if (isRunningInWebEnvironment && !requiresDarkMode) {
 				if (isDatawrapperGraphic || isUploaderEmbedPath) {
 					// Add the 'dark=false' search param
-					graphicUrlParams.set('dark', 'false');
+					if (graphicUrl.search.length) {
+						graphicUrl.search += '&dark=false';
+					} else {
+						graphicUrl.search += '?dark=false';
+					}
 				}
 			}
 
 			// Always serve graphic over https, not http
 			graphicUrl.protocol = 'https:';
 
-			graphicUrl.search = graphicUrlParams.toString();
-
 			// Finalise new iframe element
 			iframe.src = graphicUrl.href;
 
 			setupWindowListeners(iframe);
+
 			wrapperRef.current?.prepend(iframe);
 
 			setLoaded(true);
@@ -420,6 +422,7 @@ export const InteractiveBlockComponent = ({
 					}
 				},
 			);
+
 			setLoaded(true);
 		}
 	}, [loaded]);

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -346,23 +346,23 @@ export const InteractiveBlockComponent = ({
 			}
 
 			// Datawrapper-specific fix to suppress scrollbars appearing
-			if (url.includes('datawrapper')) {
-				iframe.scrolling = 'no';
-				// Turn off dark mode for Datawrapper embeds on web
-				// This should be removed if/when dark mode is implements on the website
-				if (
-					!document.querySelector('.ios') &&
-					!document.querySelector('.android')
-				) {
-					const prefersDarkScheme = window.matchMedia(
-						'(prefers-color-scheme: dark)',
-					).matches;
-					const darkMode = darkModeAvailable && prefersDarkScheme;
-					if (!darkMode) {
-						iframe.src +=
-							(iframe.src.includes('?') ? '&' : '?') +
-							'dark=false';
-					}
+			if (url.includes('datawrapper')) iframe.scrolling = 'no';
+
+			// Bespoke dark mode logic for Datawrapper and ai2html embeds on web
+			// This should be removed if/when dark mode is implements on the website
+			if (
+				!document.querySelector('.ios') &&
+				!document.querySelector('.android') &&
+				(url.includes('datawrapper') ||
+					url.includes('interactive.guim.co.uk/uploader/embed/'))
+			) {
+				const prefersDarkScheme = window.matchMedia(
+					'(prefers-color-scheme: dark)',
+				).matches;
+				const darkMode = darkModeAvailable && prefersDarkScheme;
+				if (!darkMode) {
+					iframe.src +=
+						(iframe.src.includes('?') ? '&' : '?') + 'dark=false';
 				}
 			}
 

--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -329,21 +329,22 @@ export const InteractiveBlockComponent = ({
 
 	// Define some one-time flags
 	const isDatawrapperGraphic =
-		url &&
-		url.substring &&
-		url.includes('interactive.guim.co.uk/datawrapper');
+		url && url.includes('interactive.guim.co.uk/datawrapper')
+			? true
+			: false;
 
 	const isUploaderEmbedPath =
-		url &&
-		url.substring &&
-		url.includes('interactive.guim.co.uk/uploader/embed/');
+		url && url.includes('interactive.guim.co.uk/uploader/embed/')
+			? true
+			: false;
 
 	const scriptUrlIsBoot =
 		scriptUrl &&
-		scriptUrl.substring &&
 		scriptUrl.includes(
 			'interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js',
-		);
+		)
+			? true
+			: false;
 
 	useOnce(() => {
 		// We've brought the behavior from boot.js into this file to avoid loading 2 extra scripts
@@ -351,12 +352,15 @@ export const InteractiveBlockComponent = ({
 		// Define additional one-time flags - these depend on window/document objects
 		const isRunningInWebEnvironment =
 			!document.querySelector('.ios') &&
-			!document.querySelector('.android');
+			!document.querySelector('.android')
+				? true
+				: false;
 
 		const prefersDarkScheme = window.matchMedia(
 			'(prefers-color-scheme: dark)',
 		).matches;
-		const requiresDarkMode = darkModeAvailable && prefersDarkScheme;
+		const requiresDarkMode =
+			darkModeAvailable && prefersDarkScheme ? true : false;
 
 		if (url && scriptUrlIsBoot && placeholderLinkRef.current) {
 			// Prepare for graphic url dynamic updates


### PR DESCRIPTION
## What does this change?

This explores mimicking the dark mode solution for Datawrapper (#13637) and applying it to in-house interactives. Rather than asking iframe's to reach outside themselves for information about the parent page, why not pass it down?

Tested in CODE and seems to work in principle.

## Why?

The apps have dark mode, the site has an opt-in dark mode. This leads to visual clashes when a reader's device preference is dark but they've not opted into the Guardian's dark mode specifically. If and when it's rolled out in full graphics can listen out for the preferred colour scheme, but in the meantime need a bit of bespoke logic to ensure they match on the site.

## Screenshots

| Light mode web      | Dark mode web      |
| ----------- | ---------- |
| ![image](https://github.com/user-attachments/assets/eee06863-c878-43d2-9035-bf6889b1656d) | ![image](https://github.com/user-attachments/assets/b4499789-4bc3-4e49-9d5d-de09493af746)|

Like the Datawrapper approach this is something that can/should be removed once dark mode is rolled out for the website.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
