### PR TITLE
Shorten choice cards copy on banner

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -11,7 +11,7 @@ export const ChoiceCardTestData_REGULAR = (
 			isDiscountActive
 				? `Support ${currencySymbol}${amount}/year`
 				: `Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'Support',
+		benefitsLabel: longerBenefits ? 'Support' : undefined,
 		benefits: () => [
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 		],
@@ -40,7 +40,7 @@ export const ChoiceCardTestData_REGULAR = (
 				return `Support ${currencySymbol}${amount}/month`;
 			}
 		},
-		benefitsLabel: 'All-access digital',
+		benefitsLabel: longerBenefits ? 'All-access digital' : undefined,
 		benefits: () =>
 			longerBenefits
 				? fullSupporterPlusBenefits
@@ -66,7 +66,7 @@ export const ChoiceCardTestData_US = (
 			isDiscountActive
 				? `Support ${currencySymbol}${amount}/year`
 				: `Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: 'Support',
+		benefitsLabel: longerBenefits ? 'Support' : undefined,
 		benefits: () => [
 			'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
 		],
@@ -95,7 +95,7 @@ export const ChoiceCardTestData_US = (
 				return `Support ${currencySymbol}${amount}/month`;
 			}
 		},
-		benefitsLabel: 'All-access digital',
+		benefitsLabel: longerBenefits ? 'All-access digital' : undefined,
 		benefits: () =>
 			longerBenefits
 				? fullSupporterPlusBenefits
@@ -125,5 +125,4 @@ const fullSupporterPlusBenefits = [
 const shorterSupporterPlusBenefits = [
 	'Unlimited access to the Guardian app and Feast app',
 	'Ad-free reading on all your devices',
-	'Exclusive supporter newsletter',
 ];

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -145,11 +145,12 @@ function getChoiceAmount(
 const SupportingBenefits = ({
 	benefitsLabel,
 	benefits,
+	showTicks,
 }: {
 	benefitsLabel: string | undefined;
 	benefits: string[];
+	showTicks: boolean;
 }) => {
-	const showTicks = benefits.length > 1;
 	return (
 		<div css={supportingTextStyles}>
 			{!!benefitsLabel && (
@@ -276,6 +277,9 @@ export const ThreeTierChoiceCards = ({
 													benefits={benefits(
 														currencySymbol,
 													)}
+													showTicks={
+														supportTier !== 'OneOff'
+													}
 												/>
 											) : undefined
 										}

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -149,7 +149,7 @@ const SupportingBenefits = ({
 	benefitsLabel: string | undefined;
 	benefits: string[];
 }) => {
-	const isBenefit = !!benefitsLabel;
+	const showTicks = benefits.length > 1;
 	return (
 		<div css={supportingTextStyles}>
 			{!!benefitsLabel && (
@@ -160,7 +160,7 @@ const SupportingBenefits = ({
 			<ul css={benefitsStyles}>
 				{benefits.map((benefit) => (
 					<li key={benefit}>
-						{isBenefit && <SvgTickRound size="xsmall" />}
+						{showTicks && <SvgTickRound size="xsmall" />}
 						{benefit}
 					</li>
 				))}


### PR DESCRIPTION
This applies to the banner, not the epic.

### Mobile, with only 2 benefits and no benefits label:
<img width="382" alt="Screenshot 2025-04-28 at 16 29 37" src="https://github.com/user-attachments/assets/23ec704d-d3b4-47a2-bb11-bb5ab1b0a4a6" />


### Desktop with full copy:
<img width="769" alt="Screenshot 2025-04-28 at 16 22 56" src="https://github.com/user-attachments/assets/4bb3f88d-c451-4670-9702-e60676815133" />
