### PR TITLE
Parity rendering for DCAR immersives across web/apps

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -39,13 +39,26 @@ const DecideLayoutApps = ({ article, format, renderingTarget }: AppProps) => {
 	const notSupported = <pre>Not supported</pre>;
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
-			return (
-				<ImmersiveLayout
-					article={article}
-					format={format}
-					renderingTarget={renderingTarget}
-				/>
-			);
+			switch (format.design) {
+				case ArticleDesign.Interactive: {
+					return (
+						<FullPageInteractiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+				}
+				default: {
+					return (
+						<ImmersiveLayout
+							article={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+				}
+			}
 		}
 		case ArticleDisplay.NumberedList:
 		case ArticleDisplay.Showcase: {
@@ -153,10 +166,6 @@ const DecideLayoutWeb = ({
 		case ArticleDisplay.Immersive: {
 			switch (format.design) {
 				case ArticleDesign.Interactive: {
-					// Render all 'immersive interactives' until switchover date as 'FullPageInteractive'
-					// TBD: After 'immersive interactive' changes to CAPI are merged, add logic here to either use
-					// 'InteractiveImmersiveLayout' if published after switchover date, or 'FullPageInteractiveLayout'
-					// if published before.
 					return (
 						<FullPageInteractiveLayout
 							article={article}


### PR DESCRIPTION
This rejigs `DecideLayout.tsx` for proper parity between immersive articles on the web and in apps for DCAR. It came up in testing that the same pieces were going down different paths and so rendering in unexpected ways.