### PR TITLE
Check flashing preferences before allowing autoplaying looping videos

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { log } from '@guardian/libs';
+import { log, storage } from '@guardian/libs';
 import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useEffect, useRef, useState } from 'react';
 import { submitClickComponentEvent } from '../client/ophan/ophan';
@@ -83,8 +83,8 @@ export const LoopVideo = ({
 	/**
 	 * Setup.
 	 *
-	 * Register the users motion preferences.
-	 * Creates event listeners to control playback when there are multiple videos.
+	 * 1. Register the user's motion preferences.
+	 * 2. Creates event listeners to control playback when there are multiple videos.
 	 */
 	useEffect(() => {
 		/**
@@ -93,7 +93,19 @@ export const LoopVideo = ({
 		const userPrefersReducedMotion = window.matchMedia(
 			'(prefers-reduced-motion: reduce)',
 		).matches;
-		setIsAutoplayAllowed(!userPrefersReducedMotion);
+
+		/**
+		 * The user indicates a preference for no flashing elements.
+		 * `flashingPreference` is `null` if no preference exists and
+		 * explicitly `false` when the reader has said they don't want flashing.
+		 */
+		const flashingPreferences = storage.local.get(
+			'gu.prefs.accessibility.flashing-elements',
+		);
+
+		setIsAutoplayAllowed(
+			!userPrefersReducedMotion && flashingPreferences !== false,
+		);
 
 		/**
 		 * Mutes the current video when another video is unmuted
@@ -113,7 +125,7 @@ export const LoopVideo = ({
 		};
 
 		/**
-		 * Mute the current video when a Youtube video is played
+		 * Mute the current video when a YouTube video is played
 		 * Triggered by the CustomEvent in YoutubeAtomPlayer.
 		 */
 		const handleCustomPlayYoutubeEvent = () => {


### PR DESCRIPTION
## What does this change?
Check flashing preferences before allowing autoplaying looping videos

## Why?
Flashing preferences are a guardian accessibility setting. The value is held in local storage and is either `false` if the user has set the permission or `null`. If the user has requested no flashing, we should not autoplay a video.

## Screenshots

| No autoplay on start      | 
| ----------- | 
| ![before][] | 


[before]: https://github.com/user-attachments/assets/d064db9b-974a-4aff-81de-b0cbd920a9fd

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
