### PR TITLE
Crop immersive youtube images to 5:3 with a top center offset

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -182,6 +182,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 						width={width}
 						aspectRatio={aspectRatio}
 						mobileAspectRatio={mobileAspectRatio}
+						isImmersive={isImmersive}
 					/>
 				)}
 				{hasDuration && !isVideoArticle ? (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -11,6 +11,7 @@ type Props = {
 	width: number;
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
+	isImmersive?: boolean;
 };
 
 export const YoutubeAtomPicture = ({
@@ -20,6 +21,7 @@ export const YoutubeAtomPicture = ({
 	width,
 	aspectRatio,
 	mobileAspectRatio,
+	isImmersive = false,
 }: Props) => {
 	const mobileAspect = mobileAspectRatio ?? aspectRatio;
 	const sources = generateSources(getSourceImageUrl(image), [
@@ -38,8 +40,18 @@ export const YoutubeAtomPicture = ({
 			width: 620,
 			aspectRatio: mobileAspect,
 		},
-		{ breakpoint: breakpoints.tablet, width: 700, aspectRatio },
-		{ breakpoint: breakpoints.desktop, width: 620, aspectRatio },
+		{
+			breakpoint: breakpoints.tablet,
+			width: 700,
+			aspectRatio,
+			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+		},
+		{
+			breakpoint: breakpoints.desktop,
+			width: 620,
+			aspectRatio,
+			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+		},
 	]);
 	const fallbackSource = getFallbackSource(sources);
 


### PR DESCRIPTION
## What does this change?
Crop immersive youtube images to 5:3 with a top center offset.

## Why?

This happens for standard images but not for youtube image - it was missed in the first implementation. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cb49ca28-2828-45b4-aa44-05f04eb08792
[after]: https://github.com/user-attachments/assets/6f68345c-2676-4dcd-96c8-62b9d63b9396


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
