### PR TITLE
Fix Commercial Playwright test

### DIFF
--- a/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/commercial.e2e.spec.ts
@@ -4,9 +4,7 @@ import { loadPage } from '../lib/load-page';
 import { expectToExist } from '../lib/locators';
 
 test.describe('Commercial E2E tests', () => {
-	test.skip(`It should load the expected number of ad slots`, async ({
-		page,
-	}) => {
+	test(`It should load the expected number of ad slots`, async ({ page }) => {
 		await loadPage({
 			page,
 			path: `/Article/https://www.theguardian.com/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife`,
@@ -14,14 +12,22 @@ test.describe('Commercial E2E tests', () => {
 
 		await cmpAcceptAll(page);
 
-		const totalSlots = 15;
-		const fixedSlots = 4;
-		const inlineSlots = totalSlots - fixedSlots;
+		const fixedSlots = [
+			'carrot', // Not used often, likely to be unfilled
+			'right',
+			'merchandising-high',
+			'mostpop',
+			'merchandising',
+		];
+
+		const totalSlotsExpected = 16; // All slots, even if unfilled ie. `display: none`
+		const inlineSlots = totalSlotsExpected - fixedSlots.length;
+
 		// We are excluding survey slot as they can be switched off
 		await expectToExist(
 			page,
 			'.js-ad-slot:not([data-name="survey"])',
-			totalSlots,
+			totalSlotsExpected,
 		);
 
 		// Check all inline slots are present
@@ -31,9 +37,8 @@ test.describe('Commercial E2E tests', () => {
 		}
 
 		// Check all other fixed slots
-		await expectToExist(page, '[data-name="right"]');
-		await expectToExist(page, '[data-name="merchandising-high"]');
-		await expectToExist(page, '[data-name="mostpop"]');
-		await expectToExist(page, '[data-name="merchandising"]');
+		for (const slotName of fixedSlots) {
+			await expectToExist(page, `[data-name="${slotName}"]`);
+		}
 	});
 });


### PR DESCRIPTION
## What does this change?

- Increases expected number of ad slots in the commercial Playwright test
- Specifies inclusion of carrot slot, which is very often unfilled and will have display: none

## Why?

The commercial Playwright test stopped working after this PR was merged: https://github.com/guardian/commercial/pull/1925

This is because we now set `display: none` for ad slots instead of removing them entirely when unfilled
