### PR TITLE
Football Match Summary parser

### DIFF
--- a/dotcom-rendering/scripts/jsonSchema/schema.mjs
+++ b/dotcom-rendering/scripts/jsonSchema/schema.mjs
@@ -18,6 +18,7 @@ const program = TJS.getProgramFromFiles(
 		path.resolve(`${root}/src/frontend/feCricketMatchPage.ts`),
 		path.resolve(`${root}/src/frontend/feFootballMatchListPage.ts`),
 		path.resolve(`${root}/src/frontend/feFootballTablesPage.ts`),
+		path.resolve(`${root}/src/frontend/feFootballMatchPage.ts`),
 	],
 	{
 		skipLibCheck: true,
@@ -71,6 +72,10 @@ const schemas = [
 	{
 		typeName: 'FECricketMatchPage',
 		file: `${root}/src/frontend/schemas/feCricketMatchPage.json`,
+	},
+	{
+		typeName: 'FEFootballMatchPage',
+		file: `${root}/src/frontend/schemas/feFootballMatchPage.json`,
 	},
 ];
 

--- a/dotcom-rendering/src/components/FootballMatchSummary.tsx
+++ b/dotcom-rendering/src/components/FootballMatchSummary.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
+import type { FootballTeam } from '../footballMatch';
 import { grid } from '../grid';
 import { palette } from '../palette';
-import type { TeamType } from '../types/sport';
 import { MatchNav } from './MatchNav';
 import { MatchStats } from './MatchStats';
 
@@ -27,8 +27,8 @@ const gridStyles = css`
 `;
 
 type Props = {
-	homeTeam: TeamType;
-	awayTeam: TeamType;
+	homeTeam: FootballTeam;
+	awayTeam: FootballTeam;
 	comments?: string;
 	competition: string;
 };

--- a/dotcom-rendering/src/components/MatchStats.stories.tsx
+++ b/dotcom-rendering/src/components/MatchStats.stories.tsx
@@ -84,8 +84,20 @@ DefaultInLiveblog.storyName = 'when placed in a liveblog';
 export const NoStats = () => {
 	return (
 		<MatchStats
-			home={matchReport.homeTeam}
-			away={matchReport.awayTeam}
+			home={{
+				...matchReport.homeTeam,
+				shotsOn: 0,
+				shotsOff: 0,
+				corners: 0,
+				fouls: 0,
+			}}
+			away={{
+				...matchReport.awayTeam,
+				shotsOn: 0,
+				shotsOff: 0,
+				corners: 0,
+				fouls: 0,
+			}}
 			competition="Women's Nations League"
 			format={{
 				display: ArticleDisplay.Standard,

--- a/dotcom-rendering/src/components/MatchStats.tsx
+++ b/dotcom-rendering/src/components/MatchStats.tsx
@@ -36,14 +36,6 @@ type ArticleProps = MatchStatsData & {
 
 type Props = ArticleProps | MatchSummaryProps;
 
-//For these three tournaments, we only get data for live goals, bookings and substitutions, and no other type of match stats
-const omitStatsTeams = [
-	"Women's Nations League",
-	'Europa Conference League',
-	"Women's FA Cup",
-	'Copa America',
-];
-
 const StatsGrid = ({
 	children,
 	format,
@@ -357,9 +349,18 @@ const DecideDoughnut = ({
 	}
 };
 
+/*
+	Some leagues do not return match stats - see
+	https://github.com/guardian/frontend/blob/e046d4144d0001059156f402fd5cf1af29ee9f0c/sport/app/football/controllers/MatchController.scala#L23
+*/
+function teamHasStats({ shotsOff, shotsOn, fouls, corners }: TeamType) {
+	return !(shotsOff === 0 && shotsOn === 0 && fouls === 0 && corners === 0);
+}
+
 export const MatchStats = (props: Props) => {
-	const { home, away, competition, usage } = props;
-	const showStats = !omitStatsTeams.includes(competition);
+	const { home, away, usage } = props;
+	const showStats = teamHasStats(home) && teamHasStats(away);
+
 	const format = usage === 'Article' ? props.format : undefined;
 	const backgroundColour =
 		usage === 'Article'

--- a/dotcom-rendering/src/footballMatch.ts
+++ b/dotcom-rendering/src/footballMatch.ts
@@ -1,0 +1,146 @@
+import { isOneOf } from '@guardian/libs';
+import { listParse } from './footballMatches';
+import type {
+	FEFootballMatch,
+	FEFootballPlayer,
+	FEFootballPlayerEvent,
+	FEFootballTeam,
+} from './frontend/feFootballMatch';
+import type { Result } from './lib/result';
+import { error, ok } from './lib/result';
+
+const eventTypes = ['substitution', 'dismissal', 'booking'] as const;
+const isEventType = isOneOf(eventTypes);
+
+export type PlayerEvent = {
+	eventTime: string; // minutes
+	eventType: (typeof eventTypes)[number];
+};
+
+export type FootballTeam = {
+	id: string;
+	name: string;
+	codename: string;
+	players: FootballPlayer[];
+	possession: number;
+	shotsOn: number;
+	shotsOff: number;
+	corners: number;
+	fouls: number;
+	colours: string;
+	score: number;
+	crest: string;
+	scorers: string[];
+};
+
+export type FootballPlayer = {
+	id: string;
+	name: string;
+	position: string;
+	lastName: string;
+	substitute: boolean;
+	timeOnPitch: string;
+	shirtNumber: string;
+	events: PlayerEvent[];
+};
+
+export type FootballMatch = {
+	homeTeam: FootballTeam;
+	awayTeam: FootballTeam;
+	comment: string;
+};
+
+type UnknownEventType = {
+	kind: 'UnknownEventType';
+	message: string;
+};
+
+type ParserError = UnknownEventType;
+
+const parsePlayerEvent = (
+	feFootballMatchPlayerEvent: FEFootballPlayerEvent,
+): Result<ParserError, PlayerEvent> => {
+	if (!isEventType(feFootballMatchPlayerEvent.eventType)) {
+		return error({
+			kind: 'UnknownEventType',
+			message: `Unknown Player Event Type - ${feFootballMatchPlayerEvent.eventType}`,
+		});
+	}
+
+	return ok({
+		eventTime: feFootballMatchPlayerEvent.eventTime,
+		eventType: feFootballMatchPlayerEvent.eventType,
+	});
+};
+
+const parseEvents = listParse(parsePlayerEvent);
+
+const parsePlayer = (
+	feFootballMatchPlayer: FEFootballPlayer,
+): Result<ParserError, FootballPlayer> => {
+	const parsedEvents = parseEvents(feFootballMatchPlayer.events);
+
+	if (parsedEvents.kind === 'error') {
+		return parsedEvents;
+	}
+
+	return ok({
+		id: feFootballMatchPlayer.id,
+		name: feFootballMatchPlayer.name,
+		position: feFootballMatchPlayer.position,
+		lastName: feFootballMatchPlayer.lastName,
+		substitute: feFootballMatchPlayer.substitute,
+		timeOnPitch: feFootballMatchPlayer.timeOnPitch,
+		shirtNumber: feFootballMatchPlayer.shirtNumber,
+		events: parsedEvents.value,
+	});
+};
+
+const parsePlayers = listParse(parsePlayer);
+
+const parseTeam = (
+	feFootballMatchTeam: FEFootballTeam,
+): Result<ParserError, FootballTeam> => {
+	const parsedPlayers = parsePlayers(feFootballMatchTeam.players);
+
+	if (parsedPlayers.kind === 'error') {
+		return parsedPlayers;
+	}
+
+	return ok({
+		id: feFootballMatchTeam.id,
+		name: feFootballMatchTeam.name,
+		codename: feFootballMatchTeam.codename,
+		score: feFootballMatchTeam.score,
+		scorers: feFootballMatchTeam.scorers,
+		possession: feFootballMatchTeam.possession,
+		shotsOn: feFootballMatchTeam.shotsOn,
+		shotsOff: feFootballMatchTeam.shotsOff,
+		fouls: feFootballMatchTeam.fouls,
+		corners: feFootballMatchTeam.corners,
+		colours: feFootballMatchTeam.colours,
+		crest: feFootballMatchTeam.crest,
+		players: parsedPlayers.value,
+	});
+};
+
+export const parse = (
+	feFootballMatch: FEFootballMatch,
+): Result<ParserError, FootballMatch> => {
+	const parsedHomeTeam = parseTeam(feFootballMatch.homeTeam);
+	const parsedAwayTeam = parseTeam(feFootballMatch.awayTeam);
+
+	if (parsedHomeTeam.kind === 'error') {
+		return parsedHomeTeam;
+	}
+
+	if (parsedAwayTeam.kind === 'error') {
+		return parsedAwayTeam;
+	}
+
+	return ok({
+		homeTeam: parsedHomeTeam.value,
+		awayTeam: parsedAwayTeam.value,
+		comment: feFootballMatch.comment,
+	});
+};

--- a/dotcom-rendering/src/footballMatch.ts
+++ b/dotcom-rendering/src/footballMatch.ts
@@ -5,7 +5,7 @@ import type {
 	FEFootballPlayer,
 	FEFootballPlayerEvent,
 	FEFootballTeam,
-} from './frontend/feFootballMatch';
+} from './frontend/feFootballMatchPage';
 import type { Result } from './lib/result';
 import { error, ok } from './lib/result';
 

--- a/dotcom-rendering/src/frontend/feFootballMatch.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatch.ts
@@ -1,0 +1,38 @@
+export type FEFootballPlayerEvent = {
+	eventTime: string;
+	eventType: string;
+};
+
+export type FEFootballPlayer = {
+	id: string;
+	name: string;
+	position: string;
+	lastName: string;
+	substitute: boolean;
+	timeOnPitch: string;
+	shirtNumber: string;
+	events: FEFootballPlayerEvent[];
+};
+
+export type FEFootballTeam = {
+	id: string;
+	name: string;
+	codename: string;
+	players: FEFootballPlayer[];
+	score: number;
+	scorers: string[];
+	possession: number;
+	shotsOn: number;
+	shotsOff: number;
+	corners: number;
+	fouls: number;
+	colours: string;
+	crest: string;
+};
+
+export type FEFootballMatch = {
+	id: string;
+	homeTeam: FEFootballTeam;
+	awayTeam: FEFootballTeam;
+	comment: string;
+};

--- a/dotcom-rendering/src/frontend/feFootballMatchPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchPage.ts
@@ -40,5 +40,5 @@ export type FEFootballMatch = {
 };
 
 export type FEFootballMatchPage = FEFootballDataPage & {
-	match: FEFootballMatch[];
+	match: FEFootballMatch;
 };

--- a/dotcom-rendering/src/frontend/feFootballMatchPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchPage.ts
@@ -1,3 +1,5 @@
+import type { FEFootballDataPage } from './feFootballDataPage';
+
 export type FEFootballPlayerEvent = {
 	eventTime: string;
 	eventType: string;
@@ -35,4 +37,8 @@ export type FEFootballMatch = {
 	homeTeam: FEFootballTeam;
 	awayTeam: FEFootballTeam;
 	comment: string;
+};
+
+export type FEFootballMatchPage = FEFootballDataPage & {
+	match: FEFootballMatch[];
 };

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchPage.json
@@ -46,256 +46,253 @@
             "type": "object",
             "properties": {
                 "match": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "homeTeam": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string"
-                                    },
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "codename": {
-                                        "type": "string"
-                                    },
-                                    "players": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                },
-                                                "position": {
-                                                    "type": "string"
-                                                },
-                                                "lastName": {
-                                                    "type": "string"
-                                                },
-                                                "substitute": {
-                                                    "type": "boolean"
-                                                },
-                                                "timeOnPitch": {
-                                                    "type": "string"
-                                                },
-                                                "shirtNumber": {
-                                                    "type": "string"
-                                                },
-                                                "events": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "eventTime": {
-                                                                "type": "string"
-                                                            },
-                                                            "eventType": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "eventTime",
-                                                            "eventType"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "required": [
-                                                "events",
-                                                "id",
-                                                "lastName",
-                                                "name",
-                                                "position",
-                                                "shirtNumber",
-                                                "substitute",
-                                                "timeOnPitch"
-                                            ]
-                                        }
-                                    },
-                                    "score": {
-                                        "type": "number"
-                                    },
-                                    "scorers": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "possession": {
-                                        "type": "number"
-                                    },
-                                    "shotsOn": {
-                                        "type": "number"
-                                    },
-                                    "shotsOff": {
-                                        "type": "number"
-                                    },
-                                    "corners": {
-                                        "type": "number"
-                                    },
-                                    "fouls": {
-                                        "type": "number"
-                                    },
-                                    "colours": {
-                                        "type": "string"
-                                    },
-                                    "crest": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "codename",
-                                    "colours",
-                                    "corners",
-                                    "crest",
-                                    "fouls",
-                                    "id",
-                                    "name",
-                                    "players",
-                                    "possession",
-                                    "score",
-                                    "scorers",
-                                    "shotsOff",
-                                    "shotsOn"
-                                ]
-                            },
-                            "awayTeam": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string"
-                                    },
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "codename": {
-                                        "type": "string"
-                                    },
-                                    "players": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                },
-                                                "position": {
-                                                    "type": "string"
-                                                },
-                                                "lastName": {
-                                                    "type": "string"
-                                                },
-                                                "substitute": {
-                                                    "type": "boolean"
-                                                },
-                                                "timeOnPitch": {
-                                                    "type": "string"
-                                                },
-                                                "shirtNumber": {
-                                                    "type": "string"
-                                                },
-                                                "events": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "eventTime": {
-                                                                "type": "string"
-                                                            },
-                                                            "eventType": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "eventTime",
-                                                            "eventType"
-                                                        ]
-                                                    }
-                                                }
-                                            },
-                                            "required": [
-                                                "events",
-                                                "id",
-                                                "lastName",
-                                                "name",
-                                                "position",
-                                                "shirtNumber",
-                                                "substitute",
-                                                "timeOnPitch"
-                                            ]
-                                        }
-                                    },
-                                    "score": {
-                                        "type": "number"
-                                    },
-                                    "scorers": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "possession": {
-                                        "type": "number"
-                                    },
-                                    "shotsOn": {
-                                        "type": "number"
-                                    },
-                                    "shotsOff": {
-                                        "type": "number"
-                                    },
-                                    "corners": {
-                                        "type": "number"
-                                    },
-                                    "fouls": {
-                                        "type": "number"
-                                    },
-                                    "colours": {
-                                        "type": "string"
-                                    },
-                                    "crest": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "codename",
-                                    "colours",
-                                    "corners",
-                                    "crest",
-                                    "fouls",
-                                    "id",
-                                    "name",
-                                    "players",
-                                    "possession",
-                                    "score",
-                                    "scorers",
-                                    "shotsOff",
-                                    "shotsOn"
-                                ]
-                            },
-                            "comment": {
-                                "type": "string"
-                            }
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
                         },
