### PR TITLE
Add byline to immersive youtube cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -447,6 +447,8 @@ export const FeatureCard = ({
 										discussionApiUrl={discussionApiUrl}
 										isFeatureCard={true}
 										isImmersive={isImmersive}
+										byline={byline}
+										showByline={showByline}
 									/>
 								</Island>
 							</div>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -63,6 +63,8 @@ export type Props = {
 	discussionId?: string;
 	isFeatureCard?: boolean;
 	isImmersive?: boolean;
+	byline?: string;
+	showByline?: boolean;
 };
 
 /**
@@ -117,6 +119,8 @@ export const YoutubeAtom = ({
 	discussionId,
 	isFeatureCard,
 	isImmersive,
+	byline,
+	showByline,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -263,6 +267,8 @@ export const YoutubeAtom = ({
 								discussionId={discussionId}
 								discussionApiUrl={discussionApiUrl}
 								isImmersive={isImmersive}
+								byline={byline}
+								showByline={showByline}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -126,6 +126,8 @@ type Props = {
 	discussionApiUrl?: string;
 	discussionId?: string;
 	isImmersive?: boolean;
+	byline?: string;
+	showByline?: boolean;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -151,6 +153,8 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	discussionId,
 	discussionApiUrl,
 	isImmersive,
+	byline,
+	showByline,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -217,6 +221,8 @@ export const YoutubeAtomFeatureCardOverlay = ({
 							headlineColour={palette('--feature-card-headline')}
 							kickerColour={palette('--feature-card-kicker-text')}
 							isBetaContainer={true}
+							byline={byline}
+							showByline={showByline}
 						/>
 					)}
 					{!!trailText && (

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -56,6 +56,8 @@ type Props = {
 	isFeatureCard?: boolean;
 	mobileAspectRatio?: AspectRatio;
 	isImmersive?: boolean;
+	byline?: string;
+	showByline?: boolean;
 };
 
 export const YoutubeBlockComponent = ({
@@ -95,6 +97,8 @@ export const YoutubeBlockComponent = ({
 	isFeatureCard,
 	mobileAspectRatio,
 	isImmersive,
+	byline,
+	showByline,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -206,6 +210,8 @@ export const YoutubeBlockComponent = ({
 				discussionApiUrl={discussionApiUrl}
 				isFeatureCard={isFeatureCard}
 				isImmersive={isImmersive}
+				byline={byline}
+				showByline={showByline}
 			/>
 			{!hideCaption && (
 				<Caption


### PR DESCRIPTION
## What does this change?

Show the byline in Youtube video cards if `showByline` is true. This is controlled in the fronts tool - off by default. This already exists for non-video immersive cards.

## Why?

For display parity with non-video immersive cards.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5eff52c7-0d06-494b-9fd6-dc4722a26e1e
[after]: https://github.com/user-attachments/assets/8e4ac929-0122-4c67-b572-74e4c4763c6f

