### PR TITLE
Remove browser version comments in `browser-targets.js`

### DIFF
--- a/dotcom-rendering/webpack/browser-targets.js
+++ b/dotcom-rendering/webpack/browser-targets.js
@@ -28,18 +28,6 @@ const rawTargets = getTargetsFromBrowsersList({ browsers });
  *
  * https://github.com/guardian/csnx/tree/main/libs/%40guardian/browserslist-config
  *
- * This currently returns:
- *
- * {
- *	chrome: '67.0.0',
- *	edge: '99.0.0',
- *	firefox: '78.0.0',
- *	ios: '10.3.0',
- *	opera: '91.0.0',
- *	safari: '10.1.0',
- *	samsung: '11.1.0'
- * }
- *
  * SWC however will not transpile dynamic imports when there are browser targets
  * that do not support them.
  *


### PR DESCRIPTION
## What does this change?

Remove browser version comments in `browser-targets.js` as they are out of date and don't reflect actual values.

For reference:

[browserslist-config](https://github.com/guardian/csnx/tree/main/libs/%40guardian/browserslist-config) is used to derive the browser targets SWC uses to transpile our JS:

https://github.com/guardian/dotcom-rendering/blob/14efc6e7e91b4a63dc4f23042e49dfc04e07faa6/dotcom-rendering/webpack/browser-targets.js#L15

https://github.com/guardian/dotcom-rendering/blob/14efc6e7e91b4a63dc4f23042e49dfc04e07faa6/dotcom-rendering/webpack/webpack.config.client.js#L88

Our current targets are visible here:

https://github.com/guardian/dotcom-rendering/blob/14efc6e7e91b4a63dc4f23042e49dfc04e07faa6/dotcom-rendering/webpack/browser-targets.test.ts#L20-L28
