### PR TITLE
Render tag page images as 5:4 aspect ratio

### DIFF
--- a/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.stories.tsx
@@ -18,6 +18,8 @@ export default {
 	},
 };
 
+const ASPECT_RATIO = '5:4';
+
 export const OneCardFast = () => {
 	return (
 		<FrontSection
@@ -29,6 +31,7 @@ export const OneCardFast = () => {
 				trails={trails.slice(0, 1)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -46,6 +49,7 @@ export const TwoCardFast = () => {
 				trails={trails.slice(0, 2)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -63,6 +67,7 @@ export const ThreeCardFast = () => {
 				trails={trails.slice(0, 3)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -80,6 +85,7 @@ export const FourCardFast = () => {
 				trails={trails.slice(0, 4)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -97,6 +103,7 @@ export const FiveCardFast = () => {
 				trails={trails.slice(0, 5)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -114,6 +121,7 @@ export const SixCardFast = () => {
 				trails={trails.slice(0, 6)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -131,6 +139,7 @@ export const SevenCardFast = () => {
 				trails={trails.slice(0, 7)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -148,6 +157,7 @@ export const EightCardFast = () => {
 				trails={trails.slice(0, 8)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -166,6 +176,7 @@ export const TwelveCardFast = () => {
 				trails={trails.slice(0, 12)}
 				speed="fast"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -183,6 +194,7 @@ export const OneCardSlow = () => {
 				trails={trails.slice(0, 1)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -200,6 +212,7 @@ export const TwoCardSlow = () => {
 				trails={trails.slice(0, 2)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -217,6 +230,7 @@ export const ThreeCardSlow = () => {
 				trails={trails.slice(0, 3)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -234,6 +248,7 @@ export const FourCardSlow = () => {
 				trails={trails.slice(0, 4)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -251,6 +266,7 @@ export const FiveCardSlow = () => {
 				trails={trails.slice(0, 5)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -268,6 +284,7 @@ export const SixCardSlow = () => {
 				trails={trails.slice(0, 6)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -285,6 +302,7 @@ export const SevenCardSlow = () => {
 				trails={trails.slice(0, 7)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -302,6 +320,7 @@ export const EightCardSlow = () => {
 				trails={trails.slice(0, 8)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);
@@ -320,6 +339,7 @@ export const TwelveCardSlow = () => {
 				trails={trails.slice(0, 12)}
 				speed="slow"
 				imageLoading="eager"
+				aspectRatio={ASPECT_RATIO}
 			/>
 		</FrontSection>
 	);

--- a/dotcom-rendering/src/components/DecideContainerByTrails.tsx
+++ b/dotcom-rendering/src/components/DecideContainerByTrails.tsx
@@ -8,7 +8,7 @@ import {
 } from '../lib/cardWrappers';
 import type { Tuple } from '../lib/tuple';
 import { takeFirst } from '../lib/tuple';
-import type { DCRFrontCard } from '../types/front';
+import type { AspectRatio, DCRFrontCard } from '../types/front';
 import { LI } from './Card/components/LI';
 import { UL } from './Card/components/UL';
 import type { Loading } from './CardPicture';
@@ -18,17 +18,20 @@ type Props = {
 	speed: 'fast' | 'slow';
 	imageLoading: Loading;
 	isTagPage?: boolean;
+	aspectRatio: AspectRatio;
 };
 
 type CardProps = {
 	imageLoading: Loading;
 	isTagPage?: boolean;
+	aspectRatio: AspectRatio;
 };
 
 export const OneCardFast = ({
 	trail,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trail: DCRFrontCard;
 } & CardProps) => {
@@ -41,6 +44,7 @@ export const OneCardFast = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 		</UL>
@@ -51,6 +55,7 @@ export const OneCardSlow = ({
 	trail,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trail: DCRFrontCard;
 } & CardProps) => {
@@ -63,6 +68,7 @@ export const OneCardSlow = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 		</UL>
@@ -73,6 +79,7 @@ export const TwoCard = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 2>;
 } & CardProps) => {
@@ -85,6 +92,7 @@ export const TwoCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="50%" padSides={true} showDivider={true}>
@@ -94,6 +102,7 @@ export const TwoCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 		</UL>
@@ -104,6 +113,7 @@ export const ThreeCard = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 3>;
 } & CardProps) => {
@@ -116,6 +126,7 @@ export const ThreeCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -125,6 +136,7 @@ export const ThreeCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -134,6 +146,7 @@ export const ThreeCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 		</UL>
@@ -144,6 +157,7 @@ export const FourCard = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 4>;
 } & CardProps) => {
@@ -156,6 +170,7 @@ export const FourCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -165,6 +180,7 @@ export const FourCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -174,6 +190,7 @@ export const FourCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="25%" padSides={true} showDivider={true}>
@@ -183,6 +200,7 @@ export const FourCard = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 		</UL>
@@ -193,6 +211,7 @@ export const FiveCardFast = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
 } & CardProps) => {
@@ -205,6 +224,7 @@ export const FiveCardFast = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -214,6 +234,7 @@ export const FiveCardFast = ({
 					absoluteServerTimes={true}
 					imageLoading={imageLoading}
 					isTagPage={isTagPage}
+					aspectRatio={aspectRatio}
 				/>
 			</LI>
 			<LI percentage="33.333%">
@@ -224,6 +245,7 @@ export const FiveCardFast = ({
 							showAge={true}
 							absoluteServerTimes={true}
 							isTagPage={isTagPage}
+							aspectRatio={aspectRatio}
 						/>
 					</LI>
 					<LI padSides={true}>
@@ -232,6 +254,7 @@ export const FiveCardFast = ({
 							showAge={true}
 							absoluteServerTimes={true}
 							isTagPage={isTagPage}
+							aspectRatio={aspectRatio}
 						/>
 					</LI>
 					<LI padSides={true}>
@@ -240,6 +263,7 @@ export const FiveCardFast = ({
 							showAge={true}
 							absoluteServerTimes={true}
 							isTagPage={isTagPage}
+							aspectRatio={aspectRatio}
 						/>
 					</LI>
 				</UL>
@@ -252,6 +276,7 @@ export const FiveCardSlow = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 5>;
 } & CardProps) => {
@@ -265,6 +290,7 @@ export const FiveCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
@@ -274,6 +300,7 @@ export const FiveCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -285,6 +312,7 @@ export const FiveCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -294,6 +322,7 @@ export const FiveCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -303,6 +332,7 @@ export const FiveCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -314,6 +344,7 @@ export const SixCardFast = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 6>;
 } & CardProps) => {
@@ -327,6 +358,7 @@ export const SixCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -336,6 +368,7 @@ export const SixCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -345,6 +378,7 @@ export const SixCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -354,6 +388,7 @@ export const SixCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -364,6 +399,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="50%" padSides={true} showDivider={true}>
@@ -372,6 +408,7 @@ export const SixCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -383,6 +420,7 @@ export const SixCardSlow = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 6>;
 } & CardProps) => {
@@ -396,6 +434,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -405,6 +444,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -414,6 +454,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -425,6 +466,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -434,6 +476,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -443,6 +486,7 @@ export const SixCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -454,6 +498,7 @@ export const SevenCardFast = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
 } & CardProps) => {
@@ -467,6 +512,7 @@ export const SevenCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -476,6 +522,7 @@ export const SevenCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -485,6 +532,7 @@ export const SevenCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -494,6 +542,7 @@ export const SevenCardFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -504,6 +553,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -512,6 +562,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -520,6 +571,7 @@ export const SevenCardFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -531,6 +583,7 @@ export const SevenCardSlow = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: Tuple<DCRFrontCard, 7>;
 } & CardProps) => {
@@ -544,6 +597,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -553,6 +607,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="33.333%" padSides={true} showDivider={true}>
@@ -562,6 +617,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -573,6 +629,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -582,6 +639,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -591,6 +649,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -600,6 +659,7 @@ export const SevenCardSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -611,6 +671,7 @@ export const EightOrMoreFast = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
 } & CardProps) => {
@@ -626,6 +687,7 @@ export const EightOrMoreFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -635,6 +697,7 @@ export const EightOrMoreFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -644,6 +707,7 @@ export const EightOrMoreFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -653,6 +717,7 @@ export const EightOrMoreFast = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -663,6 +728,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -671,6 +737,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -679,6 +746,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -687,6 +755,7 @@ export const EightOrMoreFast = ({
 						showAge={true}
 						absoluteServerTimes={true}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -704,6 +773,7 @@ export const EightOrMoreFast = ({
 								showAge={true}
 								absoluteServerTimes={true}
 								isTagPage={isTagPage}
+								aspectRatio={aspectRatio}
 							/>
 						</LI>
 					))}
@@ -719,6 +789,7 @@ export const EightOrMoreSlow = ({
 	trails,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: {
 	trails: [...Tuple<DCRFrontCard, 8>, ...DCRFrontCard[]];
 } & CardProps) => {
@@ -734,6 +805,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -743,6 +815,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -752,6 +825,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -761,6 +835,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -772,6 +847,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -781,6 +857,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -790,6 +867,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 				<LI percentage="25%" padSides={true} showDivider={true}>
@@ -799,6 +877,7 @@ export const EightOrMoreSlow = ({
 						absoluteServerTimes={true}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				</LI>
 			</UL>
@@ -817,6 +896,7 @@ export const EightOrMoreSlow = ({
 								absoluteServerTimes={true}
 								imageLoading={imageLoading}
 								isTagPage={isTagPage}
+								aspectRatio={aspectRatio}
 							/>
 						</LI>
 					))}
@@ -833,6 +913,7 @@ export const DecideContainerByTrails = ({
 	speed,
 	imageLoading,
 	isTagPage,
+	aspectRatio,
 }: Props) => {
 	const initialTrails = takeFirst(trails, 8);
 	if (speed === 'fast') {
@@ -845,6 +926,7 @@ export const DecideContainerByTrails = ({
 						trail={initialTrails[0]}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 2:
@@ -853,6 +935,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 3:
@@ -861,6 +944,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 4:
@@ -869,6 +953,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 5:
@@ -877,6 +962,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 6:
@@ -885,6 +971,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 7:
@@ -893,6 +980,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 8:
@@ -901,6 +989,7 @@ export const DecideContainerByTrails = ({
 						trails={[...initialTrails, ...trails.slice(8)]}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 		}
@@ -914,6 +1003,7 @@ export const DecideContainerByTrails = ({
 						trail={initialTrails[0]}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 2:
@@ -922,6 +1012,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 3:
@@ -930,6 +1021,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 4:
@@ -938,6 +1030,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 5:
@@ -946,6 +1039,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 6:
@@ -954,6 +1048,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 7:
@@ -962,6 +1057,7 @@ export const DecideContainerByTrails = ({
 						trails={initialTrails}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 			case 8:
@@ -970,6 +1066,7 @@ export const DecideContainerByTrails = ({
 						trails={[...initialTrails, ...trails.slice(8)]}
 						imageLoading={imageLoading}
 						isTagPage={isTagPage}
+						aspectRatio={aspectRatio}
 					/>
 				);
 		}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -179,6 +179,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 									speed={tagPage.speed}
 									imageLoading={imageLoading}
 									isTagPage={true}
+									aspectRatio={'5:4'}
 								/>
 							</FrontSection>
 							{mobileAdPositions.includes(index) && (

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -1,7 +1,11 @@
 import { isUndefined } from '@guardian/libs';
 import type { Loading } from '../components/CardPicture';
 import { FrontCard } from '../components/FrontCard';
-import type { DCRContainerPalette, DCRFrontCard } from '../types/front';
+import type {
+	AspectRatio,
+	DCRContainerPalette,
+	DCRFrontCard,
+} from '../types/front';
 
 type TrailProps = {
 	trail: DCRFrontCard;
@@ -10,6 +14,7 @@ type TrailProps = {
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 	isTagPage?: boolean;
+	aspectRatio?: AspectRatio;
 };
 
 /**
@@ -51,6 +56,7 @@ export const Card100Media50 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -78,6 +84,7 @@ export const Card100Media50 = ({
 					? 'horizontal'
 					: 'vertical'
 			}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -103,6 +110,7 @@ export const Card100Media75 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -130,6 +138,7 @@ export const Card100Media75 = ({
 					? 'horizontal'
 					: 'vertical'
 			}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -156,6 +165,7 @@ export const Card100Media100 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -171,6 +181,7 @@ export const Card100Media100 = ({
 			isTagPage={isTagPage}
 			supportingContent={trail.supportingContent?.slice(0, 4)}
 			supportingContentAlignment="horizontal"
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -198,6 +209,7 @@ export const Card100Media100Tall = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -214,6 +226,7 @@ export const Card100Media100Tall = ({
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
 			trailText={trail.trailText}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -239,6 +252,7 @@ export const Card75Media50Right = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -259,6 +273,7 @@ export const Card75Media50Right = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -284,6 +299,7 @@ export const Card75Media50Left = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -304,6 +320,7 @@ export const Card75Media50Left = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -329,6 +346,7 @@ export const Card25Media25 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -345,6 +363,7 @@ export const Card25Media25 = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -370,6 +389,7 @@ export const Card25Media25SmallHeadline = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -386,6 +406,7 @@ export const Card25Media25SmallHeadline = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall', tablet: 'xxsmall' }}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -412,6 +433,7 @@ export const Card25Media25Tall = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -434,6 +456,7 @@ export const Card25Media25Tall = ({
 			}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -459,6 +482,7 @@ export const Card25Media25TallNoTrail = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -474,6 +498,7 @@ export const Card25Media25TallNoTrail = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -499,6 +524,7 @@ export const Card25Media25TallSmallHeadline = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -514,6 +540,7 @@ export const Card25Media25TallSmallHeadline = ({
 			headlineSizes={{ desktop: 'xxsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -539,6 +566,7 @@ export const Card50Media50 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -554,6 +582,7 @@ export const Card50Media50 = ({
 			absoluteServerTimes={absoluteServerTimes}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -580,6 +609,7 @@ export const Card50Media50Tall = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -596,6 +626,7 @@ export const Card50Media50Tall = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'small', tablet: 'xsmall' }}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -621,6 +652,7 @@ export const Card66Media66 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -635,6 +667,7 @@ export const Card66Media66 = ({
 			imageSize="large"
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -660,6 +693,7 @@ export const Card33Media33 = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -674,6 +708,7 @@ export const Card33Media33 = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -698,6 +733,7 @@ export const Card33Media33Tall = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -713,6 +749,7 @@ export const Card33Media33Tall = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -738,6 +775,7 @@ export const Card33Media33MobileTopTall = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -754,6 +792,7 @@ export const Card33Media33MobileTopTall = ({
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xsmall' }}
 			supportingContent={trail.supportingContent?.slice(0, 2)}
 			supportingContentAlignment="vertical"
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -776,6 +815,7 @@ export const CardDefault = ({
 	containerPalette,
 	absoluteServerTimes,
 	isTagPage,
+	aspectRatio,
 }: Omit<TrailProps, 'imageLoading'>) => {
 	return (
 		<FrontCard
@@ -789,6 +829,7 @@ export const CardDefault = ({
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
 			isTagPage={isTagPage}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -812,6 +853,7 @@ export const CardDefaultMedia = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -826,6 +868,7 @@ export const CardDefaultMedia = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };
@@ -849,6 +892,7 @@ export const CardDefaultMediaMobile = ({
 	imageLoading,
 	isTagPage,
 	absoluteServerTimes,
+	aspectRatio,
 }: TrailProps) => {
 	return (
 		<FrontCard
@@ -863,6 +907,7 @@ export const CardDefaultMediaMobile = ({
 			isTagPage={isTagPage}
 			headlineSizes={{ desktop: 'xxsmall' }}
 			canPlayInline={false}
+			aspectRatio={aspectRatio}
 		/>
 	);
 };


### PR DESCRIPTION
## What does this change?
Pass through a 5:4 aspect ratio to container layouts used by tag pages.

## Why?
We would like to serve images in a 5:4 ratio on tag pages to bring them inline with modern designs. 

## Considerations
5:4 images are taller than 5:3 images. This will make the scroll depth higher on tag pages after this change which will mean it takes longer to get to ads. This might have a financial impact.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a40802f5-89d8-4899-ba0c-9b214186f342
[after]: https://github.com/user-attachments/assets/8627410e-3eb7-4e56-bda2-f60dbab14285

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
