### PR TITLE
Remove the trail that has branding from trail list if user is ad free

### DIFF
--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -19,6 +19,7 @@ type Props = {
 	discussionApiUrl: string;
 	absoluteServerTimes: boolean;
 	renderingTarget: RenderingTarget;
+	isAdFreeUser: boolean;
 };
 
 type OnwardsResponse = {
@@ -32,6 +33,20 @@ const minHeight = css`
 	min-height: 300px;
 `;
 
+const isTrailPaidContent = (trailType: FETrailType) =>
+	trailType.branding?.brandingType?.name === 'paid-content';
+
+const buildTrails = (
+	trails: FETrailType[],
+	trailLimit: number,
+	isAdFreeUser: boolean,
+): TrailType[] => {
+	return trails
+		.filter((trailType) => !(isTrailPaidContent(trailType) && isAdFreeUser))
+		.slice(0, trailLimit)
+		.map(decideTrail);
+};
+
 export const FetchOnwardsData = ({
 	url,
 	limit,
@@ -40,15 +55,9 @@ export const FetchOnwardsData = ({
 	discussionApiUrl,
 	absoluteServerTimes,
 	renderingTarget,
+	isAdFreeUser,
 }: Props) => {
 	const { data, error } = useApi<OnwardsResponse>(url);
-
-	const buildTrails = (
-		trails: FETrailType[],
-		trailLimit: number,
-	): TrailType[] => {
-		return trails.slice(0, trailLimit).map(decideTrail);
-	};
 
 	if (error) {
 		// Send the error to Sentry and then prevent the element from rendering
@@ -76,7 +85,7 @@ export const FetchOnwardsData = ({
 		<div css={minHeight}>
 			<Carousel
 				heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
-				trails={buildTrails(data.trails, limit)}
+				trails={buildTrails(data.trails, limit, isAdFreeUser)}
 				description={data.description}
 				onwardsSource={onwardsSource}
 				format={format}

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -318,6 +318,7 @@ export const OnwardsUpper = ({
 						discussionApiUrl={discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						isAdFreeUser={isAdFreeUser}
 					/>
 				</Section>
 			)}
@@ -334,6 +335,7 @@ export const OnwardsUpper = ({
 						discussionApiUrl={discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						isAdFreeUser={isAdFreeUser}
 					/>
 				</Section>
 			)}


### PR DESCRIPTION
Paired with: @arelra 
## What does this change?
It was reported that the onwards carousels are showing the branded card while the logged in user is ad free. This PR removes the card from the tails in this situation 
## Why?

## Screenshots
In both screenshots user has subscription and is logged in.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3f4a7878-0451-461e-b1b4-ca711300466e
[after]: https://github.com/user-attachments/assets/88b22258-16cc-4699-9e98-c19f370a6a95
