### PR TITLE
refactoring: avoid using negatives in sign-in gate's behaviour names

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -122,7 +122,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	mvtId: number;
 	should_show_legacy_gate_tmp: boolean; // [1]
 	hasConsented: boolean;
-	shouldNotServeMandatory: boolean; // [2]
+	shouldServeDismissible: boolean; // [2]
 	mustShowDefaultGate: boolean; // [3]
 }
 
@@ -147,7 +147,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 
 // [2]
 // date: 03rd July 2025
-// If shouldNotServeMandatory, we should not show a mandatory gate.
+// If shouldServeDismissible is true, we should show a dismissible gate.
 
 // [3]
 // date: 23rd July 2025

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -290,7 +290,7 @@ const fetchProxyGetTreatments = async (
 	mvtId: number,
 	should_show_legacy_gate_tmp: boolean,
 	hasConsented: boolean,
-	shouldNotServeMandatory: boolean,
+	shouldServeDismissible: boolean,
 	mustShowDefaultGate: boolean,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
@@ -314,7 +314,7 @@ const fetchProxyGetTreatments = async (
 		mvtId,
 		should_show_legacy_gate_tmp,
 		hasConsented,
-		shouldNotServeMandatory,
+		shouldServeDismissible,
 		mustShowDefaultGate,
 	};
 	const params = {
@@ -330,7 +330,7 @@ const fetchProxyGetTreatments = async (
 	return Promise.resolve(response);
 };
 
-const decideShouldNotServeMandatory = (): boolean => {
+const decideShouldServeDismissible = (): boolean => {
 	// Return a boolean indicating whether or not we accept mandatory gates for this call.
 	// If the answer is `false` this doesn't decide whether the gate should be displayed or not,
 	// it only means that if a gate is returned, then it must be mandatory.
@@ -400,7 +400,7 @@ const buildAuxiaGateDisplayData = async (
 		);
 	}
 
-	const shouldNotServeMandatory = decideShouldNotServeMandatory();
+	const shouldServeDismissible = decideShouldServeDismissible();
 
 	const mustShowDefaultGate = decideMustShowDefaultGate();
 
@@ -419,7 +419,7 @@ const buildAuxiaGateDisplayData = async (
 		readerPersonalData.mvtId,
 		should_show_legacy_gate_tmp,
 		readerPersonalData.hasConsented,
-		shouldNotServeMandatory,
+		shouldServeDismissible,
 		mustShowDefaultGate,
 	);
 


### PR DESCRIPTION
This introduces a refactoring to help understanding sign-in gate behaviour, something that is going to become important in a coming change.

What we do here is moving from the dichotomy ( dismissible / non dismissible ) or the dichotomy ( mandatory / non mandatory ) to the more natural, and which avoid potentially misleading negations ( dismissible / mandatory ).

Companion SDC PR: https://github.com/guardian/support-dotcom-components/pull/1399