### PR TITLE
Add option to provide an image crop offset to fastly image resizer

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -110,11 +110,13 @@ const decideImageWidths = (
 					breakpoint: breakpoints.tablet,
 					width: 700,
 					aspectRatio: '5:3',
+					cropOffset: { x: 50, y: 0 },
 				},
 				{
 					breakpoint: breakpoints.desktop,
 					width: 940,
 					aspectRatio: '5:3',
+					cropOffset: { x: 50, y: 0 },
 				},
 			];
 	}

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -40,6 +40,7 @@ export type ImageWidthType = {
 	breakpoint: number;
 	width: number;
 	aspectRatio?: AspectRatio;
+	cropOffset?: { x: number; y: number };
 };
 
 /**
@@ -403,7 +404,7 @@ export const generateSources = (
 	imageWidths
 		.slice()
 		.sort(descendingByBreakpoint)
-		.map(({ width: imageWidth, breakpoint, aspectRatio }) => {
+		.map(({ width: imageWidth, breakpoint, aspectRatio, cropOffset }) => {
 			return {
 				breakpoint,
 				width: imageWidth,
@@ -412,12 +413,14 @@ export const generateSources = (
 					imageWidth,
 					resolution: 'high',
 					aspectRatio,
+					cropOffset,
 				}),
 				lowResUrl: generateImageURL({
 					mainImage,
 					imageWidth,
 					resolution: 'low',
 					aspectRatio,
+					cropOffset,
 				}),
 			};
 		});

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -49,14 +49,19 @@ export const generateImageURL = ({
 	imageWidth,
 	resolution,
 	aspectRatio = 'none',
+	cropOffset,
 }: {
 	mainImage: string;
 	imageWidth: number;
 	resolution: 'low' | 'high';
 	aspectRatio?: string;
+	cropOffset?: { x: number; y: number };
 }): string => {
 	const url = new URL(mainImage);
-
+	const offset = cropOffset
+		? `,offset-x${cropOffset.x},offset-y${cropOffset.y}`
+		: ``;
+	const crop = `${aspectRatio}${offset}`;
 	// In CODE, we do not generate optimised replacement images
 	if (url.hostname === 's3-eu-west-1.amazonaws.com') return url.href;
 
@@ -64,7 +69,7 @@ export const generateImageURL = ({
 		width: imageWidth.toString(),
 		dpr: String(resolution === 'high' ? 2 : 1),
 		s: 'none',
-		crop: aspectRatio,
+		crop,
 	});
 
 	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${


### PR DESCRIPTION
## What does this change?
Extends our cropping capabilities to allow consumers to optionally set an offset. This lets users  determine the point at which the image is cropped rather than the default which is the centre. 

## Why?
The site is moving to 5:4 crops across the board but some cards still used 5:3 crops (specifically the immersive on tablet and desktop). Cropping from the middle strips 50% of the crop from the top and 50% of the crop from the bottom which often obscures heads. 

Following discussions with Editorial, it was decided that best approach would be to anchor the crop to the top of the image to preserve the top section. This approach allows editorial to be confident about what part of the image will be lost in the crop and requires less editorial effort than selecting separate 5:3 crops for these cards.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b4ca9bf3-2441-4285-a830-328e5de6278d
[after]: https://github.com/user-attachments/assets/1d31f748-eace-40a4-93c9-167081091560

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
