### PR TITLE
Add gallery body image component

### DIFF
--- a/dotcom-rendering/src/components/CaptionText.tsx
+++ b/dotcom-rendering/src/components/CaptionText.tsx
@@ -1,0 +1,85 @@
+import { css } from '@emotion/react';
+import { headlineMedium17, space } from '@guardian/source/foundations';
+import { type ReactNode } from 'react';
+import sanitise, { type IOptions } from 'sanitize-html';
+import { getAttrs, parseHtml } from '../lib/domUtils';
+import { palette } from '../palette';
+
+/**
+ * https://www.npmjs.com/package/sanitize-html#default-options
+ */
+const sanitiserOptions: IOptions = {
+	// We allow all tags, which includes script & style which are potentially vulnerable
+	// `allowVulnerableTags: true` suppresses this warning
+	allowVulnerableTags: true,
+	allowedTags: false, // Leave tags from CAPI alone
+	allowedAttributes: false, // Leave attributes from CAPI alone
+};
+
+const renderTextElement = (node: Node, key: number): ReactNode => {
+	const text = node.textContent?.trim() ?? '';
+	const children = Array.from(node.childNodes).map(renderTextElement);
+
+	switch (node.nodeName) {
+		case 'STRONG':
+			return text === '' ? null : (
+				<strong
+					css={css`
+						display: block;
+						${headlineMedium17}
+						padding: ${space[2]}px 0 ${space[3]}px;
+					`}
+					key={key}
+				>
+					{children}
+				</strong>
+			);
+		case 'EM':
+			return text === '' ? null : <em key={key}>{children}</em>;
+		case 'A': {
+			const attrs = getAttrs(node);
+
+			return (
+				<a
+					css={css`
+						text-decoration: none;
+						color: ${palette('--caption-link')};
+						border-bottom: 1px solid
+							${palette('--article-link-border')};
+						:hover {
+							border-bottom: 1px solid
+								${palette('--article-link-border-hover')};
+						}
+					`}
+					href={attrs?.getNamedItem('href')?.value}
+					target={attrs?.getNamedItem('target')?.value}
+					data-link-name={
+						attrs?.getNamedItem('data-link-name')?.value
+					}
+					data-component={
+						attrs?.getNamedItem('data-component')?.value
+					}
+					key={key}
+				>
+					{children}
+				</a>
+			);
+		}
+		case '#text':
+			return node.textContent;
+		default:
+			return null;
+	}
+};
+
+type Props = {
+	html: string;
+};
+
+export const CaptionText = ({ html }: Props) => (
+	<>
+		{Array.from(parseHtml(sanitise(html, sanitiserOptions)).childNodes).map(
+			renderTextElement,
+		)}
+	</>
+);

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -1,0 +1,102 @@
+import { css } from '@emotion/react';
+import { between, from, space, textSans12 } from '@guardian/source/foundations';
+import { grid } from '../grid';
+import { type ArticleFormat } from '../lib/articleFormat';
+import { palette } from '../palette';
+import { CaptionText } from './CaptionText';
+import { Island } from './Island';
+import { ShareButton } from './ShareButton.importable';
+
+type Props = {
+	captionHtml?: string;
+	credit?: string;
+	displayCredit?: boolean;
+	format: ArticleFormat;
+	pageId: string;
+	webTitle: string;
+};
+
+const styles = css`
+	${grid.column.centre}
+	color: ${palette('--caption-text')};
+	${textSans12}
+	padding-bottom: ${space[6]}px;
+
+	${between.tablet.and.desktop} {
+		padding-left: ${space[5]}px;
+		padding-right: ${space[5]}px;
+	}
+
+	${between.desktop.and.leftCol} {
+		${grid.column.right}
+
+		position: relative; /* allows the ::before to be positioned relative to this */
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: -10px; /* 10px to the left of this element */
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${palette('--article-border')};
+		}
+	}
+
+	${from.leftCol} {
+		${grid.column.left}
+
+		position: relative; /* allows the ::before to be positioned relative to this */
+
+		&::after {
+			content: '';
+			position: absolute;
+			right: -10px;
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${palette('--article-border')};
+		}
+	}
+`;
+
+export const GalleryCaption = ({
+	captionHtml,
+	credit,
+	displayCredit,
+	format,
+	pageId,
+	webTitle,
+}: Props) => {
+	const emptyCaption = captionHtml === undefined || captionHtml.trim() === '';
+	const hideCredit =
+		displayCredit === false || credit === undefined || credit === '';
+
+	if (emptyCaption && hideCredit) {
+		return null;
+	}
+
+	return (
+		<figcaption css={styles}>
+			{emptyCaption ? null : <CaptionText html={captionHtml} />}
+			{hideCredit ? null : (
+				<small
+					css={css`
+						display: block;
+						padding: ${space[2]}px 0 ${space[2]}px;
+					`}
+				>
+					{credit}
+				</small>
+			)}
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<ShareButton
+					format={format}
+					pageId={pageId}
+					webTitle={webTitle}
+					context="ArticleMeta" // TODO: update context to GalleryImage
+				/>
+			</Island>
+		</figcaption>
+	);
+};

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -1,0 +1,94 @@
+import { css } from '@emotion/react';
+import { from, space, until } from '@guardian/source/foundations';
+import { grid } from '../grid';
+import { type ArticleFormat } from '../lib/articleFormat';
+import { getImage } from '../lib/image';
+import { palette } from '../palette';
+import { type ImageBlockElement } from '../types/content';
+import { GalleryCaption } from './GalleryCaption';
+import { Picture } from './Picture';
+
+type Props = {
+	format: ArticleFormat;
+	image: ImageBlockElement;
+	pageId: string;
+	webTitle: string;
+};
+
+const styles = css`
+	${grid.container}
+	grid-auto-flow: row dense;
+	column-gap: ${space[5]}px;
+
+	${until.tablet} {
+		border-top: 1px solid ${palette('--article-border')};
+		padding-top: ${space[1]}px;
+	}
+
+	${from.tablet} {
+		&::before {
+			${grid.between('grid-start', 'centre-column-start')}
+			grid-row: span 2;
+			content: '';
+			background-color: ${palette('--article-background')};
+			border-right: 1px solid ${palette('--article-border')};
+		}
+
+		&::after {
+			${grid.between('centre-column-end', 'grid-end')}
+			grid-row: span 2;
+			content: '';
+			background-color: ${palette('--article-background')};
+			border-left: 1px solid ${palette('--article-border')};
+		}
+	}
+
+	${from.desktop} {
+		&::after {
+			${grid.between('right-column-end', 'grid-end')}
+		}
+	}
+
+	${from.leftCol} {
+		&::before {
+			${grid.between('grid-start', 'left-column-start')}
+		}
+	}
+`;
+
+export const GalleryImage = ({ format, image, pageId, webTitle }: Props) => {
+	const asset = getImage(image.media.allImages);
+
+	if (asset === undefined) {
+		return null;
+	}
+
+	const width = parseInt(asset.fields.width, 10);
+	const height = parseInt(asset.fields.height, 10);
+
+	if (isNaN(width) || isNaN(height)) {
+		return null;
+	}
+
+	return (
+		<figure css={styles}>
+			<Picture
+				alt={image.data.alt ?? ''}
+				format={format}
+				role={image.role}
+				master={asset.url}
+				width={width}
+				height={height}
+				loading="lazy"
+			/>
+			<GalleryCaption
+				captionHtml={image.data.caption}
+				credit={image.data.credit}
+				displayCredit={image.displayCredit}
+				format={format}
+				pageId={pageId}
+				webTitle={webTitle}
+			/>
+		</figure>
+	);
+};

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
-import { breakpoints } from '@guardian/source/foundations';
+import { breakpoints, from, space } from '@guardian/source/foundations';
 import { Fragment, useCallback, useEffect, useState } from 'react';
