### PR TITLE
Update `browserslist` to latest version

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -119,7 +119,7 @@
 		"babel-plugin-polyfill-corejs3": "0.12.0",
 		"babel-plugin-transform-runtime": "6.23.0",
 		"body-parser": "1.20.3",
-		"browserslist": "4.23.0",
+		"browserslist": "4.24.4",
 		"buffer": "6.0.3",
 		"chalk": "4.1.2",
 		"clean-css": "5.3.3",

--- a/dotcom-rendering/webpack/browser-targets.js
+++ b/dotcom-rendering/webpack/browser-targets.js
@@ -31,20 +31,19 @@ const rawTargets = getTargetsFromBrowsersList({ browsers });
  * SWC however will not transpile dynamic imports when there are browser targets
  * that do not support them.
  *
- * ios 10.3.0 and safari 10.1.0 do not support dynamic imports:
+ * iOS 10.3.0 does not support dynamic imports:
  *
  * https://caniuse.com/es6-module-dynamic-import
  *
- * So if unsuported versions are encountered we upgrade to the next versions that
- * do support dynamic imports i.e.:
+ * So if an unsupported version is encountered we upgrade to the next version
+ * that does support dynamic imports i.e.:
  *
- * ios 11 and safari 11.1.0
+ * iOS 11
  *
  * This is safe as browsers without dynamic import support should be
  * covered by the dynamic import polyfill.
  *
- * This logic can be removed once ios 10.3 and safari 10.1 no longer
- * appear in browserslist.
+ * This logic can be removed once iOS 10.3 no longer appears in browserslist.
  *
  * @typedef {Object.<string, string>} Targets
  * @param {Targets} targets
@@ -55,14 +54,8 @@ const upgradeTargets = (targets) => {
 		([browser, version]) => {
 			const versions = version.split('.').map(Number);
 			const major = versions[0] ?? 0;
-			const minor = versions[1] ?? 0;
 			if (browser === 'ios' && major < 11) {
 				return ['ios', '11'];
-			} else if (
-				browser === 'safari' &&
-				(major < 11 || (major === 11 && minor === 0))
-			) {
-				return ['safari', '11.1.0'];
 			}
 			return [browser, version];
 		},

--- a/dotcom-rendering/webpack/browser-targets.test.ts
+++ b/dotcom-rendering/webpack/browser-targets.test.ts
@@ -23,7 +23,7 @@ describe('Browser targets are as expected', () => {
 			firefox: '78.0.0',
 			ios: '11', // upgraded
 			opera: '105.0.0',
-			safari: '11.1.0', // upgraded
+			safari: '11.1.0',
 			samsung: '17.0.0',
 		});
 	});
