### PR TITLE
Automated hover colours

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -41,7 +41,7 @@
 		"@guardian/ophan-tracker-js": "2.3.0",
 		"@guardian/react-crossword": "6.3.0",
 		"@guardian/shimport": "1.0.2",
-		"@guardian/source": "9.0.0",
+		"@guardian/source": "10.2.0",
 		"@guardian/source-development-kitchen": "18.1.1",
 		"@guardian/support-dotcom-components": "7.5.0",
 		"@guardian/tsconfig": "0.2.0",

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -417,6 +417,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									cssOverrides={styles.linkButtonStyles}
 									theme={buttonThemes(
 										choiceCardButtonSettings,
+										'tertiary',
 									)}
 									icon={<SvgArrowRightStraight />}
 									iconSide="right"
@@ -808,7 +809,7 @@ const styles = {
 		}
 	`,
 	linkButtonStyles: css`
-		background-color: ${palette.brandAlt[400]};
+		/* background-color: ${palette.brandAlt[400]}; */
 		border-color: ${palette.brandAlt[400]};
 		width: 100%;
 	`,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -40,7 +40,13 @@ import { DesignableBannerCloseButton } from './components/DesignableBannerCloseB
 import { DesignableBannerCtas } from './components/DesignableBannerCtas';
 import { DesignableBannerHeader } from './components/DesignableBannerHeader';
 import { DesignableBannerVisual } from './components/DesignableBannerVisual';
-import type { BannerTemplateSettings, ChoiceCardSettings } from './settings';
+import type {
+	BannerTemplateSettings,
+	ChoiceCardSettings,
+	CtaSettings,
+	CtaStateSettings,
+} from './settings';
+import { buttonThemes } from './styles/buttonStyles';
 import { templateSpacing } from './styles/templateStyles';
 
 const buildImageSettings = (
@@ -187,6 +193,15 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 		: imageSettings
 		? 'main-image'
 		: '.';
+
+	// TODO: I assume we're planning on making this adjustable in RRCP in future.
+	const choiceCardButtonCtaStateSettings: CtaStateSettings = {
+		backgroundColour: '#FFE500', // ${palette.brandAlt[400]},
+		textColour: 'inherit',
+	};
+	const choiceCardButtonSettings: CtaSettings = {
+		default: choiceCardButtonCtaStateSettings,
+	};
 
 	const templateSettings: BannerTemplateSettings = {
 		containerSettings: {
@@ -428,6 +443,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									onClick={onCtaClick}
 									priority="tertiary"
 									cssOverrides={styles.linkButtonStyles}
+									theme={buttonThemes(
+										choiceCardButtonSettings,
+									)}
 									icon={<SvgArrowRightStraight />}
 									iconSide="right"
 									target="_blank"

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -204,12 +204,12 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 				),
 				textColour: hexColourToString(primaryCta.default.text),
 			},
-			hover: {
-				backgroundColour: hexColourToString(
-					primaryCta.hover.background,
-				),
-				textColour: hexColourToString(primaryCta.hover.text),
-			},
+			// hover: {
+			// 	backgroundColour: hexColourToString(
+			// 		primaryCta.hover.background,
+			// 	),
+			// 	textColour: hexColourToString(primaryCta.hover.text),
+			// },
 		},
 		secondaryCtaSettings: {
 			default: {
@@ -223,17 +223,17 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						: undefined
 				}`,
 			},
-			hover: {
-				backgroundColour: hexColourToString(
-					secondaryCta.hover.background,
-				),
-				textColour: hexColourToString(secondaryCta.hover.text),
-				border: `1px solid ${
-					secondaryCta.hover.border
-						? hexColourToString(secondaryCta.hover.border)
-						: undefined
-				}`,
-			},
+			// hover: {
+			// 	backgroundColour: hexColourToString(
+			// 		secondaryCta.hover.background,
+			// 	),
+			// 	textColour: hexColourToString(secondaryCta.hover.text),
+			// 	border: `1px solid ${
+			// 		secondaryCta.hover.border
+			// 			? hexColourToString(secondaryCta.hover.border)
+			// 			: undefined
+			// 	}`,
+			// },
 		},
 		closeButtonSettings: {
 			default: {
@@ -247,17 +247,17 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						: specialReport[100]
 				}`,
 			},
-			hover: {
-				backgroundColour: hexColourToString(
-					closeButton.hover.background,
-				),
-				textColour: hexColourToString(closeButton.hover.text),
-				border: `1px solid ${
-					closeButton.hover.border
-						? hexColourToString(closeButton.hover.border)
-						: neutral[100]
-				}`,
-			},
+			// hover: {
+			// 	backgroundColour: hexColourToString(
+			// 		closeButton.hover.background,
+			// 	),
+			// 	textColour: hexColourToString(closeButton.hover.text),
+			// 	border: `1px solid ${
+			// 		closeButton.hover.border
+			// 			? hexColourToString(closeButton.hover.border)
+			// 			: neutral[100]
+			// 	}`,
+			// },
 		},
 		highlightedTextSettings: {
 			textColour: hexColourToString(highlightedText.text),

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -413,11 +413,11 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 										threeTierChoiceCardSelectedProduct,
 									)}
 									onClick={onCtaClick}
