### PR TITLE
Redesign scrollable small to have a stacked appearance

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -86,8 +86,8 @@ const carouselStyles = css`
 	}
 `;
 
-const itemStyles = css`
-	display: flex;
+const itemStyles = (splitLeftBorder: boolean) => css`
+	display: grid;
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
@@ -100,6 +100,17 @@ const itemStyles = css`
 		width: 1px;
 		background-color: ${palette('--card-border-top')};
 		transform: translateX(-50%);
+		${splitLeftBorder
+			? `background-image: linear-gradient(
+				to bottom,
+				${palette('--card-border-top')},
+				${palette('--card-border-top')} calc(50% - 10px),
+				rgba(0, 0, 0, 0) calc(50% - 10px),
+				rgba(0, 0, 0, 0) calc(50% + 10px),
+				${palette('--card-border-top')} calc(50% + 10px),
+				${palette('--card-border-top')}
+			)`
+			: `background-color: ${palette('--card-border-top')};`}
 	}
 `;
 
@@ -280,6 +291,10 @@ export const ScrollableCarousel = ({
 	);
 };
 
-ScrollableCarousel.Item = ({ children }: { children: React.ReactNode }) => (
-	<li css={itemStyles}>{children}</li>
-);
+ScrollableCarousel.Item = ({
+	splitLeftBorder = false,
+	children,
+}: {
+	splitLeftBorder?: boolean;
+	children: React.ReactNode;
+}) => <li css={itemStyles(splitLeftBorder)}>{children}</li>;

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -86,9 +86,9 @@ const carouselStyles = css`
 	}
 `;
 
-const itemStyles = (splitLeftBorder: boolean, stackRows: boolean) => css`
+const itemStyles = (splitLeftBorder: boolean, shouldStackRows: boolean) => css`
 	display: grid;
-	grid-template-rows: ${stackRows ? `1fr 1fr` : `1fr`};
+	grid-template-rows: ${shouldStackRows ? `1fr 1fr` : `1fr`};
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
@@ -294,10 +294,10 @@ export const ScrollableCarousel = ({
 
 ScrollableCarousel.Item = ({
 	splitLeftBorder = false,
-	stackRows = false,
+	shouldStackRows = false,
 	children,
 }: {
 	splitLeftBorder?: boolean;
-	stackRows?: boolean;
+	shouldStackRows?: boolean;
 	children: React.ReactNode;
-}) => <li css={itemStyles(splitLeftBorder, stackRows)}>{children}</li>;
+}) => <li css={itemStyles(splitLeftBorder, shouldStackRows)}>{children}</li>;

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -86,11 +86,13 @@ const carouselStyles = css`
 	}
 `;
 
-const itemStyles = (splitLeftBorder: boolean) => css`
+const itemStyles = (splitLeftBorder: boolean, stackRows: boolean) => css`
 	display: grid;
