### PR TITLE
Shorten banner choice card benefits on desktop

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -450,7 +450,7 @@ const DesignableBannerV2: ReactComponent<BannerRenderProps> = ({
 								setThreeTierChoiceCardSelectedProduct
 							}
 							choices={getChoiceCardData(
-								isTabletOrAbove,
+								false,
 								false,
 								countryCode,
 							)}


### PR DESCRIPTION
Currently we shorten the benefits copy on mobile only. MRR now want this for desktop as well.

### Desktop
<img width="1167" alt="Screenshot 2025-05-01 at 13 38 15" src="https://github.com/user-attachments/assets/492ee67c-f843-443c-b904-792b48989b19" />

### Mobile
<img width="337" alt="Screenshot 2025-05-01 at 13 38 34" src="https://github.com/user-attachments/assets/36ad53e6-d5b1-42f4-843b-6d21c403aa25" />
