### PR TITLE
Feature & Immersive cards video toggle

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -321,6 +321,7 @@ export type Props = {
 	 *
 	 */
 	isImmersive?: boolean;
+	showMainVideo?: boolean;
 };
 
 export const FeatureCard = ({
@@ -358,6 +359,7 @@ export const FeatureCard = ({
 	collectionId,
 	isNewsletter = false,
 	isImmersive = false,
+	showMainVideo = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -374,7 +376,8 @@ export const FeatureCard = ({
 		canPlayInline,
 	});
 
-	const showYoutubeVideo = canPlayInline && mainMedia?.type === 'Video';
+	const showYoutubeVideo =
+		canPlayInline && showMainVideo && mainMedia?.type === 'Video';
 
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -131,6 +131,7 @@ const ImmersiveCardLayout = ({
 					headlineSizes={{ desktop: 'small' }}
 					supportingContent={card.supportingContent}
 					isImmersive={true}
+					showMainVideo={card.showMainVideo}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -77,6 +77,7 @@ export const ScrollableFeature = ({
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
+							showMainVideo={card.showMainVideo}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -79,6 +79,7 @@ export const StaticFeatureTwo = ({
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
+							showMainVideo={card.showMainVideo}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -156,6 +156,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				return '5:3';
 		}
 	};
+
 	const Highlights = () => {
 		const showHighlights =
 			// Must be opted into the Europe beta test or in preview


### PR DESCRIPTION
## What does this change?

- Will not render a Youtube video container as the card if `showMainVideo` is false.

## Why?

- So that we can control whether or not a video is displayed using a setting in the tools.

## Screenshots

The card below has Media set to Trail Image in the tool

| | Before | After |
| - | - | - |
| | ![desktop-before] | ![desktop-after] |

[desktop-before]: https://github.com/user-attachments/assets/294ad44a-c2a6-4426-8095-e3997127ff12
[desktop-after]: https://github.com/user-attachments/assets/e45d69cb-8c22-4102-b5c1-31462babd903
