### PR TITLE
Setup Hide Trails AB test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -141,6 +141,7 @@ export type Props = {
 	trailTextSize?: TrailTextSize;
 	/** A kicker image is seperate to the main media and renders as part of the kicker */
 	showKickerImage?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -407,6 +408,7 @@ export const Card = ({
 	showTopBarMobile = true,
 	trailTextSize,
 	showKickerImage = false,
+	isInHideTrailsAbTest = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -1173,6 +1175,7 @@ export const Card = ({
 									trailTextSize={trailTextSize}
 									padTop={headlinePosition === 'inner'}
 									hideUntil={hideTrailTextUntil()}
+									isInHideTrailsAbTest={isInHideTrailsAbTest}
 								/>
 							)}
 

--- a/dotcom-rendering/src/components/Card/components/TrailText.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailText.tsx
@@ -4,24 +4,12 @@ import {
 	space,
 	textSans14,
 	textSans17,
+	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import { palette } from '../../../palette';
 
 export type TrailTextSize = 'regular' | 'large';
-
-type Props = {
-	trailText: string;
-	trailTextSize?: TrailTextSize;
-	/** Optionally overrides the trail text colour */
-	trailTextColour?: string;
-	/** Controls visibility of trail text on various breakpoints */
-	hideUntil?: 'tablet' | 'desktop';
-	/** Defaults to `true`. Adds padding to the bottom of the trail text */
-	padBottom?: boolean;
-	/** Adds padding to the top of the trail text */
-	padTop?: boolean;
-};
 
 const trailTextStyles = css`
 	display: flex;
@@ -46,6 +34,26 @@ const fontStyles = (trailTextSize: TrailTextSize) => css`
 	}
 `;
 
+const isInHideTrailsAbTestStyles = css`
+	${until.tablet} {
+		display: none;
+	}
+`;
+
+type Props = {
+	trailText: string;
+	trailTextSize?: TrailTextSize;
+	/** Optionally overrides the trail text colour */
+	trailTextColour?: string;
+	/** Controls visibility of trail text on various breakpoints */
+	hideUntil?: 'tablet' | 'desktop';
+	/** Defaults to `true`. Adds padding to the bottom of the trail text */
+	padBottom?: boolean;
+	/** Adds padding to the top of the trail text */
+	padTop?: boolean;
+	isInHideTrailsAbTest?: boolean;
+};
+
 export const TrailText = ({
 	trailText: text,
 	trailTextSize = 'regular',
@@ -53,6 +61,7 @@ export const TrailText = ({
 	hideUntil,
 	padBottom = true,
 	padTop = false,
+	isInHideTrailsAbTest = false,
 }: Props) => {
 	const trailText = (
 		<div
@@ -64,6 +73,7 @@ export const TrailText = ({
 				fontStyles(trailTextSize),
 				padBottom && bottomPadding,
 				padTop && topPadding,
+				isInHideTrailsAbTest && isInHideTrailsAbTestStyles,
 			]}
 		>
 			<div

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -48,6 +48,7 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export const DecideContainer = ({
@@ -63,6 +64,7 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
+	isInHideTrailsAbTest,
 }: Props) => {
 	// If you add a new container type which contains an MPU, you must also add it to
 	switch (containerType) {
@@ -255,6 +257,7 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
+					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
 		case 'flexible/general':
@@ -268,6 +271,7 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
+					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
 		case 'scrollable/small':
@@ -282,6 +286,7 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
+						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					/>
 				</Island>
 			);
@@ -297,6 +302,7 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
+						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					/>
 				</Island>
 			);
@@ -309,6 +315,7 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
+					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
 		case 'scrollable/feature':
@@ -321,6 +328,7 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						collectionId={collectionId}
+						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					/>
 				</Island>
 			);
@@ -333,6 +341,7 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
+					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
 		default:

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { Hide, SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
@@ -203,6 +203,12 @@ const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
 `;
 
+const isInHideTrailsAbTestStyles = css`
+	${until.tablet} {
+		display: none;
+	}
+`;
+
 const videoPillStyles = css`
 	position: absolute;
 	top: ${space[2]}px;
@@ -330,6 +336,7 @@ export type Props = {
 	 */
 	isImmersive?: boolean;
 	showVideo?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export const FeatureCard = ({
@@ -367,6 +374,7 @@ export const FeatureCard = ({
 	isNewsletter = false,
 	isImmersive = false,
 	showVideo = false,
+	isInHideTrailsAbTest = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -459,6 +467,9 @@ export const FeatureCard = ({
 										isImmersive={isImmersive}
 										byline={byline}
 										showByline={showByline}
+										isInHideTrailsAbTest={
+											isInHideTrailsAbTest
+										}
 									/>
 								</Island>
 							</div>
@@ -628,7 +639,13 @@ export const FeatureCard = ({
 										) : null}
 
 										{!!trailText && (
-											<div css={trailTextWrapper}>
+											<div
+												css={[
+													trailTextWrapper,
+													isInHideTrailsAbTest &&
+														isInHideTrailsAbTestStyles,
+												]}
+											>
 												<TrailText
 													trailText={trailText}
 													trailTextColour={palette(

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -32,6 +32,7 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -92,12 +93,14 @@ const ImmersiveCardLayout = ({
 	absoluteServerTimes,
 	imageLoading,
 	collectionId,
+	isInHideTrailsAbTest,
 }: {
 	card: DCRFrontCard;
 	containerPalette?: DCRContainerPalette;
 	absoluteServerTimes: boolean;
 	imageLoading: Loading;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
 
@@ -134,6 +137,7 @@ const ImmersiveCardLayout = ({
 					supportingContent={card.supportingContent}
 					isImmersive={true}
 					showVideo={card.showVideo}
+					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			</LI>
 		</UL>
@@ -229,7 +233,7 @@ const decideSplashCardProperties = (
 	}
 };
 
-export const SplashCardLayout = ({
+const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
@@ -239,6 +243,7 @@ export const SplashCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
+	isInHideTrailsAbTest,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -249,6 +254,7 @@ export const SplashCardLayout = ({
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -262,6 +268,7 @@ export const SplashCardLayout = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 		);
 	}
@@ -329,6 +336,7 @@ export const SplashCardLayout = ({
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			</LI>
 		</UL>
@@ -391,6 +399,7 @@ const FullWidthCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
+	isInHideTrailsAbTest,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -402,6 +411,7 @@ const FullWidthCardLayout = ({
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -427,6 +437,7 @@ const FullWidthCardLayout = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 		);
 	}
@@ -474,6 +485,7 @@ const FullWidthCardLayout = ({
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			</LI>
 		</UL>
@@ -491,6 +503,7 @@ const HalfWidthCardLayout = ({
 	aspectRatio,
 	isLastRow,
 	containerLevel,
+	isInHideTrailsAbTest,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -502,6 +515,7 @@ const HalfWidthCardLayout = ({
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	if (cards.length === 0) return null;
 
@@ -555,6 +569,7 @@ const HalfWidthCardLayout = ({
 							trailText={undefined}
 							headlineSizes={undefined}
 							canPlayInline={false}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</LI>
 				);
@@ -572,6 +587,7 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
+	isInHideTrailsAbTest,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1);
 	const cards = [...groupedTrails.standard].slice(0, 19);
@@ -590,6 +606,7 @@ export const FlexibleGeneral = ({
 					isLastRow={cards.length === 0}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
+					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			)}
 
@@ -608,6 +625,7 @@ export const FlexibleGeneral = ({
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
 								collectionId={collectionId}
+								isInHideTrailsAbTest={isInHideTrailsAbTest}
 							/>
 						);
 
@@ -626,6 +644,7 @@ export const FlexibleGeneral = ({
 								aspectRatio={aspectRatio}
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
+								isInHideTrailsAbTest={isInHideTrailsAbTest}
 							/>
 						);
 				}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -29,6 +29,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 };
 
 type BoostProperties = {
@@ -134,6 +135,7 @@ export const OneCardLayout = ({
 	isLastRow,
 	isFirstRow,
 	containerLevel,
+	isInHideTrailsAbTest,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -144,6 +146,7 @@ export const OneCardLayout = ({
 	isLastRow: boolean;
 	isFirstRow: boolean;
 	containerLevel: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -163,6 +166,7 @@ export const OneCardLayout = ({
 		!card.image,
 		card.showLivePlayable,
 	);
+
 	return (
 		<UL padBottom={!isLastRow} hasLargeSpacing={!isLastRow}>
 			<LI padSides={true}>
@@ -194,6 +198,7 @@ export const OneCardLayout = ({
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			</LI>
 		</UL>
@@ -221,6 +226,7 @@ const TwoCardOrFourCardLayout = ({
 	aspectRatio,
 	isFirstRow,
 	containerLevel,
+	isInHideTrailsAbTest,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
@@ -231,6 +237,7 @@ const TwoCardOrFourCardLayout = ({
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
 	containerLevel: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 }) => {
 	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
@@ -271,6 +278,7 @@ const TwoCardOrFourCardLayout = ({
 									!isMediaCard(card.format))
 							}
 							canPlayInline={false}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</LI>
 				);
@@ -287,6 +295,7 @@ export const FlexibleSpecial = ({
 	imageLoading,
 	aspectRatio,
 	containerLevel = 'Primary',
+	isInHideTrailsAbTest,
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1);
 	const splash = [...groupedTrails.standard].slice(0, 1);
@@ -304,6 +313,7 @@ export const FlexibleSpecial = ({
 				isFirstRow={true}
 				isLastRow={splash.length === 0 && cards.length === 0}
 				containerLevel={containerLevel}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 			<OneCardLayout
 				cards={splash}
@@ -315,6 +325,7 @@ export const FlexibleSpecial = ({
 				isLastRow={cards.length === 0}
 				isFirstRow={!isNonEmptyArray(snaps)}
 				containerLevel={containerLevel}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 			<TwoCardOrFourCardLayout
 				cards={cards}
@@ -325,6 +336,7 @@ export const FlexibleSpecial = ({
 				aspectRatio={aspectRatio}
 				isFirstRow={!isNonEmptyArray(snaps) && !isNonEmptyArray(splash)}
 				containerLevel={containerLevel}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -56,6 +56,7 @@ export const FrontCard = (props: Props) => {
 		slideshowImages: trail.slideshowImages,
 		showLivePlayable: trail.showLivePlayable,
 		showVideo: trail.showVideo,
+		isInHideTrailsAbTest: trail.isInHideTrailsAbTest,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -14,6 +14,7 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ export const ScrollableFeature = ({
 	imageLoading,
 	aspectRatio,
 	collectionId,
+	isInHideTrailsAbTest,
 }: Props) => {
 	return (
 		<ScrollableCarousel
@@ -78,6 +80,7 @@ export const ScrollableFeature = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -17,6 +17,7 @@ type Props = {
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
 	sectionId: string;
+	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -35,6 +36,7 @@ export const ScrollableMedium = ({
 	showAge,
 	aspectRatio,
 	sectionId,
+	isInHideTrailsAbTest,
 }: Props) => {
 	return (
 		<ScrollableCarousel
@@ -72,6 +74,7 @@ export const ScrollableMedium = ({
 							showTopBarDesktop={false}
 							showTopBarMobile={false}
 							canPlayInline={false}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -16,6 +16,7 @@ type Props = {
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
 	sectionId: string;
+	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -60,9 +61,11 @@ export const ScrollableSmall = ({
 	showAge,
 	aspectRatio,
 	sectionId,
+	isInHideTrailsAbTest,
 }: Props) => {
 	const mobileBottomCards = [1, 3];
 	const desktopBottomCards = [2, 3];
+
 	return (
 		<ScrollableCarousel
 			carouselLength={Math.ceil(trails.length / 2)}
@@ -102,6 +105,7 @@ export const ScrollableSmall = ({
 							)}
 							showTopBarMobile={mobileBottomCards.includes(index)}
 							canPlayInline={false}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -16,6 +16,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	collectionId: number;
+	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -31,6 +32,7 @@ export const StaticFeatureTwo = ({
 	imageLoading,
 	aspectRatio,
 	collectionId,
+	isInHideTrailsAbTest,
 }: Props) => {
 	const cards = trails.slice(0, 2);
 	return (
@@ -79,6 +81,7 @@ export const StaticFeatureTwo = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -32,6 +32,7 @@ type Props = {
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export const StaticMediumFour = ({
@@ -43,6 +44,7 @@ export const StaticMediumFour = ({
 	showImage = true,
 	aspectRatio,
 	containerLevel = 'Primary',
+	isInHideTrailsAbTest,
 }: Props) => {
 	const cards = trails.slice(0, 4);
 
@@ -82,6 +84,7 @@ export const StaticMediumFour = ({
 									!isMediaCard(card.format))
 							}
 							canPlayInline={false}
+							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -65,6 +65,7 @@ export type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -121,6 +122,7 @@ export const YoutubeAtom = ({
 	isImmersive,
 	byline,
 	showByline,
+	isInHideTrailsAbTest,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -269,6 +271,7 @@ export const YoutubeAtom = ({
 								isImmersive={isImmersive}
 								byline={byline}
 								showByline={showByline}
+								isInHideTrailsAbTest={isInHideTrailsAbTest}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -133,6 +133,7 @@ type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -160,6 +161,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	isImmersive,
 	byline,
 	showByline,
+	isInHideTrailsAbTest,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -244,6 +246,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 								)}
 								trailTextSize="regular"
 								padBottom={false}
+								isInHideTrailsAbTest={isInHideTrailsAbTest}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -58,6 +58,7 @@ type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export const YoutubeBlockComponent = ({
@@ -99,6 +100,7 @@ export const YoutubeBlockComponent = ({
 	isImmersive,
 	byline,
 	showByline,
+	isInHideTrailsAbTest,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -212,6 +214,7 @@ export const YoutubeBlockComponent = ({
 				isImmersive={isImmersive}
 				byline={byline}
 				showByline={showByline}
+				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -105,7 +105,12 @@ const decideLeftContent = (front: Front, collection: DCRCollectionType) => {
 
 export const FrontLayout = ({ front, NAV }: Props) => {
 	const {
-		config: { isPaidContent, hasPageSkin: hasPageSkinConfig, pageId },
+		config: {
+			abTests,
+			isPaidContent,
+			hasPageSkin: hasPageSkinConfig,
+			pageId,
+		},
 		editionId,
 	} = front;
 
@@ -746,6 +751,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
+									isInHideTrailsAbTest={
+										pageId === 'uk' &&
+										abTests.hideTrailsVariant === 'variant'
+									}
 								/>
 							</FrontSection>
 

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -102,6 +102,7 @@ export type DCRFrontCard = {
 	branding?: Branding;
 	slideshowImages?: DCRSlideshowImage[];
 	showVideo?: boolean;
+	isInHideTrailsAbTest?: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

Hide trail text on small screens when in Hide Trails AB test

Conditions:
- Must be on the UK Network Front: https://www.theguardian.com/uk
- Web only
- Small screens (<740px), i.e. smaller than tablet

Tested in CODE.

## Why?

Hypothesis: Displaying trail text shows more of the article and reduces the need to click through. Removing trail text will have a significant positive effect on click-through rate.

## Screenshots

| Before | After |
| - | - |
| ![mobile-before] | ![mobile-after] |
| ![tablet-before] | ![tablet-after] |

[mobile-before]: https://github.com/user-attachments/assets/179e8632-24ea-48d0-9476-2102156041dc
[tablet-before]: https://github.com/user-attachments/assets/165281dc-32e6-46b0-bff2-60511667b848
[mobile-after]:  https://github.com/user-attachments/assets/7998b2bc-b34a-4641-863e-731c98fa277a
[tablet-after]: https://github.com/user-attachments/assets/4232b2c8-9d56-4689-a12a-4f1cd2af4071

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
