### PR TITLE
Don't autoplay if user prefers reduced motion

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -8,11 +8,9 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useConfig } from './ConfigContext';
 import { LoopVideoPlayer } from './LoopVideoPlayer';
 
-const videoContainerStyles = (height: number, width: number) => css`
+const videoContainerStyles = css`
 	z-index: ${getZIndex('loop-video-container')};
 	position: relative;
-	height: ${height}px;
-	width: ${width}px;
 `;
 
 type Props = {
@@ -150,11 +148,7 @@ export const LoopVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	return (
-		<div
-			className="loop-video-container"
-			ref={setNode}
-			css={videoContainerStyles(height, width)}
-		>
+		<div ref={setNode} css={videoContainerStyles}>
 			<LoopVideoPlayer
 				src={src}
 				videoId={videoId}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -22,6 +22,7 @@ type Props = {
 	height?: number;
 	hasAudio?: boolean;
 	fallbackImage: JSX.Element;
+	posterImage?: string;
 };
 
 export const LoopVideo = ({
@@ -31,6 +32,7 @@ export const LoopVideo = ({
 	height = 360,
 	hasAudio = true,
 	fallbackImage,
+	posterImage,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -39,6 +41,7 @@ export const LoopVideo = ({
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isMuted, setIsMuted] = useState(true);
 	const [currentTime, setCurrentTime] = useState(0);
+	const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 	/**
 	 * Keep a track of whether the video has been in view. We only want to
 	 * pause the video if it has been in view.
@@ -58,6 +61,13 @@ export const LoopVideo = ({
 
 		if (isInView) {
 			if (!hasBeenInView) {
+				if (
+					window.matchMedia('(prefers-reduced-motion: reduce)')
+						.matches
+				) {
+					setPrefersReducedMotion(true);
+					return;
+				}
 				// When the video first comes into view, it should autoplay
 				setIsPlaying(true);
 				void vidRef.current.play();
@@ -166,6 +176,7 @@ export const LoopVideo = ({
 				handleKeyDown={handleKeyDown}
 				onError={onError}
 				AudioIcon={AudioIcon}
+				posterImage={prefersReducedMotion ? posterImage : undefined}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -20,9 +20,9 @@ type Props = {
 	videoId: string;
 	width?: number;
 	height?: number;
+	posterImage: string;
+	fallbackImageComponent: JSX.Element;
 	hasAudio?: boolean;
-	fallbackImage: JSX.Element;
-	posterImage?: string;
 };
 
 export const LoopVideo = ({
@@ -30,9 +30,9 @@ export const LoopVideo = ({
 	videoId,
 	width = 600,
 	height = 360,
-	hasAudio = true,
-	fallbackImage,
 	posterImage,
+	fallbackImageComponent,
+	hasAudio = true,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -60,18 +60,17 @@ export const LoopVideo = ({
 		if (!vidRef.current) return;
 
 		if (isInView) {
-			if (!hasBeenInView) {
-				if (
-					window.matchMedia('(prefers-reduced-motion: reduce)')
-						.matches
-				) {
-					setPrefersReducedMotion(true);
-					return;
-				}
-				// When the video first comes into view, it should autoplay
-				setIsPlaying(true);
-				void vidRef.current.play();
+			// We only want to autoplay the first time the video comes into view.
+			if (hasBeenInView) return;
+
+			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+				setPrefersReducedMotion(true);
+				return;
 			}
+
+			setIsPlaying(true);
+			void vidRef.current.play();
+
 			setHasBeenInView(true);
 		}
 
@@ -83,7 +82,7 @@ export const LoopVideo = ({
 
 	if (renderingTarget !== 'Web') return null;
 
-	if (adapted) return fallbackImage;
+	if (adapted) return fallbackImageComponent;
 
 	const handleClick = (event: React.SyntheticEvent) => {
 		event.preventDefault();
@@ -162,7 +161,7 @@ export const LoopVideo = ({
 				width={width}
 				height={height}
 				hasAudio={hasAudio}
-				fallbackImage={fallbackImage}
+				fallbackImageComponent={fallbackImageComponent}
 				currentTime={currentTime}
 				setCurrentTime={setCurrentTime}
 				ref={vidRef}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -18,7 +18,7 @@ type Props = {
 	videoId: string;
 	width?: number;
 	height?: number;
-	posterImage: string;
+	thumbnailImage: string;
 	fallbackImageComponent: JSX.Element;
 	hasAudio?: boolean;
 };
@@ -28,7 +28,7 @@ export const LoopVideo = ({
 	videoId,
 	width = 600,
 	height = 360,
-	posterImage,
+	thumbnailImage,
 	fallbackImageComponent,
 	hasAudio = true,
 }: Props) => {
@@ -169,7 +169,9 @@ export const LoopVideo = ({
 				handleKeyDown={handleKeyDown}
 				onError={onError}
 				AudioIcon={AudioIcon}
-				posterImage={prefersReducedMotion ? posterImage : undefined}
+				thumbnailImage={
+					prefersReducedMotion ? thumbnailImage : undefined
+				}
 			/>
 		</div>
 	);

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -23,7 +23,7 @@ export const Default = {
 		videoId: 'test-video-1',
 		height: 337.5,
 		width: 600,
-		posterImage:
+		thumbnailImage:
 			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
 		fallbackImageComponent: (
 			<CardPicture

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -25,7 +25,7 @@ export const Default = {
 		width: 600,
 		posterImage:
 			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
-		fallbackImage: (
+		fallbackImageComponent: (
 			<CardPicture
 				mainImage="https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg"
 				imageSize="large"

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -23,9 +23,11 @@ export const Default = {
 		videoId: 'test-video-1',
 		height: 337.5,
 		width: 600,
+		posterImage:
+			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
 		fallbackImage: (
 			<CardPicture
-				mainImage="https://i.guim.co.uk/img/media/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg?width=465&dpr=1&s=none&crop=5%3A4"
+				mainImage="https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg"
 				imageSize="large"
 				loading="eager"
 			/>

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -42,7 +42,7 @@ type Props = {
 	width: number;
 	height: number;
 	hasAudio: boolean;
-	fallbackImage: JSX.Element;
+	fallbackImageComponent: JSX.Element;
 	isPlayable: boolean;
 	setIsPlayable: Dispatch<SetStateAction<boolean>>;
 	isPlaying: boolean;
@@ -56,8 +56,8 @@ type Props = {
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
 	/**
-	 * We show a poster image when the user has indicated that
-	 * they do not want videos to play automatically
+	 * We show a poster image when the user has indicated that they do
+	 * not want videos to play automatically, e.g. prefers reduced motion.
 	 */
 	posterImage?: string;
 };
@@ -74,7 +74,7 @@ export const LoopVideoPlayer = forwardRef(
 			width,
 			height,
 			hasAudio,
-			fallbackImage,
+			fallbackImageComponent,
 			posterImage,
 			isPlayable,
 			setIsPlayable,
@@ -133,7 +133,7 @@ export const LoopVideoPlayer = forwardRef(
 					performance on supported browsers. https://web.dev/articles/video-and-source-tags */}
 					{/* <source src={webmSrc} type="video/webm"> */}
 					<source src={src} type="video/mp4" />
-					{fallbackImage}
+					{fallbackImageComponent}
 				</video>
 				{ref && 'current' in ref && ref.current && (
 					<>

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -55,6 +55,11 @@ type Props = {
 	handleKeyDown: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
+	/**
+	 * We show a poster image when the user has indicated that
+	 * they do not want videos to play automatically
+	 */
+	posterImage?: string;
 };
 
 /**
@@ -70,6 +75,7 @@ export const LoopVideoPlayer = forwardRef(
 			height,
 			hasAudio,
 			fallbackImage,
+			posterImage,
 			isPlayable,
 			setIsPlayable,
 			isPlaying,
@@ -93,12 +99,13 @@ export const LoopVideoPlayer = forwardRef(
 				<video
 					id={loopVideoId}
 					ref={ref}
-					preload="none"
+					preload={posterImage ? 'metadata' : 'none'}
 					loop={true}
 					muted={isMuted}
 					playsInline={true}
 					height={height}
 					width={width}
+					poster={posterImage ?? undefined}
 					onPlaying={() => {
 						setIsPlaying(true);
 					}}

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -56,8 +56,9 @@ type Props = {
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
 	/**
-	 * We show a thumbnail image when the user has indicated that they do
-	 * not want videos to play automatically, e.g. prefers reduced motion.
+	 * We ONLY show a thumbnail image when the user has indicated that they do
+	 * not want videos to play automatically, e.g. prefers reduced motion. Otherwise,
+	 * we do not bother downloading the image, as the video will be autoplayed.
 	 */
 	thumbnailImage?: string;
 };

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -56,10 +56,10 @@ type Props = {
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
 	/**
-	 * We show a poster image when the user has indicated that they do
+	 * We show a thumbnail image when the user has indicated that they do
 	 * not want videos to play automatically, e.g. prefers reduced motion.
 	 */
-	posterImage?: string;
+	thumbnailImage?: string;
 };
 
 /**
@@ -75,7 +75,7 @@ export const LoopVideoPlayer = forwardRef(
 			height,
 			hasAudio,
 			fallbackImageComponent,
-			posterImage,
+			thumbnailImage,
 			isPlayable,
 			setIsPlayable,
 			isPlaying,
@@ -99,13 +99,13 @@ export const LoopVideoPlayer = forwardRef(
 				<video
 					id={loopVideoId}
 					ref={ref}
-					preload={posterImage ? 'metadata' : 'none'}
+					preload={thumbnailImage ? 'metadata' : 'none'}
 					loop={true}
 					muted={isMuted}
 					playsInline={true}
 					height={height}
 					width={width}
-					poster={posterImage ?? undefined}
+					poster={thumbnailImage ?? undefined}
 					onPlaying={() => {
 						setIsPlaying(true);
 					}}


### PR DESCRIPTION
## What does this change?

Does not autoplay looping videos if the user [prefers reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).

## Why?

We would like users to be able to switch off autoplay. We would like this to be available in an accessibility setting on this page: https://www.theguardian.com/help/accessibility-help, but this is not yet available. For now, the best option is to allow this to be controlled by whether the user prefers reduced motion.