### PR TITLE
Tweak the default section heading colour

### DIFF
--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -39,6 +39,7 @@ export const ScrollableFeature = ({
 		>
 			{trails.map((card) => {
 				const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
+
 				return (
 					<ScrollableCarousel.Item key={card.url}>
 						<FeatureCard

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -37,6 +37,7 @@ export const StaticFeatureTwo = ({
 		<UL direction="row">
 			{cards.map((card) => {
 				const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
+
 				return (
 					<LI
 						stretch={false}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -3063,7 +3063,7 @@ const articleSectionBackgroundDark: PaletteFunction = () =>
 	sourcePalette.neutral[10];
 
 const articleSectionTitleLight: PaletteFunction = () =>
-	sourcePalette.neutral[0];
+	sourcePalette.neutral[7];
 const articleSectionTitleDark: PaletteFunction = () =>
 	sourcePalette.neutral[86];
 


### PR DESCRIPTION
## What does this change?

The default section heading colour on fronts has been changed from #000 to #121212.

## Why?

To match [designs](https://www.figma.com/design/OBiUI7dJkso1GXfsovfzaY/%E2%97%88-Web-library?node-id=4699-40077&t=qMd0qTUJ7HRn9n3O-0).