### PR TITLE
Fix banner cta stickiness

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -539,7 +539,7 @@ const styles = {
 		background: ${background};
 		color: ${textColor};
 		${limitHeight ? 'max-height: 60vh;' : ''}
-		overflow: auto;
+
 		* {
 			box-sizing: border-box;
 		}


### PR DESCRIPTION
The CTA below the choice cards in the banner should be sticky at the bottom, with the content of the banner being scrollable.
The `outerContainer` incorrectly has `overflow: auto` set, and this breaks that behaviour - causing the CTA to fall off the bottom.
When this banner component was first implemented, it mistakenly added `'auto'` to the css, which accidentally broke the problematic `overflow: auto`, meaning that it behaved as expected!
A [later PR](https://github.com/guardian/dotcom-rendering/commit/b788c96e2f7323ca22660d7aba87a4fa275a3278#diff-ad96720cc7b05d64819696b88ec56f470eb7ad930e60bb94ab495eb52405d37eR535-R538) removed the invalid css `'auto'`, which caused the `overflow: auto` below it to start working.

Before:
![Screenshot 2025-05-09 at 12 46 47](https://github.com/user-attachments/assets/af3e7530-0ec4-4714-8b17-bda80c61f35e)


After:
![Screenshot 2025-05-09 at 12 46 04](https://github.com/user-attachments/assets/14e0fa2c-4fa4-4a3a-b797-728b1ef9cc83)
