### PR TITLE
Move interactive override to right place

### DIFF
--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -247,15 +247,15 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 	return (
 		<>
 			{isApps && (
-				<Island priority="critical">
-					<InteractivesNativePlatformWrapper />
-				</Island>
-			)}
-			{article.isLegacyInteractive && (
 				<>
-					<Global styles={interactiveGlobalStyles} />
+					<Island priority="critical">
+						<InteractivesNativePlatformWrapper />
+					</Island>
 					<Global styles={temporaryBodyCopyColourOverride} />
 				</>
+			)}
+			{article.isLegacyInteractive && (
+				<Global styles={interactiveGlobalStyles} />
 			)}
 			{isWeb && (
 				<>


### PR DESCRIPTION
Fixes placement mistake in https://github.com/guardian/dotcom-rendering/pull/14074.
