### PR TITLE
Revert "Test updating to c8g with reduced ASG sizes"

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 24,
-		maximumInstances: 240,
+		minimumInstances: 27,
+		maximumInstances: 270,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -52,7 +52,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Facia */
@@ -68,8 +68,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 21,
-		maximumInstances: 210,
+		minimumInstances: 30,
+		maximumInstances: 180,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -92,7 +92,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Tag pages */
@@ -108,8 +108,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 9,
-		maximumInstances: 90,
+		minimumInstances: 15,
+		maximumInstances: 150,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -132,7 +132,7 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -172,5 +172,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
 });


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#13634

The test is successful but we can revert now so we don't incur more on-demand cost as we have not reserved these instances