-                        "required": [
-                            "awayTeam",
-                            "comment",
-                            "homeTeam",
-                            "id"
-                        ]
-                    }
+                        "homeTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "codename": {
+                                    "type": "string"
+                                },
+                                "players": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "position": {
+                                                "type": "string"
+                                            },
+                                            "lastName": {
+                                                "type": "string"
+                                            },
+                                            "substitute": {
+                                                "type": "boolean"
+                                            },
+                                            "timeOnPitch": {
+                                                "type": "string"
+                                            },
+                                            "shirtNumber": {
+                                                "type": "string"
+                                            },
+                                            "events": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "eventTime": {
+                                                            "type": "string"
+                                                        },
+                                                        "eventType": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "eventTime",
+                                                        "eventType"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "events",
+                                            "id",
+                                            "lastName",
+                                            "name",
+                                            "position",
+                                            "shirtNumber",
+                                            "substitute",
+                                            "timeOnPitch"
+                                        ]
+                                    }
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "possession": {
+                                    "type": "number"
+                                },
+                                "shotsOn": {
+                                    "type": "number"
+                                },
+                                "shotsOff": {
+                                    "type": "number"
+                                },
+                                "corners": {
+                                    "type": "number"
+                                },
+                                "fouls": {
+                                    "type": "number"
+                                },
+                                "colours": {
+                                    "type": "string"
+                                },
+                                "crest": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "codename",
+                                "colours",
+                                "corners",
+                                "crest",
+                                "fouls",
+                                "id",
+                                "name",
+                                "players",
+                                "possession",
+                                "score",
+                                "scorers",
+                                "shotsOff",
+                                "shotsOn"
+                            ]
+                        },
+                        "awayTeam": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "codename": {
+                                    "type": "string"
+                                },
+                                "players": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "position": {
+                                                "type": "string"
+                                            },
+                                            "lastName": {
+                                                "type": "string"
+                                            },
+                                            "substitute": {
+                                                "type": "boolean"
+                                            },
+                                            "timeOnPitch": {
+                                                "type": "string"
+                                            },
+                                            "shirtNumber": {
+                                                "type": "string"
+                                            },
+                                            "events": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "eventTime": {
+                                                            "type": "string"
+                                                        },
+                                                        "eventType": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "eventTime",
+                                                        "eventType"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "events",
+                                            "id",
+                                            "lastName",
+                                            "name",
+                                            "position",
+                                            "shirtNumber",
+                                            "substitute",
+                                            "timeOnPitch"
+                                        ]
+                                    }
+                                },
+                                "score": {
+                                    "type": "number"
+                                },
+                                "scorers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "possession": {
+                                    "type": "number"
+                                },
+                                "shotsOn": {
+                                    "type": "number"
+                                },
+                                "shotsOff": {
+                                    "type": "number"
+                                },
+                                "corners": {
+                                    "type": "number"
+                                },
+                                "fouls": {
+                                    "type": "number"
+                                },
+                                "colours": {
+                                    "type": "string"
+                                },
+                                "crest": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "codename",
+                                "colours",
+                                "corners",
+                                "crest",
+                                "fouls",
+                                "id",
+                                "name",
+                                "players",
+                                "possession",
+                                "score",
+                                "scorers",
+                                "shotsOff",
+                                "shotsOn"
+                            ]
+                        },
+                        "comment": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "awayTeam",
+                        "comment",
+                        "homeTeam",
+                        "id"
+                    ]
                 }
             },
             "required": [

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchPage.json
@@ -1,0 +1,870 @@
+{
+    "allOf": [
+        {
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "$ref": "#/definitions/Record<string,FEFootballCompetition[]>"
+                },
+                "nav": {
+                    "$ref": "#/definitions/FENavType"
+                },
+                "editionId": {
+                    "$ref": "#/definitions/EditionId"
+                },
+                "guardianBaseURL": {
+                    "type": "string"
+                },
+                "config": {
+                    "$ref": "#/definitions/FESportPageConfig"
+                },
+                "pageFooter": {
+                    "$ref": "#/definitions/FooterType"
+                },
+                "isAdFreeUser": {
+                    "type": "boolean"
+                },
+                "canonicalUrl": {
+                    "type": "string"
+                },
+                "contributionsServiceUrl": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "config",
+                "contributionsServiceUrl",
+                "editionId",
+                "filters",
+                "guardianBaseURL",
+                "isAdFreeUser",
+                "nav",
+                "pageFooter"
+            ]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "match": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "homeTeam": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "codename": {
+                                        "type": "string"
+                                    },
+                                    "players": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "position": {
+                                                    "type": "string"
+                                                },
+                                                "lastName": {
+                                                    "type": "string"
+                                                },
+                                                "substitute": {
+                                                    "type": "boolean"
+                                                },
+                                                "timeOnPitch": {
+                                                    "type": "string"
+                                                },
+                                                "shirtNumber": {
+                                                    "type": "string"
+                                                },
+                                                "events": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "eventTime": {
+                                                                "type": "string"
+                                                            },
+                                                            "eventType": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "eventTime",
+                                                            "eventType"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "events",
+                                                "id",
+                                                "lastName",
+                                                "name",
+                                                "position",
+                                                "shirtNumber",
+                                                "substitute",
+                                                "timeOnPitch"
+                                            ]
+                                        }
+                                    },
+                                    "score": {
+                                        "type": "number"
+                                    },
+                                    "scorers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "possession": {
+                                        "type": "number"
+                                    },
+                                    "shotsOn": {
+                                        "type": "number"
+                                    },
+                                    "shotsOff": {
+                                        "type": "number"
+                                    },
+                                    "corners": {
+                                        "type": "number"
+                                    },
+                                    "fouls": {
+                                        "type": "number"
+                                    },
+                                    "colours": {
+                                        "type": "string"
+                                    },
+                                    "crest": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "codename",
+                                    "colours",
+                                    "corners",
+                                    "crest",
+                                    "fouls",
+                                    "id",
+                                    "name",
+                                    "players",
+                                    "possession",
+                                    "score",
+                                    "scorers",
+                                    "shotsOff",
+                                    "shotsOn"
+                                ]
+                            },
+                            "awayTeam": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "codename": {
+                                        "type": "string"
+                                    },
+                                    "players": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "position": {
+                                                    "type": "string"
+                                                },
+                                                "lastName": {
+                                                    "type": "string"
+                                                },
+                                                "substitute": {
+                                                    "type": "boolean"
+                                                },
+                                                "timeOnPitch": {
+                                                    "type": "string"
+                                                },
+                                                "shirtNumber": {
+                                                    "type": "string"
+                                                },
+                                                "events": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "eventTime": {
+                                                                "type": "string"
+                                                            },
+                                                            "eventType": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "eventTime",
+                                                            "eventType"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "events",
+                                                "id",
+                                                "lastName",
+                                                "name",
+                                                "position",
+                                                "shirtNumber",
+                                                "substitute",
+                                                "timeOnPitch"
+                                            ]
+                                        }
+                                    },
+                                    "score": {
+                                        "type": "number"
+                                    },
+                                    "scorers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "possession": {
+                                        "type": "number"
+                                    },
+                                    "shotsOn": {
+                                        "type": "number"
+                                    },
+                                    "shotsOff": {
+                                        "type": "number"
+                                    },
+                                    "corners": {
+                                        "type": "number"
+                                    },
+                                    "fouls": {
+                                        "type": "number"
+                                    },
+                                    "colours": {
+                                        "type": "string"
+                                    },
+                                    "crest": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "codename",
+                                    "colours",
+                                    "corners",
+                                    "crest",
+                                    "fouls",
+                                    "id",
+                                    "name",
+                                    "players",
+                                    "possession",
+                                    "score",
+                                    "scorers",
+                                    "shotsOff",
+                                    "shotsOn"
+                                ]
+                            },
+                            "comment": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "awayTeam",
+                            "comment",
+                            "homeTeam",
+                            "id"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "match"
+            ]
+        }
+    ],
+    "definitions": {
+        "Record<string,FEFootballCompetition[]>": {
+            "type": "object"
+        },
+        "FENavType": {
+            "type": "object",
+            "properties": {
+                "currentUrl": {
+                    "type": "string"
+                },
+                "pillars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "otherLinks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "brandExtensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "currentNavLink": {
+                    "$ref": "#/definitions/FELinkType"
+                },
+                "currentNavLinkTitle": {
+                    "type": "string"
+                },
+                "currentPillarTitle": {
+                    "type": "string"
+                },
+                "subNavSections": {
+                    "type": "object",
+                    "properties": {
+                        "parent": {
+                            "$ref": "#/definitions/FELinkType"
+                        },
+                        "links": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FELinkType"
+                            }
+                        }
+                    },
+                    "required": [
+                        "links"
+                    ]
+                },
+                "readerRevenueLinks": {
+                    "$ref": "#/definitions/ReaderRevenuePositions"
+                }
+            },
+            "required": [
+                "brandExtensions",
+                "currentUrl",
+                "otherLinks",
+                "pillars",
+                "readerRevenueLinks"
+            ]
+        },
+        "FELinkType": {
+            "description": "Data types for the API request bodies from clients that require transformation before internal use.\nWhere data types are coming from Frontend we try to use the 'FE' prefix.\nPrior to this we used 'CAPI' as a prefix which wasn't entirely accurate, and some data structures never received the prefix, meaning some are still missing it.",
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "longTitle": {
+                    "type": "string"
+                },
+                "iconName": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FELinkType"
+                    }
+                },
+                "pillar": {
+                    "$ref": "#/definitions/LegacyPillar"
+                },
+                "more": {
+                    "type": "boolean"
+                },
+                "classList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "title",
+                "url"
+            ]
+        },
+        "LegacyPillar": {
+            "enum": [
+                "culture",
+                "labs",
+                "lifestyle",
+                "news",
+                "opinion",
+                "sport"
+            ],
+            "type": "string"
+        },
+        "ReaderRevenuePositions": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "footer": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "sideMenu": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampHeader": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                },
+                "ampFooter": {
+                    "$ref": "#/definitions/ReaderRevenueCategories"
+                }
+            },
+            "required": [
+                "ampFooter",
+                "ampHeader",
+                "footer",
+                "header",
+                "sideMenu"
+            ]
+        },
+        "ReaderRevenueCategories": {
+            "type": "object",
+            "properties": {
+                "contribute": {
+                    "type": "string"
+                },
+                "subscribe": {
+                    "type": "string"
+                },
+                "support": {
+                    "type": "string"
+                },
+                "supporter": {
+                    "type": "string"
+                },
+                "gifting": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "contribute",
+                "subscribe",
+                "support",
+                "supporter"
+            ]
+        },
+        "EditionId": {
+            "enum": [
+                "AU",
+                "EUR",
+                "INT",
+                "UK",
+                "US"
+            ],
+            "type": "string"
+        },
+        "FESportPageConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Omit<FEFrontConfig,\"keywordIds\"|\"keywords\"|\"isFront\">"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "isFront": {
+                            "type": "boolean"
+                        },
+                        "hasSurveyAd": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "hasSurveyAd",
+                        "isFront"
+                    ]
+                }
+            ]
+        },
+        "Omit<FEFrontConfig,\"keywordIds\"|\"keywords\"|\"isFront\">": {
+            "type": "object",
+            "properties": {
+                "isSensitive": {
+                    "type": "boolean"
+                },
+                "edition": {
+                    "type": "string"
+                },
+                "section": {
+                    "type": "string"
+                },
+                "sharedAdTargeting": {
+                    "$ref": "#/definitions/SharedAdTargeting"
+                },
+                "adUnit": {
+                    "type": "string"
+                },
+                "avatarApiUrl": {
+                    "type": "string"
+                },
+                "externalEmbedHost": {
+                    "type": "string"
+                },
+                "ajaxUrl": {
+                    "type": "string"
+                },
+                "revisionNumber": {
+                    "type": "string"
+                },
+                "isProd": {
+                    "type": "boolean"
+                },
+                "switches": {
+                    "$ref": "#/definitions/Switches"
+                },
+                "locationapiurl": {
+                    "type": "string"
+                },
+                "buildNumber": {
+                    "type": "string"
+                },
+                "abTests": {
+                    "description": "Narrowest representation of the server-side tests\nobject shape, which is [defined in `frontend`](https://github.com/guardian/frontend/blob/23743723030a041e4f4f59fa265ee2be0bb51825/common/app/experiments/ExperimentsDefinition.scala#L24-L26).\n\n**Note:** This type is not support by JSON-schema, it evaluates as `object`",
+                    "type": "object"
+                },
+                "pbIndexSites": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "ampIframeUrl": {
+                    "type": "string"
+                },
+                "beaconUrl": {
+                    "type": "string"
+                },
+                "host": {
+                    "type": "string"
+                },
+                "brazeApiKey": {
+                    "type": "string"
+                },
+                "calloutsUrl": {
+                    "type": "string"
+                },
+                "requiresMembershipAccess": {
+                    "type": "boolean"
+                },
+                "onwardWebSocket": {
+                    "type": "string"
+                },
+                "a9PublisherId": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
+                },
+                "facebookIaAdUnitRoot": {
+                    "type": "string"
+                },
+                "ophanEmbedJsUrl": {
+                    "type": "string"
+                },
+                "idUrl": {
+                    "type": "string"
+                },
+                "dcrSentryDsn": {
+                    "type": "string"
+                },
+                "idWebAppUrl": {
+                    "type": "string"
+                },
+                "discussionApiUrl": {
+                    "type": "string"
+                },
+                "sentryPublicApiKey": {
+                    "type": "string"
+                },
+                "omnitureAccount": {
+                    "type": "string"
+                },
+                "dfpAccountId": {
+                    "type": "string"
+                },
+                "pageId": {
+                    "type": "string"
+                },
+                "forecastsapiurl": {
+                    "type": "string"
+                },
+                "assetsPath": {
+                    "type": "string"
+                },
+                "pillar": {
+                    "type": "string"
+                },
+                "commercialBundleUrl": {
+                    "type": "string"
+                },
+                "discussionApiClientHeader": {
+                    "type": "string"
+                },
+                "membershipUrl": {
+                    "type": "string"
+                },
+                "dfpHost": {
+                    "type": "string"
+                },
+                "cardStyle": {
+                    "type": "string"
+                },
+                "googletagUrl": {
+                    "type": "string"
+                },
+                "sentryHost": {
+                    "type": "string"
+                },
+                "shouldHideAdverts": {
+                    "type": "boolean"
+                },
+                "mmaUrl": {
+                    "type": "string"
+                },
+                "membershipAccess": {
+                    "type": "string"
+                },
+                "isPreview": {
+                    "type": "boolean"
+                },
+                "googletagJsUrl": {
+                    "type": "string"
+                },
+                "supportUrl": {
+                    "type": "string"
+                },
+                "ipsosTag": {
+                    "type": "string"
+                },
+                "ophanJsUrl": {
+                    "type": "string"
+                },
+                "isPaidContent": {
+                    "type": "boolean"
+                },
+                "mobileAppsAdUnitRoot": {
+                    "type": "string"
+                },
+                "plistaPublicApiKey": {
+                    "type": "string"
+                },
+                "frontendAssetsFullURL": {
+                    "type": "string"
+                },
+                "googleSearchId": {
+                    "type": "string"
+                },
+                "allowUserGeneratedContent": {
+                    "type": "boolean"
+                },
+                "dfpAdUnitRoot": {
+                    "type": "string"
+                },
+                "idApiUrl": {
+                    "type": "string"
+                },
+                "omnitureAmpAccount": {
+                    "type": "string"
+                },
+                "hasPageSkin": {
+                    "type": "boolean"
+                },
+                "webTitle": {
+                    "type": "string"
+                },
+                "stripePublicToken": {
+                    "type": "string"
+                },
+                "googleRecaptchaSiteKey": {
+                    "type": "string"
+                },
+                "discussionD2Uid": {
+                    "type": "string"
+                },
+                "googleSearchUrl": {
+                    "type": "string"
+                },
+                "optimizeEpicUrl": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/StageType"
+                },
+                "idOAuthUrl": {
+                    "type": "string"
+                },
+                "isDev": {
+                    "type": "boolean"
+                },
+                "thirdPartyAppsAccount": {
+                    "type": "string"
+                },
+                "avatarImagesUrl": {
+                    "type": "string"
+                },
+                "fbAppId": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a9PublisherId",
+                "abTests",
+                "adUnit",
+                "ajaxUrl",
+                "allowUserGeneratedContent",
+                "ampIframeUrl",
+                "assetsPath",
+                "avatarApiUrl",
+                "avatarImagesUrl",
+                "beaconUrl",
+                "buildNumber",
+                "calloutsUrl",
+                "commercialBundleUrl",
+                "contentType",
+                "dcrSentryDsn",
+                "dfpAccountId",
+                "dfpAdUnitRoot",
+                "dfpHost",
+                "discussionApiClientHeader",
+                "discussionApiUrl",
+                "discussionD2Uid",
+                "edition",
+                "externalEmbedHost",
+                "facebookIaAdUnitRoot",
+                "fbAppId",
+                "forecastsapiurl",
+                "frontendAssetsFullURL",
+                "googleRecaptchaSiteKey",
+                "googleSearchId",
+                "googleSearchUrl",
+                "googletagJsUrl",
+                "googletagUrl",
+                "hasPageSkin",
+                "host",
+                "idApiUrl",
+                "idOAuthUrl",
+                "idUrl",
+                "idWebAppUrl",
+                "ipsosTag",
+                "isDev",
+                "isPreview",
+                "isProd",
+                "isSensitive",
+                "locationapiurl",
+                "membershipAccess",
+                "membershipUrl",
+                "mmaUrl",
+                "mobileAppsAdUnitRoot",
+                "omnitureAccount",
+                "omnitureAmpAccount",
+                "onwardWebSocket",
+                "ophanEmbedJsUrl",
+                "ophanJsUrl",
+                "optimizeEpicUrl",
+                "pageId",
+                "pbIndexSites",
+                "pillar",
+                "plistaPublicApiKey",
+                "requiresMembershipAccess",
+                "revisionNumber",
+                "section",
+                "sentryHost",
+                "sentryPublicApiKey",
+                "sharedAdTargeting",
+                "shouldHideAdverts",
+                "stage",
+                "stripePublicToken",
+                "supportUrl",
+                "switches",
+                "webTitle"
+            ]
+        },
+        "SharedAdTargeting": {
+            "type": "object"
+        },
+        "Switches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "StageType": {
+            "enum": [
+                "CODE",
+                "DEV",
+                "PROD"
+            ],
+            "type": "string"
+        },
+        "FooterType": {
+            "type": "object",
+            "properties": {
+                "footerLinks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/FooterLink"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "footerLinks"
+            ]
+        },
+        "FooterLink": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "dataLinkName": {
+                    "type": "string"
+                },
+                "extraClasses": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dataLinkName",
+                "text",
+                "url"
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -1,4 +1,5 @@
 import type { CricketMatch } from './cricketMatch';
