### PR TITLE
Hide trails on fronts on small screens

### DIFF
--- a/dotcom-rendering/src/components/Card/components/TrailText.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailText.tsx
@@ -4,6 +4,7 @@ import {
 	space,
 	textSans14,
 	textSans17,
+	until,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import { palette } from '../../../palette';
@@ -13,6 +14,10 @@ export type TrailTextSize = 'regular' | 'large';
 const trailTextStyles = css`
 	display: flex;
 	flex-direction: column;
+
+	${until.tablet} {
+		display: none;
+	}
 `;
 
 const bottomPadding = css`

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source/foundations';
+import { from, space, until } from '@guardian/source/foundations';
 import { Hide, SvgMediaControlsPlay } from '@guardian/source/react-components';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
@@ -127,7 +127,6 @@ const immersiveOverlayContainerStyles = css`
  * reduced.) The following article has more detail on non-linear gradients:
  * https://css-tricks.com/easing-linear-gradients/
  */
-
 const overlayMaskGradientStyles = (angle: string) => css`
 	mask-image: linear-gradient(
 		${angle},
@@ -201,6 +200,10 @@ const starRatingWrapper = css`
 
 const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
+
+	${until.tablet} {
+		display: none;
+	}
 `;
 
 const videoPillStyles = css`


### PR DESCRIPTION
## What does this change?

Hide trail text on front small screens.

Note: although `<Card />` is used by the `<Carousel />` component, carousels don't use trail text.

## Why?

The [AB test](https://github.com/guardian/dotcom-rendering/pull/14108) has a positive significant effect on click-through rate.

## Screenshots

| Before | After |
| - | - |
| ![mobile-before] | ![mobile-after] |
| ![tablet-before] | ![tablet-after] |

[mobile-before]: https://github.com/user-attachments/assets/179e8632-24ea-48d0-9476-2102156041dc
[tablet-before]: https://github.com/user-attachments/assets/165281dc-32e6-46b0-bff2-60511667b848
[mobile-after]:  https://github.com/user-attachments/assets/7998b2bc-b34a-4641-863e-731c98fa277a
[tablet-after]: https://github.com/user-attachments/assets/4232b2c8-9d56-4689-a12a-4f1cd2af4071


