### PR TITLE
Playwright: Balance shards on CI by setting fullyParallel: true

### DIFF
--- a/dotcom-rendering/playwright.config.ts
+++ b/dotcom-rendering/playwright.config.ts
@@ -11,9 +11,9 @@ export const PORT = isDev ? 3030 : 9000;
  */
 export default defineConfig({
 	testDir: './playwright/tests',
-	// Don't run tests _within_ files in parallel as this causes flakiness locally - investigating
+	// Don't run tests _within_ files in parallel locally as this causes flakiness
 	// Test files still run in parallel as per the number of workers set below
-	fullyParallel: false,
+	fullyParallel: !!process.env.CI,
 	// Fail the build on CI if you accidentally left test.only in the source code
 	forbidOnly: !!process.env.CI,
 	// Retry on CI only


### PR DESCRIPTION
## What does this change?

I noticed that the Playwright jobs 2 and 4 don't run any tests!

<img width="400" alt="Screenshot 2025-06-27 at 16 35 42" src="https://github.com/user-attachments/assets/c5aec6cd-8485-416f-9da7-a82c0f47e2aa" />

<img width="400" alt="Screenshot 2025-06-27 at 16 35 25" src="https://github.com/user-attachments/assets/a1e93721-1c47-43e1-b8cc-4c34fdf39d43" />

The Playwright docs advise to set the configuration property `fullyParallel` to true on CI:

https://playwright.dev/docs/test-sharding/#balancing-shards

This allows Playwright to spread individual tests across the shards evenly. Currently tests are spread by the test file, which may create hotspots with particular shards running more tests than others.

## Why?

Even out spread of tests across shards which should mean a reduction in time taken to run the Playwright tests as hotspots are minimised.

## Screenshots

Test | Before      | After      |
| -- | ----------- | ---------- |
| 2 | ![before2][] | ![after2][] |
| 4 | ![before4][] | ![after4][] |


[before2]: https://github.com/user-attachments/assets/c5aec6cd-8485-416f-9da7-a82c0f47e2aa
[before4]: https://github.com/user-attachments/assets/a1e93721-1c47-43e1-b8cc-4c34fdf39d43
[after2]: https://github.com/user-attachments/assets/9a8f5646-a660-4139-9cf0-c86568c32469
[after4]: https://github.com/user-attachments/assets/93f9f062-f295-4fac-bfed-68aaa9f79a3c
