### PR TITLE
Remove `data-print-layout` from `Section`

### DIFF
--- a/dotcom-rendering/src/components/FrontsAdSlots.tsx
+++ b/dotcom-rendering/src/components/FrontsAdSlots.tsx
@@ -64,7 +64,6 @@ export const MerchandisingSlot = ({
 		renderAds && (
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				showTopBorder={false}
 				showSideBorders={false}

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -71,7 +71,6 @@ export const AllEditorialNewslettersPageLayout = ({
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				backgroundColour={sourcePalette.brand[400]}
 				borderColour={sourcePalette.brand[600]}

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -209,7 +209,6 @@ export const AudioLayout = (props: WebProps) => {
 			<main data-layout="AudioLayout">
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					showTopBorder={false}
 					backgroundColour={themePalette('--article-background')}
 					borderColour={themePalette('--article-border')}
@@ -457,7 +456,6 @@ export const AudioLayout = (props: WebProps) => {
 				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -524,7 +522,6 @@ export const AudioLayout = (props: WebProps) => {
 					<Section
 						fullWidth={true}
 						sectionId="comments"
-						data-print-layout="hide"
 						element="section"
 						backgroundColour={themePalette(
 							'--discussion-section-background',
@@ -556,7 +553,6 @@ export const AudioLayout = (props: WebProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -582,7 +578,6 @@ export const AudioLayout = (props: WebProps) => {
 				{renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -599,12 +594,7 @@ export const AudioLayout = (props: WebProps) => {
 
 			<>
 				{props.NAV.subNavSections && (
-					<Section
-						fullWidth={true}
-						data-print-layout="hide"
-						padSides={false}
-						element="aside"
-					>
+					<Section fullWidth={true} padSides={false} element="aside">
 						<Island
 							priority="enhancement"
 							defer={{ until: 'visible' }}
@@ -619,7 +609,6 @@ export const AudioLayout = (props: WebProps) => {
 				)}
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					padSides={false}
 					backgroundColour={sourcePalette.brand[400]}
 					borderColour={sourcePalette.brand[600]}

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -795,7 +795,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -901,7 +900,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -790,7 +790,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 				<Section
 					fullWidth={true}
 					showTopBorder={hasPageSkin}
-					data-print-layout="hide"
 					padSides={false}
 					element="aside"
 					backgroundColour={schemePalette(
@@ -810,7 +809,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				backgroundColour={brandBackground.primary}
 				borderColour={brandBorder.primary}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -872,7 +872,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -980,7 +979,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -323,7 +323,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 				)}
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					showTopBorder={false}
 					backgroundColour={themePalette('--article-background')}
 					borderColour={themePalette('--article-border')}
@@ -624,7 +623,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 				{isWeb && renderAds && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -693,7 +691,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					<Section
 						fullWidth={true}
 						sectionId="comments"
-						data-print-layout="hide"
 						element="section"
 						backgroundColour={themePalette(
 							'--discussion-section-background',
@@ -725,7 +722,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -752,7 +748,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 				{isWeb && renderAds && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -768,12 +763,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 			</main>
 
 			{isWeb && props.NAV.subNavSections && (
-				<Section
-					fullWidth={true}
-					data-print-layout="hide"
-					padSides={false}
-					element="aside"
-				>
+				<Section fullWidth={true} padSides={false} element="aside">
 					<Island priority="enhancement" defer={{ until: 'visible' }}>
 						<SubNav
 							subNavSections={props.NAV.subNavSections}
@@ -788,7 +778,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 				<>
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						backgroundColour={sourcePalette.brand[400]}
 						borderColour={sourcePalette.brand[600]}
@@ -840,7 +829,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -342,7 +342,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					<Hide from="tablet">
 						<Section
 							fullWidth={true}
-							data-print-layout="hide"
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
@@ -941,7 +940,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					{isWeb && renderAds && (
 						<Section
 							fullWidth={true}
-							data-print-layout="hide"
 							padSides={false}
 							showTopBorder={true}
 							showSideBorders={false}
@@ -1016,7 +1014,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							fullWidth={true}
 							showTopBorder={false}
 							sectionId="comments"
-							data-print-layout="hide"
 							element="section"
 							backgroundColour={themePalette(
 								'--discussion-section-background',
@@ -1051,7 +1048,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							padContent={false}
 							verticalMargins={false}
 							element="aside"
-							data-print-layout="hide"
 							data-link-name="most-popular"
 							data-component="most-popular"
 							leftColSize="wide"
@@ -1081,7 +1077,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					{isWeb && renderAds && (
 						<Section
 							fullWidth={true}
-							data-print-layout="hide"
 							padSides={false}
 							showTopBorder={false}
 							showSideBorders={false}
@@ -1102,7 +1097,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					{props.NAV.subNavSections && (
 						<Section
 							fullWidth={true}
-							data-print-layout="hide"
 							padSides={false}
 							element="aside"
 						>
@@ -1121,7 +1115,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						backgroundColour={sourcePalette.brand[400]}
 						borderColour={sourcePalette.brand[600]}
@@ -1174,7 +1167,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -467,7 +467,6 @@ export const NewsletterSignupLayout = ({
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				showTopBorder={false}
 				backgroundColour={sourcePalette.brand[400]}

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -658,7 +658,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -765,7 +764,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -757,7 +757,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -862,7 +861,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 			{isApps && (
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					backgroundColour={themePalette('--apps-footer-background')}
 					borderColour={themePalette('--article-border')}
 					padSides={false}

--- a/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
@@ -121,7 +121,6 @@ export const SportDataPageLayout = ({ sportData }: Props) => {
 				<Section
 					fullWidth={true}
 					showTopBorder={true}
-					data-print-layout="hide"
 					padSides={false}
 					element="aside"
 				>
@@ -137,7 +136,6 @@ export const SportDataPageLayout = ({ sportData }: Props) => {
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				backgroundColour={palette.brand[400]}
 				borderColour={palette.brand[600]}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -455,7 +455,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				)}
 				<Section
 					fullWidth={true}
-					data-print-layout="hide"
 					showTopBorder={false}
 					backgroundColour={themePalette('--article-background')}
 					borderColour={themePalette('--article-border')}
@@ -843,7 +842,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				{isWeb && renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -910,7 +908,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						sectionId="comments"
-						data-print-layout="hide"
 						element="section"
 						backgroundColour={themePalette(
 							'--discussion-section-background',
@@ -942,7 +939,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						padContent={false}
 						verticalMargins={false}
 						element="aside"
-						data-print-layout="hide"
 						data-link-name="most-popular"
 						data-component="most-popular"
 						backgroundColour={themePalette(
@@ -968,7 +964,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				{isWeb && renderAds && !isLabs && (
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						showTopBorder={false}
 						showSideBorders={false}
@@ -987,7 +982,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					{props.NAV.subNavSections && (
 						<Section
 							fullWidth={true}
-							data-print-layout="hide"
 							padSides={false}
 							element="aside"
 						>
@@ -1005,7 +999,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					)}
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						padSides={false}
 						backgroundColour={sourcePalette.brand[400]}
 						borderColour={sourcePalette.brand[600]}
@@ -1058,7 +1051,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 				<>
 					<Section
 						fullWidth={true}
-						data-print-layout="hide"
 						backgroundColour={themePalette('--ad-background')}
 						borderColour={themePalette('--article-border')}
 						padSides={false}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -208,7 +208,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 				<Section
 					fullWidth={true}
 					showTopBorder={true}
-					data-print-layout="hide"
 					padSides={false}
 					element="aside"
 				>
@@ -224,7 +223,6 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 
 			<Section
 				fullWidth={true}
-				data-print-layout="hide"
 				padSides={false}
 				backgroundColour={palette.brand[400]}
 				borderColour={palette.brand[600]}


### PR DESCRIPTION
If the `data-print-layout` attribute is applied to an element and set to `'hide'`, the `print.css` stylesheet is used to target some styles that hide the element:

https://github.com/guardian/dotcom-rendering/blob/fccb370dfdde0aaf0af36a67f2ff4901cdbc99f8/dotcom-rendering/src/static/css/print.css#L1-L4

However, this only works if the attribute is applied to an element in the DOM. If the attribute is instead applied as a prop to a component, and that component does not expect that prop and apply it in turn to an actual DOM element, then it's simply ignored.

The `Section` component does not take this prop, therefore these usages of `data-print-layout` have no effect.
