### PR TITLE
Crop YouTube overlay image to fit aspect ratio

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -55,6 +55,7 @@ export const YoutubeAtomPicture = ({
 				// https://stackoverflow.com/questions/10844205/html-5-strange-img-always-adds-3px-margin-at-bottom
 				// why did we add the css `vertical-align: middle;` to the img tag
 				css={css`
+					object-fit: cover;
 					vertical-align: middle;
 				`}
 			/>


### PR DESCRIPTION
## What does this change?

Crops YouTube overlay images as needed so they fill the container whilst maintaining their aspect ratio

## Why?

This prevents overlay images from being stretched when their aspect ratio does not match that of the YouTube atom

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6b7a776e-9ac3-465a-b1bd-793c0bc46064
[after]: https://github.com/user-attachments/assets/221af06d-5537-40a5-aa89-92838b992be6
