### PR TITLE
Revert "Remove heatphan carousel tracking for the scrollable carousel"

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -317,9 +317,7 @@ export const ScrollableCarousel = ({
 					),
 					stackedCardRowsStyles(shouldStackCards),
 				]}
-				// HOTFIX: We have disabled the heatphan carousel attribute as it was causing rendering issues in heatphan as these carousels are no longer scrollable on tablet and desktop.
-				// TODO: create a breakpoint option for heatphan
-				// data-heatphan-type="carousel"
+				data-heatphan-type="carousel"
 			>
 				{children}
 			</ol>


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#13833 as this is preferred by ophan