### PR TITLE
Remove Network Calls From Validate Tests

### DIFF
--- a/dotcom-rendering/src/model/validate.test.ts
+++ b/dotcom-rendering/src/model/validate.test.ts
@@ -2,31 +2,50 @@
  * @jest-environment node
  */
 
+import { Comment } from '../../fixtures/generated/fe-articles/Comment';
+import { Feature } from '../../fixtures/generated/fe-articles/Feature';
+import { Live } from '../../fixtures/generated/fe-articles/Live';
+import { MatchReport } from '../../fixtures/generated/fe-articles/MatchReport';
+import { Review } from '../../fixtures/generated/fe-articles/Review';
+import { Standard } from '../../fixtures/generated/fe-articles/Standard';
 import { validateAsFEArticle } from './validate';
 
-// TODO avoid fetch, write script to fetch new version in gen-schema.js and store as fixture files
-const urlsToTest = [
-	'https://www.theguardian.com/politics/2020/jan/16/long-bailey-says-abortion-limit-should-not-be-different-for-disability.json?dcr',
-	'https://www.theguardian.com/uk-news/2020/jan/16/benita-mehra-grenfell-inquiry-boris-johnson-appoints-engineer-with-links-to-cladding-firm.json?dcr',
-	'https://www.theguardian.com/commentisfree/2020/jan/16/boris-johnson-scottish-independence-nicola-sturgeon-snp.json?dcr',
-	'https://www.theguardian.com/sport/2020/jan/16/south-africa-england-third-test-day-one-match-report.json?dcr',
-	'https://www.theguardian.com/society/2020/jan/16/the-agony-of-weekend-loneliness-i-wont-speak-to-another-human-until-monday.json?dcr',
-	'https://www.theguardian.com/uk-news/2020/jan/22/man-74-was-shot-with-crossbow-as-he-fixed-satellite-dish-court-told.json?dcr',
-];
+const articles = [
+	{
+		name: 'Standard',
+		data: Standard,
+	},
+	{
+		name: 'Feature',
+		data: Feature,
+	},
+	{
+		name: 'Comment',
+		data: Comment,
+	},
+	{
+		name: 'Match Report',
+		data: MatchReport,
+	},
+	{
+		name: 'Review',
+		data: Review,
+	},
+	{
+		name: 'Liveblog',
+		data: Live,
+	},
+] as const;
 
 describe('validate', () => {
 	it('throws on invalid data', () => {
 		const data = { foo: 'bar' };
-		expect(() => validateAsFEArticle(data)).toThrowError(TypeError);
+		expect(() => validateAsFEArticle(data)).toThrow(TypeError);
 	});
 
-	for (const url of urlsToTest) {
-		it('confirm valid data', () => {
-			return fetch(`${url}&purge=${Date.now()}`)
-				.then((response) => response.json())
-				.then((myJson) => {
-					expect(validateAsFEArticle(myJson)).toBe(myJson);
-				});
+	for (const article of articles) {
+		it(`validates data for a ${article.name} article`, () => {
+			expect(validateAsFEArticle(article.data)).toBe(article.data);
 		});
 	}
 });


### PR DESCRIPTION
These tests were fetching JSON data to validate from frontend directly, via the network. This change switches to using local fixture files for this instead. Advantages include:

- Faster tests, due to bundling the data rather than retrieving it from the network.
- No side-effects in the tests, which means that data changing on the frontend side won't cause the tests to fail unexpectedly on an unrelated change.
- No possibility of network issues failing the tests on an arbitrary change, as occurred in #13870.
