### PR TITLE
Handle Loop Video canplaythrough event

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -365,6 +365,12 @@ export const LoopVideo = ({
 		return FallbackImageComponent;
 	}
 
+	const handleCanPlay = () => {
+		if (!isPlayable) {
+			setIsPlayable(true);
+		}
+	};
+
 	const handlePlayPauseClick = (event: React.SyntheticEvent) => {
 		event.preventDefault();
 		playPauseVideo();
@@ -466,7 +472,7 @@ export const LoopVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	return (
-		<div
+		<figure
 			ref={setNode}
 			css={videoContainerStyles}
 			className="loop-video-container"
@@ -484,9 +490,9 @@ export const LoopVideo = ({
 				setCurrentTime={setCurrentTime}
 				ref={vidRef}
 				isPlayable={isPlayable}
-				setIsPlayable={setIsPlayable}
 				playerState={playerState}
 				isMuted={isMuted}
+				handleCanPlay={handleCanPlay}
 				handlePlayPauseClick={handlePlayPauseClick}
 				handleAudioClick={handleAudioClick}
 				handleKeyDown={handleKeyDown}
@@ -496,6 +502,6 @@ export const LoopVideo = ({
 				preloadPartialData={preloadPartialData}
 				showPlayIcon={showPlayIcon}
 			/>
-		</div>
+		</figure>
 	);
 };

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -81,11 +81,11 @@ type Props = {
 	height: number;
 	FallbackImageComponent: ReactElement;
 	isPlayable: boolean;
-	setIsPlayable: Dispatch<SetStateAction<boolean>>;
 	playerState: PlayerStates;
 	currentTime: number;
 	setCurrentTime: Dispatch<SetStateAction<number>>;
 	isMuted: boolean;
+	handleCanPlay: (event: SyntheticEvent) => void;
 	handlePlayPauseClick: (event: SyntheticEvent) => void;
 	handleAudioClick: (event: SyntheticEvent) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
@@ -112,11 +112,11 @@ export const LoopVideoPlayer = forwardRef(
 			FallbackImageComponent,
 			posterImage,
 			isPlayable,
-			setIsPlayable,
 			playerState,
 			currentTime,
 			setCurrentTime,
 			isMuted,
+			handleCanPlay,
 			handlePlayPauseClick,
 			handleAudioClick,
 			handleKeyDown,
@@ -149,9 +149,8 @@ export const LoopVideoPlayer = forwardRef(
 					muted={isMuted}
 					playsInline={true}
 					poster={posterImage}
-					onCanPlay={() => {
-						setIsPlayable(true);
-					}}
+					onCanPlay={handleCanPlay}
+					onCanPlayThrough={handleCanPlay}
 					onTimeUpdate={() => {
 						if (
 							ref &&


### PR DESCRIPTION
## What does this change?

Informs the Loop VIdeo component that the video is playable if the video's `canPlayThrough` event is fired.

Uses semantic HTML for the video container.

## Why?

We already inform the Loop VIdeo component that the video is playable if the video's `canPlay` event is fired. However,
according to the MDN docs, the `canplay` event fires _"when the user agent can play the media, but estimates that not enough data has been loaded to play the media up to its end without having to stop for further buffering of content."_, suggesting that it may NOT fire if enough data is loaded to play the media to its end at the same time that user agent can play the media. Anecdotally, the `canPlay` event is always fired, but handling this extra event can only be beneficial.
