### PR TITLE
Adjust Podcast image sizes in Flexible General containers

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1030,14 +1030,14 @@ export const Card = ({
 						{media.type === 'podcast' && (
 							<>
 								{media.podcastImage?.src && !showKickerImage ? (
-									<div css={[podcastImageStyles(imageSize)]}>
+									<div css={podcastImageStyles(imageSize)}>
 										<CardPicture
 											mainImage={media.podcastImage.src}
-											imageSize={'small'}
+											imageSize="small"
 											alt={media.imageAltText}
 											loading={imageLoading}
 											roundedCorners={isOnwardContent}
-											aspectRatio={'1:1'}
+											aspectRatio="1:1"
 										/>
 									</div>
 								) : (

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -539,11 +539,7 @@ const HalfWidthCardLayout = ({
 							)}
 							supportingContentAlignment="vertical"
 							supportingContentPosition="outer"
-							imageSize={
-								card.format.design === ArticleDesign.Audio
-									? 'small'
-									: 'medium'
-							}
+							imageSize="medium"
 							aspectRatio={aspectRatio}
 							kickerText={card.kickerText}
 							showLivePlayable={false}


### PR DESCRIPTION
## What does this change?

Image size is now `medium` for podcast cards. 

## Why?

To match [designs](https://www.figma.com/design/ynmd7qODZUZkEJl20sT9fu/Fairground---Delivery-File?node-id=11232-123911&t=rZcMNfiNwCVWuZkH-0).

## Screenshots

In a `flexible/general` container

| <img width=200/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/1b3f1adb-eb16-419a-ba8a-5e05c9ebe290
[desktop-before]: https://github.com/user-attachments/assets/0e423d4d-0529-4afa-928e-56c46ee2c913
[mobile-after]:https://github.com/user-attachments/assets/d18bd67b-b08c-4677-aa5c-b8753fcf8a6c
[desktop-after]: https://github.com/user-attachments/assets/ab08d380-6323-4516-85d9-63f7723a68c8