### PR TITLE
Add support for sentry 'extra' contexts to reportError

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -56,7 +56,7 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export const reportError: ReportError = (error, feature, tags, extra) => {
+export const reportError: ReportError = (error, feature, tags, extras) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {
@@ -64,8 +64,8 @@ export const reportError: ReportError = (error, feature, tags, extra) => {
 				Sentry.setTag(key, value);
 			}
 		}
-		if (extra) {
-			Sentry.setContext('extra', extra);
+		if (extras) {
+			Sentry.setExtras(extras);
 		}
 
 		Sentry.captureException(error);

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -56,12 +56,17 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export const reportError: ReportError = (error, feature, tags) => {
+export const reportError: ReportError = (error, feature, tags, context) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {
 			for (const [key, value] of Object.entries(tags)) {
 				Sentry.setTag(key, value);
+			}
+		}
+		if (context) {
+			for (const [key, value] of Object.entries(context)) {
+				Sentry.setContext(key, value);
 			}
 		}
 		Sentry.captureException(error);

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -56,7 +56,7 @@ if (
 	Sentry.setTag('dcr.bundle', dcrJavascriptBundle('Variant'));
 }
 
-export const reportError: ReportError = (error, feature, tags, context) => {
+export const reportError: ReportError = (error, feature, tags, extra) => {
 	Sentry.withScope(() => {
 		Sentry.setTag('feature', feature);
 		if (tags) {
@@ -64,11 +64,10 @@ export const reportError: ReportError = (error, feature, tags, context) => {
 				Sentry.setTag(key, value);
 			}
 		}
-		if (context) {
-			for (const [key, value] of Object.entries(context)) {
-				Sentry.setContext(key, value);
-			}
+		if (extra) {
+			Sentry.setContext('extra', extra);
 		}
+
 		Sentry.captureException(error);
 	});
 };

--- a/dotcom-rendering/src/client/sentryLoader/sentry.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentry.ts
@@ -64,6 +64,7 @@ export const reportError: ReportError = (error, feature, tags, extras) => {
 				Sentry.setTag(key, value);
 			}
 		}
+
 		if (extras) {
 			Sentry.setExtras(extras);
 		}

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -38,10 +38,10 @@ const stubSentry = (): void => {
 		error,
 		feature,
 		tags,
-		extra,
+		extras,
 	) => {
 		// eslint-disable-next-line no-console -- fallback to console.error
-		console.error(error, feature, tags, extra);
+		console.error(error, feature, tags, extras);
 	};
 };
 

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -34,9 +34,14 @@ const isSentryEnabled = ({
 
 /** When stubbed errors are only sent to the console */
 const stubSentry = (): void => {
-	window.guardian.modules.sentry.reportError = (error, feature, tags) => {
+	window.guardian.modules.sentry.reportError = (
+		error,
+		feature,
+		tags,
+		extra,
+	) => {
 		// eslint-disable-next-line no-console -- fallback to console.error
-		console.error(error, feature, tags);
+		console.error(error, feature, tags, extra);
 	};
 };
 

--- a/dotcom-rendering/src/types/sentry.ts
+++ b/dotcom-rendering/src/types/sentry.ts
@@ -1,7 +1,6 @@
 export type ReportError = (
 	error: Error,
 	feature: string,
-	tags?: {
-		[key: string]: string;
-	},
+	tags?: Record<string, string>,
+	context?: Record<string, Record<string, unknown>>,
 ) => void;

--- a/dotcom-rendering/src/types/sentry.ts
+++ b/dotcom-rendering/src/types/sentry.ts
@@ -2,5 +2,5 @@ export type ReportError = (
 	error: Error,
 	feature: string,
 	tags?: Record<string, string>,
-	extra?: Record<string, string | Record<string, string>>,
+	extras?: Record<string, unknown>,
 ) => void;

--- a/dotcom-rendering/src/types/sentry.ts
+++ b/dotcom-rendering/src/types/sentry.ts
@@ -2,5 +2,5 @@ export type ReportError = (
 	error: Error,
 	feature: string,
 	tags?: Record<string, string>,
-	context?: Record<string, Record<string, unknown>>,
+	extra?: Record<string, string | Record<string, string>>,
 ) => void;


### PR DESCRIPTION
## Why?
This allows us to send unstructured extra context about errors when using `reportError` without modifying the error message itself, sentry will then be able to group errors more effectively.

Sentry docs: https://docs.sentry.io/platforms/javascript/enriching-events/context/

For example in commercial we currently have this error
```
Could not define slot for ${id}. A googletag size mapping could not be created
```
This will be split up for each value of `id`. But we could have `id` as a piece of extra context to the group of errors, along with other useful context!

In sentry:
<img width="1066" alt="Screenshot 2025-03-20 at 15 30 07" src="https://github.com/user-attachments/assets/46ea91a4-517e-425f-997c-9a2b0c320eb8" />


