### PR TITLE
Do not render subnav for interactive articles

### DIFF
--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -49,7 +49,6 @@ interface AppsProps extends CommonProps {
 type HeaderProps = {
 	article: ArticleDeprecated;
 	NAV: NavType;
-	format: ArticleFormat;
 	renderAds?: boolean;
 };
 
@@ -143,7 +142,7 @@ const Renderer = ({
 	return <div css={adStyles}>{output}</div>;
 };
 
-const NavHeader = ({ article, NAV, format, renderAds }: HeaderProps) => {
+const NavHeader = ({ article, NAV, renderAds }: HeaderProps) => {
 	return (
 		<section
 			/* Note, some interactives require this - e.g. https://www.theguardian.com/environment/ng-interactive/2015/jun/05/carbon-bomb-the-coal-boom-choking-china. */
@@ -177,7 +176,7 @@ const NavHeader = ({ article, NAV, format, renderAds }: HeaderProps) => {
 				discussionApiUrl={article.config.discussionApiUrl}
 				idApiUrl={article.config.idApiUrl}
 				contributionsServiceUrl={article.contributionsServiceUrl}
-				showSubNav={format.theme !== ArticleSpecial.Labs}
+				showSubNav={false}
 				showSlimNav={true}
 				hasPageSkin={false}
 				hasPageSkinContentSelfConstrain={false}
@@ -226,7 +225,6 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 						<NavHeader
 							article={article}
 							NAV={props.NAV}
-							format={format}
 							renderAds={renderAds}
 						/>
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -288,8 +288,8 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							discussionApiUrl={article.config.discussionApiUrl}
 							idApiUrl={article.config.idApiUrl}
 							contributionsServiceUrl={contributionsServiceUrl}
-							showSubNav={format.theme !== ArticleSpecial.Labs}
 							showSlimNav={true}
+							showSubNav={false}
 							hasPageSkin={false}
 							hasPageSkinContentSelfConstrain={false}
 							pageId={article.pageId}


### PR DESCRIPTION
## What does this change?

Following feedback after https://github.com/guardian/dotcom-rendering/pull/14242, remove the subnav as well, to match the layout for immersives.

## Why?

Feedback from the relevant teams.

## Screenshots

| Before      | After      | Immersive |
| ----------- | ---------- | --|
| ![before][] | ![after][] | ![immersive][] |

[before]: https://github.com/user-attachments/assets/12101779-778a-494f-8ea0-a5406e0033b4
[after]: https://github.com/user-attachments/assets/cd30bb9e-c15e-4feb-88a7-56ceb37dd5ea
[immersive]: https://github.com/user-attachments/assets/d2864e0d-4dff-430e-ae23-9f85018332b5



