### PR TITLE
Fix images on CODE

### DIFF
--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -63,7 +63,7 @@ export const generateImageURL = ({
 		: ``;
 	const crop = `${aspectRatio}${offset}`;
 	// In CODE, we do not generate optimised replacement images
-	if (url.hostname === 's3-eu-west-1.amazonaws.com') return url.href;
+	if (url.hostname === 'media.guimcode.co.uk') return url.href;
 
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -37,6 +37,8 @@ const getServiceFromUrl = (url: URL): string => {
 	}
 };
 
+const isCodeGridUrl = (url: URL) => url.hostname === 'media.guimcode.co.uk';
+
 /**
  * Generates a URL for calling the Fastly Image Optimiser.
  *
@@ -62,8 +64,6 @@ export const generateImageURL = ({
 		? `,offset-x${cropOffset.x},offset-y${cropOffset.y}`
 		: ``;
 	const crop = `${aspectRatio}${offset}`;
-	// In CODE, we do not generate optimised replacement images
-	if (url.hostname === 'media.guimcode.co.uk') return url.href;
 
 	const params = new URLSearchParams({
 		width: imageWidth.toString(),
@@ -72,7 +72,9 @@ export const generateImageURL = ({
 		crop,
 	});
 
-	return `https://i.guim.co.uk/img/${getServiceFromUrl(url)}${
+	const domain = isCodeGridUrl(url) ? 'i.guimcode.co.uk' : 'i.guim.co.uk';
+
+	return `https://${domain}/img/${getServiceFromUrl(url)}${
 		url.pathname
 	}?${params.toString()}`;
 };


### PR DESCRIPTION
## What does this change?

Fixes: https://github.com/guardian/dotcom-rendering/issues/13900

`generateImageURL` takes a standard media URL (`media.guim.co.uk`) and produces a fastly optimised one (`i.guim.co.uk`). 

~In the case of images on CODE grid, we don't need this optimisation and there is a clause to just use the standard URL instead.~

~However, it is misconfigured to use the domain `3-eu-west-1.amazonaws.com` to identify images on CODE rather than the correct `media.guimcode.co.uk`. As a result, `generateImageURL` builds malformed URLs which combine the production optimizer `i.guim.co.uk` with CODE grid URLs. This results in 403s and thus broken images on CODE.~

Update: I've changed approach to use the CODE optimizer (`i.guimcode.co.uk`) instead of maintaining the special case.

## Why?

Images can now be previewed in CODE.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1301" alt="Screenshot 2025-05-05 at 10 59 41" src="https://github.com/user-attachments/assets/cb48c6f8-a545-482c-927c-e4b99e96e4b6" /> | <img width="1298" alt="Screenshot 2025-05-05 at 10 59 54" src="https://github.com/user-attachments/assets/8fd70e6d-6478-4a5b-be8d-20d7cd5aa9e2" /> |

