### PR TITLE
Insert ads in Galleries 

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -421,20 +421,6 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const galleryInlineAdContainerStyles = css`
-	${until.tablet} {
-		margin: 0 auto;
-		display: none;
-	}
-`;
-
-const galleryInlineAdMobileContainerStyles = css`
-	${from.tablet} {
-		margin: 0 auto;
-		display: none;
-	}
-`;
-
 const galleryInlineAdStyles = css`
 	margin: ${space[3]}px auto;
 	min-height: ${getMinHeight(adSizes.mpu.height)}px;
@@ -948,13 +934,7 @@ export const AdSlot = ({
 		case 'gallery-inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<AdSlotWrapper
-					css={[
-						galleryInlineAdContainerStyles,
-						labelStyles,
-						galleryInlineAdLabelStyles,
-					]}
-				>
+				<AdSlotWrapper css={[labelStyles, galleryInlineAdLabelStyles]}>
 					<div
 						id={`dfp-ad--${advertId}`}
 						className={[
@@ -979,13 +959,7 @@ export const AdSlot = ({
 		case 'gallery-inline-mobile': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<AdSlotWrapper
-					css={[
-						galleryInlineAdMobileContainerStyles,
-						labelStyles,
-						galleryInlineAdLabelStyles,
-					]}
-				>
+				<AdSlotWrapper css={[labelStyles, galleryInlineAdLabelStyles]}>
 					<div
 						id={`dfp-ad--${advertId}--mobile`}
 						className={[
@@ -1003,7 +977,7 @@ export const AdSlot = ({
 						data-name={advertId}
 						aria-hidden="true"
 						data-label-show="true"
-						data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+						data-testid="slot"
 					/>
 				</AdSlotWrapper>
 			);

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import type { FEArticle } from '../frontend/feArticle';
+import { grid } from '../grid';
 import { labelBoxStyles, labelHeight, labelStyles } from '../lib/adStyles';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
@@ -421,11 +422,25 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const galleryInlineAdContainerStyles = css``;
+const galleryInlineAdContainerStyles = css`
+	${until.tablet} {
+		display: none;
+	}
+`;
 
-const galleryInlineAdWrapperStyles = css``;
+const galleryInlineAdWrapperStyles = css`
+	${grid.column.centre}
+`;
 
 const galleryInlineAdStyles = css``;
+
+const galleryInlineAdMobileContainerStyles = css`
+	${grid.container}
+
+	${from.tablet} {
+		display: none;
+	}
+`;
 
 const AdSlotWrapper = ({
 	children,
@@ -949,7 +964,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="gallery__img-container"
-					css={galleryInlineAdContainerStyles}
+					css={galleryInlineAdMobileContainerStyles}
 				>
 					<AdSlotWrapper css={galleryInlineAdWrapperStyles}>
 						<div

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -11,7 +11,6 @@ import {
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
 import type { FEArticle } from '../frontend/feArticle';
-import { grid } from '../grid';
 import { labelBoxStyles, labelHeight, labelStyles } from '../lib/adStyles';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
@@ -422,11 +421,11 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const galleryInlineAdContainerStyles = css`
-	${grid.column.centre}
-	width: 100%;
-	margin: ${space[3]}px auto;
+const galleryInlineAdStyles = css`
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+`;
 
+const galleryInlineAdContainerStyles = css`
 	${until.tablet} {
 		margin: 0 auto;
 		display: none;
@@ -434,18 +433,24 @@ const galleryInlineAdContainerStyles = css`
 `;
 
 const galleryInlineAdMobileContainerStyles = css`
