### PR TITLE
Ab/image widths

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -101,7 +101,7 @@ const decideImageWidths = (
 		case 'feature-large':
 			return [
 				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
-				{ breakpoint: breakpoints.tablet, width: 337, aspectRatio },
+				{ breakpoint: breakpoints.tablet, width: 340, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
 		case 'feature-immersive':

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -63,14 +63,14 @@ const decideImageWidths = (
 
 		case 'medium':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 240, aspectRatio },
+				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
 				{ breakpoint: breakpoints.tablet, width: 330, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
 
 		case 'large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 360, aspectRatio },
+				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
 				{
 					breakpoint: breakpoints.mobileLandscape,
 					width: 480,
@@ -82,7 +82,7 @@ const decideImageWidths = (
 
 		case 'jumbo':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 360, aspectRatio },
+				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
 				{
 					breakpoint: breakpoints.mobileLandscape,
 					width: 480,
@@ -94,13 +94,13 @@ const decideImageWidths = (
 
 		case 'feature':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 325, aspectRatio },
+				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
 				{ breakpoint: breakpoints.tablet, width: 220, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 300, aspectRatio },
 			];
 		case 'feature-large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 325, aspectRatio },
+				{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
 				{ breakpoint: breakpoints.tablet, width: 337, aspectRatio },
 				{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
 			];
@@ -108,7 +108,7 @@ const decideImageWidths = (
 			return [
 				{
 					breakpoint: breakpoints.mobile,
-					width: 340,
+					width: 465,
 					aspectRatio: '4:5',
 				},
 				{


### PR DESCRIPTION
## What does this change?
Increased the width requested from fastly for various image sizes.

## Why?
Images on DCR are lower quality than they ought to be. 

We should always request *at least* the minimum width that an image would occupy in a given breakpoint. 

This is easier for desktop and tablet as images have fixed widths at these breakpoints.

Below tablet, the image widths are dynamic dependent on the users screen size. As a first step, we are setting all* mobile image widths to 465 which is higher than the minimum supported breakpoint (375px). 

*some image sizes occupy smaller spaces on mobile (small) or are fixed width (podcast, highlights-card and carousel). For these, we have not increased the width requested from fastly. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