-									priority="tertiary"
+									priority="primary"
 									cssOverrides={styles.linkButtonStyles}
 									theme={buttonThemes(
 										choiceCardButtonSettings,
-										'tertiary',
+										'primary',
 									)}
 									icon={<SvgArrowRightStraight />}
 									iconSide="right"

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -219,12 +219,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 				),
 				textColour: hexColourToString(primaryCta.default.text),
 			},
-			// hover: {
-			// 	backgroundColour: hexColourToString(
-			// 		primaryCta.hover.background,
-			// 	),
-			// 	textColour: hexColourToString(primaryCta.hover.text),
-			// },
 		},
 		secondaryCtaSettings: {
 			default: {
@@ -238,17 +232,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						: undefined
 				}`,
 			},
-			// hover: {
-			// 	backgroundColour: hexColourToString(
-			// 		secondaryCta.hover.background,
-			// 	),
-			// 	textColour: hexColourToString(secondaryCta.hover.text),
-			// 	border: `1px solid ${
-			// 		secondaryCta.hover.border
-			// 			? hexColourToString(secondaryCta.hover.border)
-			// 			: undefined
-			// 	}`,
-			// },
 		},
 		closeButtonSettings: {
 			default: {
@@ -262,17 +245,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						: specialReport[100]
 				}`,
 			},
-			// hover: {
-			// 	backgroundColour: hexColourToString(
-			// 		closeButton.hover.background,
-			// 	),
-			// 	textColour: hexColourToString(closeButton.hover.text),
-			// 	border: `1px solid ${
-			// 		closeButton.hover.border
-			// 			? hexColourToString(closeButton.hover.border)
-			// 			: neutral[100]
-			// 	}`,
-			// },
 		},
 		highlightedTextSettings: {
 			textColour: hexColourToString(highlightedText.text),

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -196,7 +196,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 
 	// TODO: I assume we're planning on making this adjustable in RRCP in future.
 	const choiceCardButtonCtaStateSettings: CtaStateSettings = {
-		backgroundColour: '#FFE500', // ${palette.brandAlt[400]},
+		backgroundColour: palette.brandAlt[400],
 		textColour: 'inherit',
 	};
 	const choiceCardButtonSettings: CtaSettings = {
@@ -809,7 +809,6 @@ const styles = {
 		}
 	`,
 	linkButtonStyles: css`
-		/* background-color: ${palette.brandAlt[400]}; */
 		border-color: ${palette.brandAlt[400]};
 		width: 100%;
 	`,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -6,7 +6,7 @@
 import { css } from '@emotion/react';
 import { Button, SvgCross } from '@guardian/source/react-components';
 import type { CtaSettings } from '../settings';
-import { buttonStyles } from '../styles/buttonStyles';
+import { buttonStyles, buttonThemes } from '../styles/buttonStyles';
 
 interface DesignableBannerCloseButtonProps {
 	onCloseClick: () => void;
@@ -29,6 +29,7 @@ export function DesignableBannerCloseButton({
 					settings,
 					styles.closeButtonOverrides,
 				)}
+				theme={buttonThemes(settings)}
 				icon={<SvgCross />}
 				size="small"
 				hideLabel={true}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -29,7 +29,8 @@ export function DesignableBannerCloseButton({
 					settings,
 					styles.closeButtonOverrides,
 				)}
-				theme={buttonThemes(settings)}
+				priority="tertiary"
+				theme={buttonThemes(settings, 'tertiary')}
 				icon={<SvgCross />}
 				size="small"
 				hideLabel={true}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -7,7 +7,7 @@ import { LinkButton } from '@guardian/source/react-components';
 import { SecondaryCtaType } from '@guardian/support-dotcom-components';
 import type { BannerRenderedContent } from '../../common/types';
 import type { CtaSettings } from '../settings';
-import { buttonStyles } from '../styles/buttonStyles';
+import { buttonThemes } from '../styles/buttonStyles';
 
 interface DesignableBannerCtasProps {
 	mainOrMobileContent: BannerRenderedContent;
@@ -34,7 +34,8 @@ export function DesignableBannerCtas({
 					onClick={onPrimaryCtaClick}
 					size="small"
 					priority="primary"
-					cssOverrides={buttonStyles(primaryCtaSettings)}
+					// cssOverrides={buttonStyles(primaryCtaSettings)}
+					theme={buttonThemes(primaryCtaSettings, 'primary')}
 				>
 					{primaryCta?.ctaText}
 				</LinkButton>
@@ -45,7 +46,8 @@ export function DesignableBannerCtas({
 					onClick={onSecondaryCtaClick}
 					size="small"
 					priority="tertiary"
-					cssOverrides={buttonStyles(secondaryCtaSettings)}
+					// cssOverrides={buttonStyles(secondaryCtaSettings)}
+					theme={buttonThemes(secondaryCtaSettings, 'secondary')}
 				>
 					{secondaryCta.cta.ctaText}
 				</LinkButton>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -45,7 +45,7 @@ export function DesignableBannerCtas({
 					href={secondaryCta?.cta.ctaUrl}
 					onClick={onSecondaryCtaClick}
 					size="small"
-					priority="tertiary"
+					priority="secondary"
 					cssOverrides={buttonStyles(secondaryCtaSettings)}
 					theme={buttonThemes(secondaryCtaSettings, 'secondary')}
 				>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -7,7 +7,7 @@ import { LinkButton } from '@guardian/source/react-components';
 import { SecondaryCtaType } from '@guardian/support-dotcom-components';
 import type { BannerRenderedContent } from '../../common/types';
 import type { CtaSettings } from '../settings';
-import { buttonThemes } from '../styles/buttonStyles';
+import { buttonStyles, buttonThemes } from '../styles/buttonStyles';
 
 interface DesignableBannerCtasProps {
 	mainOrMobileContent: BannerRenderedContent;
@@ -34,7 +34,7 @@ export function DesignableBannerCtas({
 					onClick={onPrimaryCtaClick}
 					size="small"
 					priority="primary"
-					// cssOverrides={buttonStyles(primaryCtaSettings)}
+					cssOverrides={buttonStyles(primaryCtaSettings)}
 					theme={buttonThemes(primaryCtaSettings, 'primary')}
 				>
 					{primaryCta?.ctaText}
@@ -46,7 +46,7 @@ export function DesignableBannerCtas({
 					onClick={onSecondaryCtaClick}
 					size="small"
 					priority="tertiary"
-					// cssOverrides={buttonStyles(secondaryCtaSettings)}
+					cssOverrides={buttonStyles(secondaryCtaSettings)}
 					theme={buttonThemes(secondaryCtaSettings, 'secondary')}
 				>
 					{secondaryCta.cta.ctaText}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
@@ -18,7 +18,7 @@ import { useContributionsReminderEmailForm } from '../../../hooks/useContributio
 import { ensureHasPreposition, ReminderStatus } from '../../../lib/reminders';
 import type { BannerEnrichedReminderCta } from '../../common/types';
 import type { CtaSettings } from '../settings';
-import { buttonStyles } from '../styles/buttonStyles';
+import { buttonStyles, buttonThemes } from '../styles/buttonStyles';
 
 // ---- Thank you component ---- //
 
@@ -189,6 +189,10 @@ function Signup({
 							${setReminderCtaSettings &&
 							buttonStyles(setReminderCtaSettings)}
 						`}
+						theme={
+							setReminderCtaSettings &&
+							buttonThemes(setReminderCtaSettings)
+						}
 					>
 						Set reminder
 					</Button>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
@@ -22,7 +22,7 @@ export type CtaStateSettings = {
 
 export interface CtaSettings {
 	default: CtaStateSettings;
-	hover: CtaStateSettings;
+	// hover: CtaStateSettings;
 	mobile?: CtaStateSettings;
 	desktop?: CtaStateSettings;
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
@@ -22,7 +22,6 @@ export type CtaStateSettings = {
 
 export interface CtaSettings {
 	default: CtaStateSettings;
-	// hover: CtaStateSettings;
 	mobile?: CtaStateSettings;
 	desktop?: CtaStateSettings;
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/styles/buttonStyles.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/styles/buttonStyles.ts
@@ -5,14 +5,38 @@
  */
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { ThemeButton } from '@guardian/source/dist/react-components';
 import { from, until } from '@guardian/source/foundations';
 import type { CtaSettings } from '../settings';
+
+export function buttonThemes(
+	settings: CtaSettings,
+	ctaSettingsType?: string,
+): Partial<ThemeButton> {
+	if (ctaSettingsType === 'secondary') {
+		return {
+			textSecondary: settings.default.textColour,
+			backgroundSecondary: settings.default.backgroundColour,
+		};
+	}
+	if (ctaSettingsType === 'tertiary') {
+		return {
+			textTertiary: settings.default.textColour,
+			backgroundTertiary: settings.default.backgroundColour,
+		};
+	}
+
+	return {
+		textPrimary: settings.default.textColour,
+		backgroundPrimary: settings.default.backgroundColour,
+	};
+}
 
 export function buttonStyles(
 	settings: CtaSettings,
 	cssOverrides?: SerializedStyles,
 ): SerializedStyles {
-	const { default: defaultSettings, mobile, desktop, hover } = settings;
+	const { default: defaultSettings, mobile, desktop } = settings;
 
 	return css`
 		${toCssString(defaultSettings)};
@@ -23,10 +47,6 @@ export function buttonStyles(
 
 		${from.tablet} {
 			${desktop ? toCssString(desktop) : ''};
-		}
-
-		&:hover {
-			${toCssString(hover)}
 		}
 
 		${cssOverrides};

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5951,7 +5951,7 @@ type CSSCustomProperty = `--${string}`;
  * Ensures that all palette functions provide the same API, deriving a palette
  * colour from an {@linkcode ArticleFormat}.
  */
-type PaletteFunction = (f: ArticleFormat) => string;
+type PaletteFunction = (f: ArticleFormat) => string | undefined;
 /**
  * Used to validate that the palette object always has the correct shape,
  * without changing its type.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         version: 8.0.0(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/braze-components':
         specifier: 22.2.0
-        version: 22.2.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(react@18.3.1)
+        version: 22.2.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(react@18.3.1)
       '@guardian/bridget':
         specifier: 8.5.1
         version: 8.5.1
@@ -333,16 +333,16 @@ importers:
         version: 2.3.0
       '@guardian/react-crossword':
         specifier: 6.3.0
-        version: 6.3.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        version: 6.3.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
       '@guardian/source':
-        specifier: 9.0.0
-        version: 9.0.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+        specifier: 10.2.0
+        version: 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source-development-kitchen':
         specifier: 18.1.1
-        version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+        version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
         specifier: 7.5.0
         version: 7.5.0(@guardian/libs@23.0.0)(zod@3.22.4)
@@ -4746,7 +4746,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@22.2.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(react@18.3.1):
+  /@guardian/braze-components@22.2.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(react@18.3.1):
     resolution: {integrity: sha512-uSkHd6mBVTAD+BrvJZNt+oSipYHQXBdVt9Pu/VTvkliXHzT8OUsep7ObIWM1lkf3znWbqLDhoXtwS5apX2AEWQ==}
     engines: {node: ^18.15 || ^20.8}
     peerDependencies:
@@ -4757,7 +4757,7 @@ packages:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
       '@guardian/libs': 23.0.0(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/source': 9.0.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
     dev: false
 
@@ -5053,7 +5053,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@guardian/react-crossword@6.3.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+  /@guardian/react-crossword@6.3.0(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
     resolution: {integrity: sha512-6CVNzY+yZrrUYOLpaAu7KSlyU23LBiZTFNJACI935iyjYuWEtyROoOwza82h1XconuqyEd9S8iG8CjtLb+j9Ig==}
     peerDependencies:
       '@emotion/react': ^11.11.3
@@ -5070,7 +5070,7 @@ packages:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
       '@guardian/libs': 23.0.0(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/source': 9.0.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
       react: 18.3.1
       tslib: 2.6.2
@@ -5121,7 +5121,7 @@ packages:
       typescript: 5.5.3
     dev: false
 
-  /@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@9.0.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3):
+  /@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0)(@guardian/libs@23.0.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-wuMULnVjValyEz6YjrOPt054tXJkutkAbPdeV/KQHoSCSjAJnd0Cp3SZeoVog77HE/iZ0mnKaiVkK+QXpRVtCQ==}
     peerDependencies:
       '@emotion/react': ^11.11.4
@@ -5143,8 +5143,34 @@ packages:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
       '@guardian/libs': 23.0.0(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/source': 9.0.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
+      react: 18.3.1
+      tslib: 2.6.2
+      typescript: 5.5.3
+    dev: false
+
+  /@guardian/source@10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3):
+    resolution: {integrity: sha512-mPozNtjGe0ykOjyFPuMS76CAPqafV9oJpHaX1ptx+h5wAMnu6csqKLwkALd6plDM9Y5vfWM8S/UERRlFg/rnzw==}
+    peerDependencies:
+      '@emotion/react': ^11.11.4
+      '@types/react': ^18.2.79
+      react: ^18.2.0
+      tslib: ^2.6.2
+      typescript: ~5.5.2
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.1
+      mini-svg-data-uri: 1.4.4
       react: 18.3.1
       tslib: 2.6.2
       typescript: 5.5.3


### PR DESCRIPTION
## What does this change?

This bumps the version of Source to 10.2.0 in order to use the new Partial<ThemeButton> to handle the hover colours for CTAs.

Much of this is [based on PR13968](https://github.com/guardian/dotcom-rendering/pull/13968) on a fresh branch with no conflicts.

## Why?

[Trello card](https://trello.com/c/rrkYaudf/1089-banner-design-use-automatic-cta-hover-colours)

Currently in the RRCP banner design tool users have to configure the cta hover colours.
The latest version of source now has automatic hover colours on ctas, based on the main colour. If we use this instead then we can simplify the configuration of banner designs. This PR removes the hover values from the banner designs

The backend changes to support this are in the https://github.com/guardian/support-dotcom-components/pull/1364

## Screenshots

| Unhovered     | Hovered      |
| ----------- | ---------- |
| **Choice card CTA unhovered** | **Choice card CTA hovered** |
| <img width="1044" height="436" alt="Screenshot 2025-07-18 at 15 47 31" src="https://github.com/user-attachments/assets/8d28885a-7752-4e72-ae2a-36e100ce56c2" /> | <img width="1039" height="356" alt="Screenshot 2025-07-22 at 12 59 43" src="https://github.com/user-attachments/assets/c81dbfdf-458d-4f83-8800-de57bdc990c3" /> |
| **Support Button Unhovered** | **Support Button hovered** |
| <img width="542" height="528" alt="Screenshot 2025-07-18 at 15 48 59" src="https://github.com/user-attachments/assets/579873d7-a1d7-48a2-8812-f8fdcbace016" /> | <img width="530" height="512" alt="Screenshot 2025-07-18 at 15 49 16" src="https://github.com/user-attachments/assets/a4800c17-1a33-4abd-b472-27ec27007663" /> |
| **Second button unhovered** | **Second button hovered** |
| <img width="596" height="526" alt="Screenshot 2025-07-18 at 15 51 31" src="https://github.com/user-attachments/assets/0be225fa-4b19-4421-b1b4-0b80dd5d1f72" /> | <img width="544" height="525" alt="Screenshot 2025-07-18 at 15 49 36" src="https://github.com/user-attachments/assets/fd6ca0cc-938e-42a3-9e72-04416daf8d3d" /> |
| **Close button unhovered** | **Close button hovered** |
| <img width="170" height="132" alt="Screenshot 2025-07-18 at 15 47 42" src="https://github.com/user-attachments/assets/863bdf70-c44f-4515-b3d2-0442a1e54df3" />| <img width="264" height="219" alt="Screenshot 2025-07-18 at 15 47 23" src="https://github.com/user-attachments/assets/16e59113-6133-464c-9f48-11aaed25c7da" /> |

**NOTE**:  A button's priority and theme-priority need to match otherwise it will not reflect the correct colour when hover state is hit.

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
