### PR TITLE
`ValuesWithChange` Election Trackers Component

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/StackedProgress.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/StackedProgress.stories.tsx
@@ -47,19 +47,19 @@ export const UKGeneral = {
 			},
 			{
 				name: 'Lib Dem',
-				colour: palette('--uk-elections-lib-dem'),
+				colour: palette('--uk-elections-liberal-democrat'),
 				value: 70,
 				align: 'left',
 			},
 			{
 				name: 'SNP',
-				colour: palette('--uk-elections-snp'),
+				colour: palette('--uk-elections-scottish-national-party'),
 				value: 10,
 				align: 'left',
 			},
 			{
 				name: 'Reform',
-				colour: palette('--uk-elections-reform'),
+				colour: palette('--uk-elections-reform-uk'),
 				value: 5,
 				align: 'right',
 			},

--- a/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.stories.tsx
@@ -1,0 +1,248 @@
+import { palette as sourcePalette } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react';
+import { allModes } from '../../../.storybook/modes';
+import { palette } from '../../palette';
+import { ValuesWithChange } from './ValuesWithChange';
+
+const meta = {
+	title: 'Components/Election Trackers/Values With Change',
+	component: ValuesWithChange,
+	parameters: {
+		viewport: {
+			defaultViewport: 'mobileMedium',
+		},
+		colourSchemeBackground: {
+			dark: sourcePalette.neutral[20],
+		},
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+			},
+		},
+	},
+} satisfies Meta<typeof ValuesWithChange>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const UKGeneral = {
+	args: {
+		valueDescription: 'Seats',
+		changeDescription: 'Change in seats',
+		values: [
+			{
+				name: 'Lab',
+				value: 412,
+				change: 214,
+				colour: palette('--uk-elections-labour'),
+			},
+			{
+				name: 'Con',
+				value: 121,
+				change: -252,
+				colour: palette('--uk-elections-conservative'),
+			},
+			{
+				name: 'Reform',
+				value: 5,
+				change: 5,
+				colour: palette('--uk-elections-reform-uk'),
+			},
+			{
+				name: 'LD',
+				value: 72,
+				change: 64,
+				colour: palette('--uk-elections-liberal-democrat'),
+			},
+			{
+				name: 'Green',
+				value: 4,
+				change: 3,
+				colour: palette('--uk-elections-green'),
+			},
+			{
+				name: 'SNP',
+				value: 9,
+				change: -38,
+				colour: palette('--uk-elections-scottish-national-party'),
+			},
+			{
+				name: 'SF',
+				value: 7,
+				change: 0,
+				colour: palette('--uk-elections-sinn-féin'),
+			},
+			{
+				name: 'WPB',
+				value: 0,
+				change: 0,
+				colour: palette('--uk-elections-workers-party-of-britain'),
+			},
+			{
+				name: 'PC',
+				value: 4,
+				change: 2,
+				colour: palette('--uk-elections-plaid-cymru'),
+			},
+			{
+				name: 'DUP',
+				value: 5,
+				change: -3,
+				colour: palette('--uk-elections-democratic-unionist-party'),
+			},
+			{
+				name: 'Alliance',
+				value: 1,
+				change: 0,
+				colour: palette('--uk-elections-alliance'),
+			},
+			{
+				name: 'UUP',
+				value: 1,
+				change: 1,
+				colour: palette('--uk-elections-ulster-unionist-party'),
+			},
+			{
+				name: 'SDLP',
+				value: 2,
+				change: 0,
+				colour: palette(
+					'--uk-elections-social-democratic-and-labour-party',
+				),
+			},
+			{
+				name: 'Alba',
+				value: 0,
+				change: 0,
+				colour: palette('--uk-elections-alba'),
+			},
+			{
+				name: 'Others',
+				value: 7,
+				change: 4,
+				colour: palette('--uk-elections-others'),
+			},
+		],
+	},
+} satisfies Story;
+
+export const UKLocal = {
+	args: {
+		valueDescription: 'Seats',
+		changeDescription: 'Change in seats',
+		values: [
+			{
+				name: 'Con',
+				value: 319,
+				change: -635,
+				colour: palette('--uk-elections-conservative'),
+			},
+			{
+				name: 'Lab',
+				value: 98,
+				change: -198,
+				colour: palette('--uk-elections-labour'),
+			},
+			{
+				name: 'Lib Dem',
+				value: 370,
+				change: 146,
+				colour: palette('--uk-elections-liberal-democrat'),
+			},
+			{
+				name: 'Green',
+				value: 79,
+				change: 41,
+				colour: palette('--uk-elections-green'),
+			},
+			{
+				name: 'Ind',
+				value: 89,
+				change: -95,
+				colour: palette('--uk-elections-others'),
+			},
+			{
+				name: 'Meb Ker',
+				value: 3,
+				change: -2,
+				colour: palette('--uk-elections-others'),
+			},
+			{
+				name: 'R',
+				value: 2,
+				change: 0,
+				colour: palette('--uk-elections-others'),
+			},
+			{
+				name: 'Reform',
+				value: 677,
+				change: 648,
+				colour: palette('--uk-elections-reform-uk'),
+			},
+		],
+	},
+} satisfies Story;
+
+export const EUParliament = {
+	args: {
+		valueDescription: 'Seats',
+		changeDescription: 'Change in seats',
+		values: [
+			{
+				name: 'Left',
+				value: 46,
+				change: 9,
+				colour: palette('--eu-parliament-theleft'),
+			},
+			{
+				name: 'S&D',
+				value: 100,
+				change: -3,
+				colour: palette('--eu-parliament-sd'),
+			},
+			{
+				name: 'Grn/EFA',
+				value: 40,
+				change: -19,
+				colour: palette('--eu-parliament-greensefa'),
+			},
+			{
+				name: 'Renew',
+				value: 60,
+				change: -25,
+				colour: palette('--eu-parliament-renew'),
+			},
+			{
+				name: 'EPP',
+				value: 150,
+				change: 12,
+				colour: palette('--eu-parliament-epp'),
+			},
+			{
+				name: 'ECR',
+				value: 60,
+				change: 9,
+				colour: palette('--eu-parliament-ecr'),
+			},
+			{
+				name: 'NI',
+				value: 30,
+				change: 0,
+				colour: palette('--eu-parliament-ni'),
+			},
+			{
+				name: 'PfE',
+				value: 70,
+				change: 0,
+				colour: palette('--eu-parliament-unknown'),
+			},
+			{
+				name: 'ESN',
+				value: 20,
+				change: 0,
+				colour: palette('--eu-parliament-unknown'),
+			},
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.tsx
@@ -1,0 +1,202 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold17,
+	headlineBold24,
+	headlineMedium20,
+	space,
+} from '@guardian/source/foundations';
+import { palette } from '../../palette';
+
+type Props = {
+	values: ValueWithChange[];
+	/**
+	 * An accessible description of the value being used. For example: "Seats".
+	 */
+	valueDescription: string;
+	/**
+	 * An accessible description of the change in the value being used. For
+	 * example: "Change in seats".
+	 */
+	changeDescription: string;
+};
+
+/**
+ * A value with a corresponding positive, negative, or zero change. Examples:
+ * seats won by a party; votes won by a candidate.
+ */
+type ValueWithChange = {
+	/**
+	 * The name of the value in the list. For an election, this could be the
+	 * name of the group or party. It will be used as a React "key" for the
+	 * element, so each value's `name` should be unique relative to the other
+	 * sections. Note that due to the constraints of the design this cannot be
+	 * longer than about 7 characters, otherwise it will overrun its container.
+	 *
+	 * **Examples:** name of a candidate; name of a party.
+	 */
+	name: string;
+	/**
+	 * **Examples:** seats won by a party; votes won by a candidate.
+	 */
+	value: number;
+	/**
+	 * The change in the value; since the last election, for example. Can be
+	 * positive, negative or zero. If zero, it will not be shown.
+	 */
+	change: number;
+	/**
+	 * The colour used to represent the value. It expects a CSS `color` value
+	 * (e.g. a hex string). To ensure dark mode support a {@linkcode palette}
+	 * colour can be used; i.e. this property can be set to the return value of
+	 * the {@linkcode palette} function.
+	 */
+	colour: string;
+};
+
+const rowGap = 10;
+
+export const ValuesWithChange = ({
+	values,
+	valueDescription,
+	changeDescription,
+}: Props) => (
+	<ul
+		css={{
+			display: 'grid',
+			gridTemplateColumns: 'repeat(auto-fill, minmax(84px, 1fr))',
+			rowGap,
+			'--column-gap': '10px',
+			columnGap: 'var(--column-gap)',
+			/**
+			 * Used to hide parts of the borders between grid items, which are
+			 * created using pseudo-elements.
+			 */
+			overflow: 'hidden',
+			listStyle: 'none',
+			marginTop: space[2],
+			padding: 0,
+			[from.mobileLandscape]: {
+				'--column-gap': '20px',
+			},
+		}}
+	>
+		{values.map((value) => (
+			<Value
+				key={value.name}
+				value={value}
+				valueDescription={valueDescription}
+				changeDescription={changeDescription}
+			/>
+		))}
+	</ul>
+);
+
+const Value = ({
+	value,
+	valueDescription,
+	changeDescription,
+}: {
+	value: ValueWithChange;
+	valueDescription: Props['valueDescription'];
+	changeDescription: Props['changeDescription'];
+}) => (
+	<li
+		style={{
+			'--before-background-colour': value.colour,
+		}}
+		css={{
+			whiteSpace: 'nowrap',
+			color: palette('--values-with-change-value'),
+			position: 'relative',
+			['&:before']: {
+				content: '""',
+				display: 'block',
+				height: 4,
+				width: 32,
+				borderRadius: 20,
+				backgroundColor: 'var(--before-background-colour)',
+			},
+			['&:after']: {
+				content: '""',
+				position: 'absolute',
+				top: -rowGap,
+				left: 'calc(-0.5 * (var(--column-gap) + 1px))',
+				backgroundColor: palette('--values-with-change-border'),
+				height: `calc(100% + ${rowGap}px)`,
+				width: 1,
+			},
+		}}
+	>
+		<Name name={value.name} />
+		<ValueText value={value.value} valueDescription={valueDescription} />
+		<Change change={value.change} changeDescription={changeDescription} />
+	</li>
+);
+
+const ValueText = ({
+	value,
+	valueDescription,
+}: {
+	value: ValueWithChange['value'];
+	valueDescription: Props['valueDescription'];
+}) => (
+	<span
+		aria-label={valueDescription}
+		css={{
+			['&']: css(headlineBold24),
+			lineHeight: 1,
+		}}
+	>
+		{value}
+	</span>
+);
+
+const Name = ({ name }: { name: ValueWithChange['name'] }) => (
+	<div
+		css={{
+			['&']: css(headlineMedium20),
+			lineHeight: 1.2,
+		}}
+	>
+		{name}
+	</div>
+);
+
+const Change = ({
+	change,
+	changeDescription,
+}: {
+	change: number;
+	changeDescription: Props['changeDescription'];
+}) => {
+	const text = changeText(change);
+
+	if (text === undefined) {
+		return null;
+	}
+
+	return (
+		<span
+			aria-label={changeDescription}
+			css={{
+				['&']: css(headlineBold17),
+				lineHeight: 1,
+				color: palette('--values-with-change-change'),
+			}}
+		>
+			{' '}
+			{text}
+		</span>
+	);
+};
+
+const changeText = (change: number): string | undefined => {
+	if (change > 0) {
+		return `+${change}`;
+	} else if (change < 0) {
+		return change.toString();
+	}
+
+	return undefined;
+};

--- a/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ValuesWithChange.tsx
@@ -1,9 +1,8 @@
-import { css } from '@emotion/react';
 import {
 	from,
-	headlineBold17,
-	headlineBold24,
-	headlineMedium20,
+	headlineBold17Object,
+	headlineBold24Object,
+	headlineMedium20Object,
 	space,
 } from '@guardian/source/foundations';
 import { palette } from '../../palette';
@@ -144,7 +143,7 @@ const ValueText = ({
 	<span
 		aria-label={valueDescription}
 		css={{
-			['&']: css(headlineBold24),
+			...headlineBold24Object,
 			lineHeight: 1,
 		}}
 	>
@@ -155,7 +154,7 @@ const ValueText = ({
 const Name = ({ name }: { name: ValueWithChange['name'] }) => (
 	<div
 		css={{
-			['&']: css(headlineMedium20),
+			...headlineMedium20Object,
 			lineHeight: 1.2,
 		}}
 	>
@@ -180,7 +179,7 @@ const Change = ({
 		<span
 			aria-label={changeDescription}
 			css={{
-				['&']: css(headlineBold17),
+				...headlineBold17Object,
 				lineHeight: 1,
 				color: palette('--values-with-change-change'),
 			}}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7416,25 +7416,65 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[20],
 		dark: () => sourcePalette.neutral[73],
 	},
+	'--uk-elections-alba': {
+		light: () => '#2F3192',
+		dark: () => '#3C3EB9',
+	},
+	'--uk-elections-alliance': {
+		light: () => '#C9BB19',
+		dark: () => '#AB9F00',
+	},
 	'--uk-elections-conservative': {
 		light: () => sourcePalette.sport[400],
 		dark: () => '#009AE1',
+	},
+	'--uk-elections-democratic-unionist-party': {
+		light: () => '#8B0000',
+		dark: () => '#B23C2D',
+	},
+	'--uk-elections-green': {
+		light: () => '#39A566',
+		dark: () => '#39A566',
 	},
 	'--uk-elections-labour': {
 		light: () => sourcePalette.news[400],
 		dark: () => '#DC2E1C',
 	},
-	'--uk-elections-lib-dem': {
+	'--uk-elections-liberal-democrat': {
 		light: () => sourcePalette.opinion[450],
 		dark: () => sourcePalette.opinion[500],
 	},
-	'--uk-elections-reform': {
+	'--uk-elections-others': {
+		light: () => '#848484',
+		dark: () => sourcePalette.neutral[46],
+	},
+	'--uk-elections-plaid-cymru': {
+		light: () => '#135E58',
+		dark: () => '#37716B',
+	},
+	'--uk-elections-reform-uk': {
 		light: () => '#3DBBE2',
 		dark: () => '#3DBBE2',
 	},
-	'--uk-elections-snp': {
+	'--uk-elections-scottish-national-party': {
 		light: () => '#F5DC00',
 		dark: () => '#F5DC00',
+	},
+	'--uk-elections-sinn-féin': {
+		light: () => '#22874D',
+		dark: () => '#22874D',
+	},
+	'--uk-elections-social-democratic-and-labour-party': {
+		light: () => '#23B4A9',
+		dark: () => '#28B8AD',
+	},
+	'--uk-elections-ulster-unionist-party': {
+		light: () => '#004975',
+		dark: () => '#346896',
+	},
+	'--uk-elections-workers-party-of-britain': {
+		light: () => '#7D0068',
+		dark: () => '#8C136E',
 	},
 	'--us-elections-democrats': {
 		light: () => '#093CA3',
@@ -7443,6 +7483,18 @@ const paletteColours = {
 	'--us-elections-republicans': {
 		light: () => sourcePalette.news[400],
 		dark: () => '#DC2E1C',
+	},
+	'--values-with-change-border': {
+		light: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[86],
+	},
+	'--values-with-change-change': {
+		light: () => '#606060',
+		dark: () => sourcePalette.neutral[60],
+	},
+	'--values-with-change-value': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--witness-title-author': {
 		light: witnessTitleAuthor,


### PR DESCRIPTION
Adds a new election trackers component to display a list of values and the amount by which they've changed. This could be used, for example, to display a list of seats won in an election along with the changes since the last election. The included stories show examples of this.

This component is one of several that will allow rendering election trackers within DCAR.

## Screenshots

| | Light | Dark |
|--------|--------|--------|
| UK General | ![uk-general-light] | ![uk-general-dark] |
| UK Local | ![uk-local-light] | ![uk-local-dark] |
| EU Parliament | ![eu-parliament-light] | ![eu-parliament-dark] | 

[uk-general-light]: https://github.com/user-attachments/assets/5b2d5e96-5796-4d47-84b4-a3039bdf71c7
[uk-general-dark]: https://github.com/user-attachments/assets/5c603474-7a89-451f-81ac-36e53b91acdf
[uk-local-light]: https://github.com/user-attachments/assets/905cff9a-f3cc-490e-88db-df66340a05d0
[uk-local-dark]: https://github.com/user-attachments/assets/302282c3-554d-4061-aaf9-8483c8c618a1
[eu-parliament-light]: https://github.com/user-attachments/assets/aa15e599-e9c9-42bd-ad91-fd6f1198f6b3
[eu-parliament-dark]: https://github.com/user-attachments/assets/8c36476f-9417-4bfc-a61a-bb0967294345
