### PR TITLE
Adjust the amount of space above ads on fronts

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -56,7 +56,7 @@ type Props = {
 	 * If used, this can be either "Primary" or "Secondary", both of which have different styles */
 	containerLevel?: DCRContainerLevel;
 	/** Fronts containers spacing rules vary depending on the size of their container spacing which is derived from if the next container is a primary or secondary. */
-	containerSpacing?: 'large' | 'small';
+	isNextCollectionPrimary?: boolean;
 	/** Defaults to `false`. If true a Hide button is show top right allowing this section
 	 * to be collapsed
 	 */
@@ -91,6 +91,8 @@ type Props = {
 	collectionBranding?: CollectionBranding;
 	isTagPage?: boolean;
 	hasNavigationButtons?: boolean;
+	isAboveDesktopAd?: boolean;
+	isAboveMobileAd?: boolean;
 };
 
 const width = (columns: number, columnWidth: number, columnGap: number) =>
@@ -383,12 +385,20 @@ const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-const smallBottomPadding = css`
-	padding-bottom: ${space[6]}px;
-`;
-
-const largeBottomPadding = css`
-	padding-bottom: ${space[10]}px;
+const bottomPaddingBetaContainer = (
+	useLargeSpacingMobile: boolean,
+	useLargeSpacingDesktop: boolean,
+) => css`
+	${until.tablet} {
+		padding-bottom: ${useLargeSpacingMobile
+			? `${space[10]}px`
+			: `${space[6]}px`};
+	}
+	${from.tablet} {
+		padding-bottom: ${useLargeSpacingDesktop
+			? `${space[10]}px`
+			: `${space[6]}px`};
+	}
 `;
 
 const primaryLevelTopBorder = css`
@@ -503,7 +513,7 @@ export const FrontSection = ({
 	containerName,
 	containerPalette,
 	containerLevel,
-	containerSpacing,
+	isNextCollectionPrimary,
 	description,
 	editionId,
 	leftContent,
@@ -527,8 +537,12 @@ export const FrontSection = ({
 	collectionBranding,
 	isTagPage = false,
 	hasNavigationButtons = false,
+	isAboveDesktopAd = false,
+	isAboveMobileAd = false,
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
+	const showVerticalRule = !hasPageSkin;
+	const isBetaContainer = !!containerLevel;
 	const showMore =
 		canShowMore &&
 		!!title &&
@@ -536,8 +550,12 @@ export const FrontSection = ({
 		!!collectionId &&
 		!!pageId &&
 		!!ajaxUrl &&
-		!containerLevel;
-	const showVerticalRule = !hasPageSkin;
+		!isBetaContainer;
+
+	// These are for beta containers only
+	const useLargeSpacingMobile = !!isNextCollectionPrimary || isAboveMobileAd;
+	const useLargeSpacingDesktop =
+		!!isNextCollectionPrimary || isAboveDesktopAd;
 
 	/**
 	 * id is being used to set the containerId in @see {ShowMore.importable.tsx}
@@ -567,7 +585,7 @@ export const FrontSection = ({
 					),
 				}}
 			>
-				{!!containerLevel && showTopBorder && (
+				{isBetaContainer && showTopBorder && (
 					<div
 						css={[
 							containerLevel === 'Secondary'
@@ -581,7 +599,7 @@ export const FrontSection = ({
 					css={[
 						decoration,
 						sideBorders,
-						showTopBorder && !containerLevel && topBorder,
+						showTopBorder && !isBetaContainer && topBorder,
 					]}
 				/>
 
@@ -594,7 +612,7 @@ export const FrontSection = ({
 							title?.toLowerCase() === 'opinion',
 						),
 						showVerticalRule &&
-							!containerLevel &&
+							!isBetaContainer &&
 							sectionHeadlineFromLeftCol(
 								schemePalette('--section-border'),
 							),
@@ -650,7 +668,7 @@ export const FrontSection = ({
 						sectionContentRow(toggleable),
 						topPadding,
 						showVerticalRule &&
-							!!containerLevel &&
+							isBetaContainer &&
 							sectionContentBorderFromLeftCol,
 					]}
 					id={`container-${sectionId}`}
@@ -662,9 +680,12 @@ export const FrontSection = ({
 					css={[
 						sectionContentHorizontalMargins,
 						sectionBottomContent,
-						!containerLevel && bottomPadding,
-						containerSpacing === 'small' && smallBottomPadding,
-						containerSpacing === 'large' && largeBottomPadding,
+						isBetaContainer
+							? bottomPaddingBetaContainer(
+									useLargeSpacingMobile,
+									useLargeSpacingDesktop,
+							  )
+							: bottomPadding,
 					]}
 				>
 					{isString(targetedTerritory) &&

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -712,13 +712,21 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collection.collectionBranding
 								}
 								containerLevel={collection.containerLevel}
-								containerSpacing={collection.containerSpacing}
+								isNextCollectionPrimary={
+									collection.isNextCollectionPrimary
+								}
 								hasNavigationButtons={
 									collection.collectionType ===
 										'scrollable/small' ||
 									collection.collectionType ===
 										'scrollable/medium'
 								}
+								isAboveDesktopAd={desktopAdPositions.includes(
+									index + 1,
+								)}
+								isAboveMobileAd={mobileAdPositions.includes(
+									index,
+								)}
 							>
 								<DecideContainer
 									trails={trailsWithoutBranding}

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -54,13 +54,6 @@ const findCollectionSuitableForFrontBranding = (
 	return index;
 };
 
-/** Depending on the next sibling of the container, we assign either large or small spacing rules during render */
-const getContainerSpacing = (nextSiblingCollection?: FECollection) => {
-	const nextCollectionIsPrimary =
-		nextSiblingCollection?.config.collectionLevel === 'Primary';
-	return nextCollectionIsPrimary ? 'large' : 'small';
-};
-
 export const enhanceCollections = ({
 	collections,
 	editionId,
@@ -82,6 +75,7 @@ export const enhanceCollections = ({
 }): DCRCollectionType[] => {
 	const indexToShowFrontBranding =
 		findCollectionSuitableForFrontBranding(collections);
+
 	return collections.filter(isSupported).map((collection, index) => {
 		const { id, displayName, collectionType, hasMore, href, description } =
 			collection;
@@ -110,10 +104,12 @@ export const enhanceCollections = ({
 			},
 		);
 
-		const containerSpacing = getContainerSpacing(collections[index + 1]);
+		const isNextCollectionPrimary =
+			collections[index + 1]?.config.collectionLevel === 'Primary';
 		const isBetaContainer = BETA_CONTAINERS.includes(
 			collection.collectionType,
 		);
+
 		return {
 			id,
 			displayName,
@@ -125,7 +121,7 @@ export const enhanceCollections = ({
 			href,
 			containerPalette,
 			containerLevel: collection.config.collectionLevel,
-			containerSpacing,
+			isNextCollectionPrimary,
 			collectionBranding,
 			grouped: groupCards(
 				collectionType,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -124,7 +124,7 @@ export type DCRCollectionType = {
 	collectionType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	containerLevel?: DCRContainerLevel;
-	containerSpacing?: 'large' | 'small';
+	isNextCollectionPrimary?: boolean;
 	grouped: DCRGroupedTrails;
 	curated: DCRFrontCard[];
 	backfill: DCRFrontCard[];


### PR DESCRIPTION
## What does this change?

An advert should have 40px above it to separate it from other content. It is currently only 24px when below a secondary container. This updates the value to 40px, and applies to both mobile and desktop.

## Why?

To match [designs](https://www.figma.com/design/ynmd7qODZUZkEJl20sT9fu/Fairground---Delivery-File?node-id=5760-94872&t=BWmnyvQXdcb9kRz5-0).

## Screenshots

| <img width=200/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/541e606f-0049-477e-9de6-87824750e5a5
[desktop-before]: https://github.com/user-attachments/assets/caccc66a-b364-48cb-9a5f-b920b9d479fa
[mobile-after]: https://github.com/user-attachments/assets/0354a4b7-0f5a-4e45-9cd9-37d8c9552fd0
[desktop-after]: https://github.com/user-attachments/assets/ae4ed0a9-77cc-4921-b4ae-f1325c827a2b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
