### PR TITLE
Feature cards: Reinstate podcast image above blur

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -111,6 +111,18 @@ type Story = StoryObj<typeof meta>;
 
 export const Standard: Story = {};
 
+export const Immersive: Story = {
+	args: {
+		aspectRatio: '5:3',
+		mobileAspectRatio: '4:5',
+		imageSize: 'feature-immersive',
+		maxWidth: '940',
+		isImmersive: true,
+		trailText:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
+	},
+};
+
 export const Review: Story = {
 	args: {
 		image: {
@@ -122,6 +134,13 @@ export const Review: Story = {
 		trailText:
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
 		starRating: 3,
+	},
+};
+
+export const ReviewImmersive: Story = {
+	args: {
+		...Review.args,
+		...Immersive.args,
 	},
 };
 
@@ -141,6 +160,13 @@ export const SportLiveBlog: Story = {
 	},
 };
 
+export const SportLiveBlogImmersive: Story = {
+	args: {
+		...SportLiveBlog.args,
+		...Immersive.args,
+	},
+};
+
 export const Opinion: Story = {
 	args: {
 		image: {
@@ -149,6 +175,13 @@ export const Opinion: Story = {
 		},
 		showQuotes: true,
 		format: { ...cardProps.format, theme: Pillar.Opinion },
+	},
+};
+
+export const OpinionImmersive: Story = {
+	args: {
+		...Opinion.args,
+		...Immersive.args,
 	},
 };
 
@@ -173,6 +206,13 @@ export const Podcast: Story = {
 	},
 };
 
+export const PodcastImmersive: Story = {
+	args: {
+		...Podcast.args,
+		...Immersive.args,
+	},
+};
+
 export const Gallery: Story = {
 	args: {
 		format: {
@@ -187,6 +227,13 @@ export const Gallery: Story = {
 			type: 'Gallery',
 			count: '12',
 		},
+	},
+};
+
+export const GalleryImmersive: Story = {
+	args: {
+		...Gallery.args,
+		...Immersive.args,
 	},
 };
 
@@ -221,6 +268,13 @@ export const Video: Story = {
 	},
 };
 
+export const VideoImmersive: Story = {
+	args: {
+		...Video.args,
+		...Immersive.args,
+	},
+};
+
 // A standard (non-video) article with a video main media
 export const VideoMainMedia: Story = {
 	args: {
@@ -233,6 +287,13 @@ export const VideoMainMedia: Story = {
 			...cardProps.format,
 			design: ArticleDesign.Standard,
 		},
+	},
+};
+
+export const VideoMainMediaImmersive: Story = {
+	args: {
+		...VideoMainMedia.args,
+		...Immersive.args,
 	},
 };
 
@@ -251,154 +312,22 @@ export const WithTrailText: Story = {
 	},
 };
 
+export const WithTrailTextImmersive: Story = {
+	args: {
+		...WithTrailText.args,
+		...Immersive.args,
+	},
+};
+
 export const WithSublinks: Story = {
 	args: {
 		supportingContent,
 	},
 };
 
