### PR TITLE
Add A Nav For Football Competitions

### DIFF
--- a/dotcom-rendering/.storybook/modes.ts
+++ b/dotcom-rendering/.storybook/modes.ts
@@ -65,4 +65,8 @@ export const allModes = {
 		globalColourScheme: 'light',
 		viewport: breakpoints.desktop,
 	},
+	'light leftCol': {
+		globalColourScheme: 'light',
+		viewport: breakpoints.leftCol,
+	},
 };

--- a/dotcom-rendering/src/components/FootballCompetitionNav.stories.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionNav.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { allModes } from '../../.storybook/modes';
+import { FootballCompetitionNav } from './FootballCompetitionNav';
+
+const meta = {
+	component: FootballCompetitionNav,
+	title: 'Components/Football Competition Nav',
+	argTypes: {
+		selected: {
+			options: ['fixtures', 'tables', 'none'],
+			control: { type: 'select' },
+		},
+	},
+	parameters: {
+		chromatic: {
+			modes: {
+				'light mobileMedium': allModes['light mobileMedium'],
+				'light desktop': allModes['light desktop'],
+				'light leftCol': allModes['light leftCol'],
+			},
+		},
+	},
+} satisfies Meta<typeof FootballCompetitionNav>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WomensEuro2025 = {
+	args: {
+		selected: 'fixtures',
+		pageId: 'football/women-s-euro-2025/table',
+	},
+} satisfies Story;
+
+export const OtherCompetition = {
+	args: {
+		selected: 'none',
+		pageId: 'football/premierleague/table',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/FootballCompetitionNav.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionNav.tsx
@@ -61,7 +61,7 @@ export const FootballCompetitionNav = ({ selected, pageId }: Props) =>
 						href="https://www.theguardian.com/p/x27nz8"
 						css={smallLink}
 					>
-						Player's guide
+						Players guide
 					</a>
 				</li>
 				<li css={listItem}>

--- a/dotcom-rendering/src/components/FootballCompetitionNav.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionNav.tsx
@@ -42,7 +42,7 @@ export const FootballCompetitionNav = ({ selected, pageId }: Props) =>
 					style={selected === 'tables' ? selectedStyles : undefined}
 				>
 					<a
-						href="https://www.theguardian.com/football/women-s-euro-2025/table"
+						href="https://www.theguardian.com/football/women-s-euro-2025/overview"
 						css={smallLink}
 					>
 						Tables

--- a/dotcom-rendering/src/components/FootballCompetitionNav.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionNav.tsx
@@ -1,0 +1,177 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold15Object,
+	headlineBold17Object,
+	headlineBold24Object,
+	headlineBold42Object,
+	headlineMedium15Object,
+	headlineMedium17Object,
+	palette,
+} from '@guardian/source/foundations';
+import { grid } from '../grid';
+
+type Props = {
+	selected: 'fixtures' | 'tables' | 'none';
+	pageId: string;
+};
+
+export const FootballCompetitionNav = ({ selected, pageId }: Props) =>
+	pageId.includes('women-s-euro-2025') ? (
+		<nav css={nav}>
+			<a
+				href="https://www.theguardian.com/football/women-s-euro-2025"
+				css={largeLinkStyles}
+			>
+				Women's Euro 2025
+			</a>
+			<ul css={list}>
+				<li
+					css={listItem}
+					style={selected === 'fixtures' ? selectedStyles : undefined}
+				>
+					<a
+						href="https://www.theguardian.com/football/women-s-euro-2025/fixtures"
+						css={smallLink}
+					>
+						Fixtures
+					</a>
+				</li>
+				<li
+					css={listItem}
+					style={selected === 'tables' ? selectedStyles : undefined}
+				>
+					<a
+						href="https://www.theguardian.com/football/women-s-euro-2025/table"
+						css={smallLink}
+					>
+						Tables
+					</a>
+				</li>
+				<li css={listItem}>
+					<a
+						href="https://www.theguardian.com/p/x2e3za"
+						css={smallLink}
+					>
+						Top scorers
+					</a>
+				</li>
+				<li css={listItem}>
+					<a
+						href="https://www.theguardian.com/p/x27nz8"
+						css={smallLink}
+					>
+						Player's guide
+					</a>
+				</li>
+				<li css={listItem}>
+					<a
+						href="https://www.theguardian.com/football/women-s-euro-2025"
+						css={lastSmallLink}
+					>
+						Full coverage
+					</a>
+				</li>
+			</ul>
+		</nav>
+	) : null;
+
+const nav = css({
+	backgroundColor: palette.news[400],
+	'&': css(grid.paddedContainer),
+	alignContent: 'space-between',
+	height: 116,
+	[from.tablet]: {
+		height: 140,
+	},
+	[from.desktop]: {
+		height: 150,
+	},
+});
+
+const largeLinkStyles = css({
+	...headlineBold24Object,
+	color: palette.neutral[100],
+	textDecoration: 'none',
+	'&': css(grid.column.centre),
+	[from.tablet]: headlineBold42Object,
+	[from.leftCol]: css(grid.between('left-column-start', 'right-column-end')),
+});
+
+const list = css({
+	display: 'flex',
+	flexWrap: 'wrap',
+	'&': css(grid.column.all),
+	position: 'relative',
+	'--top-border-gap': '1.55rem',
+	[from.mobileLandscape]: {
+		paddingLeft: 10,
+	},
+	[from.tablet]: {
+		'--top-border-gap': '3rem',
+	},
+	backgroundImage: `linear-gradient(
+        #d84d4d 0,
+        #d84d4d 1px,
+        transparent 1px,
+        transparent var(--top-border-gap),
+        #d84d4d var(--top-border-gap),
+        #d84d4d calc(var(--top-border-gap) + 1px),
+        transparent 1px,
+        transparent var(--top-border-gap)
+    )`,
+});
+
+const selectedStyles = {
+	'--selected-height': '4px',
+	'--selected-opacity': '1',
+};
+
+const listItem = css({
+	position: 'relative',
+	'&::before': {
+		content: '""',
+		display: 'block',
+		position: 'absolute',
+		left: 0,
+		top: 0,
+		width: '100%',
+		height: 'var(--selected-height, 0)',
+		opacity: 'var(--selected-opacity, 0)',
+		backgroundColor: palette.neutral[100],
+		transition: 'height 0.3s ease-in-out, opacity 0.05s 0.1s linear',
+	},
+	'&:hover': selectedStyles,
+	[from.leftCol]: {
+		flexBasis: 160,
+	},
+});
+
+const smallLink = css({
+	...headlineBold15Object,
+	padding: '4px 10px 6px',
+	display: 'block',
+	lineHeight: 1,
+	color: palette.neutral[100],
+	textDecoration: 'none',
+	'&::after': {
+		content: '""',
+		display: 'block',
+		position: 'absolute',
+		top: 0,
+		right: 0,
+		width: 1,
+		height: '1.3rem',
+		backgroundColor: '#d84d4d',
+	},
+	[from.tablet]: headlineBold17Object,
+	[from.leftCol]: {
+		padding: '9px 10px 10px',
+	},
+});
+
+const lastSmallLink = css(smallLink, {
+	...headlineMedium15Object,
+	lineHeight: 1,
+	[from.tablet]: headlineMedium17Object,
+});

--- a/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import { initialDays, regions } from '../../fixtures/manual/footballData';
+import { WomensEuro2025 } from './FootballCompetitionNav.stories';
 import { FootballMatchesPage } from './FootballMatchesPage';
 
 const meta = {
@@ -36,5 +37,12 @@ export const Fixtures = {
 	args: {
 		...Results.args,
 		kind: 'FootballFixtures',
+	},
+} satisfies Story;
+
+export const WithCompetitionNav = {
+	args: {
+		...Fixtures.args,
+		pageId: WomensEuro2025.args.pageId,
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballMatchesPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchesPage.tsx
@@ -12,6 +12,7 @@ import type { Result } from '../lib/result';
 import { palette } from '../palette';
 import type { FootballMatchListPageKind, Region } from '../sportDataPage';
 import { AdSlot } from './AdSlot.web';
+import { FootballCompetitionNav } from './FootballCompetitionNav';
 import { FootballCompetitionSelect } from './FootballCompetitionSelect';
 import { FootballMatchList } from './FootballMatchList';
 
@@ -57,93 +58,105 @@ export const FootballMatchesPage = ({
 	renderAds,
 	pageId,
 }: Props) => (
-	<main
-		id="maincontent"
-		data-layout="FootballDataPageLayout"
-		css={css`
-			${grid.paddedContainer}
-			position: relative;
-			${from.tablet} {
-				&::before,
-				&::after {
-					content: '';
-					position: absolute;
-					border-left: 1px solid ${palette('--article-border')};
-					top: 0;
-					bottom: 0;
-				}
-
-				&::after {
-					right: 0;
-				}
-			}
-
-			padding-bottom: ${space[9]}px;
-		`}
-	>
-		<h1
+	<>
+		<FootballCompetitionNav
+			selected={kind === 'FootballFixtures' ? 'fixtures' : 'none'}
+			pageId={pageId}
+		/>
+		<main
+			id="maincontent"
+			data-layout="FootballDataPageLayout"
 			css={css`
-				${headlineBold20}
-				padding: ${space[2]}px 0 ${space[3]}px;
-				${grid.column.centre}
-				grid-row: 1;
-				${from.leftCol} {
-					${grid.between('left-column-start', 'centre-column-end')}
-				}
-			`}
-		>
-			{createTitle(kind, edition)}
-		</h1>
-
-		<div
-			css={css`
-				margin-top: ${space[3]}px;
-				margin-bottom: ${space[6]}px;
-				${grid.column.centre}
-				grid-row: 2;
-			`}
-		>
-			<FootballCompetitionSelect
-				regions={regions}
-				kind={kind}
-				pageId={pageId}
-				onChange={goToCompetitionSpecificPage}
-			/>
-		</div>
-
-		<div
-			css={css`
-				${grid.column.centre}
-				grid-row: 3;
-				${from.leftCol} {
-					${grid.between('left-column-start', 'centre-column-end')}
-				}
+				${grid.paddedContainer}
 				position: relative;
+				${from.tablet} {
+					&::before,
+					&::after {
+						content: '';
+						position: absolute;
+						border-left: 1px solid ${palette('--article-border')};
+						top: 0;
+						bottom: 0;
+					}
+
+					&::after {
+						right: 0;
+					}
+				}
+
+				padding-bottom: ${space[9]}px;
 			`}
 		>
-			<FootballMatchList
-				now={now}
-				initialDays={initialDays}
-				edition={edition}
-				getMoreDays={getMoreDays}
-				guardianBaseUrl={guardianBaseUrl}
-				nextPageNoJsUrl={nextPageNoJsUrl}
-			/>
-		</div>
-
-		{renderAds && (
-			<div
+			<h1
 				css={css`
-					${grid.column.right}
-					/** This allows the ad to grow beyond the third row content (up to line 5) */
-					grid-row: 1 / 5;
-					${until.desktop} {
-						display: none;
+					${headlineBold20}
+					padding: ${space[2]}px 0 ${space[3]}px;
+					${grid.column.centre}
+					grid-row: 1;
+					${from.leftCol} {
+						${grid.between(
+							'left-column-start',
+							'centre-column-end',
+						)}
 					}
 				`}
 			>
-				<AdSlot position="football-right" />
+				{createTitle(kind, edition)}
+			</h1>
+
+			<div
+				css={css`
+					margin-top: ${space[3]}px;
+					margin-bottom: ${space[6]}px;
+					${grid.column.centre}
+					grid-row: 2;
+				`}
+			>
+				<FootballCompetitionSelect
+					regions={regions}
+					kind={kind}
+					pageId={pageId}
+					onChange={goToCompetitionSpecificPage}
+				/>
 			</div>
-		)}
-	</main>
+
+			<div
+				css={css`
+					${grid.column.centre}
+					grid-row: 3;
+					${from.leftCol} {
+						${grid.between(
+							'left-column-start',
+							'centre-column-end',
+						)}
+					}
+					position: relative;
+				`}
+			>
+				<FootballMatchList
+					now={now}
+					initialDays={initialDays}
+					edition={edition}
+					getMoreDays={getMoreDays}
+					guardianBaseUrl={guardianBaseUrl}
+					nextPageNoJsUrl={nextPageNoJsUrl}
+				/>
+			</div>
+
+			{renderAds && (
+				<div
+					css={css`
+						${grid.column.right}
+						/** This allows the ad to grow beyond the third row content (up to line 5) */
+						grid-row: 1 / 5;
+						${until.desktop} {
+							display: none;
+						}
+					`}
+				>
+					<AdSlot position="football-right" />
+				</div>
+			)}
+		</main>
+	</>
 );

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,23 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react/*';
 import { regions } from '../../fixtures/manual/footballData';
+import { WomensEuro2025 } from './FootballCompetitionNav.stories';
 import { FootballTableList as TableListDefault } from './FootballTableList.stories';
-import { FootballTablesPage as FootballTablesPageComponent } from './FootballTablesPage';
+import { FootballTablesPage } from './FootballTablesPage';
 
 const meta = {
 	title: 'Components/Football Tables Page',
-	component: FootballTablesPageComponent,
-} satisfies Meta<typeof FootballTablesPageComponent>;
+	component: FootballTablesPage,
+} satisfies Meta<typeof FootballTablesPage>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const FootballTablesPage = {
+export const Default = {
 	args: {
 		regions,
 		pageId: 'football/tables',
 		tableCompetitions: TableListDefault.args.competitions,
 		renderAds: true,
 		guardianBaseUrl: 'https://www.theguardian.com',
+	},
+} satisfies Story;
+
+export const WithCompetitionNav = {
+	args: {
+		...Default.args,
+		pageId: WomensEuro2025.args.pageId,
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -31,7 +31,7 @@ export const FootballTablesPage = ({
 	guardianBaseUrl,
 }: Props) => (
 	<>
-		<FootballCompetitionNav selected="tables" pageId={pageId} />
+		<FootballCompetitionNav selected="none" pageId={pageId} />
 		<main
 			id="maincontent"
 			data-layout="FootballDataPageLayout"

--- a/dotcom-rendering/src/components/FootballTablesPage.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.tsx
@@ -10,6 +10,7 @@ import { grid } from '../grid';
 import { palette } from '../palette';
 import type { Region } from '../sportDataPage';
 import { AdSlot } from './AdSlot.web';
+import { FootballCompetitionNav } from './FootballCompetitionNav';
 import { FootballTableList } from './FootballTableList';
 import { FootballTablesCompetitionSelect } from './FootballTablesCompetitionSelect.importable';
 import { Island } from './Island';
@@ -29,87 +30,96 @@ export const FootballTablesPage = ({
 	renderAds,
 	guardianBaseUrl,
 }: Props) => (
-	<main
-		id="maincontent"
-		data-layout="FootballDataPageLayout"
-		css={css`
-			${grid.paddedContainer}
-			position: relative;
-			${from.tablet} {
-				&::before,
-				&::after {
-					content: '';
-					position: absolute;
-					border-left: 1px solid ${palette('--article-border')};
-					top: 0;
-					bottom: 0;
-				}
-
-				&::after {
-					right: 0;
-				}
-			}
-
-			padding-bottom: ${space[9]}px;
-		`}
-	>
-		<h1
+	<>
+		<FootballCompetitionNav selected="tables" pageId={pageId} />
+		<main
+			id="maincontent"
+			data-layout="FootballDataPageLayout"
 			css={css`
-				${headlineBold20}
-				padding: ${space[2]}px 0 ${space[3]}px;
-				${grid.column.centre}
-				grid-row: 1;
-				${from.leftCol} {
-					${grid.between('left-column-start', 'centre-column-end')}
-				}
-			`}
-		>
-			Football tables
-		</h1>
-		<div
-			css={css`
-				margin-top: ${space[3]}px;
-				margin-bottom: ${space[6]}px;
-				${grid.column.centre}
-				grid-row: 2;
-			`}
-		>
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<FootballTablesCompetitionSelect
-					regions={regions}
-					pageId={pageId}
-					guardianBaseUrl={guardianBaseUrl}
-				/>
-			</Island>
-		</div>
-		<div
-			css={css`
-				${grid.column.centre}
-				grid-row: 3;
-				${from.leftCol} {
-					${grid.between('left-column-start', 'centre-column-end')}
-				}
+				${grid.paddedContainer}
 				position: relative;
+				${from.tablet} {
+					&::before,
+					&::after {
+						content: '';
+						position: absolute;
+						border-left: 1px solid ${palette('--article-border')};
+						top: 0;
+						bottom: 0;
+					}
+
+					&::after {
+						right: 0;
+					}
+				}
+
+				padding-bottom: ${space[9]}px;
 			`}
 		>
-			<FootballTableList
-				competitions={competitions}
-				guardianBaseUrl={guardianBaseUrl}
-			/>
-		</div>
-		{renderAds && (
-			<div
+			<h1
 				css={css`
-					${grid.column.right}
-					/** This allows the ad to grow beyond the third row content (up to line 5) */
-					grid-row: 1 / 4;
-					${until.desktop} {
-						display: none;
+					${headlineBold20}
+					padding: ${space[2]}px 0 ${space[3]}px;
+					${grid.column.centre}
+					grid-row: 1;
+					${from.leftCol} {
+						${grid.between(
+							'left-column-start',
+							'centre-column-end',
+						)}
 					}
 				`}
 			>
-				<AdSlot position="football-right" />
+				Football tables
+			</h1>
+			<div
+				css={css`
+					margin-top: ${space[3]}px;
+					margin-bottom: ${space[6]}px;
+					${grid.column.centre}
+					grid-row: 2;
+				`}
+			>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<FootballTablesCompetitionSelect
+						regions={regions}
+						pageId={pageId}
+						guardianBaseUrl={guardianBaseUrl}
+					/>
+				</Island>
 			</div>
-		)}
-	</main>
+			<div
+				css={css`
+					${grid.column.centre}
+					grid-row: 3;
+					${from.leftCol} {
+						${grid.between(
+							'left-column-start',
+							'centre-column-end',
+						)}
+					}
+					position: relative;
+				`}
+			>
+				<FootballTableList
+					competitions={competitions}
+					guardianBaseUrl={guardianBaseUrl}
+				/>
+			</div>
+			{renderAds && (
+				<div
+					css={css`
+						${grid.column.right}
+						/** This allows the ad to grow beyond the third row content (up to line 5) */
+						grid-row: 1 / 4;
+						${until.desktop} {
+							display: none;
+						}
+					`}
+				>
+					<AdSlot position="football-right" />
+				</div>
+			)}
+		</main>
+	</>
 );


### PR DESCRIPTION
When major competitions are running we'd like to introduce additional navigation to the football data pages that relate to that competition: fixtures, live matches, results and tables. This will allow users to navigate between different pieces of information about said competition.

This change introduces a `FootballCompetitionNav` component to be displayed only when the `pageId` matches the given competition. For now this is hardcoded to the Women's Euro 2025 competition as a first implementation. We will make it generic and configurable for other competitions in a later change.

Credit to @alessiaAmitrano for the original atom implementation that this change is based on. Part of #14152.

## Screenshot

| Mobile | Wide |
| - | - |
| ![competition-nav-mobile] | ![competition-nav-wide] |

[competition-nav-mobile]: https://github.com/user-attachments/assets/92b36aec-13eb-43fc-9135-af6fdb123128
[competition-nav-wide]: https://github.com/user-attachments/assets/f455e451-5a6f-4dd2-83d9-d35d91f922bb
