### PR TITLE
auxia gate: introduce GetTreatments mustShowDefaultGate

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -123,6 +123,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	should_show_legacy_gate_tmp: boolean; // [1]
 	hasConsented: boolean;
 	shouldNotServeMandatory: boolean; // [2]
+	mustShowDefaultGate: boolean; // [3]
 }
 
 // [1]
@@ -147,6 +148,17 @@ export interface AuxiaProxyGetTreatmentsPayload {
 // [2]
 // date: 03rd July 2025
 // If shouldNotServeMandatory, we should not show a mandatory gate.
+
+// [3]
+// date: 23rd July 2025
+// author: Pascal
+// In order to facilitate internal testing, this attribute forces
+// the display of a sign-in gate, namely the default gu gate. If it is true then
+// the default gate is going to be displayed. Note that this applies to both auxia and
+// non auxia audiences. In particular because it also applies to auxia audiences, for which
+// the value of should_show_legacy_gate_tmp is ignored, then the information needs to come to
+// the SDC server as a new parameter in the GetTreatments payload. To trigger
+// gate display, the url should have query parameter `showgate=true`
 
 export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;


### PR DESCRIPTION
This introduces a new attribute of the signin gate GetTreatments request payload that forces the display of the default gate. This overrides any other behaviour and in particular will apply even if the user is in the Auxia audience. Note that in this latter case an API request is not going to be sent to Auxia. 

This is for Guardian internal use only. 

This is the first of two PRs, the next one is going to enforce this feature in SDC.