### PR TITLE
Update user-agent script

### DIFF
--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -44,7 +44,11 @@ const { QueryExecutionId } = await client.send(
   WHERE year = ${date.year}
 	  AND month = ${String(date.month).padStart(2, "0")}
 	  AND day = ${String(date.day).padStart(2, "0")}
-      AND request_user_agent NOT LIKE 'Guardian%'
+	  AND request_user_agent NOT LIKE 'Guardian/% CFNetwork%' 
+	  AND request_user_agent NOT LIKE 'GuardianNews/%'
+	  AND request_user_agent NOT LIKE 'Guardian\%20Editions/%'
+	  AND response_status=200
+	  AND url != '/robots.txt'
   GROUP BY request_user_agent
   ORDER BY request_count desc
   LIMIT ${100_000}`,

--- a/scripts/deno/bots.ts
+++ b/scripts/deno/bots.ts
@@ -44,7 +44,7 @@ const { QueryExecutionId } = await client.send(
   WHERE year = ${date.year}
 	  AND month = ${String(date.month).padStart(2, "0")}
 	  AND day = ${String(date.day).padStart(2, "0")}
-	  AND request_user_agent NOT LIKE 'Guardian/% CFNetwork%' 
+	  AND request_user_agent NOT LIKE 'Guardian/%Darwin%' 
 	  AND request_user_agent NOT LIKE 'GuardianNews/%'
 	  AND request_user_agent NOT LIKE 'Guardian\%20Editions/%'
 	  AND response_status=200


### PR DESCRIPTION
## What does this change?

I've updated the script:
 - To more accurately exclude our apps
 - Only include requests that return `200` (so ignore redirects and errors)
 - Only include requests to urls other than `/robots.txt`
 
## Why?
Primarily so things we've successfully blocked on the edge should no longer show up in these logs, and better reflect crawler activity that's meaningful from an IP protection perspective.
