### PR TITLE
Add xcust to skimlinks on app

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -90,6 +90,11 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			<Island priority="enhancement" defer={{ until: 'idle' }}>
 				<FocusStyles />
 			</Island>
+			{!!frontendData.affiliateLinksDisclaimer && (
+				<Island priority="feature" defer={{ until: 'idle' }}>
+					<EnhanceAffiliateLinks />
+				</Island>
+			)}
 			{(format.design === ArticleDesign.LiveBlog ||
 				format.design === ArticleDesign.DeadBlog) && (
 				<SkipTo id={'key-events-carousel'} label="Skip to key events" />
@@ -131,11 +136,6 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							serverSideTests={frontendData.config.abTests}
 						/>
 					</Island>
-					{!!frontendData.affiliateLinksDisclaimer && (
-						<Island priority="feature" defer={{ until: 'idle' }}>
-							<EnhanceAffiliateLinks />
-						</Island>
-					)}
 				</>
 			)}
 			{renderingTarget === 'Web' ? (


### PR DESCRIPTION
## What does this change?
Moves `<EnhanceAffiliateLinks />` out from under the `renderingTarget === 'Web'` check so that affiliate links on app get `xcust` data added to them.

## Why?
At the moment we're only adding the `xcust` URL parameter to Skimlinks on Web. We'd also like to collect data for Skimlinks on App, so we need to start adding the `xcust` parameter there too.