### PR TITLE
Fix typo on looping video test

### DIFF
--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -44,7 +44,7 @@ const enhanceFront = (body: unknown): Front => {
 					data.editionId,
 				),
 				isLoopingVideoTest:
-					data.config.abTests.LoopingVideoVariant === 'variant',
+					data.config.abTests.loopingVideoVariant === 'variant',
 			}),
 		},
 		mostViewed: data.mostViewed.map((trail) => decideTrail(trail)),
@@ -89,7 +89,7 @@ const enhanceTagPage = (body: unknown): TagPage => {
 		discussionApiUrl: data.config.discussionApiUrl,
 		editionId: data.editionId,
 		isLoopingVideoTest:
-			data.config.abTests.LoopingVideoVariant === 'variant',
+			data.config.abTests.loopingVideoVariant === 'variant',
 	});
 	const speed = getSpeedFromTrails(data.contents);
 


### PR DESCRIPTION
## What does this change?
`LoopingVideo` -> `loopingVideo`

## Why?
Cases matters - the test isnt recognised as `LoopingVideo`
