### PR TITLE
Fix poster image for MAM-generated video articles

### DIFF
--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -88,6 +88,7 @@ type Props = {
 	switches: Switches;
 	editionId: EditionId;
 	shouldHideAds: boolean;
+	contentType?: string;
 };
 
 export const MainMedia = ({
@@ -105,6 +106,7 @@ export const MainMedia = ({
 	switches,
 	editionId,
 	shouldHideAds,
+	contentType,
 }: Props) => {
 	return (
 		<div css={[mainMedia, chooseWrapper(format)]}>
@@ -128,6 +130,7 @@ export const MainMedia = ({
 					starRating={starRating}
 					editionId={editionId}
 					shouldHideAds={shouldHideAds}
+					contentType={contentType}
 				/>
 			))}
 		</div>

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -54,6 +54,7 @@ type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
+	contentType?: string;
 };
 
 export const YoutubeBlockComponent = ({
@@ -95,6 +96,7 @@ export const YoutubeBlockComponent = ({
 	isImmersive,
 	byline,
 	showByline,
+	contentType,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -112,6 +114,16 @@ export const YoutubeBlockComponent = ({
 	 * We need to ensure a unique id for each YouTube player on the page.
 	 */
 	const uniqueId = `${assetId}-${index}`;
+
+	// We need Video articles generated directly from Media Atom Maker
+	// to always show their poster (16:9) image, but in other cases
+	// use the override image (often supplied as 5:4 then cropped to 16:9)
+	const getPosterImage = () => {
+		if (contentType && contentType.toLowerCase() === 'video') {
+			return posterImage;
+		}
+		return overrideImage ?? posterImage;
+	};
 
 	useEffect(() => {
 		if (renderingTarget === 'Web') {
@@ -158,7 +170,7 @@ export const YoutubeBlockComponent = ({
 				atomId={id}
 				videoId={assetId}
 				uniqueId={uniqueId}
-				image={overrideImage ?? posterImage}
+				image={getPosterImage()}
 				alt={altText ?? mediaTitle ?? ''}
 				adTargeting={
 					enableAds && renderingTarget === 'Web'

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -519,6 +519,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									editionId={article.editionId}
 									hideCaption={isMedia}
 									shouldHideAds={article.shouldHideAds}
+									contentType={article.contentType}
 								/>
 							</div>
 						</GridItem>

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -96,6 +96,7 @@ type Props = {
 	isListElement?: boolean;
 	isSectionedMiniProfilesArticle?: boolean;
 	shouldHideAds: boolean;
+	contentType?: string;
 };
 
 // updateRole modifies the role of an element in a way appropriate for most
@@ -157,6 +158,7 @@ export const renderElement = ({
 	isListElement = false,
 	isSectionedMiniProfilesArticle = false,
 	shouldHideAds,
+	contentType,
 }: Props) => {
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
@@ -886,6 +888,7 @@ export const renderElement = ({
 						iconSizeOnMobile="large"
 						showTextOverlay={false}
 						hidePillOnMobile={false}
+						contentType={contentType}
 					/>
 				</Island>
 			);
@@ -953,6 +956,7 @@ export const RenderArticleElement = ({
 	isListElement,
 	isSectionedMiniProfilesArticle,
 	shouldHideAds,
+	contentType,
 }: Props) => {
 	const withUpdatedRole = updateRole(element, format);
 
@@ -979,6 +983,7 @@ export const RenderArticleElement = ({
 		isListElement,
 		isSectionedMiniProfilesArticle,
 		shouldHideAds,
+		contentType,
 	});
 
 	const needsFigure = !bareElements.has(element._type);


### PR DESCRIPTION
## What does this change?
This fix forces video articles generated through Media Atom Maker to use the 16:9 aspect ratio placeholder image over the video (before user interaction to play the video).

## Why?
By default the importable YoutubeBlockComponent will use the article's override image, if it is available, for its poster image. Since the redesign these override images, which are also used for Fronts, are often created with a 5:4 aspect ratio. However MAM videos are still created in 16:9 aspect ratio; this means that when the override image is used for the video poster the top and bottom edges of the image will be auto-cropped (via CSS `object-fit: cover`) to display over the video before play commences.

### Example 1: MAM video article that does NOT include a 5:4 cropped image for the Front.

Note that in the Front the image has its left-right sides cropped, but in the article the poster image displays correctly. 

**Front**
https://m.code.dev-theguardian.com/uk

<img width="1300" height="611" alt="Screenshot 2025-07-23 at 10 03 24" src="https://github.com/user-attachments/assets/1fd42b74-1f9f-435d-93de-9bfaecb05b48" />

**MAM**
https://video.gutools.co.uk/videos/84e5e139-9aa6-4314-9246-716be58d4f7f

<img width="729" height="657" alt="Screenshot 2025-07-22 at 13 03 04" src="https://github.com/user-attachments/assets/ae076812-c06b-48af-8214-f69d4a218364" />

**Article**
https://m.code.dev-theguardian.com/us-news/video/2025/mar/17/us-deports-alleged-gang-members-to-el-salvador-video

<img width="1327" height="674" alt="Screenshot 2025-07-22 at 13 02 51" src="https://github.com/user-attachments/assets/36a5c9f7-d141-41fa-b6ff-c2116a04c614" />

### Example 2: MAM video article that DOES include a 5:4 cropped image for the Front.

Note that in the Front the image displays as expected (5:4), but in the article the poster image is using that same 5:4 image as the poster image, leading to the top and bottom edges of the image being cropped. This is what this PR attempts to fix. 

**Front**
https://m.code.dev-theguardian.com/uk

<img width="1161" height="627" alt="Screenshot 2025-07-22 at 13 03 31" src="https://github.com/user-attachments/assets/91d6ab41-5ad9-44b7-8e45-fafbfe019a87" />

**MAM**
https://video.gutools.co.uk/videos/b5b72f88-774f-40ad-b18a-4a65900c76c4

<img width="754" height="715" alt="Screenshot 2025-07-22 at 13 04 15" src="https://github.com/user-attachments/assets/e010a81a-80f1-4159-b62b-4bcdf095413d" />

**Article**
https://m.code.dev-theguardian.com/global/video/2025/jun/03/yuck-guardian-australia-staff-taste-test-viral-healthy-tiktok-mousse-recipes-video

<img width="1233" height="694" alt="Screenshot 2025-07-22 at 13 04 02" src="https://github.com/user-attachments/assets/0efad1bb-3e4c-4ecf-9dc7-8c4b7dc6f824" />

## To test
1. When running DCAR locally, we can test the following article (for which the issue was first reported) in the local test harness: https://www.theguardian.com/australia-news/video/2025/jul/02/nsw-ses-says-vigorous-coastal-low-to-ease-from-thursday-but-not-out-of-the-woods-yet-video

2. In CODE, test the example links. **Example 1** should continue to display as expected in both the Front and the article. **Example 2** should show the correct (16:9) poster image in the article, while continuing to display the 4:4 image in the Front.

3. Perform some additional smoke checking to make sure the fix only impacts MAM-generated Video Article pages. Normal (Composer-generated) articles that use video for their main media should not be impacted, nor should this change have any impact on looping video in the Fronts

4. Run the Chromatic tests