### PR TITLE
Football match list page - remove old endpoint from prod server

### DIFF
--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -78,7 +78,6 @@ export const prodServer = (): void => {
 	app.post('/FrontJSON', logRenderTime, handleFrontJson);
 	app.post('/TagPage', logRenderTime, handleTagPage);
 	app.post('/TagPageJSON', logRenderTime, handleTagPageJson);
-	app.post('/FootballDataPage', logRenderTime, handleFootballMatchListPage);
 	app.post(
 		'/FootballMatchListPage',
 		logRenderTime,


### PR DESCRIPTION
## What does this change?
Removes the old endpoint for serving football match list pages from the prod server

Must go in after #13846 and https://github.com/guardian/frontend/pull/27931