### PR TITLE
Insert an extra ad on desktop fronts in certain conditions

### DIFF
--- a/dotcom-rendering/fixtures/manual/frontCollections.ts
+++ b/dotcom-rendering/fixtures/manual/frontCollections.ts
@@ -317,3 +317,34 @@ export const brandedTestCollections = [
 		displayName: 'Headlines',
 	},
 ] satisfies DCRCollectionType[];
+
+export const largeFlexibleGeneralCollection = [
+	{
+		...defaultValues,
+		grouped: {
+			...defaultGrouped,
+			splash: [trails[0]],
+			veryBig: [trails[1]],
+			big: [trails[2]],
+			standard: [trails[3], trails[4], trails[5], trails[6]],
+		},
+		collectionType: 'flexible/general',
+		containerLevel: 'Primary',
+	},
+] satisfies DCRCollectionType[];
+
+export const flexibleSpecialCollection = [
+	{
+		...defaultValues,
+		collectionType: 'flexible/special',
+		containerLevel: 'Primary',
+	},
+] satisfies DCRCollectionType[];
+
+export const secondaryScrollableSmallCollection = [
+	{
+		...defaultValues,
+		collectionType: 'scrollable/small',
+		containerLevel: 'Secondary',
+	},
+] satisfies DCRCollectionType[];

--- a/dotcom-rendering/fixtures/manual/frontCollections.ts
+++ b/dotcom-rendering/fixtures/manual/frontCollections.ts
@@ -333,18 +333,22 @@ export const largeFlexibleGeneralCollection = [
 	},
 ] satisfies DCRCollectionType[];
 
+export const smallFlexibleGeneralCollection = [
+	{
+		...defaultValues,
+		grouped: {
+			...defaultGrouped,
+			standard: [trails[0]],
+		},
+		collectionType: 'flexible/general',
+		containerLevel: 'Primary',
+	},
+] satisfies DCRCollectionType[];
+
 export const flexibleSpecialCollection = [
 	{
 		...defaultValues,
 		collectionType: 'flexible/special',
 		containerLevel: 'Primary',
-	},
-] satisfies DCRCollectionType[];
-
-export const secondaryScrollableSmallCollection = [
-	{
-		...defaultValues,
-		collectionType: 'scrollable/small',
-		containerLevel: 'Secondary',
 	},
 ] satisfies DCRCollectionType[];

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -39,7 +39,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
-	getFrontsBannerAdPositions,
+	getDesktopAdPositions,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
@@ -127,7 +127,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		: [];
 
 	const desktopAdPositions = renderAds
-		? getFrontsBannerAdPositions(filteredCollections, pageId)
+		? getDesktopAdPositions(filteredCollections, pageId)
 		: [];
 
 	const showMostPopular =

