### PR TITLE
Fix choice card width from desktop

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/ThreeTierChoiceCardsV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/ThreeTierChoiceCardsV2.tsx
@@ -87,6 +87,7 @@ const styles = {
 	container: css`
 		display: flex;
 		gap: ${space[5]}px;
+		background-color: inherit;
 	`,
 
 	choiceCardStyles: css`

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -747,14 +747,14 @@ const styles = {
 		}
 		${from.desktop} {
 			justify-self: end;
-			width: minmax(299px, 380px);
+			width: 299px;
 		}
 		${between.desktop.and.wide} {
-			width: minmax(380px, 495px);
+			width: 380px;
 		}
 		${from.wide} {
-			max-width: 485px;
 			align-self: start;
+			width: 380px;
 		}
 	`,
 	guardianLogoContainer: css`

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -746,11 +746,11 @@ const styles = {
 			max-width: ${phabletContentMaxWidth};
 		}
 		${from.desktop} {
-			margin: 0 ${space[3]}px;
 			justify-self: end;
+			width: minmax(299px, 380px);
 		}
 		${between.desktop.and.wide} {
-			max-width: 380px;
+			width: minmax(380px, 495px);
 		}
 		${from.wide} {
 			max-width: 485px;
@@ -813,6 +813,8 @@ const styles = {
 			margin-bottom: ${space[6]}px;
 			gap: 0;
 			margin-top: ${space[3]}px;
+			margin-right: 0;
+			margin-left: 0;
 
 			a {
 				width: 100%;
@@ -822,6 +824,15 @@ const styles = {
 				width: auto;
 			}
 		}
+		/*
+		${from.leftCol} {
+			width: 299px;
+		}
+
+		${from.wide} {
+			width: 381px;
+		}
+*/
 	`,
 	linkButtonStyles: css`
 		background-color: ${palette.brandAlt[400]};

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBannerV2.tsx
@@ -824,15 +824,6 @@ const styles = {
 				width: auto;
 			}
 		}
-		/*
-		${from.leftCol} {
-			width: 299px;
-		}
-
-		${from.wide} {
-			width: 381px;
-		}
-*/
 	`,
 	linkButtonStyles: css`
 		background-color: ${palette.brandAlt[400]};


### PR DESCRIPTION
## What does this change?

This sets a minimum width of choice cards from desktop and removes unnecessary margin.

## Why?

The choice card width from desktop was too narrow, causing issues with the pill overlapping the card heading copy slightly.  

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1886" alt="Screenshot 2025-06-25 at 12 14 08" src="https://github.com/user-attachments/assets/a75b637c-7a5e-4d72-aa7e-d831567c1ad0" /> | <img width="1884" alt="Screenshot 2025-06-25 at 12 14 23" src="https://github.com/user-attachments/assets/62ea5912-4f0f-4033-99f8-e308820a17ae" /> |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
