### PR TITLE
Text wrap for product button

### DIFF
--- a/dotcom-rendering/src/components/ProductLinkButton.stories.tsx
+++ b/dotcom-rendering/src/components/ProductLinkButton.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ProductLinkButton } from './ProductLinkButton';
 
@@ -6,7 +7,15 @@ const meta = {
 	title: 'Components/ProductLinkButton',
 	parameters: {
 		layout: 'padded',
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.leftCol,
+				breakpoints.wide,
+			],
+		},
 	},
+
 	args: {
 		label: '£6.50 for 350g at Ollie’s Kimchi',
 		url: 'https://ollieskimchi.co.uk/shop/ols/products/ollies-kimchi',
@@ -18,3 +27,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default = {} satisfies Story;
+
+export const WithLongLabel = {
+	args: {
+		label: '£10.99 for a 5 x 5 x 50cm sheet at Amazon',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/ProductLinkButton.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import {
 	LinkButton,
 	SvgArrowRightStraight,
@@ -7,6 +8,13 @@ type ProductLinkButtonProps = {
 	label: string;
 	url: string;
 };
+
+const linkButtonStyles = css`
+	max-width: 100%;
+	height: fit-content;
+	white-space: normal;
+	overflow-wrap: break-word;
+`;
 
 export const ProductLinkButton = ({ label, url }: ProductLinkButtonProps) => {
 	return (
@@ -20,6 +28,7 @@ export const ProductLinkButton = ({ label, url }: ProductLinkButtonProps) => {
 			data-ignore="global-link-styling"
 			data-link-name="in body link"
 			data-spacefinder-role="inline"
+			cssOverrides={[linkButtonStyles]}
 		>
 			{label}
 		</LinkButton>

--- a/dotcom-rendering/src/components/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/ProductLinkButton.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
 import {
 	LinkButton,
 	SvgArrowRightStraight,
@@ -12,6 +13,8 @@ type ProductLinkButtonProps = {
 const linkButtonStyles = css`
 	max-width: 100%;
 	height: fit-content;
+	padding-top: ${space[1]}px;
+	padding-bottom: ${space[1]}px;
 	white-space: normal;
 	overflow-wrap: break-word;
 `;


### PR DESCRIPTION
## What does this change?

On smaller viewports, the LinkButton component does not wrap long text, causing horizontal overflow. The button exceeds the container width instead of resizing or wrapping the label.

## Why?

To restore current functionality. 

The Filter team uses long CTAs in their buttons, which can cause layout issues on smaller breakpoints. The LinkButton component should support multiline text and wrap gracefully within its container to handle longer labels on mobile.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[after]: https://github.com/user-attachments/assets/2fc9f93d-8c41-4390-844a-da0d3c3d1b6d
[before]: https://github.com/user-attachments/assets/89fa324e-75c1-4ebc-a053-fdda1d2039ca

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
