### PR TITLE
Fix Loop Video fallback image

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -895,7 +895,7 @@ export const Card = ({
 						)}
 						{media.type === 'loop-video' && (
 							<Island
-								priority="feature"
+								priority="critical"
 								defer={{ until: 'visible' }}
 							>
 								<LoopVideo
@@ -903,19 +903,13 @@ export const Card = ({
 									height={media.mainMedia.height}
 									width={media.mainMedia.width}
 									image={media.mainMedia.image ?? ''}
-									fallbackImageComponent={
-										<CardPicture
-											mainImage={
-												media.mainMedia.image ?? ''
-											}
-											imageSize={imageSize}
-											loading={imageLoading}
-											alt={media.imageAltText}
-											aspectRatio={aspectRatio}
-										/>
-									}
 									uniqueId={uniqueId}
 									atomId={media.mainMedia.atomId}
+									fallbackImage={media.mainMedia.image ?? ''}
+									fallbackImageSize={imageSize}
+									fallbackImageLoading={imageLoading}
+									fallbackImageAlt={media.imageAltText}
+									fallbackImageAspectRatio="5:4"
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -9,7 +9,7 @@ import { generateSources, getFallbackSource } from './Picture';
 
 export type Loading = NonNullable<ImgHTMLAttributes<unknown>['loading']>;
 
-type Props = {
+export type Props = {
 	imageSize: ImageSizeType;
 	mainImage: string;
 	loading: Loading;

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -14,6 +14,7 @@ import {
 	customLoopPlayAudioEventName,
 	customYoutubePlayEventName,
 } from '../lib/video';
+import { CardPicture, type Props as CardPictureProps } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import type { PLAYER_STATES, PlayerStates } from './LoopVideoPlayer';
 import { LoopVideoPlayer } from './LoopVideoPlayer';
@@ -43,7 +44,11 @@ type Props = {
 	width: number;
 	height: number;
 	image: string;
-	fallbackImageComponent: JSX.Element;
+	fallbackImage: CardPictureProps['mainImage'];
+	fallbackImageSize: CardPictureProps['imageSize'];
+	fallbackImageLoading: CardPictureProps['loading'];
+	fallbackImageAlt: CardPictureProps['alt'];
+	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
 };
 
 export const LoopVideo = ({
@@ -53,7 +58,11 @@ export const LoopVideo = ({
 	width,
 	height,
 	image,
-	fallbackImageComponent,
+	fallbackImage,
+	fallbackImageSize,
+	fallbackImageLoading,
+	fallbackImageAlt,
+	fallbackImageAspectRatio,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -140,6 +149,16 @@ export const LoopVideo = ({
 			void playVideo();
 		}
 	};
+
+	const FallbackImageComponent = (
+		<CardPicture
+			mainImage={fallbackImage}
+			imageSize={fallbackImageSize}
+			loading={fallbackImageLoading}
+			aspectRatio={fallbackImageAspectRatio}
+			alt={fallbackImageAlt}
+		/>
+	);
 
 	/**
 	 * Setup.
@@ -333,7 +352,9 @@ export const LoopVideo = ({
 
 	if (renderingTarget !== 'Web') return null;
 
-	if (adapted) return fallbackImageComponent;
+	if (adapted) {
+		return FallbackImageComponent;
+	}
 
 	const handlePlayPauseClick = (event: React.SyntheticEvent) => {
 		event.preventDefault();
@@ -433,7 +454,7 @@ export const LoopVideo = ({
 				width={width}
 				height={height}
 				posterImage={posterImage}
-				fallbackImageComponent={fallbackImageComponent}
+				FallbackImageComponent={FallbackImageComponent}
 				currentTime={currentTime}
 				setCurrentTime={setCurrentTime}
 				ref={vidRef}

--- a/dotcom-rendering/src/components/LoopVideo.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.stories.tsx
@@ -1,7 +1,6 @@
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
-import { CardPicture } from './CardPicture';
 import { LoopVideo } from './LoopVideo.importable';
 
 export default {
@@ -21,16 +20,11 @@ export const Default = {
 	args: {
 		src: 'https://uploads.guim.co.uk/2025%2F06%2F20%2Ftesting+only%2C+please+ignore--3cb22b60-2c3f-48d6-8bce-38c956907cce-3.mp4',
 		uniqueId: 'test-video-1',
+		atomId: 'test-atom-1',
 		height: 720,
 		width: 900,
 		image: 'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
-		fallbackImageComponent: (
-			<CardPicture
-				mainImage="https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg"
-				imageSize="large"
-				loading="eager"
-			/>
-		),
+		fallbackImage: '',
 	},
 } satisfies StoryObj<typeof LoopVideo>;
 
@@ -38,7 +32,6 @@ export const Without5to4Ratio = {
 	name: 'Without 5:4 aspect ratio',
 	args: {
 		...Default.args,
-
 		src: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
 		height: 1080,
 		width: 1920,

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import type { IconProps } from '@guardian/source/react-components';
-import type { Dispatch, SetStateAction, SyntheticEvent } from 'react';
+import type {
+	Dispatch,
+	ReactElement,
+	SetStateAction,
+	SyntheticEvent,
+} from 'react';
 import { forwardRef } from 'react';
 import { palette } from '../palette';
 import { narrowPlayIconWidth, PlayIcon } from './Card/components/PlayIcon';
@@ -66,7 +71,7 @@ type Props = {
 	uniqueId: string;
 	width: number;
 	height: number;
-	fallbackImageComponent: JSX.Element;
+	FallbackImageComponent: ReactElement;
 	isPlayable: boolean;
 	setIsPlayable: Dispatch<SetStateAction<boolean>>;
 	playerState: PlayerStates;
@@ -95,7 +100,7 @@ export const LoopVideoPlayer = forwardRef(
 			uniqueId,
 			width,
 			height,
-			fallbackImageComponent,
+			FallbackImageComponent,
 			posterImage,
 			isPlayable,
 			setIsPlayable,
@@ -154,7 +159,7 @@ export const LoopVideoPlayer = forwardRef(
 					{/* Only mp4 is currently supported. Assumes the video file type is mp4. */}
 					{/* The start time is set to 1ms so that Safari will autoplay the video */}
 					<source src={`${src}#t=0.001`} type="video/mp4" />
-					{fallbackImageComponent}
+					{FallbackImageComponent}
 				</video>
 				{ref && 'current' in ref && ref.current && isPlayable && (
 					<>


### PR DESCRIPTION
## What does this change?

Passes the props for `<CardPicture />` into the <LoopVideo /> island, to call the component later

Changes the priority of the island from `feature` to `critical`. 

## Why?

We were not rendering the fallback image in its two use cases:
1. In the adapted experience, for users with [slow internet](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/client/poorPerformanceMonitoring.ts#L72).
1. When the browser doesn't support the video. To test the fallback content on browsers that support the element, you can replace <video> with a non-existing element like <notavideo>.

Since we are using Islands, we should only use serialisable props for the client-server boundary.

Adapted islands do not render unless they have `critical` priority. Note that we don't load the video if the user sees adapted content, we show a relevant image instead.

## Screenshots

| <img width=200/> | Before | After |
| - | - | - |
| adapted | ![adapted-before] | ![adapted-after] |
| cannot render video | ![cannot-before] | ![cannot-after] |

[adapted-before]: https://github.com/user-attachments/assets/8eaa8717-ed21-4207-a38b-63242329fd3e
[cannot-before]: https://github.com/user-attachments/assets/0486829f-c2fc-4c76-a153-0e743d63a5f6
[adapted-after]: https://github.com/user-attachments/assets/2613625f-a82b-4b4c-a56e-b7823ad14194
[cannot-after]: https://github.com/user-attachments/assets/58371572-adf8-40a1-91f4-2aa54f49152c

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#usage_notes
