### PR TITLE
Reorder media atom preference

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -317,8 +317,8 @@ export const enhanceCards = (
 			isLoopingVideoTest,
 			faciaCard.properties.showMainVideo ??
 				faciaCard.properties.mediaSelect?.showMainVideo,
-			faciaCard.mediaAtom ??
-				faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
+			faciaCard.properties.maybeContent?.elements.mainMediaAtom ??
+				faciaCard.mediaAtom ??
 				faciaCard.properties.maybeContent?.elements.mediaAtoms[0],
 			faciaCard.card.galleryCount,
 			faciaCard.card.audioDuration,


### PR DESCRIPTION
## What does this change?
Reorders the preference for media atoms to the following
1. faciaCard.properties.maybeContent?.elements.mainMediaAtom
2. faciaCard.mediaAtom 
3. faciaCard.properties.maybeContent?.elements.mediaAtoms[0]

## Why?
Previously, it was selecting from mediaAtom first which might *not* the main media video eg on https://m.code.dev-theguardian.com/world/live/2025/jun/22/israel-iran-war-live-trump-says-us-has-attacked-nuclear-sites-in-iran-including-fordow. 

faciaCard.properties.maybeContent?.elements.mainMediaAtom is the current implementation of media atom selection and should always come first. However, if DCR is serving an front that was pressed before this field existed, we need to look on mediaAtom or mediaAtoms instead for backwards compatibility. 

This is because we do not repress fronts when we make changes to the pressed model.  


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/9ee3d916-b322-49ea-858a-78bbec831203
[after]: https://github.com/user-attachments/assets/427b268a-b970-440c-8936-9d5010944729

<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
