### PR TITLE
Fix US Annual Discount for April

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -58,11 +58,14 @@ export const ChoiceCardTestData_REGULAR = (
 
 export const ChoiceCardTestData_US = (
 	longerBenefits: boolean,
+	isDiscountActive: boolean,
 ): ChoiceInfo[] => [
 	{
 		supportTier: 'Contribution',
 		label: (amount: number, currencySymbol: string): string =>
-			`Support ${currencySymbol}${amount}/month`,
+			isDiscountActive
+				? `Support ${currencySymbol}${amount}/year`
+				: `Support ${currencySymbol}${amount}/month`,
 		benefitsLabel: 'Support',
 		benefits: () => [
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
@@ -71,8 +74,27 @@ export const ChoiceCardTestData_US = (
 	},
 	{
 		supportTier: 'SupporterPlus',
-		label: (amount: number, currencySymbol: string): string =>
-			`Support ${currencySymbol}${amount}/month`,
+		label: (
+			amount: number,
+			currencySymbol: string,
+			discount?: number,
+		): JSX.Element | string => {
+			if (!isUndefined(discount)) {
+				return (
+					<>
+						Support{' '}
+						<s>
+							{currencySymbol}
+							{amount}
+						</s>{' '}
+						{currencySymbol}
+						{amount * (1 - discount)}/year{' '}
+					</>
+				);
+			} else {
+				return `Support ${currencySymbol}${amount}/month`;
+			}
+		},
 		benefitsLabel: 'All-access digital',
 		benefits: () =>
 			longerBenefits

--- a/dotcom-rendering/src/components/marketing/lib/choiceCards.ts
+++ b/dotcom-rendering/src/components/marketing/lib/choiceCards.ts
@@ -39,6 +39,6 @@ export const getChoiceCardData = (
 	countryCode?: string,
 ): ChoiceInfo[] => {
 	return countryCode === 'US'
-		? ChoiceCardTestData_US(longerBenefits)
+		? ChoiceCardTestData_US(longerBenefits, isDiscountActive)
 		: ChoiceCardTestData_REGULAR(longerBenefits, isDiscountActive);
 };


### PR DESCRIPTION
## What does this change?

This is to fix the Annual Discounts for April Promotion for US
## Why?

The bug happened  because the special handling of the promo wasn't passed to the US config
## Screenshots

## Before

<img width="527" alt="image" src="https://github.com/user-attachments/assets/b2fd7cae-42d6-4a3f-8973-a1798743a7b2" />

## After 

<img width="527" alt="image" src="https://github.com/user-attachments/assets/f56f2c15-ea7b-465d-b236-7f20eb1c9263" />
