### PR TITLE
Fix choice cards when same product listed twice

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -163,7 +163,27 @@ export const ThreeTierChoiceCards = ({
 					({ product, label, benefitsLabel, benefits, pill }) => {
 						const { supportTier } = product;
 
-						const selected = selectedProduct === product;
+						const isSelected = (): boolean => {
+							if (
+								product.supportTier ===
+								selectedProduct.supportTier
+							) {
+								if (
+									product.supportTier !== 'OneOff' &&
+									selectedProduct.supportTier !== 'OneOff'
+								) {
+									return (
+										product.ratePlan ===
+										selectedProduct.ratePlan
+									);
+								} else {
+									return true;
+								}
+							} else {
+								return false;
+							}
+						};
+						const selected = isSelected();
 
 						// Each radioId must be unique to the component and choice, e.g. "choicecard-epic-Contribution-Monthly"
 						const radioId = `choicecard-${id}-${supportTier}${

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -166,7 +166,12 @@ export const ThreeTierChoiceCards = ({
 						const selected =
 							selectedProduct.supportTier === supportTier;
 
-						const radioId = `choicecard-${id}-${supportTier}`;
+						// Each radioId must be unique to the component and choice, e.g. "choicecard-epic-Contribution-Monthly"
+						const radioId = `choicecard-${id}-${supportTier}${
+							supportTier !== 'OneOff'
+								? `-${product.ratePlan}`
+								: ''
+						}`;
 
 						return (
 							<div

--- a/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx
@@ -163,8 +163,7 @@ export const ThreeTierChoiceCards = ({
 					({ product, label, benefitsLabel, benefits, pill }) => {
 						const { supportTier } = product;
 
-						const selected =
-							selectedProduct.supportTier === supportTier;
+						const selected = selectedProduct === product;
 
 						// Each radioId must be unique to the component and choice, e.g. "choicecard-epic-Contribution-Monthly"
 						const radioId = `choicecard-${id}-${supportTier}${
@@ -195,7 +194,7 @@ export const ThreeTierChoiceCards = ({
 											/>
 										}
 										id={radioId}
-										value={supportTier}
+										value={radioId}
 										cssOverrides={labelOverrideStyles(
 											selected,
 										)}


### PR DESCRIPTION
It's technically possible for the epic/banner choice cards to have the same product listed more than once, for different rate plans. If this happens, the component does not distinguish between them and the input ids are the same. This is an issue because:
1. both choices are displayed as selected
2. clicking the label doesn't work correctly because the ids are the same

This PR fixes the product comparison logic, and adds the rate plan to the input ids.

Before:
<img width="566" alt="Screenshot 2025-05-21 at 11 52 32" src="https://github.com/user-attachments/assets/39c87b9b-2b1e-4d60-850e-db6182828ead" />

<img width="566" alt="Screenshot 2025-05-21 at 11 51 45" src="https://github.com/user-attachments/assets/ada1649e-8ca1-4332-abfa-82998801e148" />

After:
<img width="566" alt="Screenshot 2025-05-21 at 12 04 16" src="https://github.com/user-attachments/assets/ec6812be-d530-4b7a-bf92-5d4255c6dacd" />
<img width="566" alt="Screenshot 2025-05-21 at 11 52 02" src="https://github.com/user-attachments/assets/a730273a-786b-46cb-9c2d-6ea04b036f18" />

