### PR TITLE
handle missing main media on gallery articles

### DIFF
--- a/dotcom-rendering/src/frontend/feArticle.ts
+++ b/dotcom-rendering/src/frontend/feArticle.ts
@@ -94,6 +94,7 @@ export interface FEArticle {
 	commercialProperties: CommercialProperties;
 	starRating?: StarRating;
 	audioArticleImage?: ImageBlockElement;
+	trailPicture?: ImageBlockElement;
 	trailText: string;
 	badge?: FEArticleBadgeType;
 

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -18,7 +18,7 @@ import {
 	type TableOfContentsItem,
 } from '../model/enhanceTableOfContents';
 import { enhancePinnedPost } from '../model/pinnedPost';
-import type { ImageBlockElement, ImageForLightbox } from './content';
+import type { FEElement, ImageBlockElement, ImageForLightbox } from './content';
 import { type RenderingTarget } from './renderingTarget';
 
 /**
@@ -49,6 +49,29 @@ export type OtherArticles = ArticleFields & {
 };
 
 export type Article = Gallery | OtherArticles;
+
+export const getGalleryMainMedia = (
+	mainMediaElements: FEElement[],
+	trailImage?: ImageBlockElement,
+): ImageBlockElement => {
+	const mainMedia = mainMediaElements[0];
+
+	if (isUndefined(mainMedia)) {
+		if (isUndefined(trailImage)) {
+			throw new Error('No main media or trail picture found');
+		}
+		return trailImage;
+	}
+
+	if (
+		mainMedia._type !==
+		'model.dotcomrendering.pageElements.ImageBlockElement'
+	) {
+		throw new Error('Main media is not an image');
+	}
+
+	return mainMedia;
+};
 
 export const enhanceArticleType = (
 	data: FEArticle,
@@ -84,18 +107,6 @@ export const enhanceArticleType = (
 	if (format.design === ArticleDesign.Gallery) {
 		const design = ArticleDesign.Gallery;
 
-		const mainMedia = mainMediaElements[0];
-		if (isUndefined(mainMedia)) {
-			throw new Error('No main media found');
-		}
-
-		if (
-			mainMedia._type !==
-			'model.dotcomrendering.pageElements.ImageBlockElement'
-		) {
-			throw new Error('Main media is not an image');
-		}
-
 		return {
 			frontendData: {
 				...data,
@@ -125,7 +136,10 @@ export const enhanceArticleType = (
 						'model.dotcomrendering.pageElements.ImageBlockElement',
 				),
 			),
-			mainMedia,
+			mainMedia: getGalleryMainMedia(
+				mainMediaElements,
+				data.trailPicture,
+			),
 		};
 	}
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
