### PR TITLE
Switch to React for server-side rendering

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -167,6 +167,13 @@ module.exports = ({ build }) => ({
 			svgr,
 		],
 	},
+	resolve: {
+		alias: {
+			react: 'preact/compat',
+			'react-dom/test-utils': 'preact/test-utils',
+			'react-dom': 'preact/compat',
+		},
+	},
 });
 
 module.exports.babelExclude = {

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -31,11 +31,6 @@ const commonConfigs = ({ platform }) => ({
 			? 'source-map'
 			: 'eval-cheap-module-source-map',
 	resolve: {
-		alias: {
-			react: 'preact/compat',
-			'react-dom/test-utils': 'preact/test-utils',
-			'react-dom': 'preact/compat',
-		},
 		extensions: ['.js', '.ts', '.tsx', '.jsx'],
 	},
 	ignoreWarnings: [


### PR DESCRIPTION
## What does this change?

Moves Preact aliases from common webpack config to client config so they are only applied to client-side bundles.

> [!note]
> This was previously merged and reverted due to rendering errors caused by the use of `<br>` elements within subheadings. This was fixed in #13874.

## Why?

To switch to using React for server-side rendering in production, matching the present behaviour in dev. This is a first step to [A/B testing client-side rendering with React](https://github.com/guardian/dotcom-rendering/pull/13774) so as we're not rendering with Preact on the server and React on the client.

## Notes

### Server bundle size with Preact

| Bundle | Size |
| --- | --- |
| `server.js` | 11.74 MB |
| Total | 12.86 MB |

### Server bundle size with React

| Bundle | Size |
| --- | --- |
| `server.js` | 11.92 MB |
| Total | 13.05 MB |