+	grid-template-rows: ${stackRows ? `1fr 1fr` : `1fr`};
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
+	height: 100%;
 	:not(:first-child)::before {
 		content: '';
 		position: absolute;
@@ -98,7 +100,6 @@ const itemStyles = (splitLeftBorder: boolean) => css`
 		bottom: 0;
 		left: -10px;
 		width: 1px;
-		background-color: ${palette('--card-border-top')};
 		transform: translateX(-50%);
 		${splitLeftBorder
 			? `background-image: linear-gradient(
@@ -293,8 +294,10 @@ export const ScrollableCarousel = ({
 
 ScrollableCarousel.Item = ({
 	splitLeftBorder = false,
+	stackRows = false,
 	children,
 }: {
 	splitLeftBorder?: boolean;
+	stackRows?: boolean;
 	children: React.ReactNode;
-}) => <li css={itemStyles(splitLeftBorder)}>{children}</li>;
+}) => <li css={itemStyles(splitLeftBorder, stackRows)}>{children}</li>;

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -51,8 +51,8 @@ export const ScrollableSmall = ({
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
 		>
-			{stackedTrails.map((trails, index) => {
-				if (trails.length === 0 || trails[0] === undefined) {
+			{stackedTrails.map((column, index) => {
+				if (column.length === 0 || column[0] === undefined) {
 					return null;
 				}
 				return (
@@ -63,7 +63,7 @@ export const ScrollableSmall = ({
 					>
 						<>
 							<FrontCard
-								trail={trails[0]}
+								trail={column[0]}
 								imageLoading={imageLoading}
 								absoluteServerTimes={!!absoluteServerTimes}
 								containerPalette={containerPalette}
@@ -79,15 +79,15 @@ export const ScrollableSmall = ({
 								trailText={undefined} // unsupported
 								supportingContent={undefined} // unsupported
 								aspectRatio={aspectRatio}
-								kickerText={trails[0].kickerText}
-								showLivePlayable={trails[0].showLivePlayable}
+								kickerText={column[0].kickerText}
+								showLivePlayable={column[0].showLivePlayable}
 								showTopBarDesktop={false}
 								showTopBarMobile={false}
 								canPlayInline={false}
 							/>
-							{trails[1] && (
+							{column[1] && (
 								<FrontCard
-									trail={trails[1]}
+									trail={column[1]}
 									imageLoading={imageLoading}
 									absoluteServerTimes={!!absoluteServerTimes}
 									containerPalette={containerPalette}
@@ -103,9 +103,9 @@ export const ScrollableSmall = ({
 									trailText={undefined} // unsupported
 									supportingContent={undefined} // unsupported
 									aspectRatio={aspectRatio}
-									kickerText={trails[1].kickerText}
+									kickerText={column[1].kickerText}
 									showLivePlayable={
-										trails[1].showLivePlayable
+										column[1].showLivePlayable
 									}
 									showTopBarDesktop={true}
 									showTopBarMobile={true}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -62,6 +62,7 @@ export const ScrollableSmall = ({
 							css={css`
 								display: flex;
 								flex-direction: column;
+								justify-content: space-between;
 							`}
 						>
 							<FrontCard

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -48,7 +48,7 @@ export const ScrollableSmall = ({
 		<ScrollableCarousel
 			carouselLength={stackedTrails.length}
 			visibleCardsOnMobile={1}
-			visibleCardsOnTablet={2}
+			visibleCardsOnTablet={stackedTrails.length > 1 ? 2 : 1}
 			sectionId={sectionId}
 		>
 			{stackedTrails.map((column, index) => {

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -52,19 +51,17 @@ export const ScrollableSmall = ({
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
 		>
-			{stackedTrails.map((trails) => {
+			{stackedTrails.map((trails, index) => {
 				if (trails.length === 0 || trails[0] === undefined) {
 					return null;
 				}
 				return (
-					<ScrollableCarousel.Item key={'TODO_ADD_KEY'}>
-						<div
-							css={css`
-								display: flex;
-								flex-direction: column;
-								justify-content: space-between;
-							`}
-						>
+					<ScrollableCarousel.Item
+						splitLeftBorder={true}
+						stackRows={true}
+						key={`carousel-item-${index}`}
+					>
+						<>
 							<FrontCard
 								trail={trails[0]}
 								imageLoading={imageLoading}
@@ -115,7 +112,7 @@ export const ScrollableSmall = ({
 									canPlayInline={false}
 								/>
 							)}
-						</div>
+						</>
 					</ScrollableCarousel.Item>
 				);
 			})}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -58,7 +58,7 @@ export const ScrollableSmall = ({
 				return (
 					<ScrollableCarousel.Item
 						splitLeftBorder={true}
-						stackRows={true}
+						shouldStackRows={true}
 						key={`carousel-item-${index}`}
 					>
 						<>

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -35,39 +36,85 @@ export const ScrollableSmall = ({
 	aspectRatio,
 	sectionId,
 }: Props) => {
+	const stackedTrails = trails.reduce<DCRFrontCard[][]>((acc, trail) => {
+		if (acc.length === 0 || acc[acc.length - 1]?.length === 2) {
+			acc.push([trail]);
+		} else {
+			acc[acc.length - 1]?.push(trail);
+		}
+		return acc;
+	}, []);
+
 	return (
 		<ScrollableCarousel
-			carouselLength={trails.length}
+			carouselLength={stackedTrails.length}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
 		>
-			{trails.map((trail) => {
+			{stackedTrails.map((trails) => {
+				if (trails.length === 0 || trails[0] === undefined) {
+					return null;
+				}
 				return (
-					<ScrollableCarousel.Item key={trail.url}>
-						<FrontCard
-							trail={trail}
-							imageLoading={imageLoading}
-							absoluteServerTimes={!!absoluteServerTimes}
-							containerPalette={containerPalette}
-							containerType={containerType}
-							showAge={!!showAge}
-							headlineSizes={{
-								desktop: 'xxsmall',
-								mobile: 'xxxsmall',
-							}}
-							imagePositionOnDesktop="left"
-							imagePositionOnMobile="left"
-							imageSize="small"
-							trailText={undefined} // unsupported
-							supportingContent={undefined} // unsupported
-							aspectRatio={aspectRatio}
-							kickerText={trail.kickerText}
-							showLivePlayable={trail.showLivePlayable}
-							showTopBarDesktop={false}
-							showTopBarMobile={false}
-							canPlayInline={false}
-						/>
+					<ScrollableCarousel.Item key={'TODO_ADD_KEY'}>
+						<div
+							css={css`
+								display: flex;
+								flex-direction: column;
+							`}
+						>
+							<FrontCard
+								trail={trails[0]}
+								imageLoading={imageLoading}
+								absoluteServerTimes={!!absoluteServerTimes}
+								containerPalette={containerPalette}
+								containerType={containerType}
+								showAge={!!showAge}
+								headlineSizes={{
+									desktop: 'xxsmall',
+									mobile: 'xxxsmall',
+								}}
+								imagePositionOnDesktop="left"
+								imagePositionOnMobile="left"
+								imageSize="small"
+								trailText={undefined} // unsupported
+								supportingContent={undefined} // unsupported
+								aspectRatio={aspectRatio}
+								kickerText={trails[0].kickerText}
+								showLivePlayable={trails[0].showLivePlayable}
+								showTopBarDesktop={false}
+								showTopBarMobile={false}
+								canPlayInline={false}
+							/>
+							{trails[1] && (
+								<FrontCard
+									trail={trails[1]}
+									imageLoading={imageLoading}
+									absoluteServerTimes={!!absoluteServerTimes}
+									containerPalette={containerPalette}
+									containerType={containerType}
+									showAge={!!showAge}
+									headlineSizes={{
+										desktop: 'xxsmall',
+										mobile: 'xxxsmall',
+									}}
+									imagePositionOnDesktop="left"
+									imagePositionOnMobile="left"
+									imageSize="small"
+									trailText={undefined} // unsupported
+									supportingContent={undefined} // unsupported
+									aspectRatio={aspectRatio}
+									kickerText={trails[1].kickerText}
+									showLivePlayable={
+										trails[1].showLivePlayable
+									}
+									showTopBarDesktop={false}
+									showTopBarMobile={false}
+									canPlayInline={false}
+								/>
+							)}
+						</div>
 					</ScrollableCarousel.Item>
 				);
 			})}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -110,8 +110,8 @@ export const ScrollableSmall = ({
 									showLivePlayable={
 										trails[1].showLivePlayable
 									}
-									showTopBarDesktop={false}
-									showTopBarMobile={false}
+									showTopBarDesktop={true}
+									showTopBarMobile={true}
 									canPlayInline={false}
 								/>
 							)}


### PR DESCRIPTION
## What does this change?

Updates the design of the scrollable small so that is has column of 2 vertically stacked cards in each swipe. 

Cards are laid out as : 

+-------+--------+
|  Card A |  Card C |
+-------+--------+
|  Card B |  Card D |
+-------+--------+

To achieve this, a reducer is used to group the trail items into arrays of a maximum length of 2. These pairs are then mapped over to render each scrollable item as two vertically stacked FrontCards, creating the desired 2x2 layout.

### Why grid instead of flex?

In order to ensure that cards in the same row share the same height, the carousel has been refactored to use grid instead flex. This allows us to set the `grid-template-rows` to  `1fr 1fr`. 

As other use cases for the scrollable carousel only have 1 row, this PR adds a `shouldStackRows` property to determine if the template rows should be 1 row (1fr) or 2 rows (1fr 1fr)


## Screenshots

| mobile      | desktop      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f42c864f-1ea2-4607-8ddc-5c2a25558895
[after]: https://github.com/user-attachments/assets/1b35cc4c-b7a0-4948-8be7-8c66a8a1f5f0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
