### PR TITLE
Tag Page <p> styling

### DIFF
--- a/dotcom-rendering/src/components/TagPageHeader.tsx
+++ b/dotcom-rendering/src/components/TagPageHeader.tsx
@@ -191,7 +191,7 @@ const titleContainerStyle = css`
 `;
 
 const paragraphStyle = css`
-	${headlineMedium17}
+	${headlineMedium17};
 	color: ${palette.neutral[46]};
 `;
 
@@ -208,6 +208,10 @@ const linkStyles = css`
 	border-bottom: 1px solid ${palette.brand[500]};
 `;
 
+const pStyles = css`
+	padding-bottom: ${space[1]}px;
+`;
+
 const buildElementTree = (node: Node): ReactNode => {
 	if (isElement(node)) {
 		switch (node.nodeName) {
@@ -220,6 +224,11 @@ const buildElementTree = (node: Node): ReactNode => {
 				});
 			case 'BR':
 				return jsx('br');
+			case 'P':
+				return jsx('p', {
+					css: pStyles,
+					children: Array.from(node.childNodes).map(buildElementTree),
+				});
 			default:
 				return jsx(node.tagName.toLowerCase(), {
 					children: Array.from(node.childNodes).map(buildElementTree),
@@ -278,7 +287,6 @@ export const TagPageHeader = ({ title, description, image }: Props) => {
 	const descriptionFragment = description
 		? parseHtml(description)
 		: undefined;
-
 	return (
 		<section css={[fallbackStyles, containerStyles]}>
 			<div css={[decoration, sideBorders]} />


### PR DESCRIPTION
## What does this change?
Add 4px padding at the bottom of <p> tags. This is achieved by extending the dom tree constructor so that it explicitly recognises P tags and adds padding-bottom styling to them. It addresses some of https://github.com/guardian/dotcom-rendering/issues/11930

## Why?
To create a visual distinction between paragraphs in the description of a tag page header.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: <img width="1431" height="495" alt="Screenshot 2025-07-23 at 15 45 05" src="https://github.com/user-attachments/assets/518dc77e-6d71-4fab-be52-4dd6f6039fbc" />
[after]: <img width="1431" height="495" alt="Screenshot 2025-07-23 at 15 44 51" src="https://github.com/user-attachments/assets/53834c97-e5a8-4001-a8f4-eec3541e0484" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
