### PR TITLE
Narrow `dotcom-platform` In CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,9 @@
 /dotcom-rendering/scripts/                      @guardian/dotcom-platform
 /dotcom-rendering/src/client/islands/           @guardian/dotcom-platform
 /dotcom-rendering/src/client/userFeatures/      @guardian/supporter-revenue-stream
+/dotcom-rendering/src/components/AdBlock*       @guardian/commercial-dev
+/dotcom-rendering/src/components/AdSlot*        @guardian/commercial-dev
+/dotcom-rendering/src/components/AdP*           @guardian/commercial-dev
 /dotcom-rendering/src/components/marketing/     @guardian/growth
 /dotcom-rendering/src/server/                   @guardian/dotcom-platform
 /dotcom-rendering/webpack/                      @guardian/dotcom-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,24 @@
 # This file is matched from top down; subsequent matches override previous matches.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# By default all files are owned by these teams:
-* 												@guardian/dotcom-platform
+# Files at the root of the project
+/*                                              @guardian/dotcom-platform
 
-/dotcom-rendering/src/components/marketing/ 	@guardian/growth
+/.github/ 										@guardian/dotcom-platform
+/.husky/ 										@guardian/dotcom-platform
+/.vscode/ 										@guardian/dotcom-platform
+/apps-rendering/ 								@guardian/dotcom-platform
+
+# Files at the root of `/dotcom-rendering`
+/dotcom-rendering/*								@guardian/dotcom-platform
+
+/dotcom-rendering/.storybook/					@guardian/dotcom-platform
+/dotcom-rendering/cdk/				        	@guardian/dotcom-platform
+/dotcom-rendering/configs/				       	@guardian/dotcom-platform
+/dotcom-rendering/scripts/				       	@guardian/dotcom-platform
+/dotcom-rendering/src/client/islands/		    @guardian/dotcom-platform
 /dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
+/dotcom-rendering/src/components/marketing/ 	@guardian/growth
+/dotcom-rendering/src/server/       		    @guardian/dotcom-platform
+/dotcom-rendering/webpack/				       	@guardian/dotcom-platform
+/scripts/               				       	@guardian/dotcom-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,21 +4,21 @@
 # Files at the root of the project
 /*                                              @guardian/dotcom-platform
 
-/.github/ 										@guardian/dotcom-platform
-/.husky/ 										@guardian/dotcom-platform
-/.vscode/ 										@guardian/dotcom-platform
-/apps-rendering/ 								@guardian/dotcom-platform
+/.github/                                       @guardian/dotcom-platform
+/.husky/                                        @guardian/dotcom-platform
+/.vscode/                                       @guardian/dotcom-platform
+/apps-rendering/                                @guardian/dotcom-platform
 
 # Files at the root of `/dotcom-rendering`
-/dotcom-rendering/*								@guardian/dotcom-platform
+/dotcom-rendering/*                             @guardian/dotcom-platform
 
-/dotcom-rendering/.storybook/					@guardian/dotcom-platform
-/dotcom-rendering/cdk/				        	@guardian/dotcom-platform
-/dotcom-rendering/configs/				       	@guardian/dotcom-platform
-/dotcom-rendering/scripts/				       	@guardian/dotcom-platform
-/dotcom-rendering/src/client/islands/		    @guardian/dotcom-platform
-/dotcom-rendering/src/client/userFeatures/ 		@guardian/supporter-revenue-stream
-/dotcom-rendering/src/components/marketing/ 	@guardian/growth
-/dotcom-rendering/src/server/       		    @guardian/dotcom-platform
-/dotcom-rendering/webpack/				       	@guardian/dotcom-platform
-/scripts/               				       	@guardian/dotcom-platform
+/dotcom-rendering/.storybook/                   @guardian/dotcom-platform
+/dotcom-rendering/cdk/                          @guardian/dotcom-platform
+/dotcom-rendering/configs/                      @guardian/dotcom-platform
+/dotcom-rendering/scripts/                      @guardian/dotcom-platform
+/dotcom-rendering/src/client/islands/           @guardian/dotcom-platform
+/dotcom-rendering/src/client/userFeatures/      @guardian/supporter-revenue-stream
+/dotcom-rendering/src/components/marketing/     @guardian/growth
+/dotcom-rendering/src/server/                   @guardian/dotcom-platform
+/dotcom-rendering/webpack/                      @guardian/dotcom-platform
+/scripts/                                       @guardian/dotcom-platform


### PR DESCRIPTION
When a person or team is marked as a code owner for an area of the codebase, they are automatically requested for review whenever a PR modifies that area. At the moment, dotcom-platform is marked as a code owner for almost the entire codebase. This means that they receive a review request for essentially every PR that's opened.

This change alters the dotcom-platform team's entry in the CODEOWNERS file to target specific areas of the codebase. Note that this does not prevent PR authors from requesting reviews from dotcom-platform, or anyone else, as needed. It just narrows the list of PRs for which the team is asked for review automatically.
