### PR TITLE
Tweak progress bar

### DIFF
--- a/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/LoopVideoProgressBar.tsx
@@ -44,14 +44,14 @@ export const LoopVideoProgressBar = ({
 	if (duration <= 0) return null;
 
 	/**
-	 * We achieve a smooth progress bar by using CSS transitions. However, this means that
-	 * the time on the progress bar is roughly always about 0.25 seconds behind - the interval in
-	 * which the onTimeUpdate event on video is fired. Therefore, to the user it looks like the
-	 * progress bar ranges from 0s to duration - 0.25s. To make allowance for this, when calculating
-	 * the progress percentage, we take 0.25s off the duration, so that the progress bar reaches
-	 * closer to the end.
+	 * We achieve a smooth progress bar by using CSS transitions. Given that
+	 * onTimeUpdate firesevery 250ms or so, this means that the time on the
+	 * progress bar is always about 0.25s behind and begins 0.25s late.
+	 * Therefore, when calculating the progress percentage, we take 0.25s off the duration.
+	 *
+	 * Videos less than a second in duration will have no adjustment.
 	 */
-	const adjustedDuration = Math.max(duration - 0.25, 0.1);
+	const adjustedDuration = duration > 1 ? duration - 0.25 : duration;
 
 	const progressPercentage = Math.min(
 		(currentTime * 100) / adjustedDuration,


### PR DESCRIPTION
## What does this change?

Tweaks the progress bar:
- No longer transitions from the end of the video to the start
- Allows the progress bar to reach closer to the end of the video by manipulating the duration

## Why?

Better UI

## Screenshots

### Before

https://github.com/user-attachments/assets/a5f3c13b-6990-42c1-b165-aeac846e0ab8

### After

https://github.com/user-attachments/assets/35246189-9d3d-493b-8e21-3400361127e9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
