### PR TITLE
Give slideshow navigation background colour

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -856,6 +856,9 @@ export const Card = ({
 										<SlideshowCarousel
 											images={media.slideshowImages}
 											imageSize={imageSize}
+											hasNavigationBackgroundColour={
+												!!hasSublinks
+											}
 										/>
 									</Island>
 								</div>

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -409,6 +409,45 @@ export const DefaultSplashWithLiveUpdates: Story = {
 	},
 };
 
+const slideshowCard = {
+	...liveUpdatesCard,
+	mainMedia: undefined,
+	slideshowImages: [
+		{
+			imageSrc:
+				'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/1000.jpg',
+		},
+		{
+			imageSrc:
+				'https://media.guim.co.uk/77e960298d4339e047eac5c1986d0f3214f6285d/419_447_4772_2863/master/4772.jpg',
+		},
+		{
+			imageSrc:
+				'https://media.guim.co.uk/df5aea6391e21b5a5d2d25fd9aad81d497f99d42/0_45_3062_1837/master/3062.jpg',
+		},
+		{
+			imageSrc:
+				'https://media.guim.co.uk/5ebec1a8d662f0da39887dae16e4b2720379246e/0_0_5000_3000/master/5000.jpg',
+		},
+		{
+			imageSrc:
+				'https://media.guim.co.uk/77e960298d4339e047eac5c1986d0f3214f6285d/419_447_4772_2863/master/4772.jpg',
+		},
+	],
+} satisfies DCRFrontCard;
+
+export const DefaultSplashWithLiveUpdatesAndSlideshow: Story = {
+	name: 'Standard splash with live updates and slideshow',
+	args: {
+		frontSectionTitle: 'Standard splash with live updates and slideshow',
+		groupedTrails: {
+			...defaultGroupedTrails,
+
+			splash: [{ ...slideshowCard }],
+		},
+	},
+};
+
 export const BoostedSplashWithLiveUpdates: Story = {
 	name: 'Boosted splash with live updates',
 	args: {

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -3,6 +3,7 @@ import {
 	from,
 	space,
 	textSansBold12,
+	until,
 	width,
 } from '@guardian/source/foundations';
 import type { ThemeButton } from '@guardian/source/react-components';
@@ -73,9 +74,12 @@ const navigationStyles = (hasBackgroundColour: boolean) => css`
 	display: flex;
 	align-items: center;
 	padding-top: ${space[2]}px;
-	background-color: ${hasBackgroundColour
-		? palette('--slideshow-navigation-background')
-		: 'transparent'};
+
+	${until.tablet} {
+		background-color: ${hasBackgroundColour
+			? palette('--slideshow-navigation-background')
+			: 'transparent'};
+	}
 `;
 
 const buttonStyles = css`
@@ -218,7 +222,7 @@ export const SlideshowCarousel = ({
 			</ul>
 
 			{slideshowImageCount > 1 && (
-				<div css={[navigationStyles(hasNavigationBackgroundColour)]}>
+				<div css={navigationStyles(hasNavigationBackgroundColour)}>
 					<div css={scrollingDotStyles}>
 						<SlideshowCarouselScrollingDots
 							total={slideshowImageCount}

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -69,10 +69,13 @@ const captionStyles = css`
 	padding: ${space[10]}px ${space[2]}px ${space[2]}px;
 `;
 
-const navigationStyles = css`
+const navigationStyles = (hasBackgroundColour: boolean) => css`
 	display: flex;
 	align-items: center;
-	margin-top: ${space[2]}px;
+	padding-top: ${space[2]}px;
+	background-color: ${hasBackgroundColour
+		? palette('--slideshow-navigation-background')
+		: 'transparent'};
 `;
 
 const buttonStyles = css`
@@ -97,13 +100,17 @@ const scrollingDotStyles = css`
 	}
 `;
 
+type Props = {
+	images: readonly DCRSlideshowImage[];
+	imageSize: ImageSizeType;
+	hasNavigationBackgroundColour: boolean;
+};
+
 export const SlideshowCarousel = ({
 	images,
 	imageSize,
-}: {
-	images: readonly DCRSlideshowImage[];
-	imageSize: ImageSizeType;
-}) => {
+	hasNavigationBackgroundColour,
+}: Props) => {
 	const carouselRef = useRef<HTMLUListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
 	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
@@ -211,7 +218,7 @@ export const SlideshowCarousel = ({
 			</ul>
 
 			{slideshowImageCount > 1 && (
-				<div css={navigationStyles}>
+				<div css={[navigationStyles(hasNavigationBackgroundColour)]}>
 					<div css={scrollingDotStyles}>
 						<SlideshowCarouselScrollingDots
 							total={slideshowImageCount}

--- a/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.stories.tsx
@@ -90,6 +90,7 @@ const meta = {
 	args: {
 		images,
 		imageSize: 'medium',
+		hasNavigationBackgroundColour: false,
 	},
 	render: (args) => (
 		<Wrapper>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7143,6 +7143,14 @@ const paletteColours = {
 		light: slideshowCaptionLight,
 		dark: slideshowCaptionDark,
 	},
+	/**
+	 * The background colour should match the background colour of the
+	 * sublinks when there is at least one sublink present.
+	 */
+	'--slideshow-navigation-background': {
+		light: cardSublinksBackgroundLight,
+		dark: cardSublinksBackgroundDark,
+	},
 	'--slideshow-pagination-dot': {
 		light: slideshowPaginationDotLight,
 		dark: slideshowPaginationDotDark,


### PR DESCRIPTION
## What does this change?

Gives the navigation on a slideshow card a background colour on when the card has sublinks that have a background colour.

## Why?

So that the design looks more consistent.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/98e68ea2-6db8-4864-a0e2-7af63a0ad113
[after]: https://github.com/user-attachments/assets/ba08d901-36a0-4829-a31c-ac99b57ffdd5

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
