### PR TITLE
Rejig interactives `disableArticleSwipe` implementation

### DIFF
--- a/dotcom-rendering/src/components/InteractivesDisableArticleSwipe.importable.tsx
+++ b/dotcom-rendering/src/components/InteractivesDisableArticleSwipe.importable.tsx
@@ -7,26 +7,16 @@ export const InteractivesDisableArticleSwipe = () => {
 		getInteractionClient()
 			.disableArticleSwipe(true)
 			.catch((error) => {
-				log('dotcom', 'disableArticleSwipe(true) failed', error);
-			});
-	};
-
-	const onTouchEnd = () => {
-		getInteractionClient()
-			.disableArticleSwipe(false)
-			.catch((error) => {
-				log('dotcom', 'disableArticleSwipe(false) failed', error);
+				log('dotcom', 'disableArticleSwipe failed', error);
 			});
 	};
 	useEffect(() => {
 		document.addEventListener('touchstart', onTouchStart, {
 			passive: true,
 		});
-		document.addEventListener('touchend', onTouchEnd, { passive: true });
 
 		return () => {
 			document.removeEventListener('touchstart', onTouchStart);
-			document.removeEventListener('touchend', onTouchEnd);
 		};
 	}, []);
 	return null;

--- a/dotcom-rendering/src/components/InteractivesDisableArticleSwipe.importable.tsx
+++ b/dotcom-rendering/src/components/InteractivesDisableArticleSwipe.importable.tsx
@@ -3,12 +3,31 @@ import { useEffect } from 'react';
 import { getInteractionClient } from '../lib/bridgetApi';
 
 export const InteractivesDisableArticleSwipe = () => {
-	useEffect(() => {
-		void getInteractionClient()
+	const onTouchStart = () => {
+		getInteractionClient()
 			.disableArticleSwipe(true)
 			.catch((error) => {
-				log('dotcom', 'disableArticleSwipe failed:', error);
+				log('dotcom', 'disableArticleSwipe(true) failed', error);
 			});
+	};
+
+	const onTouchEnd = () => {
+		getInteractionClient()
+			.disableArticleSwipe(false)
+			.catch((error) => {
+				log('dotcom', 'disableArticleSwipe(false) failed', error);
+			});
+	};
+	useEffect(() => {
+		document.addEventListener('touchstart', onTouchStart, {
+			passive: true,
+		});
+		document.addEventListener('touchend', onTouchEnd, { passive: true });
+
+		return () => {
+			document.removeEventListener('touchstart', onTouchStart);
+			document.removeEventListener('touchend', onTouchEnd);
+		};
 	}, []);
 	return null;
 };


### PR DESCRIPTION
This adjusts the what was implemented in #14111 to be more akin to other uses of the same function i.e. having `onTouchStart` and `onTouchEnd` events run constantly.

Documentation over in the Android app suggests that the Bridget function only locks the _next_ swipe event. That being the case it needs to run on every interaction rather than once when the page loads. 

Now I think of it this is also safer in the sense that if someone were to interact with a carousel on an interactives article, with the prior approach it would then be left turned on!