### PR TITLE
Update loop video styles

### DIFF
--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -50,11 +50,10 @@ const narrowStyles = css`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: ${palette('--feature-card-play-icon-background')};
-	opacity: 0.7;
+	background-color: ${palette('--narrow-play-icon-background')};
 	border-radius: 50%;
-	border: 1px solid ${palette('--feature-card-play-icon-border')};
-	fill: ${palette('--feature-card-play-icon-fill')};
+	border: 1px solid ${palette('--narrow-play-icon-border')};
+	fill: ${palette('--narrow-play-icon-fill')};
 `;
 
 const theme = {

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -44,7 +44,6 @@ const audioIconContainerStyles = css`
 	justify-content: center;
 	align-items: center;
 	background-color: ${palette('--loop-video-audio-icon-background')};
-	opacity: 0.7;
 	border-radius: 50%;
 	border: 1px solid ${palette('--loop-video-audio-icon-border')};
 `;

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -31,9 +31,22 @@ const audioButtonStyles = css`
 	background: none;
 	padding: 0;
 	position: absolute;
-	bottom: ${space[8]}px;
-	right: ${space[8]}px;
+	/* Take into account the progress bar height */
+	bottom: ${space[3]}px;
+	right: ${space[2]}px;
 	cursor: pointer;
+`;
+
+const audioIconContainerStyles = css`
+	width: ${space[8]}px;
+	height: ${space[8]}px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background-color: ${palette('--loop-video-audio-icon-background')};
+	opacity: 0.7;
+	border-radius: 50%;
+	border: 1px solid ${palette('--loop-video-audio-icon-border')};
 `;
 
 type Props = {
@@ -161,14 +174,16 @@ export const LoopVideoPlayer = forwardRef(
 								}}
 								css={audioButtonStyles}
 							>
-								<AudioIcon
-									size="small"
-									theme={{
-										fill: palette(
-											'--loop-video-audio-icon',
-										),
-									}}
-								/>
+								<div css={audioIconContainerStyles}>
+									<AudioIcon
+										size="xsmall"
+										theme={{
+											fill: palette(
+												'--loop-video-audio-icon',
+											),
+										}}
+									/>
+								</div>
 							</button>
 						)}
 					</>

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -148,9 +148,9 @@ export const LoopVideoPlayer = forwardRef(
 					<source src={src} type="video/mp4" />
 					{fallbackImageComponent}
 				</video>
-				{ref && 'current' in ref && ref.current && (
+				{ref && 'current' in ref && ref.current && isPlayable && (
 					<>
-						{isPlayable && !isPlaying && (
+						{!isPlaying && (
 							<button
 								type="button"
 								onClick={handleClick}

--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -1,15 +1,32 @@
 import { css } from '@emotion/react';
+import { getZIndex } from '../lib/getZIndex';
 import { palette } from '../palette';
 
-const styles = (progressPercentage: number) => css`
+const styles = css`
 	position: absolute;
 	bottom: 0;
 	left: 0;
-	height: 7px;
+	height: 4px;
+	background-color: transparent;
 	width: 100%;
+`;
+
+const foregroundStyles = (progressPercentage: number) => css`
+	position: absolute;
+	height: 100%;
 	width: ${progressPercentage}%;
-	transition: width 0.3s linear;
+	z-index: ${getZIndex('loop-video-progress-bar-foreground')};
 	background-color: ${palette('--loop-video-progress-bar-value')};
+	transition: width 0.3s linear;
+`;
+
+const backgroundStyles = css`
+	position: absolute;
+	height: 100%;
+	width: 100%;
+	z-index: ${getZIndex('loop-video-progress-bar-background')};
+	background-color: ${palette('--loop-video-progress-bar-background')};
+	opacity: 0.7;
 `;
 
 type Props = {
@@ -43,7 +60,10 @@ export const LoopVideoProgressBar = ({
 			aria-valuenow={progressPercentage}
 			aria-valuemin={0}
 			aria-valuemax={100}
-			css={styles(progressPercentage)}
-		/>
+			css={styles}
+		>
+			<span css={foregroundStyles(progressPercentage)} />
+			<span css={backgroundStyles} />
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -7,8 +7,9 @@ const styles = css`
 	bottom: 0;
 	left: 0;
 	height: 4px;
-	background-color: transparent;
 	width: 100%;
+	z-index: ${getZIndex('loop-video-progress-bar-background')};
+	background-color: ${palette('--loop-video-progress-bar-background')};
 `;
 
 const foregroundStyles = (progressPercentage: number) => css`
@@ -18,15 +19,6 @@ const foregroundStyles = (progressPercentage: number) => css`
 	z-index: ${getZIndex('loop-video-progress-bar-foreground')};
 	background-color: ${palette('--loop-video-progress-bar-value')};
 	transition: width 0.3s linear;
-`;
-
-const backgroundStyles = css`
-	position: absolute;
-	height: 100%;
-	width: 100%;
-	z-index: ${getZIndex('loop-video-progress-bar-background')};
-	background-color: ${palette('--loop-video-progress-bar-background')};
-	opacity: 0.7;
 `;
 
 type Props = {
@@ -63,7 +55,6 @@ export const LoopVideoProgressBar = ({
 			css={styles}
 		>
 			<span css={foregroundStyles(progressPercentage)} />
-			<span css={backgroundStyles} />
 		</div>
 	);
 };

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -86,6 +86,8 @@ const indices = [
 	'rightColumnArea',
 
 	// Loop video container
+	'loop-video-progress-bar-foreground',
+	'loop-video-progress-bar-background',
 	'loop-video-container',
 
 	// Main media

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6773,8 +6773,8 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[60],
 	},
 	'--loop-video-progress-bar-background': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[7],
+		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
 	},
 	'--loop-video-progress-bar-value': {
 		light: () => sourcePalette.neutral[86],

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6535,18 +6535,6 @@ const paletteColours = {
 		light: featureCardKickerTextLight,
 		dark: () => sourcePalette.neutral[20],
 	},
-	'--feature-card-play-icon-background': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[7],
-	},
-	'--feature-card-play-icon-border': {
-		light: () => sourcePalette.neutral[60],
-		dark: () => sourcePalette.neutral[60],
-	},
-	'--feature-card-play-icon-fill': {
-		light: () => sourcePalette.neutral[100],
-		dark: () => sourcePalette.neutral[100],
-	},
 	'--feature-card-trail-text': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],
@@ -6777,8 +6765,8 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[100],
 	},
 	'--loop-video-audio-icon-background': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[7],
+		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
 	},
 	'--loop-video-audio-icon-border': {
 		light: () => sourcePalette.neutral[60],
@@ -6879,6 +6867,18 @@ const paletteColours = {
 	'--multi-byline-non-linked-text': {
 		light: multiBylineNonLinkedTextLight,
 		dark: multiBylineNonLinkedTextDark,
+	},
+	'--narrow-play-icon-background': {
+		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
+	},
+	'--narrow-play-icon-border': {
+		light: () => sourcePalette.neutral[60],
+		dark: () => sourcePalette.neutral[60],
+	},
+	'--narrow-play-icon-fill': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[100],
 	},
 	'--nav-reader-revenue-link-text': {
 		light: navReaderRevenueLinkText,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6776,6 +6776,18 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[100],
 	},
+	'--loop-video-audio-icon-background': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
+	'--loop-video-audio-icon-border': {
+		light: () => sourcePalette.neutral[60],
+		dark: () => sourcePalette.neutral[60],
+	},
+	'--loop-video-progress-bar-background': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
 	'--loop-video-progress-bar-value': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[86],


### PR DESCRIPTION
## What does this change?

Updates:
- Audio icon. This now has a background
- Progress bar. This is now smaller and also has a background.

## Why?

To match designs. Increases visibility of elements.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/447e5cbb-44be-40dc-b483-aceb51b2edc0
[after]: https://github.com/user-attachments/assets/2e46c888-0642-4018-93c0-af6844e37f5f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
