### PR TITLE
Prevent survey ad slot appearing below desktop breakpoint

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -100,6 +100,12 @@ const outOfPageStyles = css`
 	height: 0;
 `;
 
+const hideBelowDesktop = css`
+	${until.desktop} {
+		display: none;
+	}
+`;
+
 const topAboveNavContainerStyles = css`
 	padding-bottom: 18px;
 	position: relative;
@@ -705,7 +711,7 @@ export const AdSlot = ({
 						'ad-slot',
 						'ad-slot--survey',
 					].join(' ')}
-					css={[outOfPageStyles]}
+					css={[outOfPageStyles, hideBelowDesktop]}
 					data-link-name="ad slot survey"
 					data-name="survey"
 					data-label="false"


### PR DESCRIPTION
## What does this change?

Hides the survey ad slot below desktop breakpoint

## Why?

We wouldn't expect this slot to render on small screens

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/1403b1d5-edb5-4fb4-8d8f-30b0b1236d9f
[after]: https://github.com/user-attachments/assets/ed5068b9-463b-4660-b360-a8ed51a5249f
