### PR TITLE
Hide arrow when at end of Scrollable highlights container

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -71,7 +71,7 @@ const itemStyles = css`
 	margin: ${space[3]}px 10px;
 	:first-child {
 		${from.tablet} {
-			margin-left: 0px;
+			margin-left: 0;
 		}
 
 		/**
@@ -86,6 +86,9 @@ const itemStyles = css`
 			padding-left: 0;
 			margin-left: 240px; /** 240 === 3 columns and 3 column gaps  */
 		}
+	}
+	:last-child {
+		margin-right: 0;
 	}
 `;
 
@@ -172,6 +175,7 @@ const getOphanInfo = (frontId?: string) => {
 	const ophanComponentName = ophanComponentId('highlights');
 	const ophanComponentLink = `container-${0} | ${ophanComponentName}`;
 	const ophanFrontName = `Front | /${frontId}`;
+
 	return {
 		ophanComponentName,
 		ophanComponentLink,


### PR DESCRIPTION
## What does this change?

Sets the right-margin of the last card in ScrollableHighlights to have zero margin.

## Why?

So that the right-arrow doesn't appear when the end of the carousel is reached on desktop.

## Screenshots

### Before

https://github.com/user-attachments/assets/ed8991f8-2f49-45d5-a641-b1989ad61df6


### After

https://github.com/user-attachments/assets/dd4abb49-be47-417a-8f29-53dfe3c6900c
