### PR TITLE
implement football more button for when js is disabled

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -231,3 +231,6 @@ export const moreDays: FootballMatches = [
 		],
 	},
 ];
+
+export const nextPageNoJsUrl =
+	'https://www.theguardian.com/football/fixtures/more/2025/May/05';

--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -233,4 +233,4 @@ export const moreDays: FootballMatches = [
 ];
 
 export const nextPageNoJsUrl =
-	'https://www.theguardian.com/football/fixtures/more/2025/May/05';
+	'https://www.theguardian.com/football/fixtures/2025/May/05';

--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -49,17 +49,25 @@ export const Default = {
 		const canvas = within(canvasElement);
 
 		// Get element with area role link (anchor tag) with the visible text content "More"
-		const moreLink = canvas.getByRole('link', { name: /more/i });
+		const moreLinks = canvas.getAllByRole('link', { name: /more/i });
 		// Assert the href exists
-		void expect(moreLink).toHaveAttribute('href', nextPageNoJsUrl);
+		for (const moreLink of moreLinks) {
+			void expect(moreLink).toHaveAttribute('href', nextPageNoJsUrl);
+		}
 
-		// Get the button element with the visible text content "More" and click it
-		const moreButton = await canvas.findByRole('button', { name: /more/i });
-		await userEvent.click(moreButton);
+		const moreButtons = await canvas.findAllByRole('button', {
+			name: /more/i,
+		});
+		for (const moreButton of moreButtons) {
+			await userEvent.click(moreButton);
+		}
 
-		const newDays = canvasElement.querySelectorAll('section');
-		// Assert that the number of sections has increased
-		void expect(newDays.length).toBeGreaterThan(initialDays.length);
+		const rootDivs = canvasElement.querySelectorAll('[data-color-scheme]');
+		for (const rootDiv of rootDivs) {
+			const newDays = rootDiv.querySelectorAll('section');
+			// Assert that the number of sections has increased
+			void expect(newDays.length).toBeGreaterThan(initialDays.length);
+		}
 	},
 } satisfies Story;
 
@@ -68,7 +76,25 @@ export const ErrorGettingMore = {
 		...Default.args,
 		getMoreDays: () => Promise.resolve(error('failed')),
 	},
