### PR TITLE
Implement interactive URL darkmode fix for additional path groups

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -334,7 +334,10 @@ export const InteractiveBlockComponent = ({
 			: false;
 
 	const isUploaderEmbedPath =
-		url && url.includes('interactive.guim.co.uk/uploader/embed/')
+		url &&
+		(url.includes('interactive.guim.co.uk/uploader/embed/') ||
+			url.includes('superyacht') ||
+			url.includes('choropleth_map_maker'))
 			? true
 			: false;
 


### PR DESCRIPTION
## What does this change?
This work extends the work to add a `darkmode=false` search query to the end of eligible interactive embed URLs, as detailed in PR #13647 

## Why?
Following the merging of the previous PR into production, Australian colleagues have requested we add similar functionality for two types of interactives they create:
+ `superyacht` (for chart embeds)
+ `choropleth_map_maker`

## Screenshots
See testing results comment below

## Testing
Testing in the CODE environment:
+ Create an article in Composer CODE which includes a number of these interactive embeds, alongside a number of embeds that should not be affected by the change
  - View the article in Preview and record the iframe URLs for each embed
+ Deploy this branch to DCR CODE
  - Repeat the above test. Any embed which contains the text `superyacht` or `choropleth_map_maker` should now include the appended search query string - either `?darkmode=false` or `&darkmode=false`

Suitable existing interactives URLs for this test include:

**Superyacht**
- https://interactive.guim.co.uk/embed/superyacht/index.html?key=oz-datablogs-2024-federal-polling-page-poll-table&location=yacht-charter-data
- https://interactive.guim.co.uk/embed/superyacht/index.html?location=safeharbour&key=5affd5d9-5a6e-4f78-b473-331710333e78

**choropleth_map_maker**
- https://interactive.guim.co.uk/embed/iframeable/2019/03/choropleth_map_maker/v1/html/index.html?location=docsdata&key=1iJjM2HFtBi75ZkIW1QTmS1B9uSIGo4N2TzafBxTXXuE
- https://interactive.guim.co.uk/embed/iframeable/2019/03/choropleth_map_maker/v1/html/index.html?key=oz-datablogs-social-infrastructure-growth-areas

**Unaffected URLs**
- https://interactive.guim.co.uk/2023-embeds/2022/11/recurring-chart/v2/embed/waffle/main.html?dataurl=https://interactive.guim.co.uk/docsdata-test/1WAiRnmCFNhahEwOVr2Rd0HKd5nFzgoNc1-TbRZzmKo0.json
- https://interactive.guim.co.uk/embed/2025/02/deakin-dyn4/index.html