-export const Immersive: Story = {
+export const WithSublinksImmersive: Story = {
 	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-	},
-};
-
-export const ImmersiveWithSublinks: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		supportingContent,
-	},
-};
-// A standard (non-video) article with a video main media
-export const ImmersiveVideoMainMedia: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		...Video.args,
-		image: {
-			src: 'https://media.guim.co.uk/4612af5f4667888fa697139cf570b6373d93a710/2446_345_3218_1931/master/3218.jpg',
-			altText: 'alt text',
-		},
-		format: {
-			...cardProps.format,
-			design: ArticleDesign.Standard,
-		},
-	},
-};
-
-export const ImmersiveVideo: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		format: {
-			...cardProps.format,
-			design: ArticleDesign.Video,
-		},
-		image: {
-			src: 'https://media.guim.co.uk/f2aedd24e5414073a653f68112e0ad070c6f4a2b/254_0_7493_4500/master/7493.jpg',
-			altText: 'alt text',
-		},
-		mainMedia: {
-			type: 'Video',
-			id: 'video-id',
-			videoId: 'video-id',
-			height: 1080,
-			width: 1920,
-			origin: 'origin',
-			title: 'Video Title',
-			duration: 120,
-			expired: false,
-			images: [
-				{
-					url: 'https://media.guim.co.uk/video-thumbnail.jpg',
-					width: 1920,
-				},
-			],
-		},
-	},
-};
-
-export const ImmersivePodcast: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		format: {
-			...cardProps.format,
-			design: ArticleDesign.Audio,
-		},
-		image: {
-			src: 'https://media.guim.co.uk/ecb7f0bebe473d6ef1375b5cb60b78f9466a5779/0_229_3435_2061/master/3435.jpg',
-			altText: 'alt text',
-		},
-		mainMedia: {
-			type: 'Audio',
-			podcastImage: {
-				src: 'https://media.guim.co.uk/be8830289638b0948b1ba4ade906e540554ada88/0_0_5000_3000/master/5000.jpg',
-				altText: 'Football Weekly',
-			},
-			duration: '55:09',
-		},
-	},
-};
-
-export const ImmersiveGallery: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		format: {
-			...cardProps.format,
-			design: ArticleDesign.Gallery,
-		},
-		image: {
-			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
-			altText: 'alt text',
-		},
-		mainMedia: {
-			type: 'Gallery',
-			count: '12',
-		},
-	},
-};
-
-export const ImmersiveMediaCardWithSublinks: Story = {
-	args: {
-		aspectRatio: '5:3',
-		mobileAspectRatio: '4:5',
-		imageSize: 'feature-immersive',
-		maxWidth: '940',
-		isImmersive: true,
-		format: {
-			...cardProps.format,
-			design: ArticleDesign.Gallery,
-		},
-		image: {
-			src: 'https://media.guim.co.uk/7b500cfe9afe4e211ad771c86e66297c9c22993b/0_61_4801_2880/master/4801.jpg',
-			altText: 'alt text',
-		},
-		mainMedia: {
-			type: 'Gallery',
-			count: '12',
-		},
-		supportingContent,
+		...WithSublinks.args,
+		...Immersive.args,
 	},
 };

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
@@ -107,9 +107,10 @@ const overlayContainerStyles = css`
 
 const immersiveOverlayContainerStyles = css`
 	${from.tablet} {
-		height: 100%;
 		top: 0;
-		width: 25%;
+		height: 100%;
+		width: 220px;
+		z-index: 1;
 	}
 `;
 
@@ -146,7 +147,7 @@ const overlayStyles = css`
 	${overlayMaskGradientStyles('180deg')};
 
 	/* Ensure the waveform is behind the other elements, e.g. headline, pill */
