### PR TITLE
Render relevant video atom

### DIFF
--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -18,6 +18,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -307,6 +308,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: true,
 			imageSlideshowReplace: false,
@@ -620,6 +622,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -954,6 +957,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -1253,6 +1257,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -1482,6 +1487,7 @@ export const trails: [
 		properties: {
 			isBreaking: false,
 			showMainVideo: false,
+			videoReplace: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -134,6 +134,8 @@ export type FEFrontCard = {
 	properties: {
 		isBreaking: boolean;
 		showMainVideo: boolean;
+		videoReplace: boolean;
+		replacementVideoAtomId?: string;
 		showKickerTag: boolean;
 		showByline: boolean;
 		imageSlideshowReplace: boolean;
@@ -201,6 +203,7 @@ export type FEFrontCard = {
 		editionBrandings: EditionBranding[];
 		href?: string;
 		embedUri?: string;
+		mediaAtom?: FEMediaAtom;
 	};
 	header: {
 		isVideo: boolean;
@@ -259,6 +262,7 @@ export type FEFrontCard = {
 	};
 	format?: FEFormat;
 	enriched?: FESnap;
+	mediaAtom?: FEMediaAtom;
 	supportingContent?: FESupportingContent[];
 	cardStyle?: {
 		type: FEFrontCardStyle;

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -198,10 +198,9 @@ const decideMedia = (
 	audioDuration: string = '',
 	podcastImage?: PodcastSeriesImage,
 	imageHide?: boolean,
+	videoReplace?: boolean,
 ): MainMedia | undefined => {
-	// If the showVideo toggle is enabled in the fronts tool,
-	// we should return the active mediaAtom regardless of the design
-	if (showMainVideo) {
+	if (showMainVideo === true || videoReplace === true) {
 		return getActiveMediaAtom(mediaAtom);
 	}
 
@@ -286,15 +285,18 @@ export const enhanceCards = (
 
 		const isContributorTagPage = !!pageId && pageId.startsWith('profile/');
 
+		// const mainMediaAtom = faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
+		// 	faciaCard.properties.maybeContent?.elements.mediaAtoms[0];
+
 		const mainMedia = decideMedia(
 			format,
 			faciaCard.properties.showMainVideo,
-			faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
-				faciaCard.properties.maybeContent?.elements.mediaAtoms[0],
+			faciaCard.properties.mediaAtom,
 			faciaCard.card.galleryCount,
 			faciaCard.card.audioDuration,
 			podcastImage,
 			faciaCard.display.imageHide,
+			faciaCard.properties.videoReplace,
 		);
 
 		return {


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
