### PR TITLE
Fix gutter image missing in preview

### DIFF
--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -25,10 +25,7 @@ const container = css`
 
 const imageHeader = (mainUrl: string) => css`
 	background-color: ${palette.brand[400]};
-	background-image: url(${mainUrl});
-	background-repeat: no-repeat;
-	background-position: center;
-	background-size: cover;
+	background: no-repeat center/100% url('${mainUrl}');
 	width: 220px;
 	height: 132px;
 `;

--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -24,8 +24,7 @@ const container = css`
 `;
 
 const imageHeader = (mainUrl: string) => css`
-	background-color: ${palette.brand[400]};
-	background: no-repeat center/100% url('${mainUrl}');
+	background: ${palette.brand[400]} no-repeat center/100% url('${mainUrl}');
 	width: 220px;
 	height: 132px;
 `;


### PR DESCRIPTION
## What does this change?

Adds quote marks around the image URL which better copes any URLs with brackets (such the one used here)
Also tidies up the CSS around the background attributes

## Why?

The newest image had a set of brackets in the URL which caused issues as the URL itself was not quoted in the background URL CSS attribute.

This meant that the web preview option in RRCP was not showing the image at all.

## Screenshots

***NOTE***: The after screenshot is a different test with the same image that was also not working before the fix was applied.

| Before      | After      |
| ----------- | ---------- |
| <img width="383" alt="Screenshot 2025-06-25 at 16 41 04" src="https://github.com/user-attachments/assets/80c3db1a-3704-4e8a-aafd-c1675d8b503c" /> | <img width="441" alt="Screenshot 2025-06-25 at 16 47 25" src="https://github.com/user-attachments/assets/2588876c-a801-43f6-93f8-89f9b493893c" /> |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