--- a/dotcom-rendering/src/lib/frontsBannerAdExclusions.ts
+++ b/dotcom-rendering/src/lib/frontsBannerAdExclusions.ts
@@ -1,19 +1,18 @@
 import type { FrontsBannerAdCollections } from '../types/commercial';
 
 /**
- * This file is temporary.
- *
  * When inserting advert slots into fronts pages, there are some containers in which
- * we do not want to insert slots above, to ensure good page aesthetics. An example is
+ * we do not want to insert slots above to ensure good page aesthetics. An example is
  * when multiple consecutive containers are used for the same piece of news. E.g. In 2020,
- * three consecutive containers on '/uk' were used for Covid. It would be inappropriate
+ * three consecutive containers on '/uk' were used for Covid. It would not be desirable
  * to insert an ad between these sections.
  *
- * Our solution is to use a checkbox in the fronts config tool, that editors can use to
- * indicate that an advert should not be placed above a certain slot. This checkbox will
- * have the highest importance in deciding where to place fronts-banner ads on the page.
+ * If this file is frequently updated, it may be worth considering an alternative solution.
+ * We could use a checkbox in the fronts config tool that editors can use to
+ * indicate that an advert should not be placed above a certain container, instead of a
+ * hardcoded list of containers.
  *
- * Contact Dominik Lander or the commercial dev team for more information.
+ * Contact the Commercial dev team for more information.
  */
 
 export const frontsBannerExcludedCollections: FrontsBannerAdCollections = {

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -2,7 +2,7 @@ import {
 	brandedTestCollections,
 	flexibleSpecialCollection,
 	largeFlexibleGeneralCollection,
-	secondaryScrollableSmallCollection,
+	smallFlexibleGeneralCollection,
 	testCollectionsUk,
 	testCollectionsUs,
 	testCollectionsWithSecondaryLevel,
@@ -400,44 +400,141 @@ describe('Desktop Ads', () => {
 });
 
 describe('inserting an extra ad after the first collection', () => {
-	describe('on desktop', () => {
+	describe('on mobile', () => {
 		it('inserts an ad after the first collection if it is a large flexible general container and is followed by two secondary containers', () => {
+			const adPositions = getMobileAdPositions([
+				...largeFlexibleGeneralCollection,
+				{
+					...testCollection,
+					collectionType: 'scrollable/small',
+					containerLevel: 'Secondary',
+				},
+				{
+					...testCollection,
+					collectionType: 'scrollable/medium',
+					containerLevel: 'Secondary',
+				},
+			]);
+
+			expect(adPositions).toContain(0);
+		});
+
+		it('does NOT insert an ad after the first collection if it is not followed by at least two secondary containers', () => {
+			const adPositions = getMobileAdPositions([
+				...largeFlexibleGeneralCollection,
+				{
+					...testCollection,
+					collectionType: 'scrollable/small',
+					containerLevel: 'Secondary',
+				},
+				{
+					...testCollection,
+					collectionType: 'flexible/general',
+					containerLevel: 'Primary',
+				},
+			]);
+
+			expect(adPositions).not.toContain(0);
+		});
+
+		it('does NOT insert an ad after the first collection if it is a flexible special container', () => {
+			const adPositions = getMobileAdPositions([
+				...flexibleSpecialCollection,
+				{
+					...testCollection,
+					collectionType: 'scrollable/small',
+					containerLevel: 'Secondary',
+				},
+				{
+					...testCollection,
+					collectionType: 'scrollable/medium',
+					containerLevel: 'Secondary',
+				},
+			]);
+
+			expect(adPositions).not.toContain(0);
+		});
+	});
+
+	describe('on desktop', () => {
+		it('inserts an ad before the second collection if it is a secondary container, preceded by a large flexible general container and followed by a secondary container', () => {
 			const adPositions = getDesktopAdPositions(
 				[
 					...largeFlexibleGeneralCollection,
-					...secondaryScrollableSmallCollection,
-					...secondaryScrollableSmallCollection,
+					{
+						...testCollection,
+						collectionType: 'scrollable/small',
+						containerLevel: 'Secondary',
+					},
+					{
+						...testCollection,
+						collectionType: 'scrollable/medium',
+						containerLevel: 'Secondary',
+					},
 				],
 				'uk',
 			);
 
-			expect(adPositions).toEqual([1]);
+			expect(adPositions).toContain(1);
 		});
 
-		it('does NOT insert an ad after the first collection if it is not followed by at least two secondary containers', () => {
+		it('does NOT insert an ad before the second collection if it is by a small flexible general container', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...smallFlexibleGeneralCollection,
+					{
+						...testCollection,
+						collectionType: 'scrollable/small',
+						containerLevel: 'Secondary',
+					},
+					{
+						...testCollection,
+						collectionType: 'scrollable/medium',
+						containerLevel: 'Secondary',
+					},
+				],
+				'uk',
+			);
+
+			expect(adPositions).not.toContain(1);
+		});
+
+		it('does NOT insert an ad before the second collection if it is not preceded by a flexible general container', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...flexibleSpecialCollection,
+					{
+						...testCollection,
+						collectionType: 'scrollable/small',
+						containerLevel: 'Secondary',
+					},
+					{
+						...testCollection,
+						collectionType: 'scrollable/medium',
+						containerLevel: 'Secondary',
+					},
+				],
+				'uk',
+			);
+
+			expect(adPositions).not.toContain(1);
+		});
+
+		it('does NOT insert an ad before the second collection if it is not followed by a secondary container', () => {
 			const adPositions = getDesktopAdPositions(
 				[
 					...largeFlexibleGeneralCollection,
-					...secondaryScrollableSmallCollection,
+					{
+						...testCollection,
+						collectionType: 'scrollable/small',
+						containerLevel: 'Secondary',
+					},
 					...largeFlexibleGeneralCollection, // We do not insert an ad above the final collection on desktop
 				],
 				'uk',
 			);
 
-			expect(adPositions).toEqual([]);
-		});
-
-		it('does NOT insert an ad after the first collection if it is a flexible special container', () => {
-			const adPositions = getDesktopAdPositions(
-				[
-					...flexibleSpecialCollection,
-					...secondaryScrollableSmallCollection,
-					...secondaryScrollableSmallCollection,
-				],
-				'uk',
-			);
-
-			expect(adPositions).toEqual([]);
+			expect(adPositions).not.toContain(1);
 		});
 	});
 });

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -1,27 +1,45 @@
 import {
 	brandedTestCollections,
+	flexibleSpecialCollection,
+	largeFlexibleGeneralCollection,
+	secondaryScrollableSmallCollection,
 	testCollectionsUk,
 	testCollectionsUs,
 	testCollectionsWithSecondaryLevel,
 } from '../../fixtures/manual/frontCollections';
 import type { DCRCollectionType } from '../types/front';
 import {
-	type AdCandidateMobile,
-	getFrontsBannerAdPositions,
+	type AdCandidate,
+	getDesktopAdPositions,
 	getMobileAdPositions,
 	removeConsecutiveAdSlotsReducer,
 } from './getFrontsAdPositions';
 
