### PR TITLE
Resume looping video when re-enters viewport

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -95,6 +95,7 @@ export const LoopVideo = ({
 		if (isNoLongerInView) {
 			setPlayerState('PAUSED_BY_INTERSECTION_OBSERVER');
 			void vidRef.current.pause();
+			setIsMuted(true);
 		}
 
 		// If a user action paused the video, they have indicated
@@ -104,6 +105,7 @@ export const LoopVideo = ({
 			playerState === 'PAUSED_BY_INTERSECTION_OBSERVER' && isInView;
 		if (isBackInView) {
 			setPlayerState('PLAYING');
+
 			void vidRef.current.play();
 		}
 	}, [isInView, hasBeenInView, playerState]);

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -58,9 +58,6 @@ export const LoopVideo = ({
 		if (!vidRef.current) return;
 
 		if (isInView) {
-			// We only autoplay the first time the video comes into view.
-			if (hasBeenInView) return;
-
 			if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
 				setPrefersReducedMotion(true);
 				return;

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -15,6 +15,7 @@ const videoStyles = (width: number, height: number) => css`
 	cursor: pointer;
 	/* Prevents CLS by letting the browser know the space the video will take up. */
 	aspect-ratio: ${width} / ${height};
+	object-fit: cover;
 `;
 
 const playIconStyles = css`

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -20,6 +20,7 @@ const videoStyles = (width: number, height: number) => css`
 
 const playIconStyles = css`
 	position: absolute;
+	/* Center the icon */
 	top: calc(50% - ${narrowPlayIconWidth / 2}px);
 	left: calc(50% - ${narrowPlayIconWidth / 2}px);
 	cursor: pointer;
@@ -50,17 +51,23 @@ const audioIconContainerStyles = css`
 	border: 1px solid ${palette('--loop-video-audio-icon-border')};
 `;
 
+export const PLAYER_STATES = [
+	'NOT_STARTED',
+	'PLAYING',
+	'PAUSED_BY_USER',
+	'PAUSED_BY_INTERSECTION_OBSERVER',
+] as const;
+
 type Props = {
 	src: string;
 	videoId: string;
 	width: number;
 	height: number;
-	hasAudio: boolean;
 	fallbackImageComponent: JSX.Element;
 	isPlayable: boolean;
 	setIsPlayable: Dispatch<SetStateAction<boolean>>;
-	isPlaying: boolean;
-	setIsPlaying: Dispatch<SetStateAction<boolean>>;
+	playerState: (typeof PLAYER_STATES)[number];
+	setPlayerState: Dispatch<SetStateAction<(typeof PLAYER_STATES)[number]>>;
 	currentTime: number;
 	setCurrentTime: Dispatch<SetStateAction<number>>;
 	isMuted: boolean;
@@ -69,12 +76,9 @@ type Props = {
 	handleKeyDown: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
-	/**
-	 * We ONLY show a thumbnail image when the user has indicated that they do
-	 * not want videos to play automatically, e.g. prefers reduced motion. Otherwise,
-	 * we do not bother downloading the image, as the video will be autoplayed.
-	 */
-	thumbnailImage?: string;
+	posterImage?: string;
+	shouldPreload: boolean;
+	showPlayIcon: boolean;
 };
 
 /**
@@ -88,13 +92,12 @@ export const LoopVideoPlayer = forwardRef(
 			videoId,
 			width,
 			height,
-			hasAudio,
 			fallbackImageComponent,
-			thumbnailImage,
+			posterImage,
 			isPlayable,
 			setIsPlayable,
-			isPlaying,
-			setIsPlaying,
+			playerState,
+			setPlayerState,
 			currentTime,
 			setCurrentTime,
 			isMuted,
@@ -103,6 +106,8 @@ export const LoopVideoPlayer = forwardRef(
 			handleKeyDown,
 			onError,
 			AudioIcon,
+			shouldPreload,
+			showPlayIcon,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -115,15 +120,15 @@ export const LoopVideoPlayer = forwardRef(
 				<video
 					id={loopVideoId}
 					ref={ref}
-					preload={thumbnailImage ? 'metadata' : 'none'}
+					preload={shouldPreload ? 'metadata' : 'none'}
 					loop={true}
 					muted={isMuted}
 					playsInline={true}
 					height={height}
 					width={width}
-					poster={thumbnailImage ?? undefined}
+					poster={posterImage}
 					onPlaying={() => {
-						setIsPlaying(true);
+						setPlayerState('PLAYING');
 					}}
 					onCanPlay={() => {
 						setIsPlayable(true);
@@ -133,7 +138,7 @@ export const LoopVideoPlayer = forwardRef(
 							ref &&
 							'current' in ref &&
 							ref.current &&
-							isPlaying
+							playerState === 'PLAYING'
 						) {
 							setCurrentTime(ref.current.currentTime);
 						}
@@ -145,15 +150,14 @@ export const LoopVideoPlayer = forwardRef(
 					onError={onError}
 					css={videoStyles(width, height)}
 				>
-					{/* Ensure webm source is provided. Encoding the video to a webm file will improve
-					performance on supported browsers. https://web.dev/articles/video-and-source-tags */}
-					{/* <source src={webmSrc} type="video/webm"> */}
+					{/* Only mp4 is currently supported. Assumes the video file type is mp4. */}
 					<source src={src} type="video/mp4" />
 					{fallbackImageComponent}
 				</video>
 				{ref && 'current' in ref && ref.current && isPlayable && (
 					<>
-						{!isPlaying && (
+						{/* Play icon */}
+						{showPlayIcon && (
 							<button
 								type="button"
 								onClick={handleClick}
@@ -162,32 +166,32 @@ export const LoopVideoPlayer = forwardRef(
 								<PlayIcon iconWidth="narrow" />
 							</button>
 						)}
+						{/* Progress bar */}
 						<LoopVideoProgressBar
 							videoId={loopVideoId}
 							currentTime={currentTime}
 							duration={ref.current.duration}
 						/>
-						{hasAudio && (
-							<button
-								type="button"
-								onClick={(event) => {
-									event.stopPropagation(); // Don't pause the video
-									setIsMuted(!isMuted);
-								}}
-								css={audioButtonStyles}
-							>
-								<div css={audioIconContainerStyles}>
-									<AudioIcon
-										size="xsmall"
-										theme={{
-											fill: palette(
-												'--loop-video-audio-icon',
-											),
-										}}
-									/>
-								</div>
-							</button>
-						)}
+						{/* Audio icon */}
+						<button
+							type="button"
+							onClick={(event) => {
+								event.stopPropagation(); // Don't pause the video
+								setIsMuted(!isMuted);
+							}}
+							css={audioButtonStyles}
+						>
+							<div css={audioIconContainerStyles}>
+								<AudioIcon
+									size="xsmall"
+									theme={{
+										fill: palette(
+											'--loop-video-audio-icon',
+										),
+									}}
+								/>
+							</div>
+						</button>
 					</>
 				)}
 			</>

--- a/dotcom-rendering/src/lib/useIsInView.ts
+++ b/dotcom-rendering/src/lib/useIsInView.ts
@@ -42,8 +42,11 @@ type Options = {
  */
 const useIsInView = (
 	options: IntersectionObserverInit & Options,
-): [boolean, React.Dispatch<React.SetStateAction<HTMLElement | null>>] => {
-	const [isInView, setIsInView] = useState<boolean>(false);
+): [
+	boolean | null,
+	React.Dispatch<React.SetStateAction<HTMLElement | null>>,
+] => {
+	const [isInView, setIsInView] = useState<boolean | null>(null);
 	const [node, setNode] = useState<HTMLElement | null>(options.node ?? null);
 
 	const observer = useRef<IntersectionObserver | null>(null);


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
