### PR TITLE
Create new e2e test file for affiliate links tests

### DIFF
--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -20,9 +20,7 @@ test.describe('Affiliate links', () => {
 			await expectToBeVisible(page, selector);
 			await expect(disclaimerLocator).toContainText('affiliate link');
 		});
-	});
 
-	test.describe('WEB', function () {
 		test('skimlinks should have the attribute rel="sponsored"', async ({
 			page,
 		}) => {

--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -14,10 +14,10 @@ test.describe('Affiliate links', () => {
 			});
 			await cmpAcceptAll(page);
 
-			const selector = '[data-testid="affiliate-disclaimer"]';
-			const disclaimerLocator = page.locator(selector);
+			const disclaimerSelector = '[data-testid="affiliate-disclaimer"]';
+			const disclaimerLocator = page.locator(disclaimerSelector);
 			await disclaimerLocator.scrollIntoViewIfNeeded();
-			await expectToBeVisible(page, selector);
+			await expectToBeVisible(page, disclaimerSelector);
 			await expect(disclaimerLocator).toContainText('affiliate link');
 		});
 
@@ -30,8 +30,8 @@ test.describe('Affiliate links', () => {
 			});
 			await cmpAcceptAll(page);
 
-			const selector = '[href*="go.skimresources"]';
-			const skimlinkLocator = page.locator(selector).first();
+			const skimlinkSelector = '[href*="go.skimresources"]';
+			const skimlinkLocator = page.locator(skimlinkSelector).first();
 			const skimlinkRelAttribute =
 				await skimlinkLocator.getAttribute('rel');
 			expect(skimlinkRelAttribute).toBe('sponsored');

--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { expectToBeVisible } from '../lib/locators';
+
+test.describe('Affiliate links', () => {
+	test.describe('WEB', function () {
+		test('should render the affiliate disclaimer on an article containing affiliate links', async ({
+			page,
+		}) => {
+			await loadPage({
+				page,
+				path: '/Article/https://www.theguardian.com/thefilter/2025/jun/17/best-fans-uk',
+			});
+			await cmpAcceptAll(page);
+
+			const selector = '[data-testid="affiliate-disclaimer"]';
+			const disclaimerLocator = page.locator(selector);
+			await disclaimerLocator.scrollIntoViewIfNeeded();
+			await expectToBeVisible(page, selector);
+			await expect(disclaimerLocator).toContainText('affiliate link');
+		});
+	});
+
+	test.describe('WEB', function () {
+		test('skimlinks should have the attribute rel="sponsored"', async ({
+			page,
+		}) => {
+			await loadPage({
+				page,
+				path: '/Article/https://www.theguardian.com/thefilter/2025/jun/17/best-fans-uk',
+			});
+			await cmpAcceptAll(page);
+
+			const selector = '[href*="go.skimresources"]';
+			const skimlinkLocator = page.locator(selector).first();
+			const skimlinkRelAttribute =
+				await skimlinkLocator.getAttribute('rel');
+			expect(skimlinkRelAttribute).toBe('sponsored');
+		});
+	});
+});

--- a/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
@@ -96,23 +96,5 @@ test.describe('Embeds', () => {
 			await expectToBeVisible(page, embedSelector);
 			await expect(embedLocator).toContainText('Liverpool');
 		});
-
-		// Skipping for now as the change to the affiliate disclaimer block has been reverted
-		// https://github.com/guardian/frontend/pull/26749
-		test.skip('should render the affiliate disclaimer block', async ({
-			page,
-		}) => {
-			await loadPage({
-				page,
-				path: '/Article/https://www.theguardian.com/music/2020/jun/15/pet-shop-boys-where-to-start-in-their-back-catalogue',
-			});
-			await cmpAcceptAll(page);
-
-			const selector = '[data-testid="affiliate-disclaimer"]';
-			const locator = page.locator(selector);
-			await locator.scrollIntoViewIfNeeded();
-			await expectToBeVisible(page, selector);
-			await expect(locator).toContainText('affiliate link');
-		});
 	});
 });


### PR DESCRIPTION
## What does this change?

- Creates a new Playwright test file to test some of the affiliate links logic
- Moves an existing test which has been skipped for a while into this new file
- Makes sure that the existing test actually uses a URL where we expect to see the affiliate links disclaimer so that the test will pass
- Adds a test to check that affiliate links are being marked with the `rel="sponsored"` attribute

## Why?
There was one test to check the affiliate links disclaimer that has been skipped for a long while. This can now be unskipped,  and it made most sense for this to be moved to a new file, with another test being added to help us catch any potential changes to the affiliate links logic.