### PR TITLE
Enforce pseudo element double colon syntax

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -58,7 +58,7 @@ const globalOlStyles = () => css`
 	ol:not([data-ignore='global-ol-styling']) {
 		counter-reset: li;
 
-		> li:before {
+		> li::before {
 			${textEgyptian17};
 			line-height: 1.15;
 			content: counter(li);

--- a/dotcom-rendering/src/components/BackToTop.tsx
+++ b/dotcom-rendering/src/components/BackToTop.tsx
@@ -34,7 +34,7 @@ const link = css`
 `;
 
 const icon = css`
-	:before {
+	::before {
 		position: absolute;
 		top: 6px;
 		bottom: 0;

--- a/dotcom-rendering/src/components/Bio.tsx
+++ b/dotcom-rendering/src/components/Bio.tsx
@@ -37,7 +37,7 @@ const bioStyles = css`
 		display: inline-block;
 		margin-bottom: 0;
 	}
-	ul li:before {
+	ul li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 0.375rem;

--- a/dotcom-rendering/src/components/Blocks.amp.tsx
+++ b/dotcom-rendering/src/components/Blocks.amp.tsx
@@ -20,7 +20,7 @@ const adStyle = css`
 	text-align: center;
 	margin: 0 auto 12px;
 
-	:before {
+	::before {
 		content: 'Advertisement';
 		display: block;
 		${textSans12};

--- a/dotcom-rendering/src/components/BodyArticle.amp.tsx
+++ b/dotcom-rendering/src/components/BodyArticle.amp.tsx
@@ -39,7 +39,7 @@ const bulletStyle = (pillar: ArticleTheme) => css`
 		font-size: 1px;
 	}
 
-	.bullet:before {
+	.bullet::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;
@@ -79,7 +79,7 @@ const adStyle = css`
 	text-align: center;
 	margin: 4px 0 12px 20px;
 
-	:before {
+	::before {
 		content: 'Advertisement';
 		display: block;
 		${textSans12};

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -63,7 +63,7 @@ const sublinkHoverStyles = css`
 `;
 
 const topBarStyles = css`
-	:before {
+	::before {
 		border-top: 1px solid ${palette('--card-border-top')};
 		content: '';
 		z-index: 2;

--- a/dotcom-rendering/src/components/Discussion/CommentReplyPreview.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentReplyPreview.tsx
@@ -54,7 +54,7 @@ const previewStyle = css`
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	:before {
+	::before {
 		content: '';
 		position: absolute;
 		border-left: ${arrowSize}px solid

--- a/dotcom-rendering/src/components/Discussion/Dropdown.tsx
+++ b/dotcom-rendering/src/components/Discussion/Dropdown.tsx
@@ -85,7 +85,7 @@ const firstStyles = css`
 const activeStyles = css`
 	font-weight: bold;
 
-	:after {
+	::after {
 		content: '';
 		border: 2px solid ${schemedPalette('--discussion-accent-text')};
 		border-top: 0px;
@@ -120,12 +120,12 @@ const buttonStyles = css`
 	text-decoration: none;
 
 	:hover {
-		:after {
+		::after {
 			transform: translateY(0) rotate(45deg);
 		}
 	}
 
-	:after {
+	::after {
 		content: '';
 		display: inline-block;
 		width: 5px;
@@ -141,10 +141,10 @@ const buttonStyles = css`
 `;
 
 const expandedStyles = css`
-	:hover:after {
+	:hover::after {
 		transform: translateY(-1px) rotate(-135deg);
 	}
-	:after {
+	::after {
 		transform: translateY(1px) rotate(-135deg);
 	}
 `;

--- a/dotcom-rendering/src/components/Discussion/Filters.tsx
+++ b/dotcom-rendering/src/components/Discussion/Filters.tsx
@@ -28,7 +28,7 @@ const filterBar = css`
 const dividerStyles = css`
 	position: relative;
 	margin-left: ${space[2]}px;
-	:after {
+	::after {
 		content: '';
 		display: block;
 		width: 1px;

--- a/dotcom-rendering/src/components/Discussion/LoadingPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/LoadingPicks.tsx
@@ -50,7 +50,7 @@ const pickBoxStyles = css`
 	position: relative;
 	height: 150px;
 
-	:before {
+	::before {
 		content: '';
 		margin-left: ${space[6]}px;
 		position: absolute;

--- a/dotcom-rendering/src/components/Discussion/TopPick.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.tsx
@@ -120,7 +120,7 @@ const PickBubble = ({ children }: { children: React.ReactNode }) => (
 				min-height: 150px;
 			}
 
-			:before {
+			::before {
 				content: '';
 				margin-left: ${space[6]}px;
 				position: absolute;

--- a/dotcom-rendering/src/components/Dropdown.importable.tsx
+++ b/dotcom-rendering/src/components/Dropdown.importable.tsx
@@ -107,7 +107,7 @@ const linkStyles = css`
 		text-decoration: underline;
 	}
 
-	:before {
+	::before {
 		content: '';
 		border-top: 1px solid ${sourcePalette.neutral[86]};
 		display: block;
@@ -121,7 +121,7 @@ const linkStyles = css`
 const linkActive = css`
 	font-weight: bold;
 
-	:after {
+	::after {
 		content: '';
 		border: 2px solid ${sourcePalette.news[400]};
 		border-top: 0px;
@@ -136,7 +136,7 @@ const linkActive = css`
 `;
 
 const linkFirst = css`
-	:before {
+	::before {
 		content: none;
 	}
 `;
@@ -159,12 +159,12 @@ const buttonStyles = css`
 	:hover {
 		color: ${sourcePalette.brandAlt[400]};
 
-		:after {
+		::after {
 			transform: translateY(0) rotate(45deg);
 		}
 	}
 
-	:after {
+	::after {
 		content: '';
 		display: inline-block;
 		width: 5px;
@@ -180,10 +180,10 @@ const buttonStyles = css`
 `;
 
 const buttonExpanded = css`
-	:hover:after {
+	:hover::after {
 		transform: translateY(-1px) rotate(-135deg);
 	}
-	:after {
+	::after {
 		transform: translateY(1px) rotate(-135deg);
 	}
 `;

--- a/dotcom-rendering/src/components/Expandable.amp.tsx
+++ b/dotcom-rendering/src/components/Expandable.amp.tsx
@@ -20,7 +20,7 @@ const ListStyle = (iconColour: string) => css`
 		}
 	}
 
-	li:before {
+	li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;

--- a/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
+++ b/dotcom-rendering/src/components/ExpandableAtom/Body.tsx
@@ -55,7 +55,7 @@ const bodyStyling = css`
 		padding-left: 1.25rem;
 	}
 
-	ul li:before {
+	ul li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 0.375rem;

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -321,7 +321,7 @@ const Battleline = () => (
 			display: block;
 			padding: 0 4px;
 
-			&:before {
+			&::before {
 				content: '-';
 			}
 		`}

--- a/dotcom-rendering/src/components/Footer.amp.tsx
+++ b/dotcom-rendering/src/components/Footer.amp.tsx
@@ -131,7 +131,7 @@ const footerList = css`
 	position: relative;
 	padding-top: 12px;
 
-	:before {
+	::before {
 		content: '';
 		position: absolute;
 		top: 0;
@@ -175,7 +175,7 @@ const iconContainer = css`
 `;
 
 const icon = css`
-	:before {
+	::before {
 		position: absolute;
 		top: 6px;
 		bottom: 0;

--- a/dotcom-rendering/src/components/Footer.tsx
+++ b/dotcom-rendering/src/components/Footer.tsx
@@ -55,7 +55,7 @@ const pillarWrap = css`
 	> ul {
 		clear: none;
 
-		:after {
+		::after {
 			display: none;
 		}
 	}

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -320,7 +320,7 @@ const sectionContentPadded = css`
 const sectionContentBorderFromLeftCol = css`
 	position: relative;
 	${from.leftCol} {
-		:before {
+		::before {
 			content: '';
 			position: absolute;
 			top: ${space[2]}px;

--- a/dotcom-rendering/src/components/Header.amp.tsx
+++ b/dotcom-rendering/src/components/Header.amp.tsx
@@ -66,7 +66,7 @@ const pillarListItemStyle = css`
 		a {
 			padding-left: 20px;
 
-			:before {
+			::before {
 				display: none;
 			}
 		}
@@ -102,7 +102,7 @@ const pillarLinkStyle = (pillar: ArticleTheme) => css`
 		text-decoration: underline;
 	}
 
-	:before {
+	::before {
 		border-left: 1px solid rgba(255, 255, 255, 0.3);
 		top: 0;
 		z-index: 1;
@@ -113,7 +113,7 @@ const pillarLinkStyle = (pillar: ArticleTheme) => css`
 		bottom: 0;
 	}
 
-	:after {
+	::after {
 		content: '';
 		display: block;
 		top: 0;
@@ -159,14 +159,14 @@ const pattyStyles = css`
 
 	${lineStyles};
 
-	:before {
+	::before {
 		content: '';
 		top: -6px;
 		left: 0;
 		${lineStyles};
 	}
 
-	:after {
+	::after {
 		content: '';
 		top: 6px;
 		left: 0;

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -160,7 +160,7 @@ const titleWrapper = css`
 	color: ${srcPalette.neutral[100]};
 	background: linear-gradient(transparent, ${srcPalette.neutral[0]});
 
-	:before {
+	::before {
 		background-color: ${themePalette('--image-title-background')};
 		display: block;
 		content: '';

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -55,7 +55,7 @@ const dividerStyles = css`
 const bold = css`
 	${textSansBold14};
 
-	:before {
+	::before {
 		content: '';
 		height: 0.75em;
 		width: 0.75em;

--- a/dotcom-rendering/src/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/components/LeftColumn.tsx
@@ -64,7 +64,7 @@ const positionRelative = css`
 `;
 
 const partialRightBorder = (colour: string) => css`
-	:before {
+	::before {
 		content: '';
 		position: absolute;
 		top: 0;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/CollapseSectionButton.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/CollapseSectionButton.tsx
@@ -27,7 +27,7 @@ const showColumnLinksStyle = (columnInputId: string) => css`
     */
 	/* stylelint-disable-next-line selector-type-no-unknown */
 	${`#${columnInputId}`}:checked ~ & {
-		:before {
+		::before {
 			margin-top: ${space[2]}px;
 			transform: rotate(-135deg);
 		}
@@ -45,7 +45,7 @@ const collapseColumnButton = css`
 	user-select: none;
 	text-transform: capitalize;
 
-	:before {
+	::before {
 		margin-top: ${space[1]}px;
 		left: ${space[6]}px;
 		position: absolute;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/MoreSection.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/MoreSection.tsx
@@ -29,7 +29,7 @@ const columnStyle = css`
 	position: relative;
 
 	/* Remove the border from the top item on mobile */
-	:first-of-type:after {
+	:first-of-type::after {
 		content: none;
 	}
 
@@ -38,7 +38,7 @@ const columnStyle = css`
 		float: left;
 		position: relative;
 
-		:after {
+		::after {
 			content: none;
 		}
 	}
@@ -55,7 +55,7 @@ const columnStyleFromLeftCol = css`
 
 const pillarDivider = css`
 	${from.desktop} {
-		:before {
+		::before {
 			content: '';
 			display: block;
 			position: absolute;
@@ -71,7 +71,7 @@ const pillarDivider = css`
 
 const pillarDividerExtended = css`
 	${from.desktop} {
-		:after {
+		::after {
 			content: '';
 			display: block;
 			position: absolute;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Pillar.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Pillar.tsx
@@ -26,7 +26,7 @@ import { CollapseSectionButton } from './CollapseSectionButton';
 
 const pillarDivider = css`
 	${from.desktop} {
-		:before {
+		::before {
 			content: '';
 			display: block;
 			position: absolute;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
@@ -76,12 +76,12 @@ const searchSubmit = css`
 		opacity: 0;
 		pointer-events: all;
 	}
-	&:before {
+	&::before {
 		height: 12px;
 		top: ${space[3]}px;
 		width: 12px;
 	}
-	&:after {
+	&::after {
 		border-right: 0;
 		top: 17px;
 		width: 20px;

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/Pillars.tsx
@@ -76,7 +76,7 @@ const pillarBlockWithoutPageSkin = css`
 const pillarUnderlineHeight = space[1] + 1;
 
 const pillarUnderline = css`
-	:after {
+	::after {
 		height: ${pillarUnderlineHeight}px;
 		/* This CSS var is dynamically set via the style attribute*/
 		background-color: var(--pillar-underline);
@@ -104,16 +104,16 @@ const pillarUnderline = css`
 `;
 
 const forceUnderline = css`
-	:after {
+	::after {
 		transform: translateY(-${pillarUnderlineHeight}px);
 	}
-	:focus:after {
+	:focus::after {
 		transform: translateY(-${pillarUnderlineHeight}px);
 	}
 	:hover {
 		text-decoration: none;
 	}
-	:hover:after {
+	:hover::after {
 		transform: translateY(-${pillarUnderlineHeight}px);
 	}
 `;
@@ -145,13 +145,13 @@ const pillarLink = css`
 		${headlineBold20}
 	}
 
-	:focus:after {
+	:focus::after {
 		transform: translateY(-${pillarUnderlineHeight}px);
 	}
 	:hover {
 		text-decoration: none;
 	}
-	:hover:after {
+	:hover::after {
 		transform: translateY(-${pillarUnderlineHeight}px);
 	}
 `;
@@ -166,7 +166,7 @@ const firstPillarLinkOverrides = css`
 	a {
 		padding-left: 0;
 
-		:after {
+		::after {
 			width: calc(100% - 1px);
 			margin-left: 0;
 		}
@@ -174,7 +174,7 @@ const firstPillarLinkOverrides = css`
 `;
 
 export const verticalDivider = css`
-	:after {
+	::after {
 		content: '';
 		border-left: 1px solid ${themePalette('--masthead-nav-lines')};
 		display: flex;

--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -52,7 +52,7 @@ const StretchBackground = ({ children }: { children: React.ReactNode }) => (
 				margin: 0 -10px 10px;
 			}
 
-			:before {
+			::before {
 				content: '';
 				position: absolute;
 				top: 0;

--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -181,7 +181,7 @@ const StretchBackground = ({
 			background-color: ${themePalette('--match-stats-background')};
 
 			${from.leftCol} {
-				:before {
+				::before {
 					content: '';
 					position: absolute;
 					top: 0;

--- a/dotcom-rendering/src/components/PaidForBand.amp.tsx
+++ b/dotcom-rendering/src/components/PaidForBand.amp.tsx
@@ -52,7 +52,7 @@ const aboutButtonStyle = css`
 `;
 
 const aboutButtonIcon = css`
-	:after {
+	::after {
 		content: ' ';
 		display: inline-block;
 		width: 5px;

--- a/dotcom-rendering/src/components/PulsingDot.importable.tsx
+++ b/dotcom-rendering/src/components/PulsingDot.importable.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 const dotStyles = (colour?: string) => css`
 	color: ${colour && colour};
-	:before {
+	::before {
 		border-radius: 62.5rem;
 		display: inline-block;
 		position: relative;

--- a/dotcom-rendering/src/components/ShowMoreButton.amp.tsx
+++ b/dotcom-rendering/src/components/ShowMoreButton.amp.tsx
@@ -22,7 +22,7 @@ const showMore = css`
 		padding-right: 4px;
 	}
 
-	:after {
+	::after {
 		content: '';
 		background-color: ${palette.neutral[86]};
 		border-radius: 18px;

--- a/dotcom-rendering/src/components/Sidebar.amp.tsx
+++ b/dotcom-rendering/src/components/Sidebar.amp.tsx
@@ -22,7 +22,7 @@ export const Sidebar = () => {
 							margin-top: 0px;
 						}
 
-						i:before {
+						i::before {
 							transform: rotate(-135deg);
 						}
 					}
@@ -38,7 +38,7 @@ export const Sidebar = () => {
 						left: 25px;
 						position: absolute;
 
-						:before {
+						::before {
 							border: 2px solid ${palette.neutral[100]};
 							border-top: 0;
 							border-left: 0;
@@ -115,7 +115,7 @@ export const Sidebar = () => {
 				const pillarStyles = css`
 					position: relative;
 
-					:not(:last-child):after {
+					:not(:last-child)::after {
 						background-color: rgba(255, 255, 255, 0.3);
 						bottom: 0;
 						content: '';

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateFakeSocial.tsx
@@ -147,8 +147,8 @@ const separator = css`
 	text-align: center;
 	margin-top: ${space[4]}px;
 
-	:before,
-	:after {
+	::before,
+	::after {
 		content: '';
 		flex: 1;
 		border-bottom: 1px solid ${line.primary};

--- a/dotcom-rendering/src/components/Standfirst.amp.tsx
+++ b/dotcom-rendering/src/components/Standfirst.amp.tsx
@@ -16,7 +16,7 @@ const ListStyle = (iconColour: string) => css`
 		}
 	}
 
-	li:before {
+	li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;

--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -39,7 +39,7 @@ const nestedStyles = (format: ArticleFormat) => {
 			}
 		}
 
-		li:before {
+		li::before {
 			display: inline-block;
 			content: '';
 			border-radius: 50%;
@@ -258,7 +258,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 							max-width: 460px;
 						}
 						color: ${palette('--standfirst-text')};
-						li:before {
+						li::before {
 							height: 17px;
 							width: 17px;
 						}
@@ -288,7 +288,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 					return css`
 						max-width: 540px;
 						color: ${palette('--standfirst-text')};
-						li:before {
+						li::before {
 							height: 15px;
 							width: 15px;
 						}

--- a/dotcom-rendering/src/components/SubMeta.amp.tsx
+++ b/dotcom-rendering/src/components/SubMeta.amp.tsx
@@ -35,7 +35,7 @@ const linkStyle = (pillar: ArticleTheme) => css`
 	text-decoration: none;
 	color: ${pillarPalette_DO_NOT_USE[pillar].main};
 	${textSans15};
-	:after {
+	::after {
 		content: '/';
 		${textSans15};
 		position: absolute;
@@ -71,7 +71,7 @@ const sectionLinkStyle = (pillar: ArticleTheme) => css`
 	color: ${pillarPalette_DO_NOT_USE[pillar].main};
 	${article17};
 
-	:after {
+	::after {
 		content: '/';
 		${article17};
 		position: absolute;

--- a/dotcom-rendering/src/components/SubNav.importable.tsx
+++ b/dotcom-rendering/src/components/SubNav.importable.tsx
@@ -149,7 +149,7 @@ const listItemStyle = (currentPillarTitle?: string) => {
 		? frontSubNavBorder(currentPillarTitle)
 		: palette('--sub-nav-border');
 	return css`
-		:after {
+		::after {
 			content: '';
 			display: inline-block;
 			width: 0;

--- a/dotcom-rendering/src/components/SupportingContent.tsx
+++ b/dotcom-rendering/src/components/SupportingContent.tsx
@@ -56,7 +56,7 @@ const horizontalGrid = css`
 
 const horizontalLineStyle = css`
 	margin-top: ${space[3]}px;
-	:before {
+	::before {
 		position: absolute;
 		top: -${space[2]}px;
 		left: 0;
@@ -75,7 +75,7 @@ const horizontalLineStyle = css`
 
 const verticalLineStyle = css`
 	/* The last child doesn't need a dividing right line */
-	:not(:last-child):after {
+	:not(:last-child)::after {
 		content: '';
 		position: absolute;
 		top: 0;

--- a/dotcom-rendering/src/components/TextBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.amp.tsx
@@ -17,7 +17,7 @@ const ListStyle = (iconColour: string) => css`
 		}
 	}
 
-	li:before {
+	li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -193,7 +193,7 @@ const styles = (format: ArticleFormat) => css`
 		}
 	}
 
-	&:is(ul) > li:before {
+	&:is(ul) > li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 50%;

--- a/dotcom-rendering/src/components/TimelineAtom.amp.tsx
+++ b/dotcom-rendering/src/components/TimelineAtom.amp.tsx
@@ -22,7 +22,7 @@ const highlight = css`
 `;
 
 const eventIconStyle = css`
-	:before {
+	::before {
 		content: '';
 		width: 16px;
 		height: 16px;

--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -272,7 +272,7 @@ const subNavWrapper = css`
 	}
 
 	${from.tablet} {
-		:before {
+		::before {
 			content: '';
 			border-left: 1px solid ${themePalette('--masthead-nav-lines')};
 			position: absolute;
@@ -281,7 +281,7 @@ const subNavWrapper = css`
 			bottom: 0;
 		}
 
-		:after {
+		::after {
 			content: '';
 			border-left: 1px solid ${themePalette('--masthead-nav-lines')};
 			position: absolute;

--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -57,7 +57,7 @@ const alignLeftStyles = css`
 
 const verticalDividerStyles = css`
 	${from.desktop} {
-		:before {
+		::before {
 			content: '';
 			border-left: 1px solid
 				${themePalette('--masthead-top-bar-vertical-divider')};

--- a/dotcom-rendering/src/components/TopMetaLiveblog.amp.tsx
+++ b/dotcom-rendering/src/components/TopMetaLiveblog.amp.tsx
@@ -23,7 +23,7 @@ const ListStyle = (iconColour: string) => css`
 		}
 	}
 
-	li:before {
+	li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;

--- a/dotcom-rendering/src/components/TwitterBlockComponent.amp.tsx
+++ b/dotcom-rendering/src/components/TwitterBlockComponent.amp.tsx
@@ -14,7 +14,7 @@ const ListStyle = (iconColour: string) => css`
 		}
 	}
 
-	li:before {
+	li::before {
 		display: inline-block;
 		content: '';
 		border-radius: 6px;

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -453,7 +453,7 @@ const privacySettingsLinkStyles = css`
 `;
 
 const caretStyles = css`
-	&:before {
+	&::before {
 		content: '';
 		display: block;
 		position: absolute;
@@ -475,7 +475,7 @@ const caretStyles = css`
 		}
 	}
 
-	&:after {
+	&::after {
 		content: '';
 		display: block;
 		position: absolute;

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -210,7 +210,7 @@ const Box = ({ children }: { children: React.ReactNode }) => (
 			*/
 			${from.mobileLandscape} {
 				position: relative;
-				:after {
+				::after {
 					content: '';
 					display: block;
 					position: absolute;

--- a/dotcom-rendering/src/layouts/lib/interactiveLegacyStyling.ts
+++ b/dotcom-rendering/src/layouts/lib/interactiveLegacyStyling.ts
@@ -50,8 +50,8 @@ export const interactiveGlobalStyles = css`
 	/* Scope this as tightly as possible. Otherwise, e.g. box-model will break
 	footer. */
 	body article {
-		*:before,
-		*:after {
+		*::before,
+		*::after {
 			box-sizing: content-box;
 		}
 

--- a/dotcom-rendering/src/lib/verticalDivider.ts
+++ b/dotcom-rendering/src/lib/verticalDivider.ts
@@ -7,7 +7,7 @@ export const verticalDivider = (
 ): SerializedStyles => {
 	return css`
 		${from.tablet} {
-			:before {
+			::before {
 				content: '';
 				display: block;
 				position: absolute;

--- a/dotcom-rendering/src/lib/verticalDividerWithBottomOffset.ts
+++ b/dotcom-rendering/src/lib/verticalDividerWithBottomOffset.ts
@@ -8,7 +8,7 @@ export function verticalDividerWithBottomOffset(
 ): SerializedStyles {
 	return css`
 		${from.tablet} {
-			:before {
+			::before {
 				content: '';
 				display: block;
 				position: absolute;

--- a/dotcom-rendering/stylelint.config.mjs
+++ b/dotcom-rendering/stylelint.config.mjs
@@ -31,5 +31,6 @@ export default {
 					'Please use the source-foundations palette variables instead of rgba values',
 			},
 		],
+		'selector-pseudo-element-colon-notation': 'double',
 	},
 };


### PR DESCRIPTION
## What does this change?

Adds Stylelint rule to enforce double colon syntax for pseudo elements and updates existing styles

## Why?

Pseudo elements are preceded with a double colon to distinguish them from pseudo selectors which use a single colon.

```css
/* Pseudo selector */
a:hover {}

/* Pseudo element */
a::before {}

a:hover::before {}
```

For backwards compatibility modern browsers support the single colon syntax for the pseudo elements introduced in CSS levels 1 and 2 (`:first-line`, `:first-letter`, `:before` and `:after`), but require a double colon for newer pseudo elements such as `::placeholder` and `::marker`.

For clarity and consistency we should enforce the double colon syntax for _all_ pseudo elements.