-const defaultTestCollections: AdCandidateMobile[] = [...Array<number>(12)].map(
-	() => ({ collectionType: 'fixed/large/slow-XIV' }),
+const testCollection: AdCandidate = {
+	collectionType: 'fixed/large/slow-XIV',
+	displayName: 'Test Collection',
+	containerLevel: 'Primary',
+	containerPalette: 'EventPalette',
+	grouped: {
+		snap: [],
+		splash: [],
+		huge: [],
+		veryBig: [],
+		big: [],
+		standard: [],
+	},
+};
+
+const defaultTestCollections: AdCandidate[] = [...Array<number>(12)].map(
+	() => ({ ...testCollection }),
 );
 
 describe('Mobile Ads', () => {
 	it(`Should not insert ad after container if it's the first one and it's a thrasher`, () => {
 		const testCollections = [
-			{ collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
 			...defaultTestCollections,
-		] satisfies AdCandidateMobile[];
+		] satisfies AdCandidate[];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
@@ -31,16 +49,22 @@ describe('Mobile Ads', () => {
 	it(`should not insert an ad in the merchandising-high position`, () => {
 		const testCollections = [
 			...defaultTestCollections.slice(0, 3),
-			{ collectionType: 'news/most-popular' },
-		] satisfies AdCandidateMobile[];
+			{ ...testCollection, collectionType: 'news/most-popular' },
+		] satisfies AdCandidate[];
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 		expect(mobileAdPositions).not.toContain(3);
 	});
 
 	it('Should not insert ad before a thrasher container', () => {
 		const testCollections = [...defaultTestCollections];
-		testCollections.splice(6, 0, { collectionType: 'fixed/thrasher' });
-		testCollections.splice(9, 0, { collectionType: 'fixed/thrasher' });
+		testCollections.splice(6, 0, {
+			...testCollection,
+			collectionType: 'fixed/thrasher',
+		});
+		testCollections.splice(9, 0, {
+			...testCollection,
+			collectionType: 'fixed/thrasher',
+		});
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
 
@@ -50,20 +74,20 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/uk/commentisfree as a blueprint
 	it('Non-network front, with more than 4 collections, without thrashers', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'fixed/large/slow-XIV' }, // Ad position (0)
-			{ collectionType: 'fixed/medium/slow-VI' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (2)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (4)
-			{ collectionType: 'dynamic/slow-mpu' },
-			{ collectionType: 'fixed/small/slow-I' }, // Ad position (6)
-			{ collectionType: 'fixed/medium/slow-VI' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (8)
-			{ collectionType: 'fixed/small/slow-III' },
-			{ collectionType: 'fixed/medium/fast-XII' }, // Ignored - is before merch high position
-			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'fixed/large/slow-XIV' }, // Ad position (0)
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (2)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (4)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-I' }, // Ad position (6)
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (8)
+			{ ...testCollection, collectionType: 'fixed/small/slow-III' },
+			{ ...testCollection, collectionType: 'fixed/medium/fast-XII' }, // Ignored - is before merch high position
+			{ ...testCollection, collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -73,31 +97,31 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/uk as a blueprint
 	it('UK Network Front, with more than 4 collections, with thrashers at various places', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'dynamic/fast' }, // Ad position (0)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'dynamic/slow' }, // Ad position (2)
-			{ collectionType: 'dynamic/slow' },
-			{ collectionType: 'fixed/small/slow-V-mpu' }, // Ad position (4)
-			{ collectionType: 'dynamic/slow' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (8)
-			{ collectionType: 'dynamic/fast' },
-			{ collectionType: 'dynamic/fast' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (11)
-			{ collectionType: 'dynamic/slow-mpu' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (14)
-			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'fixed/video' }, // Ad position (17)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (19)
-			{ collectionType: 'dynamic/slow-mpu' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - is before merch high position
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ad position (0)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ad position (2)
+			{ ...testCollection, collectionType: 'dynamic/slow' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-mpu' }, // Ad position (4)
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (8)
+			{ ...testCollection, collectionType: 'dynamic/fast' },
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (11)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (14)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/video' }, // Ad position (17)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (19)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - is before merch high position
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -107,27 +131,27 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/international as a blueprint
 	it('International Network Front, with more than 4 collections, with thrashers at various places', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'dynamic/fast' }, // Ad position (0)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'dynamic/slow' }, // Ad position (2)
-			{ collectionType: 'dynamic/slow-mpu' },
-			{ collectionType: 'dynamic/slow' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (5)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'dynamic/fast' }, // Ad position (7)
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (11)
-			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'dynamic/slow-mpu' }, // Ad position (14)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (16)
-			{ collectionType: 'fixed/video' },
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ad position (0)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ad position (2)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' },
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (5)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ad position (7)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (11)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' }, // Ad position (14)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (16)
+			{ ...testCollection, collectionType: 'fixed/video' },
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -137,28 +161,28 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/us as a blueprint
 	it('US Network Front, with more than 4 collections, with thrashers at various places', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'dynamic/fast' }, // Ad position (0)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (2)
-			{ collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'dynamic/slow' }, // Ad position (5)
-			{ collectionType: 'dynamic/slow' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'fixed/small/slow-III' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (9)
-			{ collectionType: 'fixed/small/slow-IV' },
-			{ collectionType: 'dynamic/fast' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (12)
-			{ collectionType: 'fixed/medium/slow-VI' },
-			{ collectionType: 'dynamic/fast' }, // Ad position (14)
-			{ collectionType: 'dynamic/fast' },
-			{ collectionType: 'fixed/small/slow-V-mpu' }, // Ad position (16)
-			{ collectionType: 'fixed/video' },
-			{ collectionType: 'fixed/small/slow-III' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ad position (0)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (2)
+			{ ...testCollection, collectionType: 'dynamic/slow-mpu' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ad position (5)
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-III' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (9)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' },
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (12)
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' },
+			{ ...testCollection, collectionType: 'dynamic/fast' }, // Ad position (14)
+			{ ...testCollection, collectionType: 'dynamic/fast' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-mpu' }, // Ad position (16)
+			{ ...testCollection, collectionType: 'fixed/video' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-III' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -168,23 +192,23 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/uk/lifeandstyle as a blueprint
 	it('Lifeandstyle front, with more than 4 collections, with thrashers at various places', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'dynamic/slow' }, // Ad position (0)
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ad position (3)
-			{ collectionType: 'fixed/small/slow-V-third' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (6)
-			{ collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' },
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ad position (9)
-			{ collectionType: 'fixed/medium/slow-XII-mpu' },
-			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (12)
-			{ collectionType: 'fixed/small/slow-III' },
-			{ collectionType: 'fixed/small/slow-I' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'dynamic/slow' }, // Ad position (0)
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ad position (3)
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-third' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (6)
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' },
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ad position (9)
+			{ ...testCollection, collectionType: 'fixed/medium/slow-XII-mpu' },
+			{ ...testCollection, collectionType: 'fixed/small/fast-VIII' }, // Ignored - before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (12)
+			{ ...testCollection, collectionType: 'fixed/small/slow-III' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-I' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -194,21 +218,21 @@ describe('Mobile Ads', () => {
 
 	// We used https://www.theguardian.com/tone/recipes as a blueprint
 	it('Recipes front, with more than 4 collections, with thrasher at the first position', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'fixed/thrasher' }, // Ignored - is first container and thrasher
-			{ collectionType: 'fixed/medium/slow-VI' }, // Ad position (1)
-			{ collectionType: 'fixed/small/slow-V-third' },
-			{ collectionType: 'fixed/medium/slow-XII-mpu' }, // Ad position (3)
-			{ collectionType: 'fixed/medium/fast-XII' },
-			{ collectionType: 'fixed/small/slow-V-third' }, // Ad position (5)
-			{ collectionType: 'fixed/small/fast-VIII' },
-			{ collectionType: 'fixed/medium/fast-XI' }, // Ad position (7)
-			{ collectionType: 'fixed/small/slow-III' },
-			{ collectionType: 'fixed/small/slow-IV' }, // Ad position (9)
-			{ collectionType: 'fixed/small/slow-V-half' },
-			{ collectionType: 'fixed/small/slow-V-third' }, // Ignored - is before merch high position
-			{ collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+		const testCollections: AdCandidate[] = [
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ignored - is first container and thrasher
+			{ ...testCollection, collectionType: 'fixed/medium/slow-VI' }, // Ad position (1)
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-third' },
+			{ ...testCollection, collectionType: 'fixed/medium/slow-XII-mpu' }, // Ad position (3)
+			{ ...testCollection, collectionType: 'fixed/medium/fast-XII' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-third' }, // Ad position (5)
+			{ ...testCollection, collectionType: 'fixed/small/fast-VIII' },
+			{ ...testCollection, collectionType: 'fixed/medium/fast-XI' }, // Ad position (7)
+			{ ...testCollection, collectionType: 'fixed/small/slow-III' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-IV' }, // Ad position (9)
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-half' },
+			{ ...testCollection, collectionType: 'fixed/small/slow-V-third' }, // Ignored - is before merch high position
+			{ ...testCollection, collectionType: 'fixed/small/fast-VIII' }, // Ignored - is merch high position
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -217,47 +241,105 @@ describe('Mobile Ads', () => {
 	});
 
 	it('Europe Network Front, with beta containers and more than 4 collections, with thrashers in various places', () => {
-		const testCollections: AdCandidateMobile[] = [
-			{ collectionType: 'flexible/general', containerLevel: 'Primary' }, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
+		const testCollections: AdCandidate[] = [
 			{
+				...testCollection,
+				collectionType: 'flexible/general',
+				containerLevel: 'Primary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
 				collectionType: 'scrollable/medium',
 				containerLevel: 'Secondary',
 			}, // Ignored - is before secondary container
 			{
+				...testCollection,
 				collectionType: 'scrollable/feature',
 				containerLevel: 'Secondary',
 			}, // Ad position (4)
-			{ collectionType: 'static/feature/2', containerLevel: 'Primary' }, // Ignored - is before secondary container
 			{
+				...testCollection,
+				collectionType: 'static/feature/2',
+				containerLevel: 'Primary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
 				collectionType: 'scrollable/medium',
 				containerLevel: 'Secondary',
 			}, // Ad position (6)
-			{ collectionType: 'flexible/special', containerLevel: 'Primary' }, // Ignored - is before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (8)
-			{ collectionType: 'flexible/general', containerLevel: 'Primary' }, // Ignored is consecutive ad after position 8
-			{ collectionType: 'static/feature/2', containerLevel: 'Primary' }, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ad position (13)
-			{ collectionType: 'static/feature/2', containerLevel: 'Primary' }, // Ignored - is before secondary container
 			{
+				...testCollection,
+				collectionType: 'flexible/special',
+				containerLevel: 'Primary',
+			}, // Ignored - is before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (8)
+			{
+				...testCollection,
+				collectionType: 'flexible/general',
+				containerLevel: 'Primary',
+			}, // Ignored is consecutive ad after position 8
+			{
+				...testCollection,
+				collectionType: 'static/feature/2',
+				containerLevel: 'Primary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ad position (13)
+			{
+				...testCollection,
+				collectionType: 'static/feature/2',
+				containerLevel: 'Primary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
 				collectionType: 'scrollable/medium',
 				containerLevel: 'Secondary',
 			}, // Ignored - is before secondary container
 			{
+				...testCollection,
 				collectionType: 'scrollable/medium',
 				containerLevel: 'Secondary',
 			}, // Ignored - is before secondary container
-			{ collectionType: 'scrollable/small', containerLevel: 'Secondary' }, // Ignored - is before thrasher
-			{ collectionType: 'fixed/thrasher' }, // Ad position (18)
-			{ collectionType: 'flexible/general', containerLevel: 'Primary' }, // Ignored - is before secondary container
 			{
+				...testCollection,
+				collectionType: 'scrollable/small',
+				containerLevel: 'Secondary',
+			}, // Ignored - is before thrasher
+			{ ...testCollection, collectionType: 'fixed/thrasher' }, // Ad position (18)
+			{
+				...testCollection,
+				collectionType: 'flexible/general',
+				containerLevel: 'Primary',
+			}, // Ignored - is before secondary container
+			{
+				...testCollection,
 				collectionType: 'scrollable/feature',
 				containerLevel: 'Secondary',
 			}, // Ignored - is merch high position
-			{ collectionType: 'news/most-popular' }, // Ignored - is most viewed container
+			{ ...testCollection, collectionType: 'news/most-popular' }, // Ignored - is most viewed container
 		];
 
 		const mobileAdPositions = getMobileAdPositions(testCollections);
@@ -266,30 +348,27 @@ describe('Mobile Ads', () => {
 	});
 });
 
-describe('Standard fronts fronts-banner ad slots', () => {
+describe('Desktop Ads', () => {
 	it('calculates ad positions correctly for an example of the UK network front', () => {
-		const adPositions = getFrontsBannerAdPositions(testCollectionsUk, 'uk');
+		const adPositions = getDesktopAdPositions(testCollectionsUk, 'uk');
 
 		expect(adPositions).toEqual([3, 6, 8, 11, 14, 17]);
 	});
 
 	it('calculates ad positions correctly for an example of the US network front', () => {
-		const adPositions = getFrontsBannerAdPositions(testCollectionsUs, 'us');
+		const adPositions = getDesktopAdPositions(testCollectionsUs, 'us');
 
 		expect(adPositions).toEqual([3, 6, 8, 11, 13, 18]);
 	});
 
 	it('does NOT insert ads above or below branded content', () => {
-		const adPositions = getFrontsBannerAdPositions(
-			brandedTestCollections,
-			'uk',
-		);
+		const adPositions = getDesktopAdPositions(brandedTestCollections, 'uk');
 
 		expect(adPositions).toEqual([]);
 	});
 
 	it('does NOT insert ads above secondary level containers', () => {
-		const adPositions = getFrontsBannerAdPositions(
+		const adPositions = getDesktopAdPositions(
 			testCollectionsWithSecondaryLevel,
 			'europe',
 		);
@@ -298,7 +377,7 @@ describe('Standard fronts fronts-banner ad slots', () => {
 	});
 
 	it('inserts a maximum of 6 ads for standard fronts', () => {
-		const adPositions = getFrontsBannerAdPositions(
+		const adPositions = getDesktopAdPositions(
 			// Double number of UK collections in fixture to reach maximum
 			[...testCollectionsUk, ...testCollectionsUk],
 			'europe',
@@ -308,7 +387,7 @@ describe('Standard fronts fronts-banner ad slots', () => {
 	});
 
 	it('inserts a maximum of 8 ads for fronts with beta collections', () => {
-		const adPositions = getFrontsBannerAdPositions(
+		const adPositions = getDesktopAdPositions(
 			// 10x number of test collections in fixture to reach maximum level
 			new Array<DCRCollectionType[]>(10)
 				.fill(testCollectionsWithSecondaryLevel)
@@ -317,6 +396,49 @@ describe('Standard fronts fronts-banner ad slots', () => {
 		);
 
 		expect(adPositions.length).toEqual(8);
+	});
+});
+
+describe('inserting an extra ad after the first collection', () => {
+	describe('on desktop', () => {
+		it('inserts an ad after the first collection if it is a large flexible general container and is followed by two secondary containers', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...largeFlexibleGeneralCollection,
+					...secondaryScrollableSmallCollection,
+					...secondaryScrollableSmallCollection,
+				],
+				'uk',
+			);
+
+			expect(adPositions).toEqual([1]);
+		});
+
+		it('does NOT insert an ad after the first collection if it is not followed by at least two secondary containers', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...largeFlexibleGeneralCollection,
+					...secondaryScrollableSmallCollection,
+					...largeFlexibleGeneralCollection, // We do not insert an ad above the final collection on desktop
+				],
+				'uk',
+			);
+
+			expect(adPositions).toEqual([]);
+		});
+
+		it('does NOT insert an ad after the first collection if it is a flexible special container', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...flexibleSpecialCollection,
+					...secondaryScrollableSmallCollection,
+					...secondaryScrollableSmallCollection,
+				],
+				'uk',
+			);
+
+			expect(adPositions).toEqual([]);
+		});
 	});
 });
 

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -194,7 +194,7 @@ const getMobileAdPositions = (collections: AdCandidate[]): number[] => {
 		!adPositions.includes(1) &&
 		shouldInsertExtraAdAfterFirstContainer(collections.slice(0, 3))
 	) {
-		adPositions.unshift(0);
+		return [0, ...adPositions];
 	}
 
 	return adPositions;
@@ -440,11 +440,11 @@ const canInsertDesktopAd = (
  * Doesn't insert an ad above the final collection. We serve a merchandising slot below the
  * last collection and we don't want to sandwich the last collection between two full-width ads.
  *
- * | ------------------ |
- * | Next collection    |
- * . ------------------ | <-- Maybe ad position
- * | Current collection |
- * | ------------------ |
+ * | ------------------- |
+ * | Previous collection |
+ * . ------------------- | <-- Maybe ad position
+ * | Current collection  |
+ * | ------------------- |
  */
 const getDesktopAdPositions = (
 	collections: AdCandidate[],
@@ -507,7 +507,7 @@ const getDesktopAdPositions = (
 		!adPositionsFromReducer.includes(1) &&
 		shouldInsertExtraAdAfterFirstContainer(collections.slice(0, 3))
 	) {
-		adPositionsFromReducer.unshift(1);
+		return [1, ...adPositionsFromReducer];
 	}
 
 	return adPositionsFromReducer;


### PR DESCRIPTION
## What does this change?

Inserts an ad on NEW desktop fronts after the first container if the following are true:
- The first collection is a primary container
- The first collection is a flexible general container
- The next two collections are both Secondary containers

## Why?

Following an AB test comparing the new beta fronts with the existing fronts, we found that ad ratio has decreased. This is an attempt to bump up ad ratio on new fronts to achieve parity with the existing fronts.

The first container on a network front is often a large flexible general container, followed by multiple secondary containers. Until now, we don't insert ads above secondary containers because we don't want to separate related pieces of content. An exception is made here, as the amount of content without an ad is atypically large.

## Screenshots

### Mobile

An extra advert is inserted after the first collection.

| Before | After |
| - | - |
| ![mobile-before] | ![mobile-after] |

[mobile-before]: https://github.com/user-attachments/assets/c94ce85c-7749-42cb-8f49-fa2ebdc032e1
[mobile-after]: https://github.com/user-attachments/assets/f5fd2631-3b30-4e3d-8893-6ee49d0c0589

### Desktop

An extra advert is inserted after the first collection.

| Before | After |
| - | - |
| ![desktop-before] | ![desktop-after] |

[desktop-before]: https://github.com/user-attachments/assets/1ac8eb40-8034-4ba3-904d-37fe57173e36
[desktop-after]: https://github.com/user-attachments/assets/003e7338-2d76-4e1f-b315-d1af4e85e145


### Bonus

Now we have a better estimation of the height of a flexible general collection, we avoid the following situation. Documentary is a flexible general

| Before | After |
| - | - |
| ![desktop-before1] | ![desktop-after1] |

[desktop-before1]: https://github.com/user-attachments/assets/64798356-a0f0-4cca-9b58-532986784885
[desktop-after1]: https://github.com/user-attachments/assets/f7133b06-fae1-4318-b1df-0ec181db50c9
