### PR TITLE
Test client-side rendering with React

### DIFF
--- a/dotcom-rendering/webpack/bundles.js
+++ b/dotcom-rendering/webpack/bundles.js
@@ -9,7 +9,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = false;
+const BUILD_VARIANT = true;
 
 /**
  * Server-side test names for running variant test.

--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -139,13 +139,20 @@ module.exports = ({ build }) => ({
 			svgr,
 		],
 	},
-	resolve: {
-		alias: {
-			react: 'preact/compat',
-			'react-dom/test-utils': 'preact/test-utils',
-			'react-dom': 'preact/compat',
-		},
-	},
+	/**
+	 * Do not alias React modules in the web build variant so React is bundled
+	 * instead of Preact
+	 */
+	resolve:
+		build === 'client.web.variant'
+			? undefined
+			: {
+					alias: {
+						react: 'preact/compat',
+						'react-dom/test-utils': 'preact/test-utils',
+						'react-dom': 'preact/compat',
+					},
+			  },
 });
 
 module.exports.transpileExclude = {


### PR DESCRIPTION
## What does this change?

Use variant build to test client-side rendering with React instead of Preact

## Why?

To allow us to asses the impact of switching to React on page weight and performance