### PR TITLE
feat: Update load balancer access logs prefix

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -1061,7 +1061,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/frontend/article-rendering/PROD",
+            "Value": "application-load-balancer/PROD/frontend/article-rendering",
           },
           {
             "Key": "idle_timeout.timeout_seconds",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -210,7 +210,8 @@ export class RenderingCDKStack extends CDKStack {
 			},
 			accessLogging: {
 				enabled: true,
-				prefix: `ELBLogs/${guStack}/${guApp}/${stage}`,
+				// This is the prefix pattern DevX assume so that the logs can be shown on the Availability dashboard.
+				prefix: `application-load-balancer/${stage}/${guStack}/${guApp}`,
 			},
 			applicationLogging: {
 				enabled: true,


### PR DESCRIPTION
## What does this change?
Updates the prefix used when shipping load balancer access logs to S3. This is the prefix pattern DevX assume so that the logs can be shown on the [Availability dashboard](https://metrics.gutools.co.uk/d/zM0ouzs4z/availability-dashboard). Note, this is part of an [ongoing spike](https://docs.google.com/document/d/1fjxhWG9x_BOE0KAoC-ApWUTx8PnV0q5XgtOYb6uA9nU/edit?tab=t.0).

See also https://github.com/guardian/aws-account-setup/pull/351.
