### PR TITLE
Use url from RRCP in banner

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -114,11 +114,11 @@ const buildChoiceCardSettings = (
 };
 
 const buildUrlForThreeTierChoiceCards = (
+	baseUrl: string,
 	tracking: Tracking,
 	selectedProduct: ChoiceCard['product'],
 	countryCode?: string,
 ) => {
-	const baseUrl = 'https://support.theguardian.com/contribute';
 	const urlWithProduct =
 		selectedProduct.supportTier === 'OneOff'
 			? baseUrl
@@ -428,37 +428,42 @@ const DesignableBannerV2: ReactComponent<BannerRenderProps> = ({
 					/>
 				)}
 
-				{choiceCards && threeTierChoiceCardSelectedProduct && (
-					<div css={styles.threeTierChoiceCardsContainer}>
-						<ThreeTierChoiceCards
-							selectedProduct={threeTierChoiceCardSelectedProduct}
-							setSelectedProduct={
-								setThreeTierChoiceCardSelectedProduct
-							}
-							choices={choiceCards}
-							id={'banner'}
-						/>
+				{choiceCards &&
+					threeTierChoiceCardSelectedProduct &&
+					mainOrMobileContent.primaryCta && (
+						<div css={styles.threeTierChoiceCardsContainer}>
+							<ThreeTierChoiceCards
+								selectedProduct={
+									threeTierChoiceCardSelectedProduct
+								}
+								setSelectedProduct={
+									setThreeTierChoiceCardSelectedProduct
+								}
+								choices={choiceCards}
+								id={'banner'}
+							/>
 
-						<div css={styles.ctaContainer}>
-							<LinkButton
-								href={buildUrlForThreeTierChoiceCards(
-									tracking,
-									threeTierChoiceCardSelectedProduct,
-									countryCode,
-								)}
-								onClick={onCtaClick}
-								priority="tertiary"
-								cssOverrides={styles.linkButtonStyles}
-								icon={<SvgArrowRightStraight />}
-								iconSide="right"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Continue
-							</LinkButton>
+							<div css={styles.ctaContainer}>
+								<LinkButton
+									href={buildUrlForThreeTierChoiceCards(
+										mainOrMobileContent.primaryCta.ctaUrl,
+										tracking,
+										threeTierChoiceCardSelectedProduct,
+										countryCode,
+									)}
+									onClick={onCtaClick}
+									priority="tertiary"
+									cssOverrides={styles.linkButtonStyles}
+									icon={<SvgArrowRightStraight />}
+									iconSide="right"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Continue
+								</LinkButton>
+							</div>
 						</div>
-					</div>
-				)}
+					)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Currently the CTA for the banner choice cards uses a hardcoded url. This means that if Marketing add a promoCode parameter to the url in the RRCP then it will be ignored.
This PR brings the banner in line with the epic by using the url from the RRCP.

Note - at some point I want to improve how we configure promo codes from the RRCP (instead of making the user add it to a url). But we're not there yet.


Tested with a url containing a promoCode:
<img width="520" alt="Screenshot 2025-05-30 at 08 52 34" src="https://github.com/user-attachments/assets/b84abb39-c6f3-47b8-8f29-cd70bb9b255e" />
