### PR TITLE
Add Interactive Docs To Dev Server

### DIFF
--- a/dotcom-rendering/src/devServer/docs/interactive.tsx
+++ b/dotcom-rendering/src/devServer/docs/interactive.tsx
@@ -1,0 +1,16 @@
+import { Available } from './available';
+
+export const Interactive = () => (
+	<>
+		<Available targets={['dotcom', 'live apps', 'amp']} />
+		<p>
+			Interactives are actually a kind of <a href="../article">article</a>
+			, but DCAR has a separate endpoint for them for performance reasons.
+			You can find some examples on the{' '}
+			<a href="https://www.theguardian.com/interactive">
+				Interactives front
+			</a>
+			.
+		</p>
+	</>
+);

--- a/dotcom-rendering/src/devServer/routers/amp.ts
+++ b/dotcom-rendering/src/devServer/routers/amp.ts
@@ -1,9 +1,11 @@
 import express from 'express';
 import { Amp } from '../docs/amp';
+import { Interactive } from '../docs/interactive';
 import { sendReact } from '../send';
 
 const amp = express.Router();
 
 amp.get('/', sendReact('AMP', Amp));
+amp.get('/interactive', sendReact('Interactive', Interactive));
 
 export { amp };

--- a/dotcom-rendering/src/devServer/routers/dotcom.ts
+++ b/dotcom-rendering/src/devServer/routers/dotcom.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { Dotcom } from '../docs/dotcom';
+import { Interactive } from '../docs/interactive';
 import { sendReact } from '../send';
 
 const dotcom = Router();
 
 dotcom.get('/', sendReact('Dotcom', Dotcom));
+dotcom.get('/interactive', sendReact('Interactive', Interactive));
 
 export { dotcom };

--- a/dotcom-rendering/src/devServer/routers/liveApps.ts
+++ b/dotcom-rendering/src/devServer/routers/liveApps.ts
@@ -1,9 +1,11 @@
 import express from 'express';
+import { Interactive } from '../docs/interactive';
 import { LiveApps } from '../docs/liveApps';
 import { sendReact } from '../send';
 
 const liveApps = express.Router();
 
 liveApps.get('/', sendReact('Live Apps', LiveApps));
+liveApps.get('/interactive', sendReact('Interactive', Interactive));
 
 export { liveApps };

--- a/dotcom-rendering/src/devServer/routers/pages.ts
+++ b/dotcom-rendering/src/devServer/routers/pages.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
+import { Interactive } from '../docs/interactive';
 import { Pages } from '../docs/pages';
 import { sendReact } from '../send';
 
 const pages = Router();
 
 pages.get('/', sendReact('Pages', Pages));
+pages.get('/interactive', sendReact('Interactive', Interactive));
 
 export { pages };


### PR DESCRIPTION
Adds documentation for interactive pages, which can be rendered on dotcom, the live apps, and AMP.

Part of #13737.
