### PR TITLE
Refactor Scrollable highlights

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -9,15 +9,14 @@ import { palette } from '../../palette';
 import type { StarRating as Rating } from '../../types/content';
 import type { DCRFrontImage } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
-import { Avatar } from '../Avatar';
 import { CardLink } from '../Card/components/CardLink';
 import { CardHeadline } from '../CardHeadline';
 import type { Loading } from '../CardPicture';
-import { CardPicture } from '../CardPicture';
 import { FormatBoundary } from '../FormatBoundary';
 import { Pill } from '../Pill';
 import { StarRating } from '../StarRating/StarRating';
 import { SvgMediaControlsPlay } from '../SvgMediaControlsPlay';
+import { HighlightsCardImage } from './HighlightsCardImage';
 
 export type HighlightsCardProps = {
 	linkTo: string;
@@ -35,7 +34,7 @@ export type HighlightsCardProps = {
 	starRating?: Rating;
 };
 
-const gridContainer = css`
+const container = css`
 	display: grid;
 	background-color: ${palette('--highlights-container-background')};
 	/** Relative positioning is required to absolutely
@@ -132,90 +131,6 @@ const starWrapper = css`
 	align-self: flex-end;
 `;
 
-const decideImage = (
-	imageLoading: Loading,
-	image?: DCRFrontImage,
-	avatarUrl?: string,
-	byline?: string,
-	mainMedia?: MainMedia,
-) => {
-	if (!image && !avatarUrl) {
-		return null;
-	}
-
-	if (avatarUrl) {
-		return (
-			<Avatar
-				src={avatarUrl}
-				alt={byline ?? ''}
-				shape="cutout"
-				imageSize="large"
-			/>
-		);
-	}
-
-	if (mainMedia?.type === 'Audio' && mainMedia.podcastImage?.src) {
-		return (
-			<>
-				<CardPicture
-					imageSize="medium"
-					mainImage={mainMedia.podcastImage.src}
-					alt={mainMedia.podcastImage.altText}
-					loading={imageLoading}
-					isCircular={false}
-					aspectRatio="1:1"
-				/>
-				<div className="image-overlay" />
-			</>
-		);
-	}
-
-	if (!image) {
-		return null;
-	}
-
-	return (
-		<>
-			<CardPicture
-				imageSize="highlights-card"
-				mainImage={image.src}
-				alt={image.altText}
-				loading={imageLoading}
-				isCircular={true}
-				aspectRatio="1:1"
-			/>
-			{/* This image overlay is styled when the CardLink is hovered */}
-			<div className="image-overlay circular" />
-		</>
-	);
-};
-
-const MediaPill = ({ mainMedia }: { mainMedia: MainMedia }) => (
-	<div css={mediaIcon}>
-		{mainMedia.type === 'Video' && (
-			<Pill
-				content={secondsToDuration(mainMedia.duration)}
-				prefix="Video"
-				icon={<SvgMediaControlsPlay width={18} />}
-			/>
-		)}
-		{mainMedia.type === 'Audio' && (
-			<Pill
-				content={mainMedia.duration}
-				prefix="Podcast"
-				icon={<SvgMediaControlsPlay width={18} />}
-			/>
-		)}
-		{mainMedia.type === 'Gallery' && (
-			<Pill
-				content={mainMedia.count}
-				prefix="Gallery"
-				icon={<SvgCamera />}
-			/>
-		)}
-	</div>
-);
-
 export const HighlightsCard = ({
 	linkTo,
 	format,
@@ -235,7 +150,7 @@ export const HighlightsCard = ({
 
 	return (
 		<FormatBoundary format={format}>
-			<div css={[gridContainer, hoverStyles]}>
+			<div css={[container, hoverStyles]}>
 				<CardLink
 					linkTo={linkTo}
 					headlineText={headlineText}
@@ -264,24 +179,46 @@ export const HighlightsCard = ({
 					/>
 				</div>
 
-				{!isUndefined(starRating) ? (
+				{!isUndefined(starRating) && (
 					<div css={starWrapper}>
 						<StarRating rating={starRating} size="small" />
 					</div>
-				) : null}
+				)}
 
 				{!!mainMedia && isMediaCard && (
-					<MediaPill mainMedia={mainMedia} />
+					<div css={mediaIcon}>
+						{mainMedia.type === 'Video' && (
+							<Pill
+								content={secondsToDuration(mainMedia.duration)}
+								prefix="Video"
+								icon={<SvgMediaControlsPlay width={18} />}
+							/>
+						)}
+						{mainMedia.type === 'Audio' && (
+							<Pill
+								content={mainMedia.duration}
+								prefix="Podcast"
+								icon={<SvgMediaControlsPlay width={18} />}
+							/>
+						)}
+						{mainMedia.type === 'Gallery' && (
+							<Pill
+								content={mainMedia.count}
+								prefix="Gallery"
+								icon={<SvgCamera />}
+							/>
+						)}
+					</div>
 				)}
 
 				<div css={[imageArea, avatarUrl && avatarAlignmentStyles]}>
-					{decideImage(
-						imageLoading,
-						image,
-						avatarUrl,
-						byline,
-						mainMedia,
-					)}
+					<HighlightsCardImage
+						imageLoading={imageLoading}
+						image={image}
+						avatarUrl={avatarUrl}
+						byline={byline}
+						mainMedia={mainMedia}
+					/>
 				</div>
 			</div>
 		</FormatBoundary>

--- a/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
@@ -1,0 +1,67 @@
+import type { DCRFrontImage } from '../../types/front';
+import type { MainMedia } from '../../types/mainMedia';
+import { Avatar } from '../Avatar';
+import type { Loading } from '../CardPicture';
+import { CardPicture } from '../CardPicture';
+
+type Props = {
+	imageLoading: Loading;
+	image?: DCRFrontImage;
+	avatarUrl?: string;
+	byline?: string;
+	mainMedia?: MainMedia;
+};
+
+export const HighlightsCardImage = ({
+	imageLoading,
+	image,
+	avatarUrl,
+	byline,
+	mainMedia,
+}: Props) => {
+	if (avatarUrl) {
+		return (
+			<Avatar
+				src={avatarUrl}
+				alt={byline ?? ''}
+				shape="cutout"
+				imageSize="large"
+			/>
+		);
+	}
+
+	if (image) {
+		if (mainMedia?.type === 'Audio' && mainMedia.podcastImage?.src) {
+			return (
+				<>
+					<CardPicture
+						imageSize="medium"
+						mainImage={mainMedia.podcastImage.src}
+						alt={mainMedia.podcastImage.altText}
+						loading={imageLoading}
+						isCircular={false}
+						aspectRatio="1:1"
+					/>
+					<div className="image-overlay" />
+				</>
+			);
+		}
+
+		return (
+			<>
+				<CardPicture
+					imageSize="highlights-card"
+					mainImage={image.src}
+					alt={image.altText}
+					loading={imageLoading}
+					isCircular={true}
+					aspectRatio="1:1"
+				/>
+				{/* This image overlay is styled when the CardLink is hovered */}
+				<div className="image-overlay circular" />
+			</>
+		);
+	}
+
+	return null;
+};

--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -47,12 +47,15 @@ const carouselStyles = css`
 		scroll-padding-left: 240px;
 	}
 	${from.leftCol} {
-		scroll-padding-left: 80px;
+		scroll-padding-left: 160px;
+		padding-left: 160px;
 	}
 
 	${from.wide} {
 		scroll-padding-left: 240px;
+		padding-left: 240px;
 	}
+
 	/**
 	* Hide scrollbars
 	* See: https://stackoverflow.com/a/38994837
@@ -73,22 +76,11 @@ const itemStyles = css`
 		${from.tablet} {
 			margin-left: 0;
 		}
-
-		/**
-		* From left col we add space to the left margin to the first
-		* child so that the first card in the carousel aligns
-		* with the start of the pages content in the grid.
-		*/
-		${from.leftCol} {
-			padding-left: 160px; /** 160 === 2 columns and 2 column gaps  */
-		}
-		${from.wide} {
-			padding-left: 0;
-			margin-left: 240px; /** 240 === 3 columns and 3 column gaps  */
-		}
 	}
 	:last-child {
-		margin-right: 0;
+		${from.tablet} {
+			margin-right: 0;
+		}
 	}
 `;
 
@@ -196,6 +188,7 @@ export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 		const cardWidth =
 			carouselRef.current.querySelector('li')?.offsetWidth ?? 0;
 		const offset = direction === 'left' ? -cardWidth : cardWidth;
+
 		carouselRef.current.scrollBy({
 			left: offset,
 			behavior: 'smooth',

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -4347,15 +4347,11 @@ const linkKickerTextLight: PaletteFunction = ({ design, theme }) => {
 const linkKickerTextDark: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
-			return sourcePalette.news[500];
 		case Pillar.Opinion:
-			return sourcePalette.opinion[500];
 		case Pillar.Sport:
-			return sourcePalette.sport[500];
 		case Pillar.Culture:
-			return sourcePalette.culture[500];
 		case Pillar.Lifestyle:
-			return sourcePalette.lifestyle[500];
+			return pillarPalette(theme, 500);
 		case ArticleSpecial.SpecialReport:
 			return sourcePalette.news[500];
 		case ArticleSpecial.Labs:


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
