### PR TITLE
Apply padding to immersive interactive captions

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -484,6 +484,7 @@ export const InteractiveBlockComponent = ({
 						captionText={caption}
 						format={format}
 						isMainMedia={isMainMedia}
+						isImmersive={role === 'immersive'}
 					/>
 				)}
 			</figure>


### PR DESCRIPTION
## What does this change?

Applies `isImmersive` prop to captions in immersive interactives. This adds additional padding to compensate for the negative margins used to pull the elements outside the article container and aligns them with the body copy.

(See #13163 for the original PR which added this prop for captions on immersive images.)

## Why?

To prevent captions stretching across the full width of the viewport and touching the edges. This occurs on mobile and when the desktop breakpoint is reached (980px).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |

[before1]: https://github.com/user-attachments/assets/95e1a0f8-8dc1-436b-9098-88e3dc56bafb
[after1]: https://github.com/user-attachments/assets/6c22b615-d46a-4bf7-aab3-fe42d5eed066
[before2]: https://github.com/user-attachments/assets/5349a0c1-74b0-49bd-a934-14e812745495
[after2]: https://github.com/user-attachments/assets/0bd61a87-5909-4d17-b073-7a1964b2ba3e
