### PR TITLE
Show ToC when there is at least 1 heading

### DIFF
--- a/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.test.ts
@@ -60,20 +60,15 @@ describe('Enhance Table of Contents', () => {
 		]);
 	});
 
-	it('will not return a toc if the are fewer than 3 h2s', () => {
+	it('will not return a toc if there are no h2s', () => {
 		const input: Block[] = [
 			{
 				...blockMetaData,
 				elements: [
 					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'h2One',
-						html: '<h2>This is the h2 text</h2>',
-					},
-					{
-						_type: 'model.dotcomrendering.pageElements.SubheadingBlockElement',
-						elementId: 'h2Two',
-						html: '<h2>This is the h2 text</h2>',
+						_type: 'model.dotcomrendering.pageElements.TextBlockElement',
+						elementId: 'text',
+						html: 'Text',
 					},
 				],
 			},

--- a/dotcom-rendering/src/model/enhanceTableOfContents.ts
+++ b/dotcom-rendering/src/model/enhanceTableOfContents.ts
@@ -112,5 +112,5 @@ export const enhanceTableOfContents = (
 		}
 	}
 
-	return tocItems.length >= 3 ? tocItems : undefined;
+	return tocItems.length >= 1 ? tocItems : undefined;
 };


### PR DESCRIPTION
## What does this change?

Reduces the minimum number of headings required to trigger a table of contents from 3 to 1.

## Why?

We got this request from Rich:

> We've noticed that the ToC is still not showing on our Sports Weekend piece, but that it is because it's only appearing when there are 3 or more h2s on the page. I wondered if we could update this logic? So if the ToC is on, it shows up when there is at least 1 h2 on the page. As we will only have two h2s on our sports piece.

## Screenshots

| Composer      | Before      |After      |
| ----------- | ---------- |---------- |
| <img width="1853" alt="Screenshot 2025-04-08 at 10 36 08" src="https://github.com/user-attachments/assets/ed8783b5-ffbf-4e0a-97f2-482d029324d2" /> | <img width="886" alt="Screenshot 2025-04-08 at 10 35 56" src="https://github.com/user-attachments/assets/ec8b38de-965c-493e-b5d9-31001a1749f8" />|  <img width="897" alt="Screenshot 2025-04-08 at 10 33 28" src="https://github.com/user-attachments/assets/2bf23b7a-f3ca-4813-acec-eaad13e3c157" /> |
