### PR TITLE
Front card media atom image selection

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -99,12 +99,7 @@ export const trails: [
 			height: 288,
 			origin: 'The Guardian',
 			expired: false,
-			images: [
-				{
-					url: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
-					width: 600,
-				},
-			],
+			image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
 		},
 		isExternalLink: false,
 		showLivePlayable: false,
@@ -465,24 +460,7 @@ export const trails: [
 			width: 500,
 			height: 300,
 			origin: 'The Guardian',
-			images: [
-				{
-					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1000.jpg',
-					width: 1000,
-				},
-				{
-					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/500.jpg',
-					width: 500,
-				},
-				{
-					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/140.jpg',
-					width: 140,
-				},
-				{
-					url: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1920.jpg',
-					width: 1920,
-				},
-			],
+			image: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1920.jpg',
 			expired: false,
 		},
 		isExternalLink: false,
@@ -608,12 +586,7 @@ export const trails: [
 			height: 288,
 			origin: 'The Guardian',
 			expired: false,
-			images: [
-				{
-					url: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
-					width: 600,
-				},
-			],
+			image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
 		},
 		isExternalLink: false,
 		showLivePlayable: false,
@@ -794,28 +767,7 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 			height: 300,
 			origin: 'SNTV',
 			expired: false,
-			images: [
-				{
-					url: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/2000.jpg',
-					width: 2000,
-				},
-				{
-					url: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/1000.jpg',
-					width: 1000,
-				},
-				{
-					url: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/500.jpg',
-					width: 500,
-				},
-				{
-					url: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/140.jpg',
-					width: 140,
-				},
-				{
-					url: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/3000.jpg',
-					width: 3000,
-				},
-			],
+			image: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/3000.jpg',
 		},
 		showVideo: true,
 		image: {
@@ -849,28 +801,7 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 			height: 300,
 			origin: 'Reuters',
 			expired: false,
-			images: [
-				{
-					url: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/2000.jpg',
-					width: 2000,
-				},
-				{
-					url: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/1000.jpg',
-					width: 1000,
-				},
-				{
-					url: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/500.jpg',
-					width: 500,
-				},
-				{
-					url: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/140.jpg',
-					width: 140,
-				},
-				{
-					url: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/5358.jpg',
-					width: 5358,
-				},
-			],
+			image: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/5358.jpg',
 		},
 		showVideo: true,
 		image: {

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -64,10 +64,7 @@ const mainVideo: MainMedia = {
 	title: '’I care, but I don’t care’: Life after the Queen’s death | Anywhere but Westminster',
 	expired: false,
 	duration: 200,
-	images: [480, 640, 960, 1024, 1200].map((width) => ({
-		url: `https://i.guim.co.uk/img/media/2eb01d138eb8fba6e59ce7589a60e3ff984f6a7a/0_0_1920_1080/1920.jpg?width=${width}&quality=45&dpr=2&s=none`,
-		width,
-	})),
+	image: `https://i.guim.co.uk/img/media/2eb01d138eb8fba6e59ce7589a60e3ff984f6a7a/0_0_1920_1080/1920.jpg?width=1200&quality=45&dpr=2&s=none`,
 	width: 480,
 	height: 288,
 	origin: 'The Guardian',

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -265,14 +265,12 @@ const getMedia = ({
 		return {
 			type: 'loop-video',
 			mainMedia,
-			...(imageUrl && { imageUrl }),
 		} as const;
 	}
 	if (mainMedia?.type === 'Video' && canPlayInline) {
 		return {
 			type: 'video',
 			mainMedia,
-			...(imageUrl && { imageUrl }),
 		} as const;
 	}
 	if (slideshowImages) return { type: 'slideshow', slideshowImages } as const;
@@ -904,12 +902,12 @@ export const Card = ({
 									src={media.mainMedia.videoId}
 									height={media.mainMedia.height}
 									width={media.mainMedia.width}
-									thumbnailImage={
-										media.mainMedia.thumbnailImage ?? ''
-									}
+									image={media.mainMedia.image ?? ''}
 									fallbackImageComponent={
 										<CardPicture
-											mainImage={media.imageUrl ?? ''}
+											mainImage={
+												media.mainMedia.image ?? ''
+											}
 											imageSize={imageSize}
 											loading={imageLoading}
 											alt={media.imageAltText}
@@ -952,9 +950,8 @@ export const Card = ({
 																.duration
 												}
 												posterImage={
-													media.mainMedia.images
+													media.mainMedia.image
 												}
-												overrideImage={media.imageUrl}
 												width={media.mainMedia.width}
 												height={media.mainMedia.height}
 												origin={media.mainMedia.origin}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1013,15 +1013,7 @@ export const Card = ({
 									<div>
 										<CardPicture
 											mainImage={
-												media.imageUrl
-													? media.imageUrl
-													: media.mainMedia.images.reduce(
-															(prev, current) =>
-																prev.width >
-																current.width
-																	? prev
-																	: current,
-													  ).url
+												media.mainMedia.image ?? ''
 											}
 											imageSize={imageSize}
 											alt={headlineText}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -203,6 +203,9 @@ export const CardPicture = ({
 	aspectRatio = '5:3',
 	mobileAspectRatio,
 }: Props) => {
+	if (mainImage === '') {
+		return null;
+	}
 	const sources = generateSources(
 		mainImage,
 		decideImageWidths(imageSize, aspectRatio),

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -258,12 +258,7 @@ export const Video: Story = {
 			title: 'Video Title',
 			duration: 120,
 			expired: false,
-			images: [
-				{
-					url: 'https://media.guim.co.uk/video-thumbnail.jpg',
-					width: 1920,
-				},
-			],
+			image: 'https://media.guim.co.uk/video-thumbnail.jpg',
 		},
 	},
 };

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -235,7 +235,6 @@ const getMedia = ({
 		return {
 			type: 'video',
 			mainMedia,
-			...(imageUrl && { imageUrl }),
 		} as const;
 	}
 
@@ -427,8 +426,7 @@ export const FeatureCard = ({
 										stickyVideos={false}
 										enableAds={false}
 										duration={mainMedia.duration}
-										posterImage={mainMedia.images}
-										overrideImage={media?.imageUrl}
+										posterImage={mainMedia.image}
 										width={300}
 										height={375}
 										origin="The Guardian"
@@ -476,15 +474,7 @@ export const FeatureCard = ({
 									<div>
 										<CardPicture
 											mainImage={
-												media.imageUrl
-													? media.imageUrl
-													: media.mainMedia.images.reduce(
-															(prev, current) =>
-																prev.width >
-																current.width
-																	? prev
-																	: current,
-													  ).url
+												media.mainMedia.image ?? ''
 											}
 											imageSize={imageSize}
 											alt={headlineText}

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -259,28 +259,7 @@ const liveUpdatesCard = {
 		title: 'Spain fans celebrate at final whistle as England fans left heartbroken – video',
 		duration: 0,
 		expired: false,
-		images: [
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/2000.jpg',
-				width: 2000,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/1000.jpg',
-				width: 1000,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/500.jpg',
-				width: 500,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/140.jpg',
-				width: 140,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/4791.jpg',
-				width: 4791,
-			},
-		],
+		image: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/4791.jpg',
 	},
 	isExternalLink: false,
 	discussionApiUrl,

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -54,28 +54,7 @@ const liveUpdatesCard = {
 		title: 'Spain fans celebrate at final whistle as England fans left heartbroken – video',
 		duration: 0,
 		expired: false,
-		images: [
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/2000.jpg',
-				width: 2000,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/1000.jpg',
-				width: 1000,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/500.jpg',
-				width: 500,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/140.jpg',
-				width: 140,
-			},
-			{
-				url: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/4791.jpg',
-				width: 4791,
-			},
-		],
+		image: 'https://media.guim.co.uk/68333e95233d9c68b32b56c12205c5ded94dfbf8/0_117_4791_2696/4791.jpg',
 	},
 	isExternalLink: false,
 	discussionApiUrl,

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -36,7 +36,7 @@ type Props = {
 	uniqueId: string;
 	width: number;
 	height: number;
-	thumbnailImage: string;
+	image: string;
 	fallbackImageComponent: JSX.Element;
 };
 
@@ -45,7 +45,7 @@ export const LoopVideo = ({
 	uniqueId,
 	width,
 	height,
-	thumbnailImage,
+	image,
 	fallbackImageComponent,
 }: Props) => {
 	const adapted = useShouldAdapt();
@@ -217,9 +217,9 @@ export const LoopVideo = ({
 			isAutoplayAllowed === false ||
 			(isInView === false && !hasBeenInView)
 		) {
-			setPosterImage(thumbnailImage);
+			setPosterImage(image);
 		}
-	}, [isAutoplayAllowed, isInView, hasBeenInView, thumbnailImage]);
+	}, [isAutoplayAllowed, isInView, hasBeenInView, image]);
 
 	/**
 	 * We almost always want to preload some of the video data. If a user has prefers-reduced-motion

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -23,8 +23,7 @@ export const Default = {
 		uniqueId: 'test-video-1',
 		height: 720,
 		width: 900,
-		thumbnailImage:
-			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
+		image: 'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
 		fallbackImageComponent: (
 			<CardPicture
 				mainImage="https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg"

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -107,8 +107,8 @@ export const YoutubeBlockComponent = ({
 	const abTestParticipations = abTests?.participations ?? {};
 
 	/**
-	 * It's possible to have duplicate video atoms on the same page
-	 * For example liveblogs can have the same video for the main media and in a subsequent block
+	 * It's possible to have duplicate video atoms on the same page.
+	 * For example, liveblogs can have the same video for the main media and in a subsequent block
 	 * We need to ensure a unique id for each YouTube player on the page.
 	 */
 	const uniqueId = `${assetId}-${index}`;

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -1,7 +1,6 @@
 import type { ConsentState } from '@guardian/libs';
 import { useEffect, useState } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
-import { getLargestImageSize } from '../lib/image';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import type { AdTargeting } from '../types/commercial';
@@ -26,10 +25,7 @@ type Props = {
 	format: ArticleFormat;
 	hideCaption?: boolean;
 	overrideImage?: string;
-	posterImage?: {
-		url: string;
-		width: number;
-	}[];
+	posterImage?: string;
 	isMainMedia?: boolean;
 	height?: number;
 	width?: number;
@@ -69,7 +65,7 @@ export const YoutubeBlockComponent = ({
 	format,
 	hideCaption,
 	overrideImage,
-	posterImage = [],
+	posterImage = '',
 	expired,
 	isMainMedia,
 	height = 259,
@@ -117,12 +113,6 @@ export const YoutubeBlockComponent = ({
 	 */
 	const uniqueId = `${assetId}-${index}`;
 
-	/**
-	 * We do our own image optimization in DCR and only need 1 image.
-	 * Pick the largest image available to us to avoid up-scaling later.
-	 */
-	const largestPosterImage = getLargestImageSize(posterImage)?.url;
-
 	useEffect(() => {
 		if (renderingTarget === 'Web') {
 			const defineConsentState = async () => {
@@ -168,7 +158,7 @@ export const YoutubeBlockComponent = ({
 				atomId={id}
 				videoId={assetId}
 				uniqueId={uniqueId}
-				image={overrideImage ?? largestPosterImage}
+				image={overrideImage ?? posterImage}
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={
 					enableAds && renderingTarget === 'Web'

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.stories.tsx
@@ -214,28 +214,7 @@ export const Withimage = () => {
 				index={0}
 				expired={false}
 				duration={333}
-				posterImage={[
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/2000.jpg',
-						width: 2000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/1000.jpg',
-						width: 1000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/500.jpg',
-						width: 500,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/140.jpg',
-						width: 140,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg',
-						width: 4255,
-					},
-				]}
+				posterImage="https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg"
 				height={259}
 				width={460}
 				stickyVideos={false}
@@ -280,28 +259,7 @@ export const WithPosterAndOverlayImage = () => {
 				expired={false}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				duration={333}
-				posterImage={[
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/2000.jpg',
-						width: 2000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/1000.jpg',
-						width: 1000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/500.jpg',
-						width: 500,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/140.jpg',
-						width: 140,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg',
-						width: 4255,
-					},
-				]}
+				posterImage="https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg"
 				height={259}
 				width={460}
 				stickyVideos={false}
@@ -347,28 +305,7 @@ export const WithShowMainVideoFlagOff = () => {
 				expired={false}
 				overrideImage="https://i.guim.co.uk/img/media/49565a29c6586fe6b748926e0be96c5e9c90473c/0_0_4981_2989/500.jpg?quality=85&auto=format&fit=max&s=17c70ec70002ea34886fd6c2605cd81e"
 				duration={333}
-				posterImage={[
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/2000.jpg',
-						width: 2000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/1000.jpg',
-						width: 1000,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/500.jpg',
-						width: 500,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/140.jpg',
-						width: 140,
-					},
-					{
-						url: 'https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg',
-						width: 4255,
-					},
-				]}
+				posterImage="https://media.guim.co.uk/45c34a4312b228773b1bdec415b4253667b21ae3/0_0_4255_2394/4255.jpg"
 				height={259}
 				width={460}
 				stickyVideos={false}

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -124,6 +124,7 @@ export interface FEMediaAtom {
 	duration?: number;
 	source?: string;
 	posterImage?: { allImages: Image[] };
+	trailImage?: { allImages: Image[] };
 	expired?: boolean;
 	activeVersion?: number;
 	// channelId?: string; // currently unused

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5203,23 +5203,8 @@
                         "expired": {
                             "type": "boolean"
                         },
-                        "images": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "url": {
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "type": "number"
-                                    }
-                                },
-                                "required": [
-                                    "url",
-                                    "width"
-                                ]
-                            }
+                        "image": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -5227,7 +5212,6 @@
                         "expired",
                         "height",
                         "id",
-                        "images",
                         "origin",
                         "title",
                         "type",
@@ -5275,7 +5259,7 @@
                         "duration": {
                             "type": "number"
                         },
-                        "thumbnailImage": {
+                        "image": {
                             "type": "string"
                         }
                     },

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3216,6 +3216,20 @@
                         "allImages"
                     ]
                 },
+                "trailImage": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
                 "expired": {
                     "type": "boolean"
                 },

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3870,23 +3870,8 @@
                         "expired": {
                             "type": "boolean"
                         },
-                        "images": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "url": {
-                                        "type": "string"
-                                    },
-                                    "width": {
-                                        "type": "number"
-                                    }
-                                },
-                                "required": [
-                                    "url",
-                                    "width"
-                                ]
-                            }
+                        "image": {
+                            "type": "string"
                         }
                     },
                     "required": [
@@ -3894,7 +3879,6 @@
                         "expired",
                         "height",
                         "id",
-                        "images",
                         "origin",
                         "title",
                         "type",
@@ -3942,7 +3926,7 @@
                         "duration": {
                             "type": "number"
                         },
-                        "thumbnailImage": {
+                        "image": {
                             "type": "string"
                         }
                     },

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -1389,6 +1389,20 @@
                         "allImages"
                     ]
                 },
+                "trailImage": {
+                    "type": "object",
+                    "properties": {
+                        "allImages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Image"
+                            }
+                        }
+                    },
+                    "required": [
+                        "allImages"
+                    ]
+                },
                 "expired": {
                     "type": "boolean"
                 },

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -70,6 +70,7 @@ import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement, RoleType, StarRating } from '../types/content';
 import { ArticleDesign, type ArticleFormat } from './articleFormat';
 import type { EditionId } from './edition';
+import { getLargestImageSize } from './image';
 
 type Props = {
 	format: ArticleFormat;
@@ -857,7 +858,9 @@ export const renderElement = ({
 						isMainMedia={isMainMedia}
 						expired={element.expired}
 						overrideImage={element.overrideImage}
-						posterImage={element.posterImage}
+						posterImage={
+							getLargestImageSize(element.posterImage ?? [])?.url
+						}
 						duration={element.duration}
 						mediaTitle={element.mediaTitle}
 						altText={element.altText}

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -14,6 +14,7 @@ import type { EditionId } from '../lib/edition';
 import type { Group } from '../lib/getDataLinkName';
 import { getDataLinkNameCard } from '../lib/getDataLinkName';
 import { getLargestImageSize } from '../lib/image';
+import type { Image } from '../types/content';
 import type {
 	DCRFrontCard,
 	DCRSlideshowImage,
@@ -156,6 +157,15 @@ const decideSlideshowImages = (
 	return undefined;
 };
 
+const getLargestImageUrl = (images?: Image[]) => {
+	return getLargestImageSize(
+		images?.map(({ url, fields: { width } }) => ({
+			url,
+			width: Number(width),
+		})) ?? [],
+	)?.url;
+};
+
 /**
  * While the first Media Atom is *not* guaranteed to be the main media,
  * it *happens to be* correct in the majority of cases.
@@ -179,14 +189,7 @@ const getActiveMediaAtom = (
 				// Size fixed to a 5:4 ratio
 				width: 500,
 				height: 400,
-				thumbnailImage: getLargestImageSize(
-					mediaAtom.posterImage?.allImages.map(
-						({ url, fields: { width } }) => ({
-							url,
-							width: Number(width),
-						}),
-					) ?? [],
-				)?.url,
+				image: getLargestImageUrl(mediaAtom.posterImage?.allImages),
 			};
 		}
 
@@ -202,13 +205,7 @@ const getActiveMediaAtom = (
 				height: 300,
 				origin: mediaAtom.source ?? 'Unknown origin',
 				expired: !!mediaAtom.expired,
-				images:
-					mediaAtom.posterImage?.allImages.map(
-						({ url, fields: { width } }) => ({
-							url,
-							width: Number(width),
-						}),
-					) ?? [],
+				image: getLargestImageUrl(mediaAtom.posterImage?.allImages),
 			};
 		}
 	}

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -175,8 +175,9 @@ const decideMediaAtomImage = (
 	mediaAtom: FEMediaAtom,
 	cardTrailImage?: string,
 ) => {
-	if (videoReplace)
+	if (videoReplace) {
 		return getLargestImageUrl(mediaAtom.trailImage?.allImages);
+	}
 	return (
 		cardTrailImage ?? getLargestImageUrl(mediaAtom.trailImage?.allImages)
 	);

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -16,7 +16,7 @@ type Video = Media & {
 	title: string;
 	duration: number;
 	expired: boolean;
-	images: Array<{ url: string; width: number }>;
+	image?: string;
 };
 
 type LoopVideo = Media & {
@@ -25,7 +25,7 @@ type LoopVideo = Media & {
 	height: number;
 	width: number;
 	duration: number;
-	thumbnailImage?: string;
+	image?: string;
 };
 
 type Audio = Media & {


### PR DESCRIPTION
## What does this change?
Lifts image selection for media atoms into the enhancement step.
The image selection is first to retrieve the largest image available and then to decide if the atom should use the media atom image or the card image. 

It also refactors the image type across the different video media atoms to be an optional string. This is because this is all that is used downstream.

Finally, it protects fronts from missing images by early returning in the card picture component. Without this, an empty image string would cause the front to 404. 

## Why?
Previously, we only showed the media image if there was no a card trail image available. We now want to use the media image if the video is a replacement video, other wise we use the card trail image. 

We are also using the media trail image instead of the media poster image. This is because the trail image is in a 5:4 crop which aligns with card aspect ratios.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6502ab4c-e37f-414c-be38-d0ea2ad97c12
[after]: https://github.com/user-attachments/assets/f32424e1-6021-422c-8c3f-3efb2a5b7d0b
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
