### PR TITLE
Update endpoint path that serves football match list pages

### DIFF
--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -99,7 +99,7 @@ export const devServer = (): Handler => {
 				return handleAppsBlocks(req, res, next);
 			case 'EditionsCrossword':
 				return handleEditionsCrossword(req, res, next);
-			case 'FootballDataPage':
+			case 'FootballMatchListPage':
 				return handleFootballMatchListPage(req, res, next);
 			case 'FootballTablesPage':
 				return handleFootballTablesPage(req, res, next);

--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -79,6 +79,11 @@ export const prodServer = (): void => {
 	app.post('/TagPage', logRenderTime, handleTagPage);
 	app.post('/TagPageJSON', logRenderTime, handleTagPageJson);
 	app.post('/FootballDataPage', logRenderTime, handleFootballMatchListPage);
+	app.post(
+		'/FootballMatchListPage',
+		logRenderTime,
+		handleFootballMatchListPage,
+	);
 	app.post('/CricketMatchPage', logRenderTime, handleCricketMatchPage);
 	app.post('/FootballTablesPage', logRenderTime, handleFootballTablesPage);
 	app.post(


### PR DESCRIPTION
## What does this change?
Change the DCAR football route `FootballDataPage` to `FootballMatchListPage` in dev server and adds the new name in prod server, until we make the change in frontend. Once the change is made in frontend we can remove the old endpoint

## Why?
This is a more accurate and descriptive name, we initially thought we might serve more than one type of page at this path but instead are using a more granular approach
