### PR TITLE
Update types to expect "isImmersive" value

### DIFF
--- a/dotcom-rendering/fixtures/manual/highlights-trails.ts
+++ b/dotcom-rendering/fixtures/manual/highlights-trails.ts
@@ -43,6 +43,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'From left: Nottingham Forest’s Murillo, Tottenham’s Micky van de Ven and Manchester City’s Erling Haaland.',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -81,6 +82,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'Olly Alexander and four dancers on stage during his performace.',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -119,6 +121,7 @@ export const trails: Array<DCRFrontCard> = [
 			src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 			altText: 'A row of terraced houses with many To Let signs',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -157,6 +160,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'Baby Reindeer writer and actor Richard Gadd (Donny Dunn) and Jessica Gunning, who plays Martha, in a still from the series.',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -195,6 +199,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'From left: Nottingham Forest’s Murillo, Tottenham’s Micky van de Ven and Manchester City’s Erling Haaland.',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -233,6 +238,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'Olly Alexander and four dancers on stage during his performace.',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -271,6 +277,7 @@ export const trails: Array<DCRFrontCard> = [
 			src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 			altText: 'A row of terraced houses with many To Let signs',
 		},
+		isImmersive: false,
 	},
 	{
 		format: {
@@ -309,6 +316,7 @@ export const trails: Array<DCRFrontCard> = [
 			altText:
 				'Baby Reindeer writer and actor Richard Gadd (Donny Dunn) and Jessica Gunning, who plays Martha, in a still from the series.',
 		},
+		isImmersive: false,
 	},
 ];
 
@@ -349,4 +357,5 @@ export const defaultCard: DCRFrontCard = {
 		src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 		altText: 'A row of terraced houses with many To Let signs',
 	},
+	isImmersive: false,
 };

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -70,6 +70,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
@@ -109,6 +110,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -133,6 +135,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
@@ -156,6 +159,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
@@ -180,6 +184,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
@@ -204,6 +209,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
@@ -229,6 +235,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
@@ -253,6 +260,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 
 	{
@@ -278,6 +286,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
@@ -302,6 +311,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
@@ -326,6 +336,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
@@ -350,6 +361,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
@@ -374,6 +386,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
@@ -398,6 +411,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
@@ -422,6 +436,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/uk-news/2021/feb/16/qcovid-how-improved-algorithm-can-identify-more-higher-risk-adults',
@@ -446,6 +461,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
@@ -469,6 +485,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/society/2023/may/30/trans-activists-disrupt-kathleen-stock-speech-at-oxford-union',
@@ -493,6 +510,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/commentisfree/2023/may/31/price-controls-rishi-sunak-thatcher-prime-minister',
@@ -517,6 +535,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 	{
 		url: 'https://www.theguardian.com/tv-and-radio/2023/may/30/a-revelation-succession-matthew-macfadyen-has-been-a-consummate-shapeshifter',
@@ -558,6 +577,7 @@ export const trails: [
 		showLivePlayable: false,
 		discussionApiUrl,
 		showMainVideo: true,
+		isImmersive: false,
 	},
 ];
 
@@ -589,6 +609,7 @@ export const audioTrails: [DCRFrontCard, DCRFrontCard] = [
 			altText:
 				'A military facility destroyed by shelling near Kyiv, 1 March 2022. Photograph: Genya Savilov/AFP/Getty Images',
 		},
+		isImmersive: false,
 	},
 	{
 		format: { design: 3, display: 0, theme: 2 },
@@ -616,6 +637,7 @@ export const audioTrails: [DCRFrontCard, DCRFrontCard] = [
 			altText:
 				"TOPSHOT-FBL-EUR-C1-MILAN-FEYENOORD<br>TOPSHOT - Polish referee Szymon Marciniak gives a red card to AC Milan's French defender #19 Theo Hernandez (R) during the UEFA Champions League knockout round play-off second leg football match between AC Milan and Feyenoord at San Siro stadium in Milan, on February 18, 2025. (Photo by Piero CRUCIATTI / AFP) (Photo by PIERO CRUCIATTI/AFP via Getty Images)",
 		},
+		isImmersive: false,
 	},
 ];
 
@@ -640,6 +662,7 @@ export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 		showQuotedHeadline: false,
 		isExternalLink: false,
 		showLivePlayable: false,
+		isImmersive: false,
 	},
 	{
 		format: { design: 2, display: 1, theme: 0 },
@@ -660,6 +683,7 @@ export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 		showQuotedHeadline: false,
 		isExternalLink: false,
 		showLivePlayable: false,
+		isImmersive: false,
 	},
 ];
 
