### PR TITLE
Allow consumers to control the column and row gap sizing on scrollable carousels

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -5,6 +5,9 @@ import { nestedOphanComponents } from '../lib/ophan-helpers';
 import { palette } from '../palette';
 import { CarouselNavigationButtons } from './CarouselNavigationButtons';
 
+type GapSize = 'small' | 'medium' | 'large';
+type GapSizes = { row: GapSize; column: GapSize };
+
 type Props = {
 	children: React.ReactNode;
 	carouselLength: number;
@@ -12,6 +15,7 @@ type Props = {
 	visibleCardsOnTablet: number;
 	sectionId?: string;
 	shouldStackCards?: { desktop: boolean; mobile: boolean };
+	gapSizes?: GapSizes;
 };
 
 /**
@@ -53,7 +57,6 @@ const carouselStyles = css`
 	width: 100%;
 	grid-auto-columns: 1fr;
 	grid-auto-flow: column;
-	gap: 20px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
@@ -86,6 +89,13 @@ const carouselStyles = css`
 		scroll-padding-left: ${gridGap / 2}px;
 	}
 `;
+
+const carouselGapStyles = (column: number, row: number) => {
+	return css`
+		column-gap: ${column}px;
+		row-gap: ${row}px;
+	`;
+};
 
 const itemStyles = css`
 	display: flex;
@@ -174,6 +184,17 @@ const generateCarouselColumnStyles = (
 	`;
 };
 
+const getGapSize = (gap: GapSize) => {
+	switch (gap) {
+		case 'small':
+			return space[3];
+		case 'medium':
+			return space[4];
+		case 'large':
+			return space[5];
+	}
+};
+
 /**
  * A component used in the carousel fronts containers (e.g. small/medium/feature)
  */
@@ -184,6 +205,7 @@ export const ScrollableCarousel = ({
 	visibleCardsOnTablet,
 	sectionId,
 	shouldStackCards = { desktop: false, mobile: false },
+	gapSizes = { column: 'large', row: 'large' },
 }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
@@ -202,6 +224,9 @@ export const ScrollableCarousel = ({
 			behavior: 'smooth',
 		});
 	};
+
+	const rowGap = getGapSize(gapSizes.row);
+	const columnGap = getGapSize(gapSizes.column);
 
 	/**
 	 * Updates state of navigation buttons based on carousel's scroll position.
@@ -264,6 +289,7 @@ export const ScrollableCarousel = ({
 				ref={carouselRef}
 				css={[
 					carouselStyles,
+					carouselGapStyles(columnGap, rowGap),
 					generateCarouselColumnStyles(
 						carouselLength,
 						visibleCardsOnMobile,

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -44,6 +44,7 @@ export const ScrollableSmall = ({
 			visibleCardsOnTablet={2}
 			sectionId={sectionId}
 			shouldStackCards={{ desktop: trails.length > 2, mobile: true }}
+			gapSizes={{ column: 'large', row: 'medium' }}
 		>
 			{trails.map((trail, index) => {
 				return (


### PR DESCRIPTION
## What does this change?
Extends the scrollable carousel api to allow consumers to set the gap sizing by row or column using a small, medium, large model.

These map to 
small => space[3]
medium => space[4]
large => space[5]

It defaults to `row: large, column: large`

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/78e18baf-f24d-4c03-9148-e04bf291ca63
[after]: https://github.com/user-attachments/assets/25a3e4d0-c83f-4a15-a292-e2251864d67f


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
