### PR TITLE
Update imports to standard syntax

### DIFF
--- a/dotcom-rendering/src/components/ArticleTitle.stories.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react/*';
+import type { Meta, StoryObj } from '@storybook/react';
 import { leftColumnDecorator } from '../../.storybook/decorators/gridDecorators';
 import { defaultFormats } from '../../.storybook/decorators/splitThemeDecorator';
 import { allModes } from '../../.storybook/modes';

--- a/dotcom-rendering/src/components/FootballTable.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTable.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react/*';
+import type { Meta, StoryObj } from '@storybook/react';
 import { allModes } from '../../.storybook/modes';
 import { FootballTable as FootballTableComponent } from './FootballTable';
 

--- a/dotcom-rendering/src/components/FootballTableList.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTableList.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react/*';
+import type { Meta, StoryObj } from '@storybook/react';
 import { FootballTable as TableDefault } from './FootballTable.stories';
 import { FootballTableList as FootballTableListComponent } from './FootballTableList';
 

--- a/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
+++ b/dotcom-rendering/src/components/FootballTablesPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react/*';
+import type { Meta, StoryObj } from '@storybook/react';
 import { regions } from '../../fixtures/manual/footballData';
 import { WomensEuro2025 } from './FootballCompetitionNav.stories';
 import { FootballTableList as TableListDefault } from './FootballTableList.stories';

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/EditionDropdown.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react/*';
+import type { Meta } from '@storybook/react';
 import { EditionDropdown } from './EditionDropdown';
 
 const meta = {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/styles/buttonStyles.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/styles/buttonStyles.ts
@@ -5,8 +5,8 @@
  */
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import type { ThemeButton } from '@guardian/source/dist/react-components';
 import { from, until } from '@guardian/source/foundations';
+import type { ThemeButton } from '@guardian/source/react-components';
 import type { CtaSettings } from '../settings';
 
 export function buttonThemes(


### PR DESCRIPTION
## What does this change?

Update a few imports to standard syntax

I tried to update the eslint rules for `no-restricted-imports` to enforce this but whatever I tried (pattern, regex, unicode char) it didn't match a `*` character. Going with this for now.

