### PR TITLE
add web meta for gallery

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.web.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.web.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { between, from, space, until } from '@guardian/source/foundations';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import { grid } from '../../src/grid';
 import type { FEArticle } from '../frontend/feArticle';
 import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStyling';
 import {
@@ -55,6 +56,10 @@ const meta = (format: ArticleFormat) => {
 
 			padding-top: 2px;
 		`;
+	}
+
+	if (format.design === ArticleDesign.Gallery) {
+		return '';
 	}
 
 	return css`
@@ -182,6 +187,13 @@ export const metaContainer = (format: ArticleFormat) => {
 				case ArticleDesign.DeadBlog: {
 					return '';
 				}
+				case ArticleDesign.Gallery:
+					return css`
+						${grid.column.centre}
+						margin-bottom: ${space[3]}px;
+						margin-left: ${space[3]}px;
+						margin-right: ${space[3]}px;
+					`;
 				default:
 					return defaultMargins;
 			}

--- a/dotcom-rendering/src/components/Contributor.tsx
+++ b/dotcom-rendering/src/components/Contributor.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	headlineMedium17,
+	palette as sourcePalette,
 	textSansItalic17,
 	until,
 } from '@guardian/source/foundations';
@@ -29,24 +30,44 @@ const standfirstColourBelowDesktop = css`
 	}
 `;
 
-const bylineStyles = css`
-	${headlineMedium17}
+const bylineStyles = (format: ArticleFormat) => {
+	const defaultStyles = css`
+		${headlineMedium17}
 
-	padding-bottom: 8px;
-	font-style: italic;
+		padding-bottom: 8px;
+		font-style: italic;
 
-	color: ${schemedPalette('--byline')};
+		color: ${schemedPalette('--byline')};
 
-	a {
-		color: ${schemedPalette('--byline-anchor')};
-		font-weight: 700;
-		text-decoration: none;
-		font-style: normal;
-		:hover {
-			text-decoration: underline;
+		a {
+			color: ${schemedPalette('--byline-anchor')};
+			font-weight: 700;
+			text-decoration: none;
+			font-style: normal;
+			:hover {
+				text-decoration: underline;
+			}
 		}
+	`;
+
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+			return css`
+				${defaultStyles}
+				a {
+					font-style: italic;
+					border-bottom: 0.5px solid ${sourcePalette.neutral[46]};
+					:hover {
+						text-decoration: none;
+						border-color: ${schemedPalette('--byline-anchor')};
+					}
+				}
+			`;
+
+		default:
+			return defaultStyles;
 	}
-`;
+};
 
 const labsBylineStyles = css`
 	${textSansItalic17};
@@ -74,7 +95,7 @@ export const Contributor = ({ byline, tags, format, source }: Props) => (
 						: ''
 				}
 				css={[
-					bylineStyles,
+					bylineStyles(format),
 					format.theme === ArticleSpecial.Labs && labsBylineStyles,
 					format.design === ArticleDesign.LiveBlog &&
 						standfirstColourBelowDesktop,

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
+import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Masthead } from '../components/Masthead/Masthead';
@@ -92,6 +93,25 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					<Standfirst
 						format={format}
 						standfirst={frontendData.standfirst}
+					/>
+					<ArticleMeta
+						branding={
+							frontendData.commercialProperties[
+								frontendData.editionId
+							].branding
+						}
+						format={format}
+						pageId={frontendData.pageId}
+						webTitle={frontendData.webTitle}
+						byline={frontendData.byline}
+						tags={frontendData.tags}
+						primaryDateline={frontendData.webPublicationDateDisplay}
+						secondaryDateline={
+							frontendData.webPublicationSecondaryDateDisplay
+						}
+						isCommentable={frontendData.isCommentable}
+						discussionApiUrl={frontendData.config.discussionApiUrl}
+						shortUrlId={frontendData.config.shortUrlId}
 					/>
 					<div
 						css={[

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -359,6 +359,8 @@ const headlineBylineDark: PaletteFunction = ({ design, display, theme }) => {
 
 const bylineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
 		case ArticleDesign.Audio:
@@ -507,6 +509,8 @@ const bylineBackgroundDark: PaletteFunction = ({ design, theme }) => {
 
 const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
 				case Pillar.News:
@@ -974,6 +978,8 @@ export const tabs = {
 
 const datelineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		case ArticleDesign.Comment:
 		case ArticleDesign.Editorial:
 		case ArticleDesign.Letter:
@@ -3231,6 +3237,8 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
 					return transparentColour(sourcePalette.neutral[60], 0.5);
+				case ArticleDesign.Gallery:
+					return sourcePalette.neutral[20];
 				default:
 					return sourcePalette.neutral[86];
 			}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
