### PR TITLE
Add Cricket Docs To Dev Server

### DIFF
--- a/dotcom-rendering/src/devServer/docs/cricketScorecard.tsx
+++ b/dotcom-rendering/src/devServer/docs/cricketScorecard.tsx
@@ -1,0 +1,21 @@
+import { Available } from './available';
+
+export const CricketScorecard = () => (
+	<>
+		<Available targets={['dotcom']} />
+		<p>
+			These pages are summaries of cricket matches, and contain various
+			statistics about a match, including batters, bowlers, and the fall
+			of wickets. For example,{' '}
+			<a href="https://www.theguardian.com/sport/cricket/match/2025-02-22/england-cricket-team">
+				the cricket scorecard
+			</a>{' '}
+			for a match between England and Australia. They are typically
+			reached from a link at the top of a{' '}
+			<a href="https://www.theguardian.com/sport/live/2025/feb/22/australia-v-england-champions-trophy-updates-live">
+				cricket liveblog
+			</a>
+			, which is a kind of <a href="../article">article</a>.
+		</p>
+	</>
+);

--- a/dotcom-rendering/src/devServer/routers/dotcom.ts
+++ b/dotcom-rendering/src/devServer/routers/dotcom.ts
@@ -1,9 +1,14 @@
 import { Router } from 'express';
+import { CricketScorecard } from '../docs/cricketScorecard';
 import { Dotcom } from '../docs/dotcom';
 import { sendReact } from '../send';
 
 const dotcom = Router();
 
 dotcom.get('/', sendReact('Dotcom', Dotcom));
+dotcom.get(
+	'/cricket-scorecard',
+	sendReact('Cricket Scorecard', CricketScorecard),
+);
 
 export { dotcom };

--- a/dotcom-rendering/src/devServer/routers/pages.ts
+++ b/dotcom-rendering/src/devServer/routers/pages.ts
@@ -1,9 +1,14 @@
 import { Router } from 'express';
+import { CricketScorecard } from '../docs/cricketScorecard';
 import { Pages } from '../docs/pages';
 import { sendReact } from '../send';
 
 const pages = Router();
 
 pages.get('/', sendReact('Pages', Pages));
+pages.get(
+	'/cricket-scorecard',
+	sendReact('Cricket Scorecard', CricketScorecard),
+);
 
 export { pages };


### PR DESCRIPTION
Adds documentation for the cricket scorecard page, which can be rendered on dotcom only.

Part of #13737.
