### PR TITLE
Add isImmersive to getFrontsAdPositions.ts

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -236,7 +236,8 @@ const getCollectionHeight = (
 				return 6;
 			} else if (
 				grouped.splash[0]?.boostLevel === 'megaboost' ||
-				grouped.splash[0]?.boostLevel === 'gigaboost'
+				grouped.splash[0]?.boostLevel === 'gigaboost' ||
+				grouped.splash[0]?.isImmersive
 			) {
 				return 6;
 			} else {


### PR DESCRIPTION
## What does this change?
Adds a check for a card with the isImmersive property set to true to the ad spacing decision for flexible general.

## Why?
An immersive card is a xlarge card which is full width across all breakpoints. It renders the same size as a splash card on tablet and as a feature card below tablet. As such it should be calculated as the same space.


## Screenshots

| mobile    | tablet and above      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5aeade95-4d48-4a58-9e1e-b7f5007f43b7
[after]: https://github.com/user-attachments/assets/82dfff41-5474-43b5-b3b6-87e46aee417a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
