### PR TITLE
Editions crossword refactor

### DIFF
--- a/dotcom-rendering/fixtures/manual/editionsCrossword.ts
+++ b/dotcom-rendering/fixtures/manual/editionsCrossword.ts
@@ -1,4 +1,6 @@
-import type { CAPICrossword } from '@guardian/react-crossword/dist/@types/CAPI';
+import type { CrosswordProps } from '@guardian/react-crossword';
+
+type CAPICrossword = CrosswordProps['data'];
 
 export const quickCrossword: CAPICrossword = {
 	date: 1730598000000,

--- a/dotcom-rendering/scripts/jsonSchema/schema.mjs
+++ b/dotcom-rendering/scripts/jsonSchema/schema.mjs
@@ -58,7 +58,7 @@ const schemas = [
 		file: `${root}/src/model/block-schema.json`,
 	},
 	{
-		typeName: 'CAPICrosswords',
+		typeName: 'FEEditionsCrosswords',
 		file: `${root}/src/model/editions-crossword-schema.json`,
 	},
 	{

--- a/dotcom-rendering/src/client/main.editionsCrossword.tsx
+++ b/dotcom-rendering/src/client/main.editionsCrossword.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable ssr-friendly/no-dom-globals-in-module-scope */
-import type { CAPICrossword } from '@guardian/react-crossword/dist/@types/CAPI';
+import type { CrosswordProps } from '@guardian/react-crossword';
 import { createRoot } from 'react-dom/client';
 import { Crosswords } from '../components/Crosswords.editions';
+
+type CAPICrossword = CrosswordProps['data'];
 
 const element = document.getElementById('editions-crossword-player');
 if (!element) {

--- a/dotcom-rendering/src/components/Crosswords.editions.tsx
+++ b/dotcom-rendering/src/components/Crosswords.editions.tsx
@@ -1,8 +1,10 @@
 import { Crossword } from '@guardian/react-crossword';
-import type { CAPICrossword } from '@guardian/react-crossword/dist/@types/CAPI';
+import type { CrosswordProps } from '@guardian/react-crossword';
 import { useEffect, useState } from 'react';
 import { type CrosswordsByDate, groupByDate } from '../types/editionsCrossword';
 import { CrosswordSelect } from './CrosswordSelect.editions';
+
+type CAPICrossword = CrosswordProps['data'];
 
 type Props = {
 	crosswords: CAPICrossword[];

--- a/dotcom-rendering/src/components/EditionsCrosswordPage.tsx
+++ b/dotcom-rendering/src/components/EditionsCrosswordPage.tsx
@@ -1,8 +1,8 @@
 import { StrictMode } from 'react';
-import type { CAPICrosswords } from '../types/editionsCrossword';
+import type { FEEditionsCrosswords } from '../types/editionsCrossword';
 
 interface Props {
-	editionsCrosswords: CAPICrosswords;
+	editionsCrosswords: FEEditionsCrosswords;
 }
 
 export const EditionsCrosswordPage = ({ editionsCrosswords }: Props) => {

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -17,7 +17,7 @@ import footballTablesPageSchema from '../frontend/schemas/feFootballTablesPage.j
 import frontSchema from '../frontend/schemas/feFront.json';
 import tagPageSchema from '../frontend/schemas/feTagPage.json';
 import type { Block } from '../types/blocks';
-import type { CAPICrosswords } from '../types/editionsCrossword';
+import type { FEEditionsCrosswords } from '../types/editionsCrossword';
 import type { FENewslettersPageType } from '../types/newslettersPage';
 import blockSchema from './block-schema.json';
 import editionsCrosswordSchema from './editions-crossword-schema.json';
@@ -40,7 +40,7 @@ const validateAllEditorialNewslettersPage = ajv.compile<FENewslettersPageType>(
 	newslettersPageSchema,
 );
 const validateBlock = ajv.compile<Block[]>(blockSchema);
-const validateEditionsCrossword = ajv.compile<CAPICrosswords>(
+const validateEditionsCrossword = ajv.compile<FEEditionsCrosswords>(
 	editionsCrosswordSchema,
 );
 const validateFootballMatchListPage = ajv.compile<FEFootballMatchListPage>(
@@ -71,7 +71,7 @@ export const validateAsFEArticle = (data: unknown): FEArticle => {
 
 export const validateAsEditionsCrosswordType = (
 	data: unknown,
-): CAPICrosswords => {
+): FEEditionsCrosswords => {
 	if (validateEditionsCrossword(data)) {
 		return data;
 	}

--- a/dotcom-rendering/src/server/render.editionsCrossword.tsx
+++ b/dotcom-rendering/src/server/render.editionsCrossword.tsx
@@ -2,11 +2,11 @@ import { isString } from '@guardian/libs';
 import { EditionsCrosswordPage } from '../components/EditionsCrosswordPage';
 import { generateScriptTags, getPathFromManifest } from '../lib/assets';
 import { renderToStringWithEmotion } from '../lib/emotion';
-import type { CAPICrosswords } from '../types/editionsCrossword';
+import type { FEEditionsCrosswords } from '../types/editionsCrossword';
 import { htmlCrosswordPageTemplate } from './htmlCrosswordPageTemplate';
 
 interface Props {
-	editionsCrosswords: CAPICrosswords;
+	editionsCrosswords: FEEditionsCrosswords;
 }
 
 export const renderCrosswordHtml = ({

--- a/dotcom-rendering/src/types/editionsCrossword.ts
+++ b/dotcom-rendering/src/types/editionsCrossword.ts
@@ -1,6 +1,8 @@
-import type { CAPICrossword } from '@guardian/react-crossword/dist/@types/CAPI';
+import type { CrosswordProps } from '@guardian/react-crossword';
 
-export type CAPICrosswords = {
+type CAPICrossword = CrosswordProps['data'];
+
+export type FEEditionsCrosswords = {
 	newCrosswords: CAPICrossword[];
 };
 


### PR DESCRIPTION
## What does this change?
This change refactors the type definitions for Editions Crosswords. It renames `CAPICrosswords` to `FEEditionsCrosswords` and derives the individual crossword data type `CAPICrossword` directly from the `@guardian/react-crossword` library's `CrosswordProps`.
## Why?
This refactor enhances type clarity by explicitly naming the collection type `FEEditionsCrosswords` for its frontend context, and improves maintainability and type safety by directly using the upstream type for individual crossword data.

Follow up from https://github.com/guardian/dotcom-rendering/pull/13876

