### PR TITLE
Fix missing background colour on choice cards container

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -242,6 +242,7 @@ export const ThreeTierChoiceCards = ({
 								key={supportTier}
 								css={css`
 									position: relative;
+									background-color: inherit;
 								`}
 							>
 								{hasDiscount && (


### PR DESCRIPTION
## What does this change?

In some rare instances, the background image in an article is showing through between the radio buttons of the choice cards.  Example Safari on iPhone 12 mini (ios v14 & IOS 17.6.1).

While we have not been able to replicate this, the choice card container has no background colour explicitly set and the default for background-color is transparent.  

This change ensures it inherits the background colour from the parent container which we believe should fix this issue.

## Why?

In some rare instances, the background image in an article is showing through between the radio buttons of the choice cards which looks bad.

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
