### PR TITLE
Remove references to DesignableBannerv2

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -121,7 +121,7 @@ const buildUrlForThreeTierChoiceCards = (
 		  );
 };
 
-const DesignableBannerV2: ReactComponent<BannerRenderProps> = ({
+const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 	content,
 	onCloseClick,
 	articleCounts,
@@ -827,16 +827,10 @@ const styles = {
 	`,
 };
 
-const unvalidated = bannerWrapper(DesignableBannerV2, 'designable-banner');
-const validated = validatedBannerWrapper(
-	DesignableBannerV2,
-	'designable-banner',
-);
+const unvalidated = bannerWrapper(DesignableBanner, 'designable-banner');
+const validated = validatedBannerWrapper(DesignableBanner, 'designable-banner');
 
 export {
-	validated as DesignableBannerV2,
-	unvalidated as DesignableBannerUnvalidatedV2,
-	// temporarily until we can rename banner coming in through SDC
 	validated as DesignableBanner,
 	unvalidated as DesignableBannerUnvalidated,
 };


### PR DESCRIPTION
## What does this change?

Now that [DCR PR14141](https://github.com/guardian/dotcom-rendering/pull/14141) and [SDC PR1381](https://github.com/guardian/support-dotcom-components/pull/1381) have been merged, we can remove references to DesignableBannerV2 altogether

## Why?

DesignableBannerV2 has been renamed over the original DesignableBanner and support-dotcom-components is now returning that name for the module.  This allowed us to remove the old banner code in the background and this is the last step for that

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
