### PR TITLE
Update mediaAtom schema to match frontend

### DIFF
--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -124,6 +124,7 @@ export interface FEMediaAtom {
 	duration?: number;
 	source?: string;
 	posterImage?: { allImages: Image[] };
+	trailImage?: { allImages: Image[] };
 	expired?: boolean;
 	activeVersion?: number;
 	// channelId?: string; // currently unused

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3216,6 +3216,20 @@
                         "allImages"
                     ]
                 },
+                "trailImage": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
                 "expired": {
                     "type": "boolean"
                 },

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -1389,6 +1389,20 @@
                         "allImages"
                     ]
                 },
+                "trailImage": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
                 "expired": {
                     "type": "boolean"
                 },


### PR DESCRIPTION
## What does this change?
Extends the mediaAtom frontend type to include the newly added trailImage optional field. This field is not being used yet. 

## Why?
Keep types aligned across frontend and dcr
