### PR TITLE
The Filter - Product button open in new tab

### DIFF
--- a/dotcom-rendering/src/components/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/ProductLinkButton.tsx
@@ -12,7 +12,8 @@ export const ProductLinkButton = ({ label, url }: ProductLinkButtonProps) => {
 	return (
 		<LinkButton
 			href={url}
-			rel="sponsored"
+			rel="sponsored noreferrer noopener"
+			target="_blank"
 			iconSide="right"
 			aria-label={`Open ${label} in a new tab`}
 			icon={<SvgArrowRightStraight />}


### PR DESCRIPTION
## What does this change?

Makes the product button on filter articles open in a new tab.

## Why?

Currently, when a user clicks on an affiliate link that link automatically opens in the new window, taking the user away from the original Guardian content. Whilst opening links in a new window is considered useability and accessability best practice for some kind of URLs (especially in news) this is not considered to be the case in e-comm use cases as it prohibits the user from evaluating multiple products that may have been recommended in a piece of content. 

