### PR TITLE
Extend text content width of immersive youtube cards

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -77,11 +77,16 @@ const textOverlayStyles = css`
 	backdrop-filter: blur(12px) brightness(0.5);
 `;
 
+/**
+ * Why 268px?
+ * 220 is the width of 4 columns on tablet and 3 columns on desktop.
+ * 48px is to ensure the gradient does not render the content inaccessible.
+ */
 const immersiveOverlayStyles = css`
 	${from.tablet} {
 		height: 100%;
-		width: 25%;
-		padding: ${space[2]}px 64px ${space[2]}px ${space[2]}px;
+		width: 268px;
+		padding: ${space[2]}px ${space[12]}px ${space[2]}px ${space[2]}px;
 		backdrop-filter: blur(12px) brightness(0.5);
 		${overlayMaskGradientStyles('270deg')}
 	}


### PR DESCRIPTION
## What does this change?

Increases the size of the overlay on Youtube immersive cards to 268px and adjusts the content padding-right to 48px.

## Why?

Extends the changes made [in this PR](https://github.com/guardian/dotcom-rendering/pull/14048) to Youtube immersives.

The mask gradient is stlll 64px in width, but I believe this is fine for now.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/450714a9-2f00-4e08-914a-32a928b3f190
[after]: https://github.com/user-attachments/assets/83e34732-6d2a-43e2-ad4a-f287141abe57

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
