### PR TITLE
Use correct image size for highlights card

### DIFF
--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -25,6 +25,7 @@ export type ImageSizeType =
 	| 'jumbo'
 	| 'carousel'
 	| 'podcast'
+	| 'highlights-card'
 	| 'feature'
 	| 'feature-large'
 	| 'feature-immersive';

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -44,6 +44,11 @@ const decideImageWidths = (
 		case 'podcast':
 			return [{ breakpoint: breakpoints.mobile, width: 80, aspectRatio }];
 
+		case 'highlights-card':
+			return [
+				{ breakpoint: breakpoints.mobile, width: 112, aspectRatio },
+			];
+
 		case 'carousel':
 			return [
 				{ breakpoint: breakpoints.mobile, width: 220, aspectRatio },

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -165,7 +165,7 @@ const decideImage = (
 					isCircular={false}
 					aspectRatio="1:1"
 				/>
-				<div className="image-overlay"> </div>
+				<div className="image-overlay" />
 			</>
 		);
 	}
@@ -177,7 +177,7 @@ const decideImage = (
 	return (
 		<>
 			<CardPicture
-				imageSize="medium"
+				imageSize="highlights-card"
 				mainImage={image.src}
 				alt={image.altText}
 				loading={imageLoading}
@@ -185,7 +185,7 @@ const decideImage = (
 				aspectRatio="1:1"
 			/>
 			{/* This image overlay is styled when the CardLink is hovered */}
-			<div className="image-overlay circular"> </div>
+			<div className="image-overlay circular" />
 		</>
 	);
 };


### PR DESCRIPTION
## What does this change?

Uses correct image size for highlights card.

## Why?

Images in highlights cards are 112px by 112px. We now correctly optimise the image for its dimensions

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/ab14d72d-2f8c-4d1e-862d-327861261d3d
[after]: https://github.com/user-attachments/assets/158b53d8-17e4-48b7-9159-665309a000cc

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
