### PR TITLE
Remove top ad on mobile beta fronts

### DIFF
--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -218,7 +218,7 @@ describe('Mobile Ads', () => {
 
 	it('Europe Network Front, with beta containers and more than 4 collections, with thrashers in various places', () => {
 		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'flexible/general', containerLevel: 'Primary' }, // Ad position (0)
+			{ collectionType: 'flexible/general', containerLevel: 'Primary' }, // Ignored - is before secondary container
 			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
 			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
 			{
@@ -262,7 +262,7 @@ describe('Mobile Ads', () => {
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
-		expect(mobileAdPositions).toEqual([0, 4, 6, 8, 13, 18]);
+		expect(mobileAdPositions).toEqual([4, 6, 8, 13, 18]);
 	});
 });
 

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -109,9 +109,8 @@ const canInsertMobileAd =
 
 		/** Additional rules exist for "beta" fronts which have primary and secondary level containers */
 		const betaFrontRules = [
-			// Allow insertion after first container at any time but for all other situations,
-			// prevent insertion before a secondary level container
-			index === 0 || !isBeforeSecondaryLevelContainer(index, collections),
+			// Prevent insertion before a secondary level container
+			!isBeforeSecondaryLevelContainer(index, collections),
 			// Prevent insertion before a branded container
 			!isBeforeBrandedContainer(index, collections),
 		];


### PR DESCRIPTION
## What does this change?

On beta containers, no longer insert an ad after the first container on mobile. 

## Why?

We initially inserted an ad after the first container as we were confident that there would be enough space between this ad and the next

## Screenshots

_Ad slots highlighted with thick blue border._

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fd913ead-a1a4-49f3-83f3-b7a7cf18e38b
[after]: https://github.com/user-attachments/assets/8ec00827-2790-4c03-ade8-11df18ca37a3