### PR TITLE
Only add `MatchNav` scoreboard placeholders for articles

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchSummary.tsx
+++ b/dotcom-rendering/src/components/FootballMatchSummary.tsx
@@ -54,6 +54,7 @@ export const FootballMatchSummary = ({ match }: Props) => (
 				homeTeam={match.homeTeam}
 				awayTeam={match.awayTeam}
 				comments={match.comments}
+				usage="MatchSummary"
 			/>
 		</div>
 		<div

--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -141,6 +141,7 @@ export const GetMatchNav = ({
 				homeTeam={data.homeTeam}
 				awayTeam={data.awayTeam}
 				comments={data.comments}
+				usage="Article"
 			/>
 		);
 	}

--- a/dotcom-rendering/src/components/MatchNav.stories.tsx
+++ b/dotcom-rendering/src/components/MatchNav.stories.tsx
@@ -54,24 +54,26 @@ export const Default = () => {
 			homeTeam={homeTeam}
 			awayTeam={awayTeam}
 			comments="Here is a comments string"
+			usage="Article"
 		/>
 	);
 };
 Default.storyName = 'default';
 
-export const ZeroZero = () => {
+export const NilNil = () => {
 	return (
 		<MatchNav
 			homeTeam={{ ...homeTeam, score: 0, scorers: [] }}
 			awayTeam={{ ...awayTeam, score: 0, scorers: [] }}
 			comments="Neither team scored any goals"
+			usage="Article"
 		/>
 	);
 };
-ZeroZero.storyName = 'zero - zero';
+NilNil.storyName = 'nil - nil';
 
 export const NoComments = () => {
-	return <MatchNav homeTeam={homeTeam} awayTeam={awayTeam} />;
+	return <MatchNav homeTeam={homeTeam} awayTeam={awayTeam} usage="Article" />;
 };
 NoComments.storyName = 'with no comments';
 
@@ -93,6 +95,7 @@ export const InContext = () => {
 						homeTeam={homeTeam}
 						awayTeam={awayTeam}
 						comments="Here is a comments string"
+						usage="Article"
 					/>
 				</ArticleContainer>
 				<RightColumn>
@@ -109,7 +112,19 @@ export const NoScore = () => {
 		<MatchNav
 			homeTeam={{ ...homeTeam, score: undefined, scorers: [] }}
 			awayTeam={{ ...awayTeam, score: undefined, scorers: [] }}
+			usage="Article"
 		/>
 	);
 };
 NoScore.storyName = 'with no scores';
+
+export const NilNilInMatchSummary = () => {
+	return (
+		<MatchNav
+			homeTeam={{ ...homeTeam, score: 0, scorers: [] }}
+			awayTeam={{ ...awayTeam, score: 0, scorers: [] }}
+			usage="MatchSummary"
+		/>
+	);
+};
+NilNilInMatchSummary.storyName = 'nil - nil in match summary';

--- a/dotcom-rendering/src/components/MatchNav.tsx
+++ b/dotcom-rendering/src/components/MatchNav.tsx
@@ -17,6 +17,7 @@ type Props = {
 	homeTeam: Team;
 	awayTeam: Team;
 	comments?: string;
+	usage: 'MatchSummary' | 'Article';
 };
 
 const Row = ({ children }: { children: React.ReactNode }) => (
@@ -155,15 +156,7 @@ const TeamNav = ({
 				`}
 			>
 				<TeamName name={name} />
-				<Scorers
-					scorers={[
-						...scorers,
-						// this ensures we reserve space for at least three scorers per team
-						'placeholder-1',
-						'placeholder-2',
-						'placeholder-3',
-					].slice(0, Math.max(3, scorers.length))}
-				/>
+				<Scorers scorers={scorers} />
 			</div>
 			<CrestRow>
 				<Crest crest={crest} />
@@ -207,7 +200,16 @@ const YellowBorder = () => (
 	/>
 );
 
-export const MatchNav = ({ homeTeam, awayTeam, comments }: Props) => (
+const addScorerPlaceholders = (scorers: string[]): string[] =>
+	[
+		...scorers,
+		// this ensures we reserve space for at least three scorers per team
+		'placeholder-1',
+		'placeholder-2',
+		'placeholder-3',
+	].slice(0, Math.max(3, scorers.length));
+
+export const MatchNav = ({ homeTeam, awayTeam, comments, usage }: Props) => (
 	<div
 		css={css`
 			display: flex;
@@ -227,14 +229,22 @@ export const MatchNav = ({ homeTeam, awayTeam, comments }: Props) => (
 				name={homeTeam.name}
 				score={homeTeam.score}
 				crest={homeTeam.crest}
-				scorers={homeTeam.scorers}
+				scorers={
+					usage === 'Article'
+						? addScorerPlaceholders(homeTeam.scorers)
+						: homeTeam.scorers
+				}
 			/>
 			<YellowBorder />
 			<TeamNav
 				name={awayTeam.name}
 				score={awayTeam.score}
 				crest={awayTeam.crest}
-				scorers={awayTeam.scorers}
+				scorers={
+					usage === 'Article'
+						? addScorerPlaceholders(awayTeam.scorers)
+						: awayTeam.scorers
+				}
 			/>
 		</Row>
 		{!!comments && <Comments comments={comments} />}


### PR DESCRIPTION
## What does this change?
Makes it so that the logic that adds placeholder scorers to `MatchNav` component (see #11675) only happens for articles/minute by minutes.

## Why?
This component is now used for match summaries, and we don't need to reserve that space since it's a server side rendered page. To maintain visual parity with the old frontend version we don't add any placeholders

## Screenshots

| Before (match summary)      | After  (match summary)    |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a456d9e0-3bea-4f14-85ea-68c1fafe3914
[after]: https://github.com/user-attachments/assets/b422f048-bbae-41a1-b6ab-e6de2a823a53

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://github.com/user-attachments/assets/b422f048-bbae-41a1-b6ab-e6de2a823a53
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
