### PR TITLE
`data-rendering-target` attribute for DCAR interactive articles in apps

### DIFF
--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -26,6 +26,7 @@ type BaseProps = {
 	hasSurveyAd?: boolean;
 	weAreHiring: boolean;
 	onlyLightColourScheme?: boolean;
+	isInteractive?: boolean;
 };
 
 interface WebProps extends BaseProps {
@@ -74,6 +75,7 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		onlyLightColourScheme = false,
 		weAreHiring,
 		config,
+		isInteractive = false,
 	} = props;
 
 	const doNotIndex = (): boolean => {
@@ -206,7 +208,11 @@ https://workforus.theguardian.com/careers/product-engineering/
 	return `<!doctype html>
         <html lang="en" ${
 			onlyLightColourScheme ? 'data-color-scheme="light"' : ''
-		} ${renderingTarget === 'Apps' ? 'data-rendering-target="apps"' : ''}>
+		} ${
+			renderingTarget === 'Apps' && isInteractive
+				? 'data-rendering-target="apps"'
+				: ''
+		}>
             <head>
 			    ${
 					weAreHiring

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -123,6 +123,9 @@ window.twttr = (function(d, s, id) {
 				: undefined,
 		config,
 		onlyLightColourScheme: false,
+		isInteractive:
+			design === ArticleDesign.FullPageInteractive ||
+			design === ArticleDesign.Interactive,
 	});
 
 	return {


### PR DESCRIPTION
This introduces a new `data-rendering-target` data attribute to be conditionally added to the `<html>` tag on DCAR interactive articles on apps. All being well this will form part of a new, formalised contract of information interactive devs can bank on being available.
