### PR TITLE
Move from img to background url on div for svg images on gutter support ask

### DIFF
--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -23,8 +23,12 @@ const container = css`
 	gap: ${space[1]}px;
 `;
 
-const imageHeader = css`
+const imageHeader = (mainUrl: string) => css`
 	background-color: ${palette.brand[400]};
+	background-image: url(${mainUrl});
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: cover;
 	text-align: center;
 	padding: 15px 0;
 	width: 220px;
@@ -97,14 +101,11 @@ export const GutterAsk: ReactComponent<GutterAskRenderProps> = ({
 		<>
 			{variant && (
 				<div css={container}>
-					<div css={imageHeader}>
-						<img
-							src={variant.image.mainUrl}
-							alt={variant.image.altText}
-							width="150"
-							height="100"
-						/>
-					</div>
+					<div
+						css={imageHeader(variant.image.mainUrl)}
+						role="img"
+						aria-label={variant.image.altText}
+					></div>
 					<div css={textBlock}>
 						<div css={bodySection}>
 							<Copy paragraphs={variant.bodyCopy} />

--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -29,8 +29,6 @@ const imageHeader = (mainUrl: string) => css`
 	background-repeat: no-repeat;
 	background-position: center;
 	background-size: cover;
-	text-align: center;
-	padding: 15px 0;
 	width: 220px;
 	height: 132px;
 `;

--- a/dotcom-rendering/src/components/marketing/gutters/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/gutters/utils/storybook.ts
@@ -4,8 +4,8 @@ import type { GutterAskRenderProps } from '../GutterAsk';
 const variant: GutterContent = {
 	image: {
 		mainUrl:
-			'https://uploads.guim.co.uk/2025/04/25/Liveblog_Gutter_150x100.svg',
-		altText: 'Facts are Sacred',
+			'https://uploads.guim.co.uk/2025/06/12/not_for_sale_bg_scaled.svg',
+		altText: 'Not for sale',
 	},
 	bodyCopy: [
 		'The Guardian’s expert news coverage is funded by people like you, not a billionaire owner. Will you help us keep our independent journalism free and open to all today?',

--- a/dotcom-rendering/src/components/marketing/gutters/utils/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/gutters/utils/storybook.ts
@@ -3,8 +3,9 @@ import type { GutterAskRenderProps } from '../GutterAsk';
 
 const variant: GutterContent = {
 	image: {
-		mainUrl: 'https://uploads.guim.co.uk/2025/01/22/not_for_sale.svg',
-		altText: 'Not for Sale',
+		mainUrl:
+			'https://uploads.guim.co.uk/2025/04/25/Liveblog_Gutter_150x100.svg',
+		altText: 'Facts are Sacred',
 	},
 	bodyCopy: [
 		'The Guardian’s expert news coverage is funded by people like you, not a billionaire owner. Will you help us keep our independent journalism free and open to all today?',


### PR DESCRIPTION
## What does this change?

This moves from using the <img> tag with padding surrounding the image (and using a background colour to define the background colour of the SVG image) to adding the image as a background to its container `<div>` and adding an aria role in lieu of alt text.

**_NOTE_**: We will need an alternative image to the original 'Not for Sale' image to the existing gutter liveblog asks in RRCP just before deploying this change as it doesn't have the required background colour or padding to fit the space properly.

## Why?

On creating alternative images to use in Gutter Liveblog Asks, there have been issues with the newer SVG image rendering too small for the space and having a weird margin colour.  

This results from the original image having no background or margin within the image itself so the code was adapted to allow for that.

This change should make it easier in future for designers to provide images in the defined dimensions of 150 x 100 which should fit nicely into the space.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="611" alt="Screenshot 2025-06-09 at 09 53 04" src="https://github.com/user-attachments/assets/5ac05e4d-0437-4552-8446-d28aca816192" /> | <img width="535" alt="Screenshot 2025-06-09 at 09 53 27" src="https://github.com/user-attachments/assets/4e1e291a-7d0e-4406-a44d-d01536f6a1c8" /> |

## Accessibility

While this removes the alt tag, a role of img with an associated label containing the alt text has been added to the containing div.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
