### PR TITLE
Add a comment to link to gateway's persistUserBenefitsCookies

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -35,6 +35,16 @@ const requestNewData = async () => {
 	return syncDataFromUserBenefitsApi(authStatus).then(persistResponse);
 };
 
+/**
+ * Persist the user benefits response to cookies
+ *
+ * If new cookies are added/removed/edited, update the persistUserBenefitsCookie function in Gateway
+ * https://github.com/guardian/gateway/blob/252b2b2f24be826da42c6e7c1b1e202594184023/src/server/lib/user-features.ts#L88
+ *
+ * In gateway, the cookies are set after authentication.
+ *
+ * @param {UserBenefits} userBenefitsResponse
+ */
 const persistResponse = (userBenefitsResponse: UserBenefits) => {
 	createOrRenewCookie(USER_BENEFITS_EXPIRY_COOKIE);
 	if (userBenefitsResponse.hideSupportMessaging) {


### PR DESCRIPTION
## What does this change?
Adds a comment linking to the persistUserBenefitsCookies function in the gateway repo.
## Why?
The user-benefits API can be called from both Gateway (during authentication) and DCR (on page load if the cookies are missing). This comment helps inform developers that any updates to the cookie logic in DCR should also be reflected in Gateway.
