### PR TITLE
Fix date bug - always format match day date using UTC timezone

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof meta>;
 export const Default = {
 	args: {
 		now: '2025-03-24T15:53:12.604Z',
-		edition: 'UK',
+		edition: 'US',
 		guardianBaseUrl: 'https://www.theguardian.com',
 		initialDays,
 		getMoreDays: () => Promise.resolve(ok(moreDays)),

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -72,15 +72,6 @@ const footballMatchesGridStyles = css`
 	}
 `;
 
-const getDateFormatter = (edition: EditionId): Intl.DateTimeFormat =>
-	new Intl.DateTimeFormat('en-GB', {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-		timeZone: getTimeZoneFromEdition(edition),
-	});
-
 const getTimeFormatter = (edition: EditionId): Intl.DateTimeFormat =>
 	new Intl.DateTimeFormat(getLocaleFromEdition(edition), {
 		hour: '2-digit',
@@ -392,7 +383,13 @@ export const FootballMatchList = ({
 	getMoreDays,
 	now,
 }: Props) => {
-	const dateFormatter = getDateFormatter(edition);
+	const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+		weekday: 'long',
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		timeZone: 'UTC',
+	});
 	const timeFormatter = getTimeFormatter(edition);
 
 	const [days, setDays] = useState(initialDays);


### PR DESCRIPTION
## What does this change?

Always format the date for the match day in list of football matches using UTC time

## Why?

Fixes a bug where match day dates where incorrect in the US - we were using the local time zone to format the date but the date is sent from frontend as simply a date "2024-03-28" without any timestamp.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3a22040e-d509-4b64-8953-46267d440f16
[after]: https://github.com/user-attachments/assets/e7c29eda-a338-4005-b88c-913365bdf998
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