@@ -36,20 +36,6 @@ describe('Upgrade browser targets', () => {
 		expect(upgradeTargets({ ios: '10' })).toEqual({ ios: '11' });
 		expect(upgradeTargets({ ios: '10.3' })).toEqual({ ios: '11' });
 		expect(upgradeTargets({ ios: '10.9.9' })).toEqual({ ios: '11' });
-		// safari < 11.1
-		expect(upgradeTargets({ safari: '10.11' })).toEqual({
-			safari: '11.1.0',
-		});
-		expect(upgradeTargets({ safari: '11' })).toEqual({ safari: '11.1.0' });
-		expect(upgradeTargets({ safari: '11.0' })).toEqual({
-			safari: '11.1.0',
-		});
-		expect(upgradeTargets({ safari: '11.0.11' })).toEqual({
-			safari: '11.1.0',
-		});
-		expect(upgradeTargets({ safari: '11.0.11' })).toEqual({
-			safari: '11.1.0',
-		});
 	});
 	test('do not modify targets for supported later versions', () => {
 		// ios >= 11
@@ -58,13 +44,5 @@ describe('Upgrade browser targets', () => {
 		expect(upgradeTargets({ ios: '11.0.0' })).toEqual({ ios: '11.0.0' });
 		expect(upgradeTargets({ ios: '12' })).toEqual({ ios: '12' });
 		expect(upgradeTargets({ ios: '14.10.1' })).toEqual({ ios: '14.10.1' });
-		// safari >= 11.1
-		expect(upgradeTargets({ safari: '11.1' })).toEqual({ safari: '11.1' });
-		expect(upgradeTargets({ safari: '11.1.0' })).toEqual({
-			safari: '11.1.0',
-		});
-		expect(upgradeTargets({ safari: '12.10.0' })).toEqual({
-			safari: '12.10.0',
-		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
         version: 8.1.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
-        version: 6.1.0(browserslist@4.23.0)(tslib@2.6.2)
+        version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 50.13.0
         version: 50.13.0(@swc/core@1.9.2)(@types/node@20.14.10)(aws-cdk-lib@2.179.0)(aws-cdk@2.179.0)(constructs@10.3.0)(typescript@5.5.3)
@@ -572,8 +572,8 @@ importers:
         specifier: 1.20.3
         version: 1.20.3
       browserslist:
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.24.4
+        version: 4.24.4
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -3804,13 +3804,13 @@ packages:
     resolution: {integrity: sha512-Sr2bvoUprOwuYVI4K1fpvDlOj5/5AMfTMZ/kx7gc8q/AUggIoejU3uvF00nFq9/AAe1EpLQcNU/mOfih8+oDGg==}
     dev: false
 
-  /@guardian/browserslist-config@6.1.0(browserslist@4.23.0)(tslib@2.6.2):
+  /@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2):
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
     peerDependencies:
       browserslist: ^4.22.2
       tslib: ^2.6.2
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.24.4
       tslib: 2.6.2
     dev: false
 
@@ -8654,28 +8654,6 @@ packages:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
     dev: false
 
-  /browserslist@4.23.0:
-    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001668
-      electron-to-chromium: 1.5.38
-      node-releases: 2.0.18
-      update-browserslist-db: 1.1.0(browserslist@4.23.0)
-    dev: false
-
-  /browserslist@4.24.0:
-    resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001707
-      electron-to-chromium: 1.5.123
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.24.0)
-    dev: false
-
   /browserslist@4.24.4:
     resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -8838,10 +8816,6 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: false
-
-  /caniuse-lite@1.0.30001668:
-    resolution: {integrity: sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==}
     dev: false
 
   /caniuse-lite@1.0.30001707:
@@ -10203,10 +10177,6 @@ packages:
 
   /electron-to-chromium@1.5.123:
     resolution: {integrity: sha512-refir3NlutEZqlKaBLK0tzlVLe5P2wDKS7UQt/3SpibizgsRAPOsqQC3ffw1nlv3ze5gjRQZYHoPymgVZkplFA==}
-    dev: false
-
-  /electron-to-chromium@1.5.38:
-    resolution: {integrity: sha512-VbeVexmZ1IFh+5EfrYz1I0HTzHVIlJa112UEWhciPyeOcKJGeTv6N8WnG4wsQB81DGCaVEGhpSb6o6a8WYFXXg==}
     dev: false
 
   /emittery@0.13.1:
@@ -14880,10 +14850,6 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: false
 
-  /node-releases@2.0.18:
-    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
-    dev: false
-
   /node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
     dev: false
@@ -18186,28 +18152,6 @@ packages:
       webpack-virtual-modules: 0.6.1
     dev: false
 
-  /update-browserslist-db@1.1.0(browserslist@4.23.0):
-    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.23.0
-      escalade: 3.2.0
-      picocolors: 1.1.1
-    dev: false
-
-  /update-browserslist-db@1.1.3(browserslist@4.24.0):
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.24.0
-      escalade: 3.2.0
-      picocolors: 1.1.1
-    dev: false
-
   /update-browserslist-db@1.1.3(browserslist@4.24.4):
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -18722,7 +18666,7 @@ packages:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.14.0
-      browserslist: 4.24.0
+      browserslist: 4.24.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.5.3
@@ -18762,7 +18706,7 @@ packages:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.14.0
-      browserslist: 4.24.0
+      browserslist: 4.24.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.5.3


### PR DESCRIPTION
## What does this change?

- Bumps `browserslist` to 4.24.4
- Removes logic to 'upgrade' Safari versions below 11.1.0 in target browsers 

## Why?

- Gets rid of warning about outdated `caniuse-lite` database when starting the dev server
- Safari 11.1.0 is the oldest version that appears in our browser usage data so we no longer need to upgrade older versions