### PR TITLE
[A/B Testing POC] Add first-pass Ophan reporting for client-side AB tests using the new framework

### DIFF
--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -71,6 +71,12 @@ export const SetABTests = ({
 	const { renderingTarget } = useConfig();
 	const [ophan, setOphan] = useState<Awaited<ReturnType<typeof getOphan>>>();
 
+	const errorReporter = (e: unknown) =>
+		window.guardian.modules.sentry.reportError(
+			e instanceof Error ? e : Error(String(e)),
+			'ab-tests',
+		);
+
 	useEffect(() => {
 		getOphan(renderingTarget)
 			.then(setOphan)
@@ -100,11 +106,7 @@ export const SetABTests = ({
 
 		const betaAb = new BetaABTests({
 			ophanRecord: ophan.record,
-			errorReporter: (e) =>
-				window.guardian.modules.sentry.reportError(
-					e instanceof Error ? e : Error(String(e)),
-					'ab-tests',
-				),
+			errorReporter,
 		});
 
 		const ab = new AB({
@@ -116,11 +118,7 @@ export const SetABTests = ({
 			forcedTestVariants: allForcedTestVariants,
 			ophanRecord: ophan.record,
 			serverSideTests,
-			errorReporter: (e) =>
-				window.guardian.modules.sentry.reportError(
-					e instanceof Error ? e : Error(String(e)),
-					'ab-tests',
-				),
+			errorReporter,
 		});
 		const allRunnableTests = ab.allRunnableTests(tests);
 		const participations = runnableTestsToParticipations(allRunnableTests);

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -130,6 +130,11 @@ export const SetABTests = ({
 
 		setBetaABTests(betaAb);
 
+		window.guardian.modules.abTests.isUserInTest = (
+			testId: string,
+			variantId: string,
+		) => betaAb.isUserInTest(testId, variantId);
+
 		ab.trackABTests(allRunnableTests);
 		ab.registerImpressionEvents(allRunnableTests);
 		ab.registerCompleteEvents(allRunnableTests);

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { getOphan } from '../client/ophan/ophan';
 import { tests } from '../experiments/ab-tests';
 import { runnableTestsToParticipations } from '../experiments/lib/ab-participations';
+import { BetaABTests } from '../experiments/lib/beta-ab-tests';
 import { getForcedParticipationsFromUrl } from '../lib/getAbUrlHash';
 import { setABTests } from '../lib/useAB';
 import type { ABTestSwitches } from '../model/enhance-switches';
@@ -97,6 +98,15 @@ export const SetABTests = ({
 			...getForcedParticipationsFromUrl(window.location.hash),
 		};
 
+		const betaAb = new BetaABTests({
+			ophanRecord: ophan.record,
+			errorReporter: (e) =>
+				window.guardian.modules.sentry.reportError(
+					e instanceof Error ? e : Error(String(e)),
+					'ab-tests',
+				),
+		});
+
 		const ab = new AB({
 			mvtId: mvtId ?? -1,
 			mvtMaxValue,
@@ -123,6 +133,7 @@ export const SetABTests = ({
 		ab.trackABTests(allRunnableTests);
 		ab.registerImpressionEvents(allRunnableTests);
 		ab.registerCompleteEvents(allRunnableTests);
+		betaAb.trackABTests();
 		log('dotcom', 'AB tests initialised');
 	}, [
 		abTestSwitches,

--- a/dotcom-rendering/src/components/SetABTests.importable.tsx
+++ b/dotcom-rendering/src/components/SetABTests.importable.tsx
@@ -7,7 +7,7 @@ import { tests } from '../experiments/ab-tests';
 import { runnableTestsToParticipations } from '../experiments/lib/ab-participations';
 import { BetaABTests } from '../experiments/lib/beta-ab-tests';
 import { getForcedParticipationsFromUrl } from '../lib/getAbUrlHash';
-import { setABTests } from '../lib/useAB';
+import { setABTests, setBetaABTests } from '../lib/useAB';
 import type { ABTestSwitches } from '../model/enhance-switches';
 import type { ServerSideTests } from '../types/config';
 import { useConfig } from './ConfigContext';
@@ -127,6 +127,8 @@ export const SetABTests = ({
 			api: ab,
 			participations,
 		});
+
+		setBetaABTests(betaAb);
 
 		ab.trackABTests(allRunnableTests);
 		ab.registerImpressionEvents(allRunnableTests);

--- a/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
+++ b/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
@@ -10,6 +10,7 @@ export interface BetaABTestAPI {
 type ABParticipations = {
 	[testId: string]: string;
 };
+
 interface OphanABEvent {
 	variantName: string;
 	complete: string | boolean;

--- a/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
+++ b/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
@@ -2,7 +2,7 @@ import { getCookie } from '@guardian/libs';
 
 const AB_COOKIE_NAME = 'Client_AB_Tests';
 
-interface ABTestAPI {
+export interface BetaABTestAPI {
 	isUserInTest: (testId: string, variantId: string) => boolean;
 	trackABTests: () => void;
 }
@@ -63,7 +63,7 @@ const getParticipations = (): ABParticipations => {
 	return {};
 };
 
-export class BetaABTests implements ABTestAPI {
+export class BetaABTests implements BetaABTestAPI {
 	private participations: ABParticipations;
 	private ophanRecord: OphanRecordFunction;
 	private errorReporter: ErrorReporter;

--- a/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
+++ b/dotcom-rendering/src/experiments/lib/beta-ab-tests.ts
@@ -1,0 +1,45 @@
+const AB_COOKIE_NAME = 'Client_AB_Tests';
+
+type ABTestAPI = {
+	isUserInTest: (testId: string, variantId: string) => boolean;
+};
+
+type ABParticipations = {
+	[testId: string]: string;
+};
+
+export class BetaABTests implements ABTestAPI {
+	private participations: ABParticipations;
+
+	constructor() {
+		this.participations = this.getParticipations();
+	}
+
+	isUserInTest(testId: string, variantId: string): boolean {
+		return this.participations[testId] === variantId;
+	}
+
+	private getParticipations(): ABParticipations {
+		const cookieValues = document.cookie.split(';');
+		const ABTestCookie =
+			cookieValues.find((cookie) =>
+				cookie.startsWith(`${AB_COOKIE_NAME}=`),
+			) ?? '';
+		const cookieRegex = /=(.+)/;
+		const userTestBuckets = cookieRegex.exec(ABTestCookie)?.[1];
+
+		if (userTestBuckets) {
+			return userTestBuckets
+				.split(',')
+				.reduce<ABParticipations>((participations, abParticipation) => {
+					const [testId, variantId] = abParticipation.split(':');
+					if (testId && variantId) {
+						participations[testId] = variantId;
+					}
+					return participations;
+				}, {});
+		}
+
+		return {};
+	}
+}

--- a/dotcom-rendering/src/lib/useAB.ts
+++ b/dotcom-rendering/src/lib/useAB.ts
@@ -1,6 +1,7 @@
 import type { ABTestAPI, Participations } from '@guardian/ab-core';
 import { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
+import type { BetaABTestAPI } from '../experiments/lib/beta-ab-tests';
 
 type ABTests = {
 	api: ABTestAPI;
@@ -25,4 +26,16 @@ export const useAB = (): ABTests | undefined => {
 
 export const setABTests = ({ api, participations }: ABTests): void => {
 	void mutate(key, { api, participations }, false);
+};
+
+export const useBetaAB = (): BetaABTestAPI | undefined => {
+	const { data } = useSWRImmutable(
+		'beta-ab-tests',
+		() => new Promise<BetaABTestAPI>(() => {}),
+	);
+	return data;
+};
+
+export const setBetaABTests = (api: BetaABTestAPI): void => {
+	void mutate('beta-ab-tests', api, false);
 };

--- a/dotcom-rendering/src/model/guardian.ts
+++ b/dotcom-rendering/src/model/guardian.ts
@@ -56,6 +56,9 @@ export interface Guardian {
 		sentry: {
 			reportError: ReportError;
 		};
+		abTests: {
+			isUserInTest?: (testId: string, variantId: string) => boolean;
+		};
 	};
 	adBlockers: unknown;
 }
@@ -161,6 +164,7 @@ export const createGuardian = ({
 			sentry: {
 				reportError: () => null,
 			},
+			abTests: {},
 		},
 	};
 };


### PR DESCRIPTION
## What does this change?

This adds Ophan reporting and test state access via a React hook and `window.guardian` for client-side tests using the new framework, reading the test state from cookies and re-creating a more limited set of the functionality currently contained in `@guardian/ab-core`.

## Why?

Ophan reporting is a vital aspect of the A/B testing process, and we will not be able to use ab-core as-is with the new framework, as it expects test data in a particular structured format that the new framework is seeking to move away from. This is a simple first-pass at a new implementation.