### PR TITLE
Give sublinks grey background on media cards

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -439,29 +439,71 @@ export const trails: [
 		isImmersive: false,
 	},
 	{
-		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
+		url: 'https://www.theguardian.com/world/video/2025/mar/06/how-nanoplastics-are-invading-our-bodies-video-report',
 		showByline: false,
-		byline: 'Sarah Boseley Health editor',
+		byline: ' Neelam Tailor, Alex Healey, Ali Assaf, Steve Glew, Ryan Baxter',
 		image: {
-			src: 'https://media.guim.co.uk/6d152e60fdb37dbbc063a68e2cffccf97cdab183/0_40_5458_3275/master/5458.jpg',
-			altText: 'A covid vaccine',
+			src: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg',
+			altText:
+				'Plastics are everywhere, but their smallest fragments – nanoplastics – are making their way into the deepest parts of our bodies, including our brains and breast milk',
 		},
 		format: {
 			display: ArticleDisplay.Standard,
 			theme: Pillar.News,
-			design: ArticleDesign.Analysis,
+			design: ArticleDesign.Video,
 		},
-		webPublicationDate: '2021-02-16T18:42:44.000Z',
-		headline:
-			'QCovid: how improved algorithm can identify more higher-risk adults',
-		dataLinkName: 'news | group-0 | card-@1',
+		webPublicationDate: '2025-03-06T10:14:00.000Z',
+		headline: 'How plastics are invading our brain cells – video',
+		dataLinkName: 'media | group-0 | card-@11',
 		showQuotedHeadline: false,
-		mainMedia: undefined,
+		mainMedia: {
+			type: 'Video',
+			id: '966acc06-a238-4d5f-b477-816eec0476f3',
+			videoId: '4JUvvbpx2So',
+			duration: 322,
+			title: 'How plastics are invading our brain cells – video',
+			width: 500,
+			height: 300,
+			origin: 'The Guardian',
+			images: [
+				{
+					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1000.jpg',
+					width: 1000,
+				},
+				{
+					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/500.jpg',
+					width: 500,
+				},
+				{
+					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/140.jpg',
+					width: 140,
+				},
+				{
+					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1920.jpg',
+					width: 1920,
+				},
+			],
+			expired: false,
+		},
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
 		isImmersive: false,
+		trailText:
+			'Plastics are everywhere, but their smallest fragments – nanoplastics – are making their way into the deepest parts of our bodies, including our brains and breast milk',
+		supportingContent: [
+			{
+				format: {
+					display: ArticleDisplay.Standard,
+					theme: Pillar.News,
+					design: ArticleDesign.Standard,
+				},
+				headline:
+					'Edwyn Collins: ‘Could an Orange Juice reunion ever be on the cards? No!’',
+				url: '/culture/2025/mar/06/edwyn-collins-could-an-orange-juice-reunion-ever-be-on-the-cards-no',
+			},
+		],
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -337,6 +337,40 @@ export const WithMediaType = () => {
 	);
 };
 
