### PR TITLE
Display line between cards in secondary Flexible General containers on mobile

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -62,7 +62,7 @@ const sublinkHoverStyles = css`
 	}
 `;
 
-const desktopTopBarStyles = css`
+const topBarStyles = css`
 	:before {
 		border-top: 1px solid ${palette('--card-border-top')};
 		content: '';
@@ -72,11 +72,13 @@ const desktopTopBarStyles = css`
 		background-color: unset;
 	}
 `;
-
 const mobileTopBarStyles = css`
 	${until.tablet} {
-		${desktopTopBarStyles}
+		${topBarStyles}
 	}
+`;
+const desktopTopBarStyles = css`
+	${topBarStyles}
 `;
 
 const onwardContentStyles = css`

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -502,3 +502,15 @@ export const WithSpecialPaletteVariations = {
 		</>
 	),
 } satisfies Story;
+
+export const SecondaryContainerStandardCards: Story = {
+	name: 'Secondary container with standard cards',
+	args: {
+		frontSectionTitle: 'Secondary container standard cards',
+		containerLevel: 'Secondary',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			standard: standardCards.slice(0, 4),
+		},
+	},
+};

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -506,7 +506,8 @@ export const StandardCardLayout = ({
 							showTopBarMobile={
 								!isFirstRow ||
 								(containerLevel === 'Primary' &&
-									!isMediaCard(card.format))
+									!isMediaCard(card.format)) ||
+								(containerLevel !== 'Primary' && cardIndex > 0)
 							}
 							trailText={undefined}
 							// On standard cards, we increase the headline size if the trail image has been hidden


### PR DESCRIPTION
## What does this change?

Always display a grey dividing line between the two articles in secondary Flexible General containers on mobile.

## Why?
 
- To match designs
- Builds on the work in https://github.com/guardian/dotcom-rendering/pull/13476

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f65fdad3-6792-4968-9094-de13e0b65802
[after]: https://github.com/user-attachments/assets/62c7b3d2-6f5a-41e0-8220-c043640e1311

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
