### PR TITLE
Loop video tracking

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -911,6 +911,7 @@ export const Card = ({
 											aspectRatio={aspectRatio}
 										/>
 									}
+									atomId={media.mainMedia.id}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -9,6 +9,7 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useConfig } from './ConfigContext';
 import type { PLAYER_STATES } from './LoopVideoPlayer';
 import { LoopVideoPlayer } from './LoopVideoPlayer';
+import { ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 
 const videoContainerStyles = css`
 	z-index: ${getZIndex('loop-video-container')};
@@ -78,7 +79,7 @@ export const LoopVideo = ({
 				{
 					component: {
 						componentType: 'LOOP_VIDEO',
-						id: atomId,
+						id: `gu-video-loop-${atomId}`,
 					},
 					action: 'VIEW',
 				},
@@ -99,6 +100,9 @@ export const LoopVideo = ({
 			}
 
 			setPlayerState('PLAYING');
+			if (!hasBeenInView) {
+				ophanTrackerWeb(atomId, 'loop')('play');
+			}
 			setHasBeenInView(true);
 
 			void vidRef.current.play();

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { log } from '@guardian/libs';
 import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import { getZIndex } from '../lib/getZIndex';
 import { useIsInView } from '../lib/useIsInView';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
@@ -67,7 +68,25 @@ export const LoopVideo = ({
 	}, []);
 
 	/**
-	 * Autoplays the video when it comes into view.
+	 * Tracks the first time the video has been in view in Ophan
+	 */
+	useEffect(() => {
+		if (isInView && !hasBeenInView) {
+			void submitComponentEvent(
+				{
+					component: {
+						componentType: 'LOOP_VIDEO',
+						id: videoId,
+					},
+					action: 'VIEW',
+				},
+				'Web',
+			);
+		}
+	}, [isInView, hasBeenInView, videoId]);
+
+	/**
+	 * Autoplay the video when it comes into view.
 	 */
 	useEffect(() => {
 		if (!vidRef.current || playerState === 'PAUSED_BY_USER') return;

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -17,6 +17,7 @@ const videoContainerStyles = css`
 
 type Props = {
 	src: string;
+	atomId: string;
 	videoId: string;
 	width: number;
 	height: number;
@@ -26,6 +27,7 @@ type Props = {
 
 export const LoopVideo = ({
 	src,
+	atomId,
 	videoId,
 	width,
 	height,
@@ -76,14 +78,14 @@ export const LoopVideo = ({
 				{
 					component: {
 						componentType: 'LOOP_VIDEO',
-						id: videoId,
+						id: atomId,
 					},
 					action: 'VIEW',
 				},
 				'Web',
 			);
 		}
-	}, [isInView, hasBeenInView, videoId]);
+	}, [isInView, hasBeenInView, atomId]);
 
 	/**
 	 * Autoplay the video when it comes into view.

--- a/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
@@ -26,17 +26,19 @@ const getAppsMediaEvent = (
 	}
 };
 
-const ophanTrackerWeb = (id: string) => {
+type VideoType = 'youtube' | 'loop';
+
+const ophanTrackerWeb = (id: string, videoType: VideoType) => {
 	return (trackingEvent: VideoEventKey): void => {
 		void getOphan('Web').then((ophan) => {
 			const event = {
 				video: {
-					id: `gu-video-youtube-${id}`,
+					id: `gu-video-${videoType}-${id}`,
 					eventType: `video:content:${trackingEvent}`,
 				} satisfies VideoEvent,
 			} satisfies EventPayload;
 			log('dotcom', {
-				from: 'YoutubeAtom event emitter web',
+				from: `${videoType}Atom event emitter web`,
 				id,
 				event,
 			});

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -184,7 +184,7 @@ export const YoutubeBlockComponent = ({
 				duration={duration}
 				eventEmitters={
 					renderingTarget === 'Web'
-						? [ophanTrackerWeb(id)]
+						? [ophanTrackerWeb(id, 'youtube')]
 						: [ophanTrackerApps(id)]
 				}
 				format={format}

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -174,6 +174,7 @@ const getActiveMediaAtom = (
 		if (asset?.platform === 'Url' && isLoopingVideoTest) {
 			return {
 				type: 'LoopVideo',
+				id: mediaAtom.id,
 				videoId: asset.id,
 				duration: mediaAtom.duration ?? 0,
 				// Size fixed to a 5:4 ratio

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -21,6 +21,7 @@ type Video = Media & {
 
 type LoopVideo = Media & {
 	type: 'LoopVideo';
+	id: string;
 	videoId: string;
 	height: number;
 	width: number;


### PR DESCRIPTION
## What does this change?
Adds first view and first play tracking to the loop video component.

- **First view tracking** : uses the Ophan 'VIEW' action via component event tracking. As we only want to track this once the first time the video comes into view, we check that the component is in view, and hasn't already been in view. 

- **First play tracking** : extends the video event emitter helper functions previously used only by the youtube atom player to track the first play. It determines it its the first play by running only if the video has not been in view.

We would like to send the atom id along with the tracking, so this has been piped through from the enhancement step to the loop video player.

## Why?
This was requested by Data and Insight to help understand user interaction with the looping videos on launch.  

## Screenshots

| First View      | First Play      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/9098a1bb-17b2-43fb-85b1-e71a54681224
[after]: https://github.com/user-attachments/assets/44e64bfa-e8e5-42de-8791-fb3f1e9e2c39

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
