### PR TITLE
Revert "Switch back to Preact for server-side rendering"

### DIFF
--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -139,6 +139,13 @@ module.exports = ({ build }) => ({
 			svgr,
 		],
 	},
+	resolve: {
+		alias: {
+			react: 'preact/compat',
+			'react-dom/test-utils': 'preact/test-utils',
+			'react-dom': 'preact/compat',
+		},
+	},
 });
 
 module.exports.transpileExclude = {

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -30,11 +30,6 @@ const commonConfigs = ({ platform }) => ({
 			? 'source-map'
 			: 'eval-cheap-module-source-map',
 	resolve: {
-		alias: {
-			react: 'preact/compat',
-			'react-dom/test-utils': 'preact/test-utils',
-			'react-dom': 'preact/compat',
-		},
 		extensions: ['.js', '.ts', '.tsx', '.jsx'],
 	},
 	ignoreWarnings: [


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#13901

We tested running React in production for a day without issue, but rolled back out of caution ahead of the launch of the homepage redesign. With that out of the way we're ready to switch back to server-side rendering with React.