### PR TITLE
Scroll to a card in a carousel when focused

### DIFF
--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -11,8 +11,8 @@ type GapSizes = { row: GapSize; column: GapSize };
 type Props = {
 	children: React.ReactNode;
 	carouselLength: number;
-	visibleCardsOnMobile: number;
-	visibleCardsOnTablet: number;
+	visibleCarouselSlidesOnMobile: number;
+	visibleCarouselSlidesOnTablet: number;
 	sectionId?: string;
 	shouldStackCards?: { desktop: boolean; mobile: boolean };
 	gapSizes?: GapSizes;
@@ -134,6 +134,9 @@ const stackedRowLeftBorderStyles = css`
 	}
 `;
 
+/**
+ * When cards are "stacked", each slide in the carousel will have two cards instead of one
+ */
 const stackedCardRowsStyles = ({
 	mobile,
 	desktop,
@@ -152,21 +155,22 @@ const stackedCardRowsStyles = ({
  * Generates CSS styles for a grid layout used in a carousel.
  *
  * @param {number} totalCards - The total number of cards in the carousel.
- * @param {number} visibleCardsOnMobile - Number of cards to show at once on mobile.
- * @param {number} visibleCardsOnTablet - Number of cards to show at once on tablet.
+ * @param {number} visibleCarouselSlidesOnMobile - Number of cards to show at once on mobile.
+ * @param {number} visibleCarouselSlidesOnTablet - Number of cards to show at once on tablet.
  * @returns {string} - The CSS styles for the grid layout.
  */
 const generateCarouselColumnStyles = (
 	totalCards: number,
-	visibleCardsOnMobile: number,
-	visibleCardsOnTablet: number,
+	visibleCarouselSlidesOnMobile: number,
+	visibleCarouselSlidesOnTablet: number,
 ) => {
 	const peepingCardWidth = space[8];
 	const cardGap = 20;
 	const offsetPeepingCardWidth =
-		peepingCardWidth / visibleCardsOnMobile + cardGap;
+		peepingCardWidth / visibleCarouselSlidesOnMobile + cardGap;
 	const offsetCardGap =
-		(cardGap * (visibleCardsOnTablet - 1)) / visibleCardsOnTablet;
+		(cardGap * (visibleCarouselSlidesOnTablet - 1)) /
+		visibleCarouselSlidesOnTablet;
 
 	return css`
 		/**
@@ -181,24 +185,28 @@ const generateCarouselColumnStyles = (
 		grid-template-columns: repeat(
 			${totalCards},
 			calc(
-				(100% / ${visibleCardsOnMobile}) - ${offsetPeepingCardWidth}px +
-					${gridGapMobile / visibleCardsOnMobile}px
+				(100% / ${visibleCarouselSlidesOnMobile}) -
+					${offsetPeepingCardWidth}px +
+					${gridGapMobile / visibleCarouselSlidesOnMobile}px
 			)
 		);
 		${from.mobileLandscape} {
 			grid-template-columns: repeat(
 				${totalCards},
 				calc(
-					(100% / ${visibleCardsOnMobile}) -
+					(100% / ${visibleCarouselSlidesOnMobile}) -
 						${offsetPeepingCardWidth}px +
-						${gridGap / visibleCardsOnMobile}px
+						${gridGap / visibleCarouselSlidesOnMobile}px
 				)
 			);
 		}
 		${from.tablet} {
 			grid-template-columns: repeat(
 				${totalCards},
-				calc(${100 / visibleCardsOnTablet}% - ${offsetCardGap}px)
+				calc(
+					(${100 / visibleCarouselSlidesOnTablet}%) -
+						${offsetCardGap}px
+				)
 			);
 		}
 	`;
@@ -221,8 +229,8 @@ const getGapSize = (gap: GapSize) => {
 export const ScrollableCarousel = ({
 	children,
 	carouselLength,
-	visibleCardsOnMobile,
-	visibleCardsOnTablet,
+	visibleCarouselSlidesOnMobile,
+	visibleCarouselSlidesOnTablet,
 	sectionId,
 	shouldStackCards = { desktop: false, mobile: false },
 	gapSizes = { column: 'large', row: 'large' },
@@ -231,7 +239,7 @@ export const ScrollableCarousel = ({
 	const [previousButtonEnabled, setPreviousButtonEnabled] = useState(false);
 	const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
 
-	const showNavigation = carouselLength > visibleCardsOnTablet;
+	const showNavigation = carouselLength > visibleCarouselSlidesOnTablet;
 
 	const scrollTo = (direction: 'left' | 'right') => {
 		if (!carouselRef.current) return;
@@ -312,8 +320,8 @@ export const ScrollableCarousel = ({
 					carouselGapStyles(columnGap, rowGap),
 					generateCarouselColumnStyles(
 						carouselLength,
-						visibleCardsOnMobile,
-						visibleCardsOnTablet,
+						visibleCarouselSlidesOnMobile,
+						visibleCarouselSlidesOnTablet,
 					),
 					stackedCardRowsStyles(shouldStackCards),
 				]}

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -34,8 +34,8 @@ export const ScrollableFeature = ({
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
-			visibleCardsOnMobile={1}
-			visibleCardsOnTablet={3}
+			visibleCarouselSlidesOnMobile={1}
+			visibleCarouselSlidesOnTablet={3}
 		>
 			{trails.map((card) => {
 				return (

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -79,7 +79,6 @@ const itemStyles = css`
 		* child so that the first card in the carousel aligns
 		* with the start of the pages content in the grid.
 		*/
-
 		${from.leftCol} {
 			padding-left: 160px; /** 160 === 2 columns and 2 column gaps  */
 		}
@@ -137,6 +136,7 @@ const nextButtonFadeStyles = css`
 		${palette('--highlights-container-end-fade')} 100%
 	);
 `;
+
 /**
  * Generates CSS styles for a grid layout used in a carousel.
  *

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -39,8 +39,8 @@ export const ScrollableMedium = ({
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}
-			visibleCardsOnMobile={2}
-			visibleCardsOnTablet={4}
+			visibleCarouselSlidesOnMobile={2}
+			visibleCarouselSlidesOnTablet={4}
 			sectionId={sectionId}
 		>
 			{trails.map((trail) => {

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -66,8 +66,8 @@ export const ScrollableSmall = ({
 	return (
 		<ScrollableCarousel
 			carouselLength={Math.ceil(trails.length / 2)}
-			visibleCardsOnMobile={1}
-			visibleCardsOnTablet={2}
+			visibleCarouselSlidesOnMobile={1}
+			visibleCarouselSlidesOnTablet={2}
 			sectionId={sectionId}
 			shouldStackCards={{ desktop: trails.length > 2, mobile: true }}
 			gapSizes={{ column: 'large', row: 'medium' }}


### PR DESCRIPTION
## What does this change?

When a card within a carousel is partially visible and gains focus, the carousel is scrolled such that the card is fully in view.

If a carousel has two slides fully visible (scrollable medium only) and the second card in a carousel is given focus, then the carousel is scrolled if needed, so that the second card is on the left.

## Why?

UX improvements

## Videos

### Before

#### Tabbing forwards

https://github.com/user-attachments/assets/38aa6fe3-5e99-43e9-a8b2-6b199d30a023

#### Tabbing backwards

https://github.com/user-attachments/assets/a9e1ee1e-f419-4c96-932c-3e766735c968

### After

#### Tabbing forwards

https://github.com/user-attachments/assets/38d021e5-9c08-4140-b7f2-75cbcf5ee71e

#### Tabbing backwards

https://github.com/user-attachments/assets/2360969e-9313-48ec-a486-82ffd49adb95


