### PR TITLE
Dev server page - remove AMP and tidy up

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -55,6 +55,23 @@
 			</li>
 			<li>
 				<a
+					href="/AppsArticle/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+					>Apps Article</a
+				>
+			</li>
+			<li>
+				<a href="/Front/https://www.theguardian.com/international"
+					>Front</a
+				>
+			</li>
+			<li>
+				<a
+					href="/TagPage/https://www.theguardian.com/tone/minutebyminute"
+					>Tag Page</a
+				>
+			</li>
+			<li>
+				<a
 					href="/Interactive/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
 					>Interactive</a
 				>
@@ -66,26 +83,9 @@
 				>
 			</li>
 			<li>
-				<a href="/Front/https://www.theguardian.com/international"
-					>International Front</a
-				>
-			</li>
-			<li>
-				<a
-					href="/TagPage/https://www.theguardian.com/tone/minutebyminute"
-					>Tag Page</a
-				>
-			</li>
-			<li>
-				<a
-					href="/AppsArticle/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
-					>📱 Apps Article</a
-				>
-			</li>
-			<li>
 				<a
 					href="/EmailNewsletters/https://api.nextgen.guardianapps.co.uk/email-newsletters"
-					>📧 All Newsletters page</a
+					>Email Newsletters page</a
 				>
 			</li>
 		</ul>

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -35,46 +35,45 @@
 			<li>
 				<a
 					href="/Article/https://www.theguardian.com/travel/2024/apr/03/walking-londons-unsung-river-nature-culture-and-moments-of-wonder-along-the-river-lea"
-					>Article</a
+					>🌍 Article</a
 				>
 			</li>
 			<li>
 				<a
 					href="/AppsArticle/https://www.theguardian.com/travel/2024/apr/03/walking-londons-unsung-river-nature-culture-and-moments-of-wonder-along-the-river-lea"
-					>Apps Article</a
+					>📱 Apps Article</a
 				>
 			</li>
 			<li>
 				<a href="/Front/https://www.theguardian.com/international"
-					>Front</a
+					>🖼️ Front</a
 				>
 			</li>
 			<li>
 				<a
 					href="/TagPage/https://www.theguardian.com/tone/minutebyminute"
-					>Tag Page</a
+					>🏷️ Tag Page</a
 				>
 			</li>
 			<li>
 				<a
 					href="/Interactive/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
-					>Interactive</a
+					>✨ Interactive</a
 				>
 			</li>
 			<li>
 				<a
 					href="/AppsInteractive/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
-					>Apps Interactive</a
+					>💫 Apps Interactive</a
 				>
 			</li>
 			<li>
 				<a
 					href="/EmailNewsletters/https://api.nextgen.guardianapps.co.uk/email-newsletters"
-					>Email Newsletters</a
+					>📧 Email Newsletters</a
 				>
 			</li>
 		</ul>
-
 		<form name="url-form">
 			<input
 				type="url"

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -55,20 +55,8 @@
 			</li>
 			<li>
 				<a
-					href="/AMPArticle/https://amp.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance"
-					>⚡️Article</a
-				>
-			</li>
-			<li>
-				<a
 					href="/Interactive/https://www.theguardian.com/global-development/ng-interactive/2022/jun/09/the-black-sea-blockade-mapping-the-impact-of-war-in-ukraine-on-the-worlds-food-supply-interactive"
 					>Interactive</a
-				>
-			</li>
-			<li>
-				<a
-					href="/AMPInteractive/https://www.theguardian.com/world/2021/mar/24/how-a-container-ship-blocked-the-suez-canal-visual-guide"
-					>⚡️Interactive</a
 				>
 			</li>
 			<li>
@@ -81,19 +69,12 @@
 				<a href="/Front/https://www.theguardian.com/international"
 					>International Front</a
 				>
-				(<a href="/FrontJSON/https://www.theguardian.com/international"
-					>Enhanced JSON</a
-				>)
 			</li>
 			<li>
 				<a
 					href="/TagPage/https://www.theguardian.com/tone/minutebyminute"
 					>Tag Page</a
 				>
-				(<a
-					href="/FrontJSON/https://www.theguardian.com/tone/minutebyminute"
-					>Enhanced JSON</a
-				>)
 			</li>
 			<li>
 				<a
@@ -341,7 +322,6 @@
 					<td class="links">
 						<article-link product="dotcom" env="DEV"></article-link>
 						<article-link product="apps" env="DEV"></article-link>
-						<article-link product="amp" env="DEV"></article-link>
 					</td>
 					<td class="links">
 						<article-link
@@ -349,7 +329,6 @@
 							env="CODE"
 						></article-link>
 						<article-link product="apps" env="CODE"></article-link>
