### PR TITLE
Auxia gate: make second cta optional

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxia.tsx
@@ -80,25 +80,27 @@ export const SignInGateAuxia = ({
 				>
 					{firstCtaName}
 				</LinkButton>
-				<Button
-					data-testid="sign-in-gate-main_dismiss"
-					data-ignore="global-link-styling"
-					cssOverrides={laterButton}
-					priority="subdued"
-					size="small"
-					onClick={async () => {
-						dismissGate();
-						trackLink(
-							ophanComponentId,
-							'not-now',
-							renderingTarget,
-							abTest,
-						);
-						await logTreatmentInteractionCall('DISMISSED', '');
-					}}
-				>
-					{secondCtaName}
-				</Button>
+				{!!secondCtaName && (
+					<Button
+						data-testid="sign-in-gate-main_dismiss"
+						data-ignore="global-link-styling"
+						cssOverrides={laterButton}
+						priority="subdued"
+						size="small"
+						onClick={async () => {
+							dismissGate();
+							trackLink(
+								ophanComponentId,
+								'not-now',
+								renderingTarget,
+								abTest,
+							);
+							await logTreatmentInteractionCall('DISMISSED', '');
+						}}
+					>
+						{secondCtaName}
+					</Button>
+				)}
 			</div>
 
 			<p css={[bodySeparator, bodyBold, signInHeader]}>

--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -95,7 +95,7 @@ export interface TreatmentContentDecoded {
 	body: string;
 	first_cta_name: string;
 	first_cta_link: string;
-	second_cta_name: string;
+	second_cta_name?: string;
 }
 
 export interface AuxiaAPIResponseDataUserTreatment {


### PR DESCRIPTION
Auxia may not return the `second_cta_name` field, meaning there is no second CTA.
This PR updates the component to handle this correctly