### PR TITLE
Remove Stacked Carousels AB test

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -1,4 +1,3 @@
-import { Hide } from '@guardian/source/react-components';
 import type { ImgHTMLAttributes } from 'react';
 import type {
 	AspectRatio,
@@ -49,7 +48,6 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
-	shouldShowCarouselsAsStacked?: boolean;
 };
 
 export const DecideContainer = ({
@@ -65,7 +63,6 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
-	shouldShowCarouselsAsStacked,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -274,41 +271,6 @@ export const DecideContainer = ({
 				/>
 			);
 		case 'scrollable/small':
-			if (shouldShowCarouselsAsStacked) {
-				return (
-					<>
-						<Hide from="tablet">
-							<StaticMediumFour
-								trails={trails}
-								containerPalette={containerPalette}
-								showAge={showAge}
-								absoluteServerTimes={absoluteServerTimes}
-								imageLoading={imageLoading}
-								aspectRatio={aspectRatio}
-							/>
-						</Hide>
-						{/* scrollable/small is not a carousel above the tablet breakpoint */}
-						<Hide until="tablet">
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<ScrollableSmall
-									trails={trails}
-									imageLoading={imageLoading}
-									containerType={'scrollable/small'}
-									containerPalette={containerPalette}
-									showAge={showAge}
-									absoluteServerTimes={absoluteServerTimes}
-									aspectRatio={aspectRatio}
-									sectionId={sectionId}
-								/>
-							</Island>
-						</Hide>
-					</>
-				);
-			}
-
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<ScrollableSmall
@@ -324,19 +286,6 @@ export const DecideContainer = ({
 				</Island>
 			);
 		case 'scrollable/medium':
-			if (shouldShowCarouselsAsStacked) {
-				return (
-					<StaticMediumFour
-						trails={trails}
-						containerPalette={containerPalette}
-						showAge={showAge}
-						absoluteServerTimes={absoluteServerTimes}
-						imageLoading={imageLoading}
-						aspectRatio={aspectRatio}
-					/>
-				);
-			}
-
 			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<ScrollableMedium

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -105,12 +105,7 @@ const decideLeftContent = (front: Front, collection: DCRCollectionType) => {
 
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
-		config: {
-			abTests,
-			isPaidContent,
-			hasPageSkin: hasPageSkinConfig,
-			pageId,
-		},
+		config: { isPaidContent, hasPageSkin: hasPageSkinConfig, pageId },
 		editionId,
 	} = front;
 
@@ -751,11 +746,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
-									shouldShowCarouselsAsStacked={
-										pageId === 'uk' &&
-										abTests.stackedCarouselsVariant ===
-											'variant'
-									}
 								/>
 							</FrontSection>
 


### PR DESCRIPTION
## What does this change?

Removes the Stacked Carousels [AB test](https://github.com/guardian/dotcom-rendering/pull/14027).

## Why?

The test has finished.