-						<article-link product="amp" env="CODE"></article-link>
 					</td>
 					<td class="links">
 						<article-link
@@ -357,7 +336,6 @@
 							env="PROD"
 						></article-link>
 						<article-link product="apps" env="PROD"></article-link>
-						<article-link product="amp" env="PROD"></article-link>
 					</td>
 				</tr>
 			</template>
@@ -405,9 +383,7 @@
 			<div class="test-article-header">
 				<span>type</span>
 				<span>local</span>
-				<span>local-amp</span>
 				<span>production</span>
-				<span>production-amp</span>
 			</div>
 		</div>
 
@@ -417,9 +393,7 @@
 			<div class="test-article-header">
 				<span>type</span>
 				<span>local</span>
-				<span>local-amp</span>
 				<span>production</span>
-				<span>production-amp</span>
 			</div>
 		</div>
 
@@ -734,9 +708,7 @@
 			             <div class="test-article">
 			                 <span>${a.name}</span>
 			                 <span><a href="/Article/https://www.theguardian.com${a.article}">🔗</a> <a href="/Article/http://localhost:9000${a.article}">🔗(local FE)</a></span>
-			                 <span><a href="/AMPArticle/https://www.theguardian.com${a.article}">🔗</a> <a href="/AMPArticle/http://localhost:9000${a.article}">🔗(local FE)</a></span>
 			                 <span><a href="https://www.theguardian.com${a.article}">example</a></span>
-			                 <span><a href="https://amp.theguardian.com${a.article}">example</a></span>
 			             </div>
 			         `;
 
@@ -916,7 +888,7 @@
 
 			class ArticleLink extends HTMLElement {
 				/**
-				 * @typedef {'dotcom' | 'apps' | 'amp'} Product
+				 * @typedef {'dotcom' | 'apps'} Product
 				 * @typedef {'PROD' | 'CODE' | 'DEV'} Env
 				 */
 
@@ -938,8 +910,6 @@
 						case 'dotcom':
 						case 'apps':
 							return 'https://www.theguardian.com';
-						case 'amp':
-							return 'https://amp.theguardian.com';
 					}
 				}
 
@@ -952,8 +922,6 @@
 						case 'dotcom':
 						case 'apps':
 							return 'https://m.code.dev-theguardian.com';
-						case 'amp':
-							return 'https://amp.code.dev-theguardian.com';
 					}
 				}
 
@@ -977,8 +945,6 @@
 							return '/Article';
 						case 'apps':
 							return '/AppsArticle';
-						case 'amp':
-							return '/AMPArticle';
 					}
 				}
 
@@ -1027,8 +993,6 @@
 							return '🌍 Dotcom';
 						case 'apps':
 							return '📱 Apps';
-						case 'amp':
-							return '⚡️ AMP';
 					}
 				}
 
@@ -1081,13 +1045,9 @@
 					const env = this.getAttribute('env');
 					const href = this.getAttribute('href');
 
-					if (
-						product !== 'dotcom' &&
-						product !== 'apps' &&
-						product !== 'amp'
-					) {
+					if (product !== 'dotcom' && product !== 'apps') {
 						this.textContent =
-							"article-link error: 'product' must be one of: 'dotcom', 'apps' or 'amp'";
+							"article-link error: 'product' must be one of: 'dotcom' or 'apps'";
 						return;
 					}
 

--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -20,42 +20,27 @@
 			}
 			.test-articles-list span {
 				display: inline-block;
-				width: 8em;
 				line-height: 2em;
+				margin-right: 2em;
 			}
-			.test-article-header span {
-				font-weight: bold;
-			}
-			.test-article > span:nth-child(1),
-			.test-article-header > span:nth-child(1) {
+			.test-article > span:nth-child(1) {
 				width: 14em !important;
 			}
 		</style>
 	</head>
 	<body>
-		<h2>Default Endpoints</h2>
-
-		<form name="url-form">
-			<input
-				type="url"
-				name="url-input"
-				size="100"
-				required
-				placeholder="https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
-			/>
-			<input type="submit" value="Add" />
-		</form>
+		<h2>Pages</h2>
 
 		<ul id="default-endpoints">
 			<li>
 				<a
-					href="/Article/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+					href="/Article/https://www.theguardian.com/travel/2024/apr/03/walking-londons-unsung-river-nature-culture-and-moments-of-wonder-along-the-river-lea"
 					>Article</a
 				>
 			</li>
 			<li>
 				<a
-					href="/AppsArticle/https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+					href="/AppsArticle/https://www.theguardian.com/travel/2024/apr/03/walking-londons-unsung-river-nature-culture-and-moments-of-wonder-along-the-river-lea"
 					>Apps Article</a
 				>
 			</li>
@@ -85,10 +70,21 @@
 			<li>
 				<a
 					href="/EmailNewsletters/https://api.nextgen.guardianapps.co.uk/email-newsletters"
-					>Email Newsletters page</a
+					>Email Newsletters</a
 				>
 			</li>
 		</ul>
+
+		<form name="url-form">
+			<input
+				type="url"
+				name="url-input"
+				size="100"
+				required
+				placeholder="https://www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software"
+			/>
+			<input type="submit" value="Add" />
+		</form>
 
 		<section>
 			<h2>Article Examples</h2>
@@ -288,12 +284,9 @@
 				<table>
 					<thead>
 						<tr>
-							<th rowspan="2">Headline</th>
-							<th rowspan="2">Description</th>
-							<th rowspan="2">Format</th>
-							<th colspan="3">Links</th>
-						</tr>
-						<tr>
+							<th>Headline</th>
+							<th>Description</th>
+							<th>Format</th>
 							<th>DEV</th>
 							<th>CODE</th>
 							<th>PROD</th>
@@ -379,23 +372,11 @@
 
 		<h2>Test Articles By Element</h2>
 
-		<div id="test-articles-by-element" class="test-articles-list">
-			<div class="test-article-header">
-				<span>type</span>
-				<span>local</span>
-				<span>production</span>
-			</div>
-		</div>
+		<div id="test-articles-by-element" class="test-articles-list"></div>
 
 		<h2>Test Articles By Atom Type</h2>
 
-		<div id="test-articles-by-atom-type" class="test-articles-list">
-			<div class="test-article-header">
-				<span>type</span>
-				<span>local</span>
-				<span>production</span>
-			</div>
-		</div>
+		<div id="test-articles-by-atom-type" class="test-articles-list"></div>
 
 		<h2>Test Articles By Element (Missing)</h2>
 		<ul>
@@ -707,8 +688,9 @@
 			const makeTestArticle = (a) => `
 			             <div class="test-article">
 			                 <span>${a.name}</span>
