### PR TITLE
Render immersive feature media cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -331,13 +331,6 @@ export const FeatureCard = ({
 
 	const showYoutubeVideo = canPlayInline && mainMedia?.type === 'Video';
 
-	console.log({
-		isVideoMainMedia,
-		isVideoArticle,
-		showYoutubeVideo,
-		mobileAspectRatio,
-		aspectRatio,
-	});
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;
 
@@ -410,6 +403,7 @@ export const FeatureCard = ({
 										discussionId={discussionId}
 										discussionApiUrl={discussionApiUrl}
 										isFeatureCard={true}
+										isImmersive={isImmersive}
 									/>
 								</Island>
 							</div>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -157,13 +157,6 @@ const podcastImageContainerStyles = css`
 const podcastImageStyles = css`
 	height: 80px;
 	width: 80px;
-	position: absolute;
-	/**
-	 * Displays 8px above the text.
-	 * desired space above text (8px) - padding-top of text container (64px) = -56px
-	 */
-	bottom: -${space[14]}px;
-	left: ${space[2]}px;
 `;
 
 const starRatingWrapper = css`
@@ -483,33 +476,6 @@ export const FeatureCard = ({
 											immersiveOverlayContainerStyles,
 									]}
 								>
-									{mainMedia?.type === 'Audio' &&
-										!!mainMedia.podcastImage?.src && (
-											<div
-												css={
-													podcastImageContainerStyles
-												}
-											>
-												<div css={podcastImageStyles}>
-													<CardPicture
-														mainImage={
-															mainMedia
-																.podcastImage
-																.src
-														}
-														imageSize="podcast"
-														alt={
-															mainMedia
-																.podcastImage
-																.altText ?? ''
-														}
-														loading="lazy"
-														roundedCorners={false}
-														aspectRatio="1:1"
-													/>
-												</div>
-											</div>
-										)}
 									<div
 										css={[
 											overlayStyles,
@@ -517,6 +483,38 @@ export const FeatureCard = ({
 												immersiveOverlayStyles,
 										]}
 									>
+										{mainMedia?.type === 'Audio' &&
+											!!mainMedia.podcastImage?.src && (
+												<div
+													css={
+														podcastImageContainerStyles
+													}
+												>
+													<div
+														css={podcastImageStyles}
+													>
+														<CardPicture
+															mainImage={
+																mainMedia
+																	.podcastImage
+																	.src
+															}
+															imageSize="podcast"
+															alt={
+																mainMedia
+																	.podcastImage
+																	.altText ??
+																''
+															}
+															loading="lazy"
+															roundedCorners={
+																false
+															}
+															aspectRatio="1:1"
+														/>
+													</div>
+												</div>
+											)}
 										{/**
 										 * Without the wrapping div the headline and byline would have space
 										 * inserted between them due to being direct children of the flex container

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -331,6 +331,13 @@ export const FeatureCard = ({
 
 	const showYoutubeVideo = canPlayInline && mainMedia?.type === 'Video';
 
+	console.log({
+		isVideoMainMedia,
+		isVideoArticle,
+		showYoutubeVideo,
+		mobileAspectRatio,
+		aspectRatio,
+	});
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;
 
@@ -382,6 +389,7 @@ export const FeatureCard = ({
 										hideCaption={true}
 										pauseOffscreenVideo={true}
 										aspectRatio={aspectRatio}
+										mobileAspectRatio={mobileAspectRatio}
 										altText={headlineText}
 										kickerText={kickerText}
 										trailText={

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,8 +196,8 @@ export const SplashCardLayout = ({
 	const card = cards[0];
 	if (!card) return null;
 
-	const isImmersive = false; // TODO: replace with live data from fronts tool - used for testing
-	const shouldShowImmersive = isImmersive;
+	// TODO: replace with live data from fronts tool - used for testing
+	const shouldShowImmersive = false;
 
 	if (shouldShowImmersive) {
 		return (

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,7 +196,7 @@ export const SplashCardLayout = ({
 	const card = cards[0];
 	if (!card) return null;
 
-	const isImmersive = true; // TODO: replace with live data from fronts tool - used for testing
+	const isImmersive = false; // TODO: replace with live data from fronts tool - used for testing
 	const shouldShowImmersive = isImmersive;
 
 	if (shouldShowImmersive) {

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,8 +196,8 @@ export const SplashCardLayout = ({
 	const card = cards[0];
 	if (!card) return null;
 
-	const isImmersive = false; // TODO: replace with live data from fronts tool - used for testing
-	const shouldShowImmersive = isImmersive && !isMediaCard(card.format);
+	const isImmersive = true; // TODO: replace with live data from fronts tool - used for testing
+	const shouldShowImmersive = isImmersive;
 
 	if (shouldShowImmersive) {
 		return (

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -24,12 +24,10 @@ const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 	}
 };
 
-const decideMobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
-	const paddingRatio = getAspectRatioPadding(aspectRatio);
-	console.log(aspectRatio, paddingRatio);
+const mobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	return css`
 		${until.tablet} {
-			padding-bottom: ${paddingRatio};
+			padding-bottom: ${getAspectRatioPadding(aspectRatio)};
 		}
 	`;
 };
@@ -45,7 +43,6 @@ export const MaintainAspectRatio = ({
 	const paddingBottom = aspectRatio
 		? getAspectRatioPadding(aspectRatio)
 		: `${(height / width) * 100}%`;
-	console.log({ mobileAspectRatio });
 	return (
 		<div
 			css={[
@@ -62,8 +59,7 @@ export const MaintainAspectRatio = ({
 						left: 0;
 					}
 				`,
-				mobileAspectRatio &&
-					decideMobileAspectRatioStyles(mobileAspectRatio),
+				mobileAspectRatio && mobileAspectRatioStyles(mobileAspectRatio),
 			]}
 		>
 			{children}

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -10,7 +10,7 @@ type Props = {
 	children: React.ReactNode;
 };
 
-const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
+const getAspectRatioPadding = (aspectRatio: AspectRatio): string => {
 	switch (aspectRatio) {
 		case '5:4':
 			return '80%';
@@ -19,12 +19,11 @@ const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
 		case '1:1':
 			return '100%';
 		case '5:3':
-		default:
 			return '60%';
 	}
 };
 
-const mobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
+const mobileAspectRatioStyles = (aspectRatio: AspectRatio) => {
 	return css`
 		${until.tablet} {
 			padding-bottom: ${getAspectRatioPadding(aspectRatio)};

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -1,40 +1,70 @@
 import { css } from '@emotion/react';
 import type { AspectRatio } from '../types/front';
+import { until } from '@guardian/source/foundations';
 
 type Props = {
 	height: number;
 	width: number;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 	children: React.ReactNode;
+};
+
+const getAspectRatioPadding = (aspectRatio?: AspectRatio): string => {
+	switch (aspectRatio) {
+		case '5:4':
+			return '80%';
+		case '4:5':
+			return '125%';
+		case '1:1':
+			return '100%';
+		case '5:3':
+		default:
+			return '60%';
+	}
+};
+
+const decideMobileAspectRatioStyles = (aspectRatio?: AspectRatio) => {
+	const paddingRatio = getAspectRatioPadding(aspectRatio);
+	console.log(aspectRatio, paddingRatio);
+	return css`
+		${until.tablet} {
+			padding-bottom: ${paddingRatio};
+		}
+	`;
 };
 
 export const MaintainAspectRatio = ({
 	height,
 	width,
 	aspectRatio,
+	mobileAspectRatio,
 	children,
 }: Props) => {
 	/* https://css-tricks.com/aspect-ratio-boxes/ */
-	const paddingBottom =
-		aspectRatio === '5:4'
-			? `${(4 / 5) * 100}%`
-			: `${(height / width) * 100}%`;
-
+	const paddingBottom = aspectRatio
+		? getAspectRatioPadding(aspectRatio)
+		: `${(height / width) * 100}%`;
+	console.log({ mobileAspectRatio });
 	return (
 		<div
-			css={css`
-				/* position relative to contain the absolutely positioned iframe plus any Overlay image */
-				position: relative;
-				padding-bottom: ${paddingBottom};
-				& > iframe,
-				& > video {
-					width: 100%;
-					height: 100%;
-					position: absolute;
-					top: 0;
-					left: 0;
-				}
-			`}
+			css={[
+				css`
+					/* position relative to contain the absolutely positioned iframe plus any Overlay image */
+					position: relative;
+					padding-bottom: ${paddingBottom};
+					& > iframe,
+					& > video {
+						width: 100%;
+						height: 100%;
+						position: absolute;
+						top: 0;
+						left: 0;
+					}
+				`,
+				mobileAspectRatio &&
+					decideMobileAspectRatioStyles(mobileAspectRatio),
+			]}
 		>
 			{children}
 		</div>

--- a/dotcom-rendering/src/components/MaintainAspectRatio.tsx
+++ b/dotcom-rendering/src/components/MaintainAspectRatio.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import type { AspectRatio } from '../types/front';
 import { until } from '@guardian/source/foundations';
+import type { AspectRatio } from '../types/front';
 
 type Props = {
 	height: number;

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -51,6 +51,7 @@ export type Props = {
 	hidePillOnMobile: boolean;
 	renderingTarget: RenderingTarget;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 	trailText?: string;
 	headlineSizes?: ResponsiveFontSize;
 	isVideoArticle?: boolean;
@@ -103,6 +104,7 @@ export const YoutubeAtom = ({
 	hidePillOnMobile,
 	renderingTarget,
 	aspectRatio,
+	mobileAspectRatio,
 	trailText,
 	headlineSizes,
 	isVideoArticle,
@@ -200,6 +202,7 @@ export const YoutubeAtom = ({
 					height={height}
 					width={width}
 					aspectRatio={aspectRatio}
+					mobileAspectRatio={mobileAspectRatio}
 				>
 					{
 						/**

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -62,6 +62,7 @@ export type Props = {
 	discussionApiUrl?: string;
 	discussionId?: string;
 	isFeatureCard?: boolean;
+	isImmersive?: boolean;
 };
 
 /**
@@ -115,6 +116,7 @@ export const YoutubeAtom = ({
 	discussionApiUrl,
 	discussionId,
 	isFeatureCard,
+	isImmersive,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -251,6 +253,7 @@ export const YoutubeAtom = ({
 								duration={duration}
 								kicker={kicker}
 								aspectRatio={aspectRatio}
+								mobileAspectRatio={mobileAspectRatio}
 								trailText={trailText}
 								isVideoArticle={isVideoArticle}
 								webPublicationDate={webPublicationDate}
@@ -259,6 +262,7 @@ export const YoutubeAtom = ({
 								linkTo={linkTo}
 								discussionId={discussionId}
 								discussionApiUrl={discussionApiUrl}
+								isImmersive={isImmersive}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
+import { from, space } from '@guardian/source/foundations';
 import type { ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
@@ -49,17 +49,9 @@ const hoverStyles = css`
 	}
 `;
 
-const textOverlayStyles = css`
-	width: 100%;
-	position: absolute;
-	bottom: 0;
-	display: flex;
-	flex-direction: column;
-	text-align: start;
-	gap: ${space[1]}px;
-	padding: 64px ${space[2]}px ${space[2]}px;
+const overlayMaskGradientStyles = (angle: string) => css`
 	mask-image: linear-gradient(
-		180deg,
+		${angle},
 		transparent 0px,
 		rgba(0, 0, 0, 0.0381) 8px,
 		rgba(0, 0, 0, 0.1464) 16px,
@@ -70,7 +62,29 @@ const textOverlayStyles = css`
 		rgba(0, 0, 0, 0.9619) 56px,
 		rgb(0, 0, 0) 64px
 	);
+`;
+const textOverlayStyles = css`
+	width: 100%;
+	position: absolute;
+	bottom: 0;
+	display: flex;
+	flex-direction: column;
+	text-align: start;
+	gap: ${space[1]}px;
+	padding: 64px ${space[2]}px ${space[2]}px;
+	${overlayMaskGradientStyles('180deg')};
+
 	backdrop-filter: blur(12px) brightness(0.5);
+`;
+
+const immersiveOverlayStyles = css`
+	${from.tablet} {
+		height: 100%;
+		width: 25%;
+		padding: ${space[2]}px 64px ${space[2]}px ${space[2]}px;
+		backdrop-filter: blur(12px) brightness(0.5);
+		${overlayMaskGradientStyles('270deg')}
+	}
 `;
 
 const videoPillStyles = css`
@@ -92,6 +106,7 @@ type Props = {
 	duration?: number; // in seconds
 	kicker?: string;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 	trailText?: string;
 	isVideoArticle?: boolean;
 	webPublicationDate?: string;
@@ -100,6 +115,7 @@ type Props = {
 	linkTo?: string;
 	discussionApiUrl?: string;
 	discussionId?: string;
+	isImmersive?: boolean;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -115,6 +131,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	kicker,
 	format,
 	aspectRatio,
+	mobileAspectRatio,
 	trailText,
 	isVideoArticle,
 	webPublicationDate,
@@ -123,6 +140,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	linkTo,
 	discussionId,
 	discussionApiUrl,
+	isImmersive,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -153,6 +171,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 						height={height}
 						width={width}
 						aspectRatio={aspectRatio}
+						mobileAspectRatio={mobileAspectRatio}
 					/>
 				)}
 				{hasDuration && !isVideoArticle ? (
@@ -165,7 +184,12 @@ export const YoutubeAtomFeatureCardOverlay = ({
 				) : null}
 				<div className="image-overlay" />
 				<PlayIcon iconWidth="narrow" />
-				<div css={[textOverlayStyles]}>
+				<div
+					css={[
+						textOverlayStyles,
+						isImmersive && immersiveOverlayStyles,
+					]}
+				>
 					{!!kicker && (
 						<Kicker
 							text={kicker}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -10,6 +10,7 @@ type Props = {
 	height: number;
 	width: number;
 	aspectRatio?: AspectRatio;
+	mobileAspectRatio?: AspectRatio;
 };
 
 export const YoutubeAtomPicture = ({
@@ -18,11 +19,25 @@ export const YoutubeAtomPicture = ({
 	height,
 	width,
 	aspectRatio,
+	mobileAspectRatio,
 }: Props) => {
+	const mobileAspect = mobileAspectRatio ?? aspectRatio;
 	const sources = generateSources(getSourceImageUrl(image), [
-		{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
-		{ breakpoint: breakpoints.mobileLandscape, width: 645, aspectRatio },
-		{ breakpoint: breakpoints.phablet, width: 620, aspectRatio },
+		{
+			breakpoint: breakpoints.mobile,
+			width: 465,
+			aspectRatio: mobileAspect,
+		},
+		{
+			breakpoint: breakpoints.mobileLandscape,
+			width: 645,
+			aspectRatio: mobileAspect,
+		},
+		{
+			breakpoint: breakpoints.phablet,
+			width: 620,
+			aspectRatio: mobileAspect,
+		},
 		{ breakpoint: breakpoints.tablet, width: 700, aspectRatio },
 		{ breakpoint: breakpoints.desktop, width: 620, aspectRatio },
 	]);

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -55,6 +55,7 @@ type Props = {
 	discussionId?: string;
 	isFeatureCard?: boolean;
 	mobileAspectRatio?: AspectRatio;
+	isImmersive?: boolean;
 };
 
 export const YoutubeBlockComponent = ({
@@ -93,6 +94,7 @@ export const YoutubeBlockComponent = ({
 	discussionId,
 	isFeatureCard,
 	mobileAspectRatio,
+	isImmersive,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -203,6 +205,7 @@ export const YoutubeBlockComponent = ({
 				discussionId={discussionId}
 				discussionApiUrl={discussionApiUrl}
 				isFeatureCard={isFeatureCard}
+				isImmersive={isImmersive}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -54,6 +54,7 @@ type Props = {
 	discussionApiUrl?: string;
 	discussionId?: string;
 	isFeatureCard?: boolean;
+	mobileAspectRatio?: AspectRatio;
 };
 
 export const YoutubeBlockComponent = ({
@@ -91,6 +92,7 @@ export const YoutubeBlockComponent = ({
 	discussionApiUrl,
 	discussionId,
 	isFeatureCard,
+	mobileAspectRatio,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -190,6 +192,7 @@ export const YoutubeBlockComponent = ({
 				hidePillOnMobile={hidePillOnMobile}
 				renderingTarget={renderingTarget}
 				aspectRatio={aspectRatio}
+				mobileAspectRatio={mobileAspectRatio}
 				trailText={trailText}
 				headlineSizes={headlineSizes}
 				isVideoArticle={isVideoArticle}


### PR DESCRIPTION
## What does this change?
Updates the render path for immersive feature media cards. This allows the card to switch aspect ratio from tablet and above. This builds on the work in https://github.com/guardian/dotcom-rendering/pull/13535

## Why?
Previously immersive features had only been enabled for non-media cards to avoid pr bloat. This PR extends the card variant to media cards.

## Screenshots

### Video

| Video      | Podcast      | Gallery      |
| ----------- | ---------- | ---------- |

| ![after][] | ![after1][] | ![after2][] |

[after]: https://github.com/user-attachments/assets/6482d242-6a1e-4d6a-9455-3bb9d24a358d
[after1]: https://github.com/user-attachments/assets/85f85912-9327-40a6-9719-034020b2c52f
[after2]: https://github.com/user-attachments/assets/6880f1aa-2d85-44bf-b377-6dd034f1212f


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
