### PR TITLE
Fix football table Typescript errors after merge

### DIFF
--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -109,7 +109,7 @@ export const FootballTablesPage = ({
 					}
 				`}
 			>
-				<AdSlot position="right-football" />
+				<AdSlot position="football-right" />
 			</div>
 		)}
 	</main>

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -1,9 +1,12 @@
-import type { TeamScore } from './footballMatches';
+export type TeamResultScore = {
+	name: string;
+	score: number;
+};
 
 export type TeamResult = {
 	id: string;
-	self: TeamScore;
-	foe: TeamScore;
+	self: TeamResultScore;
+	foe: TeamResultScore;
 };
 
 export type FootballTableCompetition = {


### PR DESCRIPTION
## What does this change?

Fixes the tsc step https://github.com/guardian/dotcom-rendering/actions/runs/14108893435/job/39522104899

## Why?

There were some changes to main between creating the branch and merging https://github.com/guardian/dotcom-rendering/pull/13639


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
