### PR TITLE
Refactor Dateline Text Colour

### DIFF
--- a/dotcom-rendering/src/components/Dateline.tsx
+++ b/dotcom-rendering/src/components/Dateline.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { textSans12, until } from '@guardian/source/foundations';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
-import { useConfig } from './ConfigContext';
 
 const datelineStyles = css`
 	${textSans12};
@@ -11,7 +10,7 @@ const datelineStyles = css`
 	margin-bottom: 6px;
 
 	${until.desktop} {
-		color: var(--mobile-color);
+		color: var(--mobile-colour);
 	}
 `;
 
@@ -43,22 +42,18 @@ export const Dateline = ({
 	secondaryDateline,
 	format,
 }: Props) => {
-	const { renderingTarget } = useConfig();
 	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
-	const isApps = renderingTarget === 'Apps';
 
 	// for liveblog smaller breakpoints article meta is located in the same
 	// container as standfirst and needs the same styling as standfirst on web
-	const mobileColor = {
-		'--mobile-color': isApps
-			? palette('--dateline-mobile')
-			: isLiveBlog
+	const mobileColour = {
+		'--mobile-colour': isLiveBlog
 			? palette('--standfirst-text')
-			: 'inherit',
+			: palette('--dateline'),
 	};
 	if (secondaryDateline && !secondaryDateline.includes(primaryDateline)) {
 		return (
-			<details css={[datelineStyles]} style={mobileColor}>
+			<details css={datelineStyles} style={mobileColour}>
 				<summary css={primaryStyles}>
 					<span css={hoverUnderline}>{primaryDateline}</span>
 				</summary>
@@ -67,7 +62,7 @@ export const Dateline = ({
 		);
 	}
 	return (
-		<div css={[datelineStyles]} style={mobileColor}>
+		<div css={datelineStyles} style={mobileColour}>
 			{primaryDateline}
 		</div>
 	);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -964,25 +964,6 @@ export const tabs = {
 	};
 };
 
-const datelineMobileLight: PaletteFunction = ({ design, theme }) => {
-	switch (design) {
-		case ArticleDesign.LiveBlog:
-			return sourcePalette.neutral[100];
-		case ArticleDesign.Picture:
-		case ArticleDesign.Video:
-		case ArticleDesign.Audio:
-			return sourcePalette.neutral[46];
-		default:
-			if (
-				theme === ArticleSpecial.SpecialReportAlt &&
-				design !== ArticleDesign.DeadBlog
-			) {
-				return sourcePalette.specialReportAlt[100];
-			}
-			return sourcePalette.neutral[46];
-	}
-};
-
 const datelineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Comment:
@@ -994,15 +975,8 @@ const datelineLight: PaletteFunction = ({ design, theme }) => {
 				default:
 					return sourcePalette.neutral[20];
 			}
-		case ArticleDesign.Analysis:
-		case ArticleDesign.Explainer:
-		case ArticleDesign.Feature:
 		case ArticleDesign.FullPageInteractive:
 		case ArticleDesign.Interactive:
-		case ArticleDesign.Interview:
-		case ArticleDesign.NewsletterSignup:
-		case ArticleDesign.PhotoEssay:
-		case ArticleDesign.Review:
 			return sourcePalette.neutral[60];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -6303,10 +6277,6 @@ const paletteColours = {
 	'--dateline': {
 		light: datelineLight,
 		dark: datelineDark,
-	},
-	'--dateline-mobile': {
-		light: datelineMobileLight,
-		dark: standfirstTextDark,
 	},
 	'--design-tag-background': {
 		light: designTagBackground,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -992,10 +992,10 @@ const datelineLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleSpecial.SpecialReportAlt:
 					return sourcePalette.specialReportAlt[100];
 				default:
-					return sourcePalette.neutral[46];
+					return sourcePalette.neutral[38];
 			}
 		default:
-			return sourcePalette.neutral[46];
+			return sourcePalette.neutral[38];
 	}
 };
 
@@ -1017,10 +1017,10 @@ const datelineDark: PaletteFunction = ({ design, theme }) => {
 				case ArticleSpecial.SpecialReportAlt:
 					return sourcePalette.neutral[93];
 				default:
-					return sourcePalette.neutral[60];
+					return sourcePalette.neutral[73];
 			}
 		default:
-			return sourcePalette.neutral[60];
+			return sourcePalette.neutral[73];
 	}
 };
 


### PR DESCRIPTION
There are a few issues with the dateline text colour, including it appearing:

- Too close to the background colour on picture, video and audio articles at narrower breakpoints.
- Inconsistent across different breakpoints within the same article.
- Inconsistent between apps and web.

This change fixes some bugs and attempts to flatten out many of the inconsistencies. Some of the consequences of this change include:

- The colour on picture, audio and video articles is now much lighter, making it clearly stand out from the background.
- The colour is now typically the same across different breakpoints within the same article, except in the case of liveblogs where the design is necessarily different at different breakpoints.
- The text is now darker on a number of web articles (e.g. features), matching the design on apps.
- The text is now darker on some apps articles (e.g. comment), matching the design on web.
- The text is now lighter in dark mode on some articles.

## Screenshots

| Description | Before | After |
|--------|--------|--------|
| Picture Web (Narrow) | ![picture-before] | ![picture-after] |
| Video Web (Narrow)  | ![video-before] | ![video-after] |
| Audio Web (Narrow)  | ![audio-before] | ![audio-after] |
| Feature Web (Wide) | ![feature-wide-web-before] | ![feature-wide-web-after] |
| Feature Web (Narrow) | ![feature-narrow-web-before] | ![feature-narrow-web-after] |
| Feature Apps (Narrow) | ![feature-narrow-apps-before] | ![feature-narrow-apps-after] |
| Comment Apps | ![comment-apps-before] | ![comment-apps-after] |
| Dark Mode | ![dark-mode-before] | ![dark-mode-after] |
 
[feature-wide-web-before]: https://github.com/user-attachments/assets/0e7f6fae-ae15-4f1f-97a1-7c2a80348aac
[feature-wide-web-after]: https://github.com/user-attachments/assets/13aebb39-8316-445c-bbf7-d0a99afe0087
[feature-narrow-web-before]: https://github.com/user-attachments/assets/866c3cb5-442e-4894-8845-051034e53929
[feature-narrow-web-after]: https://github.com/user-attachments/assets/a250df50-311e-4006-8138-1b3367d6948e
[comment-apps-before]: https://github.com/user-attachments/assets/4ac95422-d3ed-40c4-836c-1f93f69c5e39
[comment-apps-after]: https://github.com/user-attachments/assets/bc8ba608-1ece-4d01-a876-de66dd069136
[feature-narrow-apps-after]: https://github.com/user-attachments/assets/68934527-df45-4f5e-aa49-f050990c5baf
[feature-narrow-apps-before]: https://github.com/user-attachments/assets/b9bc682b-52bc-4565-8328-e95077b839d9
[audio-after]: https://github.com/user-attachments/assets/fd0316be-8277-42f7-9a29-f69f3c13c9b8
[audio-before]: https://github.com/user-attachments/assets/d2660e83-14ac-4e68-9ce6-bdffb0b9abf8
[video-before]: https://github.com/user-attachments/assets/a94c12d0-034c-4779-94b2-402741534253
[video-after]: https://github.com/user-attachments/assets/23b19d40-d861-47a3-8aef-935f31341ff0
[picture-after]: https://github.com/user-attachments/assets/97d42065-4386-46eb-8a4e-07de8223157f
[picture-before]: https://github.com/user-attachments/assets/85c2259b-5150-4e3a-b248-2bb1c512cfdb
[dark-mode-after]: https://github.com/user-attachments/assets/d1f2c0df-42e0-41a7-8224-8f553f6ae4ea
[dark-mode-before]: https://github.com/user-attachments/assets/0fa40460-a8e6-4702-859c-7f30c99782d1
