### PR TITLE
Accessibility preferences

### DIFF
--- a/dotcom-rendering/src/components/Accessibility.importable.stories.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { Accessibility as AccessibilityComponent } from './Accessibility.importable';
+
+const meta = {
+	component: AccessibilityComponent,
+	title: 'Components/Accessibility',
+	decorators: [
+		splitTheme([
+			{
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.News,
+			},
+		]),
+	],
+} satisfies Meta<typeof AccessibilityComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Accessibility = {} satisfies Story;

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -122,7 +122,7 @@ export const Accessibility = () => {
 
 	return (
 		<FrontSection title="Preferences" editionId="UK" discussionApiUrl="">
-			<div>
+			<form>
 				<fieldset css={formStyle}>
 					<p>
 						We aim to make this site accessible to a wide audience
@@ -151,33 +151,33 @@ export const Accessibility = () => {
 						description="autoplaying video"
 					/>
 				</fieldset>
-			</div>
 
-			<br />
+				<br />
 
-			<fieldset css={formStyle}>
-				<p>
-					We offer beta support for a dark colour scheme on the web.
-					The colour scheme preference will follow your system
-					settings.
-				</p>
-				<label>
-					<input
-						type="checkbox"
-						checked={shouldParticipate}
-						onChange={(e) => {
-							setParticipate(e.target.checked);
-						}}
-						data-link-name="prefers-colour-scheme"
-					/>
-					<span css={bold}>
-						Participate in the dark colour scheme beta{' '}
-					</span>
-					{shouldParticipate
-						? ' Untick this to opt out (browser will refresh)'
-						: ' Tick this to opt in (browser will refresh)'}
-				</label>
-			</fieldset>
+				<fieldset css={formStyle}>
+					<p>
+						We offer beta support for a dark colour scheme on the
+						web. The colour scheme preference will follow your
+						system settings.
+					</p>
+					<label>
+						<input
+							type="checkbox"
+							checked={shouldParticipate}
+							onChange={(e) => {
+								setParticipate(e.target.checked);
+							}}
+							data-link-name="prefers-colour-scheme"
+						/>
+						<span css={bold}>
+							Participate in the dark colour scheme beta{' '}
+						</span>
+						{shouldParticipate
+							? ' Untick this to opt out (browser will refresh)'
+							: ' Tick this to opt in (browser will refresh)'}
+					</label>
+				</fieldset>
+			</form>
 		</FrontSection>
 	);
 };

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -52,7 +52,7 @@ const PreferenceToggle = ({
 	);
 };
 
-export const useStoredBooleanPreference = (
+const useStoredBooleanPreference = (
 	key: string,
 	defaultValue: boolean,
 ): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -19,7 +19,7 @@ const bold = css`
 	font-weight: bold;
 `;
 
-// This is hardcoded, and must be changed if the experiment bucket changes
+// This is hard coded, and must be changed if the experiment bucket changes
 // https://github.com/guardian/frontend/blob/09f49b80/common/app/experiments/Experiments.scala#L57
 const darkModeCookieName = 'X-GU-Experiment-0perc-D';
 

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -32,10 +32,9 @@ const darkModeCookieName = 'X-GU-Experiment-0perc-D';
  */
 export const Accessibility = () => {
 	const { darkModeAvailable } = useConfig();
-	const [shouldFlash, setShouldFlash] = useState<boolean | undefined>();
-	const [participate, setParticipate] = useState<boolean>(darkModeAvailable);
-
-	const checked = shouldFlash ?? true;
+	const [shouldFlash, setShouldFlash] = useState<boolean>(true);
+	const [shouldParticipate, setParticipate] =
+		useState<boolean>(darkModeAvailable);
 
 	useEffect(() => {
 		const flashingPreference = storage.local.get(
@@ -55,7 +54,7 @@ export const Accessibility = () => {
 	}, [shouldFlash]);
 
 	useEffect(() => {
-		if (participate) {
+		if (shouldParticipate) {
 			setCookie({
 				name: darkModeCookieName,
 				value: 'true',
@@ -67,11 +66,12 @@ export const Accessibility = () => {
 		const timeout = setTimeout(() => {
 			// we must reload the page for the preference to take effect,
 			// as this relies on a server-side test & cookie combination
-			if (participate !== darkModeAvailable) window.location.reload();
+			if (shouldParticipate !== darkModeAvailable)
+				window.location.reload();
 		}, 1200);
 
 		return () => clearTimeout(timeout);
-	}, [participate, darkModeAvailable]);
+	}, [shouldParticipate, darkModeAvailable]);
 
 	const toggleFlash = (): void => {
 		setShouldFlash((prev) => (isUndefined(prev) ? false : !prev));
@@ -96,12 +96,12 @@ export const Accessibility = () => {
 					<label>
 						<input
 							type="checkbox"
-							checked={checked}
+							checked={shouldFlash}
 							onChange={toggleFlash}
 							data-link-name="flashing-elements"
 						/>
 						<span css={bold}>Allow flashing elements </span>
-						{checked
+						{shouldFlash
 							? 'Untick this to disable flashing and moving elements'
 							: 'Tick this to enable flashing or moving elements'}
 					</label>
@@ -118,7 +118,7 @@ export const Accessibility = () => {
 					<label>
 						<input
 							type="checkbox"
-							checked={participate}
+							checked={shouldParticipate}
 							onChange={(e) => {
 								setParticipate(e.target.checked);
 							}}
@@ -127,7 +127,7 @@ export const Accessibility = () => {
 						<span css={bold}>
 							Participate in the dark colour scheme beta{' '}
 						</span>
-						{participate
+						{shouldParticipate
 							? 'Untick this to opt out (browser will refresh)'
 							: 'Tick this to opt in (browser will refresh)'}
 					</label>

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -79,7 +79,7 @@ export const Accessibility = () => {
 
 	return (
 		<FrontSection title="Preferences" editionId="UK" discussionApiUrl="">
-			<form>
+			<div>
 				<fieldset css={formStyle}>
 					<p>
 						We aim to make this site accessible to a wide audience
@@ -132,7 +132,7 @@ export const Accessibility = () => {
 							: 'Tick this to opt in (browser will refresh)'}
 					</label>
 				</fieldset>
-			</form>
+			</div>
 		</FrontSection>
 	);
 };

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -23,6 +23,35 @@ const bold = css`
 // https://github.com/guardian/frontend/blob/09f49b80/common/app/experiments/Experiments.scala#L57
 const darkModeCookieName = 'X-GU-Experiment-0perc-D';
 
+const PreferenceToggle = ({
+	label,
+	checked,
+	onChange,
+	dataLinkName,
+	description,
+}: {
+	label: string;
+	checked: boolean;
+	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	dataLinkName: string;
+	description: string;
+}) => {
+	return (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={onChange}
+				data-link-name={dataLinkName}
+			/>
+			<span css={bold}>{label}</span>
+			{checked
+				? `Untick this to disable ${description}`
+				: `Tick this to enable ${description}`}
+		</label>
+	);
+};
+
 /**
  * Updates the user's accessibility preferences
  *
@@ -66,8 +95,9 @@ export const Accessibility = () => {
 		const timeout = setTimeout(() => {
 			// we must reload the page for the preference to take effect,
 			// as this relies on a server-side test & cookie combination
-			if (shouldParticipate !== darkModeAvailable)
+			if (shouldParticipate !== darkModeAvailable) {
 				window.location.reload();
+			}
 		}, 1200);
 
 		return () => clearTimeout(timeout);
@@ -93,46 +123,41 @@ export const Accessibility = () => {
 						functionalities.
 					</p>
 
-					<label>
-						<input
-							type="checkbox"
-							checked={shouldFlash}
-							onChange={toggleFlash}
-							data-link-name="flashing-elements"
-						/>
-						<span css={bold}>Allow flashing elements </span>
-						{shouldFlash
-							? 'Untick this to disable flashing and moving elements'
-							: 'Tick this to enable flashing or moving elements'}
-					</label>
-				</fieldset>
-
-				<br />
-
-				<fieldset css={formStyle}>
-					<p>
-						We offer beta support for a dark colour scheme on the
-						web. The colour scheme preference will follow your
-						system settings.
-					</p>
-					<label>
-						<input
-							type="checkbox"
-							checked={shouldParticipate}
-							onChange={(e) => {
-								setParticipate(e.target.checked);
-							}}
-							data-link-name="prefers-colour-scheme"
-						/>
-						<span css={bold}>
-							Participate in the dark colour scheme beta{' '}
-						</span>
-						{shouldParticipate
-							? 'Untick this to opt out (browser will refresh)'
-							: 'Tick this to opt in (browser will refresh)'}
-					</label>
+					<PreferenceToggle
+						label="Allow flashing elements"
+						checked={shouldFlash}
+						onChange={toggleFlash}
+						dataLinkName="flashing-elements"
+						description="flashing and moving elements"
+					/>
 				</fieldset>
 			</div>
+
+			<br />
+
+			<fieldset css={formStyle}>
+				<p>
+					We offer beta support for a dark colour scheme on the web.
+					The colour scheme preference will follow your system
+					settings.
+				</p>
+				<label>
+					<input
+						type="checkbox"
+						checked={shouldParticipate}
+						onChange={(e) => {
+							setParticipate(e.target.checked);
+						}}
+						data-link-name="prefers-colour-scheme"
+					/>
+					<span css={bold}>
+						Participate in the dark colour scheme beta{' '}
+					</span>
+					{shouldParticipate
+						? 'Untick this to opt out (browser will refresh)'
+						: 'Tick this to opt in (browser will refresh)'}
+				</label>
+			</fieldset>
 		</FrontSection>
 	);
 };

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -181,16 +181,16 @@ export const LoopVideo = ({
 		).matches;
 
 		/**
-		 * The user indicates a preference for no flashing elements.
-		 * `flashingPreference` is `null` if no preference exists and
-		 * explicitly `false` when the reader has said they don't want flashing.
+		 * The user indicates a preference for no autoplaying videos.
+		 * `autoplayPreference` is explicitly `false` when the reader
+		 *  has said they don't want flashing.
 		 */
-		const flashingPreferences = storage.local.get(
-			'gu.prefs.accessibility.flashing-elements',
+		const autoplayPreferences = storage.local.get(
+			'gu.prefs.accessibility.autoplay-video',
 		);
 
 		setIsAutoplayAllowed(
-			!userPrefersReducedMotion && flashingPreferences !== false,
+			!userPrefersReducedMotion && autoplayPreferences !== false,
 		);
 
 		/**

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -180,21 +180,15 @@ export const LoopVideo = ({
 			'(prefers-reduced-motion: reduce)',
 		).matches;
 
-		const flashingPreference = storage.local.get(
-			'gu.prefs.accessibility.flashing-elements',
-		);
-
 		const autoplayPreference = storage.local.get(
 			'gu.prefs.accessibility.autoplay-video',
 		);
 		/**
-		 * `flashingPreference` and `autoplayPreference` are explicitly `false`
-		 *  when the user has said they don't want flashing elements or autoplaying video.
+		 * `autoplayPreference` is explicitly `false`
+		 *  when the user has said they don't want autoplay video.
 		 */
 		setIsAutoplayAllowed(
-			!userPrefersReducedMotion &&
-				autoplayPreference !== false &&
-				flashingPreference !== false,
+			!userPrefersReducedMotion && autoplayPreference !== false,
 		);
 
 		/**

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -180,17 +180,21 @@ export const LoopVideo = ({
 			'(prefers-reduced-motion: reduce)',
 		).matches;
 
-		/**
-		 * The user indicates a preference for no autoplaying videos.
-		 * `autoplayPreference` is explicitly `false` when the reader
-		 *  has said they don't want flashing.
-		 */
-		const autoplayPreferences = storage.local.get(
-			'gu.prefs.accessibility.autoplay-video',
+		const flashingPreference = storage.local.get(
+			'gu.prefs.accessibility.flashing-elements',
 		);
 
+		const autoplayPreference = storage.local.get(
+			'gu.prefs.accessibility.autoplay-video',
+		);
+		/**
+		 * `flashingPreference` and `autoplayPreference` are explicitly `false`
+		 *  when the user has said they don't want flashing elements or autoplaying video.
+		 */
 		setIsAutoplayAllowed(
-			!userPrefersReducedMotion && autoplayPreferences !== false,
+			!userPrefersReducedMotion &&
+				autoplayPreference !== false &&
+				flashingPreference !== false,
 		);
 
 		/**


### PR DESCRIPTION
## What does this change?
This PR adds a new accessibility preference to enable/disable looping videos. This PR refactors the wider component to make it more generic so that it is more easily extendable for future preferences. 

## Why?
Looping videos are being introduced on the fronts. In order to be accessible, we want to offer users the ability to turn these off if desired. 

## Screenshots

<img width="869" height="530" alt="Screenshot 2025-07-14 at 17 28 32" src="https://github.com/user-attachments/assets/c99b0b68-ffae-4f0d-95ca-a3c2ee13923b" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
