### PR TITLE
Use correct image size for Flexible containers in half-width slot

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -835,6 +835,7 @@ export const Card = ({
 							media.type === 'slideshow' && isFlexibleContainer
 						}
 						padImage={isMediaCardOrNewsletter && isBetaContainer}
+						isBetaContainer={isBetaContainer}
 					>
 						{media.type === 'slideshow' &&
 							(isFlexibleContainer ? (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -873,6 +873,7 @@ export const Card = ({
 								imagePositionOnDesktop={imagePositionOnDesktop}
 								imagePositionOnMobile={imagePositionOnMobile}
 								isBetaContainer={isBetaContainer}
+								isFlexibleContainer={isFlexibleContainer}
 							>
 								<Avatar
 									src={media.avatarUrl}

--- a/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
@@ -8,6 +8,7 @@ type Props = {
 	imagePositionOnDesktop: ImagePositionType;
 	imagePositionOnMobile: ImagePositionType;
 	isBetaContainer: boolean;
+	isFlexibleContainer: boolean;
 };
 
 const sideMarginStyles = css`
@@ -27,6 +28,7 @@ const largerTopMargin = css`
 const sizingStyles = (
 	imageSize: ImageSizeType,
 	isBetaContainer: boolean,
+	isFlexibleContainer: boolean,
 	isVerticalOnDesktop: boolean,
 	isVerticalOnMobile: boolean,
 ) => {
@@ -79,10 +81,19 @@ const sizingStyles = (
 
 	switch (imageSize) {
 		case 'small':
-			return css`
-				width: 80px;
-				height: 80px;
-			`;
+			return isFlexibleContainer
+				? css`
+						width: 90px;
+						height: 90px;
+						${until.tablet} {
+							height: 80px;
+							width: 80px;
+						}
+				  `
+				: css`
+						width: 80px;
+						height: 80px;
+				  `;
 		case 'large':
 			return css`
 				width: 150px;
@@ -124,6 +135,7 @@ export const AvatarContainer = ({
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
 	isBetaContainer,
+	isFlexibleContainer,
 }: Props) => {
 	const isVerticalOnDesktop =
 		imagePositionOnDesktop === 'top' || imagePositionOnDesktop === 'bottom';
@@ -139,6 +151,7 @@ export const AvatarContainer = ({
 				sizingStyles(
 					imageSize,
 					isBetaContainer,
+					isFlexibleContainer,
 					isVerticalOnDesktop,
 					isVerticalOnMobile,
 				),

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -18,27 +18,36 @@ const sizingStyles = css`
 const flexBasisStyles = ({
 	imageSize,
 	imageType,
+	isBetaContainer,
 }: {
 	imageSize: ImageSizeType;
 	imageType?: CardImageType;
+	isBetaContainer: boolean;
 }): SerializedStyles => {
 	if (imageType === 'avatar') {
 		return css`
 			flex-basis: 100%;
 		`;
 	}
+
 	switch (imageSize) {
 		default:
 		case 'small':
-			return css`
-				flex-basis: 75%;
-				${between.tablet.and.desktop} {
-					flex-basis: 60%;
-				}
-				${from.desktop} {
-					flex-basis: 70%;
-				}
-			`;
+			return isBetaContainer
+				? css`
+						${from.tablet} {
+							flex-basis: 50%;
+						}
+				  `
+				: css`
+						flex-basis: 75%;
+						${between.tablet.and.desktop} {
+							flex-basis: 60%;
+						}
+						${from.desktop} {
+							flex-basis: 70%;
+						}
+				  `;
 		case 'medium':
 			return css`
 				${from.tablet} {
@@ -139,7 +148,7 @@ export const ContentWrapper = ({
 			css={[
 				sizingStyles,
 				imageDirectionDesktop === 'horizontal' &&
-					flexBasisStyles({ imageSize, imageType }),
+					flexBasisStyles({ imageSize, imageType, isBetaContainer }),
 				padContent &&
 					!isBetaContainer &&
 					css`

--- a/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ImageWrapper.tsx
@@ -44,6 +44,7 @@ type Props = {
 	 */
 	hideImageOverlay?: boolean;
 	padImage?: boolean;
+	isBetaContainer?: boolean;
 };
 
 const imageOverlayContainerStyles = css`
@@ -81,21 +82,27 @@ const imagePaddingStyles = (
  */
 const flexBasisStyles = ({
 	imageSize,
+	isBetaContainer,
 }: {
 	imageSize: ImageSizeType;
+	isBetaContainer: boolean;
 }): SerializedStyles => {
 	switch (imageSize) {
 		default:
 		case 'small':
-			return css`
-				flex-basis: 25%;
-				${between.tablet.and.desktop} {
-					flex-basis: 40%;
-				}
-				${from.desktop} {
-					flex-basis: 30%;
-				}
-			`;
+			return isBetaContainer
+				? css`
+						flex-basis: 50%;
+				  `
+				: css`
+						flex-basis: 25%;
+						${between.tablet.and.desktop} {
+							flex-basis: 40%;
+						}
+						${from.desktop} {
+							flex-basis: 30%;
+						}
+				  `;
 		case 'medium':
 			return css`
 				flex-basis: 50%;
@@ -154,6 +161,7 @@ export const ImageWrapper = ({
 	imagePositionOnMobile,
 	hideImageOverlay,
 	padImage,
+	isBetaContainer,
 }: Props) => {
 	const isHorizontalOnDesktop =
 		imagePositionOnDesktop === 'left' || imagePositionOnDesktop === 'right';
@@ -170,6 +178,7 @@ export const ImageWrapper = ({
 					isHorizontalOnDesktop &&
 					flexBasisStyles({
 						imageSize,
+						isBetaContainer: !!isBetaContainer,
 					}),
 				imageType === 'avatar' &&
 					css`

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -206,6 +206,7 @@ export const CardPicture = ({
 	if (mainImage === '') {
 		return null;
 	}
+
 	const sources = generateSources(
 		mainImage,
 		decideImageWidths(imageSize, aspectRatio),

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -549,7 +549,7 @@ const HalfWidthCardLayout = ({
 							)}
 							supportingContentAlignment="vertical"
 							supportingContentPosition="outer"
-							imageSize="medium"
+							imageSize="small"
 							aspectRatio={aspectRatio}
 							kickerText={card.kickerText}
 							showLivePlayable={false}

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -1,7 +1,11 @@
 import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { discussionApiUrl } from '../../fixtures/manual/discussionApiUrl';
-import { loopVideoCard, trails } from '../../fixtures/manual/trails';
+import {
+	loopVideoCard,
+	opinionTrails,
+	trails,
+} from '../../fixtures/manual/trails';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import type {
 	DCRContainerPalette,
@@ -153,6 +157,20 @@ export const Five: Story = {
 		collectionId: 1,
 	},
 };
+
+export const OpinionStandardCards: Story = {
+	name: 'With one splash card and two standard opinion cards',
+	args: {
+		frontSectionTitle: 'Opinion standard cards',
+		groupedTrails: {
+			...emptyGroupedTrails,
+			snap: [],
+			standard: [...trails.slice(0, 1), ...opinionTrails.slice(0, 2)],
+		},
+		collectionId: 1,
+	},
+};
+
 export const DefaultSplashWithImageSupression: Story = {
 	name: 'Standard splash with image supression',
 	args: {

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -245,7 +245,7 @@ const TwoOrFourCardLayout = ({
 							)}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
-							imageSize="medium"
+							imageSize="small"
 							aspectRatio={aspectRatio}
 							kickerText={card.kickerText}
 							showLivePlayable={false}


### PR DESCRIPTION
## What does this change?

Uses the `small` image size instead of `medium` in the half-width layout of the Flexible General & Flexible Special containers.

## Why?

We have been serving unnecessarily large images in the Flexible containers half-width layout slot. The width available at the breakpoints is as follows:
- Desktop: 220px
- Tablet: 160px
- Mobile: 122.5px

The `small` image size matches up to the space available, whereas the `medium` image size is too large:

```
case 'small':
	return [
		{ breakpoint: breakpoints.mobile, width: 120, aspectRatio },
		{ breakpoint: breakpoints.tablet, width: 160, aspectRatio },
		{ breakpoint: breakpoints.desktop, width: 220, aspectRatio },
	];

case 'medium':
	return [
		{ breakpoint: breakpoints.mobile, width: 465, aspectRatio },
		{ breakpoint: breakpoints.tablet, width: 330, aspectRatio },
		{ breakpoint: breakpoints.desktop, width: 460, aspectRatio },
	];
```

## Screenshots

The below screenshots show the width available for images in the Flexible General half-width layout slot at the different breakpoints.

| <img width=120/> | |
| - | - |
| mobile | ![mobile-before] |
| tablet | ![tablet-before] |
| desktop | ![desktop-before] |

[mobile-before]: https://github.com/user-attachments/assets/9ca1912a-e258-41db-abc1-688eb1153e45
[tablet-before]: https://github.com/user-attachments/assets/3a9fba5d-68bc-4928-83a0-8c25012250b3
[desktop-before]: https://github.com/user-attachments/assets/032e403a-acfd-438e-8362-8b608010dba9

### Flexible General half-width layout slot example

<img width="1006" height="564" alt="image" src="https://github.com/user-attachments/assets/61c196b7-5609-409e-841f-65699f577f83" />

