### PR TITLE
allow any start URL in the manifest

### DIFF
--- a/dotcom-rendering/src/static/manifest.json
+++ b/dotcom-rendering/src/static/manifest.json
@@ -41,6 +41,6 @@
 		}
 	],
 	"name": "The Guardian",
-	"scope": "https://www.theguardian.com/",
+	"scope": "/",
 	"theme_color": "#052962"
 }

--- a/dotcom-rendering/src/static/manifest.json
+++ b/dotcom-rendering/src/static/manifest.json
@@ -42,6 +42,5 @@
 	],
 	"name": "The Guardian",
 	"scope": "https://www.theguardian.com/",
-	"start_url": "https://www.theguardian.com/",
 	"theme_color": "#052962"
 }


### PR DESCRIPTION
## What does this change?

#8727 added a better "add to homescreen/dock" experience, but it always opens at the site root, whatever page you add it from.

This removes that, so that any route under the guardian domain can be saved.

A more complete solution would be to generate manifests programatically, so that we could set a more suitable name etc (e.g. "World News") but this is a much quicker fix.

## Why?

In response to user feedback that they could not bookmark specific pages.

