### PR TITLE
Loop video fixes

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardLayout.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLayout.tsx
@@ -5,8 +5,6 @@ import type { DCRContainerType } from '../../../types/front';
 import type { CardImageType } from '../../../types/layout';
 import type { ImagePositionType } from './ImageWrapper';
 
-const padding = 20;
-
 export type GapSize = 'none' | 'tiny' | 'small' | 'medium' | 'large';
 
 export type GapSizes = { row: GapSize; column: GapSize };
@@ -30,6 +28,7 @@ const containerStyles = css`
 
 // Until mobile landscape, show 1 card on small screens
 // Above mobile landscape, show 1 full card and min 20vw of second card
+const padding = 20;
 const videoWidth = css`
 	min-width: 300px;
 	max-width: 600px;

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -51,11 +51,9 @@ const hoverStyles = css`
 	:hover .card-headline .show-underline {
 		text-decoration: underline;
 	}
-`;
 
-/** When we hover on sublinks, we want to prevent the general hover styles applying */
-const sublinkHoverStyles = css`
-	:has(ul.sublinks:hover) {
+	/** When we hover on sublinks, we want to prevent the general hover styles applying */
+	:has(ul.sublinks:hover, .loop-video-container:hover) {
 		.card-headline .show-underline {
 			text-decoration: none;
 		}
@@ -110,7 +108,6 @@ export const CardWrapper = ({
 					css={[
 						baseCardStyles,
 						hoverStyles,
-						sublinkHoverStyles,
 						showTopBarDesktop && desktopTopBarStyles,
 						showTopBarMobile && mobileTopBarStyles,
 						isOnwardContent && onwardContentStyles,

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -52,7 +52,8 @@ const hoverStyles = css`
 		text-decoration: underline;
 	}
 
-	/** When we hover on sublinks, we want to prevent the general hover styles applying */
+	/** We want to prevent the general hover styles applying when
+	    a click won't result in navigating to the main article */
 	:has(ul.sublinks:hover, .loop-video-container:hover) {
 		.card-headline .show-underline {
 			text-decoration: none;

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -8,9 +8,10 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useConfig } from './ConfigContext';
 import { LoopVideoPlayer } from './LoopVideoPlayer';
 
-const videoContainerStyles = css`
+const videoContainerStyles = (width: number) => css`
 	z-index: ${getZIndex('loop-video-container')};
 	position: relative;
+	width: ${width}px;
 `;
 
 type Props = {
@@ -169,7 +170,7 @@ export const LoopVideo = ({
 	return (
 		<div
 			ref={setNode}
-			css={videoContainerStyles}
+			css={videoContainerStyles(width)}
 			className="loop-video-container"
 		>
 			<LoopVideoPlayer

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -167,7 +167,11 @@ export const LoopVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	return (
-		<div ref={setNode} css={videoContainerStyles}>
+		<div
+			ref={setNode}
+			css={videoContainerStyles}
+			className="loop-video-container"
+		>
 			<LoopVideoPlayer
 				src={src}
 				videoId={videoId}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -16,8 +16,8 @@ const videoContainerStyles = css`
 type Props = {
 	src: string;
 	videoId: string;
-	width?: number;
-	height?: number;
+	width: number;
+	height: number;
 	thumbnailImage: string;
 	fallbackImageComponent: JSX.Element;
 	hasAudio?: boolean;
@@ -146,6 +146,7 @@ export const LoopVideo = ({
 		switch (event.key) {
 			case 'Enter':
 			case ' ':
+				event.preventDefault();
 				playPauseVideo();
 				break;
 			case 'Escape':

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -7,13 +7,14 @@ import { palette } from '../palette';
 import { narrowPlayIconWidth, PlayIcon } from './Card/components/PlayIcon';
 import { LoopVideoProgressBar } from './LoopVideoProgressBar';
 
-const videoStyles = css`
+const videoStyles = (width: number, height: number) => css`
 	position: relative;
 	width: 100%;
-	height: auto;
 	/* Find out why this is needed to align the video with its container. */
 	margin-bottom: -3px;
 	cursor: pointer;
+	/* Prevents CLS by letting the browser know the space the video will take up. */
+	aspect-ratio: ${width} / ${height};
 `;
 
 const playIconStyles = css`
@@ -104,6 +105,7 @@ export const LoopVideoPlayer = forwardRef(
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
+		// Assumes that the video is unique on the page.
 		const loopVideoId = `loop-video-${videoId}`;
 
 		return (
@@ -140,7 +142,7 @@ export const LoopVideoPlayer = forwardRef(
 					role="button"
 					tabIndex={0}
 					onError={onError}
-					css={videoStyles}
+					css={videoStyles(width, height)}
 				>
 					{/* Ensure webm source is provided. Encoding the video to a webm file will improve
 					performance on supported browsers. https://web.dev/articles/video-and-source-tags */}


### PR DESCRIPTION
## What does this change?

- Update loop video props. Width and height are mandatory.
- Prevent "Enter" and "Space" keys from triggering default events, e.g. if the video is focused, "Space" should not scroll the user down the page on Chrome.
- Prevent hover styles applying to card when video is hovered. This stops the card from looking like a link when the video is hovered. To click on the card, you must click on the card outside of the video area.
- Prevent CLS by letting the browser know the aspect ratio of the video. The browser works out how much space is needed for the video before it is loaded and reserves the space on the page.