### PR TITLE
release utm_source=newsshowcase

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -342,11 +342,9 @@ const decideShouldServeDismissible = (): boolean => {
 
 	// This may be extended in the future.
 
-	// const params = new URLSearchParams(window.location.search);
-	// const value: string | null = params.get('utm_source');
-	// return value === 'newsshowcase';
-
-	return false;
+	const params = new URLSearchParams(window.location.search);
+	const value: string | null = params.get('utm_source');
+	return value === 'newsshowcase';
 };
 
 const decideShowDefaultGate = (): ShowGateValues => {


### PR DESCRIPTION
With this change adding the query parameter/value `utm_source=newsshowcase` to a Guardian url that is sign-in gate eligible will ensure that if a gate is served then it be dismissible. (This doesn't guaranty a gate displays or not, only that if displayed, then it will be dismissible).