### PR TITLE
Fix ad iframe whitespace

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -50,15 +50,15 @@ const adSlotStyles = css`
 
 		/* used by native ads that set a background using messenger e.g. fabric that set a background outside of the ad using an absolutely positioned element */
 		position: relative;
+		width: fit-content;
+		margin-left: auto;
+		margin-right: auto;
 
 		/*
 			Ensure that the ad slot is centred,
 			the element with this class name is inserted by GAM into the ad slot
 		*/
 		.ad-slot__content {
-			margin-left: auto;
-			margin-right: auto;
-
 			/* When a native ad is served, GAM sets this to inline-block as an inline style, but we want it to be block as inline-block can cause whitespace to render newlines as white space, see https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#:~:text=If%20there%20is%20formatting%20whitespace%20between%20adjacent%20inline%20elements%2C%20this%20will%20result%20in%20space%20in%20the%20layout%2C%20just%20like%20the%20spaces%20between%20words%20in%20text. */
 			/* stylelint-disable-next-line declaration-no-important */
 			display: block !important;

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -48,6 +48,9 @@ const adSlotStyles = css`
 		/* this is centring the ad iframe as they are display: inline; elements by default */
 		text-align: center;
 
+		/* used by native ads that set a background using messenger e.g. fabric that set a background outside of the ad using an absolutely positioned element */
+		position: relative;
+
 		/*
 			Ensure that the ad slot is centred,
 			the element with this class name is inserted by GAM into the ad slot
@@ -55,6 +58,17 @@ const adSlotStyles = css`
 		.ad-slot__content {
 			margin-left: auto;
 			margin-right: auto;
+
+			/* When a native ad is served, GAM sets this to inline-block as an inline style, but we want it to be block as inline-block can cause whitespace to render newlines as white space, see https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#:~:text=If%20there%20is%20formatting%20whitespace%20between%20adjacent%20inline%20elements%2C%20this%20will%20result%20in%20space%20in%20the%20layout%2C%20just%20like%20the%20spaces%20between%20words%20in%20text. */
+			/* stylelint-disable-next-line declaration-no-important */
+			display: block !important;
+
+			/* iframes are inline by default, so we need to set them to block to avoid the same whitespace quirk mentioned in the above comment */
+			iframe {
+				display: block;
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 
 		@media print {

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -45,11 +45,9 @@ const adSlotContainerStyles = css`
 
 const adSlotStyles = css`
 	.ad-slot {
-		/* this is centring the ad iframe as they are display: inline; elements by default */
-		text-align: center;
-
 		/* used by native ads that set a background using messenger e.g. fabric that set a background outside of the ad using an absolutely positioned element */
 		position: relative;
+
 		width: fit-content;
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
## What does this change?
Add some styles to ensure ad iframes and their containers `.ad-slot__content` use `display: block`

## Why?
Without forcing these to be blocks they are subject to a whitespace quirk that exists with `inline` and `inline-*` elements, basically new lines in HTML get rendered as a small amount of white space. In our case an extra 3px for certain types of ads especially native ones.

This wasn't noticeable at all, but as I was doing some work to reserve 250px for top-above-nav I noticed this small layout shift!

Applying this styling to all ads make sense, we do not position any ads truly 'inline'.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


 
[before]: https://github.com/user-attachments/assets/da07b39c-70e2-4545-af73-1ea2ceae2247

[after]: https://github.com/user-attachments/assets/75874f03-d5dd-4664-81e2-3566fc9715fe

Before
<video src="https://github.com/user-attachments/assets/4ff6b636-e3ee-487a-9920-3609d334bd49" /> 

After
<video src="https://github.com/user-attachments/assets/0176ec70-9c6e-4258-bf4e-29622d762a7d" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
