### PR TITLE
Prevent LogTreatmentInteraction with default gate

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -412,6 +412,16 @@ const auxiaLogTreatmentInteraction = async (
 	actionName: AuxiaInteractionActionName,
 	browserId: string | undefined,
 ): Promise<void> => {
+	// We have two types of gates: the standard Auxia gate and the
+	// gu default gate that is being served from SDC
+	// They are indistinguishable in terms of their structure, but the SDC
+	// gate comes with treatmentId: 'default-treatment-id'
+	// In this case, we should not run LogTreatmentInteraction
+
+	if (userTreatment.treatmentId === 'default-treatment-id') {
+		return;
+	}
+
 	const url = `${contributionsServiceUrl}/auxia/log-treatment-interaction`;
 	const headers = {
 		'Content-Type': 'application/json',


### PR DESCRIPTION

This prevent LogTreatmentInteraction with default gate.

The default id is defined here: https://github.com/guardian/support-dotcom-components/blob/d8dfcc35e268e3319fea3ae3a5fdd9710bc9a73c/src/server/signin-gate/lib.ts#L134

(This is the first of two PRs. In a latter one, I am going to better signal the difference between the GU default gate and an Auxia gate)