-			                 <span><a href="/Article/https://www.theguardian.com${a.article}">🔗</a> <a href="/Article/http://localhost:9000${a.article}">🔗(local FE)</a></span>
-			                 <span><a href="https://www.theguardian.com${a.article}">example</a></span>
+			                 <span><a href="/Article/https://www.theguardian.com${a.article}">local</a></span>
+							 <span><a href="/Article/http://localhost:9000${a.article}">local FE</a></span>
+			                 <span><a href="https://www.theguardian.com${a.article}">prod</a></span>
 			             </div>
 			         `;
 


### PR DESCRIPTION
## What does this change?

Dev server page updates:

- remove AMP from all examples
- separate local, local FE and prod columns in test article tables
- reorder default endpoints and rename to 'Pages'
- update main test article to [this article](http://localhost:3030/Article/https://www.theguardian.com/travel/2024/apr/03/walking-londons-unsung-river-nature-culture-and-moments-of-wonder-along-the-river-lea), which has ads enabled and is long enough to show multiple inline ads
- move article input box below default links. I get the impression it's not widely used, but I can move it back if folks prefer it where it was.
- emojification

## Screenshots

| section     | Before      | After      |
| ----------- | ----------- | ---------- |
| default endpoints <img width="400"/> | ![befored][] | ![afterd][] |
| article examples <img width="400"/> | ![beforea][] | ![aftera][] |
| test articles  <img width="400"/>  | ![beforet][] | ![aftert][] |
| default test article <img width="400"/>  | ![beforeda][] | ![afterda][] |

[befored]: https://github.com/user-attachments/assets/36dcb046-998d-431d-ad26-b3144e6f7420
[afterd]: https://github.com/user-attachments/assets/ca0af013-f817-4154-9880-666c8ab6a796

[beforea]: https://github.com/user-attachments/assets/c7c78d09-6064-4dc1-88f5-abe22a90694e
[aftera]: https://github.com/user-attachments/assets/36279ea0-8106-476d-a40a-658b3bd21474

[beforet]: https://github.com/user-attachments/assets/fc2528a3-c8de-4ee1-bb77-46cfd6260932
[aftert]: https://github.com/user-attachments/assets/49046032-7d20-4693-a03a-917179b667b0

[beforeda]: https://github.com/user-attachments/assets/0ebf6e9e-9a85-41b0-bde1-eb6dab9c3ad0
[afterda]: https://github.com/user-attachments/assets/36ea10b0-739c-4675-af61-eddc15b5413c
