### PR TITLE
Update link to React context ADR

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -86,7 +86,7 @@ There are some concepts to learn, that will make working with Dotcom Rendering c
 
 -   Design and Display Types use the [Switch Pattern](docs/patterns/switch-on-display-design.md)
 -   [DecideLayout](docs/patterns/decide-layout.md)
--   [Prop Drilling](https://kentcdodds.com/blog/prop-drilling/) (and [why we don't use React Context](docs/architecture/016-react-context-api.md))
+-   [Prop Drilling](https://kentcdodds.com/blog/prop-drilling/) (and [why we rarely use React Context](docs/architecture/028-react-context-api.md))
 -   Dynamic imports
 -   [Enhancers](docs/patterns/enhancers.md)
 -   Data generated in Frontend


### PR DESCRIPTION
## What does this change?

Updates a dead link to point to the right ADR, and rewords slightly. Hope I got it right!

## Why?

Link should work, and wording should match current state of the repo.