### PR TITLE
Add loop video UI tests to flexible containers

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -5,7 +5,25 @@ import {
 	Pillar,
 } from '../../src/lib/articleFormat';
 import type { DCRFrontCard } from '../../src/types/front';
-import { discussionApiUrl } from './discussionApiUrl';
+
+const defaultCardProps = {
+	dataLinkName: 'news | group-0 | card-@1',
+	discussionApiUrl:
+		'https://discussion.code.dev-theguardian.com/discussion-api',
+	format: {
+		theme: Pillar.News,
+		design: ArticleDesign.Standard,
+		display: ArticleDisplay.Standard,
+	},
+	isExternalLink: false,
+	isImmersive: false,
+	mainMedia: undefined,
+	showByline: false,
+	showLivePlayable: false,
+	showQuotedHeadline: false,
+	supportingContent: [],
+	webPublicationDate: '2019-12-02T09:45:30.000Z',
+};
 
 /** Helper to get x number of sublinks */
 export const getSublinks = (
@@ -47,16 +65,15 @@ export const trails: [
 	DCRFrontCard,
 ] = [
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/business/2019/dec/02/directors-climate-disclosures-tci-hedge-fund',
 		headline:
 			"Punish directors who don't make climate disclosures, says hedge fund",
-		showByline: false,
 		byline: 'Julia Kollewe',
 		image: {
 			src: 'https://media.guim.co.uk/d4124d7bb89be381cbe9d72c849fad136f843086/0_84_4974_2985/master/4974.jpg',
 			altText: 'Pollution from a factory',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: Pillar.Opinion,
 			design: ArticleDesign.Comment,
@@ -65,30 +82,22 @@ export const trails: [
 		dataLinkName: 'news | group-0 | card-@1',
 		showQuotedHeadline: true,
 		supportingContent: getSublinks(3),
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/environment/2019/dec/02/migration-v-climate-europes-new-political-divide',
 		headline: "Migration v climate: Europe's new political divide",
-		showByline: false,
 		byline: 'Shaun Walker in Budapest',
 		image: {
 			src: 'https://media.guim.co.uk/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg',
 			altText: 'A protest',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: Pillar.News,
 			design: ArticleDesign.Video,
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@2',
-		showQuotedHeadline: false,
 		mainMedia: {
 			type: 'Video',
 			id: 'abcdef',
@@ -101,22 +110,16 @@ export const trails: [
 			expired: false,
 			image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
 		},
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
 		headline: 'An active live blog',
-		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: {
 			src: 'https://media.guim.co.uk/e8de0c5e27a2d92ced64f690daf48fd9b3b5c079/0_0_5101_3061/master/5101.jpg',
 			altText: 'A flood',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: Pillar.News,
 			design: ArticleDesign.LiveBlog,
@@ -124,15 +127,9 @@ export const trails: [
 		},
 		kickerText: 'Live',
 		dataLinkName: 'news | group-0 | card-@3',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/environment/2019/nov/27/climate-emergency-world-may-have-crossed-tipping-points',
 		headline: 'An inactive live sport blog - as it happened',
 		showByline: true,
@@ -141,7 +138,6 @@ export const trails: [
 			src: 'https://media.guim.co.uk/1774967ff6b9127a43b06c0685d1fd499c965141/98_0_3413_2048/master/3413.jpg',
 			altText: 'Some icecaps',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: Pillar.Opinion,
 			design: ArticleDesign.Comment,
@@ -149,118 +145,59 @@ export const trails: [
 		},
 		dataLinkName: 'news | group-0 | card-@4',
 		showQuotedHeadline: true,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2019/nov/26/european-parliament-split-on-declaring-climate-emergency',
 		headline: 'European parliament split on declaring climate emergency',
-		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: {
 			src: 'https://media.guim.co.uk/6db4a6d23e6e8d78ca6893f14b03e79869b2fef1/0_220_3500_2101/master/3500.jpg',
 			altText:
 				'Youth for Climate activists stage a protest inside the EU parliament last week',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		dataLinkName: 'news | group-0 | card-@5',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2019/nov/23/north-pole-explorers-on-thin-ice-as-climate-change-hits-expedition',
 		headline:
 			'North Pole  explorers on thin ice as climate change hits expedition',
-		showByline: false,
 		byline: 'Simon Murphy',
 		image: {
 			src: 'https://media.guim.co.uk/deb1f0b7f61ebbed2086a55dc34fecb2433a04bc/0_0_6000_3600/master/6000.jpg',
 			altText: 'Some icecaps that are proably melting',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		dataLinkName: 'news | group-0 | card-@6',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/environment/2019/oct/25/scientists-glacial-rivers-absorb-carbon-faster-rainforests',
 		headline:
 			'Glacial rivers absorb carbon faster than rainforests, scientists find',
-		showByline: false,
 		byline: 'Leyland Cecco',
 		starRating: 4,
 		image: {
 			src: 'https://media.guim.co.uk/5e8ea90ae9f503aa1c98fd35dbf13235b1207fea/0_490_3264_1958/master/3264.jpg',
 			altText: 'Some snowy peaks',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		dataLinkName: 'news | group-0 | card-@7',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/business/2019/oct/20/uk-urges-world-bank-to-channel-more-money-into-tackling-climate-crisis',
 		headline:
 			'UK urges World Bank to channel more money into tackling climate crisis',
-		showByline: false,
 		byline: 'Larry Elliott  in Washington',
 		image: {
 			src: 'https://media.guim.co.uk/2905d1c09d1a27de1c183dfa5cdcc10c869932d9/0_124_5472_3284/master/5472.jpg',
 			altText: 'A polluted pond',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		dataLinkName: 'news | group-0 | card-@8',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
-
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/politics/live/2021/feb/17/uk-covid-nationwide-rapid-testing-lockdown-coronavirus-latest-update',
-		showByline: false,
 		byline: 'Yohannes Lowe',
 		image: {
 			src: 'https://media.guim.co.uk/77e960298d4339e047eac5c1986d0f3214f6285d/419_447_4772_2863/master/4772.jpg',
@@ -275,142 +212,75 @@ export const trails: [
 		headline:
 			'UK Covid live: England lockdown to be eased in stages, says PM, amid reports of nationwide mass testing',
 		dataLinkName: 'news | group-0 | card-@9',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2021/feb/17/uk-to-begin-worlds-first-covid-human-challenge-study-within-weeks',
-		showByline: false,
 		byline: 'Nicola Davis and agency',
 		image: {
 			src: 'https://media.guim.co.uk/56d554a7c453dc1040f70453a01fefcb227f2055/0_0_3060_1836/master/3060.jpg',
 			altText: 'Covid',
 		},
-		format: {
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-		},
 		webPublicationDate: '2021-02-17T10:03:02.000Z',
 		headline:
 			'UK to infect up to 90 healthy volunteers with Covid in world first trial',
 		dataLinkName: 'news | group-0 | card-@10',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2021/feb/17/scottish-government-inadequately-prepared-for-covid-audit-scotland-report',
-		showByline: false,
 		byline: 'Libby Brooks Scotland correspondent',
 		image: {
 			src: 'https://media.guim.co.uk/df5aea6391e21b5a5d2d25fd9aad81d497f99d42/0_45_3062_1837/master/3062.jpg',
 			altText: 'Ambulance',
 		},
-		format: {
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-		},
 		webPublicationDate: '2021-02-17T11:11:43.000Z',
 		headline:
 			'Scottish government inadequately prepared for Covid, says watchdog',
 		dataLinkName: 'news | group-0 | card-@11',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/society/2021/feb/16/encouraging-signs-covid-vaccine-over-80s-deaths-fall-england',
-		showByline: false,
 		byline: 'Anna Leach, Ashley Kirk and Pamela Duncan',
 		image: {
 			src: 'https://media.guim.co.uk/5ebec1a8d662f0da39887dae16e4b2720379246e/0_0_5000_3000/master/5000.jpg',
 			altText: 'A covid vaccine',
 		},
-		format: {
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-		},
 		webPublicationDate: '2021-02-16T16:00:55.000Z',
 		headline:
 			'‘Encouraging’ signs for Covid vaccine as over-80s deaths fall in England',
 		dataLinkName: 'news | group-0 | card-@12',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
-		showByline: false,
 		byline: 'Nicola Davis and Natalie Grover',
 		image: {
 			src: 'https://media.guim.co.uk/046002abfc13c8cf7f0c40454349eb0e95d842b2/0_147_3884_2331/master/3884.jpg',
 			altText: 'Dido Harding',
 		},
-		format: {
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-		},
 		webPublicationDate: '2021-02-16T18:22:53.000Z',
 		headline:
 			'Contact tracing alone has little impact on curbing Covid spread, report finds',
 		dataLinkName: 'news | group-0 | card-@1',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2021/feb/16/covid-almost-2m-more-people-asked-shield-england',
-		showByline: false,
 		byline: 'Sarah Boseley Health editor and Aamna Mohdin Community affairs correspondent',
 		image: {
 			src: 'https://media.guim.co.uk/9e47ac13c7ffc63ee56235e8ef64301d6ed96d03/0_90_3520_2111/master/3520.jpg',
 			altText: 'A covid vaccine',
 		},
-		format: {
-			display: ArticleDisplay.Standard,
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-		},
 		webPublicationDate: '2021-02-16T16:35:45.000Z',
 		headline:
 			'Ethnicity and poverty are Covid risk factors, new Oxford modelling tool shows',
 		dataLinkName: 'news | group-0 | card-@13',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/politics/live/2021/feb/16/uk-covid-live-coronavirus-sturgeon-return-scottish-schools-latest-updates',
-		showByline: false,
 		byline: 'Nicola Slawson',
 		image: {
 			src: 'https://media.guim.co.uk/c01ad5ee63034e0f478959fc7a705c93debf8ba7/0_220_4104_2462/master/4104.jpg',
@@ -425,17 +295,10 @@ export const trails: [
 		headline:
 			'UK Covid: 799 more deaths and 10,625 new cases reported; Scottish schools in phased return from Monday – as it happened',
 		dataLinkName: 'news | group-0 | card-@14',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/video/2025/mar/06/how-nanoplastics-are-invading-our-bodies-video-report',
-		showByline: false,
 		byline: ' Neelam Tailor, Alex Healey, Ali Assaf, Steve Glew, Ryan Baxter',
 		image: {
 			src: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/91_0_1800_1080/master/1800.jpg',
@@ -450,7 +313,6 @@ export const trails: [
 		webPublicationDate: '2025-03-06T10:14:00.000Z',
 		headline: 'How plastics are invading our brain cells – video',
 		dataLinkName: 'media | group-0 | card-@11',
-		showQuotedHeadline: false,
 		mainMedia: {
 			type: 'Video',
 			id: '966acc06-a238-4d5f-b477-816eec0476f3',
@@ -463,11 +325,6 @@ export const trails: [
 			image: 'https://media.guim.co.uk/13dd7e5c4ca32a53cd22dfd90ac1845ef5e5d643/0_0_1920_1080/1920.jpg',
 			expired: false,
 		},
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 		trailText:
 			'Plastics are everywhere, but their smallest fragments – nanoplastics – are making their way into the deepest parts of our bodies, including our brains and breast milk',
 		supportingContent: [
@@ -484,59 +341,39 @@ export const trails: [
 		],
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/world/2019/nov/28/eu-parliament-declares-climate-emergency',
 		headline: 'An active sport blog',
-		showByline: false,
 		byline: 'Jennifer Rankin in Brussels',
 		image: {
 			src: 'https://media.guim.co.uk/e8de0c5e27a2d92ced64f690daf48fd9b3b5c079/0_0_5101_3061/master/5101.jpg',
 			altText: 'A flood',
 		},
-		webPublicationDate: '2019-12-02T09:45:30.000Z',
 		format: {
 			theme: Pillar.Sport,
 			design: ArticleDesign.LiveBlog,
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@15',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/society/2023/may/30/trans-activists-disrupt-kathleen-stock-speech-at-oxford-union',
 		headline:
 			'Gender-critical feminist’s speech temporarily stopped after protester glues themself to floor',
-		showByline: false,
 		byline: 'Matthew Weaver',
 		image: {
 			src: 'https://media.guim.co.uk/981abafa6ed4eaabdf7e743e6786aea3d9b7dbb2/0_417_901_540/500.jpg',
 			altText: 'Someone who has glued themselves to the floor',
 		},
 		webPublicationDate: '2023-05-30T09:45:30.000Z',
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Standard,
-			display: ArticleDisplay.Standard,
-		},
 		dataLinkName: 'news | group-0 | card-@16',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/commentisfree/2023/may/31/price-controls-rishi-sunak-thatcher-prime-minister',
 		headline:
 			'The prime minister is stubbornly attached to an outdated ideology, but has no plan for adapting to volatile times, says Guardian columnist Rafael Behr',
-		showByline: false,
 		byline: 'Rafael Behr',
 		image: {
 			src: 'https://media.guim.co.uk/c6f821af41bd2d0c7125b9bf335545db1c122a84/0_184_6984_4190/500.jpg',
@@ -549,19 +386,12 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@17',
-		showQuotedHeadline: false,
-		mainMedia: undefined,
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		url: 'https://www.theguardian.com/tv-and-radio/2023/may/30/a-revelation-succession-matthew-macfadyen-has-been-a-consummate-shapeshifter',
 		headline:
 			'From HBO’s hit series to Shakespeare, the stage to Spooks, the actor’s global star status has been sealed',
-		showByline: false,
 		byline: 'Caroline Davies',
 		image: {
 			src: 'https://media.guim.co.uk/5efb440557a0237d92cc5e8c7553106a2826d545/781_288_1137_682/500.jpg',
@@ -574,7 +404,6 @@ export const trails: [
 			display: ArticleDisplay.Standard,
 		},
 		dataLinkName: 'news | group-0 | card-@18',
-		showQuotedHeadline: false,
 		supportingContent: getSublinks(3),
 		mainMedia: {
 			type: 'Video',
@@ -588,25 +417,17 @@ export const trails: [
 			expired: false,
 			image: 'https://i.guim.co.uk/img/media/e060e9b7c92433b3dfeccc98b9206778cda8b8e8/0_180_6680_4009/master/6680.jpg?width=600&quality=45&dpr=2&s=none',
 		},
-		isExternalLink: false,
-		showLivePlayable: false,
-		discussionApiUrl,
-		showVideo: true,
-		isImmersive: false,
 	},
 ];
 
 export const audioTrails: [DCRFrontCard, DCRFrontCard] = [
 	{
+		...defaultCardProps,
 		format: { design: 3, display: 0, theme: 0 },
 		url: '/news/audio/2025/feb/19/from-the-archive-was-it-inevitable-a-short-history-of-russias-war-on-ukraine-podcast',
 		headline:
 			'Was it inevitable? A short history of Russia’s war on Ukraine',
-		showQuotedHeadline: false,
 		dataLinkName: 'media | group-0 | card-@1',
-		discussionApiUrl: '',
-		isExternalLink: false,
-		showLivePlayable: false,
 		trailText:
 			'This week, from 2022: To understand the tragedy of this war, it is worth going back beyond the last few weeks and months, and even beyond Vladimir Putin. By Keith Gessen. Read by Andrew McGregor',
 		webPublicationDate: '2025-02-19T05:00:25.000Z',
@@ -624,17 +445,13 @@ export const audioTrails: [DCRFrontCard, DCRFrontCard] = [
 			altText:
 				'A military facility destroyed by shelling near Kyiv, 1 March 2022. Photograph: Genya Savilov/AFP/Getty Images',
 		},
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		format: { design: 3, display: 0, theme: 2 },
 		url: '/football/audio/2025/feb/19/celtic-bayern-munich-champions-league-chaos-football-weekly-podcast',
 		headline: 'Celtic’s heartbreak and Champions League playoff chaos ',
-		showQuotedHeadline: false,
 		dataLinkName: 'media | group-0 | card-@1',
-		discussionApiUrl: '',
-		isExternalLink: false,
-		showLivePlayable: false,
 		trailText:
 			'Max Rushden is joined by Barry Glendenning, Paul Watson, Nick Ames, Ewan Murray and Jim Burke to discuss the latest Champions League playoff games, Everton’s new ground and much more',
 		webPublicationDate: '2025-02-19T14:11:54.000Z',
@@ -652,12 +469,12 @@ export const audioTrails: [DCRFrontCard, DCRFrontCard] = [
 			altText:
 				"TOPSHOT-FBL-EUR-C1-MILAN-FEYENOORD<br>TOPSHOT - Polish referee Szymon Marciniak gives a red card to AC Milan's French defender #19 Theo Hernandez (R) during the UEFA Champions League knockout round play-off second leg football match between AC Milan and Feyenoord at San Siro stadium in Milan, on February 18, 2025. (Photo by Piero CRUCIATTI / AFP) (Photo by PIERO CRUCIATTI/AFP via Getty Images)",
 		},
-		isImmersive: false,
 	},
 ];
 
 export const opinionTrails: [DCRFrontCard, DCRFrontCard] = [
 	{
+		...defaultCardProps,
 		format: { design: 8, display: 0, theme: 1 },
 		dataLinkName: 'comment | group-0 | card-@6',
 		url: '/commentisfree/2025/apr/28/populists-nigel-farage-reform-chaos-brexit',
@@ -666,13 +483,8 @@ export const opinionTrails: [DCRFrontCard, DCRFrontCard] = [
 		trailText:
 			'Centrists won’t beat Reform UK by echoing its messages. They should emphasise the true unworkability of policies like Brexit, says Guardian columnist Andy Beckett',
 		webPublicationDate: '2025-04-28T05:00:53.000Z',
-		discussionApiUrl:
-			'https://discussion.code.dev-theguardian.com/discussion-api',
 		discussionId: '/p/x253na',
-		isImmersive: false,
 		showQuotedHeadline: true,
-		isExternalLink: false,
-		showLivePlayable: false,
 		avatarUrl: 'https://uploads.guim.co.uk/2022/09/20/Andy_Beckett_v2.png',
 		image: {
 			src: 'https://media.guim.co.uk/f55906c2b9116946c778cd1fca808a6dae764d01/0_0_9528_5715/master/9528.jpg',
@@ -681,6 +493,7 @@ export const opinionTrails: [DCRFrontCard, DCRFrontCard] = [
 		},
 	},
 	{
+		...defaultCardProps,
 		format: { design: 8, display: 0, theme: 1 },
 		dataLinkName: 'comment | group-0 | card-@5',
 		url: '/commentisfree/2025/apr/28/duttons-comments-show-we-are-back-to-punching-down-on-indigenous-australians-for-attention-and-votes',
@@ -689,18 +502,14 @@ export const opinionTrails: [DCRFrontCard, DCRFrontCard] = [
 		trailText:
 			'It is disingenuous for politicians to be shocked when people decide to turn words into action, even in the predawn hush of Anzac Day',
 		webPublicationDate: '2025-04-28T05:19:42.000Z',
-		discussionApiUrl:
-			'https://discussion.code.dev-theguardian.com/discussion-api',
 		byline: 'Lorena Allam',
-		isImmersive: false,
 		showQuotedHeadline: true,
-		showLivePlayable: false,
-		isExternalLink: false,
 	},
 ];
 
 export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 	{
+		...defaultCardProps,
 		format: { design: 2, display: 1, theme: 4 },
 		dataLinkName: 'media | group-0 | card-@5',
 		url: '/fashion/gallery/2025/feb/01/we-love-fashion-fixes-for-the-week-ahead-in-pictures',
@@ -709,20 +518,15 @@ export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 			'On trend hoods, eye-catching tights and David Beckham models for Boss',
 		webPublicationDate: '2025-02-01T23:45:55.000Z',
 		kickerText: 'Fashion fixes',
-		supportingContent: [],
-		discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
 		mainMedia: { type: 'Gallery', count: '6' },
 		image: {
 			src: 'https://media.guim.co.uk/003d9dbe35c7a64a1e109a38450f3704deaeac24/2_240_3598_2159/master/3598.jpg',
 			altText:
 				'Barbour X Erdem Dhalia Wax Jacket RRP £519.00 Available at Barbour.com (1)',
 		},
-		showQuotedHeadline: false,
-		isExternalLink: false,
-		showLivePlayable: false,
-		isImmersive: false,
 	},
 	{
+		...defaultCardProps,
 		format: { design: 2, display: 1, theme: 0 },
 		dataLinkName: 'media | group-0 | card-@2',
 		url: '/global-development/gallery/2025/feb/07/goma-congolese-photographer-arlette-bashizi-home-city-rwandan-backed-m23-rebels',
@@ -731,22 +535,18 @@ export const galleryTrails: [DCRFrontCard, DCRFrontCard] = [
 			'Congolese photographer Arlette Bashizi documented for Reuters the lead-up to and aftermath of the seizure of her home city by Rwandan-backed M23 rebels',
 		webPublicationDate: '2025-02-07T05:00:36.000Z',
 		kickerText: 'Democratic Republic of the Congo',
-		discussionApiUrl: 'https://discussion.theguardian.com/discussion-api',
 		mainMedia: { type: 'Gallery', count: '27' },
 		showVideo: false,
 		image: {
 			src: 'https://media.guim.co.uk/69ac2383ea611126b54373865dac3e7e77981d7e/0_39_5500_3302/master/5500.jpg',
 			altText: 'A group of people in the street, some looking worried',
 		},
-		showQuotedHeadline: false,
-		isExternalLink: false,
-		showLivePlayable: false,
-		isImmersive: false,
 	},
 ];
 
 export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 	{
+		...defaultCardProps,
 		format: { design: 4, display: 0, theme: 2 },
 		dataLinkName: 'media | group-0 | card-@3',
 		url: '/football/video/2024/dec/16/rashford-and-garnacho-omission-from-team-to-push-them-harder-says-amorim-video',
@@ -755,8 +555,6 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 		trailText:
 			"Amorim said the team proved by the victory against City that they 'can leave anyone outside the squad and manage to win'",
 		webPublicationDate: '2024-12-16T15:21:02.000Z',
-		discussionApiUrl:
-			'https://discussion.code.dev-theguardian.com/discussion-api',
 		mainMedia: {
 			type: 'Video',
 			id: 'fa2ee832-c5e7-4305-8387-f0277d2d9e27',
@@ -769,19 +567,14 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 			expired: false,
 			image: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_56_3000_1688/3000.jpg',
 		},
-		showVideo: true,
 		image: {
 			src: 'https://media.guim.co.uk/0cab2d745b3423b0fac318c9ee09b79678f568f8/0_47_3000_1800/master/3000.jpg',
 			altText:
 				"Amorim said the team proved by the victory against City that they 'can leave anyone outside the squad and manage to win'",
 		},
-		showQuotedHeadline: false,
-		isExternalLink: false,
-		showLivePlayable: false,
-		isImmersive: false,
 	},
 	{
-		format: { design: 0, display: 0, theme: 0 },
+		...defaultCardProps,
 		dataLinkName: 'news | group-0 | card-@2',
 		url: '/uk-news/2025/jan/22/prince-harry-says-sun-publisher-made-historic-admission-as-he-settles-case',
 		headline:
@@ -789,8 +582,6 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 		trailText:
 			'News Group Newspapers offered Harry ‘full and unequivocal apology’ for ‘serious intrusion’ by the paper',
 		webPublicationDate: '2025-01-22T18:51:14.000Z',
-		discussionApiUrl:
-			'https://discussion.code.dev-theguardian.com/discussion-api',
 		mainMedia: {
 			type: 'Video',
 			id: '03ac0c90-3a66-448c-8562-b66a9ca9360e',
@@ -803,14 +594,9 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 			expired: false,
 			image: 'https://media.guim.co.uk/908aa315f66a09bc6ea607b6049cd72decd2dfa6/0_0_5358_3014/5358.jpg',
 		},
-		showVideo: true,
 		image: {
 			src: 'https://media.guim.co.uk/4612af5f4667888fa697139cf570b6373d93a710/2446_345_3218_1931/master/3218.jpg',
 			altText: 'Prince Harry leaves the high court in June 2023',
 		},
-		showQuotedHeadline: false,
-		isExternalLink: false,
-		showLivePlayable: false,
-		isImmersive: false,
 	},
 ];

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -600,3 +600,24 @@ export const videoTrails: [DCRFrontCard, DCRFrontCard] = [
 		},
 	},
 ];
+
+export const loopVideoCard: DCRFrontCard = {
+	...defaultCardProps,
+	dataLinkName: 'news | group-0 | card-@2',
+	url: '/uk-news/2025/jan/22/prince-harry-says-sun-publisher-made-historic-admission-as-he-settles-case',
+	headline: 'Headline for looping video card',
+	trailText: 'Trail text for looping video card',
+	mainMedia: {
+		type: 'LoopVideo',
+		atomId: '3cb22b60-2c3f-48d6-8bce-38c956907cce',
+		videoId:
+			'https://uploads.guim.co.uk/2025%2F06%2F20%2Ftesting+only%2C+please+ignore--3cb22b60-2c3f-48d6-8bce-38c956907cce-3.mp4',
+		duration: 0,
+		width: 500,
+		height: 400,
+	},
+	image: {
+		src: 'https://media.guim.co.uk/966bf085fb982b1103aaba42a812b09726cc0a3c/1417_104_1378_1104/master/1378.jpg',
+		altText: 'Wyatt Russell and Florence Pugh in Thunderbolts*.',
+	},
+};

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -615,6 +615,7 @@ export const loopVideoCard: DCRFrontCard = {
 		duration: 0,
 		width: 500,
 		height: 400,
+		image: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
 	},
 	image: {
 		src: 'https://media.guim.co.uk/966bf085fb982b1103aaba42a812b09726cc0a3c/1417_104_1378_1104/master/1378.jpg',

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -966,8 +966,13 @@ export const Card = ({
 													containerType ===
 													'fixed/video'
 												}
-												//** TODO: IMPROVE THIS MAPPING */
-												// image size defaults to small if not provided. However, if the headline size is large or greater, we want to assume the image is also large so that the play icon is correctly sized.
+												/*
+												 * TODO: IMPROVE THIS MAPPING
+												 *
+												 * Image size defaults to small if not provided. However, if the
+												 * headline size is large or greater, we want to assume the image
+												 * is also large so that the play icon is correctly sized.
+												 */
 												iconSizeOnDesktop={
 													[
 														'small',

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
 import {
 	getSublinks,
+	loopVideoCard,
 	opinionTrails,
 	trails,
 } from '../../fixtures/manual/trails';
@@ -543,6 +544,18 @@ export const ImmersiveCardsSplashAndStandard: Story = {
 				{ ...splashCard, isImmersive: true, supportingContent: [] },
 			],
 			standard: [{ ...trails[0], isImmersive: true }],
+		},
+	},
+};
+
+export const LoopVideoCards: Story = {
+	name: 'Looping video cards',
+	args: {
+		frontSectionTitle: 'Loop video cards',
+		groupedTrails: {
+			...emptyGroupedTrails,
+			splash: [loopVideoCard],
+			standard: [loopVideoCard], // Loop video is disabled at standard card size
 		},
 	},
 };

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -18,7 +18,7 @@ import type {
 import { FlexibleGeneral } from './FlexibleGeneral';
 import { FrontSection } from './FrontSection';
 
-const defaultGroupedTrails: DCRGroupedTrails = {
+const emptyGroupedTrails: DCRGroupedTrails = {
 	huge: [],
 	veryBig: [],
 	big: [],
@@ -143,7 +143,7 @@ const meta = {
 	},
 	args: {
 		frontSectionTitle: 'Flexible general',
-		groupedTrails: defaultGroupedTrails,
+		groupedTrails: emptyGroupedTrails,
 		showAge: true,
 		absoluteServerTimes: true,
 		imageLoading: 'eager',
@@ -171,7 +171,7 @@ export const SplashWithStandards: Story = {
 	args: {
 		frontSectionTitle: 'Splash with stardards',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [{ ...splashCard, supportingContent: [] }],
 			standard: standardCards,
 		},
@@ -182,7 +182,7 @@ export const SplashWithSublinks: Story = {
 	name: 'Standard splash with sublinks',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [{ ...splashCard, image: undefined }],
 		},
 	},
@@ -203,7 +203,7 @@ export const SplashWithSublinks: Story = {
 				<FlexibleGeneral
 					{...args}
 					groupedTrails={{
-						...defaultGroupedTrails,
+						...emptyGroupedTrails,
 						splash: [{ ...splashCard, supportingContent }],
 					}}
 				/>
@@ -276,7 +276,7 @@ export const SplashBoostLevels: Story = {
 	name: 'Splash boost levels',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [{ ...splashCard, image: undefined }],
 		},
 	},
@@ -297,7 +297,7 @@ export const SplashBoostLevels: Story = {
 				<FlexibleGeneral
 					{...args}
 					groupedTrails={{
-						...defaultGroupedTrails,
+						...emptyGroupedTrails,
 						splash: [
 							{
 								...splashCard,
@@ -324,7 +324,7 @@ export const SplashWithImageSupression: Story = {
 	name: 'Splash with image supression',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [{ ...splashCard, image: undefined }],
 		},
 	},
@@ -345,7 +345,7 @@ export const SplashWithImageSupression: Story = {
 				<FlexibleGeneral
 					{...args}
 					groupedTrails={{
-						...defaultGroupedTrails,
+						...emptyGroupedTrails,
 						splash: [
 							{ ...splashCard, boostLevel, image: undefined },
 						],
@@ -369,7 +369,7 @@ export const SplashWithLiveUpdates: Story = {
 	name: 'Splash with live updates',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [{ ...splashCard, image: undefined }],
 		},
 	},
@@ -391,7 +391,7 @@ export const SplashWithLiveUpdates: Story = {
 				<FlexibleGeneral
 					{...args}
 					groupedTrails={{
-						...defaultGroupedTrails,
+						...emptyGroupedTrails,
 						splash: [{ ...liveUpdatesCard, boostLevel }],
 					}}
 				/>
@@ -441,7 +441,7 @@ export const DefaultSplashWithLiveUpdatesAndSlideshow: Story = {
 	args: {
 		frontSectionTitle: 'Standard splash with live updates and slideshow',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 
 			splash: [{ ...slideshowCard }],
 		},
@@ -453,7 +453,7 @@ export const StandardCards: Story = {
 	args: {
 		frontSectionTitle: 'Standard cards',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			standard: trails.slice(0, 4),
 		},
 	},
@@ -464,7 +464,7 @@ export const OpinionStandardCards: Story = {
 	args: {
 		frontSectionTitle: 'Opinion standard cards',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			standard: opinionTrails.slice(0, 2),
 		},
 	},
@@ -490,7 +490,7 @@ export const WithSpecialPaletteVariations = {
 	name: 'With special palette variations',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [
 				{
 					...splashCard,
@@ -527,7 +527,7 @@ export const SecondaryContainerStandardCards: Story = {
 		frontSectionTitle: 'Secondary container with standard cards',
 		containerLevel: 'Secondary',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			standard: standardCards.slice(0, 4),
 		},
 	},
@@ -538,7 +538,7 @@ export const ImmersiveCardsSplashAndStandard: Story = {
 	args: {
 		frontSectionTitle: 'Immersive cards',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			splash: [
 				{ ...splashCard, isImmersive: true, supportingContent: [] },
 			],

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -15,7 +15,7 @@ type FlexibleSpecialArgsAndCustomArgs = React.ComponentProps<
 	typeof FlexibleSpecial
 > & { frontSectionTitle: string };
 
-const defaultGroupedTrails: DCRGroupedTrails = {
+const emptyGroupedTrails: DCRGroupedTrails = {
 	huge: [],
 	veryBig: [],
 	big: [],
@@ -75,7 +75,7 @@ const meta = {
 		},
 	},
 	args: {
-		groupedTrails: defaultGroupedTrails,
+		groupedTrails: emptyGroupedTrails,
 		showAge: true,
 		absoluteServerTimes: true,
 		imageLoading: 'eager',
@@ -102,7 +102,7 @@ export const One: Story = {
 	name: 'With one splash card',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 1),
 		},
@@ -113,7 +113,7 @@ export const Two: Story = {
 	name: 'With one splash card and one standard card',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 2),
 		},
@@ -124,7 +124,7 @@ export const Three: Story = {
 	name: 'With one splash card and two standard cards',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 3),
 		},
@@ -135,7 +135,7 @@ export const Four: Story = {
 	name: 'With one splash card and three standard cards',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 4),
 		},
@@ -146,7 +146,7 @@ export const Five: Story = {
 	name: 'With one splash card and four standard cards',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 5),
 		},
@@ -158,7 +158,7 @@ export const DefaultSplashWithImageSupression: Story = {
 	args: {
 		frontSectionTitle: 'Standard splash with image supression',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...trails[0], image: undefined }],
 		},
@@ -171,7 +171,7 @@ export const BoostedSplashWithImageSupression: Story = {
 	args: {
 		frontSectionTitle: 'Boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...trails[0], boostLevel: 'boost', image: undefined }],
 		},
@@ -184,7 +184,7 @@ export const MegaBoostedSplashWithImageSupression: Story = {
 	args: {
 		frontSectionTitle: 'Mega boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [
 				{ ...trails[0], boostLevel: 'megaboost', image: undefined },
@@ -199,7 +199,7 @@ export const GigaBoostedSplashWithImageSupression: Story = {
 	args: {
 		frontSectionTitle: 'Giga boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [
 				{ ...trails[0], boostLevel: 'gigaboost', image: undefined },
@@ -214,7 +214,7 @@ export const DefaultSplashWithLiveUpdates: Story = {
 	args: {
 		frontSectionTitle: 'Standard splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...liveUpdatesCard }],
 		},
@@ -227,7 +227,7 @@ export const BoostedSplashWithLiveUpdates: Story = {
 	args: {
 		frontSectionTitle: 'Boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...liveUpdatesCard, boostLevel: 'boost' }],
 		},
@@ -240,7 +240,7 @@ export const MegaBoostedSplashWithLiveUpdates: Story = {
 	args: {
 		frontSectionTitle: 'Mega boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...liveUpdatesCard, boostLevel: 'megaboost' }],
 		},
@@ -253,7 +253,7 @@ export const GigaBoostedSplashWithLiveUpdates: Story = {
 	args: {
 		frontSectionTitle: 'Giga boosted splash',
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...liveUpdatesCard, boostLevel: 'gigaboost' }],
 		},
@@ -281,7 +281,7 @@ export const WithSpecialPaletteVariations = {
 	name: 'With special palette variations',
 	args: {
 		groupedTrails: {
-			...defaultGroupedTrails,
+			...emptyGroupedTrails,
 			snap: [],
 			standard: trails.slice(0, 5),
 		},

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -1,7 +1,7 @@
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
-import { trails } from '../../fixtures/manual/trails';
+import { loopVideoCard, trails } from '../../fixtures/manual/trails';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import type {
 	DCRContainerPalette,
@@ -256,6 +256,19 @@ export const GigaBoostedSplashWithLiveUpdates: Story = {
 			...emptyGroupedTrails,
 			snap: [],
 			standard: [{ ...liveUpdatesCard, boostLevel: 'gigaboost' }],
+		},
+		collectionId: 1,
+	},
+};
+
+export const LoopVideoCards: Story = {
+	name: 'Looping video cards',
+	args: {
+		frontSectionTitle: 'Looping video',
+		groupedTrails: {
+			...emptyGroupedTrails,
+			snap: [loopVideoCard],
+			standard: [loopVideoCard],
 		},
 		collectionId: 1,
 	},

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -37,6 +37,21 @@ export const dispatchCustomPlayAudioEvent = (uniqueId: string) => {
 	);
 };
 
+const logAndReportError = (src: string, error: Error) => {
+	const message = `Autoplay failure for loop video. Source: ${src} could not be played. Error: ${String(
+		error,
+	)}`;
+
+	if (error instanceof Error) {
+		window.guardian.modules.sentry.reportError(
+			new Error(message),
+			'loop-video',
+		);
+	}
+
+	log('dotcom', message);
+};
+
 type Props = {
 	src: string;
 	atomId: string;
@@ -102,18 +117,9 @@ export const LoopVideo = ({
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- In earlier versions of the HTML specification, play() didn't return a value
 		if (startPlayPromise !== undefined) {
 			await startPlayPromise
-				.catch((error) => {
+				.catch((error: Error) => {
 					// Autoplay failed
-					const message = `Autoplay failure for loop video. Source: ${src} could not be played. Error: ${error}`;
-					if (error instanceof Error) {
-						window.guardian.modules.sentry.reportError(
-							new Error(message),
-							'loop-video',
-						);
-					}
-
-					log('dotcom', message);
-
+					logAndReportError(src, error);
 					setPosterImage(image);
 					setShowPlayIcon(true);
 				})


### PR DESCRIPTION
## What does this change?

Adds loop video UI tests to flexible containers

## Why?

Better test coverage

## Screenshots

| Flexible General    | Flexible Special     |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5a46d408-034b-4c01-9d42-4b41af2cc1c4
[after]: https://github.com/user-attachments/assets/cbad8a90-684d-4a0e-81d4-c1d95e1ee5e0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
