### PR TITLE
Allow replacement videos on fronts

### DIFF
--- a/dotcom-rendering/fixtures/manual/highlights-trails.ts
+++ b/dotcom-rendering/fixtures/manual/highlights-trails.ts
@@ -37,7 +37,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/ae0cb00e76ef1aa0ec283cfcfb91ba7378f8b9ec/0_0_5000_3000/master/5000.jpg',
 			altText:
@@ -76,7 +76,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/b403e3cfdc32f5b6ba5d3f38fa44ba2ebf388a1c/0_130_4178_2508/master/4178.jpg',
 			altText:
@@ -116,7 +116,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 			altText: 'A row of terraced houses with many To Let signs',
@@ -154,7 +154,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/3718341a0b0da9a1d13f640c097a1388177fee8b/0_22_6000_3600/master/6000.jpg',
 			altText:
@@ -193,7 +193,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/ae0cb00e76ef1aa0ec283cfcfb91ba7378f8b9ec/0_0_5000_3000/master/5000.jpg',
 			altText:
@@ -232,7 +232,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/b403e3cfdc32f5b6ba5d3f38fa44ba2ebf388a1c/0_130_4178_2508/master/4178.jpg',
 			altText:
@@ -272,7 +272,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 			altText: 'A row of terraced houses with many To Let signs',
@@ -310,7 +310,7 @@ export const trails: Array<DCRFrontCard> = [
 		embedUri: undefined,
 		branding: undefined,
 		slideshowImages: undefined,
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/3718341a0b0da9a1d13f640c097a1388177fee8b/0_22_6000_3600/master/6000.jpg',
 			altText:
@@ -352,7 +352,7 @@ export const defaultCard: DCRFrontCard = {
 	embedUri: undefined,
 	branding: undefined,
 	slideshowImages: undefined,
-	showMainVideo: false,
+	showVideo: false,
 	image: {
 		src: 'https://media.guim.co.uk/dc9dcb8a8d29815e132f798b1d3e7acd528a9df3/0_295_5256_3153/master/5256.jpg',
 		altText: 'A row of terraced houses with many To Let signs',

--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -17,7 +17,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -306,7 +306,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: true,
 			imageSlideshowReplace: false,
@@ -619,7 +619,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -953,7 +953,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -1252,7 +1252,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,
@@ -1481,7 +1481,7 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showMainVideo: false,
+			showVideo: false,
 			showKickerTag: false,
 			showByline: false,
 			imageSlideshowReplace: false,

--- a/dotcom-rendering/fixtures/manual/show-more-trails.ts
+++ b/dotcom-rendering/fixtures/manual/show-more-trails.ts
@@ -17,10 +17,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: false,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {
@@ -306,10 +309,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: true,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {
@@ -619,10 +625,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: false,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {
@@ -953,10 +962,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: false,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {
@@ -1252,10 +1264,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: false,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {
@@ -1481,10 +1496,13 @@ export const trails: [
 	{
 		properties: {
 			isBreaking: false,
-			showVideo: false,
+			mediaSelect: {
+				showMainVideo: false,
+				imageSlideshowReplace: false,
+				videoReplace: false,
+			},
 			showKickerTag: false,
 			showByline: false,
-			imageSlideshowReplace: false,
 			maybeContent: {
 				trail: {
 					trailPicture: {

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -69,7 +69,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -109,7 +109,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -134,7 +134,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -158,7 +158,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -183,7 +183,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -208,7 +208,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -234,7 +234,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -259,7 +259,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 
@@ -285,7 +285,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -310,7 +310,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -335,7 +335,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -360,7 +360,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -385,7 +385,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -410,7 +410,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -435,7 +435,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -488,7 +488,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 		trailText:
 			'Plastics are everywhere, but their smallest fragments – nanoplastics – are making their way into the deepest parts of our bodies, including our brains and breast milk',
@@ -526,7 +526,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -551,7 +551,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -576,7 +576,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 	{
@@ -618,7 +618,7 @@ export const trails: [
 		isExternalLink: false,
 		showLivePlayable: false,
 		discussionApiUrl,
-		showMainVideo: true,
+		showVideo: true,
 		isImmersive: false,
 	},
 ];
@@ -760,7 +760,7 @@ export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 		kickerText: 'Democratic Republic of the Congo',
 		discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
 		mainMedia: { type: 'Gallery', count: '27' },
-		showMainVideo: false,
+		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/69ac2383ea611126b54373865dac3e7e77981d7e/0_39_5500_3302/master/5500.jpg',
 			altText: 'A group of people in the street, some looking worried',
@@ -817,7 +817,7 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 				},
 			],
 		},
-		showMainVideo: true,
+		showVideo: true,
 		image: {
 			src: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_47_3000_1800/master/3000.jpg',
 			altText:
@@ -872,7 +872,7 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 				},
 			],
 		},
-		showMainVideo: true,
+		showVideo: true,
 		image: {
 			src: 'https://media.guim.co.uk/4612af5f4667888fa697139cf570b6373d93a710/2446_345_3218_1931/master/3218.jpg',
 			altText: 'Prince Harry leaves the high court in June 2023',

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -43,7 +43,7 @@ const basicCardProps: CardProps = {
 	canPlayInline: true,
 	imageLoading: 'eager',
 	discussionApiUrl: 'https://discussion.theguardian.com/discussion-api/',
-	showMainVideo: true,
+	showVideo: true,
 	absoluteServerTimes: true,
 };
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -138,7 +138,7 @@ export type Props = {
 	liveUpdatesPosition?: Position;
 	onwardsSource?: OnwardsSource;
 	pauseOffscreenVideo?: boolean;
-	showMainVideo?: boolean;
+	showVideo?: boolean;
 	isTagPage?: boolean;
 	/** Allows the consumer to set an aspect ratio on the image of 5:3, 5:4, 4:5 or 1:1 */
 	aspectRatio?: AspectRatio;
@@ -400,7 +400,7 @@ export const Card = ({
 	liveUpdatesPosition = 'inner',
 	onwardsSource,
 	pauseOffscreenVideo = false,
-	showMainVideo = true,
+	showVideo = true,
 	absoluteServerTimes,
 	isTagPage = false,
 	aspectRatio,
@@ -890,7 +890,7 @@ export const Card = ({
 						)}
 						{media.type === 'video' && (
 							<>
-								{showMainVideo ? (
+								{showVideo ? (
 									<div
 										data-chromatic="ignore"
 										data-component="youtube-atom"

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -321,7 +321,7 @@ export type Props = {
 	 *
 	 */
 	isImmersive?: boolean;
-	showMainVideo?: boolean;
+	showVideo?: boolean;
 };
 
 export const FeatureCard = ({
@@ -359,7 +359,7 @@ export const FeatureCard = ({
 	collectionId,
 	isNewsletter = false,
 	isImmersive = false,
-	showMainVideo = false,
+	showVideo = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -377,7 +377,7 @@ export const FeatureCard = ({
 	});
 
 	const showYoutubeVideo =
-		canPlayInline && showMainVideo && mainMedia?.type === 'Video';
+		canPlayInline && showVideo && mainMedia?.type === 'Video';
 
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -131,7 +131,7 @@ const ImmersiveCardLayout = ({
 					headlineSizes={{ desktop: 'medium', tablet: 'small' }}
 					supportingContent={card.supportingContent}
 					isImmersive={true}
-					showMainVideo={card.showMainVideo}
+					showVideo={card.showVideo}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -56,7 +56,7 @@ export const FrontCard = (props: Props) => {
 		branding: trail.branding,
 		slideshowImages: trail.slideshowImages,
 		showLivePlayable: trail.showLivePlayable,
-		showMainVideo: trail.showMainVideo,
+		showVideo: trail.showVideo,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -77,7 +77,7 @@ export const ScrollableFeature = ({
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
-							showMainVideo={card.showMainVideo}
+							showVideo={card.showVideo}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -79,7 +79,7 @@ export const StaticFeatureTwo = ({
 							collectionId={collectionId}
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
-							showMainVideo={card.showMainVideo}
+							showVideo={card.showVideo}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -259,6 +259,7 @@ export type FEFrontCard = {
 	};
 	format?: FEFormat;
 	enriched?: FESnap;
+	mediaAtom?: FEMediaAtom;
 	supportingContent?: FESupportingContent[];
 	cardStyle?: {
 		type: FEFrontCardStyle;

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -133,10 +133,19 @@ export interface FEMediaAtom {
 export type FEFrontCard = {
 	properties: {
 		isBreaking: boolean;
-		showMainVideo: boolean;
+		/** Legacy fields retained for backward compatibility:
+		 * `showMainVideo` and `imageSlideshowReplace` have been moved into `mediaSelect`,
+		 * but must remain at the top level to support unrepressed or older front data.
+		 */
+		showMainVideo?: boolean;
+		imageSlideshowReplace?: boolean;
+		mediaSelect?: {
+			showMainVideo: boolean;
+			imageSlideshowReplace: boolean;
+			videoReplace: boolean;
+		};
 		showKickerTag: boolean;
 		showByline: boolean;
-		imageSlideshowReplace: boolean;
 		maybeContent?: {
 			trail: {
 				trailPicture?: {

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -484,15 +484,35 @@
                                                     "type": "boolean"
                                                 },
                                                 "showMainVideo": {
+                                                    "description": "Legacy fields retained for backward compatibility:\n`showMainVideo` and `imageSlideshowReplace` have been moved into `mediaSelect`,\nbut must remain at the top level to support unrepressed or older front data.",
                                                     "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "mediaSelect": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "showMainVideo": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "imageSlideshowReplace": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "videoReplace": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "imageSlideshowReplace",
+                                                        "showMainVideo",
+                                                        "videoReplace"
+                                                    ]
                                                 },
                                                 "showKickerTag": {
                                                     "type": "boolean"
                                                 },
                                                 "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
                                                     "type": "boolean"
                                                 },
                                                 "maybeContent": {
@@ -878,13 +898,11 @@
                                             },
                                             "required": [
                                                 "editionBrandings",
-                                                "imageSlideshowReplace",
                                                 "isBreaking",
                                                 "isCrossword",
                                                 "isLiveBlog",
                                                 "showByline",
                                                 "showKickerTag",
-                                                "showMainVideo",
                                                 "webTitle"
                                             ]
                                         },
@@ -1124,6 +1142,9 @@
                                                     "type": "string"
                                                 }
                                             }
+                                        },
+                                        "mediaAtom": {
+                                            "$ref": "#/definitions/FEMediaAtom"
                                         },
                                         "supportingContent": {
                                             "type": "array",
@@ -1244,15 +1265,35 @@
                                                     "type": "boolean"
                                                 },
                                                 "showMainVideo": {
+                                                    "description": "Legacy fields retained for backward compatibility:\n`showMainVideo` and `imageSlideshowReplace` have been moved into `mediaSelect`,\nbut must remain at the top level to support unrepressed or older front data.",
                                                     "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "mediaSelect": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "showMainVideo": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "imageSlideshowReplace": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "videoReplace": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "imageSlideshowReplace",
+                                                        "showMainVideo",
+                                                        "videoReplace"
+                                                    ]
                                                 },
                                                 "showKickerTag": {
                                                     "type": "boolean"
                                                 },
                                                 "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
                                                     "type": "boolean"
                                                 },
                                                 "maybeContent": {
@@ -1638,13 +1679,11 @@
                                             },
                                             "required": [
                                                 "editionBrandings",
-                                                "imageSlideshowReplace",
                                                 "isBreaking",
                                                 "isCrossword",
                                                 "isLiveBlog",
                                                 "showByline",
                                                 "showKickerTag",
-                                                "showMainVideo",
                                                 "webTitle"
                                             ]
                                         },
@@ -1884,6 +1923,9 @@
                                                     "type": "string"
                                                 }
                                             }
+                                        },
+                                        "mediaAtom": {
+                                            "$ref": "#/definitions/FEMediaAtom"
                                         },
                                         "supportingContent": {
                                             "type": "array",
@@ -2004,15 +2046,35 @@
                                                     "type": "boolean"
                                                 },
                                                 "showMainVideo": {
+                                                    "description": "Legacy fields retained for backward compatibility:\n`showMainVideo` and `imageSlideshowReplace` have been moved into `mediaSelect`,\nbut must remain at the top level to support unrepressed or older front data.",
                                                     "type": "boolean"
+                                                },
+                                                "imageSlideshowReplace": {
+                                                    "type": "boolean"
+                                                },
+                                                "mediaSelect": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "showMainVideo": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "imageSlideshowReplace": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "videoReplace": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "imageSlideshowReplace",
+                                                        "showMainVideo",
+                                                        "videoReplace"
+                                                    ]
                                                 },
                                                 "showKickerTag": {
                                                     "type": "boolean"
                                                 },
                                                 "showByline": {
-                                                    "type": "boolean"
-                                                },
-                                                "imageSlideshowReplace": {
                                                     "type": "boolean"
                                                 },
                                                 "maybeContent": {
@@ -2398,13 +2460,11 @@
                                             },
                                             "required": [
                                                 "editionBrandings",
-                                                "imageSlideshowReplace",
                                                 "isBreaking",
                                                 "isCrossword",
                                                 "isLiveBlog",
                                                 "showByline",
                                                 "showKickerTag",
-                                                "showMainVideo",
                                                 "webTitle"
                                             ]
                                         },
@@ -2644,6 +2704,9 @@
                                                     "type": "string"
                                                 }
                                             }
+                                        },
+                                        "mediaAtom": {
+                                            "$ref": "#/definitions/FEMediaAtom"
                                         },
                                         "supportingContent": {
                                             "type": "array",

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -13,15 +13,35 @@
                                 "type": "boolean"
                             },
                             "showMainVideo": {
+                                "description": "Legacy fields retained for backward compatibility:\n`showMainVideo` and `imageSlideshowReplace` have been moved into `mediaSelect`,\nbut must remain at the top level to support unrepressed or older front data.",
                                 "type": "boolean"
+                            },
+                            "imageSlideshowReplace": {
+                                "type": "boolean"
+                            },
+                            "mediaSelect": {
+                                "type": "object",
+                                "properties": {
+                                    "showMainVideo": {
+                                        "type": "boolean"
+                                    },
+                                    "imageSlideshowReplace": {
+                                        "type": "boolean"
+                                    },
+                                    "videoReplace": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "imageSlideshowReplace",
+                                    "showMainVideo",
+                                    "videoReplace"
+                                ]
                             },
                             "showKickerTag": {
                                 "type": "boolean"
                             },
                             "showByline": {
-                                "type": "boolean"
-                            },
-                            "imageSlideshowReplace": {
                                 "type": "boolean"
                             },
                             "maybeContent": {
@@ -407,13 +427,11 @@
                         },
                         "required": [
                             "editionBrandings",
-                            "imageSlideshowReplace",
                             "isBreaking",
                             "isCrossword",
                             "isLiveBlog",
                             "showByline",
                             "showKickerTag",
-                            "showMainVideo",
                             "webTitle"
                         ]
                     },
@@ -653,6 +671,9 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "mediaAtom": {
+                        "$ref": "#/definitions/FEMediaAtom"
                     },
                     "supportingContent": {
                         "type": "array",

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -147,7 +147,8 @@ const decideSlideshowImages = (
 	const assets = trail.properties.image?.item.assets;
 	const shouldShowSlideshow =
 		trail.properties.image?.type === 'ImageSlideshow' &&
-		trail.properties.imageSlideshowReplace;
+		(trail.properties.mediaSelect?.imageSlideshowReplace ||
+			trail.properties.imageSlideshowReplace);
 	if (shouldShowSlideshow && assets && assets.length > 0) {
 		return assets;
 	}
@@ -198,10 +199,11 @@ const decideMedia = (
 	audioDuration: string = '',
 	podcastImage?: PodcastSeriesImage,
 	imageHide?: boolean,
+	videoReplace?: boolean,
 ): MainMedia | undefined => {
 	// If the showVideo toggle is enabled in the fronts tool,
 	// we should return the active mediaAtom regardless of the design
-	if (showMainVideo) {
+	if (showMainVideo || videoReplace) {
 		return getActiveMediaAtom(mediaAtom);
 	}
 
@@ -288,13 +290,16 @@ export const enhanceCards = (
 
 		const mainMedia = decideMedia(
 			format,
-			faciaCard.properties.showMainVideo,
-			faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
+			faciaCard.properties.showMainVideo ||
+				faciaCard.properties.mediaSelect?.showMainVideo,
+			faciaCard.mediaAtom ??
+				faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
 				faciaCard.properties.maybeContent?.elements.mediaAtoms[0],
 			faciaCard.card.galleryCount,
 			faciaCard.card.audioDuration,
 			podcastImage,
 			faciaCard.display.imageHide,
+			faciaCard.properties.mediaSelect?.videoReplace,
 		);
 
 		return {
@@ -344,7 +349,10 @@ export const enhanceCards = (
 			embedUri: faciaCard.properties.embedUri ?? undefined,
 			branding,
 			slideshowImages: decideSlideshowImages(faciaCard),
-			showMainVideo: faciaCard.properties.showMainVideo,
+			showVideo:
+				faciaCard.properties.showMainVideo ||
+				faciaCard.properties.mediaSelect?.showMainVideo ||
+				faciaCard.properties.mediaSelect?.videoReplace,
 			...(!!imageSrc && {
 				image: {
 					src: imageSrc,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -147,7 +147,7 @@ const decideSlideshowImages = (
 	const assets = trail.properties.image?.item.assets;
 	const shouldShowSlideshow =
 		trail.properties.image?.type === 'ImageSlideshow' &&
-		(trail.properties.mediaSelect?.imageSlideshowReplace ||
+		(trail.properties.mediaSelect?.imageSlideshowReplace ??
 			trail.properties.imageSlideshowReplace);
 	if (shouldShowSlideshow && assets && assets.length > 0) {
 		return assets;
@@ -290,7 +290,7 @@ export const enhanceCards = (
 
 		const mainMedia = decideMedia(
 			format,
-			faciaCard.properties.showMainVideo ||
+			faciaCard.properties.showMainVideo ??
 				faciaCard.properties.mediaSelect?.showMainVideo,
 			faciaCard.mediaAtom ??
 				faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
@@ -350,8 +350,8 @@ export const enhanceCards = (
 			branding,
 			slideshowImages: decideSlideshowImages(faciaCard),
 			showVideo:
-				faciaCard.properties.showMainVideo ||
-				faciaCard.properties.mediaSelect?.showMainVideo ||
+				(faciaCard.properties.showMainVideo ??
+					faciaCard.properties.mediaSelect?.showMainVideo) ||
 				faciaCard.properties.mediaSelect?.videoReplace,
 			...(!!imageSrc && {
 				image: {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -102,7 +102,7 @@ export type DCRFrontCard = {
 	embedUri?: string;
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
-	showMainVideo?: boolean;
+	showVideo?: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

### Allows editors to replace trails with videos on fronts

This PR introduces support for replacing trail images with videos on fronts. The corresponding frontend implementation can be found here: [guardian/frontend#27915](https://github.com/guardian/frontend/pull/27915)

### Model Updates

To enable this functionality, the FE model has been extended to include a new `mediaSelect` property, which encapsulates the following options:
- `videoReplace`: enables video replacement for a trail
- `showMainMedia`: determines whether the main media video should be shown
- `canShowSlideShows`: allows the display of slideshows

### Backwards Compatibility

Since fronts are not automatically repressed when the FE model changes, `showMainMedia` and `canShowSlideShows` still need to be present at the top level of the model to ensure compatibility with existing/older fronts.

### Renaming for Clarity

This PR also renames `showMainVideo` to `showVideo` on both the `card` and `trail` models. This change reflects its expanded role, now covering both main media and replacement videos.

## Why?

Previously, editors could only show a video on a front if it was the main media. This changes gives greater flexibility and control to front editors. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
