### PR TITLE
Remove crossword dependency exception

### DIFF
--- a/dotcom-rendering/scripts/env/check-deps.js
+++ b/dotcom-rendering/scripts/env/check-deps.js
@@ -8,10 +8,6 @@ if (pkg.devDependencies) {
 	process.exit(1);
 }
 
-/**
- * We don't check packages that are not semver-compatible
- * @type {RegExp[]}
- */
 const mismatches = Object.entries(pkg.dependencies).filter(
 	([, version]) =>
 		!semver.valid(version) && !version.startsWith('workspace:'),


### PR DESCRIPTION
## What does this change?
Removes crossword dependency exception
## Why?
Tidy up following https://github.com/guardian/dotcom-rendering/pull/13876
