### PR TITLE
Remove font boost from image supression for standard non-boosted cards in a flexible general

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -551,15 +551,7 @@ const HalfWidthCardLayout = ({
 								(containerLevel !== 'Primary' && cardIndex > 0)
 							}
 							trailText={undefined}
-							headlineSizes={
-								!card.image &&
-								card.format.design !== ArticleDesign.Comment
-									? {
-											desktop: 'small',
-											tablet: 'xsmall',
-									  }
-									: undefined
-							}
+							headlineSizes={undefined}
 							canPlayInline={false}
 						/>
 					</LI>

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -358,6 +358,7 @@ export const enhanceCards = (
 			isCrossword: faciaCard.properties.isCrossword,
 			isNewsletter,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
+			// show latest 3 updates from a live blog
 			showLivePlayable: faciaCard.display.showLivePlayable,
 			avatarUrl:
 				!isContributorTagPage &&


### PR DESCRIPTION
## What does this change?
Previously, if an image on a standard non-boosted cards in a flexible general was supressed, the headline font size would increase by 1 level. This PR is removing this logic so that standard non-boosted cards in a flexible general with/without images have the same font size. 

NB - this change does not affect flexible general splash cards or cards that have been boosted. These cards will still get a font size uplift if their image is removed. 

## Why?
This has been requested by Editorial to prevent imageless card headlines seeming more prominent on the front. 

## Screenshots by breakpoint (mobile, tablet, desktop)

| Before      | After      |
| ----------- | ---------- |
| ![beforem][] | ![afterm][] |
| ![beforet][] | ![aftert][] |
| ![befored][] | ![afterd][] |

[beforem]: https://github.com/user-attachments/assets/d478be3c-0f46-4a46-a6d4-a33fdef25e6e
[afterd]: https://github.com/user-attachments/assets/20fb5e6e-ee8f-48c9-b767-991e44995668

[beforet]: https://github.com/user-attachments/assets/57db8312-8bca-4aab-a99d-c252bb38328e
[afterm]: https://github.com/user-attachments/assets/a8b04351-6e77-410a-9d6c-c167541ae9eb
[befored]: https://github.com/user-attachments/assets/ca7d3f37-fe27-405e-acc4-b6716d8b58a6
[aftert]: https://github.com/user-attachments/assets/c3f8868b-d5c0-4514-9fc4-313327109c8c
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
