### PR TITLE
Secondary level title font size

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -2,12 +2,14 @@ import { css } from '@emotion/react';
 import {
 	article17,
 	between,
+	from,
 	headlineBold17,
 	headlineBold24,
 	headlineBold28,
 	space,
 	textEgyptian17,
 	textSansBold17,
+	textSansBold20,
 	until,
 } from '@guardian/source/foundations';
 import { type EditionId, getEditionFromId } from '../lib/edition';
@@ -42,6 +44,9 @@ const primaryTitleStyles = css`
 `;
 const secondaryTitleStyles = css`
 	${textSansBold17};
+	${from.tablet} {
+		${textSansBold20};
+	}
 `;
 
 const headerStylesWithUrl = css`


### PR DESCRIPTION
## do not merge - this is awaiting editorial sign off which is delayed by easter break

## What does this change?
Set secondary level container title font size to text sans 20 on tablet and desktop but keep mobile at text sans 17

## Why?
this has been requested by design

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![after][] | ![before][] |

[before]: https://github.com/user-attachments/assets/508c2b87-5f83-426d-a9d8-02862b8ae295
[after]: https://github.com/user-attachments/assets/4fda0a8c-d259-47fa-a4fb-502b95e44705


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
