### PR TITLE
Add Observer footer

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -22,6 +22,7 @@ import type { TagType } from '../types/tag';
 import { Island } from './Island';
 import { LiveBlogRenderer } from './LiveBlogRenderer';
 import { TableOfContents } from './TableOfContents.importable';
+import { textBlockStyles } from './TextBlockComponent';
 
 type Props = {
 	format: ArticleFormat;
@@ -140,6 +141,24 @@ export const ArticleBody = ({
 		format.design === ArticleDesign.Crossword;
 	const language = decideLanguage(lang);
 	const languageDirection = decideLanguageDirection(isRightToLeftLang);
+	const hasObserverPublicationTag = tags.find(
+		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
+	);
+	const { removeObserver = false } = switches;
+
+	const ObserverFooter = () => {
+		return (
+			<ul css={textBlockStyles(format)}>
+				<li>
+					<p>
+						This is the archive of The Observer up until 21/04/2025.
+						The Observer is now owned and operated by Tortoise
+						Media.
+					</p>
+				</li>
+			</ul>
+		);
+	};
 
 	if (
 		format.design === ArticleDesign.LiveBlog ||
@@ -233,6 +252,7 @@ export const ArticleBody = ({
 					contributionsServiceUrl={contributionsServiceUrl}
 				/>
 			</div>
+			{hasObserverPublicationTag && removeObserver && <ObserverFooter />}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -144,8 +144,6 @@ export const ArticleBody = ({
 	const hasObserverPublicationTag = tags.find(
 		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
 	);
-	const { removeObserver = false } = switches;
-
 	const ObserverFooter = () => {
 		return (
 			<ul css={textBlockStyles(format)}>
@@ -252,7 +250,7 @@ export const ArticleBody = ({
 					contributionsServiceUrl={contributionsServiceUrl}
 				/>
 			</div>
-			{hasObserverPublicationTag && removeObserver && <ObserverFooter />}
+			{hasObserverPublicationTag && <ObserverFooter />}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -142,7 +142,8 @@ export const ArticleBody = ({
 	const language = decideLanguage(lang);
 	const languageDirection = decideLanguageDirection(isRightToLeftLang);
 	const hasObserverPublicationTag = tags.find(
-		(tag) => tag.type === 'Publication' && tag.title === 'The Observer',
+		(tag) =>
+			tag.type === 'Publication' && tag.id === 'publication/theobserver',
 	);
 	const ObserverFooter = () => {
 		return (

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -162,7 +162,7 @@ const sanitiserOptions: IOptions = {
 	},
 };
 
-const styles = (format: ArticleFormat) => css`
+export const textBlockStyles = (format: ArticleFormat) => css`
 	margin-bottom: ${remSpace[3]};
 	word-break: break-word;
 	${format.theme === ArticleSpecial.Labs ? textSans17 : article17};
@@ -257,7 +257,7 @@ const buildElementTree =
 
 		switch (node.nodeName) {
 			case 'P': {
-				return jsx('p', { css: styles(format), children });
+				return jsx('p', { css: textBlockStyles(format), children });
 			}
 			case 'BLOCKQUOTE':
 				return jsx('blockquote', {
@@ -312,7 +312,7 @@ const buildElementTree =
 
 					return node.textContent;
 				}
-				return jsx('p', { css: styles(format), children });
+				return jsx('p', { css: textBlockStyles(format), children });
 			}
 			case 'SPAN':
 				if (
@@ -325,14 +325,14 @@ const buildElementTree =
 						children,
 					});
 				}
-				return jsx('p', { css: styles(format), children });
+				return jsx('p', { css: textBlockStyles(format), children });
 			case 'BR':
 				return jsx('br', {
 					key,
 				});
 			case 'STRIKE':
 				return jsx('s', {
-					css: styles(format),
+					css: textBlockStyles(format),
 					key,
 					children,
 				});
@@ -359,7 +359,7 @@ const buildElementTree =
 			case 'U':
 			case 'DEL':
 				return jsx(node.nodeName.toLowerCase(), {
-					css: styles(format),
+					css: textBlockStyles(format),
 					key,
 					children,
 				});


### PR DESCRIPTION
## Do not merge!

Do not merge until 22nd April 2025

## What does this change?

Adds a note to the end of articles with the Observer publication tag which explains that the Observer is no longer owned by the Guardian.

~It's behind the feature switch `remove-observer` which was added here: https://github.com/guardian/frontend/pull/27913.~

~The frontend PR needs to go in first.~

**EDIT: We've abandoned the feature switch in favour of just merging it at the correct time (April 22nd)**

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="668" alt="Screenshot 2025-04-15 at 12 18 48" src="https://github.com/user-attachments/assets/868e92f8-34f9-4fdc-b579-615dc5dd2f6a" /> | <img width="660" alt="Screenshot 2025-04-15 at 12 18 57" src="https://github.com/user-attachments/assets/25ffaf5a-0a25-49bf-a696-db8e609fd169" /> |

