### PR TITLE
Set play icon when autoplay fails

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -117,15 +117,15 @@ export const LoopVideo = ({
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- In earlier versions of the HTML specification, play() didn't return a value
 		if (startPlayPromise !== undefined) {
 			await startPlayPromise
+				.then(() => {
+					// Autoplay succeeded
+					setPlayerState('PLAYING');
+				})
 				.catch((error: Error) => {
 					// Autoplay failed
 					logAndReportError(src, error);
 					setPosterImage(image);
-					setShowPlayIcon(true);
-				})
-				.then(() => {
-					// Autoplay succeeded
-					setPlayerState('PLAYING');
+					setPlayerState('PAUSED_BY_BROWSER');
 				});
 		}
 	}, [src, image]);


### PR DESCRIPTION
## What does this change?

Sets the play state when autoplay fails so that the play icon can be set appropriately. 

Reorders the `.then` and `.catch` so that .then runs first. Without this, .then will still run even if .catch is called. This results in a state where the video cannot play but it is attempting to call .play anyway.
 
## Why?
We are getting erratic behaviour when a user is on a low battery device where the autoplay function has failed but the play icon isn't displaying. 
