### PR TITLE
Test reserving 250px for top-above-nav

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -47,6 +47,7 @@ type DefaultProps = {
 	display?: ArticleDisplay;
 	isPaidContent?: boolean;
 	hasPageskin?: boolean;
+	isIn250ReservationVariant?: boolean;
 };
 
 // for dark ad labels
@@ -106,12 +107,29 @@ const hideBelowDesktop = css`
 	}
 `;
 
+const containerMinHeight = getMinHeight(250, space[5]);
+
 const topAboveNavContainerStyles = css`
-	padding-bottom: 18px;
+	padding-bottom: ${space[5]}px;
 	position: relative;
 	margin: 0 auto;
 	text-align: left;
 	display: block;
+`;
+
+const topAboveNavContainerVaraintStyles = css`
+	padding-bottom: ${space[5]}px;
+	position: relative;
+	margin: 0 auto;
+	text-align: left;
+	display: block;
+	width: 100%;
+	min-height: ${containerMinHeight}px;
+
+	/* Remove the min-height when the ad has rendered, so that the container can shrink if the ad is smaller */
+	&[top-above-nav-ad-rendered='true'] {
+		min-height: auto;
+	}
 `;
 
 /**
@@ -412,6 +430,7 @@ export const AdSlot = ({
 	index,
 	hasPageskin = false,
 	shouldHideReaderRevenue = false,
+	isIn250ReservationVariant,
 }: Props) => {
 	switch (position) {
 		case 'right':
@@ -590,7 +609,13 @@ export const AdSlot = ({
 		}
 		case 'top-above-nav': {
 			return (
-				<AdSlotWrapper css={topAboveNavContainerStyles}>
+				<AdSlotWrapper
+					css={
+						isIn250ReservationVariant
+							? topAboveNavContainerVaraintStyles
+							: topAboveNavContainerStyles
+					}
+				>
 					<div
 						id="dfp-ad--top-above-nav"
 						className={[

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -2,6 +2,7 @@ import { css, Global } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial';
 import { space } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import type { ServerSideTests } from '../types/config';
 import { AdBlockAsk } from './AdBlockAsk.importable';
 import { AdSlot } from './AdSlot.web';
 import { Hide } from './Hide';
@@ -18,64 +19,99 @@ const borderBottomHeight = 1;
 const headerMinHeight =
 	TOP_ABOVE_NAV_HEIGHT + padding + AD_LABEL_HEIGHT + borderBottomHeight;
 
-const headerAdWrapper = css`
-	z-index: 1080;
-	width: 100%;
-	background-color: ${palette('--ad-background')};
-	min-height: ${headerMinHeight}px;
-	border-bottom: ${borderBottomHeight}px solid ${palette('--ad-border')};
+const headerAdWrapper = (isIn250ReservationVariant: boolean) =>
+	isIn250ReservationVariant
+		? css`
+				z-index: 1080;
+				width: 100%;
+				background-color: ${palette('--ad-background')};
+				border-bottom: 1px solid ${palette('--ad-border')};
 
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
 
-	position: sticky;
-	top: 0;
-`;
+				position: sticky;
+				top: 0;
+		  `
+		: css`
+				z-index: 1080;
+				width: 100%;
+				background-color: ${palette('--ad-background')};
+				min-height: ${headerMinHeight}px;
+				border-bottom: ${borderBottomHeight}px solid
+					${palette('--ad-border')};
+
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+
+				position: sticky;
+				top: 0;
+		  `;
 
 /**
  * Ensure the top-above-nav/ad-block-ask containing div is always of a certain minimum height
  */
