### PR TITLE
Fix main image story for DesignableBannersV2

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBannerV2.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBannerV2.stories.tsx
@@ -185,9 +185,8 @@ export const MainImage: Story = {
 		},
 		tracking: {
 			...tracking,
-			abTestVariant: 'THREE_TIER_CHOICE_CARDS',
+			abTestVariant: 'MAIN_IMAGE',
 		},
-		choiceCardAmounts: regularChoiceCardAmounts,
 	},
 };
 


### PR DESCRIPTION
## What does this change?

The main image story for DesignableBannersV2 should not have choice card configuration as the design has no choice cards so this removes the extra configuration and changes the tracking abTestVariant name (the latter is less relevant but a useful indicator to devs).  

## Why?

This extra configuration may be causing issues with the live-preview in RRCP for equivalent banners as it uses these stories under the hood.  While I have been unable to replicate the problem while running Storybook in PROD or locally this need to be fixed and it will help rule it out as a cause of the live-preview problem.

## Screenshots

No visible change to the story but potentially fixes the following issue in live-preview.

<img width="1507" alt="Screenshot 2025-06-13 at 11 06 10" src="https://github.com/user-attachments/assets/58489a18-cf09-48b4-a591-3273db40fcc7" />

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
