### PR TITLE
should_show_legacy_gate_tmp

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -120,7 +120,27 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	gateDismissCount: number;
 	countryCode: string;
 	mvtId: number;
+	should_show_legacy_gate_tmp: boolean; // [1]
 }
+
+// [1]
+
+// date: 13th May 2025
+// comment id: 5395f64b
+
+// This is a temporary attribute that is being introduced to smooth (and reduce risk) the
+// transfer of gate management from the client side to SDC for the non Auxia part of the Audience
+
+// We are going to start rerouting gate requests to the SDC endpoint, but without having yet
+// implemented the old gate display logic into SDC. This attribute is then going to carry over
+// the local decision, there by allowing SDC to copy the local decision and know whether to
+// return a (gu-default gate) gate.
+
+// Once the correct logic has been implemented in SDC, this attribute will be decommissioned as no longer
+// necessary.
+
+// Obviously, the value it carries for standard Auxia audience requests in irrelevant.
+// We will be setting it to false.
 
 export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -536,6 +536,7 @@ const fetchProxyGetTreatments = async (
 	gateDismissCount: number,
 	countryCode: string,
 	mvtId: number,
+	should_show_legacy_gate_tmp: boolean,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
@@ -556,6 +557,7 @@ const fetchProxyGetTreatments = async (
 		gateDismissCount,
 		countryCode,
 		mvtId,
+		should_show_legacy_gate_tmp,
 	};
 	const params = {
 		method: 'POST',
@@ -594,7 +596,18 @@ const buildAuxiaGateDisplayData = async (
 		gateDismissCount,
 		readerPersonalData.countryCode,
 		readerPersonalData.mvtId,
+		false, // [1]
 	);
+	// [1] This is the default value for should_show_legacy_gate_tmp, and irrelevant in the Auxia
+	// audience share.
+
+	// It's going to reflect legacy decision (will be set to true or false)
+	// when we make this call for the legacy gate.
+
+	// And this will last as long as it takes to correctly reproduce the local non auxia logic into SDC.
+
+	// See comment id 5395f64b for context.
+
 	if (response.status && response.data) {
 		const answer = {
 			browserId: readerPersonalData.browserId,


### PR DESCRIPTION
This is a temporary attribute that is being introduced to smooth (and reduce risk) the transfer of gate management from the client side to SDC for the non Auxia part of the Audience.

We are going to start rerouting legacy gate requests to the SDC endpoint, but without having yet implemented the old gate display logic into SDC. This attribute is then going to carry over the local decision, there by allowing SDC to copy the local decision and know whether to return a (gu-default gate) gate.

Once the correct logic has been implemented in SDC, this attribute will be decommissioned as no longer necessary.

Obviously, the value it carries for standard Auxia audience requests in irrelevant. We will be setting it to false in the Auxia case. 