### PR TITLE
Refactor media type

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -15,7 +15,7 @@ import {
 import { palette } from '../palette';
 import CameraSvg from '../static/icons/camera.svg';
 import VideoSvg from '../static/icons/video-icon.svg';
-import type { MediaType } from '../types/layout';
+import type { MainMedia } from '../types/mainMedia';
 
 type Props = {
 	captionText?: string;
@@ -26,7 +26,7 @@ type Props = {
 	shouldLimitWidth?: boolean;
 	isOverlaid?: boolean;
 	isLeftCol?: boolean;
-	mediaType?: MediaType;
+	mediaType?: MainMedia['type'];
 	isMainMedia?: boolean;
 	isImmersive?: boolean;
 };

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -279,7 +279,7 @@ export type Props = {
 	imagePositionOnDesktop?: ImagePositionType /** TODO Remove this prop  */;
 	imagePositionOnMobile?: ImagePositionType /** TODO Remove this prop  */;
 	/** Size is ignored when position = 'top' because in that case the image flows based on width */
-	imageSize?: ImageSizeType;
+	imageSize: ImageSizeType;
 	imageLoading: Loading;
 	showClock?: boolean;
 	mainMedia?: MainMedia;
@@ -335,7 +335,7 @@ export const FeatureCard = ({
 	image,
 	imagePositionOnDesktop = 'top',
 	imagePositionOnMobile = 'left',
-	imageSize = 'small',
+	imageSize,
 	trailText,
 	imageLoading,
 	showClock,

--- a/dotcom-rendering/src/components/MediaMeta.tsx
+++ b/dotcom-rendering/src/components/MediaMeta.tsx
@@ -5,10 +5,10 @@ import {
 	SvgVideo,
 } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
-import type { MediaType } from '../types/layout';
+import type { MainMedia } from '../types/mainMedia';
 
 type Props = {
-	mediaType: MediaType;
+	mediaType: MainMedia['type'];
 	hasKicker: boolean;
 };
 
@@ -39,7 +39,7 @@ const wrapperStyles = css`
 	margin-top: 4px;
 `;
 
-export const Icon = ({ mediaType }: { mediaType: MediaType }) => {
+export const Icon = ({ mediaType }: { mediaType: MainMedia['type'] }) => {
 	switch (mediaType) {
 		case 'Gallery':
 			return <SvgCamera />;
@@ -54,7 +54,7 @@ const MediaIcon = ({
 	mediaType,
 	hasKicker,
 }: {
-	mediaType: MediaType;
+	mediaType: MainMedia['type'];
 	hasKicker: boolean;
 }) => {
 	return (

--- a/dotcom-rendering/src/types/layout.ts
+++ b/dotcom-rendering/src/types/layout.ts
@@ -37,6 +37,4 @@ export type SmallHeadlineSize =
 	| 'huge'
 	| 'ginormous';
 
-export type MediaType = 'Video' | 'Audio' | 'Gallery';
-
 export type LeftColSize = 'compact' | 'wide';


### PR DESCRIPTION
## What does this change?

1. Deletes duplicate type `MediaType`. This can be inferred from elsewhere.
1. Image size should not be optional.

## Why?

1. Refactor.
1. It is important to pass the correct sizes so that images can be optimised.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
