### PR TITLE
Apply `interactiveGlobalStyles` to app and web interactives

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -238,12 +238,11 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 	return (
 		<>
+			{article.isLegacyInteractive && (
+				<Global styles={interactiveGlobalStyles} />
+			)}
 			{isWeb && (
 				<>
-					{article.isLegacyInteractive && (
-						<Global styles={interactiveGlobalStyles} />
-					)}
-
 					<div>
 						{renderAds && (
 							<Stuck>


### PR DESCRIPTION
This moves `interactiveGlobalStyles` to be applied to app as well as web interactive articles. During testing it's come up that atoms are trying to interact with classes that are there in web but not app DCAR. This hopefully addresses that.