### PR TITLE
Add styles to dev server

### DIFF
--- a/dotcom-rendering/src/devServer/docs/article.tsx
+++ b/dotcom-rendering/src/devServer/docs/article.tsx
@@ -1,9 +1,10 @@
 import { Available } from './available';
+import { descriptionLinks } from './styles';
 
 const OtherExamples = () => (
 	<>
 		<h3>Other Examples</h3>
-		<dl>
+		<dl css={descriptionLinks}>
 			<dt>
 				<a href="https://www.theguardian.com/tone/minutebyminute">
 					Minute-by-minute tag page

--- a/dotcom-rendering/src/devServer/docs/available.tsx
+++ b/dotcom-rendering/src/devServer/docs/available.tsx
@@ -1,3 +1,5 @@
+import { space, textEgyptianBold17Object } from '@guardian/source/foundations';
+
 type Target = 'dotcom' | 'live apps' | 'editions app' | 'amp';
 
 const href = (target: Target): string => {
@@ -27,9 +29,22 @@ function* links(targets: Target[]) {
 
 export const Available = ({ targets }: { targets: Target[] }) => (
 	<dl>
-		<dt>Available targets</dt>
-		<dd>
-			<ul>{Array.from(links(targets))}</ul>
+		<dt css={textEgyptianBold17Object}>Available targets:</dt>
+		<dd
+			css={{
+				margin: 0,
+			}}
+		>
+			<ul
+				css={{
+					listStyle: 'none',
+					padding: 0,
+					display: 'flex',
+					gap: space[3],
+				}}
+			>
+				{Array.from(links(targets))}
+			</ul>
 		</dd>
 	</dl>
 );

--- a/dotcom-rendering/src/devServer/docs/doc.tsx
+++ b/dotcom-rendering/src/devServer/docs/doc.tsx
@@ -1,4 +1,15 @@
+import { css } from '@emotion/react';
+import {
+	article17Object,
+	headlineBold24Object,
+	headlineMedium20Object,
+	headlineMedium24Object,
+	headlineMedium34Object,
+	palette,
+	space,
+} from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
+import { grid } from '../../grid';
 
 const Charset = () => <meta charSet="UTF-8" />;
 
@@ -16,23 +27,70 @@ const Head = ({ title, path }: { title: string; path: string }) => (
 );
 
 const Body = ({ title, children }: { title: string; children: ReactNode }) => (
-	<body>
-		<nav>
-			<ul>
-				<li>
-					<a href="/">Home</a>
-				</li>
-				<li>
-					<a href="/pages">Pages</a>
-				</li>
-				<li>
-					<a href="/targets">Targets</a>
-				</li>
-			</ul>
-		</nav>
-		<h1>{title}</h1>
-		{children}
+	<body
+		css={{
+			h1: headlineMedium34Object,
+			h2: {
+				...headlineMedium24Object,
+				borderBottomWidth: 1,
+				borderBottomStyle: 'solid',
+				borderBottomColor: palette.neutral[86],
+				marginTop: space[9],
+				marginBottom: 0,
+			},
+			h3: headlineMedium20Object,
+			a: {
+				color: palette.brand[400],
+				textUnderlineOffset: 5,
+			},
+			['&']: css(grid.container),
+			margin: 0,
+			...article17Object,
+		}}
+	>
+		<Nav />
+		<main css={grid.column.centre}>
+			<h1>{title}</h1>
+			{children}
+		</main>
 	</body>
+);
+
+const Nav = () => (
+	<nav
+		css={{
+			a: {
+				textDecoration: 'none',
+				color: palette.neutral[100],
+			},
+			display: 'grid',
+			gridTemplateColumns: 'subgrid',
+			['&']: css(grid.column.all),
+			backgroundColor: palette.brand[400],
+			...headlineBold24Object,
+		}}
+	>
+		<ul
+			css={{
+				listStyle: 'none',
+				padding: 0,
+				margin: `${space[3]}px 0`,
+				display: 'flex',
+				gap: space[6],
+				['&']: css(grid.column.centre),
+			}}
+		>
+			<li>
+				<a href="/">Home</a>
+			</li>
+			<li>
+				<a href="/pages">Pages</a>
+			</li>
+			<li>
+				<a href="/targets">Targets</a>
+			</li>
+		</ul>
+	</nav>
 );
 
 export const Doc = ({

--- a/dotcom-rendering/src/devServer/docs/styles.ts
+++ b/dotcom-rendering/src/devServer/docs/styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+
+export const descriptionLinks = css({
+	dt: {
+		paddingBottom: space[1],
+	},
+	dd: {
+		paddingBottom: space[1],
+	},
+});


### PR DESCRIPTION
Styles the new docs pages on the dev server to make them easier to read and so that they work across all breakpoints.

To see the new styles: run the dev server locally, navigate to `/pages`, and browse from there.

Part of #13737.

## Screenshots

| Before | After |
|--------|--------|
| ![before] | ![after] | 

[after]: https://github.com/user-attachments/assets/fcb54724-86d8-49bd-a461-7f2db27d9afc
[before]: https://github.com/user-attachments/assets/51c40c86-8d44-4ea0-88bf-14503d9c3a4e
