### PR TITLE
Football tables ad - grid row

### DIFF
--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -101,9 +101,8 @@ export const FootballTablesPage = ({
 			<div
 				css={css`
 					${grid.column.right}
-					/**  ToDo: review what line to grow the ad to */
 					/** This allows the ad to grow beyond the third row content (up to line 5) */
-					grid-row: 1 / 5;
+					grid-row: 1 / 4;
 					${until.desktop} {
 						display: none;
 					}


### PR DESCRIPTION
## What does this change?
Changes the grid-row spanning for ads on the side of football tables pages

## Why?
Resolves a todo comment, 4 is the row at the end of the grid that the ad slot needs to span to

## Screenshots
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/b37b34aa-eb8d-4bf4-94a3-bb9293f00d38" />
<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
