### PR TITLE
Further crossword print layout optimisation

### DIFF
--- a/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CrosswordComponent.importable.tsx
@@ -4,8 +4,10 @@ import type { CrosswordProps } from '@guardian/react-crossword-next';
 import {
 	between,
 	from,
+	headlineBold14,
 	headlineBold17,
 	space,
+	textSans12,
 	textSans14,
 	textSansItalic12,
 } from '@guardian/source/foundations';
@@ -29,6 +31,12 @@ const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 				height: 2em;
 				margin-bottom: 0.5em;
 				text-transform: capitalize;
+				@media print {
+					${headlineBold14};
+					border: none;
+					height: auto;
+					margin-bottom: 0.25em;
+				}
 			`}
 		>
 			{children}
@@ -114,6 +122,10 @@ const Layout: CrosswordProps['Layout'] = ({
 			<div
 				css={css`
 					flex-basis: ${gridWidth}px;
+					@media print {
+						flex-basis: auto;
+						max-width: 90mm;
+					}
 				`}
 			>
 				<FocusedClue
@@ -211,6 +223,7 @@ const Layout: CrosswordProps['Layout'] = ({
 						}
 						@media print {
 							flex-direction: row;
+							${textSans12};
 						}
 					`}
 				>

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -71,6 +71,17 @@ const CrosswordGrid = ({ children }: { children: React.ReactNode }) => (
 					'meta   instructions  .'
 					'body   body          right-column';
 			}
+
+			@media print {
+				grid-template-columns: 1fr;
+				grid-template-areas:
+					'title'
+					'headline'
+					'standfirst'
+					'meta'
+					'instructions'
+					'body';
+			}
 		`}
 	>
 		{children}


### PR DESCRIPTION
## What does this change?

- Forces single column page grid when printing
- Restricts width of crossword grid
- Reduces clue text size and removes borders and extra spacing from headers

## Why?

To improve the crossword print layout and help to ensure they can be printed on a single page

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4338ef42-5248-4fe3-9529-fd6839f38e6e
[after]: https://github.com/user-attachments/assets/91722b87-e4f5-4aad-bbc4-e44b7571179f