+import { grid } from '../grid';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -465,15 +466,38 @@ export const Sources = ({ sources }: { sources: ImageSource[] }) => {
 	);
 };
 
-const styles = ({ design }: ArticleFormat, isLightbox: boolean) => {
+const galleryBodyImageStyles = css`
+	${grid.column.all}
+
+	${from.tablet} {
+		${grid.column.centre}
+	}
+
+	${from.desktop} {
+		padding-bottom: ${space[10]}px;
+	}
+
+	${from.leftCol} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
+
+const styles = (
+	{ design }: ArticleFormat,
+	isLightbox: boolean,
+	isMainMedia: boolean,
+) => {
 	if (design === ArticleDesign.Gallery) {
-		return css`
-			img {
-				width: 100%;
-				height: 100%;
-				object-fit: cover;
-			}
-		`;
+		return css(
+			css`
+				img {
+					width: 100%;
+					height: 100%;
+					object-fit: cover;
+				}
+			`,
+			isMainMedia ? undefined : galleryBodyImageStyles,
+		);
 	}
 	return isLightbox ? flex : block;
 };
@@ -539,7 +563,7 @@ export const Picture = ({
 	const fallbackSource = getFallbackSource(sources);
 
 	return (
-		<picture css={styles(format, isLightbox)}>
+		<picture css={styles(format, isLightbox, isMainMedia)}>
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 			{format.display === ArticleDisplay.Immersive && isMainMedia && (
 				<>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -4,6 +4,7 @@ import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMetaApps } from '../components/ArticleMeta.apps';
 import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
+import { GalleryImage } from '../components/GalleryImage';
 import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Masthead } from '../components/Masthead/Masthead';
 import { Standfirst } from '../components/Standfirst';
@@ -66,7 +67,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 			)}
 			<main
 				css={{
-					backgroundColor: palette('--article-background'),
+					backgroundColor: palette('--article-inner-background'),
 				}}
 			>
 				<div css={border}>Labs header</div>
@@ -146,7 +147,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					) : null}
 					<div
 						css={[
-							border,
 							css`
 								${grid.column.centre}
 								${from.leftCol} {
@@ -158,15 +158,20 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						Main media caption
 					</div>
 					<div
-						css={[
-							border,
-							grid.between('centre-column-start', 'grid-end'),
-						]}
+						css={[grid.between('centre-column-start', 'grid-end')]}
 					>
 						Meta
 					</div>
 				</header>
-				<div css={border}>Body</div>
+				{gallery.images.map((element, idx) => (
+					<GalleryImage
+						image={element}
+						format={format}
+						pageId={frontendData.pageId}
+						webTitle={frontendData.webTitle}
+						key={idx}
+					/>
+				))}
 				<div css={border}>Submeta</div>
 			</main>
 		</>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2241,6 +2241,8 @@ const standfirstBackgroundLight: PaletteFunction = ({
 				default:
 					return sourcePalette.neutral[93];
 			}
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[7];
 		default:
 			return articleBackgroundLight({ design, display, theme });
 	}
@@ -2282,6 +2284,7 @@ const standfirstBackgroundDark: PaletteFunction = ({ design, theme }) => {
 				default:
 					return sourcePalette.neutral[10];
 			}
+		case ArticleDesign.Gallery:
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -2659,6 +2662,7 @@ const captionTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Picture:
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
+				case ArticleDesign.Gallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[46];
@@ -2686,6 +2690,8 @@ const captionTextDark: PaletteFunction = ({ design, theme }) => {
 				default:
 					return sourcePalette.neutral[60];
 			}
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[60];
 	}
@@ -2695,29 +2701,36 @@ const captionPhotoEssayMainMediaTextLight = () => sourcePalette.neutral[46];
 const captionPhotoEssayMainMediaTextDark = () => sourcePalette.neutral[60];
 
 const captionLink: PaletteFunction = ({ design, theme }) => {
-	if (design === ArticleDesign.NewsletterSignup) {
-		return sourcePalette.neutral[0];
-	}
 	if (design === ArticleDesign.Analysis && theme === Pillar.News) {
 		return sourcePalette.news[300];
 	}
-	switch (theme) {
-		case Pillar.News:
-			return sourcePalette.news[400];
-		case Pillar.Opinion:
-			return sourcePalette.opinion[400];
-		case Pillar.Sport:
-			return sourcePalette.sport[300];
-		case Pillar.Culture:
-			return sourcePalette.culture[400];
-		case Pillar.Lifestyle:
-			return sourcePalette.lifestyle[400];
-		case ArticleSpecial.Labs:
-			return sourcePalette.labs[400];
-		case ArticleSpecial.SpecialReport:
-			return sourcePalette.specialReport[300];
-		case ArticleSpecial.SpecialReportAlt:
-			return sourcePalette.specialReportAlt[200];
+
+	switch (design) {
+		case ArticleDesign.NewsletterSignup:
+			return sourcePalette.neutral[0];
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
+		default:
+			switch (theme) {
+				case Pillar.News:
+					return sourcePalette.news[400];
+				case Pillar.Opinion:
+					return sourcePalette.opinion[400];
+				case Pillar.Sport:
+					return sourcePalette.sport[300];
+				case Pillar.Culture:
+					return sourcePalette.culture[400];
+				case Pillar.Lifestyle:
+					return sourcePalette.lifestyle[400];
+				case ArticleSpecial.Labs:
+					return sourcePalette.labs[400];
+				case ArticleSpecial.SpecialReport:
+					return sourcePalette.specialReport[300];
+				case ArticleSpecial.SpecialReportAlt:
+					return sourcePalette.specialReportAlt[200];
+				default:
+					return sourcePalette.neutral[100];
+			}
 	}
 };
 
@@ -2976,7 +2989,7 @@ const articleBackgroundLight: PaletteFunction = ({
 		case ArticleDesign.FullPageInteractive:
 			return 'transparent';
 		case ArticleDesign.Gallery:
-			return sourcePalette.neutral[7];
+			return 'rgba(0,0,0,.25)';
 		default:
 			switch (theme) {
 				case ArticleSpecial.SpecialReport:
@@ -3020,6 +3033,8 @@ const articleBackgroundDark: PaletteFunction = ({ design, theme }) => {
 				default:
 					return sourcePalette.neutral[10];
 			}
+		case ArticleDesign.Gallery:
+			return 'rgba(0,0,0,.25)'; // TODO: is this the correct color for dark mode?
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -3035,6 +3050,8 @@ const articleInnerBackgroundLight: PaletteFunction = ({ design, theme }) => {
 				default:
 					return sourcePalette.neutral[0];
 			}
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[7];
 
 		default:
 			return 'transparent';
@@ -3108,6 +3125,8 @@ const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.Audio) {
 		return sourcePalette.neutral[46];
 	}
+
+	if (design === ArticleDesign.Gallery) return sourcePalette.neutral[46];
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
@@ -3135,6 +3154,7 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Comment:
 			return sourcePalette.neutral[20];
 		case ArticleDesign.Interactive:
+		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[46];
 		default:
 			return sourcePalette.neutral[20];
@@ -3216,6 +3236,10 @@ const articleLinkHoverDark: PaletteFunction = (f) => articleLinkTextDark(f);
 const articleLinkBorderHoverLight: PaletteFunction = ({ design, theme }) => {
 	if (design === ArticleDesign.Audio) {
 		return sourcePalette.neutral[86];
+	}
+
+	if (design === ArticleDesign.Gallery) {
+		return sourcePalette.neutral[97];
 	}
 
 	if (theme === ArticleSpecial.Labs) {


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
