### PR TITLE
Extend gradient overlay on immersive feature  cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -109,7 +109,12 @@ const immersiveOverlayContainerStyles = css`
 	${from.tablet} {
 		top: 0;
 		height: 100%;
-		width: 220px;
+		/**
+		* Why 268px?
+		* 220 is the width of 4 columns on tablet and 3 columns on desktop.
+		* 48px is to ensure the gradient does not render the content inaccessible.
+		*/
+		width: 268px;
 		z-index: 1;
 	}
 `;
@@ -155,7 +160,11 @@ const overlayStyles = css`
 const immersiveOverlayStyles = css`
 	${from.tablet} {
 		height: 100%;
-		padding: ${space[2]}px 64px ${space[2]}px ${space[2]}px;
+		/**
+		* Why 48px right padding?
+		* 48px is to point at which the gradient can go behind the content whilst maintaining accessibility.
+		*/
+		padding: ${space[2]}px ${space[12]}px ${space[2]}px ${space[2]}px;
 		backdrop-filter: blur(12px) brightness(0.5);
 		${overlayMaskGradientStyles('270deg')}
 	}


### PR DESCRIPTION
## What does this change?
Increases the size of the overlay on immersive cards to 268px and adjusts the content padding-right to 48px
### Why 268px and 48px? 

220px is the size of 3 columns on desktop above and 4 columns on tablet (the desired space for the content). 
48px padding is added to the right of the content is to ensure the gradient does not render the content inaccessible.

## Screenshots
### Tablet
| before      | after      |
| ----------- | ---------- |
| ![before][] | ![tableta][] |

### Desktop
| before      | after      |
| ----------- | ---------- |
| ![beforea][] | ![desktopa][] |

[before]:https://github.com/user-attachments/assets/0464fd98-ad3d-4f24-a81a-2dbd90aa8c29
[beforea]: https://github.com/user-attachments/assets/3aebec10-c4fe-4f32-a517-814f32f582d4

[tableta]: https://github.com/user-attachments/assets/acf4ff5e-06f9-4471-b348-10d9fe143634
[desktopa]: https://github.com/user-attachments/assets/3a0b4ffd-db0b-4d85-95c2-662f39341e9e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
