### PR TITLE
Loop video component

### DIFF
--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -43,15 +43,8 @@ const wideIconStyles = (
 	}
 `;
 
-const narrowPlayIconWidth = 56;
+export const narrowPlayIconWidth = 56;
 const narrowStyles = css`
-	position: absolute;
-	/**
-	 * Subject to change. We will wait to see how fronts editors use the
-	 * headlines and standfirsts before we decide on a final position.
-	 */
-	top: 35%;
-	left: calc(50% - ${narrowPlayIconWidth / 2}px);
 	width: ${narrowPlayIconWidth}px;
 	height: ${narrowPlayIconWidth}px;
 	display: flex;

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -8,9 +8,11 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useConfig } from './ConfigContext';
 import { LoopVideoPlayer } from './LoopVideoPlayer';
 
-const videoContainerStyles = css`
+const videoContainerStyles = (height: number, width: number) => css`
 	z-index: ${getZIndex('loop-video-container')};
 	position: relative;
+	height: ${height}px;
+	width: ${width}px;
 `;
 
 type Props = {
@@ -36,7 +38,7 @@ export const LoopVideo = ({
 	const [isPlayable, setIsPlayable] = useState(false);
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isMuted, setIsMuted] = useState(true);
-	const [elapsedTime, setElapsedTime] = useState(0);
+	const [currentTime, setCurrentTime] = useState(0);
 	/**
 	 * Keep a track of whether the video has been in view. We only want to
 	 * pause the video if it has been in view.
@@ -69,22 +71,9 @@ export const LoopVideo = ({
 		}
 	}, [isInView, hasBeenInView, isPlayable, isPlaying]);
 
-	/**
-	 * Progress bar updates
-	 */
-	useEffect(() => {
-		const interval = setInterval(() => {
-			setElapsedTime(vidRef.current?.currentTime ?? 0);
-		}, 40);
-
-		return () => clearInterval(interval);
-	}, []);
-
 	if (renderingTarget !== 'Web') return null;
 
-	if (adapted) {
-		return fallbackImage;
-	}
+	if (adapted) return fallbackImage;
 
 	const handleClick = (event: React.SyntheticEvent) => {
 		event.preventDefault();
@@ -115,7 +104,7 @@ export const LoopVideo = ({
 			);
 
 			vidRef.current.currentTime = newTime;
-			setElapsedTime(newTime);
+			setCurrentTime(newTime);
 		}
 	};
 
@@ -128,7 +117,7 @@ export const LoopVideo = ({
 				vidRef.current.duration;
 
 			vidRef.current.currentTime = newTime;
-			setElapsedTime(newTime);
+			setCurrentTime(newTime);
 		}
 	};
 
@@ -155,7 +144,7 @@ export const LoopVideo = ({
 		<div
 			className="loop-video-container"
 			ref={setNode}
-			css={videoContainerStyles}
+			css={videoContainerStyles(height, width)}
 		>
 			<LoopVideoPlayer
 				src={src}
@@ -164,6 +153,8 @@ export const LoopVideo = ({
 				height={height}
 				hasAudio={hasAudio}
 				fallbackImage={fallbackImage}
+				currentTime={currentTime}
+				setCurrentTime={setCurrentTime}
 				ref={vidRef}
 				isPlayable={isPlayable}
 				setIsPlayable={setIsPlayable}
@@ -174,7 +165,6 @@ export const LoopVideo = ({
 				handleClick={handleClick}
 				handleKeyDown={handleKeyDown}
 				onError={onError}
-				elapsedTime={elapsedTime}
 				AudioIcon={AudioIcon}
 			/>
 		</div>

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -1,48 +1,16 @@
 import { css } from '@emotion/react';
 import { log } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
 import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
 import { getZIndex } from '../lib/getZIndex';
 import { useIsInView } from '../lib/useIsInView';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
-import { palette } from '../palette';
-import { narrowPlayIconWidth, PlayIcon } from './Card/components/PlayIcon';
 import { useConfig } from './ConfigContext';
-import { LoopVideoProgressBar } from './LoopVideoProgressBar';
+import { LoopVideoPlayer } from './LoopVideoPlayer';
 
 const videoContainerStyles = css`
 	z-index: ${getZIndex('loop-video-container')};
