### PR TITLE
Use `cleanTeamName` everywhere we parse football team names

### DIFF
--- a/dotcom-rendering/src/footballMatch.ts
+++ b/dotcom-rendering/src/footballMatch.ts
@@ -8,6 +8,7 @@ import type {
 } from './frontend/feFootballMatchPage';
 import type { Result } from './lib/result';
 import { error, ok } from './lib/result';
+import { cleanTeamName } from './sportDataPage';
 
 const eventTypes = ['substitution', 'dismissal', 'booking'] as const;
 const isEventType = isOneOf(eventTypes);
@@ -109,7 +110,7 @@ const parseTeam = (
 
 	return ok({
 		id: feFootballMatchTeam.id,
-		name: feFootballMatchTeam.name,
+		name: cleanTeamName(feFootballMatchTeam.name),
 		codename: feFootballMatchTeam.codename,
 		score: feFootballMatchTeam.score,
 		scorers: feFootballMatchTeam.scorers,

--- a/dotcom-rendering/src/footballMatches.ts
+++ b/dotcom-rendering/src/footballMatches.ts
@@ -8,6 +8,7 @@ import type {
 	FEResult,
 } from './frontend/feFootballMatchListPage';
 import { error, ok, type Result } from './lib/result';
+import { cleanTeamName } from './sportDataPage';
 
 export type Team = {
 	name: string;
@@ -381,14 +382,6 @@ export const getParserErrorMessage = (parserError: ParserError): string => {
 export const parse: (
 	frontendData: FEMatchByDateAndCompetition[],
 ) => Result<ParserError, FootballMatches> = listParse(parseFootballDay);
-
-const cleanTeamName = (teamName: string): string => {
-	return teamName
-		.replace('Ladies', '')
-		.replace('Holland', 'The Netherlands')
-		.replace('Bialystock', 'Białystok')
-		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
-};
 
 // This comes from Frontend
 const paStatusToMatchStatus: Record<string, string> = {

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -7,6 +7,7 @@ import type {
 	FETeamResult,
 } from './frontend/feFootballTablesPage';
 import { error, ok, type Result } from './lib/result';
+import { cleanTeamName } from './sportDataPage';
 
 type TeamScore = {
 	name: string;
@@ -122,7 +123,7 @@ const parseEntry = (
 	return ok({
 		position: team.rank,
 		team: {
-			name: team.name,
+			name: cleanTeamName(team.name),
 			id: team.id,
 			url: teamUrl,
 		},

--- a/dotcom-rendering/src/footballTables.ts
+++ b/dotcom-rendering/src/footballTables.ts
@@ -96,12 +96,12 @@ const parseResult = (result: FETeamResult): Result<ParserError, TeamResult> => {
 		matchId: result.matchId,
 		self: {
 			id: result.self.id,
-			name: result.self.name,
+			name: cleanTeamName(result.self.name),
 			score: result.self.score,
 		},
 		foe: {
 			id: result.foe.id,
-			name: result.foe.name,
+			name: cleanTeamName(result.foe.name),
 			score: result.foe.score,
 		},
 	});

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -60,3 +60,11 @@ export type SportPageKind = FootballPageKind | CricketMatchPage['kind'];
 export type FootballDataPage = FootballMatchListPage | FootballTablesPage;
 
 export type SportDataPage = FootballDataPage | CricketMatchPage;
+
+export const cleanTeamName = (teamName: string): string => {
+	return teamName
+		.replace('Ladies', '')
+		.replace('Holland', 'The Netherlands')
+		.replace('Bialystock', 'Białystok')
+		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
+};


### PR DESCRIPTION
## What does this change?
Adds `cleanTeamName` transform to football team names in parsing steps for tables and match summaries

## Why?
Consistency with match lists and existing frontend behaviour
