### PR TITLE
Fix banner headline colour override

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import {
 	between,
-	brand,
 	from,
 	neutral,
 	palette,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -554,7 +554,6 @@ const styles = {
 	headerOverrides: css`
 		/* stylelint-disable declaration-no-important */
 		h2 {
-			color: ${brand[400]} !important;
 			margin-top: ${space[1]}px !important;
 			margin-bottom: ${space[2]}px !important;
 			${until.phablet} {


### PR DESCRIPTION
## What does this change?

There was an override for the colour of the headline introduced with the changes to the new banner to re-enable images together with the 3-tier choice cards.

This removes that colour override.

## Why?

It was noticed that the selected colour was not applying to the headline in designable banners.

## Screenshots

Here the headline is intended to be white not blue. 

| Before      | After      |
| ----------- | ---------- |
| <img width="682" alt="Screenshot 2025-05-21 at 11 52 02" src="https://github.com/user-attachments/assets/f5ebbc4a-34aa-4592-9cb8-27a73f4e05eb" /> | <img width="682" alt="Screenshot 2025-05-21 at 11 53 05" src="https://github.com/user-attachments/assets/781e753f-fdb4-4ba3-bce1-24a3ce115a9c" /> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
