### PR TITLE
Disable choice cards on banner if not VAT compliant

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -309,9 +309,13 @@ const DesignableBannerV2: ReactComponent<BannerRenderProps> = ({
 		? content.mainContent
 		: content.mobileContent;
 
+	const isVatCompliantCountry =
+		choiceCardAmounts?.testName !== 'VAT_COMPLIANCE';
+
 	const showChoiceCards = !!(
 		templateSettings.choiceCardSettings &&
-		choiceCardAmounts?.amountsCardData
+		choiceCardAmounts?.amountsCardData &&
+		isVatCompliantCountry
 	);
 
 	const getHeaderContainerCss = () => {


### PR DESCRIPTION
We already disable the choice cards on the epic if the user is not in a VAT compliant region:
https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx#L39

This PR adds the same functionality for the banner.

Tested by setting country to one that is in the `VAT_COMPLIANCE` amounts test and confirming that the choice cards are not displayed:

<img width="1264" alt="Screenshot 2025-05-06 at 13 59 04" src="https://github.com/user-attachments/assets/8a14d3f3-75a2-4baa-a937-0c1f7641e566" />
<img width="338" alt="Screenshot 2025-05-06 at 13 59 18" src="https://github.com/user-attachments/assets/aa8fd684-765d-4d3e-9825-5442481c196e" />
