### PR TITLE
Add galleries to the article model

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -42,7 +42,7 @@ interface AppProps extends BaseProps {
  */
 export const ArticlePage = (props: WebProps | AppProps) => {
 	const {
-		article: { format, frontendData },
+		article: { design, display, theme, frontendData },
 		renderingTarget,
 	} = props;
 
@@ -57,6 +57,12 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 
 	const isWeb = renderingTarget === 'Web';
 	const { darkModeAvailable } = useConfig();
+
+	const format = {
+		design,
+		display,
+		theme,
+	};
 
 	return (
 		<StrictMode>

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -27,7 +27,7 @@ export const renderArticle = (
 	prefetchScripts: string[];
 	html: string;
 } => {
-	const { format, frontendData } = article;
+	const { design, frontendData } = article;
 	const renderingTarget = 'Apps';
 	const config: Config = {
 		renderingTarget,
@@ -118,13 +118,13 @@ window.twttr = (function(d, s, id) {
 		weAreHiring: !!frontendData.config.switches.weAreHiring,
 		canonicalUrl: frontendData.canonicalUrl,
 		initTwitter:
-			pageHasTweetElements || format.design === ArticleDesign.LiveBlog
+			pageHasTweetElements || design === ArticleDesign.LiveBlog
 				? initTwitter
 				: undefined,
 		config,
 		onlyLightColourScheme:
-			format.design === ArticleDesign.FullPageInteractive ||
-			format.design === ArticleDesign.Interactive,
+			design === ArticleDesign.FullPageInteractive ||
+			design === ArticleDesign.Interactive,
 	});
 
 	return {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -32,8 +32,8 @@ interface Props {
 	article: Article;
 }
 
-const decideTitle = ({ format, frontendData }: Article): string => {
-	if (format.theme === Pillar.Opinion && frontendData.byline) {
+const decideTitle = ({ theme, frontendData }: Article): string => {
+	if (theme === Pillar.Opinion && frontendData.byline) {
 		return `${frontendData.headline} | ${frontendData.byline} | The Guardian`;
 	}
 	return `${frontendData.headline} | ${frontendData.sectionLabel} | The Guardian`;
@@ -42,7 +42,7 @@ const decideTitle = ({ format, frontendData }: Article): string => {
 export const renderHtml = ({
 	article,
 }: Props): { html: string; prefetchScripts: string[] } => {
-	const { format, frontendData } = article;
+	const { design, display, theme, frontendData } = article;
 	const NAV = {
 		...extractNAV(frontendData.nav),
 		selectedPillar: getCurrentPillar(frontendData),
@@ -142,10 +142,16 @@ export const renderHtml = ({
 		unknownConfig: frontendData.config,
 	});
 
+	const format = {
+		design,
+		display,
+		theme,
+	};
+
 	const getAmpLink = (tags: TagType[]) => {
 		if (
-			format.design === ArticleDesign.Interactive ||
-			format.design === ArticleDesign.FullPageInteractive
+			design === ArticleDesign.Interactive ||
+			design === ArticleDesign.FullPageInteractive
 		) {
 			return undefined;
 		}
@@ -208,7 +214,7 @@ window.twttr = (function(d, s, id) {
 		twitterData,
 		section,
 		initTwitter:
-			pageHasTweetElements || format.design === ArticleDesign.LiveBlog
+			pageHasTweetElements || design === ArticleDesign.LiveBlog
 				? initTwitter
 				: undefined,
 		canonicalUrl,
@@ -218,8 +224,8 @@ window.twttr = (function(d, s, id) {
 		hasLiveBlogTopAd: !!frontendData.config.hasLiveBlogTopAd,
 		hasSurveyAd: !!frontendData.config.hasSurveyAd,
 		onlyLightColourScheme:
-			format.design === ArticleDesign.FullPageInteractive ||
-			format.design === ArticleDesign.Interactive,
+			design === ArticleDesign.FullPageInteractive ||
+			design === ArticleDesign.Interactive,
 	});
 
 	return { html: pageHtml, prefetchScripts };

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -1,5 +1,10 @@
 import type { FEArticle } from '../frontend/feArticle';
-import { type ArticleFormat, decideFormat } from '../lib/articleFormat';
+import {
+	ArticleDesign,
+	type ArticleDisplay,
+	type ArticleTheme,
+	decideFormat,
+} from '../lib/articleFormat';
 import type { ImageForAppsLightbox } from '../model/appsLightboxImages';
 import { appsLightboxImages } from '../model/appsLightboxImages';
 import { buildCrosswordBlock } from '../model/buildCrosswordBlock';
@@ -12,7 +17,7 @@ import {
 	type TableOfContentsItem,
 } from '../model/enhanceTableOfContents';
 import { enhancePinnedPost } from '../model/pinnedPost';
-import type { ImageForLightbox } from './content';
+import type { ImageBlockElement, ImageForLightbox } from './content';
 import { type RenderingTarget } from './renderingTarget';
 
 /**
@@ -26,10 +31,22 @@ export type ArticleDeprecated = FEArticle & {
 	tableOfContents?: TableOfContentsItem[];
 };
 
-export type Article = {
-	format: ArticleFormat;
+export type ArticleFields = {
 	frontendData: ArticleDeprecated;
+	display: ArticleDisplay;
+	theme: ArticleTheme;
 };
+
+export type Gallery = ArticleFields & {
+	design: ArticleDesign.Gallery;
+	images: ImageBlockElement[];
+};
+
+export type OtherArticles = ArticleFields & {
+	design: Exclude<ArticleDesign, ArticleDesign.Gallery>;
+};
+
+export type Article = Gallery | OtherArticles;
 
 export const enhanceArticleType = (
 	data: FEArticle,
@@ -62,8 +79,44 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
+	if (format.design === ArticleDesign.Gallery) {
+		const design = ArticleDesign.Gallery;
+		return {
+			frontendData: {
+				...data,
+				mainMediaElements,
+				blocks,
+				standfirst: enhanceStandfirst(data.standfirst),
+				commercialProperties: enhanceCommercialProperties(
+					data.commercialProperties,
+				),
+				tableOfContents: data.showTableOfContents
+					? enhanceTableOfContents(enhancedBlocks)
+					: undefined,
+				/**
+				 * This function needs to run at a higher level to most other enhancers
+				 * because it needs both mainMediaElements and blocks in scope
+				 */
+				imagesForLightbox,
+				imagesForAppsLightbox: appsLightboxImages(imagesForLightbox),
+			},
+			design,
+			display: format.display,
+			theme: format.theme,
+			images: blocks.flatMap((block) =>
+				block.elements.filter(
+					(element) =>
+						element._type ===
+						'model.dotcomrendering.pageElements.ImageBlockElement',
+				),
+			),
+		};
+	}
+
 	return {
-		format,
+		design: format.design,
+		display: format.display,
+		theme: format.theme,
 		frontendData: {
 			...data,
 			mainMediaElements,


### PR DESCRIPTION
The article design, display and theme have been moved to the root of the article model in order to use the design as a discriminated field for different article types. This way, different articles can have different fields from one another. In this case, galleries can have the list of images which is all they contain.

Co-authored-by: Jamie B <53781962+JamieB-gu@users.noreply.github.com>