@@ -717,6 +741,7 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 		showQuotedHeadline: false,
 		isExternalLink: false,
 		showLivePlayable: false,
+		isImmersive: false,
 	},
 	{
 		format: { design: 0, display: 0, theme: 0 },
@@ -770,5 +795,6 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 		showQuotedHeadline: false,
 		isExternalLink: false,
 		showLivePlayable: false,
+		isImmersive: false,
 	},
 ];

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -351,6 +351,7 @@ export const SpecialReportWithoutPalette: Story = {
 					snapData: {},
 					isCrossword: false,
 					discussionApiUrl,
+					isImmersive: false,
 				},
 			],
 		},

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -263,6 +263,7 @@ const liveUpdatesCard = {
 		design: ArticleDesign.Standard,
 		display: ArticleDisplay.Standard,
 	}),
+	isImmersive: false,
 } satisfies DCRFrontCard;
 
 export const FourSublinkSplashWithLiveUpdates: Story = {

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -196,9 +196,7 @@ const SplashCardLayout = ({
 	const card = cards[0];
 	if (!card) return null;
 
-	// TODO: replace with live data from fronts tool - used for testing
-	const shouldShowImmersive = false;
-
+	const shouldShowImmersive = card.isImmersive;
 	if (shouldShowImmersive) {
 		return (
 			<UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -80,6 +80,7 @@ const liveUpdatesCard = {
 	isExternalLink: false,
 	discussionApiUrl,
 	showLivePlayable: true,
+	isImmersive: false,
 } satisfies DCRFrontCard;
 
 const meta = {

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -41,6 +41,7 @@ const frontCard = {
 	byline: 'Byline text',
 	showByline: true,
 	dataLinkName: 'data-link-name',
+	isImmersive: false,
 } satisfies DCRFrontCard;
 
 const trails = new Array(6)

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -250,6 +250,7 @@ export type FEFrontCard = {
 	display: {
 		isBoosted: boolean;
 		boostLevel?: BoostLevel;
+		isImmersive?: boolean;
 		showBoostedHeadline: boolean;
 		showQuotedHeadline: boolean;
 		imageHide: boolean;

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -1067,6 +1067,9 @@
                                                 "boostLevel": {
                                                     "$ref": "#/definitions/BoostLevel"
                                                 },
+                                                "isImmersive": {
+                                                    "type": "boolean"
+                                                },
                                                 "showBoostedHeadline": {
                                                     "type": "boolean"
                                                 },
@@ -1824,6 +1827,9 @@
                                                 "boostLevel": {
                                                     "$ref": "#/definitions/BoostLevel"
                                                 },
+                                                "isImmersive": {
+                                                    "type": "boolean"
+                                                },
                                                 "showBoostedHeadline": {
                                                     "type": "boolean"
                                                 },
@@ -2580,6 +2586,9 @@
                                                 },
                                                 "boostLevel": {
                                                     "$ref": "#/definitions/BoostLevel"
+                                                },
+                                                "isImmersive": {
+                                                    "type": "boolean"
                                                 },
                                                 "showBoostedHeadline": {
                                                     "type": "boolean"

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -596,6 +596,9 @@
                             "boostLevel": {
                                 "$ref": "#/definitions/BoostLevel"
                             },
+                            "isImmersive": {
+                                "type": "boolean"
+                            },
                             "showBoostedHeadline": {
                                 "type": "boolean"
                             },

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -324,6 +324,7 @@ export const enhanceCards = (
 			snapData: enhanceSnaps(faciaCard.enriched),
 			isBoosted: faciaCard.display.isBoosted,
 			boostLevel: faciaCard.display.boostLevel,
+			isImmersive: !!faciaCard.display.isImmersive,
 			isCrossword: faciaCard.properties.isCrossword,
 			isNewsletter,
 			isCartoon,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -90,6 +90,7 @@ export type DCRFrontCard = {
 	snapData?: DCRSnapType;
 	isBoosted?: boolean;
 	boostLevel?: BoostLevel;
+	isImmersive: boolean;
 	isCrossword?: boolean;
 	isNewsletter?: boolean;
 	isCartoon?: boolean;


### PR DESCRIPTION
## What does this change?
Updates the frontend model and the DCR card model to expect the `isImmersive` property. 

On the frontend model the value is optional as all fronts will have this property pressed (eg old fronts). 

On the DCR model, the value is required as we coorece the frontend property to a boolean during the enhancement step and can be confident this property exists. 


## Why?
Immersive is a new card style that can only be used in a flexible general container. It is toggled on / off in the fronts tool at the card meta level. 