-	> * {
+	> :not(.waveform) {
 		z-index: 1;
 	}
 `;
@@ -169,6 +170,20 @@ const podcastImageContainerStyles = css`
 const podcastImageStyles = css`
 	height: 80px;
 	width: 80px;
+`;
+
+const nonImmersivePodcastImageStyles = css`
+	position: absolute;
+	/**
+	* Displays 8px above the text.
+	* desired space above text (8px) - padding-top of text container (64px) = -56px
+	*/
+	bottom: -${space[14]}px;
+	left: ${space[2]}px;
+
+	${from.tablet} {
+		display: none;
+	}
 `;
 
 const starRatingWrapper = css`
@@ -353,7 +368,7 @@ export const FeatureCard = ({
 							isExternalLink={isExternalLink}
 						/>
 					)}
-					<div css={[contentStyles]}>
+					<div css={contentStyles}>
 						{showYoutubeVideo && (
 							<div
 								data-chromatic="ignore"
@@ -488,6 +503,38 @@ export const FeatureCard = ({
 											immersiveOverlayContainerStyles,
 									]}
 								>
+									{mainMedia?.type === 'Audio' &&
+										!!mainMedia.podcastImage?.src && (
+											<div
+												css={
+													podcastImageContainerStyles
+												}
+											>
+												<div
+													css={[
+														podcastImageStyles,
+														nonImmersivePodcastImageStyles,
+													]}
+												>
+													<CardPicture
+														mainImage={
+															mainMedia
+																.podcastImage
+																.src
+														}
+														imageSize="podcast"
+														alt={
+															mainMedia
+																.podcastImage
+																.altText ?? ''
+														}
+														loading="lazy"
+														roundedCorners={false}
+														aspectRatio="1:1"
+													/>
+												</div>
+											</div>
+										)}
 									<div
 										css={[
 											overlayStyles,
@@ -495,38 +542,6 @@ export const FeatureCard = ({
 												immersiveOverlayStyles,
 										]}
 									>
-										{mainMedia?.type === 'Audio' &&
-											!!mainMedia.podcastImage?.src && (
-												<div
-													css={
-														podcastImageContainerStyles
-													}
-												>
-													<div
-														css={podcastImageStyles}
-													>
-														<CardPicture
-															mainImage={
-																mainMedia
-																	.podcastImage
-																	.src
-															}
-															imageSize="podcast"
-															alt={
-																mainMedia
-																	.podcastImage
-																	.altText ??
-																''
-															}
-															loading="lazy"
-															roundedCorners={
-																false
-															}
-															aspectRatio="1:1"
-														/>
-													</div>
-												</div>
-											)}
 										{/**
 										 * Without the wrapping div the headline and byline would have space
 										 * inserted between them due to being direct children of the flex container
@@ -585,17 +600,46 @@ export const FeatureCard = ({
 											</div>
 										)}
 
-										{mainMedia?.type === 'Audio' && (
-											<div css={waveformStyles}>
-												<WaveForm
-													seed={mainMedia.duration}
-													height={64}
-													// Just enough to cover the full width of the feature card in it's largest form
-													bars={233}
-													barWidth={2}
-												/>
-											</div>
-										)}
+										{isImmersive &&
+											mainMedia?.type === 'Audio' &&
+											!!mainMedia.podcastImage?.src && (
+												<div
+													css={
+														podcastImageContainerStyles
+													}
+												>
+													<div
+														css={[
+															podcastImageStyles,
+															css`
+																${until.tablet} {
+																	display: none;
+																}
+															`,
+														]}
+													>
+														<CardPicture
+															mainImage={
+																mainMedia
+																	.podcastImage
+																	.src
+															}
+															imageSize="podcast"
+															alt={
+																mainMedia
+																	.podcastImage
+																	.altText ??
+																''
+															}
+															loading="lazy"
+															roundedCorners={
+																false
+															}
+															aspectRatio="1:1"
+														/>
+													</div>
+												</div>
+											)}
 
 										<CardFooter
 											format={format}
@@ -644,6 +688,24 @@ export const FeatureCard = ({
 											mainMedia={mainMedia}
 											isNewsletter={isNewsletter}
 										/>
+
+										{!isImmersive &&
+											mainMedia?.type === 'Audio' && (
+												<div
+													css={waveformStyles}
+													className="waveform"
+												>
+													<WaveForm
+														seed={
+															mainMedia.duration
+														}
+														height={64}
+														// Just enough to cover the full width of the feature card in it's largest form
+														bars={233}
+														barWidth={2}
+													/>
+												</div>
+											)}
 									</div>
 									{/* On video article cards, the duration is displayed in the footer */}
 									{!isVideoArticle &&
@@ -663,6 +725,21 @@ export const FeatureCard = ({
 										</div>
 									) : null}
 								</div>
+
+								{isImmersive && mainMedia?.type === 'Audio' && (
+									<div
+										css={waveformStyles}
+										className="waveform"
+									>
+										<WaveForm
+											seed={mainMedia.duration}
+											height={64}
+											// Just enough to cover the full width of the feature card in it's largest form
+											bars={314}
+											barWidth={2}
+										/>
+									</div>
+								)}
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
## What does this change?

The blur on feature cards no longer includes the podcast image in determining its height.

Updates the immersive podcast feature cards [to match designs](https://www.figma.com/design/6NWdhzJfb3uraFgalGaNAE/Card-Components?node-id=4367-27559&t=PxVnod7XOSozt7gs-0) (except for the pill - this will be done in a follow-up PR)

## Why?

Fixes a regression missed by Chromatic.

## Screenshots

| <img width=200/> | Before | After |
| - | - | - |
| Feature card | ![1-before] | ![1-after] |
| Immersive tablet | ![2-before] | ![2-after] |
| Immersive desktop | ![3-before] | ![3-after] |

[1-before]: https://github.com/user-attachments/assets/a79d4f26-3870-441c-b30a-d7a758654e9c
[2-before]: https://github.com/user-attachments/assets/595429ce-2011-414e-aea4-3bcb8d502889
[3-before]: https://github.com/user-attachments/assets/2f8e1af4-c682-4e5b-8522-769779adad78
[1-after]: https://github.com/user-attachments/assets/8b6453e4-bb89-45e7-83bf-3392faaf30ef
[2-after]: https://github.com/user-attachments/assets/f4105dc1-17c2-48e7-b7ce-0cebe93fb335
[3-after]: https://github.com/user-attachments/assets/7b19ecdb-0504-4292-bb42-caa8eeb77e19
