### PR TITLE
Signed in user e2e test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,12 +26,20 @@ jobs:
     with:
       container-image: ${{ needs.container.outputs.container-image }}
 
+  playwright-secure:
+    needs: [container]
+    uses: ./.github/workflows/playwright-secure.yml
+    with:
+      container-image: ${{ needs.container.outputs.container-image }}
+    secrets:
+      IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
+
   publish:
     permissions:
       id-token: write
       contents: read
       pull-requests: write # required by riff-raff action
-    needs: [container, prettier, jest, lint, playwright]
+    needs: [container, prettier, jest, lint, playwright, playwright-secure]
     uses: ./.github/workflows/publish.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}

--- a/.github/workflows/playwright-secure.yml
+++ b/.github/workflows/playwright-secure.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   playwright-secure:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright-secure.yml
+++ b/.github/workflows/playwright-secure.yml
@@ -1,0 +1,99 @@
+on:
+  workflow_call:
+    secrets:
+      IDAPI_CLIENT_ACCESS_TOKEN:
+        required: true
+    inputs:
+      container-image:
+        description: 'Image used by DCR service'
+        required: true
+        type: string
+
+jobs:
+  playwright-secure:
+    runs-on: ubuntu-latest
+    services:
+      DCR:
+        image: ${{ inputs.container-image }}
+        ports:
+          - 9000:9000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node environment
+        uses: ./.github/actions/setup-node-env
+
+      - name: Set up nginx secure server
+        run: |
+          # Turn off mandb updates
+          sudo mv /usr/bin/mandb /usr/bin/mandb-OFF
+          sudo cp -p /bin/true /usr/bin/mandb
+          # Update dependencies
+          sudo apt-get update -y
+          # Install libnss3-tools
+          sudo apt-get install -y libnss3-tools
+          # Install mkcert
+          wget -q https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64
+          sudo cp mkcert-v1.4.3-linux-amd64 /usr/local/bin/mkcert
+          sudo chmod +x /usr/local/bin/mkcert
+          # Install dev-nginx
+          wget -q https://github.com/guardian/dev-nginx/releases/latest/download/dev-nginx.tar.gz
+          sudo mkdir -p /usr/local/bin/dev-nginx
+          sudo tar -xzf dev-nginx.tar.gz -C /usr/local
+          sudo chmod +x /usr/local/bin/dev-nginx
+          # Create https://r.thegulocal.com to proxy to locahost:9000
+          sudo ./dotcom-rendering/scripts/nginx/setup-ci.sh
+          # Move the dotcom-rendering nginx config to the right place for GitHub runners and restart nginx
+          sudo cp /etc/nginx/servers/dotcom-rendering.conf /etc/nginx/conf.d/dotcom-rendering.conf
+          sudo dev-nginx restart-nginx
+
+      - name: Check local server
+        run: |
+          STATUS=$(curl -o /dev/null -s -w "%{http_code}" -k http://localhost:9000)
+          echo "HTTP Status: $STATUS"
+          if [ "$STATUS" -eq 200 ]; then
+            echo "Local server is reachable with status 200"
+          else
+            echo "Local server is not reachable. Status: $STATUS"
+            exit 1
+          fi
+
+      - name: Check secure server
+        run: |
+          STATUS=$(curl -o /dev/null -s -w "%{http_code}" -k https://r.thegulocal.com)
+          echo "HTTPS Status: $STATUS"
+          if [ "$STATUS" -eq 200 ]; then
+            echo "Secure server is reachable with status 200"
+          else
+            echo "Secure server is not reachable. Status: $STATUS"
+            exit 1
+          fi
+
+      - name: Check IDAPI_CLIENT_ACCESS_TOKEN is set
+        run: |
+          if [ -z "$IDAPI_CLIENT_ACCESS_TOKEN" ]; then
+            echo "IDAPI_CLIENT_ACCESS_TOKEN is empty or undefined"
+          else
+            echo "IDAPI_CLIENT_ACCESS_TOKEN is defined"
+          fi
+        env:
+          IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
+
+      - name: Install Playwright Browsers
+        run: pnpm playwright install --with-deps chromium
+        working-directory: ./dotcom-rendering
+
+      - name: Run Playwright
+        run: pnpm playwright test e2e.secure.spec.ts
+        working-directory: ./dotcom-rendering
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+          IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-secure
+          path: ./dotcom-rendering/playwright-report
+          retention-days: 5

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   playwright:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # keep aligned with the number of shards used by `playwright test`
+        # keep aligned with --shard parameter below
         group: [1, 2, 3, 4, 5, 6, 7, 8]
     services:
       DCR:
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./dotcom-rendering
 
       - name: Run Playwright
-        run: pnpm playwright test --shard=${{ matrix.group }}/8
+        run: pnpm playwright test e2e.spec.ts --shard=${{ matrix.group }}/8
         working-directory: ./dotcom-rendering
         env:
           NODE_ENV: production

--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const isDev = process.env.NODE_ENV !== 'production';
-/**
- * The server port for local development or CI
- */
+export const isCI = !!process.env.CI;
+export const isDev = !isCI;
 export const PORT = isDev ? 3030 : 9000;
+export const ORIGIN = `http://localhost:${PORT}`;
+export const ORIGIN_SECURE = `https://r.thegulocal.com`;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -30,6 +30,7 @@ export default defineConfig({
 		video: {
 			mode: 'retain-on-failure',
 		},
+		ignoreHTTPSErrors: true,
 	},
 	// Configure projects for major browsers
 	projects: [
@@ -41,7 +42,7 @@ export default defineConfig({
 	webServer: {
 		// On CI the server is already started so a no-op
 		command: isDev ? 'make dev' : ':',
-		url: `http://localhost:${PORT}`,
+		url: ORIGIN,
 		reuseExistingServer: true,
 		stdout: 'pipe',
 		stderr: 'pipe',

--- a/dotcom-rendering/playwright/lib/secure-server.ts
+++ b/dotcom-rendering/playwright/lib/secure-server.ts
@@ -1,0 +1,16 @@
+import { ORIGIN_SECURE } from '../../playwright.config';
+
+const isSecureServerAvailable = async (): Promise<boolean> => {
+	try {
+		const response = await fetch(ORIGIN_SECURE, {
+			method: 'HEAD',
+		});
+		return response.status === 200;
+	} catch (error) {
+		// eslint-disable-next-line no-console -- test code
+		console.error('Error in isSecureServerAvailable:', error);
+		return false;
+	}
+};
+
+export { isSecureServerAvailable };

--- a/dotcom-rendering/playwright/lib/sign-in.ts
+++ b/dotcom-rendering/playwright/lib/sign-in.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'node:crypto';
+import type { BrowserContext, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { cmpAcceptAll } from './cmp';
+import { loadPage } from './load-page';
+import { expectToExist } from './locators';
+
+type IDAPITestUserOptions = {
+	primaryEmailAddress?: `${string}@theguardian.com`;
+	isUserEmailValidated?: boolean;
+	socialLinks?: Array<{
+		socialId: number;
+		network: 'facebook' | 'apple' | 'google';
+	}>;
+	password?: string;
+	deleteAfterMinute?: boolean;
+	isGuestUser?: boolean;
+	doNotSetUsername?: boolean;
+};
+
+type IDAPITestUserResponse = [
+	{
+		key: 'GU_U';
+		value: string;
+	},
+	{
+		key: 'SC_GU_LA';
+		sessionCookie: boolean;
+		value: string;
+	},
+	{
+		key: 'SC_GU_U';
+		value: string;
+	},
+];
+
+type IDAPITestUser = {
+	email: string;
+	cookies: IDAPITestUserResponse;
+	password: string;
+};
+
+const createTestUser = async (): Promise<IDAPITestUser> => {
+	try {
+		if (!process.env.IDAPI_CLIENT_ACCESS_TOKEN) {
+			throw new Error(
+				'IDAPI_CLIENT_ACCESS_TOKEN environment variable is not set',
+			);
+		}
+		const email = `dcr-e2e-${randomUUID()}@theguardian.com`;
+		const password = randomUUID();
+		const response = await fetch(
+			'https://idapi.code.dev-theguardian.com/user/test',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-GU-ID-Client-Access-Token': `Bearer ${process.env.IDAPI_CLIENT_ACCESS_TOKEN}`,
+				},
+				body: JSON.stringify({
+					primaryEmailAddress: email,
+					isUserEmailValidated: true,
+					socialLinks: [],
+					password,
+					deleteAfterMinute: true,
+					isGuestUser: false,
+					doNotSetUsername: false,
+				} as IDAPITestUserOptions),
+			},
+		);
+
+		if (!response.ok) {
+			throw new Error(
+				`Failed to create IDAPI test user: ${response.statusText}`,
+			);
+		}
+
+		const responseBody = (await response.json()) as {
+			values: IDAPITestUserResponse;
+		};
+
+		return {
+			email,
+			cookies: responseBody.values,
+			password,
+		};
+	} catch (error) {
+		throw new Error(`Failed to create IDAPI test user: ${String(error)}`);
+	}
+};
+
+const signIn = async (
+	page: Page,
+	context: BrowserContext,
+	path: string,
+): Promise<void> => {
+	// load the page and CMP accept all
+	await loadPage({
+		page,
+		path,
+		useSecure: true,
+		waitUntil: 'load',
+	});
+	await cmpAcceptAll(page);
+
+	// create a test user in the CODE environment
+	await page.goto('https://profile.code.dev-theguardian.com', {
+		waitUntil: 'load',
+	});
+
+	await page.click('text="Sign in"');
+	await page.waitForLoadState('load');
+	await expectToExist(page, 'a:text("Sign in with a password instead")');
+
+	const { email, password } = await createTestUser();
+	await page.fill('input[name=email]', email);
+	await page.click('a:text("Sign in with a password instead")');
+
+	await page.waitForLoadState('load');
+	await expectToExist(page, '[data-cy="main-form-submit-button"]');
+	await page.fill('input[name=password]', password);
+	await page.click('[data-cy="main-form-submit-button"]');
+
+	// wait for the redirect to CODE domain
+	// in CI this will redirect to /us so use a glob pattern
+	await page.waitForURL('https://m.code.dev-theguardian.com/**', {
+		waitUntil: 'domcontentloaded',
+	});
+
+	// create the GU_U cookie to simulate a signed-in user
+	await context.addCookies([
+		{
+			name: 'GU_U',
+			value: 'true',
+			expires: Math.floor(Date.now() / 1000) + 60 * 60 * 24, // unix timestamp 1 year from now
+			domain: 'r.thegulocal.com',
+			path: '/',
+		},
+	]);
+
+	// navigate back to the original path
+	await loadPage({
+		page,
+		path,
+		useSecure: true,
+		waitUntil: 'load',
+	});
+};
+
+const expectToBeSignedIn = async (page: Page): Promise<void> => {
+	await expect(
+		page
+			.locator(`gu-island[name="TopBar"]`)
+			.first()
+			.getByText('My account'),
+	).toBeVisible();
+};
+
+export { createTestUser, expectToBeSignedIn, signIn };

--- a/dotcom-rendering/playwright/tests/signed-in.e2e.secure.spec.ts
+++ b/dotcom-rendering/playwright/tests/signed-in.e2e.secure.spec.ts
@@ -1,0 +1,26 @@
+import { test } from '@playwright/test';
+import { isSecureServerAvailable } from '../lib/secure-server';
+import { expectToBeSignedIn, signIn } from '../lib/sign-in';
+
+test.describe('Signed in readers', () => {
+	test('should sign in a user and display account details', async ({
+		context,
+		page,
+	}) => {
+		const path =
+			'/Article/https://www.theguardian.com/commentisfree/2025/jan/14/bradford-radical-culture-city-of-culture-bronte';
+		const secureServerAvailable = await isSecureServerAvailable();
+
+		if (secureServerAvailable) {
+			// eslint-disable-next-line no-console -- e2e test
+			console.log('Secure server is available, running sign-in test');
+			await signIn(page, context, path);
+			await expectToBeSignedIn(page);
+		} else {
+			// eslint-disable-next-line no-console -- e2e test
+			console.log(
+				'Secure server is not available, skipping sign-in test',
+			);
+		}
+	});
+});

--- a/dotcom-rendering/playwright/tests/signed-out.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/signed-out.e2e.spec.ts
@@ -4,13 +4,21 @@ import { disableCMP } from '../lib/cmp';
 import { waitForIsland } from '../lib/islands';
 import { loadPageWithOverrides } from '../lib/load-page';
 
-test.describe('Signed in readers', () => {
-	test('should not display signed in texts when users are not signed in', async ({
+test.describe('Signed out readers', () => {
+	test('should not display signed in text when users are not signed in', async ({
 		context,
 		page,
 	}) => {
 		await disableCMP(context);
 		await loadPageWithOverrides(page, standardArticle);
+
+		await waitForIsland(page, 'TopBar');
+		// Check that the top bar is showing the reader as signed out
+		const signInText = await page
+			.locator('[data-testid="topbar-signin"]')
+			.textContent();
+
+		expect(signInText).toContain('Sign in');
 
 		await waitForIsland(page, 'DiscussionWeb');
 

--- a/dotcom-rendering/scripts/nginx/nginx-mappings-ci.yaml
+++ b/dotcom-rendering/scripts/nginx/nginx-mappings-ci.yaml
@@ -1,0 +1,5 @@
+name: dotcom-rendering
+domain-root: thegulocal.com
+mappings:
+  - prefix: r
+    port: 9000

--- a/dotcom-rendering/scripts/nginx/setup-ci.sh
+++ b/dotcom-rendering/scripts/nginx/setup-ci.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+dev-nginx setup-app ${DIR}/nginx-mappings-ci.yaml
+echo "🌎 Successfully installed CI config. https://r.thegulocal.com is now setup."

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -5,9 +5,11 @@
  */
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
-	const isLocalHost = window.location.hostname === 'localhost';
+	const isDevHost = ['localhost', 'r.thegulocal.com'].includes(
+		window.location.hostname,
+	);
 	// Use relative path if running locally or in CI
-	return isDev || isLocalHost
+	return isDev || isDevHost
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -146,6 +146,7 @@ const SignIn = ({ idUrl }: { idUrl: string }) => (
 			'guardian_signin_header',
 		)}`}
 		data-link-name={nestedOphanComponents('header', 'topbar', 'signin')}
+		data-testid="topbar-signin"
 	>
 		<ProfileIcon /> Sign in
 	</a>

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -116,11 +116,14 @@ export const createGuardian = ({
 	 */
 	unknownConfig?: ConfigType | object;
 }): Guardian => {
+	const isProd =
+		process.env.NODE_ENV === 'production' &&
+		process.env.GU_STAGE === 'PROD';
 	return {
 		config: {
 			// This indicates to the client side code that we are running a dotcom-rendering rendered page.
 			isDotcomRendering: true,
-			isDev: process.env.NODE_ENV !== 'production',
+			isDev: !isProd,
 			stage,
 			frontendAssetsFullURL,
 			page: Object.assign(unknownConfig, {

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -115,7 +115,7 @@ renderer.get('/FootballMatchListPage/*', handleFootballMatchListPage);
 renderer.get('/FootballTablesPage/*', handleFootballTablesPage);
 renderer.get('/CricketMatchPage/*', handleCricketMatchPage);
 renderer.get('/FootballMatchSummaryPage/*', handleFootballMatchPage);
-// POST routes for running frontend locally
+// POST routes for running frontend and e2e tests locally
 renderer.post('/Article', handleArticle);
 renderer.post('/ArticleJson', handleArticleJson);
 renderer.post('/AMPArticle', handleAMPArticle);


### PR DESCRIPTION
## What does this change?

Adds the capability to:

- e2e test signed in behaviour
- setups a secure server on CI to allow e2e tests for any features that require a secure server (e.g. YouTube)

The flow for signing in a user is as follows:

- creates a test user via the IDAPI CODE endpoint
    - requires the secret `IDAPI_CLIENT_ACCESS_TOKEN`
- signs into the CODE environment using the test credentials
- sets the `GU_U` cookie
- relies on third party cookies as per the [detailed-setup-guide.md](https://github.com/guardian/dotcom-rendering/blob/6a4f5eea64e4baca3f237a0ca3496f3b42894467/dotcom-rendering/docs/contributing/detailed-setup-guide.md?plain=1#L80)

The sign-in flow requires DCR to be run on a known secure server, hence this change also adds setup on CI for the server `https://r.gulocal.com`.

Regular e2e tests and secure tests are distinguished by the test filename postfix of:

- regular: *.e2e.spec.ts
- secure: *.e2e.secure.spec.ts

The above file patterns are used as filters for the the workflows `playwright.yml` and `playwright-secure.yml`

## Why?

Since the move to Okta we have lost the ability to test sign-in flows.

This change restores that capability.

## Notes

This test introduces a dependency on CODE infrastructure which we need to monitor. Identity's e2e tests also rely on the same CODE endpoints so there is some existing load but DCR's tests will increase the request volume to that endpoint.

We'll need to monitor this test for any flakiness.

If the complexity of maintaining this test outweighs its usefulness then we can revert.

## Screenshots

https://github.com/user-attachments/assets/f234d370-29f2-4f1d-bfa7-b1c6a30d4f74

