### PR TITLE
add mvtId to the payload of get-treatments

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -119,6 +119,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	tagIds: string[];
 	gateDismissCount: number;
 	countryCode: string;
+	mvtId: number;
 }
 
 export interface AuxiaProxyGetTreatmentsResponse {

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -535,6 +535,7 @@ const fetchProxyGetTreatments = async (
 	tagIds: string[],
 	gateDismissCount: number,
 	countryCode: string,
+	mvtId: number,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
@@ -554,6 +555,7 @@ const fetchProxyGetTreatments = async (
 		tagIds,
 		gateDismissCount,
 		countryCode,
+		mvtId,
 	};
 	const params = {
 		method: 'POST',
@@ -591,6 +593,7 @@ const buildAuxiaGateDisplayData = async (
 		tagIds,
 		gateDismissCount,
 		readerPersonalData.countryCode,
+		readerPersonalData.mvtId,
 	);
 	if (response.status && response.data) {
 		const answer = {


### PR DESCRIPTION
Tiny follow up of https://github.com/guardian/dotcom-rendering/pull/13938 . Here we add mvtId to the payload of get-treatments