### PR TITLE
Allow Chromatic to run for Dependabot PRs if `run_chromatic` label is present

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -11,12 +11,8 @@ jobs:
     name: Chromatic
     runs-on: ubuntu-latest
     # Run Chromatic only if `run_chromatic` label has been applied or we're
-    # pushing to `main`. Skip if this is a Dependabot PR as this is handled
-    # by the subsequent job.
-    if: |
-      (contains(github.event.pull_request.labels.*.name, 'run_chromatic')  ||  github.ref == 'refs/heads/main') &&
-      (!contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      github.event.pull_request.user.login != 'dependabot')
+    # pushing to `main`.
+    if: contains(github.event.pull_request.labels.*.name, 'run_chromatic')  ||  github.ref == 'refs/heads/main'
     steps:
       - name: Checkout - On Pull Request
         uses: actions/checkout@v4


### PR DESCRIPTION
## What does this change?

Run Chromatic for Dependabot PRs if `run_chromatic` label is present

## Why?

We trigger Chromatic on PRs by adding the label `run_chromatic`.  However, we currently don't run Chromatic on PRs when the label `dependencies` is present and created by the `dependabot` user. Given Chromatic is still a required check this leaves Dependabot PRs in a confusing state where we either have to force a merge or modify the labels to force Chromatic to run.

It's also possible for dependency updates to modify the rendered output, for example React or Emotion updates, so running Chromatic (assuming tests are not skipped) give us more confidence in the update.

This PR removes the skip-if-present check for the `dependencies` label & the user `dependabot` so adding `run_chromatic` will work on a PR.