### PR TITLE
Update `browser-support` doc with the last run of `@guardian/browserslist`

### DIFF
--- a/dotcom-rendering/docs/principles/browser-support.md
+++ b/dotcom-rendering/docs/principles/browser-support.md
@@ -14,25 +14,26 @@ such as supporting TLS (IE<6, Firefox 1). These browsers will not be able to see
 These are [browsers that we publicly recommend](https://www.theguardian.com/help/recommended-browsers) our
 audience use. They will receive the modern experience.
 
-If a browser version has more than 0.2% of traffic, it is considered to be a candidate for recommendation.
+If a browser version has more than 0.01% of traffic, it is considered to be a candidate for recommendation.
+
 All browser versions above and including the minimum candidate version are considered recommended browsers.
 
-As of 6th November 2018, our browser usage for browsers versions with over 0.2% of traffic over the last 14 days
-looks like:
+As of 19th February 2024, our recommended browsers list is:
 
-| Browser           | Min version | Usage >= version |
-| ----------------- | ----------- | ---------------- |
-| Chrome            | 49          | 46.95%           |
-| iOS Safari        | 10.2        | 26.97%           |
-| Firefox           | 48          | 3.07%            |
-| Safari            | 10          | 3.02%            |
-| Internet Explorer | 11          | 2.79%            |
-| Samsung Internet  | 7           | 2.01%            |
-| Edge              | 17          | 1.31%            |
-| UC Browser        | 12          | 0.30%            |
-| Opera             | 56          | 0.25%            |
+| Browser           | Min version |
+| ----------------- | ----------- |
+| Chrome            | 70          |
+| Chrome (Android)  | 119         |
+| Edge              | 109         |
+| Firefox           | 78          |
+| Firefox (Android) | 119         |
+| Opera             | 95          |
+| Opera (mobile)    | 73          |
+| Safari            | 11.1        |
+| Safari (iOS)      | 10.3        |
+| Samsung Internet  | 17          |
 
-The above table was calculated based on data from Google Analytics.
+The above table was calculated by [@guardian/browserslist-config](https://github.com/guardian/csnx/tree/main/libs/%40guardian/browserslist-config) based on data from Google Analytics.
 
 ## Cutting the mustard
 


### PR DESCRIPTION
## What does this change?

Update `browser-support` doc with the last run of `@guardian/browserslist` as of Feb 2024.

We still need to:

- update with the new mechanism for browser usage but that has not been finalised
- revisit the 'cutting the mustard' as it is probably no longer necessary

## Why?

Reduce potential confusion.