-const headerMinSizeStyles = css`
-	min-height: ${adSizes.leaderboard.height}px;
-	min-width: ${adSizes.leaderboard.width}px;
-`;
+const headerMinSizeStyles = (isIn250ReservationVariant: boolean) =>
+	isIn250ReservationVariant
+		? undefined
+		: css`
+				min-height: ${adSizes.leaderboard.height}px;
+				min-width: ${adSizes.leaderboard.width}px;
+		  `;
 
 export const HeaderAdSlot = ({
 	shouldHideReaderRevenue,
 	isPaidContent,
+	abTests,
 }: {
 	shouldHideReaderRevenue: boolean;
 	isPaidContent: boolean;
-}) => (
-	<div css={headerWrapper}>
-		<Global
-			styles={css`
-				/**
+	abTests: ServerSideTests;
+}) => {
+	const isIn250ReservationVariant =
+		abTests.topAboveNav250ReservationVariant === 'variant';
+	return (
+		<div css={headerWrapper}>
+			<Global
+				styles={css`
+					/**
 				* Hides the top-above-nav ad-slot container when a
 				* Bonzai TrueSkin (Australian 3rd Party page skin) is shown
 				*/
-				.bz-custom-container
-					~ #bannerandheader
-					.top-banner-ad-container {
-					display: none;
-				}
-			`}
-		/>
-		<Hide when="below" breakpoint="tablet">
-			<div css={[headerAdWrapper]} className="top-banner-ad-container">
-				<div css={headerMinSizeStyles}>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<AdBlockAsk
-							size="leaderboard"
-							slotId="dfp-ad--top-above-nav"
-							shouldHideReaderRevenue={shouldHideReaderRevenue}
-							isPaidContent={isPaidContent}
+					.bz-custom-container
+						~ #bannerandheader
+						.top-banner-ad-container {
+						display: none;
+					}
+				`}
+			/>
+			<Hide when="below" breakpoint="tablet">
+				<div
+					css={[headerAdWrapper(isIn250ReservationVariant)]}
+					className="top-banner-ad-container"
+				>
+					<div css={headerMinSizeStyles(isIn250ReservationVariant)}>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<AdBlockAsk
+								size="leaderboard"
+								slotId="dfp-ad--top-above-nav"
+								shouldHideReaderRevenue={
+									shouldHideReaderRevenue
+								}
+								isPaidContent={isPaidContent}
+							/>
+						</Island>
+						<AdSlot
+							position="top-above-nav"
+							isIn250ReservationVariant={
+								isIn250ReservationVariant
+							}
 						/>
-					</Island>
-					<AdSlot position="top-above-nav" />
+					</div>
 				</div>
-			</div>
-		</Hide>
-	</div>
-);
+			</Hide>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/HeaderAdSlot.tsx
+++ b/dotcom-rendering/src/components/HeaderAdSlot.tsx
@@ -19,47 +19,42 @@ const borderBottomHeight = 1;
 const headerMinHeight =
 	TOP_ABOVE_NAV_HEIGHT + padding + AD_LABEL_HEIGHT + borderBottomHeight;
 
-const headerAdWrapper = (isIn250ReservationVariant: boolean) =>
-	isIn250ReservationVariant
-		? css`
-				z-index: 1080;
-				width: 100%;
-				background-color: ${palette('--ad-background')};
-				border-bottom: 1px solid ${palette('--ad-border')};
+const headerAdWrapperStylesVariant = css`
+	z-index: 1080;
+	width: 100%;
+	background-color: ${palette('--ad-background')};
+	border-bottom: 1px solid ${palette('--ad-border')};
 
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
 
-				position: sticky;
-				top: 0;
-		  `
-		: css`
-				z-index: 1080;
-				width: 100%;
-				background-color: ${palette('--ad-background')};
-				min-height: ${headerMinHeight}px;
-				border-bottom: ${borderBottomHeight}px solid
-					${palette('--ad-border')};
+	position: sticky;
+	top: 0;
+`;
 
-				display: flex;
-				flex-direction: column;
-				justify-content: center;
+const headerAdWrapperStylesControl = css`
+	z-index: 1080;
+	width: 100%;
+	background-color: ${palette('--ad-background')};
+	min-height: ${headerMinHeight}px;
+	border-bottom: 1px solid ${palette('--ad-border')};
 
-				position: sticky;
-				top: 0;
-		  `;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	position: sticky;
+	top: 0;
+`;
 
 /**
  * Ensure the top-above-nav/ad-block-ask containing div is always of a certain minimum height
  */
