### PR TITLE
Update Loop Video stories

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -19,10 +19,10 @@ export default {
 export const Default = {
 	name: 'Default',
 	args: {
-		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
+		src: 'https://uploads.guim.co.uk/2025%2F06%2F20%2Ftesting+only%2C+please+ignore--3cb22b60-2c3f-48d6-8bce-38c956907cce-3.mp4',
 		videoId: 'test-video-1',
-		height: 1080,
-		width: 1920,
+		height: 720,
+		width: 900,
 		thumbnailImage:
 			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
 		fallbackImageComponent: (
@@ -35,20 +35,13 @@ export const Default = {
 	},
 } satisfies StoryObj<typeof LoopVideo>;
 
-export const WithWebmFile = {
-	name: 'With Webm File',
+export const Without5to4Ratio = {
+	name: 'Without 5:4 aspect ratio',
 	args: {
 		...Default.args,
-		height: 496,
-		width: 620,
-		src: 'https://interactive.guim.co.uk/atoms/2023/01/2025-trump-100-days/assets/v/1746020259/videos/header-video.webm',
-	},
-} satisfies StoryObj<typeof LoopVideo>;
 
-export const WithoutAudio = {
-	name: 'Without Audio',
-	args: {
-		...Default.args,
-		hasAudio: false,
+		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
+		height: 1080,
+		width: 1920,
 	},
 } satisfies StoryObj<typeof LoopVideo>;


### PR DESCRIPTION
## What does this change?

- Make default Loop Video story 5:4 aspect ratio.
- Remove `WithWebmFile` and `WithoutAudio` stories, as they are not currently relevant: we don't have an audio flag in the data and we currently only send mp4 files.
- Add `Without5to4Ratio` story. We don't check that this requirement is filled so we should make sure we handle the use case gracefully.

## Why?

This is the aspect ratio we expect all looping videos to be, for now.

