### PR TITLE
feat: add focus management for interactive choice cards in DesignableBanner

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -23,7 +23,7 @@ import type {
 	Image,
 } from '@guardian/support-dotcom-components/dist/shared/types';
 import type { ChoiceCard } from '@guardian/support-dotcom-components/dist/shared/types/props/choiceCards';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
 	removeMediaRulePrefix,
 	useMatchMedia,
@@ -135,6 +135,17 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 		setIosAppBannerPresent(
 			window.innerHeight != window.document.documentElement.clientHeight,
 		);
+	}, []);
+
+	const bannerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const firstInteractiveChoiceCard = bannerRef.current?.querySelector(
+			'input',
+		) as HTMLElement | null;
+		if (firstInteractiveChoiceCard) {
+			firstInteractiveChoiceCard.focus();
+		}
 	}, []);
 
 	useEffect(() => {
@@ -275,6 +286,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 
 	return (
 		<div
+			ref={bannerRef}
+			role="alert"
+			tabIndex={-1}
 			css={styles.outerContainer(
 				templateSettings.containerSettings.backgroundColour,
 				iosAppBannerPresent,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -140,11 +140,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 	const bannerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		const firstInteractiveChoiceCard = bannerRef.current?.querySelector(
-			'input',
-		) as HTMLElement | null;
-		if (firstInteractiveChoiceCard) {
-			firstInteractiveChoiceCard.focus();
+		if (bannerRef.current) {
+			bannerRef.current.focus();
 		}
 	}, []);
 


### PR DESCRIPTION
## What does this change?

Implements keyboard navigation improvements for the DesignableBanner component by:

- Adding `role="alert"` to announce the banner to screen readers when it appears
- Adding `tabIndex={-1}` to make the banner programmatically focusable without adding it to the normal tab order
- Adding automatic focus management that focuses the banner container when it mounts
- Maintaining existing escape key functionality for closing the banner

## Why?

This addresses accessibility issues identified in the Banner keyboard navigation task:

- Users previously had to tab through the entire webpage before reaching banner controls
- The banner now receives immediate focus when it appears, allowing users to quickly tab to interactive elements (choice cards, CTAs, close button)
- Follows WCAG guidelines for focus management and provides better keyboard navigation experience
- The `role="alert"` ensures screen readers announce the banner immediately when it appears
- Using `tabIndex={-1}` prevents visual focus ring while still enabling programmatic focus

The escape key functionality was already implemented via the `useEscapeShortcut` hook in the `withCloseable` HOC, so this change focuses on improving the initial focus behavior without disrupting existing functionality.
