### PR TITLE
Immersive features in non splash slots

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -44,6 +44,29 @@ const aBasicLink = {
 	},
 };
 
+const supportingContent = [
+	{
+		...aBasicLink,
+		headline: 'Headline 1',
+		kickerText: 'Kicker',
+	},
+	{
+		...aBasicLink,
+		headline: 'Headline 2',
+		kickerText: 'Kicker',
+		format: {
+			theme: Pillar.Sport,
+			design: ArticleDesign.Gallery,
+			display: ArticleDisplay.Standard,
+		},
+	},
+	{
+		...aBasicLink,
+		headline: 'Headline 3',
+		kickerText: 'Kicker',
+	},
+];
+
 const CardWrapper = ({
 	maxWidth,
 	children,
@@ -230,36 +253,152 @@ export const WithTrailText: Story = {
 
 export const WithSublinks: Story = {
 	args: {
-		supportingContent: [
-			{
-				...aBasicLink,
-				headline: 'Headline 1',
-				kickerText: 'Kicker',
-			},
-			{
-				...aBasicLink,
-				headline: 'Headline 2',
-				kickerText: 'Kicker',
-				format: {
-					theme: Pillar.Sport,
-					design: ArticleDesign.Gallery,
-					display: ArticleDisplay.Standard,
-				},
-			},
-			{
-				...aBasicLink,
-				headline: 'Headline 3',
-				kickerText: 'Kicker',
-			},
-		],
+		supportingContent,
 	},
 };
 
-export const StandardImmersive: Story = {
+export const Immersive: Story = {
 	args: {
 		aspectRatio: '5:3',
 		mobileAspectRatio: '4:5',
 		imageSize: 'feature-immersive',
 		maxWidth: '940',
+		isImmersive: true,
+	},
+};
+
+export const ImmersiveWithSublinks: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		supportingContent,
+	},
+};
+// A standard (non-video) article with a video main media
+export const ImmersiveVideoMainMedia: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		...Video.args,
+		image: {
+			src: 'https://media.guim.co.uk/4612af5f4667888fa697139cf570b6373d93a710/2446_345_3218_1931/master/3218.jpg',
+			altText: 'alt text',
+		},
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Standard,
+		},
+	},
+};
+
+export const ImmersiveVideo: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Video,
+		},
+		image: {
+			src: 'https://media.guim.co.uk/f2aedd24e5414073a653f68112e0ad070c6f4a2b/254_0_7493_4500/master/7493.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Video',
+			id: 'video-id',
+			videoId: 'video-id',
+			height: 1080,
+			width: 1920,
+			origin: 'origin',
+			title: 'Video Title',
+			duration: 120,
+			expired: false,
+			images: [
+				{
+					url: 'https://media.guim.co.uk/video-thumbnail.jpg',
+					width: 1920,
+				},
+			],
+		},
+	},
+};
+
+export const ImmersivePodcast: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Audio,
+		},
+		image: {
+			src: 'https://media.guim.co.uk/ecb7f0bebe473d6ef1375b5cb60b78f9466a5779/0_229_3435_2061/master/3435.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Audio',
+			podcastImage: {
+				src: 'https://media.guim.co.uk/be8830289638b0948b1ba4ade906e540554ada88/0_0_5000_3000/master/5000.jpg',
+				altText: 'Football Weekly',
+			},
+			duration: '55:09',
+		},
+	},
+};
+
+export const ImmersiveGallery: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Gallery,
+		},
+		image: {
+			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Gallery',
+			count: '12',
+		},
+	},
+};
+
+export const ImmersiveMediaCardWithSublinks: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		format: {
+			...cardProps.format,
+			design: ArticleDesign.Gallery,
+		},
+		image: {
+			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
+			altText: 'alt text',
+		},
+		mainMedia: {
+			type: 'Gallery',
+			count: '12',
+		},
+		supportingContent,
 	},
 };

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -324,6 +324,13 @@ export const FeatureCard = ({
 
 	const showYoutubeVideo = canPlayInline && mainMedia?.type === 'Video';
 
+	console.log({
+		isVideoMainMedia,
+		isVideoArticle,
+		showYoutubeVideo,
+		mobileAspectRatio,
+		aspectRatio,
+	});
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;
 

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -324,13 +324,6 @@ export const FeatureCard = ({
 
 	const showYoutubeVideo = canPlayInline && mainMedia?.type === 'Video';
 
-	console.log({
-		isVideoMainMedia,
-		isVideoArticle,
-		showYoutubeVideo,
-		mobileAspectRatio,
-		aspectRatio,
-	});
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -554,3 +554,18 @@ export const SecondaryContainerStandardCards: Story = {
 		},
 	},
 };
+
+export const ContainerWithImmersiveCardInSplashAndNonSplash: Story = {
+	name: 'Secondary container with standard cards',
+	args: {
+		frontSectionTitle: 'Secondary container standard cards',
+		containerLevel: 'Secondary',
+		groupedTrails: {
+			...defaultGroupedTrails,
+			splash: [
+				{ ...splashCard, isImmersive: true, supportingContent: [] },
+			],
+			standard: [{ ...trails[0], isImmersive: true }],
+		},
+	},
+};

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -13,23 +13,23 @@ const boostedCard = {
 } satisfies DCRFrontCard;
 
 describe('FlexibleGeneral', () => {
-	it('Should return a one card row layout if one standard card is provided', () => {
+	it('Should return a one card half width row layout if one standard card is provided', () => {
 		expect(decideCardPositions([standardCard])).toEqual([
 			{
-				layout: 'oneCard',
+				layout: 'oneCardHalfWidth',
 				cards: [standardCard],
 			},
 		]);
 	});
-	it('Should return a one card boosted row layout if one boosted card is provided', () => {
+	it('Should return a one card full width row layout if one boosted card is provided', () => {
 		expect(decideCardPositions([boostedCard])).toEqual([
-			{ layout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'oneCardFullWidth', cards: [boostedCard] },
 		]);
 	});
-	it('Should return a one card boosted row layout if one immersive card is provided', () => {
+	it('Should return a one card full width row layout if one immersive card is provided', () => {
 		expect(decideCardPositions([boostedCard])).toEqual([
 			{
-				layout: 'oneCardBoosted',
+				layout: 'oneCardFullWidth',
 				cards: [{ ...standardCard, isImmersive: true }],
 			},
 		]);
@@ -40,14 +40,14 @@ describe('FlexibleGeneral', () => {
 		]);
 	});
 
-	it('Should return a one card row layout if one card without boost level is provided', () => {
+	it('Should return a one card half width row layout if one card without boost level is provided', () => {
 		const cardWithoutBoostLevel = {
 			...standardCard,
 			boostLevel: undefined,
 		};
 		expect(decideCardPositions([cardWithoutBoostLevel])).toEqual([
 			{
-				layout: 'oneCard',
+				layout: 'oneCardHalfWidth',
 				cards: [cardWithoutBoostLevel],
 			},
 		]);
@@ -76,9 +76,9 @@ describe('FlexibleGeneral', () => {
 				standardCard,
 			]),
 		).toEqual([
-			{ layout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'oneCardFullWidth', cards: [boostedCard] },
 			{ layout: 'twoCard', cards: [standardCard, standardCard] },
-			{ layout: 'oneCard', cards: [standardCard] },
+			{ layout: 'oneCardHalfWidth', cards: [standardCard] },
 		]);
 	});
 
@@ -91,8 +91,8 @@ describe('FlexibleGeneral', () => {
 				standardCard,
 			]),
 		).toEqual([
-			{ layout: 'oneCard', cards: [standardCard] },
-			{ layout: 'oneCardBoosted', cards: [boostedCard] },
+			{ layout: 'oneCardHalfWidth', cards: [standardCard] },
+			{ layout: 'oneCardFullWidth', cards: [boostedCard] },
 			{ layout: 'twoCard', cards: [standardCard, standardCard] },
 		]);
 	});

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -27,7 +27,9 @@ describe('FlexibleGeneral', () => {
 		]);
 	});
 	it('Should return a one card full width row layout if one immersive card is provided', () => {
-		expect(decideCardPositions([boostedCard])).toEqual([
+		expect(
+			decideCardPositions([{ ...standardCard, isImmersive: true }]),
+		).toEqual([
 			{
 				layout: 'oneCardFullWidth',
 				cards: [{ ...standardCard, isImmersive: true }],

--- a/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.test.tsx
@@ -26,6 +26,14 @@ describe('FlexibleGeneral', () => {
 			{ layout: 'oneCardBoosted', cards: [boostedCard] },
 		]);
 	});
+	it('Should return a one card boosted row layout if one immersive card is provided', () => {
+		expect(decideCardPositions([boostedCard])).toEqual([
+			{
+				layout: 'oneCardBoosted',
+				cards: [{ ...standardCard, isImmersive: true }],
+			},
+		]);
+	});
 	it('Should return a two card row layout if two standard cards are provided', () => {
 		expect(decideCardPositions([standardCard, standardCard])).toEqual([
 			{ layout: 'twoCard', cards: [standardCard, standardCard] },

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -34,7 +34,7 @@ type Props = {
 	collectionId: number;
 };
 
-type RowLayout = 'oneCard' | 'oneCardBoosted' | 'twoCard';
+type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
 
 type GroupedRow = {
 	layout: RowLayout;
@@ -62,7 +62,7 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 			card.isImmersive ||
 			(card.boostLevel && card.boostLevel !== 'default')
 		) {
-			return [...acc, createNewRow('oneCardBoosted', card)];
+			return [...acc, createNewRow('oneCardFullWidth', card)];
 		}
 
 		// Otherwise we need to check the status of the current row
@@ -70,12 +70,12 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 
 		// If the current row has one card, we can add one more standard card to it
 		// We change the row layout to 'twoCard' to indicate that it is now full
-		if (row && row.layout === 'oneCard') {
+		if (row && row.layout === 'oneCardHalfWidth') {
 			return [...acc.slice(0, acc.length - 1), addCardToRow(row, card)];
 		}
 		// Otherwise we consider the row to be 'full' and start a new row
 		else {
-			return [...acc, createNewRow('oneCard', card)];
+			return [...acc, createNewRow('oneCardHalfWidth', card)];
 		}
 	}, []);
 };
@@ -375,7 +375,7 @@ const decideCardProperties = (
 	}
 };
 
-const BoostedCardLayout = ({
+const FullWidthCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -475,7 +475,7 @@ const BoostedCardLayout = ({
 	);
 };
 
-const StandardCardLayout = ({
+const HalfWidthCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -87,21 +87,18 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
  * It can be used in any slot within the container.
  */
 const ImmersiveCardLayout = ({
-	cards,
+	card,
 	containerPalette,
 	absoluteServerTimes,
 	imageLoading,
 	collectionId,
 }: {
-	cards: DCRFrontCard[];
+	card: DCRFrontCard;
 	containerPalette?: DCRContainerPalette;
 	absoluteServerTimes: boolean;
 	imageLoading: Loading;
 	collectionId: number;
 }) => {
-	const card = cards[0];
-	if (!card) return null;
-
 	return (
 		<UL padBottom={true}>
 			<LI key={card.url} padSides={true}>
@@ -263,7 +260,7 @@ export const SplashCardLayout = ({
 	if (shouldShowImmersive) {
 		return (
 			<ImmersiveCardLayout
-				cards={cards}
+				card={card}
 				containerPalette={containerPalette}
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
@@ -423,7 +420,7 @@ const FullWidthCardLayout = ({
 	if (shouldShowImmersive) {
 		return (
 			<ImmersiveCardLayout
-				cards={cards}
+				card={card}
 				containerPalette={containerPalette}
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -172,7 +172,61 @@ const decideSplashCardProperties = (
 	}
 };
 
-const SplashCardLayout = ({
+const ImmersiveCardLayout = ({
+	cards,
+	containerPalette,
+	absoluteServerTimes,
+	imageLoading,
+	collectionId,
+}: {
+	cards: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	absoluteServerTimes: boolean;
+	imageLoading: Loading;
+	collectionId: number;
+}) => {
+	const card = cards[0];
+	if (!card) return null;
+
+	return (
+		<UL padBottom={true}>
+			<LI key={card.url} padSides={true}>
+				<FeatureCard
+					collectionId={collectionId}
+					linkTo={card.url}
+					format={card.format}
+					headlineText={card.headline}
+					byline={card.byline}
+					showByline={card.showByline}
+					webPublicationDate={card.webPublicationDate}
+					kickerText={card.kickerText}
+					showClock={false}
+					image={card.image}
+					canPlayInline={true}
+					starRating={card.starRating}
+					dataLinkName={card.dataLinkName}
+					discussionApiUrl={card.discussionApiUrl}
+					discussionId={card.discussionId}
+					mainMedia={card.mainMedia}
+					isExternalLink={card.isExternalLink}
+					// branding={card.branding}
+					containerPalette={containerPalette}
+					trailText={card.trailText}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+					aspectRatio={'5:3'}
+					mobileAspectRatio={'4:5'}
+					imageSize="feature-immersive"
+					headlineSizes={{ desktop: 'small' }}
+					supportingContent={card.supportingContent}
+					isImmersive={true}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
+export const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -199,40 +253,13 @@ const SplashCardLayout = ({
 	const shouldShowImmersive = card.isImmersive;
 	if (shouldShowImmersive) {
 		return (
-			<UL>
-				<LI key={card.url} padSides={true}>
-					<FeatureCard
-						collectionId={collectionId}
-						linkTo={card.url}
-						format={card.format}
-						headlineText={card.headline}
-						byline={card.byline}
-						showByline={card.showByline}
-						webPublicationDate={card.webPublicationDate}
-						kickerText={card.kickerText}
-						showClock={false}
-						image={card.image}
-						canPlayInline={true}
-						starRating={card.starRating}
-						dataLinkName={card.dataLinkName}
-						discussionApiUrl={card.discussionApiUrl}
-						discussionId={card.discussionId}
-						mainMedia={card.mainMedia}
-						isExternalLink={card.isExternalLink}
-						// branding={card.branding}
-						containerPalette={containerPalette}
-						trailText={card.trailText}
-						absoluteServerTimes={absoluteServerTimes}
-						imageLoading={imageLoading}
-						aspectRatio={'5:3'}
-						mobileAspectRatio={'4:5'}
-						imageSize="feature-immersive"
-						headlineSizes={{ desktop: 'small' }}
-						supportingContent={card.supportingContent}
-						isImmersive={true}
-					/>
-				</LI>
-			</UL>
+			<ImmersiveCardLayout
+				cards={cards}
+				containerPalette={containerPalette}
+				absoluteServerTimes={absoluteServerTimes}
+				imageLoading={imageLoading}
+				collectionId={collectionId}
+			/>
 		);
 	}
 
@@ -355,6 +382,7 @@ const BoostedCardLayout = ({
 	isFirstRow,
 	isLastRow,
 	containerLevel,
+	collectionId,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -365,6 +393,7 @@ const BoostedCardLayout = ({
 	isFirstRow: boolean;
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
+	collectionId: number;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -379,6 +408,21 @@ const BoostedCardLayout = ({
 		card.boostLevel,
 		card.avatarUrl,
 	);
+
+	// TODO: replace with live data from fronts tool - used for testing
+	const shouldShowImmersive = false;
+
+	if (shouldShowImmersive) {
+		return (
+			<ImmersiveCardLayout
+				cards={cards}
+				containerPalette={containerPalette}
+				absoluteServerTimes={absoluteServerTimes}
+				imageLoading={imageLoading}
+				collectionId={collectionId}
+			/>
+		);
+	}
 
 	return (
 		<UL
@@ -568,6 +612,7 @@ export const FlexibleGeneral = ({
 								isFirstRow={!splash.length && i === 0}
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
+								collectionId={collectionId}
 							/>
 						);
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -57,8 +57,11 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	});
 
 	return cards.reduce<GroupedCards>((acc, card) => {
-		// Early return if the card is boosted since it takes up a whole row
-		if (card.boostLevel && card.boostLevel !== 'default') {
+		// Early return if the card is boosted or immersive since it takes up a whole row
+		if (
+			card.isImmersive ||
+			(card.boostLevel && card.boostLevel !== 'default')
+		) {
 			return [...acc, createNewRow('oneCardBoosted', card)];
 		}
 
@@ -409,8 +412,7 @@ const BoostedCardLayout = ({
 		card.avatarUrl,
 	);
 
-	// TODO: replace with live data from fronts tool - used for testing
-	const shouldShowImmersive = false;
+	const shouldShowImmersive = card.isImmersive;
 
 	if (shouldShowImmersive) {
 		return (

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -80,6 +80,66 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 	}, []);
 };
 
+/**
+ * ImmersiveCardLayout is a special case of the card layout that is used for cards with the isImmersive property.
+ * It is a single feature card that takes up the full width of the container on all breakpoints.
+ * It is used in the FlexibleGeneral only.
+ * It can be used in any slot within the container.
+ */
+const ImmersiveCardLayout = ({
+	cards,
+	containerPalette,
+	absoluteServerTimes,
+	imageLoading,
+	collectionId,
+}: {
+	cards: DCRFrontCard[];
+	containerPalette?: DCRContainerPalette;
+	absoluteServerTimes: boolean;
+	imageLoading: Loading;
+	collectionId: number;
+}) => {
+	const card = cards[0];
+	if (!card) return null;
+
+	return (
+		<UL padBottom={true}>
+			<LI key={card.url} padSides={true}>
+				<FeatureCard
+					collectionId={collectionId}
+					linkTo={card.url}
+					format={card.format}
+					headlineText={card.headline}
+					byline={card.byline}
+					showByline={card.showByline}
+					webPublicationDate={card.webPublicationDate}
+					kickerText={card.kickerText}
+					showClock={false}
+					image={card.image}
+					canPlayInline={true}
+					starRating={card.starRating}
+					dataLinkName={card.dataLinkName}
+					discussionApiUrl={card.discussionApiUrl}
+					discussionId={card.discussionId}
+					mainMedia={card.mainMedia}
+					isExternalLink={card.isExternalLink}
+					// branding={card.branding}
+					containerPalette={containerPalette}
+					trailText={card.trailText}
+					absoluteServerTimes={absoluteServerTimes}
+					imageLoading={imageLoading}
+					aspectRatio={'5:3'}
+					mobileAspectRatio={'4:5'}
+					imageSize="feature-immersive"
+					headlineSizes={{ desktop: 'small' }}
+					supportingContent={card.supportingContent}
+					isImmersive={true}
+				/>
+			</LI>
+		</UL>
+	);
+};
+
 type BoostedSplashProperties = {
 	headlineSizes: ResponsiveFontSize;
 	imagePositionOnDesktop: ImagePositionType;
@@ -173,60 +233,6 @@ const decideSplashCardProperties = (
 				trailTextSize: 'large',
 			};
 	}
-};
-
-const ImmersiveCardLayout = ({
-	cards,
-	containerPalette,
-	absoluteServerTimes,
-	imageLoading,
-	collectionId,
-}: {
-	cards: DCRFrontCard[];
-	containerPalette?: DCRContainerPalette;
-	absoluteServerTimes: boolean;
-	imageLoading: Loading;
-	collectionId: number;
-}) => {
-	const card = cards[0];
-	if (!card) return null;
-
-	return (
-		<UL padBottom={true}>
-			<LI key={card.url} padSides={true}>
-				<FeatureCard
-					collectionId={collectionId}
-					linkTo={card.url}
-					format={card.format}
-					headlineText={card.headline}
-					byline={card.byline}
-					showByline={card.showByline}
-					webPublicationDate={card.webPublicationDate}
-					kickerText={card.kickerText}
-					showClock={false}
-					image={card.image}
-					canPlayInline={true}
-					starRating={card.starRating}
-					dataLinkName={card.dataLinkName}
-					discussionApiUrl={card.discussionApiUrl}
-					discussionId={card.discussionId}
-					mainMedia={card.mainMedia}
-					isExternalLink={card.isExternalLink}
-					// branding={card.branding}
-					containerPalette={containerPalette}
-					trailText={card.trailText}
-					absoluteServerTimes={absoluteServerTimes}
-					imageLoading={imageLoading}
-					aspectRatio={'5:3'}
-					mobileAspectRatio={'4:5'}
-					imageSize="feature-immersive"
-					headlineSizes={{ desktop: 'small' }}
-					supportingContent={card.supportingContent}
-					isImmersive={true}
-				/>
-			</LI>
-		</UL>
-	);
 };
 
 export const SplashCardLayout = ({
@@ -602,9 +608,9 @@ export const FlexibleGeneral = ({
 
 			{groupedCards.map((row, i) => {
 				switch (row.layout) {
-					case 'oneCardBoosted':
+					case 'oneCardFullWidth':
 						return (
-							<BoostedCardLayout
+							<FullWidthCardLayout
 								cards={row.cards}
 								containerPalette={containerPalette}
 								showAge={showAge}
@@ -618,11 +624,11 @@ export const FlexibleGeneral = ({
 							/>
 						);
 
-					case 'oneCard':
+					case 'oneCardHalfWidth':
 					case 'twoCard':
 					default:
 						return (
-							<StandardCardLayout
+							<HalfWidthCardLayout
 								cards={row.cards}
 								containerPalette={containerPalette}
 								showAge={showAge}


### PR DESCRIPTION
## What does this change?
Extracts the immersive feature card into its own component and implements this in the splash and the boosted slots. 

## Why?
Previously, immersive cards had been scoped to splash only but this has been extended and "immersive" will now be a boost variant for standard cards. 

This means we can render immersive feature cards in the boosted layout as well as the splash layout.

This is not wired up to the model and by extension the fronts tool yet but once this is, the immersive value will come through to DCR as a boost level.

## Screenshots

![Screenshot 2025-03-25 at 09 25 58](https://github.com/user-attachments/assets/ff67846c-7d59-4495-b769-05264af8573c)


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
