### PR TITLE
Update all DCR stacks from c7g to c8g

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -52,7 +52,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Facia */
@@ -92,7 +92,7 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Tag pages */
@@ -132,7 +132,7 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });
 
 /** Interactive */
@@ -172,5 +172,5 @@ new RenderingCDKStack(cdkApp, 'InteractiveRendering-PROD', {
 			},
 		},
 	},
-	instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM),
+	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
 });


### PR DESCRIPTION
## What does this change?

Update all c7g instances to c8g

## Why?

Update all instances to the latest generation available for improved performance

https://aws.amazon.com/about-aws/whats-new/2025/01/amazon-ec2-c8g-instances-additional-regions/

[https://instances.vantage.sh/?filter=c7g.medium|c8g.medium&compare_on=true&selected=c7g.medium,c8g.medium](https://instances.vantage.sh/?filter=c7g.medium%7Cc8g.medium&compare_on=true&selected=c7g.medium,c8g.medium)

Related:
https://github.com/guardian/platform/pull/1709