### PR TITLE
Looping video: Use a fallback image for replacement video

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -167,20 +167,23 @@ const getLargestImageUrl = (images?: Image[]) => {
 };
 
 /**
- * If we have a replacement video, we should use the largest available trail image from the media atom.
- * For all other videos, we should use the card's trail image where it is available and fall back to the media trail image.
- * */
+ * If we have a replacement video, we should prioritise the largest available trail image from the media atom.
+ * For all other videos, we should prioritise the card's trail image.
+ */
 const decideMediaAtomImage = (
 	videoReplace: boolean,
 	mediaAtom: FEMediaAtom,
 	cardTrailImage?: string,
 ) => {
-	if (videoReplace) {
-		return getLargestImageUrl(mediaAtom.trailImage?.allImages);
-	}
-	return (
-		cardTrailImage ?? getLargestImageUrl(mediaAtom.trailImage?.allImages)
+	const largestMediaAtomImage = getLargestImageUrl(
+		mediaAtom.trailImage?.allImages,
 	);
+
+	if (videoReplace) {
+		return largestMediaAtomImage ?? cardTrailImage;
+	}
+
+	return cardTrailImage ?? largestMediaAtomImage;
 };
 
 /**


### PR DESCRIPTION
## What does this change?

If a replacement video atom doesn't have a trail image, use the trail image of the card. Note that if the replacement video atom does have a trail image, then this is still prioritised over the card trail image.

## Why?

When a looping video is selected and a replacement video is used, we use the replacement video atom's trail image as the poster image and the fallback image. However, often these video atoms are created without a trail image, meaning that our Looping Video doesn't have an image to show as poster/fallback.

## Screenshots

Assumes that the replacement video atom does not have an associated trail image

| <img width=300/> | Before | After |
| - | - | - |
| Partially scrolled into view | ![p-before] | ![p-after] |
| Users with poor internet | ![a-before] | ![a-after] |

[p-before]: https://github.com/user-attachments/assets/7720f9f6-1944-4fb3-b2e1-9b1bc598db61
[a-before]: https://github.com/user-attachments/assets/b030ca55-4ec2-4697-b759-21fa8fb0bb66
[p-after]: https://github.com/user-attachments/assets/77db50e8-aa29-4df0-bdde-3a6369c11d4b
[a-after]: https://github.com/user-attachments/assets/82dda0b3-e8e4-4cc9-aaa6-23c2504e8a56