-	play: Default.play,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Get the button element with the visible text content "More" and click it
+		const moreButtons = await canvas.findAllByRole('button', {
+			name: /more/i,
+		});
+		for (const moreButton of moreButtons) {
+			await userEvent.click(moreButton);
+		}
+
+		const rootDivs = canvasElement.querySelectorAll('[data-color-scheme]');
+		for (const rootDiv of rootDivs) {
+			// Assert that the error message appears
+			await within(rootDiv as HTMLElement).findByText(
+				/Could not get more matches\. Please try again later!/i,
+			);
+		}
+	},
 } satisfies Story;
 
 export const NoMoreDays = {

--- a/dotcom-rendering/src/components/FootballMatchList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { userEvent, within } from '@storybook/test';
+import { expect, userEvent, within } from '@storybook/test';
 import { allModes } from '../../.storybook/modes';
-import { initialDays, moreDays } from '../../fixtures/manual/footballData';
+import {
+	initialDays,
+	moreDays,
+	nextPageNoJsUrl,
+} from '../../fixtures/manual/footballData';
 import { error, ok } from '../lib/result';
 import { FootballMatchList } from './FootballMatchList';
 
@@ -39,13 +43,23 @@ export const Default = {
 		guardianBaseUrl: 'https://www.theguardian.com',
 		initialDays,
 		getMoreDays: () => Promise.resolve(ok(moreDays)),
+		nextPageNoJsUrl,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const moreButtons = canvas.getAllByRole('button');
-		for (const moreButton of moreButtons) {
-			await userEvent.click(moreButton);
-		}
+
+		// Get element with area role link (anchor tag) with the visible text content "More"
+		const moreLink = canvas.getByRole('link', { name: /more/i });
+		// Assert the href exists
+		void expect(moreLink).toHaveAttribute('href', nextPageNoJsUrl);
+
+		// Get the button element with the visible text content "More" and click it
+		const moreButton = await canvas.findByRole('button', { name: /more/i });
+		await userEvent.click(moreButton);
+
+		const newDays = canvasElement.querySelectorAll('section');
+		// Assert that the number of sections has increased
+		void expect(newDays.length).toBeGreaterThan(initialDays.length);
 	},
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -512,8 +512,7 @@ export const FootballMatchList = ({
 									}}
 									icon={<SvgPlus />}
 									size="xsmall"
-									onClick={(e) => {
-										e.preventDefault(); // prevent navigation when JS is enabled
+									onClick={() => {
 										void getMoreDays().then((moreDays) => {
 											if (moreDays.kind === 'ok') {
 												setIsError(false);

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -34,6 +34,7 @@ type Props = {
 	guardianBaseUrl: string;
 	getMoreDays?: () => Promise<Result<'failed', FootballMatches>>;
 	now: string;
+	nextPageNoJsUrl?: string;
 };
 
 const REMOVE_TRAILING_DOTS_REGEX = /\.+$/;
@@ -423,6 +424,7 @@ export const FootballMatchList = ({
 	guardianBaseUrl,
 	initialDays,
 	getMoreDays,
+	nextPageNoJsUrl,
 	now,
 }: Props) => {
 	const dateFormatter = new Intl.DateTimeFormat('en-GB', {
@@ -478,9 +480,10 @@ export const FootballMatchList = ({
 				</section>
 			))}
 
-			{getMoreDays === undefined ? null : (
+			{getMoreDays === undefined ||
+			nextPageNoJsUrl === undefined ? null : (
 				<div css={footballMatchesGridStyles}>
-					<div
+					<a
 						css={css`
 							grid-column: centre-column-start / centre-column-end;
 
@@ -488,6 +491,7 @@ export const FootballMatchList = ({
 								padding-top: ${space[10]}px;
 							}
 						`}
+						href={nextPageNoJsUrl}
 					>
 						<Button
 							theme={{
@@ -501,7 +505,8 @@ export const FootballMatchList = ({
 							}}
 							icon={<SvgPlus />}
 							size="xsmall"
-							onClick={() => {
+							onClick={(e) => {
+								e.preventDefault(); // prevent navigation when JS is enabled
 								void getMoreDays().then((moreDays) => {
 									if (moreDays.kind === 'ok') {
 										setIsError(false);
@@ -527,7 +532,7 @@ export const FootballMatchList = ({
 								later!
 							</InlineError>
 						) : null}
-					</div>
+					</a>
 				</div>
 			)}
 		</>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -486,21 +486,66 @@ export const FootballMatchList = ({
 
 			{getMoreDays === undefined ||
 			nextPageNoJsUrl === undefined ? null : (
-				<div
-					css={[
-						footballMatchesGridStyles,
-						css`
+				<div css={footballMatchesGridStyles}>
+					<div
+						css={css`
 							grid-column: centre-column-start / centre-column-end;
 
 							${until.leftCol} {
 								padding-top: ${space[10]}px;
 							}
-						`,
-					]}
-				>
-					{hydrated ? (
-						<>
-							<Button
+						`}
+					>
+						{hydrated ? (
+							<>
+								<Button
+									theme={{
+										textPrimary: palette(
+											'--button-text-primary',
+										),
+										backgroundPrimary: palette(
+											'--button-background-primary',
+										),
+										backgroundPrimaryHover: palette(
+											'--button-background-primary-hover',
+										),
+									}}
+									icon={<SvgPlus />}
+									size="xsmall"
+									onClick={(e) => {
+										e.preventDefault(); // prevent navigation when JS is enabled
+										void getMoreDays().then((moreDays) => {
+											if (moreDays.kind === 'ok') {
+												setIsError(false);
+												setDays(
+													days.concat(moreDays.value),
+												);
+											} else {
+												setIsError(true);
+											}
+										});
+									}}
+								>
+									More
+								</Button>
+								{isError ? (
+									<InlineError
+										cssOverrides={css`
+											padding-top: ${space[4]}px;
+											color: ${palette(
+												'--football-match-list-error',
+											)};
+										`}
+									>
+										Could not get more matches. Please try
+										again later!
+									</InlineError>
+								) : null}
+							</>
+						) : (
+							<LinkButton
+								href={nextPageNoJsUrl}
+								size="xsmall"
 								theme={{
 									textPrimary: palette(
 										'--button-text-primary',
@@ -512,55 +557,11 @@ export const FootballMatchList = ({
 										'--button-background-primary-hover',
 									),
 								}}
-								icon={<SvgPlus />}
-								size="xsmall"
-								onClick={(e) => {
-									e.preventDefault(); // prevent navigation when JS is enabled
-									void getMoreDays().then((moreDays) => {
-										if (moreDays.kind === 'ok') {
-											setIsError(false);
-											setDays(
-												days.concat(moreDays.value),
-											);
-										} else {
-											setIsError(true);
-										}
-									});
-								}}
 							>
 								More
-							</Button>
-							{isError ? (
-								<InlineError
-									cssOverrides={css`
-										padding-top: ${space[4]}px;
-										color: ${palette(
-											'--football-match-list-error',
-										)};
-									`}
-								>
-									Could not get more matches. Please try again
-									later!
-								</InlineError>
-							) : null}
-						</>
-					) : (
-						<LinkButton
-							href={nextPageNoJsUrl}
-							size="xsmall"
-							theme={{
-								textPrimary: palette('--button-text-primary'),
-								backgroundPrimary: palette(
-									'--button-background-primary',
-								),
-								backgroundPrimaryHover: palette(
-									'--button-background-primary-hover',
-								),
-							}}
-						>
-							More
-						</LinkButton>
-					)}
+							</LinkButton>
+						)}
+					</div>
 				</div>
 			)}
 		</>

--- a/dotcom-rendering/src/components/FootballMatchList.tsx
+++ b/dotcom-rendering/src/components/FootballMatchList.tsx
@@ -14,7 +14,7 @@ import {
 	LinkButton,
 	SvgPlus,
 } from '@guardian/source/react-components';
-import { Fragment, type ReactNode, useEffect, useState } from 'react';
+import { Fragment, type ReactNode, useState } from 'react';
 import type {
 	FootballMatch,
 	FootballMatches,
@@ -27,6 +27,7 @@ import {
 	getTimeZoneFromEdition,
 } from '../lib/edition';
 import type { Result } from '../lib/result';
+import { useHydrated } from '../lib/useHydrated';
 import { palette } from '../palette';
 
 type Props = {
@@ -440,12 +441,7 @@ export const FootballMatchList = ({
 	const [days, setDays] = useState(initialDays);
 	const [isError, setIsError] = useState<boolean>(false);
 
-	const [jsLoaded, setJsLoaded] = useState(false);
-
-	useEffect(() => {
-		// This will only run after JS has loaded on the client
-		setJsLoaded(true);
-	}, []);
+	const hydrated = useHydrated();
 
 	return (
 		<>
@@ -502,7 +498,7 @@ export const FootballMatchList = ({
 						`,
 					]}
 				>
-					{jsLoaded ? (
+					{hydrated ? (
 						<>
 							<Button
 								theme={{

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -21,6 +21,7 @@ type Props = {
 	kind: FootballMatchListPageKind;
 	initialDays: FootballMatches;
 	edition: EditionId;
+	nextPageNoJsUrl?: string;
 	goToCompetitionSpecificPage: (tag: string) => void;
 	getMoreDays?: () => Promise<Result<'failed', FootballMatches>>;
 	renderAds: boolean;
@@ -50,6 +51,7 @@ export const FootballMatchesPage = ({
 	kind,
 	initialDays,
 	edition,
+	nextPageNoJsUrl,
 	goToCompetitionSpecificPage,
 	getMoreDays,
 	renderAds,
@@ -125,6 +127,7 @@ export const FootballMatchesPage = ({
 				edition={edition}
 				getMoreDays={getMoreDays}
 				guardianBaseUrl={guardianBaseUrl}
+				nextPageNoJsUrl={nextPageNoJsUrl}
 			/>
 		</div>
 

--- a/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPageWrapper.importable.tsx
@@ -68,6 +68,7 @@ type Props = {
 	kind: FootballMatchListPageKind;
 	initialDays: FootballMatches;
 	secondPage?: string;
+	nextPageNoJsUrl?: string;
 	edition: EditionId;
 	renderAds: boolean;
 	pageId: string;
@@ -81,6 +82,7 @@ export const FootballMatchesPageWrapper = ({
 	kind,
 	initialDays,
 	secondPage,
+	nextPageNoJsUrl,
 	edition,
 	renderAds,
 	pageId,
@@ -95,6 +97,7 @@ export const FootballMatchesPageWrapper = ({
 			initialDays={initialDays}
 			now={now}
 			edition={edition}
+			nextPageNoJsUrl={nextPageNoJsUrl}
 			goToCompetitionSpecificPage={goToCompetitionSpecificPage(
 				guardianBaseUrl,
 			)}

--- a/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
@@ -93,5 +93,6 @@ export type FEFootballMatchListPage = FEFootballDataPage & {
 	filters: Record<string, FEFootballCompetition[]>;
 	matchesList: FEMatchByDateAndCompetition[];
 	nextPage?: string;
+	nextPageNoJs?: string;
 	previousPage?: string;
 };

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
@@ -114,6 +114,9 @@
                 "nextPage": {
                     "type": "string"
                 },
+                "nextPageNoJs": {
+                    "type": "string"
+                },
                 "previousPage": {
                     "type": "string"
                 }

--- a/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
@@ -40,6 +40,7 @@ const SportsPage = ({
 						kind={sportData.kind}
 						initialDays={sportData.matchesList}
 						secondPage={sportData.nextPage}
+						nextPageNoJsUrl={sportData.nextPageNoJsUrl}
 						edition={sportData.editionId}
 						renderAds={renderAds}
 						pageId={sportData.config.pageId}

--- a/dotcom-rendering/src/server/handler.sportDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.sportDataPage.web.ts
@@ -93,6 +93,7 @@ const parseFEFootballMatchList = (
 		now: new Date().toISOString(),
 		kind: decideMatchListPageKind(data.config.pageId),
 		nextPage: data.nextPage,
+		nextPageNoJsUrl: `${data.config.ajaxUrl}${data.nextPageNoJs}`,
 		previousPage: data.previousPage,
 		regions: parseFEFootballCompetitionRegions(data.filters),
 		nav: {

--- a/dotcom-rendering/src/server/handler.sportDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.sportDataPage.web.ts
@@ -75,6 +75,14 @@ const parseFEFootballCompetitionRegions = (
 		.sort(sortRegionsFunction);
 };
 
+const getNextPageNoJsUrl = (isProd: boolean, nextPageNoJs?: string) => {
+	if (!nextPageNoJs) {
+		return undefined;
+	}
+	if (isProd) return `https://www.theguardian.com${nextPageNoJs}`;
+	return `https://code.dev-theguardian.com${nextPageNoJs}`;
+};
+
 const parseFEFootballMatchList = (
 	data: FEFootballMatchListPage,
 ): FootballMatchListPage => {
@@ -93,7 +101,10 @@ const parseFEFootballMatchList = (
 		now: new Date().toISOString(),
 		kind: decideMatchListPageKind(data.config.pageId),
 		nextPage: data.nextPage,
-		nextPageNoJsUrl: `${data.config.ajaxUrl}${data.nextPageNoJs}`,
+		nextPageNoJsUrl: getNextPageNoJsUrl(
+			data.config.isProd,
+			data.nextPageNoJs,
+		),
 		previousPage: data.previousPage,
 		regions: parseFEFootballCompetitionRegions(data.filters),
 		nav: {

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -29,6 +29,7 @@ export type SportPageConfig = {
 
 export type FootballMatchListPage = FootballData & {
 	nextPage?: string;
+	nextPageNoJsUrl?: string;
 	previousPage?: string;
 	matchesList: FootballMatches;
 	now: string;


### PR DESCRIPTION
## What does this change?
This change adds support for a fallback `More` button on the football matches pages for when JavaScript is disabled in the browser.

## Why introduce nextPageNoJsUrl:

There is a convention in frontend routing where for any page route (e.g. /football/fixtures/more/:year/:month/:day), there is also a corresponding .json route (e.g. /football/fixtures/more/:year/:month/:day.json). These .json routes return the full data required to render a page, including config and navigation.

In DCAR the `More` button is using the .json route to fetch more matches. However, this returns far more data than necessary — config, nav, and other unrelated information — when all that is needed is a list of matches to append to the current view.

Upon further investigation, we noticed that the HTML version of the `/more/` routes serves the same content as the equivalent non-/more/ routes. Based on this, we decided to remove the HTML versions of the /more/ routes to simplify routing. The PR for this: https://github.com/guardian/frontend/pull/27939

However, we later realised that the DCAR implementation did not support a non-JavaScript experience for the More button. To fix this, we needed a way to render the More button as a fallback link (i.e. an anchor tag) that simply navigates to the next page of matches when JavaScript is disabled.

Since the `/more/` routes are being deprecated, we now use the equivalent non-/more/ route to construct that fallback link — this is provided via the new `nextPageNoJsUrl` prop.


## TOTO:
This PR can be merged after https://github.com/guardian/frontend/pull/27946