### PR TITLE
Loop video - extra keyboard options

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -58,7 +58,7 @@ export const LoopVideo = ({
 		if (!vidRef.current) return;
 
 		if (isInView) {
-			// We only want to autoplay the first time the video comes into view.
+			// We only autoplay the first time the video comes into view.
 			if (hasBeenInView) return;
 
 			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
@@ -82,17 +82,29 @@ export const LoopVideo = ({
 
 	if (adapted) return fallbackImageComponent;
 
+	const playVideo = () => {
+		if (!vidRef.current) return;
+		setIsPlaying(true);
+		void vidRef.current.play();
+	};
+
+	const pauseVideo = () => {
+		if (!vidRef.current) return;
+		setIsPlaying(false);
+		void vidRef.current.pause();
+	};
+
+	const playPauseVideo = () => {
+		if (isPlaying) {
+			pauseVideo();
+		} else {
+			playVideo();
+		}
+	};
+
 	const handleClick = (event: React.SyntheticEvent) => {
 		event.preventDefault();
-		if (!vidRef.current) return;
-
-		if (isPlaying) {
-			setIsPlaying(false);
-			void vidRef.current.pause();
-		} else {
-			setIsPlaying(true);
-			void vidRef.current.play();
-		}
+		playPauseVideo();
 	};
 
 	const onError = () => {
@@ -134,13 +146,19 @@ export const LoopVideo = ({
 		switch (event.key) {
 			case 'Enter':
 			case ' ':
-				handleClick(event);
+				playPauseVideo();
+				break;
+			case 'Escape':
+				pauseVideo();
 				break;
 			case 'ArrowRight':
 				seekForward();
 				break;
 			case 'ArrowLeft':
 				seekBackward();
+				break;
+			case 'm':
+				setIsMuted(!isMuted);
 				break;
 		}
 	};


### PR DESCRIPTION
## What does this change?

Adds a few keyboard options to the Loop video. Neither are essential, but very minor positives.
- "Escape" to pause the video. We use "Escape" to close banners, so maybe users might expect this key to stop anything they could find annoying (autoplaying video). 
- "m" to mute/unmute. It would be good to have a keyboard shortcut for controlling audio. The choice of key is a guess at what most users might expect would mute audio.