### PR TITLE
Change DCAR interactives platform identifier from class to data attribute

### DIFF
--- a/dotcom-rendering/src/components/InteractivesNativePlatformWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/InteractivesNativePlatformWrapper.importable.tsx
@@ -8,7 +8,10 @@ export const InteractivesNativePlatformWrapper = () => {
 		void getInteractivesClient()
 			.getNativePlatform()
 			.then((platform) =>
-				document.body.classList.add(NativePlatform[platform]),
+				document.documentElement.setAttribute(
+					'data-app-os',
+					NativePlatform[platform],
+				),
 			)
 			.catch((error) => {
 				log('dotcom', 'getNativePlatform check failed:', error);


### PR DESCRIPTION
This adjusts the work done in https://github.com/guardian/dotcom-rendering/pull/14006 and uses data attributes instead of classes. There are a few reasons for this:

- Carrying over the exact same class names creates more problems than it solves for old interactives. They're often used as the condition for manipulating elements in the DOM based on apps templates class names, which don't exist any more in DCAR
- It's consistent with how other information is handed down in DCAR for interactives. See https://github.com/guardian/dotcom-rendering/pull/14011 and https://github.com/guardian/dotcom-rendering/pull/11982
- It creates a clear before/after for interactive atom code. If it includes `body.ios` and the like, it's pre-migration

Now we have `data-app-os="ios"`/`data-app-os="android"` attributes on the root rather `class="ios"`/`class="android"` on the body.