### PR TITLE
Backfilled cards should be treated according to their allocated group

### DIFF
--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -103,12 +103,15 @@ export const groupCards = (
 			};
 		}
 		case 'flexible/general': {
-			const splash = curated.filter(({ card }) => card.group === '3');
+			const splash = [
+				...curated.filter(({ card }) => card.group === '3'),
+				...backfill.filter(({ card }) => card.group === '3'),
+			];
 
-			// Backfilled cards will always be treated as 'standard' cards
+			// Backfilled cards have been allocated to groups based on the max items in each group
 			const standard = [
 				...curated.filter(({ card }) => card.group !== '3'),
-				...backfill,
+				...backfill.filter(({ card }) => card.group !== '3'),
 			];
 
 			const enhanceOptions = (offset = 0) => ({


### PR DESCRIPTION
## What does this change?

Treats backfilled cards in flexible general container as Splash if they are in group 3.

## Why?

For Flexible General, the fronts tool allows the configuration of the max items in each group, and this allocation is used to assign backfilled cards to groups. Therefore we should look in backfill for splash cards as well as in curated.
