### PR TITLE
Don't reserve nav button space for tablet scrollable/small and scrollable/medium

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -411,9 +411,6 @@ const secondaryLevelTopBorder = css`
 `;
 
 const carouselNavigationPlaceholder = css`
-	${between.tablet.and.leftCol} {
-		min-height: 44px;
-	}
 	.hidden & {
 		display: none;
 	}


### PR DESCRIPTION
## What does this change?
Remove scrollable/small and scrollable/medium from having reserved space for carousel buttons on tablet. This is because neither container is scrollable anymore on tablet. 

## Why?

This is because:

    - scrollable/small now stacks into a 2x2 grid on tablet
    - scrollable/medium is now limited to 4 cards which all appear on screen on tablet

and as such do not need to reserve space for carousel buttons. Without this change, there is far too much space the above the first row. 

Design have requested that we keep the ability to house tablet carousel buttons here and so this pr does not rip out the associated code. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/9f79faa6-ac51-47f8-9486-8c94e66e42a1
[after]: https://github.com/user-attachments/assets/24c9466d-5375-4e1c-ad7e-9f0a670c404f


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
