### PR TITLE
Add Editions App Docs To Dev Server

### DIFF
--- a/dotcom-rendering/src/devServer/docs/available.tsx
+++ b/dotcom-rendering/src/devServer/docs/available.tsx
@@ -1,0 +1,35 @@
+type Target = 'dotcom' | 'live apps' | 'editions app' | 'amp';
+
+const href = (target: Target): string => {
+	switch (target) {
+		case 'dotcom':
+			return '/targets/dotcom';
+		case 'live apps':
+			return '/targets/live-apps';
+		case 'editions app':
+			return '/targets/editions-app';
+		case 'amp':
+			return '/targets/amp';
+	}
+};
+
+function* links(targets: Target[]) {
+	const unique = new Set(targets);
+
+	for (const element of unique.values()) {
+		yield (
+			<li key={element}>
+				<a href={href(element)}>{element}</a>
+			</li>
+		);
+	}
+}
+
+export const Available = ({ targets }: { targets: Target[] }) => (
+	<dl>
+		<dt>Available targets</dt>
+		<dd>
+			<ul>{Array.from(links(targets))}</ul>
+		</dd>
+	</dl>
+);

--- a/dotcom-rendering/src/devServer/docs/editionsCrosswords.tsx
+++ b/dotcom-rendering/src/devServer/docs/editionsCrosswords.tsx
@@ -1,0 +1,12 @@
+import { Available } from './available';
+
+export const EditionsCrosswords = () => (
+	<>
+		<Available targets={['editions app']} />
+		<p>
+			The only page powered by DCAR in the Editions app is the crosswords
+			player, which contains a list of recent crosswords and a way to play
+			them.
+		</p>
+	</>
+);

--- a/dotcom-rendering/src/devServer/routers/editionsApp.ts
+++ b/dotcom-rendering/src/devServer/routers/editionsApp.ts
@@ -1,9 +1,14 @@
 import express from 'express';
 import { EditionsApp } from '../docs/editionsApp';
+import { EditionsCrosswords } from '../docs/editionsCrosswords';
 import { sendReact } from '../send';
 
 const editionsApp = express.Router();
 
 editionsApp.get('/', sendReact('Editions App', EditionsApp));
+editionsApp.get(
+	'/crosswords',
+	sendReact('Editions Crosswords', EditionsCrosswords),
+);
 
 export { editionsApp };


### PR DESCRIPTION
Adds documentation for the editions crosswords page, the only editions app page rendered by DCAR.

Part of #13737.
