### PR TITLE
Limit banner height to 60vh if ios banner detected

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -534,7 +534,7 @@ const styles = {
 	) => css`
 		background: ${background};
 		color: ${textColor};
-		${limitHeight ? 'max-height: 70vh;' : 'auto'}
+		${limitHeight ? 'max-height: 60vh;' : ''}
 		overflow: auto;
 		* {
 			box-sizing: border-box;


### PR DESCRIPTION
We already shorten the banner if the "open in app" banner is present on ios. This PR lowers it further to 60%