### PR TITLE
Remove no longer relevant todo from `SvgMediaControlsPlay` icon

### DIFF
--- a/dotcom-rendering/src/components/SvgMediaControlsPlay.tsx
+++ b/dotcom-rendering/src/components/SvgMediaControlsPlay.tsx
@@ -1,8 +1,3 @@
-/**
- * TODO: This is a local copy of the updated `SvgMediaControlsPlay` icon which
- * is required by the new media card designs and can be removed once the Source
- * icon library has been updated and published.
- */
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source/foundations';
 import { type IconProps } from '@guardian/source/react-components';


### PR DESCRIPTION
## What does this change?

Removes todo to remove copy of icon once Source icon library has been updated

## Why?

This icon was added to the project as an updated version of Source's `SvgMediaControlsPlay` icon (required for Fairground designs) as a new release of Source with an updated icon library was not available.

An updated icon library is now available in Source v9, but the copy of the icon in DCAR has since been modified such that we can no longer swap it out for the canonical Source version. The todo is therefore no longer relevant as we need to retain the customised version.