### PR TITLE
Update new front dark mode: highlights container and feature cards

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5501,12 +5501,21 @@ const mastheadVeggieBurgerBackground: PaletteFunction = () =>
 const mastheadVeggieBurgerBackgroundHover: PaletteFunction = () =>
 	sourcePalette.brandAlt[300];
 
-const mastheadHighlightsBackground: PaletteFunction = () =>
+const mastheadHighlightsBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[97];
-const mastheadHighlightsBorder: PaletteFunction = () =>
-	sourcePalette.neutral[60];
+const mastheadHighlightsBackgroundDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
 
-const highlightsCardHeadline: PaletteFunction = () => sourcePalette.neutral[7];
+const mastheadHighlightsBorderLight: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+const mastheadHighlightsBorderDark: PaletteFunction = () =>
+	sourcePalette.neutral[46];
+
+const highlightsCardHeadlineLight: PaletteFunction = () =>
+	sourcePalette.neutral[7];
+const highlightsCardHeadlineDark: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+
 const highlightsCardKickerText: PaletteFunction = (format) => {
 	switch (format.theme) {
 		case Pillar.Opinion:
@@ -5523,6 +5532,25 @@ const highlightsCardKickerText: PaletteFunction = (format) => {
 		case ArticleSpecial.SpecialReportAlt:
 			return sourcePalette.specialReportAlt[200];
 	}
+};
+
+const highlightContainerStartLight: PaletteFunction = () => {
+	return sourcePalette.neutral[97];
+};
+const highlightContainerStartDark: PaletteFunction = () => {
+	return sourcePalette.neutral[10];
+};
+const highlightContainerMidFadeLight: PaletteFunction = () => {
+	return transparentColour(sourcePalette.neutral[97], 0.6);
+};
+const highlightContainerMidFadeDark: PaletteFunction = () => {
+	return transparentColour(sourcePalette.neutral[10], 0.6);
+};
+const highlightContainerEndFadeLight: PaletteFunction = () => {
+	return 'transparent';
+};
+const highlightContainerEndFadeDark: PaletteFunction = () => {
+	return 'transparent';
 };
 
 const pinnedPostBorderLight: PaletteFunction = ({ theme }) => {
@@ -5577,17 +5605,6 @@ const youtubeOverlayKicker: PaletteFunction = ({ theme }: ArticleFormat) => {
 		case ArticleSpecial.SpecialReportAlt:
 			return sourcePalette.news[500];
 	}
-};
-
-const highlightContainerStartFade: PaletteFunction = () => {
-	return sourcePalette.neutral[97];
-};
-const highlightContainerMidFade: PaletteFunction = () => {
-	return 'rgba(250, 250, 250, 0.6)';
-};
-
-const highlightContainerEndFade: PaletteFunction = () => {
-	return 'transparent';
 };
 
 const designTagText: PaletteFunction = ({ theme }) => {
@@ -5753,7 +5770,7 @@ const editorialButtonText: PaletteFunction = (format: ArticleFormat) => {
 	}
 };
 
-const featureCardKickerTextLight: PaletteFunction = ({ theme }) => {
+const featureCardKickerText: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
 		case ArticleSpecial.SpecialReport:
@@ -6521,19 +6538,19 @@ const paletteColours = {
 	},
 	'--feature-card-background': {
 		light: () => sourcePalette.neutral[93],
-		dark: () => sourcePalette.neutral[38],
+		dark: () => sourcePalette.neutral[93],
 	},
 	'--feature-card-footer-text': {
 		light: () => sourcePalette.neutral[86],
-		dark: () => sourcePalette.neutral[20],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--feature-card-headline': {
 		light: () => sourcePalette.neutral[97],
-		dark: () => sourcePalette.neutral[20],
+		dark: () => sourcePalette.neutral[97],
 	},
 	'--feature-card-kicker-text': {
-		light: featureCardKickerTextLight,
-		dark: () => sourcePalette.neutral[20],
+		light: featureCardKickerText,
+		dark: featureCardKickerText,
 	},
 	'--feature-card-play-icon-background': {
 		light: () => sourcePalette.neutral[7],
@@ -6645,32 +6662,32 @@ const paletteColours = {
 		dark: headlineMatchTextDark,
 	},
 	'--highlights-card-headline': {
-		light: highlightsCardHeadline,
-		dark: highlightsCardHeadline,
+		light: highlightsCardHeadlineLight,
+		dark: highlightsCardHeadlineDark,
 	},
 	'--highlights-card-kicker-text': {
 		light: highlightsCardKickerText,
 		dark: highlightsCardKickerText,
 	},
 	'--highlights-container-background': {
-		light: mastheadHighlightsBackground,
-		dark: mastheadHighlightsBackground,
+		light: mastheadHighlightsBackgroundLight,
+		dark: mastheadHighlightsBackgroundDark,
 	},
 	'--highlights-container-border': {
-		light: mastheadHighlightsBorder,
-		dark: mastheadHighlightsBorder,
+		light: mastheadHighlightsBorderLight,
+		dark: mastheadHighlightsBorderDark,
 	},
 	'--highlights-container-end-fade': {
-		light: highlightContainerEndFade,
-		dark: highlightContainerEndFade,
+		light: highlightContainerEndFadeLight,
+		dark: highlightContainerEndFadeDark,
 	},
 	'--highlights-container-mid-fade': {
-		light: highlightContainerMidFade,
-		dark: highlightContainerMidFade,
+		light: highlightContainerMidFadeLight,
+		dark: highlightContainerMidFadeDark,
 	},
 	'--highlights-container-start-fade': {
-		light: highlightContainerStartFade,
-		dark: highlightContainerStartFade,
+		light: highlightContainerStartLight,
+		dark: highlightContainerStartDark,
 	},
 	'--image-title-background': {
 		light: imageTitleBackground,


### PR DESCRIPTION
## What does this change?

Updates dark mode colours for the Highlights container and Feature cards.

## Why?

Dark mode readiness.

## Screenshots

| <img width=250/> | Before | After |
| - | - | - |
| Highlights container | ![mobile-before] | ![mobile-after] |
| Feature card | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/e950284d-bac3-4af2-85b8-79d81491d79c
[desktop-before]: https://github.com/user-attachments/assets/ec4030db-f16f-4e90-aef0-713245b48506
[mobile-after]: https://github.com/user-attachments/assets/6f985284-c564-4a1d-b1c5-c2634518b44a
[desktop-after]: https://github.com/user-attachments/assets/3a6dc6b2-6227-4e28-88e5-e4336981c427

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
