### PR TITLE
Remove heatphan carousel tracking for the scrollable carousel

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -317,7 +317,9 @@ export const ScrollableCarousel = ({
 					),
 					stackedCardRowsStyles(shouldStackCards),
 				]}
-				data-heatphan-type="carousel"
+				// HOTFIX: We have disabled the heatphan carousel attribute as it was causing rendering issues in heatphan as these carousels are no longer scrollable on tablet and desktop.
+				// TODO: create a breakpoint option for heatphan
+				// data-heatphan-type="carousel"
 			>
 				{children}
 			</ol>


### PR DESCRIPTION
## What does this change?
Disables heatphan carousel tracking on the scrollable carousel.

## Why?
The scrollable carousel has been redesigned and is only scrollable now on mobile. This is causing issues with heatphan rendering as it is expecting a carousel component on all breakpoints. 

For now, we are disabling this property so that heatphan works correctly on desktop (which accounts for the majority of heatphan use). 

Longer term, we will need a consider a more robust solution through a Fronts and Curation and Ophan collaboration.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
