### PR TITLE
Prevent mobile front ads from being placed before a labs container

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -17,7 +17,7 @@ type GroupedCounts = {
 
 export type AdCandidateMobile = Pick<
 	DCRCollectionType,
-	'collectionType' | 'containerLevel'
+	'collectionType' | 'containerLevel' | 'containerPalette'
 >;
 
 /** The Merch high slot is directly before the most viewed container  */
@@ -40,6 +40,11 @@ const isMerchHighPosition = (
 
 const isBeforeThrasher = (index: number, collections: AdCandidateMobile[]) =>
 	collections[index + 1]?.collectionType === 'fixed/thrasher';
+
+const isBeforeBrandedContainer = (
+	index: number,
+	collections: AdCandidateMobile[],
+) => collections[index + 1]?.containerPalette === 'Branded';
 
 const isMostViewedContainer = (collection: AdCandidateMobile) =>
 	collection.collectionType === 'news/most-popular';
@@ -74,12 +79,14 @@ const canInsertMobileAd =
 		 * - Is NOT the slot used for the merch high position
 		 * - Is NOT a thrasher if it is the first container
 		 * - Is NOT before a thrasher
+		 * - Is NOT before a branded container
 		 * - Is NOT the most viewed container
 		 */
 		const rules = [
 			!isMerchHighPosition(index, merchHighPosition),
 			!isFirstContainerAndThrasher(collection.collectionType, index),
 			!isBeforeThrasher(index, collections),
+			!isBeforeBrandedContainer(index, collections),
 			!isMostViewedContainer(collection),
 		];
 

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -79,14 +79,12 @@ const canInsertMobileAd =
 		 * - Is NOT the slot used for the merch high position
 		 * - Is NOT a thrasher if it is the first container
 		 * - Is NOT before a thrasher
-		 * - Is NOT before a branded container
 		 * - Is NOT the most viewed container
 		 */
 		const rules = [
 			!isMerchHighPosition(index, merchHighPosition),
 			!isFirstContainerAndThrasher(collection.collectionType, index),
 			!isBeforeThrasher(index, collections),
-			!isBeforeBrandedContainer(index, collections),
 			!isMostViewedContainer(collection),
 		];
 
@@ -95,6 +93,8 @@ const canInsertMobileAd =
 			// Allow insertion after first container at any time but for all other situations,
 			// prevent insertion before a secondary level container
 			index === 0 || !isBeforeSecondaryLevelContainer(index, collections),
+			// Prevent insertion before a branded container
+			!isBeforeBrandedContainer(index, collections),
 		];
 
 		// Ad insertion is possible if every condition is met


### PR DESCRIPTION
## What does this change?
Adds a rule to the mobile front ad placement logic to prevent ads from being inserted before labs containers.

## Why?
At the moment on fronts with the new design, it's possible for ads to appear both before and after a labs container on mobile. We'd like to prevent this from happening, so we're preventing ads from being added before labs containers.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="200" alt="Screenshot 2025-03-31 at 16 14 03" src="https://github.com/user-attachments/assets/ef724409-7083-4914-8b68-de2d9402772e" /> | <img width="200" alt="Screenshot 2025-03-31 at 16 14 47" src="https://github.com/user-attachments/assets/47d684c0-7149-4773-95e7-d5b636a2a215" /> |




