### PR TITLE
Require sign in for show/hide functionality

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -91,7 +91,6 @@ type Props = {
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
 	hasNavigationButtons?: boolean;
-	isBetaContainer?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -310,7 +309,7 @@ const sectionContentRow = (toggleable: boolean) => css`
 	grid-row: ${toggleable ? 'content-toggleable' : 'content'};
 `;
 
-const sectionContentPadded = css`
+const sectionContentHorizontalMargins = css`
 	${from.tablet} {
 		margin-left: -10px;
 		margin-right: -10px;
@@ -528,7 +527,6 @@ export const FrontSection = ({
 	collectionBranding,
 	isTagPage = false,
 	hasNavigationButtons = false,
-	isBetaContainer,
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
 	const showMore =
@@ -540,6 +538,7 @@ export const FrontSection = ({
 		!!ajaxUrl &&
 		!containerLevel;
 	const showVerticalRule = !hasPageSkin;
+
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
 	 * this id pre-existed showMore so is probably also being used for something else.
@@ -632,10 +631,7 @@ export const FrontSection = ({
 				{(isToggleable || hasNavigationButtons) && (
 					<div css={sectionControls}>
 						{isToggleable && (
-							<ShowHideButton
-								sectionId={sectionId}
-								isBetaContainer={!!isBetaContainer}
-							/>
+							<ShowHideButton sectionId={sectionId} />
 						)}
 						{hasNavigationButtons && (
 							<div
@@ -650,7 +646,7 @@ export const FrontSection = ({
 				<div
 					css={[
 						sectionContent,
-						sectionContentPadded,
+						sectionContentHorizontalMargins,
 						sectionContentRow(toggleable),
 						topPadding,
 						showVerticalRule &&
@@ -664,7 +660,7 @@ export const FrontSection = ({
 
 				<div
 					css={[
-						sectionContentPadded,
+						sectionContentHorizontalMargins,
 						sectionBottomContent,
 						!containerLevel && bottomPadding,
 						containerSpacing === 'small' && smallBottomPadding,

--- a/dotcom-rendering/src/components/Section.tsx
+++ b/dotcom-rendering/src/components/Section.tsx
@@ -369,10 +369,7 @@ export const Section = ({
 							/>
 						</MaybeHideAboveLeftCol>
 						{toggleable && !!sectionId && (
-							<ShowHideButton
-								sectionId={sectionId}
-								isBetaContainer={false}
-							/>
+							<ShowHideButton sectionId={sectionId} />
 						)}
 					</div>
 					{toggleable && sectionId ? (

--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -5,7 +5,6 @@ import { palette } from '../palette';
 
 type Props = {
 	sectionId: string;
-	isBetaContainer: boolean;
 };
 
 const showHideButtonCss = css`
@@ -23,14 +22,13 @@ const showHideButtonCss = css`
  * This component creates the styled button for showing & hiding a container,
  * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
  **/
-export const ShowHideButton = ({ sectionId, isBetaContainer }: Props) => {
+export const ShowHideButton = ({ sectionId }: Props) => {
 	return (
 		<ButtonLink
 			priority="secondary"
 			data-link-name="Hide"
 			cssOverrides={showHideButtonCss}
 			data-show-hide-button={sectionId}
-			data-beta-container={isBetaContainer}
 			aria-controls={sectionId}
 			aria-expanded={true}
 			theme={{

--- a/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
+++ b/dotcom-rendering/src/components/ShowHideContainers.importable.tsx
@@ -88,30 +88,24 @@ export const ShowHideContainers = () => {
 	const containerStates = getContainerStates();
 
 	useEffect(() => {
+		/**
+		 * We need to know if a user is signed in before we can make any further decisions about show/hide buttons.
+		 * If the state is still pending, return early to prevent any flickering of the buttons.
+		 */
+		if (isSignedIn === 'Pending') return;
+
 		const showHideButtons = document.querySelectorAll<HTMLElement>(
 			'[data-show-hide-button]',
 		);
 
 		for (const button of showHideButtons) {
-			/**
-			 * We need to know if a user is signed in before we can make any further decisions about show/hide buttons.
-			 * If the state is still pending, return early to prevent any flickering of the buttons.
-			 */
-			if (isSignedIn === 'Pending') return;
-
 			const sectionId = button.getAttribute('data-show-hide-button');
-			const isBetaContainer = button.getAttribute('data-beta-container');
-
 			if (!sectionId) continue;
 
 			/**
-			 * We have disabled show hide for beta containers when the user is not signed in.
-			 * It is currently still available for legacy containers regardless of sign in state.
-			 *
-			 * Once beta containers are in production, show hide will be behind a sign in flag for all containers.
-			 * At this point, the isBetaContainer check can be removed from the below code.
+			 * Show/hide is only enabled for signed in users.
 			 */
-			if (isBetaContainer === 'true' && !isSignedIn) {
+			if (!isSignedIn) {
 				button.classList.add('hidden');
 			} else {
 				initialiseShowHide(sectionId, button, containerStates);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -44,7 +44,6 @@ import {
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import { ophanComponentId } from '../lib/ophan-helpers';
-import { BETA_CONTAINERS } from '../model/enhanceCollections';
 import type { NavType } from '../model/extract-nav';
 import { palette as schemePalette } from '../palette';
 import type {
@@ -448,9 +447,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									discussionApiUrl={
 										front.config.discussionApiUrl
 									}
-									isBetaContainer={BETA_CONTAINERS.includes(
-										collection.collectionType,
-									)}
 								>
 									<FrontMostViewed
 										displayName={collection.displayName}
@@ -721,9 +717,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection.collectionType ===
 										'scrollable/medium'
 								}
-								isBetaContainer={BETA_CONTAINERS.includes(
-									collection.collectionType,
-								)}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}


### PR DESCRIPTION
## What does this change?

Removes show/hide from non-beta containers.

## Why?

We already require users to be signed in to use show/hide functionality on beta containers. As we (editorial) update fronts to use these new containers, we no longer need to make an exception in the code for non-beta containers. This keeps the code tidy.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/35fba4a9-046a-4c1e-b20a-4a9b81d24a0d
[after]: https://github.com/user-attachments/assets/58ce0731-a01e-46a4-8cdf-1225033e13b7

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
