### PR TITLE
Noindex non-production pages

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -77,7 +77,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 	} = props;
 
 	const doNotIndex = (): boolean => {
-		const isDevelopment = process.env.NODE_ENV !== 'production';
+		const isDevelopment = process.env.GU_STAGE !== 'PROD';
 
 		const hasNoIndexPattern = Boolean(
 			canonicalUrl?.includes('tracking/commissioningdesk'),


### PR DESCRIPTION
## What does this change?
Adds a `noindex` robots meta tag to non-production pages (determined by `GU_STAGE != 'PROD'`).  This prevents code content from appearing in search results.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/13380
