### PR TITLE
Full-page interactives in DCAR apps

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -100,8 +100,13 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 					);
 
 				case ArticleDesign.FullPageInteractive: {
-					// Should be FullPageInteractiveLayout once implemented for apps
-					return notSupported;
+					return (
+						<FullPageInteractiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
 				}
 				case ArticleDesign.LiveBlog:
 				case ArticleDesign.DeadBlog:
@@ -157,6 +162,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				}
@@ -234,6 +240,7 @@ const DecideLayoutWeb = ({
 							article={article}
 							NAV={NAV}
 							format={format}
+							renderingTarget={renderingTarget}
 						/>
 					);
 				}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -206,11 +206,11 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 
 	return (
 		<>
+			{article.isLegacyInteractive && (
+				<Global styles={interactiveGlobalStyles} />
+			)}
 			{isWeb && (
 				<>
-					{article.isLegacyInteractive && (
-						<Global styles={interactiveGlobalStyles} />
-					)}
 					<header
 						css={css`
 							background-color: ${themePalette(

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -203,6 +203,7 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 		editionId,
 	} = article;
 	const isWeb = renderingTarget === 'Web';
+	const isApps = renderingTarget === 'Apps';
 
 	return (
 		<>
@@ -240,6 +241,20 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 						)}
 					</header>
 				</>
+			)}
+			{isApps && format.theme === ArticleSpecial.Labs && (
+				<Stuck>
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						padSides={true}
+						backgroundColour={sourcePalette.labs[400]}
+						borderColour={sourcePalette.neutral[60]}
+						sectionId="labs-header"
+					>
+						<LabsHeader editionId={editionId} />
+					</Section>
+				</Stuck>
 			)}
 
 			<Section

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -24,14 +24,30 @@ import { palette as themePalette } from '../palette';
 import type { ArticleDeprecated } from '../types/article';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
-interface Props {
+interface CommonProps {
+	article: ArticleDeprecated;
+	format: ArticleFormat;
+	renderingTarget: RenderingTarget;
+}
+
+interface WebProps extends CommonProps {
+	NAV: NavType;
+	renderingTarget: 'Web';
+}
+
+interface AppsProps extends CommonProps {
+	renderingTarget: 'Apps';
+}
+
+type HeaderProps = {
 	article: ArticleDeprecated;
 	NAV: NavType;
 	format: ArticleFormat;
-}
+};
 
 type RendererProps = {
 	format: ArticleFormat;
@@ -120,7 +136,7 @@ const Renderer = ({
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ article, NAV, format }: Props) => {
+const NavHeader = ({ article, NAV, format }: HeaderProps) => {
 	// Typically immersives use the slim nav, but this switch is used to force
 	// the full nav - typically during special events such as Project 200, or
 	// the Euros. The motivation is to better onboard new visitors; interactives
@@ -180,39 +196,51 @@ const NavHeader = ({ article, NAV, format }: Props) => {
 	);
 };
 
-export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
+export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { host },
 		editionId,
 	} = article;
+	const isWeb = renderingTarget === 'Web';
 
 	return (
 		<>
-			{article.isLegacyInteractive && (
-				<Global styles={interactiveGlobalStyles} />
-			)}
-			<header
-				css={css`
-					background-color: ${themePalette('--article-background')};
-				`}
-			>
-				<NavHeader article={article} NAV={NAV} format={format} />
+			{isWeb && (
+				<>
+					{article.isLegacyInteractive && (
+						<Global styles={interactiveGlobalStyles} />
+					)}
+					<header
+						css={css`
+							background-color: ${themePalette(
+								'--article-background',
+							)};
+						`}
+					>
+						<NavHeader
+							article={article}
+							NAV={props.NAV}
+							format={format}
+						/>
 
-				{format.theme === ArticleSpecial.Labs && (
-					<Stuck>
-						<Section
-							fullWidth={true}
-							showTopBorder={false}
-							padSides={true}
-							backgroundColour={sourcePalette.labs[400]}
-							borderColour={sourcePalette.neutral[60]}
-							sectionId="labs-header"
-						>
-							<LabsHeader editionId={editionId} />
-						</Section>
-					</Stuck>
-				)}
-			</header>
+						{format.theme === ArticleSpecial.Labs && (
+							<Stuck>
+								<Section
+									fullWidth={true}
+									showTopBorder={false}
+									padSides={true}
+									backgroundColour={sourcePalette.labs[400]}
+									borderColour={sourcePalette.neutral[60]}
+									sectionId="labs-header"
+								>
+									<LabsHeader editionId={editionId} />
+								</Section>
+							</Stuck>
+						)}
+					</header>
+				</>
+			)}
 
 			<Section
 				fullWidth={true}
@@ -246,7 +274,7 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 				</article>
 			</Section>
 
-			{NAV.subNavSections && (
+			{isWeb && props.NAV.subNavSections && (
 				<Section
 					fullWidth={true}
 					padSides={false}
@@ -255,8 +283,8 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 				>
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
-							subNavSections={NAV.subNavSections}
-							currentNavLink={NAV.currentNavLink}
+							subNavSections={props.NAV.subNavSections}
+							currentNavLink={props.NAV.currentNavLink}
 							position="footer"
 							isInteractive={true}
 						/>
@@ -264,51 +292,57 @@ export const FullPageInteractiveLayout = ({ article, NAV, format }: Props) => {
 				</Section>
 			)}
 
-			<Section
-				fullWidth={true}
-				padSides={false}
-				backgroundColour={sourcePalette.brand[400]}
-				borderColour={sourcePalette.brand[600]}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.footer}
-					editionId={article.editionId}
-				/>
-			</Section>
+			{isWeb && (
+				<>
+					<Section
+						fullWidth={true}
+						padSides={false}
+						backgroundColour={sourcePalette.brand[400]}
+						borderColour={sourcePalette.brand[600]}
+						showSideBorders={false}
+						element="footer"
+					>
+						<Footer
+							pageFooter={article.pageFooter}
+							selectedPillar={props.NAV.selectedPillar}
+							pillars={props.NAV.pillars}
+							urls={article.nav.readerRevenueLinks.header}
+							editionId={article.editionId}
+						/>
+					</Section>
 
-			<BannerWrapper>
-				<Island priority="feature" defer={{ until: 'idle' }}>
-					<StickyBottomBanner
+					<BannerWrapper>
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<StickyBottomBanner
+								contentType={article.contentType}
+								contributionsServiceUrl={
+									article.contributionsServiceUrl
+								}
+								idApiUrl={article.config.idApiUrl}
+								isMinuteArticle={
+									article.pageType.isMinuteArticle
+								}
+								isPaidContent={article.pageType.isPaidContent}
+								isPreview={!!article.config.isPreview}
+								isSensitive={article.config.isSensitive}
+								pageId={article.pageId}
+								sectionId={article.config.section}
+								shouldHideReaderRevenue={
+									article.shouldHideReaderRevenue
+								}
+								remoteBannerSwitch={
+									!!article.config.switches.remoteBanner
+								}
+								tags={article.tags}
+							/>
+						</Island>
+					</BannerWrapper>
+					<MobileStickyContainer
 						contentType={article.contentType}
-						contributionsServiceUrl={
-							article.contributionsServiceUrl
-						}
-						idApiUrl={article.config.idApiUrl}
-						isMinuteArticle={article.pageType.isMinuteArticle}
-						isPaidContent={article.pageType.isPaidContent}
-						isPreview={!!article.config.isPreview}
-						isSensitive={article.config.isSensitive}
 						pageId={article.pageId}
-						sectionId={article.config.section}
-						shouldHideReaderRevenue={
-							article.shouldHideReaderRevenue
-						}
-						remoteBannerSwitch={
-							!!article.config.switches.remoteBanner
-						}
-						tags={article.tags}
 					/>
-				</Island>
-			</BannerWrapper>
-			<MobileStickyContainer
-				contentType={article.contentType}
-				pageId={article.pageId}
-			/>
+				</>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -243,18 +243,20 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 				</>
 			)}
 			{isApps && format.theme === ArticleSpecial.Labs && (
-				<Stuck>
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						padSides={true}
-						backgroundColour={sourcePalette.labs[400]}
-						borderColour={sourcePalette.neutral[60]}
-						sectionId="labs-header"
-					>
-						<LabsHeader editionId={editionId} />
-					</Section>
-				</Stuck>
+				<header>
+					<Stuck>
+						<Section
+							fullWidth={true}
+							showTopBorder={false}
+							padSides={true}
+							backgroundColour={sourcePalette.labs[400]}
+							borderColour={sourcePalette.neutral[60]}
+							sectionId="labs-header"
+						>
+							<LabsHeader editionId={editionId} />
+						</Section>
+					</Stuck>
+				</header>
 			)}
 
 			<Section


### PR DESCRIPTION
## What does this change?

This effectively replicates work done by @abeddow91 and the @guardian/dotcom-platform crew in https://github.com/guardian/dotcom-rendering/pull/9090. With beta testing underway for DCAR standard interactive articles in apps, we'd ideally like to include immersive interactives as well.

Some context is important here: years ago a fair bit of groundwork was done to add a third type of interactive article - full page - and it seems `FullPageInteractiveLayout.tsx` was intended to accommodate both immersive interactives and the then-impending new type. Given the ongoing discussions around templating I don't think that should hold up the DCAR rollout. Whether we want to pick up full page interactives or not we can pick that up further down the line.

### Examples of immersive interactive articles

- https://www.theguardian.com/books/ng-interactive/2023/aug/04/this-months-best-paperbacks-lucy-worsley-erin-kelly-and-more
- https://www.theguardian.com/environment/ng-interactive/2021/sep/25/greta-thunberg-i-really-see-the-value-of-friendship-apart-from-the-climate-almost-nothing-else-matters

## Screenshots

Immersive articles rendering via DCAR in CODE:

<img width="1708" alt="image" src="https://github.com/user-attachments/assets/06468374-c9df-4db1-a377-3646f14c9666" />

<img width="1705" alt="image" src="https://github.com/user-attachments/assets/74e59447-7237-4e66-b69c-48cdfc2500c5" />



