### PR TITLE
Separate left border carousel styles 

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { useEffect, useRef, useState } from 'react';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { palette } from '../palette';
@@ -92,15 +92,35 @@ const itemStyles = css`
 	scroll-snap-align: start;
 	grid-area: span 1;
 	position: relative;
+`;
+
+const leftBorderStyles = css`
+	content: '';
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: -10px;
+	width: 1px;
+	background-color: ${palette('--card-border-top')};
+	transform: translateX(-50%);
+`;
+
+const singleRowLeftBorderStyles = css`
 	:not(:first-child)::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: -10px;
-		width: 1px;
-		background-color: ${palette('--card-border-top')};
-		transform: translateX(-50%);
+		${leftBorderStyles}
+	}
+`;
+
+const stackedRowLeftBorderStyles = css`
+	${from.tablet} {
+		:not(:first-child)::before {
+			${leftBorderStyles}
+		}
+	}
+	${until.tablet} {
+		:not(:first-child):not(:nth-child(2))::before {
+			${leftBorderStyles}
+		}
 	}
 `;
 
@@ -297,6 +317,21 @@ export const ScrollableCarousel = ({
 	);
 };
 
-ScrollableCarousel.Item = ({ children }: { children: React.ReactNode }) => (
-	<li css={itemStyles}>{children}</li>
+ScrollableCarousel.Item = ({
+	isStackingCarousel = false,
+	children,
+}: {
+	isStackingCarousel?: boolean;
+	children: React.ReactNode;
+}) => (
+	<li
+		css={[
+			itemStyles,
+			isStackingCarousel
+				? stackedRowLeftBorderStyles
+				: singleRowLeftBorderStyles,
+		]}
+	>
+		{children}
+	</li>
 );

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -19,6 +19,32 @@ type Props = {
 };
 
 /**
+ * The scrollable small container displays in the following ways:
+ * It is limited to 4 cards maximum and displays in a 2x2 grid.
+ * It is scrollable on mobile and static on tablet and desktop.
+ * On mobile, each column is scrollable
+ *
+ * The layout of cards within the 2x2 grid differs between breakpoints:
+ *
+ * On mobile, the layout is:
+ *
+ * +--------+--------+
+ * | Card 0 | Card 2 |
+ * +--------+--------+
+ * | Card 1 | Card 3 |
+ * +--------+--------+
+ *
+ * On tablet and above, the layout is:
+ *
+ * +--------+--------+
+ * | Card 0 | Card 1 |
+ * +--------+--------+
+ * | Card 2 | Card 3 |
+ * +--------+--------+
+ *
+ */
+
+/**
  * A container used on fronts to display a carousel of small cards
  *
  * ## Why does this need to be an Island?
@@ -47,7 +73,10 @@ export const ScrollableSmall = ({
 		>
 			{trails.map((trail, index) => {
 				return (
-					<ScrollableCarousel.Item key={trail.url}>
+					<ScrollableCarousel.Item
+						key={trail.url}
+						isStackingCarousel={true}
+					>
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}


### PR DESCRIPTION
## What does this change?
Separate left border carousel styles so that these can be applied differently if the carousel has stacked rows or not, depending on breakpoint.

## Why?
Cards in the first column should not have a left border. This works as is for single rows by not applying the before styling if the carousel is a single row. 

However, if the carousel has stacked rows, on mobile, the second card is also in the first column and should no have a left border.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before-m][] | ![after-m][] |

[before-m]: https://github.com/user-attachments/assets/e9abca2a-a636-4077-9b06-3ec87b4ec0e0
[after-m]: https://github.com/user-attachments/assets/4a8d5f94-3bcf-49bf-8b07-fc1d278bc9a5

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
