### PR TITLE
Add reducer to remove consecutive ad slots for fronts with secondary level containers

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -60,14 +60,14 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'fixed/medium/slow-VI' },
 			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (8)
 			{ collectionType: 'fixed/small/slow-III' },
-			{ collectionType: 'fixed/medium/fast-XII' }, // Ad position (10)
+			{ collectionType: 'fixed/medium/fast-XII' }, // Ignored - is before merch high position
 			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
 			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 2, 4, 6, 8, 10]);
+		expect(mobileAdPositions).toEqual([0, 2, 4, 6, 8]);
 	});
 
 	// We used https://www.theguardian.com/uk as a blueprint
@@ -79,7 +79,7 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'dynamic/slow' },
 			{ collectionType: 'fixed/small/slow-V-mpu' }, // Ad position (4)
 			{ collectionType: 'dynamic/slow' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (6)
+			{ collectionType: 'fixed/thrasher' },
 			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (8)
 			{ collectionType: 'dynamic/fast' },
@@ -89,19 +89,19 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (14)
 			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (16)
-			{ collectionType: 'fixed/video' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (18)
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/video' }, // Ad position (17)
 			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'dynamic/slow-mpu' }, // Ad position (20)
-			{ collectionType: 'fixed/small/slow-IV' },
+			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (19)
+			{ collectionType: 'dynamic/slow-mpu' },
+			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - is before merch high position
 			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
 			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 2, 4, 6, 8, 11, 14, 16, 18, 20]);
+		expect(mobileAdPositions).toEqual([0, 2, 4, 8, 11, 14, 17, 19]);
 	});
 
 	// We used https://www.theguardian.com/international as a blueprint
@@ -116,22 +116,22 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'fixed/small/slow-IV' },
 			{ collectionType: 'dynamic/fast' }, // Ad position (7)
 			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (9)
+			{ collectionType: 'fixed/thrasher' },
 			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (11)
 			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (13)
-			{ collectionType: 'dynamic/slow-mpu' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (15)
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/slow-mpu' }, // Ad position (14)
 			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'fixed/video' }, // Ad position (17)
+			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (16)
+			{ collectionType: 'fixed/video' },
 			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
 			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 2, 5, 7, 9, 11, 13, 15, 17]);
+		expect(mobileAdPositions).toEqual([0, 2, 5, 7, 11, 14, 16]);
 	});
 
 	// We used https://www.theguardian.com/us as a blueprint
@@ -141,10 +141,10 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'fixed/small/slow-IV' },
 			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (2)
 			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (4)
-			{ collectionType: 'dynamic/slow' },
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'dynamic/slow' }, // Ad position (5)
 			{ collectionType: 'dynamic/slow' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (7)
+			{ collectionType: 'fixed/thrasher' },
 			{ collectionType: 'fixed/small/slow-III' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (9)
 			{ collectionType: 'fixed/small/slow-IV' },
@@ -162,7 +162,7 @@ describe('Mobile Ads', () => {
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 2, 4, 7, 9, 12, 14, 16]);
+		expect(mobileAdPositions).toEqual([0, 2, 5, 9, 12, 14, 16]);
 	});
 
 	// We used https://www.theguardian.com/uk/lifeandstyle as a blueprint
@@ -170,15 +170,15 @@ describe('Mobile Ads', () => {
 		const testCollections: AdCandidateMobile[] = [
 			{ collectionType: 'dynamic/slow' }, // Ad position (0)
 			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (2)
-			{ collectionType: 'fixed/medium/slow-VI' },
-			{ collectionType: 'fixed/small/slow-V-third' }, // Ad position (4)
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' }, // Ad position (3)
+			{ collectionType: 'fixed/small/slow-V-third' },
 			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (6)
 			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (8)
-			{ collectionType: 'fixed/medium/slow-VI' },
-			{ collectionType: 'fixed/medium/slow-XII-mpu' }, // Ad position (10)
+			{ collectionType: 'fixed/thrasher' },
+			{ collectionType: 'fixed/medium/slow-VI' }, // Ad position (9)
+			{ collectionType: 'fixed/medium/slow-XII-mpu' },
 			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - before thrasher
 			{ collectionType: 'fixed/thrasher' }, // Ad position (12)
 			{ collectionType: 'fixed/small/slow-III' },
@@ -188,7 +188,7 @@ describe('Mobile Ads', () => {
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 2, 4, 6, 8, 10, 12]);
+		expect(mobileAdPositions).toEqual([0, 3, 6, 9, 12]);
 	});
 
 	// We used https://www.theguardian.com/tone/recipes as a blueprint
@@ -205,14 +205,14 @@ describe('Mobile Ads', () => {
 			{ collectionType: 'fixed/small/slow-III' },
 			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (9)
 			{ collectionType: 'fixed/small/slow-V-half' },
-			{ collectionType: 'fixed/small/slow-V-third' }, // Ad position (11)
+			{ collectionType: 'fixed/small/slow-V-third' }, // Ignored - is before merch high position
 			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
 			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([1, 3, 5, 7, 9, 11]);
+		expect(mobileAdPositions).toEqual([1, 3, 5, 7, 9]);
 	});
 
 	it('Europe Network Front, with beta containers and more than 4 collections, with thrashers in various places', () => {

--- a/dotcom-rendering/src/lib/getTagPageAdPositions.ts
+++ b/dotcom-rendering/src/lib/getTagPageAdPositions.ts
@@ -3,7 +3,7 @@ import {
 	MAX_FRONTS_BANNER_ADS,
 	MAX_FRONTS_MOBILE_ADS,
 } from './commercial-constants';
-import { removeConsecutiveAdSlotsReducer } from './getFrontsAdPositions';
+import { isEvenIndex } from './getFrontsAdPositions';
 
 /**
  * Uses a very similar approach to pressed fronts, except we
@@ -17,6 +17,7 @@ const getTagPageMobileAdPositions = (
 	collections: Array<GroupedTrailsBase>,
 ): number[] => {
 	return collections
+		.filter(isEvenIndex)
 		.map((collection) =>
 			collections.findIndex(
 				({ day, month, year }) =>
@@ -26,7 +27,6 @@ const getTagPageMobileAdPositions = (
 			),
 		)
 		.filter((adPosition: number) => adPosition !== -1)
-		.reduce(removeConsecutiveAdSlotsReducer, [])
 		.slice(0, MAX_FRONTS_MOBILE_ADS);
 };
 


### PR DESCRIPTION
## What does this change?

Prevents ad slots from sandwiching a container:
- leaves existing logic in place for current fronts where we take every other ad slot as a possible position
- includes additional logic for new, beta fronts to prevent ad slots being inserted for two consecutive front containers

Additionally:
- Prevents ad slots being inserted _before_ the merch high as well as preventing slots appearing _in_ the merch high position. This will stop the "sandwiching" of containers between ad slots at the bottom of the page, since this is where the merch high is currently and it has differing placement logic from other mobile slots

## Why?

A result of the homepage redesign test was that there was a noticeable increase in ad ratio and ad revenue per 1000 page views on mobile web.

To attempt to reduce this effect, we are trying to sensibly lower the number of ads shown on mobile fronts to improve the overall user experience on these pages.

## Screenshots

Example of single secondary container appearing underneath initial primary container, with primary container following it:
```
Header 
------
Primary
Secondary
Primary
```

_Ad slots highlighted with thick blue border_

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e097fc29-eb55-4094-ab96-3278ae18135d
[after]: https://github.com/user-attachments/assets/5d6bda1d-dd26-46dd-8b45-36c8eb5197d6