-const headerMinSizeStyles = (isIn250ReservationVariant: boolean) =>
-	isIn250ReservationVariant
-		? undefined
-		: css`
-				min-height: ${adSizes.leaderboard.height}px;
-				min-width: ${adSizes.leaderboard.width}px;
-		  `;
+const headerMinSizeStyles = css`
+	min-height: ${adSizes.leaderboard.height}px;
+	min-width: ${adSizes.leaderboard.width}px;
+`;
 
 export const HeaderAdSlot = ({
 	shouldHideReaderRevenue,
@@ -89,10 +84,16 @@ export const HeaderAdSlot = ({
 			/>
 			<Hide when="below" breakpoint="tablet">
 				<div
-					css={[headerAdWrapper(isIn250ReservationVariant)]}
+					css={[
+						isIn250ReservationVariant
+							? headerAdWrapperStylesVariant
+							: headerAdWrapperStylesControl,
+					]}
 					className="top-banner-ad-container"
 				>
-					<div css={headerMinSizeStyles(isIn250ReservationVariant)}>
+					<div
+						css={!isIn250ReservationVariant && headerMinSizeStyles}
+					>
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<AdBlockAsk
 								size="leaderboard"

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -173,6 +173,7 @@ export const AudioLayout = (props: WebProps) => {
 								shouldHideReaderRevenue={
 									!!article.config.shouldHideReaderRevenue
 								}
+								abTests={article.config.abTests}
 							/>
 						</Section>
 					</Stuck>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -325,6 +325,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 									shouldHideReaderRevenue={
 										!!article.config.shouldHideReaderRevenue
 									}
+									abTests={article.config.abTests}
 								/>
 							</Section>
 						</Stuck>

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -145,6 +145,7 @@ export const CrosswordLayout = (props: Props) => {
 									shouldHideReaderRevenue={
 										!!article.config.shouldHideReaderRevenue
 									}
+									abTests={article.config.abTests}
 								/>
 							</Section>
 						</div>

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -202,6 +202,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 							<HeaderAdSlot
 								isPaidContent={!!front.config.isPaidContent}
 								shouldHideReaderRevenue={false}
+								abTests={front.config.abTests}
 							/>
 						</Section>
 					</Stuck>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -174,6 +174,7 @@ const NavHeader = ({ article, NAV, format, renderAds }: HeaderProps) => {
 								shouldHideReaderRevenue={
 									!!article.config.shouldHideReaderRevenue
 								}
+								abTests={article.config.abTests}
 							/>
 						</Section>
 					</div>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -280,6 +280,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 												!!article.config
 													.shouldHideReaderRevenue
 											}
+											abTests={article.config.abTests}
 										/>
 									</Section>
 								</div>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -316,6 +316,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									shouldHideReaderRevenue={
 										!!article.config.shouldHideReaderRevenue
 									}
+									abTests={article.config.abTests}
 								/>
 							</Section>
 						</Stuck>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -232,6 +232,7 @@ export const NewsletterSignupLayout = ({
 								shouldHideReaderRevenue={
 									!!article.config.shouldHideReaderRevenue
 								}
+								abTests={article.config.abTests}
 							/>
 						</Section>
 					</Stuck>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -299,6 +299,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 									shouldHideReaderRevenue={
 										!!article.config.shouldHideReaderRevenue
 									}
+									abTests={article.config.abTests}
 								/>
 							</Section>
 						</Stuck>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -272,6 +272,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 												!!article.config
 													.shouldHideReaderRevenue
 											}
+											abTests={article.config.abTests}
 										/>
 									</Section>
 								</Stuck>
@@ -317,6 +318,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													!!article.config
 														.shouldHideReaderRevenue
 												}
+												abTests={article.config.abTests}
 											/>
 										</Section>
 									</Stuck>

--- a/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
@@ -96,6 +96,7 @@ export const SportDataPageLayout = ({ sportData }: Props) => {
 							<HeaderAdSlot
 								isPaidContent={!!sportData.config.isPaidContent}
 								shouldHideReaderRevenue={false}
+								abTests={sportData.config.abTests}
 							/>
 						</Section>
 					</Stuck>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -413,6 +413,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									shouldHideReaderRevenue={
 										!!article.config.shouldHideReaderRevenue
 									}
+									abTests={article.config.abTests}
 								/>
 							</Section>
 						</Stuck>

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -80,6 +80,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 							<HeaderAdSlot
 								isPaidContent={!!tagPage.config.isPaidContent}
 								shouldHideReaderRevenue={false}
+								abTests={tagPage.config.abTests}
 							/>
 						</Section>
 					</Stuck>

--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -99,6 +99,10 @@ const adSlotStyles = css`
 			margin: 0;
 			overflow: visible;
 			width: 100%;
+
+			&[data-label-show='true'] {
+				min-height: calc(250px + ${labelHeight}px);
+			}
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?
Add a test setting the min-height of the top-abov-nav to 250px

Currently 0% for review and while we wait for sample sizes.

## Why?
This is the first in a series of tests that commercial will be carrying out regarding top-above-nav space reservation and placement.

Currently only 90px is reserved at the top, but 75% of the time an ad of 250px height displays, resulting in CLS as it resizes. This change would reduce CLS for those 75% of cases!

In order for the slot to shrink, the `min-height` needs to be moved from the `.top-banner-ad-container` to the the ad slot container as this element gets `[top-above-nav-ad-rendered='true']` set on it when the ad has rendered which we can use to override the `min-height` to `auto` once the ad has rendered so it will shrink back down if the ad is smaller than 250px.

## Screenshots

| Control      | Variant      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |


[before]: https://github.com/user-attachments/assets/68a54bc3-6ccd-4d13-8d38-b77a5c7adf58
[after]: https://github.com/user-attachments/assets/891149ca-9639-4de4-a2c6-fb0b3f207fdf
[before2]: https://github.com/user-attachments/assets/ce9ec402-07f9-4927-8954-27bcaef59b08
[after2]: https://github.com/user-attachments/assets/ba7c8f8a-8d68-4424-babc-5f6d1b4952a9



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
