### PR TITLE
auxia gate: introduce GetTreatment mustShowDefaultGate

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -123,6 +123,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	should_show_legacy_gate_tmp: boolean; // [1]
 	hasConsented: boolean;
 	shouldNotServeMandatory: boolean; // [2]
+	mustShowDefaultGate: boolean; // [3]
 }
 
 // [1]
@@ -147,6 +148,17 @@ export interface AuxiaProxyGetTreatmentsPayload {
 // [2]
 // date: 03rd July 2025
 // If shouldNotServeMandatory, we should not show a mandatory gate.
+
+// [3]
+// date: 23rd July 2025
+// author: Pascal
+// In order to facilitate internal testing, this attribute forces
+// the display of a sign-in gate, namely the default gu gate. If it is true then
+// the default gate is going to be displayed. Note that this applies to both auxia and
+// non auxia audiences. In particular because it also applies to auxia audiences, for which
+// the value of should_show_legacy_gate_tmp is ignored, then the information needs to come to
+// the SDC server as a new parameter in the GetTreatments payload. To trigger
+// gate display, the url should have query parameter `showgate=true`
 
 export interface AuxiaProxyGetTreatmentsResponse {
 	status: boolean;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -291,6 +291,7 @@ const fetchProxyGetTreatments = async (
 	should_show_legacy_gate_tmp: boolean,
 	hasConsented: boolean,
 	shouldNotServeMandatory: boolean,
+	mustShowDefaultGate: boolean,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
@@ -314,6 +315,7 @@ const fetchProxyGetTreatments = async (
 		should_show_legacy_gate_tmp,
 		hasConsented,
 		shouldNotServeMandatory,
+		mustShowDefaultGate,
 	};
 	const params = {
 		method: 'POST',
@@ -344,6 +346,21 @@ const decideShouldNotServeMandatory = (): boolean => {
 	// return value === 'newsshowcase';
 
 	return false;
+};
+
+const decideMustShowDefaultGate = (): boolean => {
+	// In order to facilitate internal testing, this function observes a query parameter which forces
+	// the display of a sign-in gate, namely the default gu gate. If this returns true then
+	// the default gate is going to be displayed. Note that this applies to both auxia and
+	// non auxia audiences. In particular because it also applies to auxia audiences, for which
+	// the value of should_show_legacy_gate_tmp is ignored, then the information will come to
+	// the SDC server as a new parameter in the GetTreatments payload.
+
+	// to trigger gate display, the url should have query parameter `showgate=true`
+
+	const params = new URLSearchParams(window.location.search);
+	const value: string | null = params.get('showgate');
+	return value === 'true';
 };
 
 const buildAuxiaGateDisplayData = async (
@@ -385,6 +402,8 @@ const buildAuxiaGateDisplayData = async (
 
 	const shouldNotServeMandatory = decideShouldNotServeMandatory();
 
+	const mustShowDefaultGate = decideMustShowDefaultGate();
+
 	const response = await fetchProxyGetTreatments(
 		contributionsServiceUrl,
 		pageId,
@@ -401,6 +420,7 @@ const buildAuxiaGateDisplayData = async (
 		should_show_legacy_gate_tmp,
 		readerPersonalData.hasConsented,
 		shouldNotServeMandatory,
+		mustShowDefaultGate,
 	);
 
 	if (response.status && response.data) {


### PR DESCRIPTION
This introduces a new attribute of the signin gate GetTreatments request payload that forces the display of the default gate. This overrides any other behaviour and in particular will apply even if the user is in the Auxia audience. Note that in this latter case an API request is not going to be sent to Auxia. 

This is for Guardian internal use only. 

This is the first of two PRs, the next one is going to enforce this feature in SDC.