### PR TITLE
Upgrade to @guardian/react-crossword v6

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -50,7 +50,7 @@
 		"@guardian/libs": "22.0.0",
 		"@guardian/ophan-tracker-js": "2.2.5",
 		"@guardian/react-crossword": "2.0.2",
-		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@5.0.0",
+		"@guardian/react-crossword-next": "npm:@guardian/react-crossword@6.0.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "9.0.0",
 		"@guardian/source-development-kitchen": "17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,8 +365,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@guardian/react-crossword-next':
-        specifier: npm:@guardian/react-crossword@5.0.0
-        version: /@guardian/react-crossword@5.0.0(@emotion/react@11.11.3)(@guardian/libs@22.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        specifier: npm:@guardian/react-crossword@6.0.0
+        version: /@guardian/react-crossword@6.0.0(@emotion/react@11.11.3)(@guardian/libs@22.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -4242,8 +4242,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /@guardian/react-crossword@5.0.0(@emotion/react@11.11.3)(@guardian/libs@22.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
-    resolution: {integrity: sha512-L7Vaxc+z8w5Sm+bjJMsqnm3wELDu/LvretdPBCogMt6vebloA1okK9qapzLH8Y7ZvR4ly6vKOx8niHnRST3YxQ==}
+  /@guardian/react-crossword@6.0.0(@emotion/react@11.11.3)(@guardian/libs@22.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+    resolution: {integrity: sha512-QIwEc62KoHNu1fygKxsTpGYWkDcLP9VDz89ZQihxKX4ec3qiZZcKI34NYX/hgL/oQUF08Tml2ms2jn0cdiQp4A==}
     peerDependencies:
       '@emotion/react': ^11.11.3
       '@guardian/libs': ^22.0.0


### PR DESCRIPTION
## What does this change?

- upgrade to `@guardian/react-crossword@6`

## Why?

This version provides a number of [accessibility improvements](https://github.com/guardian/csnx/pull/2021):

- increase text contrast of completed clues (bump opacity 0.5 -> 0.6)
- increase anagram helper text contrast (replace light text colour with light background colour)
- make check word aria-label consistent with check all ("check all and remove incorrect letters")
- increase size of control buttons (xsmall -> small)
- increase text size of focussed clue (12px -> 14px)
- add a requires confirmation check to check all button – consistent with Reveal All and Clear All
- force focus on text input when anagram helper opens – autofocus doesn't appear to work when the player is consumed in DCR 

