### PR TITLE
Remove benefitsLabel from recurring contribution on choice cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCardData.tsx
@@ -11,7 +11,6 @@ export const ChoiceCardTestData_REGULAR = (
 			isDiscountActive
 				? `Support ${currencySymbol}${amount}/year`
 				: `Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: longerBenefits ? 'Support' : undefined,
 		benefits: () => ['Give to the Guardian every month with Support'],
 		recommended: false,
 	},
@@ -64,7 +63,6 @@ export const ChoiceCardTestData_US = (
 			isDiscountActive
 				? `Support ${currencySymbol}${amount}/year`
 				: `Support ${currencySymbol}${amount}/month`,
-		benefitsLabel: longerBenefits ? 'Support' : undefined,
 		benefits: () => ['Give to the Guardian every month with Support'],
 		recommended: false,
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -145,12 +145,11 @@ function getChoiceAmount(
 const SupportingBenefits = ({
 	benefitsLabel,
 	benefits,
-	showTicks,
 }: {
 	benefitsLabel: string | undefined;
 	benefits: string[];
-	showTicks: boolean;
 }) => {
+	const showTicks = benefits.length > 1;
 	return (
 		<div css={supportingTextStyles}>
 			{!!benefitsLabel && (
@@ -277,9 +276,6 @@ export const ThreeTierChoiceCards = ({
 													benefits={benefits(
 														currencySymbol,
 													)}
-													showTicks={
-														supportTier !== 'OneOff'
-													}
 												/>
 											) : undefined
 										}


### PR DESCRIPTION
A small copy update on the epic/banner choice cards, as there are no "benefits" with a recurring contribution.

Before:
<img width="563" alt="Screenshot 2025-05-13 at 12 58 34" src="https://github.com/user-attachments/assets/4b335641-c474-445b-83e3-ddd32ca712c7" />


After:

<img width="569" alt="Screenshot 2025-05-13 at 12 54 00" src="https://github.com/user-attachments/assets/4b3d17fd-6422-4596-a3a6-7cfccb1d97f5" />
<img width="569" alt="Screenshot 2025-05-13 at 12 57 14" src="https://github.com/user-attachments/assets/173c47f4-ec06-4dce-be63-0344b499ea02" />
<img width="569" alt="Screenshot 2025-05-13 at 12 57 19" src="https://github.com/user-attachments/assets/22d066e4-1b0f-46db-a784-025936d8c805" />
