### PR TITLE
Switch back to Preact for server-side rendering

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -139,13 +139,6 @@ module.exports = ({ build }) => ({
 			svgr,
 		],
 	},
-	resolve: {
-		alias: {
-			react: 'preact/compat',
-			'react-dom/test-utils': 'preact/test-utils',
-			'react-dom': 'preact/compat',
-		},
-	},
 });
 
 module.exports.babelExclude = {

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -30,6 +30,11 @@ const commonConfigs = ({ platform }) => ({
 			? 'source-map'
 			: 'eval-cheap-module-source-map',
 	resolve: {
+		alias: {
+			react: 'preact/compat',
+			'react-dom/test-utils': 'preact/test-utils',
+			'react-dom': 'preact/compat',
+		},
 		extensions: ['.js', '.ts', '.tsx', '.jsx'],
 	},
 	ignoreWarnings: [


### PR DESCRIPTION
## What does this change?

Switches back to server-side rendering with Preact (#13893 temporarily enabled React on the server).

## Why?

Out of caution due to the upcoming launch of the homepage redesign we've decided to temporarily test running React on the server for a day rather than switching permanently. Assuming we don't run into any issues we plan to enable this again following the launch.
