### PR TITLE
Bump immersive card headline size from small to medium on desktop

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -128,7 +128,7 @@ const ImmersiveCardLayout = ({
 					aspectRatio={'5:3'}
 					mobileAspectRatio={'4:5'}
 					imageSize="feature-immersive"
-					headlineSizes={{ desktop: 'small' }}
+					headlineSizes={{ desktop: 'medium', tablet: 'small' }}
 					supportingContent={card.supportingContent}
 					isImmersive={true}
 				/>


### PR DESCRIPTION
## What does this change?
Bump immersive card headline size from small to medium on desktop

## Why?
This was requested by design.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/381cde89-7d4d-4fce-8bbc-f4f02abd9c62
[after]: https://github.com/user-attachments/assets/397ebe05-2fee-4a2b-b211-002aae20b2ac

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
