### PR TITLE
Update height of scrollable small in getFrontsAdPositions.ts

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -185,13 +185,13 @@ const getCollectionHeight = (
 		// Some thrashers are very small. Since we'd prefer to have ads above content rather than thrashers,
 		// err on the side of inserting fewer ads, by setting the number on the small side for thrashers
 		case 'fixed/thrasher':
-		case 'scrollable/small':
 			return 0.5;
 
 		case 'fixed/small/slow-IV':
 		case 'fixed/small/slow-V-mpu':
 		case 'nav/list':
 		case 'nav/media-list':
+		case 'scrollable/small':
 		case 'scrollable/medium':
 		case 'static/medium/4':
 			return 1;


### PR DESCRIPTION
## What does this change?

The scrollable small has been redesigned. 

The container is now twice the height on desktop and tablet, the same as scrollable medium.

As such, the height of scrollable small has been moved from 0.5 to 1 so that it can be correctly calculated when deciding ad positioning. 

