### PR TITLE
Speedup CI: turn off mandb updates on Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Set up Node environment
         uses: ./.github/actions/setup-node-env
 
+      - name: Turn off mandb updates
+        run: |
+          sudo mv /usr/bin/mandb /usr/bin/mandb-OFF
+          sudo cp -p /bin/true /usr/bin/mandb
+
       - name: Install Playwright Browsers
         run: pnpm playwright install --with-deps chromium
         working-directory: ./dotcom-rendering


### PR DESCRIPTION
## What does this change?

Speedup CI: turn off [mandb](https://man7.org/linux/man-pages/man8/mandb.8.html) updates on Playwright tests as they can take up to ~30s+.

When running GH workflow jobs that install packages on linux runners, mandb will update itself. When watching the Playwright workflow running I noticed that mandb updates can intermittently pause for up to 30s 😱, as you can see here in this video (sound on):

https://github.com/user-attachments/assets/844b83d6-a975-497a-915e-b9c99ea17337

We don't need mandb on CI so this PR attempts to turn off mandb updates.

## Why?

Speedup CI, reduce overall time of the Playwright workflow.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4f91f0ee-2b62-4d76-ae7d-4c9625ec8c84
[after]: https://github.com/user-attachments/assets/31f3877d-29ae-4453-98d8-6b5a351e0c50