+export const WithMediaTypeAndSublinks = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Video,
+						theme: Pillar.Sport,
+					}}
+					containerType="flexible/general"
+					mainMedia={{ ...mainVideo, duration: 30 }}
+					headlineText="Video"
+					imagePositionOnDesktop="top"
+					imagePositionOnMobile="left"
+					supportingContent={[
+						{
+							...aBasicLink,
+							headline: 'Headline 1',
+							kickerText: 'Kicker',
+						},
+						{
+							...aBasicLink,
+							headline: 'Headline 2',
+							kickerText: 'Kicker',
+						},
+					]}
+				/>
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
 export const WithMediaTypeSpecialReportAlt = () => {
 	return (
 		<CardGroup>
@@ -1728,11 +1762,9 @@ export const WithAVerticalGapWhenScrollableSmallContainer = () => {
 export const WithBetaContainerAndSublinks = () => {
 	return (
 		<CardGroup>
-			{/* With an image */}
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
-					image={undefined}
 					containerType="flexible/general"
 					imagePositionOnMobile="bottom"
 					supportingContent={[
@@ -1749,10 +1781,17 @@ export const WithBetaContainerAndSublinks = () => {
 					]}
 				/>
 			</CardWrapper>
-			{/* Without an image */}
+		</CardGroup>
+	);
+};
+
+export const WithBetaContainerAndSublinksNoImage = () => {
+	return (
+		<CardGroup>
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
+					image={undefined}
 					containerType="flexible/general"
 					imagePositionOnMobile="bottom"
 					supportingContent={[

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -707,9 +707,7 @@ export const Card = ({
 						(imagePositionOnMobile === 'bottom' ||
 							isMediaCard(format)))
 				}
-				fillBackgroundOnDesktop={
-					isMediaCard(format) && imagePositionOnDesktop === 'top'
-				}
+				fillBackgroundOnDesktop={isBetaContainer && isMediaCard(format)}
 			/>
 		);
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -688,13 +688,12 @@ export const Card = ({
 	 * - Returns `null` if `supportingContent` is unavailable or `sublinkPosition` is `none`.
 	 * - Renders `SupportingContent` for all breakpoints if `sublinkPosition` is `outer`.
 	 * - If `sublinkPosition` is `inner`, hides `SupportingContent` from tablet but displays it on smaller breakpoints.
-	 *
 	 */
-	const decideOuterSublinks = () => {
+	const decideSublinks = () => {
 		if (!hasSublinks) return null;
 		if (sublinkPosition === 'none') return null;
 
-		const OuterSublinks = () => (
+		const Sublinks = () => (
 			<SupportingContent
 				supportingContent={supportingContent}
 				containerPalette={containerPalette}
@@ -704,18 +703,22 @@ export const Card = ({
 					!!isFlexSplash ||
 					(isBetaContainer &&
 						!!image &&
-						imagePositionOnMobile === 'bottom')
+						(imagePositionOnMobile === 'bottom' ||
+							isMediaCard(format)))
+				}
+				fillBackgroundOnDesktop={
+					isMediaCard(format) && imagePositionOnDesktop === 'top'
 				}
 			/>
 		);
 
 		if (sublinkPosition === 'outer') {
-			return <OuterSublinks />;
+			return <Sublinks />;
 		}
 
 		return (
 			<Hide from={isFlexSplash ? 'desktop' : 'tablet'}>
-				<OuterSublinks />
+				<Sublinks />
 			</Hide>
 		);
 	};
@@ -1241,7 +1244,8 @@ export const Card = ({
 
 			<div
 				css={
-					/** We allow this area to take up more space so that cards without sublinks next to cards with sublinks have the same meta alignment */
+					/** We allow this area to take up more space so that cards without
+					 * sublinks next to cards with sublinks have the same meta alignment */
 					isBetaContainer &&
 					(imagePositionOnDesktop === 'left' ||
 						imagePositionOnDesktop === 'right') &&
@@ -1253,10 +1257,7 @@ export const Card = ({
 					`
 				}
 				style={{
-					padding:
-						isMediaCardOrNewsletter || isOnwardContent
-							? `0 ${space[2]}px`
-							: 0,
+					padding: isOnwardContent ? `0 ${space[2]}px` : 0,
 				}}
 			>
 				{showLivePlayable && liveUpdatesPosition === 'outer' && (
@@ -1276,7 +1277,8 @@ export const Card = ({
 						></LatestLinks>
 					</Island>
 				)}
-				{decideOuterSublinks()}
+
+				{decideSublinks()}
 
 				{isOpinionCardWithAvatar && (
 					<CardFooter

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -689,7 +689,7 @@ export const Card = ({
 	 * - Renders `SupportingContent` for all breakpoints if `sublinkPosition` is `outer`.
 	 * - If `sublinkPosition` is `inner`, hides `SupportingContent` from tablet but displays it on smaller breakpoints.
 	 */
-	const decideSublinks = () => {
+	const decideOuterSublinks = () => {
 		if (!hasSublinks) return null;
 		if (sublinkPosition === 'none') return null;
 
@@ -699,6 +699,7 @@ export const Card = ({
 				containerPalette={containerPalette}
 				alignment={supportingContentAlignment}
 				isDynamo={isDynamo}
+				isMedia={isMediaCard(format)}
 				fillBackgroundOnMobile={
 					!!isFlexSplash ||
 					(isBetaContainer &&
@@ -726,6 +727,7 @@ export const Card = ({
 	const decideInnerSublinks = () => {
 		if (!hasSublinks) return null;
 		if (sublinkPosition !== 'inner') return null;
+
 		return (
 			<Hide until={isFlexSplash ? 'desktop' : 'tablet'}>
 				<SupportingContent
@@ -1278,7 +1280,7 @@ export const Card = ({
 					</Island>
 				)}
 
-				{decideSublinks()}
+				{decideOuterSublinks()}
 
 				{isOpinionCardWithAvatar && (
 					<CardFooter

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -61,7 +61,6 @@ const standardCards = standards.map((card, index) => {
 				boostLevel: 'megaboost',
 				supportingContent: getSublinks(2),
 			});
-
 		default:
 			return enhanceCardFields({});
 	}

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -46,16 +46,13 @@ const standardCards = standards.map((card, index) => {
 		}) satisfies DCRFrontCard;
 
 	switch (index + 1) {
-		// The second card has two sublinks
 		case 2:
 			return enhanceCardFields({ supportingContent: getSublinks(2) });
-		// The third card is boosted and has one sublink
 		case 3:
 			return enhanceCardFields({
 				boostLevel: 'boost',
 				supportingContent: getSublinks(1),
 			});
-		// The fifth card is megaboosted and has two sublinks
 		case 5:
 			return enhanceCardFields({
 				boostLevel: 'megaboost',

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -16,6 +16,7 @@ type Props = {
 	alignment: Alignment;
 	containerPalette?: DCRContainerPalette;
 	isDynamo?: boolean;
+	isMedia?: boolean;
 	/** Allows sublinks container to have a background colour on mobile screen sizes */
 	fillBackgroundOnMobile?: boolean;
 	/** Allows sublinks container to have a background colour on desktop screen sizes */
@@ -120,19 +121,23 @@ const wrapperStyles = css`
 	}
 `;
 
-const backgroundFillMobile = css`
+const backgroundFillMobile = (isMedia: boolean) => css`
 	${until.tablet} {
 		padding: ${space[2]}px;
 		padding-bottom: ${space[3]}px;
-		background-color: ${palette('--card-sublinks-background')};
+		background-color: ${isMedia
+			? palette('--card-media-sublinks-background')
+			: palette('--card-sublinks-background')};
 	}
 `;
 
-const backgroundFillDesktop = css`
+const backgroundFillDesktop = (isMedia: boolean) => css`
 	${from.tablet} {
 		padding: ${space[2]}px;
 		padding-bottom: ${space[3]}px;
-		background-color: ${palette('--card-sublinks-background')};
+		background-color: ${isMedia
+			? palette('--card-media-sublinks-background')
+			: palette('--card-sublinks-background')};
 	}
 `;
 
@@ -141,6 +146,7 @@ export const SupportingContent = ({
 	alignment,
 	containerPalette,
 	isDynamo,
+	isMedia = false,
 	fillBackgroundOnMobile = false,
 	fillBackgroundOnDesktop = false,
 }: Props) => {
@@ -153,8 +159,8 @@ export const SupportingContent = ({
 				wrapperStyles,
 				baseGrid,
 				(isDynamo ?? alignment === 'horizontal') && horizontalGrid,
-				fillBackgroundOnMobile && backgroundFillMobile,
-				fillBackgroundOnDesktop && backgroundFillDesktop,
+				fillBackgroundOnMobile && backgroundFillMobile(isMedia),
+				fillBackgroundOnDesktop && backgroundFillDesktop(isMedia),
 			]}
 		>
 			{supportingContent.map((subLink, index) => {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5663,6 +5663,11 @@ const cardSublinksBackgroundLight: PaletteFunction = () =>
 const cardSublinksBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
 
+const cardMediaSublinksBackgroundLight: PaletteFunction = () =>
+	sourcePalette.neutral[97];
+const cardMediaSublinksBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[20];
+
 const latestLinksDottedLineLight: PaletteFunction = () =>
 	sourcePalette.neutral[60];
 const latestLinksDottedLineDark: PaletteFunction = () =>
@@ -6121,6 +6126,10 @@ const paletteColours = {
 	'--card-media-icon': {
 		light: cardMediaIconLight,
 		dark: cardMediaIconDark,
+	},
+	'--card-media-sublinks-background': {
+		light: cardMediaSublinksBackgroundLight,
+		dark: cardMediaSublinksBackgroundDark,
 	},
 	'--card-media-waveform': {
 		light: cardMediaWaveformLight,


### PR DESCRIPTION
## What does this change?

Media Cards have sublinks - however on mobile web they are not staying within a grey bounding box and look disconnected from the story.

## Why?

Design tweaks.

## Screenshots

| <img width=200/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/bbf98d83-0390-404b-9dd1-3115f8339b89
[desktop-before]: https://github.com/user-attachments/assets/72002b51-a880-4eac-a1a9-94a77b96e9fb
[mobile-after]: https://github.com/user-attachments/assets/1c0b0739-e5ef-4554-bdab-cf06c1ea9d1b
[desktop-after]: https://github.com/user-attachments/assets/b09addc1-2d8f-4c30-b2a1-b2ab318e61b7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
