### PR TITLE
Scrollable small stacked redesign

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -113,7 +113,7 @@ const stackedCardRowsStyles = ({
 }) => css`
 	grid-template-rows: ${mobile ? `1fr 1fr` : `1fr`};
 	${from.tablet} {
-		grid-auto-flow: row;
+		grid-auto-flow: ${desktop ? `row` : `column`};
 		grid-template-rows: ${desktop ? `1fr 1fr` : `1fr`};
 	}
 `;

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -11,6 +11,7 @@ type Props = {
 	visibleCardsOnMobile: number;
 	visibleCardsOnTablet: number;
 	sectionId?: string;
+	shouldStackCards?: { desktop: boolean; mobile: boolean };
 };
 
 /**
@@ -103,6 +104,20 @@ const itemStyles = css`
 	}
 `;
 
+const stackedCardRowsStyles = ({
+	mobile,
+	desktop,
+}: {
+	mobile: boolean;
+	desktop: boolean;
+}) => css`
+	grid-template-rows: ${mobile ? `1fr 1fr` : `1fr`};
+	${from.tablet} {
+		grid-auto-flow: row;
+		grid-template-rows: ${desktop ? `1fr 1fr` : `1fr`};
+	}
+`;
+
 /**
  * Generates CSS styles for a grid layout used in a carousel.
  *
@@ -168,6 +183,7 @@ export const ScrollableCarousel = ({
 	visibleCardsOnMobile,
 	visibleCardsOnTablet,
 	sectionId,
+	shouldStackCards = { desktop: false, mobile: false },
 }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
@@ -253,6 +269,7 @@ export const ScrollableCarousel = ({
 						visibleCardsOnMobile,
 						visibleCardsOnTablet,
 					),
+					stackedCardRowsStyles(shouldStackCards),
 				]}
 				data-heatphan-type="carousel"
 			>

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -41,6 +41,7 @@ export const ScrollableSmall = ({
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
+			shouldStackCards={{ desktop: trails.length > 2, mobile: true }}
 		>
 			{trails.map((trail) => {
 				return (

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -35,15 +35,17 @@ export const ScrollableSmall = ({
 	aspectRatio,
 	sectionId,
 }: Props) => {
+	const mobileBottomCards = [1, 3];
+	const desktopBottomCards = [2, 3];
 	return (
 		<ScrollableCarousel
-			carouselLength={trails.length}
+			carouselLength={trails.length % 2}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
 			shouldStackCards={{ desktop: trails.length > 2, mobile: true }}
 		>
-			{trails.map((trail) => {
+			{trails.map((trail, index) => {
 				return (
 					<ScrollableCarousel.Item key={trail.url}>
 						<FrontCard
@@ -65,8 +67,10 @@ export const ScrollableSmall = ({
 							aspectRatio={aspectRatio}
 							kickerText={trail.kickerText}
 							showLivePlayable={trail.showLivePlayable}
-							showTopBarDesktop={false}
-							showTopBarMobile={false}
+							showTopBarDesktop={desktopBottomCards.includes(
+								index,
+							)}
+							showTopBarMobile={mobileBottomCards.includes(index)}
 							canPlayInline={false}
 						/>
 					</ScrollableCarousel.Item>

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -39,7 +39,7 @@ export const ScrollableSmall = ({
 	const desktopBottomCards = [2, 3];
 	return (
 		<ScrollableCarousel
-			carouselLength={trails.length % 2}
+			carouselLength={Math.ceil(trails.length / 2)}
 			visibleCardsOnMobile={1}
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -43,8 +43,6 @@ export default meta;
 
 type Story = StoryObj<typeof ScrollableSmall>;
 
-export const WithMultipleCards = {};
-
 export const WithFourCards = {
 	args: {
 		trails: trails.slice(0, 4),
@@ -57,15 +55,15 @@ export const WithThreeCards = {
 	},
 };
 
-export const WithOneCard = {
-	args: {
-		trails: trails.slice(0, 1),
-	},
-};
-
 export const WithTwoCards = {
 	args: {
 		trails: trails.slice(0, 2),
+	},
+};
+
+export const WithOneCard = {
+	args: {
+		trails: trails.slice(0, 1),
 	},
 };
 


### PR DESCRIPTION
## What does this change?

Updates the design of the scrollable small so that it displays in a 2 x 2 grid. 

The layout differs depending on the breakpoint : 

*On mobile*, the layout is: 

+-------+--------+
|  Card A |  Card C |
+-------+--------+
|  Card B |  Card D |
+-------+--------+

*On tablet and above*, the layout is: 

+-------+--------+
|  Card A |  Card B |
+-------+--------+
|  Card C |  Card D |
+-------+--------+

This container has been limited to maximum 4 cards. As such, the container is now only a carousel on mobile; on tablet and desktop all 4 cards are visible on screen. 

Scrollable small uses a reusable carousel. To maintain this reusability, a shouldStackCards property has been added which can be controlled at a mobile/desktop level. When true, this property adds an second template row and, if desktop, uses a row auto-flow rather than column. 


## Screenshots

| mobile      | desktop      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b6f11d91-0d4c-4e97-a54e-12c385d85664
[after]: https://github.com/user-attachments/assets/0f622a26-5ae1-48e2-931b-73f4da8390ad