### PR TITLE
Reduce ASG sizes after upgrading to c8g

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,8 +28,8 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 27,
-		maximumInstances: 270,
+		minimumInstances: 24,
+		maximumInstances: 240,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -68,8 +68,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 30,
-		maximumInstances: 180,
+		minimumInstances: 21,
+		maximumInstances: 210,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,
@@ -108,8 +108,8 @@ new RenderingCDKStack(cdkApp, 'TagPageRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'tag-page-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 15,
-		maximumInstances: 150,
+		minimumInstances: 9,
+		maximumInstances: 90,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
## What does this change?

Reduce ASG sizes after upgrading to c8g.

Following [analysis](https://docs.google.com/spreadsheets/d/1a-coA9LF9wTzN4CnNq7NOPZ_RwS984xZBdGNJfBF9Cw/edit?gid=0#gid=0) we are confident c8g instances provide a ~30% performance improvement to latency metrics. This PR updates all stacks to the new minimum number of c8g instances to replicate our current performance profile.

