### PR TITLE
Set if looping videos can play inline on a front

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -254,7 +254,7 @@ const getMedia = ({
 	canPlayInline?: boolean;
 	isBetaContainer: boolean;
 }) => {
-	if (mainMedia?.type === 'LoopVideo') {
+	if (mainMedia?.type === 'LoopVideo' && canPlayInline) {
 		return {
 			type: 'loop-video',
 			mainMedia,
@@ -887,18 +887,18 @@ export const Card = ({
 								/>
 							</AvatarContainer>
 						)}
-						{mainMedia?.type === 'LoopVideo' && (
+						{media.type === 'loop-video' && (
 							<Island
 								priority="feature"
 								defer={{ until: 'visible' }}
 							>
 								<LoopVideo
-									src={mainMedia.videoId}
-									height={mainMedia.height}
-									width={mainMedia.width}
-									videoId={mainMedia.videoId}
+									src={media.mainMedia.videoId}
+									height={media.mainMedia.height}
+									width={media.mainMedia.width}
+									videoId={media.mainMedia.videoId}
 									thumbnailImage={
-										mainMedia.thumbnailImage ?? ''
+										media.mainMedia.thumbnailImage ?? ''
 									}
 									fallbackImageComponent={
 										<CardPicture

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -99,6 +99,8 @@ const ImmersiveCardLayout = ({
 	imageLoading: Loading;
 	collectionId: number;
 }) => {
+	const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
+
 	return (
 		<UL padBottom={true}>
 			<LI key={card.url} padSides={true}>
@@ -113,7 +115,7 @@ const ImmersiveCardLayout = ({
 					kickerText={card.kickerText}
 					showClock={false}
 					image={card.image}
-					canPlayInline={true}
+					canPlayInline={isLoopingVideo ? false : true}
 					starRating={card.starRating}
 					dataLinkName={card.dataLinkName}
 					discussionApiUrl={card.discussionApiUrl}

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -38,6 +38,7 @@ export const ScrollableFeature = ({
 			visibleCardsOnTablet={3}
 		>
 			{trails.map((card) => {
+				const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
 				return (
 					<ScrollableCarousel.Item key={card.url}>
 						<FeatureCard
@@ -54,7 +55,7 @@ export const ScrollableFeature = ({
 							}
 							showClock={false}
 							image={card.image}
-							canPlayInline={true}
+							canPlayInline={isLoopingVideo ? false : true}
 							starRating={card.starRating}
 							dataLinkName={card.dataLinkName}
 							discussionApiUrl={card.discussionApiUrl}

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -71,6 +71,7 @@ export const ScrollableMedium = ({
 							showLivePlayable={trail.showLivePlayable}
 							showTopBarDesktop={false}
 							showTopBarMobile={false}
+							canPlayInline={false}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -33,10 +33,10 @@ export const StaticFeatureTwo = ({
 	collectionId,
 }: Props) => {
 	const cards = trails.slice(0, 2);
-
 	return (
 		<UL direction="row">
 			{cards.map((card) => {
+				const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
 				return (
 					<LI
 						stretch={false}
@@ -59,7 +59,7 @@ export const StaticFeatureTwo = ({
 							}
 							showClock={false}
 							image={card.image}
-							canPlayInline={true}
+							canPlayInline={isLoopingVideo ? false : true}
 							starRating={card.starRating}
 							dataLinkName={card.dataLinkName}
 							discussionApiUrl={card.discussionApiUrl}


### PR DESCRIPTION
## What does this change?
Make use of the canPlayInline card property to dictate if looping videos can play on a front. 

## Why?
Looped videos should only play inline on certain cards in certain containers. 

![Screenshot 2025-06-18 at 13 39 07](https://github.com/user-attachments/assets/27b42f2d-afe7-4fb8-befa-cf63b9c473b2)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/00f79d82-b971-464a-9511-4664b229c00c
[before1]: https://github.com/user-attachments/assets/844c8332-84ac-400b-9ae9-3a381ab39148
[before2]: https://github.com/user-attachments/assets/0047d48b-234a-4a6f-8f19-6444a9c0d211
[before3]: https://github.com/user-attachments/assets/4f27812a-3d68-4034-b845-68331055835b
[after2]: https://github.com/user-attachments/assets/ef76f2fd-77bf-4559-bf7e-6eab79b045f7
[after3]: https://github.com/user-attachments/assets/94acf63f-e62d-422b-bf49-468dbe3864ce
[after1]: https://github.com/user-attachments/assets/8fcd1a72-1526-4787-8183-d319ff8ce8bc
[after]: https://github.com/user-attachments/assets/4acead07-8339-48b5-80d7-3b4e12664628

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
