### PR TITLE
Add 50% europe beta test

### DIFF
--- a/dotcom-rendering/src/client/adaptiveSite.ts
+++ b/dotcom-rendering/src/client/adaptiveSite.ts
@@ -21,7 +21,9 @@ export const shouldAdapt = async (): Promise<boolean> => {
 	 * This is a temporary measure to ensure that the front is not adapted during testing.
 	 */
 	if (
-		window.guardian.config.tests.europeBetaFrontVariant === 'variant' &&
+		(window.guardian.config.tests.europeBetaFrontVariant === 'variant' ||
+			window.guardian.config.tests.europeBetaFrontTest2Variant ===
+				'variant') &&
 		window.location.pathname === '/europe'
 	) {
 		return false;

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -156,11 +156,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				return '5:3';
 		}
 	};
-
 	const Highlights = () => {
 		const showHighlights =
 			// Must be opted into the Europe beta test or in preview
-			abTests.europeBetaFrontVariant === 'variant' || isPreview;
+			abTests.europeBetaFrontVariant === 'variant' ||
+			abTests.europeBetaFrontTest2Variant === 'variant' ||
+			isPreview;
 
 		const highlightsCollection =
 			front.pressedPage.collections.find(isHighlights);


### PR DESCRIPTION
This uses the naming convention europeBetaFrontTest2 to align with apps.

This test is for 50% of users. By seperating the 0% and 50% tests, we can have an immediate go live via a switch, rather than having to wait for a deploy.

This test will run from 22nd April  to 29th april inclusive

The corresponding frontend PR is https://github.com/guardian/frontend/pull/27920
