### PR TITLE
Adds a default story to DesignableBannerV2 with empty configuration

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBannerV2.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBannerV2.stories.tsx
@@ -40,6 +40,9 @@ const meta: Meta<Props> = {
 export default meta;
 
 type Story = StoryObj<Props>;
+export const Default: Story = {
+	name: 'Basic DesignableBannerV2',
+};
 
 const regularChoiceCardAmounts: SelectedAmountsVariant = {
 	testName: 'Storybook_test',


### PR DESCRIPTION
## What does this change?

This adds a default story that can be used, with passed configuration, to test banners via the live-preview option in RRCP.

## Why?

There is an issue with live-preview which is showing choice cards where there should be none - it is believed that this is because live-preview is pointing to a pre-configured story which contains choice cards.
This creates an unconfigured story that can be used for the live-previews as it will only handle the configuration passed to it with no extras.

## Screenshots

This adds a single new story which is the default DesignableBannerV2.

<img width="1192" alt="Screenshot 2025-06-13 at 13 07 39" src="https://github.com/user-attachments/assets/79213aa9-9dc1-443b-aa0a-7e56df162e93" />

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
