### PR TITLE
Change support reminder text input to email input to take advantage of the client validation

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedOut.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicReminderSignedOut.tsx
@@ -175,6 +175,8 @@ export const ContributionsEpicReminderSignedOut: ReactComponent<
 							<div css={formWrapper}>
 								<div css={inputWrapper}>
 									<TextInput
+										type="email"
+										name="email"
 										label="Email address"
 										error={inputError}
 										value={email}


### PR DESCRIPTION
## What does this change?

This tiny fix will help to ensure the reader receives notification of an invalid email address before it hits our validation where it will fail anyway without the reader knowing.

## Why?

We have found a significant number of email addresses we receive as support reminder requests are failing validation and end up on the DLQ where we can only delete them.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="529" alt="Screenshot 2025-06-19 at 11 54 18" src="https://github.com/user-attachments/assets/bb635e81-f631-401b-8c34-c954476c93ed" /> | <img width="735" alt="Screenshot 2025-06-19 at 11 53 05" src="https://github.com/user-attachments/assets/324aac47-5bf1-4a35-abd3-f173e3d2b240" /> |
| <img width="558" alt="Screenshot 2025-06-19 at 11 53 57" src="https://github.com/user-attachments/assets/70e52bc2-aad2-4831-bf08-5e2b565e4836" /> | <img width="751" alt="Screenshot 2025-06-19 at 11 53 41" src="https://github.com/user-attachments/assets/d49e7fc0-5742-4fec-a3cb-c709e57f3eb9" /> |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
