### PR TITLE
 Configure rules on inserting an ad after the first container in beta fronts

### DIFF
--- a/dotcom-rendering/fixtures/manual/frontCollections.ts
+++ b/dotcom-rendering/fixtures/manual/frontCollections.ts
@@ -345,10 +345,27 @@ export const smallFlexibleGeneralCollection = [
 	},
 ] satisfies DCRCollectionType[];
 
-export const flexibleSpecialCollection = [
+export const smallFlexibleSpecialCollection = [
 	{
 		...defaultValues,
 		collectionType: 'flexible/special',
 		containerLevel: 'Primary',
+		grouped: {
+			...defaultGrouped,
+			standard: [trails[0]],
+		},
+	},
+] satisfies DCRCollectionType[];
+
+export const largeFlexibleSpecialCollection = [
+	{
+		...defaultValues,
+		collectionType: 'flexible/special',
+		containerLevel: 'Primary',
+		grouped: {
+			...defaultGrouped,
+			snap: [trails[0]],
+			standard: [trails[1], trails[2], trails[3], trails[4]],
+		},
 	},
 ] satisfies DCRCollectionType[];

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -1,8 +1,9 @@
 import {
 	brandedTestCollections,
-	flexibleSpecialCollection,
 	largeFlexibleGeneralCollection,
+	largeFlexibleSpecialCollection,
 	smallFlexibleGeneralCollection,
+	smallFlexibleSpecialCollection,
 	testCollectionsUk,
 	testCollectionsUs,
 	testCollectionsWithSecondaryLevel,
@@ -246,7 +247,7 @@ describe('Mobile Ads', () => {
 				...testCollection,
 				collectionType: 'flexible/general',
 				containerLevel: 'Primary',
-			}, // Ignored - is before secondary container
+			}, // Ignored - is before secondary container and is not large enough
 			{
 				...testCollection,
 				collectionType: 'scrollable/small',
@@ -399,9 +400,9 @@ describe('Desktop Ads', () => {
 	});
 });
 
-describe('inserting an extra ad after the first collection', () => {
+describe('inserting an ad after the first collection', () => {
 	describe('on mobile', () => {
-		it('inserts an ad after the first collection if it is a large flexible general container and is followed by two secondary containers', () => {
+		it('inserts an ad after the first collection if it is a LARGE flexible general container', () => {
 			const adPositions = getMobileAdPositions([
 				...largeFlexibleGeneralCollection,
 				{
@@ -417,29 +418,12 @@ describe('inserting an extra ad after the first collection', () => {
 			]);
 
 			expect(adPositions).toContain(0);
+			expect(adPositions).not.toContain(1);
 		});
 
-		it('does NOT insert an ad after the first collection if it is not followed by at least two secondary containers', () => {
+		it('inserts an ad after the first collection if it is a LARGE flexible special container', () => {
 			const adPositions = getMobileAdPositions([
-				...largeFlexibleGeneralCollection,
-				{
-					...testCollection,
-					collectionType: 'scrollable/small',
-					containerLevel: 'Secondary',
-				},
-				{
-					...testCollection,
-					collectionType: 'flexible/general',
-					containerLevel: 'Primary',
-				},
-			]);
-
-			expect(adPositions).not.toContain(0);
-		});
-
-		it('does NOT insert an ad after the first collection if it is a flexible special container', () => {
-			const adPositions = getMobileAdPositions([
-				...flexibleSpecialCollection,
+				...largeFlexibleSpecialCollection,
 				{
 					...testCollection,
 					collectionType: 'scrollable/small',
@@ -452,12 +436,39 @@ describe('inserting an extra ad after the first collection', () => {
 				},
 			]);
 
+			expect(adPositions).toContain(0);
+			expect(adPositions).not.toContain(1);
+		});
+
+		it('does NOT insert an ad after the first collection if it is a SMALL flexible general container', () => {
+			const adPositions = getMobileAdPositions([
+				...smallFlexibleGeneralCollection,
+				{
+					...testCollection,
+					collectionType: 'scrollable/small',
+					containerLevel: 'Secondary',
+				},
+			]);
+
+			expect(adPositions).not.toContain(0);
+		});
+
+		it('does NOT insert an ad after the first collection if it is a SMALL flexible special container', () => {
+			const adPositions = getMobileAdPositions([
+				...smallFlexibleSpecialCollection,
+				{
+					...testCollection,
+					collectionType: 'scrollable/small',
+					containerLevel: 'Secondary',
+				},
+			]);
+
 			expect(adPositions).not.toContain(0);
 		});
 	});
 
 	describe('on desktop', () => {
-		it('inserts an ad before the second collection if it is a secondary container, preceded by a large flexible general container and followed by a secondary container', () => {
+		it('inserts an ad before the second collection if it is preceded by a LARGE flexible general container', () => {
 			const adPositions = getDesktopAdPositions(
 				[
 					...largeFlexibleGeneralCollection,
@@ -476,9 +487,32 @@ describe('inserting an extra ad after the first collection', () => {
 			);
 
 			expect(adPositions).toContain(1);
+			expect(adPositions).not.toContain(2);
 		});
 
-		it('does NOT insert an ad before the second collection if it is by a small flexible general container', () => {
+		it('inserts an ad before the second collection if it is preceded by a LARGE flexible special container', () => {
+			const adPositions = getDesktopAdPositions(
+				[
+					...largeFlexibleSpecialCollection,
+					{
+						...testCollection,
+						collectionType: 'scrollable/small',
+						containerLevel: 'Secondary',
+					},
+					{
+						...testCollection,
+						collectionType: 'scrollable/medium',
+						containerLevel: 'Secondary',
+					},
+				],
+				'uk',
+			);
+
+			expect(adPositions).toContain(1);
+			expect(adPositions).not.toContain(2);
+		});
+
+		it('does NOT insert an ad before the second collection if it is preceded by a SMALL flexible general container', () => {
 			const adPositions = getDesktopAdPositions(
 				[
 					...smallFlexibleGeneralCollection,
@@ -499,10 +533,10 @@ describe('inserting an extra ad after the first collection', () => {
 			expect(adPositions).not.toContain(1);
 		});
 
-		it('does NOT insert an ad before the second collection if it is not preceded by a flexible general container', () => {
+		it('does NOT insert an ad before the second collection if it is preceded by a SMALL flexible special container', () => {
 			const adPositions = getDesktopAdPositions(
 				[
-					...flexibleSpecialCollection,
+					...smallFlexibleSpecialCollection,
 					{
 						...testCollection,
 						collectionType: 'scrollable/small',
@@ -513,23 +547,6 @@ describe('inserting an extra ad after the first collection', () => {
 						collectionType: 'scrollable/medium',
 						containerLevel: 'Secondary',
 					},
-				],
-				'uk',
-			);
-
-			expect(adPositions).not.toContain(1);
-		});
-
-		it('does NOT insert an ad before the second collection if it is not followed by a secondary container', () => {
-			const adPositions = getDesktopAdPositions(
-				[
-					...largeFlexibleGeneralCollection,
-					{
-						...testCollection,
-						collectionType: 'scrollable/small',
-						containerLevel: 'Secondary',
-					},
-					...largeFlexibleGeneralCollection, // We do not insert an ad above the final collection on desktop
 				],
 				'uk',
 			);


### PR DESCRIPTION
## What does this change?

- Loosen rules on inserting an ad after first container. Insert an ad after the first container if is large enough to do so.
- Update Flexible Special height estimation.
- Simplifies the code on maybe inserting the first ad. It is no longer a special case.

## Why?

An attempt to find the balance between ad-ratio/revenue and UX.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/f10a626b-6727-411e-983d-6b24f457f5e0
[after]: https://github.com/user-attachments/assets/8af4780e-bf0e-486b-a971-d85a07b65816
[before2]: https://github.com/user-attachments/assets/9e1c3823-3ba1-40ee-9ff9-ca846748f0a7
[after2]: https://github.com/user-attachments/assets/df43476c-5b4e-4467-8647-4b8612750a00


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
