### PR TITLE
Remove flex basis from podcast image

### DIFF
--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -164,8 +164,7 @@ export const ImageWrapper = ({
 			css={[
 				(imageType === 'slideshow' ||
 					imageType === 'picture' ||
-					imageType === 'video' ||
-					imageType === 'podcast') &&
+					imageType === 'video') &&
 					isHorizontalOnDesktop &&
 					flexBasisStyles({
 						imageSize,


### PR DESCRIPTION
## What does this change?

Remove flex basis from podcast image

## Why?

To match designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5877de88-8569-4e65-ab6f-096e119f4392
[after]: https://github.com/user-attachments/assets/23edc258-3e7d-44d3-85dd-5d503b6ada29