+import type { FootballMatch } from './footballMatch';
 import type { FootballMatches } from './footballMatches';
 import type { FootballTableCompetitions } from './footballTables';
 import type { FESportPageConfig } from './frontend/feFootballDataPage';
@@ -42,6 +43,11 @@ export type FootballTablesPage = FootballData & {
 export type CricketMatchPage = SportPageConfig & {
 	match: CricketMatch;
 	kind: 'CricketMatch';
+};
+
+export type FootballMatchSummaryPage = SportPageConfig & {
+	match: FootballMatch;
+	kind: 'MatchSummary';
 };
 
 export type FootballMatchListPageKind = FootballMatchListPage['kind'];


### PR DESCRIPTION
## What does this change?

Adds a frontend schema for football match summaries, and a parser that transforms this into the type we need in our component. 

Also changes the decision on whether to show match stats within the component - from a per competition basis to using the data from the match itself. This matches frontend's [implementation](https://github.com/guardian/frontend/blob/e046d4144d0001059156f402fd5cf1af29ee9f0c/sport/app/football/controllers/MatchController.scala#L23). If all the stats are zero we assume it's from a competition that returns no statistics. 

Since this component is already used for match reports I have tested against match reports from these competitions.
Example tested locally: https://www.theguardian.com/football/2025/apr/08/womens-nations-league-belgium-england-match-report

Unchanged before and after
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/dcd64d3a-49d4-4991-828b-17df88310e83" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
