### PR TITLE
Skip `commercial.e2e.spec.ts`

### DIFF
--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -4,7 +4,9 @@ import { loadPage } from '../lib/load-page';
 import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
-	test.skip(`It should load the expected number of ad slots`, async ({ page }) => {
+	test.skip(`It should load the expected number of ad slots`, async ({
+		page,
+	}) => {
 		await loadPage({
 			page,
 			path: `/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,

--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -4,7 +4,7 @@ import { loadPage } from '../lib/load-page';
 import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
-	test(`It should load the expected number of ad slots`, async ({ page }) => {
+	test.skip(`It should load the expected number of ad slots`, async ({ page }) => {
 		await loadPage({
 			page,
 			path: `/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,


### PR DESCRIPTION
## What does this change?

Skip `commercial.e2e.spec.ts` as it is failing

https://github.com/guardian/dotcom-rendering/actions/runs/14860492362/job/41724026329?pr=13908

https://github.com/guardian/dotcom-rendering/actions/runs/14858505094/job/41717505459?pr=13909#step:6:18

