### PR TITLE
Update LiveBlock Datetime Colour

### DIFF
--- a/dotcom-rendering/src/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import {
-	palette,
+	palette as sourcePalette,
 	space,
 	textSans12,
 	textSansBold12,
 } from '@guardian/source/foundations';
 import { SvgPinned } from '@guardian/source/react-components';
-import { palette as themePalette } from '../palette';
+import { palette } from '../palette';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 import { DateTime } from './DateTime';
@@ -64,16 +64,16 @@ const FirstPublished = ({
 					width: fit-content;
 					flex-direction: row;
 					text-decoration: none;
+					color: ${palette('--live-block-datetime-text')};
 
 					:hover {
-						filter: brightness(30%);
+						color: ${palette('--live-block-datetime-text-hover')};
 					}
 				`}
 			>
 				{!isPinnedPost && (
 					<span
 						css={css`
-							color: ${palette.neutral[46]};
 							font-weight: bold;
 							margin-right: ${space[2]}px;
 						`}
@@ -91,7 +91,6 @@ const FirstPublished = ({
 				<span
 					css={css`
 						${textSans12};
-						color: ${palette.neutral[46]};
 					`}
 				>
 					{firstPublishedDisplay ?? fallbackDate(publishedDate)}
@@ -119,13 +118,13 @@ const FirstPublished = ({
 							width: 14px;
 							height: 14px;
 							border-radius: 50%;
-							background-color: ${themePalette(
+							background-color: ${palette(
 								'--live-block-border-top',
 							)};
 							align-self: center;
 							margin-left: ${space[2]}px;
 							svg {
-								fill: ${palette.neutral[100]};
+								fill: ${sourcePalette.neutral[100]};
 							}
 						`}
 					>

--- a/dotcom-rendering/src/components/LastUpdated.tsx
+++ b/dotcom-rendering/src/components/LastUpdated.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { palette, textSans12 } from '@guardian/source/foundations';
+import { textSans12 } from '@guardian/source/foundations';
+import { palette } from '../palette';
 import { DateTime } from './DateTime';
 
 const LastUpdated = ({ lastUpdated }: { lastUpdated: number }) => {
@@ -9,7 +10,7 @@ const LastUpdated = ({ lastUpdated }: { lastUpdated: number }) => {
 				display: flex;
 				align-items: flex-end;
 				${textSans12};
-				color: ${palette.neutral[46]};
+				color: ${palette('--live-block-datetime-text')};
 			`}
 		>
 			Updated at&nbsp;

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6777,6 +6777,14 @@ const paletteColours = {
 		light: liveBlockContainerBackgroundLight,
 		dark: liveBlockContainerBackgroundDark,
 	},
+	'--live-block-datetime-text': {
+		light: () => sourcePalette.neutral[38],
+		dark: () => sourcePalette.neutral[73],
+	},
+	'--live-block-datetime-text-hover': {
+		light: () => sourcePalette.neutral[20],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--loop-video-audio-icon': {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[100],


### PR DESCRIPTION
The blocks on liveblogs (and deadblogs) have up to two possible datetimes. They have a "first published" datetime that appears at the top and, optionally, a "last updated" datetime that appears in the bottom right.

The colours for these did not look correct in dark mode because they only had hardcoded light mode versions. This change moves these colours into the palette and introduces dark mode versions. It also updates the colour from the `neutral` palette used for light mode.

In addition, previously the hover colour was relying on a `filter`, which did not work correctly in dark mode. This change replaces this with a dedicated hover colour in the palette.

## Screenshots

| Description | Before | After |
|--------|--------|--------|
| Light | ![liveblog-light-before] | ![liveblog-light-after] |
| Dark | ![liveblog-dark-before] | ![liveblog-dark-after] |
| Hover | ![liveblog-hover-before] | ![liveblog-hover-after] | 

[liveblog-light-before]: https://github.com/user-attachments/assets/6d80be31-4b4e-4d0a-a670-5a1f666e7b98
[liveblog-light-after]: https://github.com/user-attachments/assets/7557bb1f-7dab-4167-b8ce-a798e77f8140
[liveblog-dark-before]: https://github.com/user-attachments/assets/1f7702f2-9812-42c4-9327-0e6319950f77
[liveblog-dark-after]: https://github.com/user-attachments/assets/590d6c44-1f46-4d1c-90ae-526e9300f106
[liveblog-hover-before]: https://github.com/user-attachments/assets/f6d278af-634e-406f-bb65-aa482a0e82a7
[liveblog-hover-after]: https://github.com/user-attachments/assets/2f7609c5-d9b0-49e3-a28f-c6321b67c2cc
