### PR TITLE
Add the rendering set up for the HideMobileHighlights test

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -315,8 +315,9 @@ export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 		'HideMobileHighlights',
 		'variant',
 	);
+	const isUkFront = frontId === 'uk';
 
-	if (isInHighlightsAbTestVariant) {
+	if (isInHighlightsAbTestVariant && isUkFront) {
 		return (
 			<Hide until="tablet">
 				<ScrollableHighlightsCarousel


### PR DESCRIPTION
In the test, if the user is in the **variant** and **on the UK network front**, we hide the highlights carousel until the tablet breakpoint. We check which front we are on using the frontId. 

Otherwise, we render the highlights carousel at all breakpoints.

The test is running 5% of users and is running for 6 days. After which point this PR can be reverted.

The accompanying Frontend PR is available here https://github.com/guardian/frontend/pull/27991

## What does this change?
It exports a wrapper for the scrollable highlights container instead of the scrollable highlights itself. If the user is in the test variant, the wrapper wraps the highlights container in a Hide component with the hidden until tablet set. Other wise, it returns the highlights container unwrapped.

## Why?

This is to allow D&I to analyse the impact of the highlights container on CTR for mobile web.

## Screenshots

https://github.com/user-attachments/assets/5d562cee-2d6e-4e84-9434-bdca978c532e


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
