### PR TITLE
Support scores above ten in the match nav

### DIFF
--- a/dotcom-rendering/src/components/Score.stories.tsx
+++ b/dotcom-rendering/src/components/Score.stories.tsx
@@ -20,7 +20,15 @@ export const Default = () => {
 			<Score score={9} />
 			<Score score={10} />
 			<Score score={11} />
-			<p>^ We only go up to 10 at the moment 🤷‍♀</p>
+			<Score score={12} />
+			<Score score={13} />
+			<Score score={14} />
+			<Score score={15} />
+			<Score score={16} />
+			<Score score={17} />
+			<Score score={18} />
+			<Score score={31} />
+			<Score score={NaN} />
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Score.stories.tsx
+++ b/dotcom-rendering/src/components/Score.stories.tsx
@@ -28,6 +28,7 @@ export const Default = () => {
 			<Score score={17} />
 			<Score score={18} />
 			<Score score={31} />
+			<Score score={0.5} />
 			<Score score={NaN} />
 		</>
 	);

--- a/dotcom-rendering/src/components/Score.tsx
+++ b/dotcom-rendering/src/components/Score.tsx
@@ -64,8 +64,8 @@ const ScoreNumber = ({ score }: Props) => {
 		default:
 			return (
 				<>
-					<ScoreNumber score={Number(score.toString()[0])} />
-					<ScoreNumber score={Number(score.toString().slice(1))} />
+					<ScoreNumber score={Math.trunc(score / 10)} />
+					<ScoreNumber score={score % 10} />
 				</>
 			);
 	}

--- a/dotcom-rendering/src/components/Score.tsx
+++ b/dotcom-rendering/src/components/Score.tsx
@@ -34,7 +34,7 @@ type Props = {
 };
 
 const ScoreNumber = ({ score }: Props) => {
-	if (Number.isNaN(score)) {
+	if (Number.isNaN(score) || !Number.isInteger(score)) {
 		return null;
 	}
 

--- a/dotcom-rendering/src/components/Score.tsx
+++ b/dotcom-rendering/src/components/Score.tsx
@@ -34,7 +34,7 @@ type Props = {
 };
 
 const ScoreNumber = ({ score }: Props) => {
-	if (Number.isNaN(score) || !Number.isInteger(score)) {
+	if (!Number.isInteger(score) || score < 0) {
 		return null;
 	}
 

--- a/dotcom-rendering/src/components/Score.tsx
+++ b/dotcom-rendering/src/components/Score.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { text } from '@guardian/source/foundations';
+import { palette } from '../palette';
 import { Eight } from './numbers/Eight';
 import { Five } from './numbers/Five';
 import { Four } from './numbers/Four';
@@ -12,103 +12,69 @@ import { Three } from './numbers/Three';
 import { Two } from './numbers/Two';
 import { Zero } from './numbers/Zero';
 
+const ScoreStyles = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			position: relative;
+			width: 3.75rem;
+			height: 3.75rem;
+			border-radius: 1.875rem;
+			border: 0.0625rem solid ${palette('--football-score-border')};
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		`}
+	>
+		{children}
+	</div>
+);
+
 type Props = {
 	score: number;
 };
 
-export const Score = ({ score }: Props) => {
-	const ScoreStyles = ({ children }: { children: React.ReactNode }) => (
-		<div
-			css={css`
-				position: relative;
-				width: 3.75rem;
-				height: 3.75rem;
-				border-radius: 1.875rem;
-				border: 0.0625rem solid ${text.primary};
-
-				svg {
-					position: absolute;
-					top: 0;
-					left: 0;
-					right: 0;
-					bottom: 0;
-					margin: auto;
-				}
-			`}
-		>
-			{children}
-		</div>
-	);
-
-	if (Number.isNaN(score)) return <ScoreStyles> </ScoreStyles>;
+const ScoreNumber = ({ score }: Props) => {
+	if (Number.isNaN(score)) {
+		return null;
+	}
 
 	switch (score) {
 		case 0:
-			return (
-				<ScoreStyles>
-					<Zero />
-				</ScoreStyles>
-			);
+			return <Zero />;
 		case 1:
-			return (
-				<ScoreStyles>
-					<One />
-				</ScoreStyles>
-			);
+			return <One />;
 		case 2:
-			return (
-				<ScoreStyles>
-					<Two />
-				</ScoreStyles>
-			);
+			return <Two />;
 		case 3:
-			return (
-				<ScoreStyles>
-					<Three />
-				</ScoreStyles>
-			);
+			return <Three />;
 		case 4:
-			return (
-				<ScoreStyles>
-					<Four />
-				</ScoreStyles>
-			);
+			return <Four />;
 		case 5:
-			return (
-				<ScoreStyles>
-					<Five />
-				</ScoreStyles>
-			);
+			return <Five />;
 		case 6:
-			return (
-				<ScoreStyles>
-					<Six />
-				</ScoreStyles>
-			);
+			return <Six />;
 		case 7:
-			return (
-				<ScoreStyles>
-					<Seven />
-				</ScoreStyles>
-			);
+			return <Seven />;
 		case 8:
-			return (
-				<ScoreStyles>
-					<Eight />
-				</ScoreStyles>
-			);
+			return <Eight />;
 		case 9:
-			return (
-				<ScoreStyles>
-					<Nine />
-				</ScoreStyles>
-			);
+			return <Nine />;
 		case 10:
+			return <Ten />;
 		default:
 			return (
-				<ScoreStyles>
-					<Ten />
-				</ScoreStyles>
+				<>
+					<ScoreNumber score={Number(score.toString()[0])} />
+					<ScoreNumber score={Number(score.toString().slice(1))} />
+				</>
 			);
 	}
+};
+
+export const Score = ({ score }: Props) => {
+	return (
+		<ScoreStyles>
+			<ScoreNumber score={score} />
+		</ScoreStyles>
+	);
 };

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6595,6 +6595,10 @@ const paletteColours = {
 		light: () => sourcePalette.sport[500],
 		dark: () => sourcePalette.sport[500],
 	},
+	'--football-score-border': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
 	'--football-sub-text': {
 		light: () => sourcePalette.neutral[46],
 		dark: () => sourcePalette.neutral[73],


### PR DESCRIPTION
## What does this change?

Add the ability for the scores in match navs to display scores above 10, currently it just caps it

## Why?

It happens - see https://www.theguardian.com/football/match/4476810 
<img width="640" alt="image" src="https://github.com/user-attachments/assets/f678bb93-cf50-42a6-b497-301edc58428b" />
<img width="987" alt="image" src="https://github.com/user-attachments/assets/016fb650-56d5-4ed7-916d-a959b1ad1975" />


## Screenshots

| Before    1-10  | After   1-10   | Before Above 10 | After Above 10 |
| ----------- | ---------- | ----------- | ---------- | 
| ![before1-10][] | ![after1-10][] | ![before10][] | ![after10][] |

[before1-10]: https://github.com/user-attachments/assets/584c9fea-ec66-4870-8e08-58b33aa23479
[after1-10]: https://github.com/user-attachments/assets/6941073e-4e06-48f8-8f18-dbcbad5c6581

[before10]: https://github.com/user-attachments/assets/fcc5c963-e4d7-4e2d-b92f-edd2b2e329b9
[after10]: https://github.com/user-attachments/assets/792e5fc6-b3c8-4cbf-90e9-08203914b3be


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
