### PR TITLE
Further changes to tables of contents

### DIFF
--- a/dotcom-rendering/src/components/TableOfContents.importable.tsx
+++ b/dotcom-rendering/src/components/TableOfContents.importable.tsx
@@ -141,10 +141,7 @@ export const TableOfContents = ({ tableOfContents, format }: Props) => {
 	return (
 		<details
 			open={open}
-			css={[
-				detailsStyles,
-				tableOfContents.length > 5 ? stickyStyles : undefined,
-			]}
+			css={[detailsStyles, stickyStyles]}
 			data-component="table-of-contents"
 		>
 			<summary


### PR DESCRIPTION
## What does this change?

Makes two changes to the behaviour of the ToC (Table of Contents) component:

1) always make the ToC sticky regardless of number of items
2) automatically collapse the ToC when it becomes sticky (i.e. when it reaches the top of the viewport)

For 2) I went with the approach detailed here:

https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/

There might be a less hacky way though?

## Why?

Following on from https://github.com/guardian/dotcom-rendering/pull/12895 and https://github.com/guardian/dotcom-rendering/pull/13743 we got some feedback from Rich:

> Can we make the logic so it's always sticky? 
> 
> I don't know how inherently it's linked to the logic of the open vs. collapsed on page load. Currently when there is less than 5 the ToC is open on load, more than 5 collapsed. But obviously for a menu that is sticky but has less than 5 items, we want it to be open on load but collapse when it becomes sticky. 
> 
> Hope that makes sense and I'm not over complicating things too much!

## Screenshots

### Before

https://github.com/user-attachments/assets/562b9a50-c93f-4085-ad60-c1c94fc90d78

### After

https://github.com/user-attachments/assets/ba0de636-3c6d-4a56-bddb-9171d1817be0


