### PR TITLE
Fix looping video autoplay bug on Safari

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -139,10 +139,10 @@ export const LoopVideo = ({
 	}, [uniqueId]);
 
 	useEffect(() => {
-		if (isInView) {
+		if (isInView && !hasBeenInView) {
 			setHasBeenInView(true);
 		}
-	}, [isInView]);
+	}, [isInView, hasBeenInView]);
 
 	/**
 	 * Autoplay the video when it comes into view.

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -145,7 +145,8 @@ export const LoopVideoPlayer = forwardRef(
 					css={videoStyles(width, height)}
 				>
 					{/* Only mp4 is currently supported. Assumes the video file type is mp4. */}
-					<source src={src} type="video/mp4" />
+					{/* The start time is set to 1ms so that Safari will autoplay the video */}
+					<source src={`${src}#t=0.001`} type="video/mp4" />
 					{fallbackImageComponent}
 				</video>
 				{ref && 'current' in ref && ref.current && isPlayable && (

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -76,7 +76,7 @@ type Props = {
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: (iconProps: IconProps) => JSX.Element;
 	posterImage?: string;
-	shouldPreload: boolean;
+	preloadPartialData: boolean;
 	showPlayIcon: boolean;
 };
 
@@ -104,7 +104,7 @@ export const LoopVideoPlayer = forwardRef(
 			handleKeyDown,
 			onError,
 			AudioIcon,
-			shouldPreload,
+			preloadPartialData,
 			showPlayIcon,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
@@ -117,7 +117,7 @@ export const LoopVideoPlayer = forwardRef(
 				<video
 					id={loopVideoId}
 					ref={ref}
-					preload={shouldPreload ? 'metadata' : 'none'}
+					preload={preloadPartialData ? 'metadata' : 'none'}
 					loop={true}
 					muted={isMuted}
 					playsInline={true}


### PR DESCRIPTION
## What does this change?

Sets the start time of the video to 1ms.

Moves side-effects caused by intersection observer or player state in `useEffect`'s.

## Why?

Safari does not fire the [canPlay](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplay_event) event when a video is ready to be played. Other browsers fire this event at the expected time. It does fire the `canPlay` event if a non-zero start time is set.

An alternative workaround involves using the [loadedmetadata](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadedmetadata_event) event instead. However, this may have drawbacks if there is a gap between the metadata being loaded and the video being ready to play, so I opted for the former workaround.

## Screenshares

### Before

https://github.com/user-attachments/assets/3305456e-457b-4364-b69a-d74870ee8349

### After

https://github.com/user-attachments/assets/10c68c45-059e-495a-acd7-25a1a02d09d1
