### PR TITLE
Limit interactives body copy colour override to apps

### DIFF
--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -26,6 +26,7 @@ import type { ArticleDeprecated } from '../types/article';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
+import { temporaryBodyCopyColourOverride } from './InteractiveLayout';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -206,21 +207,16 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 
 	return (
 		<>
-			<Global
-				styles={css`
-					.content__main-column--interactive p {
-						/* stylelint-disable-next-line declaration-no-important */
-						color: ${themePalette('--article-text')} !important;
-					}
-				`}
-			/>
 			{article.isLegacyInteractive && (
 				<Global styles={interactiveGlobalStyles} />
 			)}
 			{isApps && (
-				<Island priority="critical">
-					<InteractivesNativePlatformWrapper />
-				</Island>
+				<>
+					<Island priority="critical">
+						<InteractivesNativePlatformWrapper />
+					</Island>
+					<Global styles={temporaryBodyCopyColourOverride} />
+				</>
 			)}
 			{isWeb && (
 				<>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -200,6 +200,13 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
+export const temporaryBodyCopyColourOverride = css`
+	.content__main-column--interactive p {
+		/* stylelint-disable-next-line declaration-no-important */
+		color: ${themePalette('--article-text')} !important;
+	}
+`;
+
 interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
@@ -239,21 +246,16 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	const renderAds = isWeb && canRenderAds(article);
 	return (
 		<>
-			<Global
-				styles={css`
-					.content__main-column--interactive p {
-						/* stylelint-disable-next-line declaration-no-important */
-						color: ${themePalette('--article-text')} !important;
-					}
-				`}
-			/>
 			{isApps && (
 				<Island priority="critical">
 					<InteractivesNativePlatformWrapper />
 				</Island>
 			)}
 			{article.isLegacyInteractive && (
-				<Global styles={interactiveGlobalStyles} />
+				<>
+					<Global styles={interactiveGlobalStyles} />
+					<Global styles={temporaryBodyCopyColourOverride} />
+				</>
 			)}
 			{isWeb && (
 				<>


### PR DESCRIPTION
This tightens the scope of the interactives body copy colour override applied in https://github.com/guardian/dotcom-rendering/pull/14049. Having this apply to web and apps is unnecessary because a) web doesn't have dark mode, and b) this is a temporary measure anyway so keeping the scope narrow makes sense on all fronts.