-	cursor: pointer;
 	position: relative;
-`;
-
-const videoStyles = css`
-	position: relative;
-	width: 100%;
-	height: auto;
-	/* Find out why this is needed to align the video with its container. */
-	margin-bottom: -3px;
-`;
-
-const playIconStyles = css`
-	position: absolute;
-	top: calc(50% - ${narrowPlayIconWidth / 2}px);
-	left: calc(50% - ${narrowPlayIconWidth / 2}px);
-	cursor: pointer;
-	border: none;
-	background: none;
-	padding: 0;
-`;
-
-const audioButtonStyles = css`
-	border: none;
-	background: none;
-	padding: 0;
-	position: absolute;
-	bottom: ${space[8]}px;
-	right: ${space[8]}px;
-	cursor: pointer;
 `;
 
 type Props = {
@@ -78,8 +46,6 @@ export const LoopVideo = ({
 	const [isInView, setNode] = useIsInView({
 		repeat: true,
 		threshold: 0.5,
-		node: vidRef.current ?? undefined,
-		debounce: true,
 	});
 
 	/**
@@ -167,7 +133,7 @@ export const LoopVideo = ({
 	};
 
 	const handleKeyDown = (
-		event: React.KeyboardEvent<HTMLDivElement>,
+		event: React.KeyboardEvent<HTMLVideoElement>,
 	): void => {
 		switch (event.key) {
 			case 'Enter':
@@ -189,66 +155,28 @@ export const LoopVideo = ({
 		<div
 			className="loop-video-container"
 			ref={setNode}
-			onClick={handleClick}
-			onKeyDown={handleKeyDown}
-			role="button"
-			tabIndex={0}
 			css={videoContainerStyles}
 		>
-			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Captions will be considered later. */}
-			<video
-				id={`loop-video-${videoId}`}
-				ref={vidRef}
-				preload="none"
-				loop={true}
-				muted={isMuted}
-				playsInline={true}
-				height={height}
+			<LoopVideoPlayer
+				src={src}
+				videoId={videoId}
 				width={width}
-				onPlaying={() => {
-					setIsPlaying(true);
-				}}
-				onCanPlay={() => {
-					setIsPlayable(true);
-				}}
+				height={height}
+				hasAudio={hasAudio}
+				fallbackImage={fallbackImage}
+				ref={vidRef}
+				isPlayable={isPlayable}
+				setIsPlayable={setIsPlayable}
+				isPlaying={isPlaying}
+				setIsPlaying={setIsPlaying}
+				isMuted={isMuted}
+				setIsMuted={setIsMuted}
+				handleClick={handleClick}
+				handleKeyDown={handleKeyDown}
 				onError={onError}
-				css={videoStyles}
-			>
-				{/* Ensure webm source is provided */}
-				{/* <source src={webmSrc} type="video/webm"> */}
-				<source src={src} type="video/mp4" />
-				{fallbackImage}
-			</video>
-			{vidRef.current && (
-				<>
-					{isPlayable && !isPlaying && (
-						<div css={playIconStyles}>
-							<PlayIcon iconWidth="narrow" />
-						</div>
-					)}
-					<LoopVideoProgressBar
-						currentTime={elapsedTime}
-						duration={vidRef.current.duration}
-					/>
-					{hasAudio && (
-						<button
-							type="button"
-							onClick={(event) => {
-								event.stopPropagation(); // Don't pause the video
-								setIsMuted(!isMuted);
-							}}
-							css={audioButtonStyles}
-						>
-							<AudioIcon
-								size="small"
-								theme={{
-									fill: palette('--loop-video-audio-icon'),
-								}}
-							/>
-						</button>
-					)}
-				</>
-			)}
+				elapsedTime={elapsedTime}
+				AudioIcon={AudioIcon}
+			/>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -47,7 +47,7 @@ const audioButtonStyles = css`
 
 type Props = {
 	src: string;
-	videoId?: string;
+	videoId: string;
 	width?: number;
 	height?: number;
 	hasAudio?: boolean;

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -3,15 +3,11 @@ import { log } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
 import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
-import type { FEAspectRatio } from '../frontend/feFront';
 import { getZIndex } from '../lib/getZIndex';
 import { useIsInView } from '../lib/useIsInView';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { palette } from '../palette';
-import type { ImageSizeType } from './Card/components/ImageWrapper';
 import { narrowPlayIconWidth, PlayIcon } from './Card/components/PlayIcon';
-import type { Loading } from './CardPicture';
-import { CardPicture } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import { LoopVideoProgressBar } from './LoopVideoProgressBar';
 
@@ -49,33 +45,22 @@ const audioButtonStyles = css`
 	cursor: pointer;
 `;
 
-type ImageProps = {
-	posterImage: string;
-	imageSize: ImageSizeType;
-	imageLoading: Loading;
-	altText?: string;
-	aspectRatio?: FEAspectRatio;
-};
-
-type Props = ImageProps & {
+type Props = {
 	src: string;
 	videoId?: string;
 	width?: number;
 	height?: number;
 	hasAudio?: boolean;
+	fallbackImage: JSX.Element;
 };
 
 export const LoopVideo = ({
 	src,
 	videoId,
-	posterImage,
-	imageSize,
-	imageLoading,
-	altText,
-	aspectRatio,
 	width = 600,
 	height = 360,
 	hasAudio = true,
+	fallbackImage,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -132,15 +117,7 @@ export const LoopVideo = ({
 	if (renderingTarget !== 'Web') return null;
 
 	if (adapted) {
-		return (
-			<CardPicture
-				mainImage={posterImage}
-				imageSize={imageSize}
-				alt={altText}
-				loading={imageLoading}
-				aspectRatio={aspectRatio}
-			/>
-		);
+		return fallbackImage;
 	}
 
 	const handleClick = (event: React.SyntheticEvent) => {
@@ -226,7 +203,6 @@ export const LoopVideo = ({
 				loop={true}
 				muted={isMuted}
 				playsInline={true}
-				poster={posterImage}
 				height={height}
 				width={width}
 				onPlaying={() => {
@@ -241,13 +217,7 @@ export const LoopVideo = ({
 				{/* Ensure webm source is provided */}
 				{/* <source src={webmSrc} type="video/webm"> */}
 				<source src={src} type="video/mp4" />
-				<CardPicture
-					mainImage={posterImage}
-					imageSize={imageSize}
-					alt={altText}
-					loading={imageLoading}
-					aspectRatio={aspectRatio}
-				/>
+				{fallbackImage}
 			</video>
 			{vidRef.current && (
 				<>

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -1,0 +1,284 @@
+import { css } from '@emotion/react';
+import { log } from '@guardian/libs';
+import { space } from '@guardian/source/foundations';
+import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
+import { useEffect, useRef, useState } from 'react';
+import type { FEAspectRatio } from '../frontend/feFront';
+import { getZIndex } from '../lib/getZIndex';
+import { useIsInView } from '../lib/useIsInView';
+import { useShouldAdapt } from '../lib/useShouldAdapt';
+import { palette } from '../palette';
+import type { ImageSizeType } from './Card/components/ImageWrapper';
+import { narrowPlayIconWidth, PlayIcon } from './Card/components/PlayIcon';
+import type { Loading } from './CardPicture';
+import { CardPicture } from './CardPicture';
+import { useConfig } from './ConfigContext';
+import { LoopVideoProgressBar } from './LoopVideoProgressBar';
+
+const videoContainerStyles = css`
+	z-index: ${getZIndex('loop-video-container')};
+	cursor: pointer;
+	position: relative;
+`;
+
+const videoStyles = css`
+	position: relative;
+	width: 100%;
+	height: auto;
+	/* Find out why this is needed to align the video with its container. */
+	margin-bottom: -3px;
+`;
+
+const playIconStyles = css`
+	position: absolute;
+	top: calc(50% - ${narrowPlayIconWidth / 2}px);
+	left: calc(50% - ${narrowPlayIconWidth / 2}px);
+	cursor: pointer;
+	border: none;
+	background: none;
+	padding: 0;
+`;
+
+const audioButtonStyles = css`
+	border: none;
+	background: none;
+	padding: 0;
+	position: absolute;
+	bottom: ${space[8]}px;
+	right: ${space[8]}px;
+	cursor: pointer;
+`;
+
+type ImageProps = {
+	posterImage: string;
+	imageSize: ImageSizeType;
+	imageLoading: Loading;
+	altText?: string;
+	aspectRatio?: FEAspectRatio;
+};
+
+type Props = ImageProps & {
+	src: string;
+	videoId?: string;
+	width?: number;
+	height?: number;
+	hasAudio?: boolean;
+};
+
+export const LoopVideo = ({
+	src,
+	videoId,
+	posterImage,
+	imageSize,
+	imageLoading,
+	altText,
+	aspectRatio,
+	width = 600,
+	height = 360,
+	hasAudio = true,
+}: Props) => {
+	const adapted = useShouldAdapt();
+	const { renderingTarget } = useConfig();
+	const vidRef = useRef<HTMLVideoElement>(null);
+	const [isPlayable, setIsPlayable] = useState(false);
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [isMuted, setIsMuted] = useState(true);
+	const [elapsedTime, setElapsedTime] = useState(0);
+	/**
+	 * Keep a track of whether the video has been in view. We only want to
+	 * pause the video if it has been in view.
+	 */
+	const [hasBeenInView, setHasBeenInView] = useState(false);
+
+	const [isInView, setNode] = useIsInView({
+		repeat: true,
+		threshold: 0.5,
+		node: vidRef.current ?? undefined,
+		debounce: true,
+	});
+
+	/**
+	 * Pause the video when the user scrolls past it.
+	 */
+	useEffect(() => {
+		if (!vidRef.current) return;
+
+		if (isInView) {
+			if (!hasBeenInView) {
+				// When the video first comes into view, it should autoplay
+				setIsPlaying(true);
+				void vidRef.current.play();
+			}
+			setHasBeenInView(true);
+		}
+
+		if (!isInView && hasBeenInView && isPlayable && isPlaying) {
+			setIsPlaying(false);
+			void vidRef.current.pause();
+		}
+	}, [isInView, hasBeenInView, isPlayable, isPlaying]);
+
+	/**
+	 * Progress bar updates
+	 */
+	useEffect(() => {
+		const interval = setInterval(() => {
+			setElapsedTime(vidRef.current?.currentTime ?? 0);
+		}, 40);
+
+		return () => clearInterval(interval);
+	}, []);
+
+	if (renderingTarget !== 'Web') return null;
+
+	if (adapted) {
+		return (
+			<CardPicture
+				mainImage={posterImage}
+				imageSize={imageSize}
+				alt={altText}
+				loading={imageLoading}
+				aspectRatio={aspectRatio}
+			/>
+		);
+	}
+
+	const handleClick = (event: React.SyntheticEvent) => {
+		event.preventDefault();
+		if (!vidRef.current) return;
+
+		if (isPlaying) {
+			setIsPlaying(false);
+			void vidRef.current.pause();
+		} else {
+			setIsPlaying(true);
+			void vidRef.current.play();
+		}
+	};
+
+	const onError = () => {
+		window.guardian.modules.sentry.reportError(
+			new Error(`Loop video could not be played. source: ${src}`),
+			'loop-video',
+		);
+		log('dotcom', `Loop video could not be played. source: ${src}`);
+	};
+
+	const seekForward = () => {
+		if (vidRef.current) {
+			const newTime = Math.min(
+				vidRef.current.currentTime + 1,
+				vidRef.current.duration,
+			);
+
+			vidRef.current.currentTime = newTime;
+			setElapsedTime(newTime);
+		}
+	};
+
+	const seekBackward = () => {
+		if (vidRef.current) {
+			// Allow the user to cycle to the end of the video using the arrow keys
+			const newTime =
+				(((vidRef.current.currentTime - 1) % vidRef.current.duration) +
+					vidRef.current.duration) %
+				vidRef.current.duration;
+
+			vidRef.current.currentTime = newTime;
+			setElapsedTime(newTime);
+		}
+	};
+
+	const handleKeyDown = (
+		event: React.KeyboardEvent<HTMLDivElement>,
+	): void => {
+		switch (event.key) {
+			case 'Enter':
+			case ' ':
+				handleClick(event);
+				break;
+			case 'ArrowRight':
+				seekForward();
+				break;
+			case 'ArrowLeft':
+				seekBackward();
+				break;
+		}
+	};
+
+	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
+
+	return (
+		<div
+			className="loop-video-container"
+			ref={setNode}
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+			role="button"
+			tabIndex={0}
+			css={videoContainerStyles}
+		>
+			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Captions will be considered later. */}
+			<video
+				id={`loop-video-${videoId}`}
+				ref={vidRef}
+				preload="none"
+				loop={true}
+				muted={isMuted}
+				playsInline={true}
+				poster={posterImage}
+				height={height}
+				width={width}
+				onPlaying={() => {
+					setIsPlaying(true);
+				}}
+				onCanPlay={() => {
+					setIsPlayable(true);
+				}}
+				onError={onError}
+				css={videoStyles}
+			>
+				{/* Ensure webm source is provided */}
+				{/* <source src={webmSrc} type="video/webm"> */}
+				<source src={src} type="video/mp4" />
+				<CardPicture
+					mainImage={posterImage}
+					imageSize={imageSize}
+					alt={altText}
+					loading={imageLoading}
+					aspectRatio={aspectRatio}
+				/>
+			</video>
+			{vidRef.current && (
+				<>
+					{isPlayable && !isPlaying && (
+						<div css={playIconStyles}>
+							<PlayIcon iconWidth="narrow" />
+						</div>
+					)}
+					<LoopVideoProgressBar
+						currentTime={elapsedTime}
+						duration={vidRef.current.duration}
+					/>
+					{hasAudio && (
+						<button
+							type="button"
+							onClick={(event) => {
+								event.stopPropagation(); // Don't pause the video
+								setIsMuted(!isMuted);
+							}}
+							css={audioButtonStyles}
+						>
+							<AudioIcon
+								size="small"
+								theme={{
+									fill: palette('--loop-video-audio-icon'),
+								}}
+							/>
+						</button>
+					)}
+				</>
+			)}
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -21,6 +21,8 @@ export const Default = {
 	args: {
 		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
 		videoId: 'test-video-1',
+		height: 337.5,
+		width: 600,
 		fallbackImage: (
 			<CardPicture
 				mainImage="https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4"

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -14,6 +14,7 @@ export const Default = {
 	name: 'Default',
 	args: {
 		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
+		videoId: 'test-video-1',
 		fallbackImage: (
 			<CardPicture
 				mainImage="https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4"
@@ -24,7 +25,7 @@ export const Default = {
 	},
 } satisfies StoryObj<typeof LoopVideo>;
 
-export const WithouAudio = {
+export const WithoutAudio = {
 	name: 'Without Audio',
 	args: {
 		...Default.args,

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { CardPicture } from './CardPicture';
@@ -8,6 +9,11 @@ export default {
 	title: 'Components/LoopVideo',
 	decorators: [centreColumnDecorator],
 	render: (args) => <LoopVideo {...args} />,
+	parameters: {
+		chromatic: {
+			viewports: [breakpoints.mobile, breakpoints.wide],
+		},
+	},
 } satisfies Meta<typeof LoopVideo>;
 
 export const Default = {

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { LoopVideo } from './LoopVideo.importable';
+
+export default {
+	component: LoopVideo,
+	title: 'Components/LoopVideo',
+	decorators: [centreColumnDecorator],
+	render: (args) => <LoopVideo {...args} />,
+} satisfies Meta<typeof LoopVideo>;
+
+export const Default = {
+	name: 'Default',
+	args: {
+		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
+		posterImage:
+			'https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4',
+		imageSize: 'large',
+		imageLoading: 'eager',
+	},
+} satisfies StoryObj<typeof LoopVideo>;
+
+export const WithouAudio = {
+	name: 'Without Audio',
+	args: {
+		...Default.args,
+		hasAudio: false,
+	},
+} satisfies StoryObj<typeof LoopVideo>;

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { CardPicture } from './CardPicture';
 import { LoopVideo } from './LoopVideo.importable';
 
 export default {
@@ -13,10 +14,13 @@ export const Default = {
 	name: 'Default',
 	args: {
 		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
-		posterImage:
-			'https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4',
-		imageSize: 'large',
-		imageLoading: 'eager',
+		fallbackImage: (
+			<CardPicture
+				mainImage="https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4"
+				imageSize="large"
+				loading="eager"
+			/>
+		),
 	},
 } satisfies StoryObj<typeof LoopVideo>;
 

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -85,11 +85,13 @@ export const LoopVideoPlayer = forwardRef(
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
+		const loopVideoId = `loop-video-${videoId}`;
+
 		return (
 			<>
 				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Captions will be considered later. */}
 				<video
-					id={`loop-video-${videoId}`}
+					id={loopVideoId}
 					ref={ref}
 					preload="none"
 					loop={true}
@@ -138,6 +140,7 @@ export const LoopVideoPlayer = forwardRef(
 							</button>
 						)}
 						<LoopVideoProgressBar
+							videoId={loopVideoId}
 							currentTime={currentTime}
 							duration={ref.current.duration}
 						/>

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -47,12 +47,13 @@ type Props = {
 	setIsPlayable: Dispatch<SetStateAction<boolean>>;
 	isPlaying: boolean;
 	setIsPlaying: Dispatch<SetStateAction<boolean>>;
+	currentTime: number;
+	setCurrentTime: Dispatch<SetStateAction<number>>;
 	isMuted: boolean;
 	setIsMuted: Dispatch<SetStateAction<boolean>>;
 	handleClick: (event: SyntheticEvent) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
-	elapsedTime: number;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
 };
 
@@ -73,12 +74,13 @@ export const LoopVideoPlayer = forwardRef(
 			setIsPlayable,
 			isPlaying,
 			setIsPlaying,
+			currentTime,
+			setCurrentTime,
 			isMuted,
 			setIsMuted,
 			handleClick,
 			handleKeyDown,
 			onError,
-			elapsedTime,
 			AudioIcon,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
@@ -101,6 +103,16 @@ export const LoopVideoPlayer = forwardRef(
 					onCanPlay={() => {
 						setIsPlayable(true);
 					}}
+					onTimeUpdate={() => {
+						if (
+							ref &&
+							'current' in ref &&
+							ref.current &&
+							isPlaying
+						) {
+							setCurrentTime(ref.current.currentTime);
+						}
+					}}
 					onClick={handleClick}
 					onKeyDown={handleKeyDown}
 					role="button"
@@ -117,12 +129,16 @@ export const LoopVideoPlayer = forwardRef(
 				{ref && 'current' in ref && ref.current && (
 					<>
 						{isPlayable && !isPlaying && (
-							<div css={playIconStyles}>
+							<button
+								type="button"
+								onClick={handleClick}
+								css={playIconStyles}
+							>
 								<PlayIcon iconWidth="narrow" />
-							</div>
+							</button>
 						)}
 						<LoopVideoProgressBar
-							currentTime={elapsedTime}
+							currentTime={currentTime}
 							duration={ref.current.duration}
 						/>
 						{hasAudio && (

--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -1,41 +1,15 @@
 import { css } from '@emotion/react';
 import { palette } from '../palette';
 
-const styles = css`
+const styles = (progressPercentage: number) => css`
 	position: absolute;
 	bottom: 0;
 	left: 0;
 	height: 7px;
 	width: 100%;
-
-	progress {
-		display: block;
-		width: 100%;
-		height: 100%;
-		border: none;
-		-moz-border-radius: 0;
-		-webkit-border-radius: 0;
-		border-radius: 0;
-	}
-
-	/* background: */
-	progress::-webkit-progress-bar {
-		background-color: transparent;
-	}
-	progress {
-		background-color: transparent;
-	}
-
-	/* value: */
-	progress::-webkit-progress-value {
-		background-color: ${palette('--loop-video-progress-bar-value')};
-	}
-	progress::-moz-progress-bar {
-		background-color: ${palette('--loop-video-progress-bar-value')};
-	}
-	progress {
-		color: ${palette('--loop-video-progress-bar-value')};
-	}
+	width: ${progressPercentage}%;
+	transition: width 0.3s linear;
+	background-color: ${palette('--loop-video-progress-bar-value')};
 `;
 
 type Props = {
@@ -46,12 +20,10 @@ type Props = {
 export const LoopVideoProgressBar = ({ currentTime, duration }: Props) => {
 	if (duration <= 0) return null;
 
-	const progressPercentage =
-		duration > 0 ? (currentTime * 100) / duration : 0;
+	const progressPercentage = (currentTime * 100) / duration;
+	if (Number.isNaN(progressPercentage)) {
+		return null;
+	}
 
-	return (
-		<div css={styles} className="progress-bar">
-			<progress value={progressPercentage / 100} />
-		</div>
-	);
+	return <div role="progressbar" css={styles(progressPercentage)} />;
 };

--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -1,0 +1,57 @@
+import { css } from '@emotion/react';
+import { palette } from '../palette';
+
+const styles = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	height: 7px;
+	width: 100%;
+
+	progress {
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: none;
+		-moz-border-radius: 0;
+		-webkit-border-radius: 0;
+		border-radius: 0;
+	}
+
+	/* background: */
+	progress::-webkit-progress-bar {
+		background-color: transparent;
+	}
+	progress {
+		background-color: transparent;
+	}
+
+	/* value: */
+	progress::-webkit-progress-value {
+		background-color: ${palette('--loop-video-progress-bar-value')};
+	}
+	progress::-moz-progress-bar {
+		background-color: ${palette('--loop-video-progress-bar-value')};
+	}
+	progress {
+		color: ${palette('--loop-video-progress-bar-value')};
+	}
+`;
+
+type Props = {
+	currentTime: number;
+	duration: number;
+};
+
+export const LoopVideoProgressBar = ({ currentTime, duration }: Props) => {
+	if (duration <= 0) return null;
+
+	const progressPercentage =
+		duration > 0 ? (currentTime * 100) / duration : 0;
+
+	return (
+		<div css={styles} className="progress-bar">
+			<progress value={progressPercentage / 100} />
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -13,11 +13,22 @@ const styles = (progressPercentage: number) => css`
 `;
 
 type Props = {
+	videoId: string;
 	currentTime: number;
 	duration: number;
 };
 
-export const LoopVideoProgressBar = ({ currentTime, duration }: Props) => {
+/**
+ * A progress bar for the loop video component.
+ *
+ * Why don't we use the <progress /> element?
+ * It was not possible to properly style the native progress element in safari.
+ */
+export const LoopVideoProgressBar = ({
+	videoId,
+	currentTime,
+	duration,
+}: Props) => {
 	if (duration <= 0) return null;
 
 	const progressPercentage = (currentTime * 100) / duration;
@@ -25,5 +36,14 @@ export const LoopVideoProgressBar = ({ currentTime, duration }: Props) => {
 		return null;
 	}
 
-	return <div role="progressbar" css={styles(progressPercentage)} />;
+	return (
+		<div
+			role="progressbar"
+			aria-labelledby={videoId}
+			aria-valuenow={progressPercentage}
+			aria-valuemin={0}
+			aria-valuemax={100}
+			css={styles(progressPercentage)}
+		/>
+	);
 };

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -6,7 +6,7 @@ import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
 import type { AspectRatio } from '../../types/front';
 import { CardFooter } from '../Card/components/CardFooter';
-import { PlayIcon } from '../Card/components/PlayIcon';
+import { narrowPlayIconWidth, PlayIcon } from '../Card/components/PlayIcon';
 import { TrailText } from '../Card/components/TrailText';
 import type { ResponsiveFontSize } from '../CardHeadline';
 import { CardHeadline } from '../CardHeadline';
@@ -85,6 +85,16 @@ const immersiveOverlayStyles = css`
 		backdrop-filter: blur(12px) brightness(0.5);
 		${overlayMaskGradientStyles('270deg')}
 	}
+`;
+
+const playIconStyles = css`
+	position: absolute;
+	/**
+      * Subject to change. We will wait to see how fronts editors use the
+	  * headlines and standfirsts before we decide on a final position.
+	  */
+	top: 35%;
+	left: calc(50% - ${narrowPlayIconWidth / 2}px);
 `;
 
 const videoPillStyles = css`
@@ -183,7 +193,9 @@ export const YoutubeAtomFeatureCardOverlay = ({
 					</div>
 				) : null}
 				<div className="image-overlay" />
-				<PlayIcon iconWidth="narrow" />
+				<div css={playIconStyles}>
+					<PlayIcon iconWidth="narrow" />
+				</div>
 				<div
 					css={[
 						textOverlayStyles,

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -85,6 +85,9 @@ const indices = [
 	'bodyArea',
 	'rightColumnArea',
 
+	// Loop video container
+	'loop-video-container',
+
 	// Main media
 	'mainMedia',
 

--- a/dotcom-rendering/src/lib/useIsInView.ts
+++ b/dotcom-rendering/src/lib/useIsInView.ts
@@ -29,7 +29,9 @@ type Options = {
 	 * If `true`, trigger the hook on all intersections.
 	 */
 	repeat?: true;
-	/** Set the initial HTML Element, if known. */
+	/**
+	 * Set the initial HTML Element, if known.
+	 */
 	node?: HTMLElement;
 };
 
@@ -70,6 +72,7 @@ const useIsInView = (
 
 	useEffect(() => {
 		if (!node) return;
+
 		// Check for browser support https://caniuse.com/intersectionobserver
 		if (!('IntersectionObserver' in window)) return;
 

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6772,6 +6772,14 @@ const paletteColours = {
 		light: liveBlockContainerBackgroundLight,
 		dark: liveBlockContainerBackgroundDark,
 	},
+	'--loop-video-audio-icon': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[100],
+	},
+	'--loop-video-progress-bar-value': {
+		light: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--masthead-nav-background': {
 		light: mastheadNavBackground,
 		dark: mastheadNavBackground,


### PR DESCRIPTION
## What does this change?

Adds a loop video component.

## Why?

The first step towards playing looping video on our fronts.

## Screenshots


https://github.com/user-attachments/assets/4e04f0d4-c2bc-43f5-8bef-860bea2cb8da



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
