### PR TITLE
Created stacked carousel component and use in scrollable small

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -281,7 +281,6 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
-						sectionId={sectionId}
 					/>
 				</Island>
 			);

--- a/dotcom-rendering/src/components/ScrollableCarouselStacked.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarouselStacked.tsx
@@ -1,0 +1,187 @@
+import { css } from '@emotion/react';
+import { from, space } from '@guardian/source/foundations';
+import { useRef } from 'react';
+import { palette } from '../palette';
+
+type Props = {
+	children: React.ReactNode;
+	carouselLength: number;
+	visibleCardsOnMobile: number;
+	visibleCardsOnTablet: number;
+};
+
+/**
+ * Grid sizing values to calculate negative margin used to pull navigation
+ * buttons outside of container into the outer grid column at wide breakpoint.
+ */
+const gridGap = 20;
+const gridGapMobile = 10;
+
+/**
+ * On mobile the carousel extends into the outer margins to use the full width
+ * of the screen. From tablet onwards the carousel sits within the page grid.
+ *
+ * The FrontSection container adds a -10px negative margin to either side of
+ * the content from tablet so we add the margins back to align the carousel with
+ * the grid. From leftCol we retain FrontSection's -10px negative margin on the
+ * left side so that the carousel extends into the the middle of the gutter
+ * between the grid columns to meet the dividing line.
+ */
+const containerStyles = css`
+	position: relative;
+	margin-left: -${gridGapMobile}px;
+	margin-right: -${gridGapMobile}px;
+	${from.mobileLandscape} {
+		margin-left: -${gridGap}px;
+		margin-right: -${gridGap}px;
+	}
+	${from.tablet} {
+		margin-left: ${gridGap / 2}px;
+		margin-right: ${gridGap / 2}px;
+	}
+	${from.leftCol} {
+		margin-left: 0;
+	}
+`;
+
+const carouselStyles = css`
+	display: grid;
+	width: 100%;
+	grid-auto-flow: unset;
+	grid-auto-columns: unset;
+	grid-auto-rows: unset;
+	gap: 20px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	overscroll-behavior: contain auto;
+
+	::-webkit-scrollbar {
+		display: none;
+	}
+	scrollbar-width: none;
+
+	padding-left: ${gridGapMobile}px;
+	padding-right: ${gridGapMobile}px;
+	scroll-padding-left: ${gridGapMobile}px;
+	${from.mobileLandscape} {
+		padding-left: ${gridGap}px;
+		padding-right: ${gridGap}px;
+		scroll-padding-left: ${gridGap}px;
+	}
+	${from.tablet} {
+		padding-left: 0;
+		padding-right: 0;
+		scroll-padding-left: 0;
+	}
+	${from.leftCol} {
+		padding-left: ${gridGap / 2}px;
+		scroll-padding-left: ${gridGap / 2}px;
+	}
+
+	grid-template-rows: repeat(2, auto);
+`;
+
+const itemStyles = css`
+	display: flex;
+	scroll-snap-align: start;
+	grid-area: span 1;
+	position: relative;
+	:not(:first-child)::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: -10px;
+		width: 1px;
+		background-color: ${palette('--card-border-top')};
+		transform: translateX(-50%);
+	}
+`;
+
+/**
+ * Generates CSS styles for a grid layout used in a carousel.
+ *
+ * @param {number} totalCards - The total number of cards in the carousel.
+ * @param {number} visibleCardsOnMobile - Number of cards to show at once on mobile.
+ * @param {number} visibleCardsOnTablet - Number of cards to show at once on tablet.
+ * @returns {string} - The CSS styles for the grid layout.
+ */
+const generateCarouselColumnStyles = (
+	totalCards: number,
+	visibleCardsOnMobile: number,
+	visibleCardsOnTablet: number,
+) => {
+	const columns = Math.ceil(totalCards / 2);
+	const peepingCardWidth = space[8];
+	const cardGap = 20;
+	const offsetPeepingCardWidth =
+		peepingCardWidth / visibleCardsOnMobile + cardGap;
+	const offsetCardGap =
+		(cardGap * (visibleCardsOnTablet - 1)) / visibleCardsOnTablet;
+
+	return css`
+		grid-template-columns: repeat(
+			${columns},
+			calc(
+				(100% / ${visibleCardsOnMobile}) - ${offsetPeepingCardWidth}px +
+					${gridGapMobile / visibleCardsOnMobile}px
+			)
+		);
+
+		${from.mobileLandscape} {
+			grid-template-columns: repeat(
+				${columns},
+				calc(
+					(100% / ${visibleCardsOnMobile}) -
+						${offsetPeepingCardWidth}px +
+						${gridGap / visibleCardsOnMobile}px
+				)
+			);
+		}
+		${from.tablet} {
+			grid-template-columns: repeat(
+				${columns},
+				calc(${100 / visibleCardsOnTablet}% - ${offsetCardGap}px)
+			);
+		}
+	`;
+};
+
+/**
+ * A component used in the scrollable small carousel to display up to two stacked rows of cards.
+ */
+export const ScrollableCarouselStacked = ({
+	children,
+	carouselLength,
+	visibleCardsOnMobile,
+	visibleCardsOnTablet,
+}: Props) => {
+	const carouselRef = useRef<HTMLOListElement | null>(null);
+
+	return (
+		<div css={containerStyles}>
+			<ol
+				ref={carouselRef}
+				css={[
+					carouselStyles,
+					generateCarouselColumnStyles(
+						carouselLength,
+						visibleCardsOnMobile,
+						visibleCardsOnTablet,
+					),
+				]}
+				data-heatphan-type="carousel"
+			>
+				{children}
+			</ol>
+		</div>
+	);
+};
+
+ScrollableCarouselStacked.Item = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => <li css={itemStyles}>{children}</li>;

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -5,7 +5,7 @@ import type {
 	DCRFrontCard,
 } from '../types/front';
 import { FrontCard } from './FrontCard';
-import { ScrollableCarousel } from './ScrollableCarousel';
+import { ScrollableCarouselStacked } from './ScrollableCarouselStacked';
 
 type Props = {
 	trails: DCRFrontCard[];
@@ -15,7 +15,6 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
-	sectionId: string;
 };
 
 /**
@@ -33,18 +32,16 @@ export const ScrollableSmall = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
-	sectionId,
 }: Props) => {
 	return (
-		<ScrollableCarousel
+		<ScrollableCarouselStacked
 			carouselLength={trails.length}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
-			sectionId={sectionId}
 		>
 			{trails.map((trail) => {
 				return (
-					<ScrollableCarousel.Item key={trail.url}>
+					<ScrollableCarouselStacked.Item key={trail.url}>
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}
@@ -68,9 +65,9 @@ export const ScrollableSmall = ({
 							showTopBarMobile={false}
 							canPlayInline={false}
 						/>
-					</ScrollableCarousel.Item>
+					</ScrollableCarouselStacked.Item>
 				);
 			})}
-		</ScrollableCarousel>
+		</ScrollableCarouselStacked>
 	);
 };


### PR DESCRIPTION
## What does this change?

Adds a stacked carousel component used in the scrollable small container. I preferred creating a new carousel rather than trying to adapt the previous one, as this felt different enough (and maybe in the future there'll be more use cases for this component), but open to feedback on this. 

todo: account for smaller number of cards in containers

## Why?

Part of this [F&C ticket ](https://trello.com/c/q3sBz3pX/1114-web-stacked-small-carousel)

## Video

https://github.com/user-attachments/assets/a40ac310-7ba4-43b5-ad65-33eaf8e08675


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
