### PR TITLE
Add `top-above-nav` background placeholder

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -115,7 +115,7 @@ const topAboveNavContainerStyles = css`
 	display: block;
 `;
 
-const topAboveNavContainerVaraintStyles = css`
+const topAboveNavContainerVariantStyles = css`
 	padding-bottom: ${space[5]}px;
 	position: relative;
 	margin: 0 auto;
@@ -127,6 +127,13 @@ const topAboveNavContainerVaraintStyles = css`
 	/* Remove the min-height when the ad has rendered, so that the container can shrink if the ad is smaller */
 	&[top-above-nav-ad-rendered='true'] {
 		min-height: auto;
+	}
+
+	.ad-slot--top-above-nav:not([data-google-query-id]) {
+		margin: 24px auto 0;
+		height: 250px;
+		width: 970px;
+		background-color: ${palette.neutral[93]};
 	}
 `;
 
@@ -405,15 +412,6 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
-const topAboveNavBackground = css`
-	.ad-slot--top-above-nav:not([data-google-query-id]) {
-		margin: 0 auto;
-		height: ${getMinHeight(250)}px;
-		width: 970px;
-		background-color: ${palette.neutral[86]};
-	}
-`;
-
 const AdSlotWrapper = ({
 	children,
 	css: additionalCss,
@@ -607,12 +605,11 @@ export const AdSlot = ({
 		case 'top-above-nav': {
 			return (
 				<AdSlotWrapper
-					css={[
+					css={
 						isIn250ReservationVariant
-							? topAboveNavContainerVaraintStyles
-							: topAboveNavContainerStyles,
-						topAboveNavBackground,
-					]}
+							? topAboveNavContainerVariantStyles
+							: topAboveNavContainerStyles
+					}
 				>
 					<div
 						id="dfp-ad--top-above-nav"

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -405,6 +405,15 @@ const crosswordBannerMobileAdStyles = css`
 	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
 `;
 
+const topAboveNavBackground = css`
+	.ad-slot--top-above-nav:not([data-google-query-id]) {
+		margin: 0 auto;
+		height: ${getMinHeight(250)}px;
+		width: 970px;
+		background-color: ${palette.neutral[93]};
+	}
+`;
+
 const AdSlotWrapper = ({
 	children,
 	css: additionalCss,
@@ -598,11 +607,12 @@ export const AdSlot = ({
 		case 'top-above-nav': {
 			return (
 				<AdSlotWrapper
-					css={
+					css={[
 						isIn250ReservationVariant
 							? topAboveNavContainerVaraintStyles
-							: topAboveNavContainerStyles
-					}
+							: topAboveNavContainerStyles,
+						topAboveNavBackground,
+					]}
 				>
 					<div
 						id="dfp-ad--top-above-nav"

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -128,14 +128,19 @@ const topAboveNavContainerVariantStyles = css`
 	&[top-above-nav-ad-rendered='true'] {
 		min-height: auto;
 	}
-`;
 
-const topAboveNavBackgroundVariantStyles = css`
-	.ad-slot--top-above-nav:not([data-google-query-id]) {
-		margin: 24px auto 0;
-		height: 250px;
-		width: 970px;
-		background-color: ${palette.neutral[93]};
+	/* Ad placeholder grey box rendered while loading the ad */
+	&:not([top-above-nav-ad-rendered='true']) {
+		::before {
+			content: '';
+			position: absolute;
+			height: 250px;
+			width: 970px;
+			top: ${labelHeight}px;
+			left: 50%;
+			transform: translateX(-50%);
+			background-color: ${palette.neutral[93]};
+		}
 	}
 `;
 
@@ -609,10 +614,7 @@ export const AdSlot = ({
 				<AdSlotWrapper
 					css={
 						isIn250ReservationVariant
-							? [
-									topAboveNavContainerVariantStyles,
-									topAboveNavBackgroundVariantStyles,
-							  ]
+							? topAboveNavContainerVariantStyles
 							: topAboveNavContainerStyles
 					}
 				>

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -128,7 +128,9 @@ const topAboveNavContainerVariantStyles = css`
 	&[top-above-nav-ad-rendered='true'] {
 		min-height: auto;
 	}
+`;
 
+const topAboveNavBackgroundVariantStyles = css`
 	.ad-slot--top-above-nav:not([data-google-query-id]) {
 		margin: 24px auto 0;
 		height: 250px;
@@ -607,7 +609,10 @@ export const AdSlot = ({
 				<AdSlotWrapper
 					css={
 						isIn250ReservationVariant
-							? topAboveNavContainerVariantStyles
+							? [
+									topAboveNavContainerVariantStyles,
+									topAboveNavBackgroundVariantStyles,
+							  ]
 							: topAboveNavContainerStyles
 					}
 				>

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -410,7 +410,7 @@ const topAboveNavBackground = css`
 		margin: 0 auto;
 		height: ${getMinHeight(250)}px;
 		width: 970px;
-		background-color: ${palette.neutral[93]};
+		background-color: ${palette.neutral[86]};
 	}
 `;
 


### PR DESCRIPTION
Co-authored-by: @on-ye 

## What does this change?

This PR reserves a grey background for `top-above-nav` to show that an ad will be displayed in this place until the ad loads and actually displayed we remove the background. We are reserving a width of `970px` and height of `250px` after leaving space for the height of the ad label.

## Why?

We want to have better UX and a way to be explicit than an ad will be shown until it actually loads. 

## Screenshots

**Before**

https://github.com/user-attachments/assets/897b011b-9947-41b1-9d29-8693b15b8577

**After** 

https://github.com/user-attachments/assets/deef9778-303e-458b-ac5a-5e0d24f88715

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