-	${grid.column.centre}
-	width: 100%;
-	margin: ${space[3]}px auto;
-
 	${from.tablet} {
 		margin: 0 auto;
 		display: none;
 	}
 `;
 
-const galleryInlineAdStyles = css`
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+/*** The top-above-nav-mobile and inline slots label should be dark even in light mode.
+ * Other slots will stay the same as the mentioned ad slots are
+ * the only ones to overlay the dark section of Gallery pages.
+ */
+const galleryInlineAdLabelStyles = css`
+	.ad-slot--dark[data-label-show='true']:not(
+			.ad-slot--interscroller
+		)::before {
+		background-color: ${schemedPalette('--ad-background-article-inner')};
+		border-top-color: ${schemedPalette('--ad-border-article-inner')};
+		color: ${schemedPalette('--ad-labels-text-article-inner')};
+	}
 `;
 
 const AdSlotWrapper = ({
@@ -938,62 +943,64 @@ export const AdSlot = ({
 		case 'gallery-inline': {
 			const advertId = `inline${index + 1}`;
 			return (
-				<div
-					className="gallery__img-container"
-					css={galleryInlineAdContainerStyles}
+				<AdSlotWrapper
+					css={[
+						galleryInlineAdContainerStyles,
+						labelStyles,
+						galleryInlineAdLabelStyles,
+					]}
 				>
-					<AdSlotWrapper>
-						<div
-							id={`dfp-ad--${advertId}`}
-							className={[
-								'js-ad-slot',
-								'ad-slot',
-								`ad-slot--${advertId}`,
-								'ad-slot--gallery-inline',
-								'ad-slot--dark',
-								'hide-until-tablet',
-								'ad-slot--rendered',
-							].join(' ')}
-							css={galleryInlineAdStyles}
-							data-link-name={`ad slot ${advertId}`}
-							data-name={advertId}
-							aria-hidden="true"
-							data-label-show="true"
-							data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
-						/>
-					</AdSlotWrapper>
-				</div>
+					<div
+						id={`dfp-ad--${advertId}`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--gallery-inline',
+							'ad-slot--dark',
+							'hide-until-tablet',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={galleryInlineAdStyles}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+						data-label-show="true"
+						data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+					/>
+				</AdSlotWrapper>
 			);
 		}
 		case 'gallery-inline-mobile': {
 			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
 			return (
-				<div
-					className="gallery__img-container"
-					css={galleryInlineAdMobileContainerStyles}
+				<AdSlotWrapper
+					css={[
+						galleryInlineAdMobileContainerStyles,
+						labelStyles,
+						galleryInlineAdLabelStyles,
+					]}
 				>
-					<AdSlotWrapper>
-						<div
-							id={`dfp-ad--${advertId}--mobile`}
-							className={[
-								'js-ad-slot',
-								'ad-slot',
-								`ad-slot--${advertId}`,
-								'ad-slot--gallery-inline',
-								'ad-slot--dark',
-								'ad-slot--mobile',
-								'mobile-only',
-								'ad-slot--rendered',
-							].join(' ')}
-							css={galleryInlineAdStyles}
-							data-link-name={`ad slot ${advertId}`}
-							data-name={advertId}
-							aria-hidden="true"
-							data-label-show="true"
-							data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
-						/>
-					</AdSlotWrapper>
-				</div>
+					<div
+						id={`dfp-ad--${advertId}--mobile`}
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							`ad-slot--${advertId}`,
+							'ad-slot--gallery-inline',
+							'ad-slot--dark',
+							'ad-slot--mobile',
+							'mobile-only',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={galleryInlineAdStyles}
+						data-link-name={`ad slot ${advertId}`}
+						data-name={advertId}
+						aria-hidden="true"
+						data-label-show="true"
+						data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+					/>
+				</AdSlotWrapper>
 			);
 		}
 	}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -951,7 +951,7 @@ export const AdSlot = ({
 						data-name={advertId}
 						aria-hidden="true"
 						data-label-show="true"
-						data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+						data-testid="slot"
 					/>
 				</AdSlotWrapper>
 			);

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -23,7 +23,8 @@ type IndexedSlot =
 	| 'liveblog-inline'
 	| 'liveblog-inline-mobile'
 	| 'mobile-front'
-	| 'gallery-inline';
+	| 'gallery-inline'
+	| 'gallery-inline-mobile';
 
 // TODO move to commercial
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
@@ -420,7 +421,9 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const galleryImgContainerStyles = css``;
+const galleryInlineAdContainerStyles = css``;
+
+const galleryInlineAdWrapperStyles = css``;
 
 const galleryInlineAdStyles = css``;
 
@@ -916,7 +919,7 @@ export const AdSlot = ({
 			return (
 				<div
 					className="gallery__img-container"
-					css={galleryImgContainerStyles}
+					css={galleryInlineAdContainerStyles}
 				>
 					<AdSlotWrapper>
 						<div
@@ -928,6 +931,37 @@ export const AdSlot = ({
 								'ad-slot--gallery-inline',
 								'ad-slot--dark',
 								'hide-until-tablet',
+								'ad-slot--rendered',
+							].join(' ')}
+							css={galleryInlineAdStyles}
+							data-link-name={`ad slot ${advertId}`}
+							data-name={advertId}
+							aria-hidden="true"
+							data-label-show="true"
+							data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+						/>
+					</AdSlotWrapper>
+				</div>
+			);
+		}
+		case 'gallery-inline-mobile': {
+			const advertId = index === 0 ? 'top-above-nav' : `inline${index}`;
+			return (
+				<div
+					className="gallery__img-container"
+					css={galleryInlineAdContainerStyles}
+				>
+					<AdSlotWrapper css={galleryInlineAdWrapperStyles}>
+						<div
+							id={`dfp-ad--${advertId}--mobile`}
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								`ad-slot--${advertId}`,
+								'ad-slot--gallery-inline',
+								'ad-slot--dark',
+								'ad-slot--mobile',
+								'mobile-only',
 								'ad-slot--rendered',
 							].join(' ')}
 							css={galleryInlineAdStyles}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -421,10 +421,6 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const galleryInlineAdStyles = css`
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
-`;
-
 const galleryInlineAdContainerStyles = css`
 	${until.tablet} {
 		margin: 0 auto;
@@ -437,6 +433,13 @@ const galleryInlineAdMobileContainerStyles = css`
 		margin: 0 auto;
 		display: none;
 	}
+`;
+
+const galleryInlineAdStyles = css`
+	.ad-slot--dark {
+		background-color: ${schemedPalette('--ad-background-article-inner')};
+	}
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 `;
 
 /*** The top-above-nav-mobile and inline slots label should be dark even in light mode.

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -22,7 +22,8 @@ type IndexedSlot =
 	| 'fronts-banner'
 	| 'liveblog-inline'
 	| 'liveblog-inline-mobile'
-	| 'mobile-front';
+	| 'mobile-front'
+	| 'gallery-inline';
 
 // TODO move to commercial
 type SlotNamesWithPageSkin = SlotName | 'pageskin';
@@ -418,6 +419,10 @@ const mobileStickyAdStylesFullWidth = css`
 const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
+
+const galleryImgContainerStyles = css``;
+
+const galleryInlineAdStyles = css``;
 
 const AdSlotWrapper = ({
 	children,
@@ -904,6 +909,36 @@ export const AdSlot = ({
 						aria-hidden="true"
 					/>
 				</AdSlotWrapper>
+			);
+		}
+		case 'gallery-inline': {
+			const advertId = `inline${index + 1}`;
+			return (
+				<div
+					className="gallery__img-container"
+					css={galleryImgContainerStyles}
+				>
+					<AdSlotWrapper>
+						<div
+							id={`dfp-ad--${advertId}`}
+							className={[
+								'js-ad-slot',
+								'ad-slot',
+								`ad-slot--${advertId}`,
+								'ad-slot--gallery-inline',
+								'ad-slot--dark',
+								'hide-until-tablet',
+								'ad-slot--rendered',
+							].join(' ')}
+							css={galleryInlineAdStyles}
+							data-link-name={`ad slot ${advertId}`}
+							data-name={advertId}
+							aria-hidden="true"
+							data-label-show="true"
+							data-testid="slot" //doesn't exist in Frontend so do we need it in DCR?
+						/>
+					</AdSlotWrapper>
+				</div>
 			);
 		}
 	}

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -436,10 +436,12 @@ const galleryInlineAdMobileContainerStyles = css`
 `;
 
 const galleryInlineAdStyles = css`
-	.ad-slot--dark {
-		background-color: ${schemedPalette('--ad-background-article-inner')};
-	}
+	margin: ${space[3]}px auto;
 	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+
+	&.ad-slot--fluid {
+		margin: ${space[3]}px auto;
+	}
 `;
 
 /*** The top-above-nav-mobile and inline slots label should be dark even in light mode.

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -423,23 +423,29 @@ const crosswordBannerMobileAdStyles = css`
 `;
 
 const galleryInlineAdContainerStyles = css`
+	${grid.column.centre}
+	width: 100%;
+	margin: ${space[3]}px auto;
+
 	${until.tablet} {
+		margin: 0 auto;
 		display: none;
 	}
 `;
-
-const galleryInlineAdWrapperStyles = css`
-	${grid.column.centre}
-`;
-
-const galleryInlineAdStyles = css``;
 
 const galleryInlineAdMobileContainerStyles = css`
-	${grid.container}
+	${grid.column.centre}
+	width: 100%;
+	margin: ${space[3]}px auto;
 
 	${from.tablet} {
+		margin: 0 auto;
 		display: none;
 	}
+`;
+
+const galleryInlineAdStyles = css`
+	min-height: ${getMinHeight(adSizes.mpu.height)}px;
 `;
 
 const AdSlotWrapper = ({
@@ -966,7 +972,7 @@ export const AdSlot = ({
 					className="gallery__img-container"
 					css={galleryInlineAdMobileContainerStyles}
 				>
-					<AdSlotWrapper css={galleryInlineAdWrapperStyles}>
+					<AdSlotWrapper>
 						<div
 							id={`dfp-ad--${advertId}--mobile`}
 							className={[

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -18,7 +18,7 @@ export const MobileAdSlot = ({
 	);
 };
 
-export const GalleryDesktopAdSlot = ({
+export const DesktopAdSlot = ({
 	renderAds,
 	adSlotIndex,
 }: {

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -30,7 +30,7 @@ export const GalleryInlineAdSlot = ({
 			<AdSlot
 				data-print-layout="hide"
 				position="gallery-inline"
-				index={adSlotIndex + 1}
+				index={adSlotIndex}
 			/>
 		)
 	);

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -1,0 +1,23 @@
+import { AdSlot } from './AdSlot.web';
+
+export const GalleryInlineAdSlot = ({
+	renderAds,
+	hasPageSkin,
+	adSlotIndex,
+}: {
+	renderAds: boolean;
+	hasPageSkin: boolean;
+	adSlotIndex: number;
+}) => {
+	return (
+		renderAds &&
+		!hasPageSkin && (
+			<AdSlot
+				data-print-layout="hide"
+				position="gallery-inline"
+				index={adSlotIndex}
+				hasPageskin={hasPageSkin}
+			/>
+		)
+	);
+};

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -23,21 +23,17 @@ export const MobileAdSlot = ({
 
 export const GalleryInlineAdSlot = ({
 	renderAds,
-	hasPageSkin,
 	adSlotIndex,
 }: {
 	renderAds: boolean;
-	hasPageSkin: boolean;
 	adSlotIndex: number;
 }) => {
 	return (
-		renderAds &&
-		!hasPageSkin && (
+		renderAds && (
 			<AdSlot
 				data-print-layout="hide"
 				position="gallery-inline"
 				index={adSlotIndex + 1}
-				hasPageskin={hasPageSkin}
 			/>
 		)
 	);

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -1,4 +1,25 @@
+import { Hide } from '@guardian/source/react-components';
 import { AdSlot } from './AdSlot.web';
+
+export const MobileAdSlot = ({
+	renderAds,
+	adSlotIndex,
+}: {
+	renderAds: boolean;
+	adSlotIndex: number;
+}) => {
+	return (
+		renderAds && (
+			<Hide from="tablet">
+				<AdSlot
+					data-print-layout="hide"
+					position="gallery-inline-mobile"
+					index={adSlotIndex}
+				/>
+			</Hide>
+		)
+	);
+};
 
 export const GalleryInlineAdSlot = ({
 	renderAds,
@@ -15,7 +36,7 @@ export const GalleryInlineAdSlot = ({
 			<AdSlot
 				data-print-layout="hide"
 				position="gallery-inline"
-				index={adSlotIndex}
+				index={adSlotIndex + 1}
 				hasPageskin={hasPageSkin}
 			/>
 		)

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -18,7 +18,7 @@ export const MobileAdSlot = ({
 	);
 };
 
-export const GalleryInlineAdSlot = ({
+export const GalleryDesktopAdSlot = ({
 	renderAds,
 	adSlotIndex,
 }: {

--- a/dotcom-rendering/src/components/GalleryAdSlots.tsx
+++ b/dotcom-rendering/src/components/GalleryAdSlots.tsx
@@ -1,4 +1,3 @@
-import { Hide } from '@guardian/source/react-components';
 import { AdSlot } from './AdSlot.web';
 
 export const MobileAdSlot = ({
@@ -10,13 +9,11 @@ export const MobileAdSlot = ({
 }) => {
 	return (
 		renderAds && (
-			<Hide from="tablet">
-				<AdSlot
-					data-print-layout="hide"
-					position="gallery-inline-mobile"
-					index={adSlotIndex}
-				/>
-			</Hide>
+			<AdSlot
+				data-print-layout="hide"
+				position="gallery-inline-mobile"
+				index={adSlotIndex}
+			/>
 		)
 	);
 };

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -14,12 +14,10 @@ import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Caption } from '../components/Caption';
 import { Footer } from '../components/Footer';
-import {
-	GalleryDesktopAdSlot,
-	MobileAdSlot,
-} from '../components/GalleryAdSlots';
+import { DesktopAdSlot, MobileAdSlot } from '../components/GalleryAdSlots';
 import { GalleryImage } from '../components/GalleryImage';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
+import { Hide } from '../components/Hide';
 import { Island } from '../components/Island';
 import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Masthead } from '../components/Masthead/Masthead';
@@ -278,29 +276,24 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 								webTitle={frontendData.webTitle}
 							/>
 							{isWeb && shouldShowAds && (
-								<div
-									className={[
-										'gallery__item gallery__item--advert',
-									].join(' ')}
-									css={galleryItemAdvertStyles}
-								>
-									<div
-										className="gallery__img-container"
-										css={galleryInlineAdContainerStyles}
-									>
-										<GalleryDesktopAdSlot
-											renderAds={renderAds}
-											adSlotIndex={adPositions.indexOf(
-												index,
-											)}
-										/>
-
-										<MobileAdSlot
-											renderAds={renderAds}
-											adSlotIndex={adPositions.indexOf(
-												index,
-											)}
-										/>
+								<div css={galleryItemAdvertStyles}>
+									<div css={galleryInlineAdContainerStyles}>
+										<Hide when="below" breakpoint="tablet">
+											<DesktopAdSlot
+												renderAds={renderAds}
+												adSlotIndex={adPositions.indexOf(
+													index,
+												)}
+											/>
+										</Hide>
+										<Hide when="above" breakpoint="tablet">
+											<MobileAdSlot
+												renderAds={renderAds}
+												adSlotIndex={adPositions.indexOf(
+													index,
+												)}
+											/>
+										</Hide>
 									</div>
 									<div css={galleryBorder}></div>
 								</div>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, palette as sourcePalette, space, until } from '@guardian/source/foundations';
+import { from, palette as sourcePalette } from '@guardian/source/foundations';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
@@ -30,7 +30,7 @@ import {
 	getMobileAdPositions,
 } from '../lib/getGalleryAdPositions';
 import type { NavType } from '../model/extract-nav';
-import { palette, palette as themePalette } from '../palette';
+import { palette as themePalette } from '../palette';
 import type { Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
@@ -64,54 +64,8 @@ const headerStyles = css`
 	}
 `;
 
-// const galleryItemAdvertStyles = css`
-// 	figure {
-//         display: flex;
-//         flex-direction: column-reverse;
-//     }
-
-//     // On mobile/tablet the images should be 100% of the width of the screen
-//     ${until.tablet} {
-//         margin-left: -20px;
-//         margin-right: -20px;
-//         padding-top: 12px;
-//         border-top: 1px solid #ccc;
-
-//         &:first-of-type {
-//             border-top: 0;
-//         }
-//     }
-
-//     ${until.mobileLandscape} {
-//         margin-left: ${-20 * 0.5}px;
-//         margin-right: ${-20 * 0.5}px;
-//     }
-
-//     ${from.desktop} {
-//         position: relative;
-//         border-top: 0;
-//         padding: 0;
-
-//         figure {
-//             flex-direction: row;
-//         }
-//     }
-// }`;
-
 const galleryItemAdvertStyles = css`
-	${grid.paddedContainer}
-	grid-auto-flow: row dense;
-	background-color: ${palette('--article-inner-background')};
-
-	${until.tablet} {
-		border-top: 1px solid ${palette('--article-border')};
-		padding-top: ${space[1]}px;
-	}
-
-	${from.tablet} {
-		border-left: 1px solid ${palette('--article-border')};
-		border-right: 1px solid ${palette('--article-border')};
-	}
+	${grid.container}
 `;
 
 export const GalleryLayout = (props: WebProps | AppProps) => {
@@ -273,29 +227,31 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 								pageId={frontendData.pageId}
 								webTitle={frontendData.webTitle}
 							/>
-							{isWeb && desktopAdPositions.includes(index) && (
+							{isWeb && (
 								<div
 									className={[
 										'gallery__item gallery__item--advert',
 									].join(' ')}
 									css={galleryItemAdvertStyles}
 								>
-									<GalleryInlineAdSlot
-										renderAds={renderAds}
-										adSlotIndex={desktopAdPositions.indexOf(
-											index,
-										)}
-									/>
-								</div>
-							)}
-
-							{isWeb && mobileAdPositions.includes(index) && (
-								<MobileAdSlot
-									renderAds={renderAds}
-									adSlotIndex={mobileAdPositions.indexOf(
-										index,
+									{desktopAdPositions.includes(index) && (
+										<GalleryInlineAdSlot
+											renderAds={renderAds}
+											adSlotIndex={desktopAdPositions.indexOf(
+												index,
+											)}
+										/>
 									)}
-								/>
+
+									{mobileAdPositions.includes(index) && (
+										<MobileAdSlot
+											renderAds={renderAds}
+											adSlotIndex={mobileAdPositions.indexOf(
+												index,
+											)}
+										/>
+									)}
+								</div>
 							)}
 						</Fragment>
 					);

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -3,7 +3,6 @@ import {
 	from,
 	palette as sourcePalette,
 	space,
-	until,
 } from '@guardian/source/foundations';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
@@ -74,10 +73,6 @@ const galleryItemAdvertStyles = css`
 	grid-auto-flow: row dense;
 	background-color: ${themePalette('--article-inner-background')};
 
-	${until.tablet} {
-		padding-top: ${space[1]}px;
-	}
-
 	${from.tablet} {
 		border-left: 1px solid ${themePalette('--article-border')};
 		border-right: 1px solid ${themePalette('--article-border')};
@@ -87,7 +82,11 @@ const galleryItemAdvertStyles = css`
 const galleryInlineAdContainerStyles = css`
 	${grid.column.centre}
 	width: 100%;
-	margin: ${space[3]}px auto;
+	margin: 0 auto;
+
+	${from.desktop} {
+		padding-bottom: ${space[10]}px;
+	}
 `;
 
 export const GalleryLayout = (props: WebProps | AppProps) => {

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -5,6 +5,7 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
@@ -17,7 +18,6 @@ import { Footer } from '../components/Footer';
 import { DesktopAdSlot, MobileAdSlot } from '../components/GalleryAdSlots';
 import { GalleryImage } from '../components/GalleryImage';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
-import { Hide } from '../components/Hide';
 import { Island } from '../components/Island';
 import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Masthead } from '../components/Masthead/Masthead';
@@ -278,7 +278,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 							{isWeb && shouldShowAds && (
 								<div css={galleryItemAdvertStyles}>
 									<div css={galleryInlineAdContainerStyles}>
-										<Hide when="below" breakpoint="tablet">
+										<Hide until="tablet">
 											<DesktopAdSlot
 												renderAds={renderAds}
 												adSlotIndex={adPositions.indexOf(
@@ -286,7 +286,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 												)}
 											/>
 										</Hide>
-										<Hide when="above" breakpoint="tablet">
+										<Hide from="tablet">
 											<MobileAdSlot
 												renderAds={renderAds}
 												adSlotIndex={adPositions.indexOf(
@@ -331,6 +331,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					/>
 				</Section>
 			)}
+			{/** Most Popular container goes here */}
 			{isWeb && renderAds && !isLabs && (
 				<Section
 					fullWidth={true}

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	between,
 	from,
 	palette as sourcePalette,
 	space,
@@ -86,6 +87,37 @@ const galleryInlineAdContainerStyles = css`
 
 	${from.desktop} {
 		padding-bottom: ${space[10]}px;
+	}
+`;
+
+const galleryBorder = css`
+	position: relative;
+	${between.desktop.and.leftCol} {
+		${grid.column.right}
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: -10px; /* 10px to the left of this element */
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${themePalette('--article-border')};
+		}
+	}
+
+	${from.leftCol} {
+		${grid.column.left}
+
+		&::after {
+			content: '';
+			position: absolute;
+			right: -10px;
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${themePalette('--article-border')};
+		}
 	}
 `;
 
@@ -283,6 +315,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 											/>
 										)}
 									</div>
+									<div css={galleryBorder}></div>
 								</div>
 							)}
 						</Fragment>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { from, palette as sourcePalette } from '@guardian/source/foundations';
+import {
+	from,
+	palette as sourcePalette,
+	space,
+	until,
+} from '@guardian/source/foundations';
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
 import { AppsFooter } from '../components/AppsFooter.importable';
@@ -65,7 +70,19 @@ const headerStyles = css`
 `;
 
 const galleryItemAdvertStyles = css`
-	${grid.container}
+	${grid.paddedContainer}
+	grid-auto-flow: row dense;
+	background-color: ${themePalette('--article-inner-background')};
+
+	${until.tablet} {
+		border-top: 1px solid ${themePalette('--article-border')};
+		padding-top: ${space[1]}px;
+	}
+
+	${from.tablet} {
+		border-left: 1px solid ${themePalette('--article-border')};
+		border-right: 1px solid ${themePalette('--article-border')};
+	}
 `;
 
 export const GalleryLayout = (props: WebProps | AppProps) => {
@@ -92,6 +109,9 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 	const mobileAdPositions = renderAds
 		? getMobileAdPositions(gallery.images)
 		: [];
+
+	const shouldShowAnyAd =
+		desktopAdPositions.length > 0 || mobileAdPositions.length > 0;
 
 	return (
 		<>
@@ -227,7 +247,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 								pageId={frontendData.pageId}
 								webTitle={frontendData.webTitle}
 							/>
-							{isWeb && (
+							{isWeb && shouldShowAnyAd && (
 								<div
 									className={[
 										'gallery__item gallery__item--advert',

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -266,9 +266,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					const index = idx + 1;
 
 					return (
-						<Fragment
-							key={element.elementId || `gallery-item-${index}`}
-						>
+						<Fragment key={element.elementId}>
 							<GalleryImage
 								image={element}
 								format={format}
@@ -284,7 +282,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 								>
 									<GalleryInlineAdSlot
 										renderAds={renderAds}
-										hasPageSkin={false}
 										adSlotIndex={desktopAdPositions.indexOf(
 											index,
 										)}

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -75,7 +75,6 @@ const galleryItemAdvertStyles = css`
 	background-color: ${themePalette('--article-inner-background')};
 
 	${until.tablet} {
-		border-top: 1px solid ${themePalette('--article-border')};
 		padding-top: ${space[1]}px;
 	}
 
@@ -83,6 +82,12 @@ const galleryItemAdvertStyles = css`
 		border-left: 1px solid ${themePalette('--article-border')};
 		border-right: 1px solid ${themePalette('--article-border')};
 	}
+`;
+
+const galleryInlineAdContainerStyles = css`
+	${grid.column.centre}
+	width: 100%;
+	margin: ${space[3]}px auto;
 `;
 
 export const GalleryLayout = (props: WebProps | AppProps) => {
@@ -109,9 +114,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 	const mobileAdPositions = renderAds
 		? getMobileAdPositions(gallery.images)
 		: [];
-
-	const shouldShowAnyAd =
-		desktopAdPositions.length > 0 || mobileAdPositions.length > 0;
 
 	return (
 		<>
@@ -238,6 +240,12 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 				</header>
 				{gallery.images.map((element, idx) => {
 					const index = idx + 1;
+					const shouldShowDesktopAd =
+						desktopAdPositions.includes(index);
+					const shouldShowMobileAd =
+						mobileAdPositions.includes(index);
+					const shouldShowAnyAd =
+						shouldShowDesktopAd || shouldShowMobileAd;
 
 					return (
 						<Fragment key={element.elementId}>
@@ -254,23 +262,28 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 									].join(' ')}
 									css={galleryItemAdvertStyles}
 								>
-									{desktopAdPositions.includes(index) && (
-										<GalleryInlineAdSlot
-											renderAds={renderAds}
-											adSlotIndex={desktopAdPositions.indexOf(
-												index,
-											)}
-										/>
-									)}
+									<div
+										className="gallery__img-container"
+										css={galleryInlineAdContainerStyles}
+									>
+										{shouldShowDesktopAd && (
+											<GalleryInlineAdSlot
+												renderAds={renderAds}
+												adSlotIndex={desktopAdPositions.indexOf(
+													index,
+												)}
+											/>
+										)}
 
-									{mobileAdPositions.includes(index) && (
-										<MobileAdSlot
-											renderAds={renderAds}
-											adSlotIndex={mobileAdPositions.indexOf(
-												index,
-											)}
-										/>
-									)}
+										{shouldShowMobileAd && (
+											<MobileAdSlot
+												renderAds={renderAds}
+												adSlotIndex={mobileAdPositions.indexOf(
+													index,
+												)}
+											/>
+										)}
+									</div>
 								</div>
 							)}
 						</Fragment>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -314,7 +314,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					}
 				/>
 			</main>
-			{isWeb && renderAds && (
+			{isWeb && renderAds && !isLabs && (
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -81,12 +81,18 @@ const galleryItemAdvertStyles = css`
 `;
 
 const galleryInlineAdContainerStyles = css`
-	${grid.column.centre}
-	width: 100%;
-	margin: 0 auto;
+	${grid.column.all}
+
+	${from.tablet} {
+		${grid.column.centre}
+	}
 
 	${from.desktop} {
 		padding-bottom: ${space[10]}px;
+	}
+
+	${from.leftCol} {
+		${grid.between('centre-column-start', 'right-column-end')}
 	}
 `;
 

--- a/dotcom-rendering/src/lib/getGalleryAdPositions.ts
+++ b/dotcom-rendering/src/lib/getGalleryAdPositions.ts
@@ -1,0 +1,10 @@
+import type { ImageBlockElement } from '../types/content';
+
+const getDesktopAdPositions = (images: ImageBlockElement[]): number[] => {
+	const adPositions = images
+		.map((image) => images.indexOf(image) + 1)
+		.filter((position) => position % 4 === 0);
+	return adPositions;
+};
+
+export { getDesktopAdPositions };

--- a/dotcom-rendering/src/lib/getGalleryAdPositions.ts
+++ b/dotcom-rendering/src/lib/getGalleryAdPositions.ts
@@ -1,10 +1,10 @@
 import type { ImageBlockElement } from '../types/content';
 
 /**
- * @param images - An array of ImageBlockElement objects representing the images in the gallery.
- * @description This function calculates the positions in the gallery where ads should be placed.
+ * This function calculates the positions in the gallery where ads should be placed.
  * The ad position will be the same for all breakpoints, after every 4 images will have an ad slot.
- * What make the difference between mobile and desktop slot ids are in GalleryAdSlots.tsx and AdSlot.web.tsx.
+ * The logic difference between mobile and desktop slot ids is in GalleryAdSlots.tsx and AdSlot.web.tsx.
+ * @param images - An array of ImageBlockElement objects representing the images in the gallery.
  * @returns An array of numbers representing the positions where ads should be placed.
  */
 const getAdPositions = (images: ImageBlockElement[]): number[] => {

--- a/dotcom-rendering/src/lib/getGalleryAdPositions.ts
+++ b/dotcom-rendering/src/lib/getGalleryAdPositions.ts
@@ -1,17 +1,17 @@
 import type { ImageBlockElement } from '../types/content';
 
-const getMobileAdPositions = (images: ImageBlockElement[]): number[] => {
+/**
+ * @param images - An array of ImageBlockElement objects representing the images in the gallery.
+ * @description This function calculates the positions in the gallery where ads should be placed.
+ * The ad position will be the same for all breakpoints, after every 4 images will have an ad slot.
+ * What make the difference between mobile and desktop slot ids are in GalleryAdSlots.tsx and AdSlot.web.tsx.
+ * @returns An array of numbers representing the positions where ads should be placed.
+ */
+const getAdPositions = (images: ImageBlockElement[]): number[] => {
 	const adPositions = images
 		.map((image) => images.indexOf(image) + 1)
 		.filter((position) => position % 4 === 0);
 	return adPositions;
 };
 
-const getDesktopAdPositions = (images: ImageBlockElement[]): number[] => {
-	const adPositions = images
-		.map((image) => images.indexOf(image) + 1)
-		.filter((position) => position % 4 === 0);
-	return adPositions;
-};
-
-export { getDesktopAdPositions, getMobileAdPositions };
+export { getAdPositions };

--- a/dotcom-rendering/src/lib/getGalleryAdPositions.ts
+++ b/dotcom-rendering/src/lib/getGalleryAdPositions.ts
@@ -1,5 +1,12 @@
 import type { ImageBlockElement } from '../types/content';
 
+const getMobileAdPositions = (images: ImageBlockElement[]): number[] => {
+	const adPositions = images
+		.map((image) => images.indexOf(image) + 1)
+		.filter((position) => position % 4 === 0);
+	return adPositions;
+};
+
 const getDesktopAdPositions = (images: ImageBlockElement[]): number[] => {
 	const adPositions = images
 		.map((image) => images.indexOf(image) + 1)
@@ -7,4 +14,4 @@ const getDesktopAdPositions = (images: ImageBlockElement[]): number[] => {
 	return adPositions;
 };
 
-export { getDesktopAdPositions };
+export { getDesktopAdPositions, getMobileAdPositions };

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1879,13 +1879,14 @@ const articleInnerAdLabelsTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[46];
 				default:
 					return sourcePalette.neutral[86];
 			}
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[46];
 	}
@@ -1901,7 +1902,6 @@ const articleInnerAdBackgroundLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[97];
@@ -1910,6 +1910,8 @@ const articleInnerAdBackgroundLight: PaletteFunction = ({ design, theme }) => {
 			}
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[93];
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[7];
 		default:
 			return sourcePalette.neutral[97];
 	}
@@ -1929,13 +1931,14 @@ const articleInnerAdBorderLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[20];
 			}
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[20];
 		default:
 			return sourcePalette.neutral[86];
 	}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1879,6 +1879,7 @@ const articleInnerAdLabelsTextLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
+		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[46];
@@ -1900,6 +1901,7 @@ const articleInnerAdBackgroundLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
+		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[97];
@@ -1927,6 +1929,7 @@ const articleInnerAdBorderLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
+		case ArticleDesign.Gallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[86];

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1920,6 +1920,8 @@ const articleInnerAdBackgroundDark: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[7];
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[10];
 		default:
 			return sourcePalette.neutral[20];
 	}


### PR DESCRIPTION
## What does this change?

This PR inserts ads in Galleries DCR. Check issue https://github.com/guardian/dotcom-rendering/issues/12293?reload=1?reload=1

The changes includes:

- `top-above-nav` slot for desktop which appears as the first element on the page.
- All inline ads in the body of the Gallery which renders after every 4 images for desktop.
- `top-above-nav--mobile` as the first slot in the body of the Gallery and then `inline1`, `inline2`, etc... for mobile which still renders after every 4 images similar to desktop.
- `merchandising-high` for mobile and desktop but in the Labs Galleries migration we are not showing this slot so I already added the condition for it in this PR.
- `merchandising` for mobile and desktop. Also not showing in Labs Galleries after migration. 
- All the styling should be correct (ad label, borders, light mode palette, dark mode palette, etc...)

At the moment `merchandising-high` and `merchandising` are stacked because the "Related stories" and "Most popular" containers are not added yet. 

All the screenshots are captured in light mode because we are still haven't worked on ads in App. That will be next step after we are done with Web. 

To-do:
- Insert `most-pop` slot for desktop which should be added as part of the "Most popular" container. We don't show it for mobile breakpoint. See https://github.com/guardian/dotcom-rendering/pull/9642

## Why?

This is part of the Galleries migration from Frontend to DCR.

## Screenshots

| PROD      | DEV      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |
| ![before6][] | ![after6][] |
| ![before7][] | ![after7][] |
| ![before8][] | ![after8][] |

[before]: https://github.com/user-attachments/assets/ddacc372-27dd-4e13-9605-4d17dc08658e
[after]: https://github.com/user-attachments/assets/bca3a2ec-710a-465d-8c67-47faf03ba97f

[before2]: https://github.com/user-attachments/assets/4516ef00-6a15-4629-a5e7-cbaf5e10771a
[after2]: https://github.com/user-attachments/assets/9203fa88-a2fa-4f40-84fb-f004d145b6b1

[before3]: https://github.com/user-attachments/assets/7da45283-f319-429f-b0fb-aba897230e05
[after3]: https://github.com/user-attachments/assets/638bf521-3f35-4d2e-843b-292ea2d7d5c6

[before4]: https://github.com/user-attachments/assets/05282ad3-f136-4a21-8b9b-99020c014f0f
[after4]: https://github.com/user-attachments/assets/5127dff8-99a7-48de-8c0c-03b159fc6393

[before5]: https://github.com/user-attachments/assets/d7918e14-7db2-4bdc-8940-6159ba4a9e57
[after5]: https://github.com/user-attachments/assets/330d2e4e-e2b5-43f4-9a7d-c824103da1ae

[before6]: https://github.com/user-attachments/assets/9b301c88-615e-4ed5-827b-5d2b129df086
[after6]: https://github.com/user-attachments/assets/94a10eaf-5792-46c8-beae-f6e7ec2e5168

[before7]: https://github.com/user-attachments/assets/d3e39eb0-f1cc-466e-b801-7e33cf9a971c
[after7]: https://github.com/user-attachments/assets/1af6ce67-b929-43ee-833a-695f340a1094

[before8]: https://github.com/user-attachments/assets/ec330bad-602e-409e-975a-a676381b058f
[after8]: https://github.com/user-attachments/assets/114e6c8f-f293-4c48-be87-3121be4522b8

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]:https://example.com/before2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
