### PR TITLE
Convert `get-content-from-url` To TypeScript

### DIFF
--- a/dotcom-rendering/src/server/lib/get-content-from-url.ts
+++ b/dotcom-rendering/src/server/lib/get-content-from-url.ts
@@ -1,14 +1,18 @@
-/** @type {(_: [string, unknown]) => _ is [string, string]} */
-const isStringTuple = (_) => typeof _[1] === 'string';
+import type { IncomingHttpHeaders } from 'node:http';
+import { isObject } from '@guardian/libs';
+import type { Handler } from 'express';
+
+const isStringTuple = (_: [string, unknown]): _ is [string, string] =>
+	typeof _[1] === 'string';
 
 /**
  * Get DCR content from a `theguardian.com` URL.
  * Takes in optional `X-Gu-*` headers to send.
- *
- * @param {URL} url
- * @param {import('http').IncomingHttpHeaders} _headers
  */
-async function getContentFromURL(url, _headers) {
+async function getContentFromURL(
+	url: URL,
+	_headers: IncomingHttpHeaders,
+): Promise<unknown> {
 	// searchParams will only work for the first set of query params because 'url' is already a query param itself
 	const searchparams = url.searchParams.toString();
 
@@ -16,8 +20,7 @@ async function getContentFromURL(url, _headers) {
 	const jsonUrl = `${url.origin}${url.pathname}.json?dcr=true&${searchparams}`;
 
 	// Explicitly pass through GU headers - this enables us to override properties such as region in CI
-	/** @type {HeadersInit} */
-	const headers = Object.fromEntries(
+	const headers: HeadersInit = Object.fromEntries(
 		Object.entries(_headers)
 			.filter(
 				([key]) =>
@@ -32,7 +35,7 @@ async function getContentFromURL(url, _headers) {
 	const { html, ...config } = await fetch(jsonUrl, { headers })
 		.then((response) => response.json())
 		.catch((error) => {
-			if (error?.type === 'invalid-json') {
+			if (isObject(error) && error.type === 'invalid-json') {
 				throw new Error(
 					'Did not receive JSON response - are you sure this URL supports .json?dcr requests?',
 				);
@@ -43,13 +46,10 @@ async function getContentFromURL(url, _headers) {
 	return config;
 }
 
-exports.default = getContentFromURL;
-
 /**
- * @param {string} requestUrl
- * @returns {URL | undefined} the parsed URL, or false if there’s no fully qualified path
+ * @returns the parsed URL, or `undefined` if there’s no fully qualified path
  */
-const parseURL = (requestUrl) => {
+export const parseURL = (requestUrl: string): URL | undefined => {
 	try {
 		return new URL(
 			decodeURIComponent(requestUrl.split('/').slice(2).join('/')),
@@ -59,10 +59,7 @@ const parseURL = (requestUrl) => {
 	}
 };
 
-exports.parseURL = parseURL;
-
-/** @type {import('webpack-dev-server').ExpressRequestHandler} */
-exports.getContentFromURLMiddleware = async (req, res, next) => {
+export const getContentFromURLMiddleware: Handler = async (req, res, next) => {
 	if (req.path === '/EditionsCrossword') {
 		try {
 			const url = new URL(


### PR DESCRIPTION
TypeScript is more robust than JS with typed JSDoc comments.

Also removed the `getContentFromURL` default export as it wasn't used anywhere and it was causing a lint error.

Part of #13737. Requires #13851, so opening as draft for now.
