### PR TITLE
add query parameter to enforce local gate logic

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -372,6 +372,15 @@ const decideShowDefaultGate = (): ShowGateValues => {
 	return undefined;
 };
 
+const decideShouldEnforceLocalLogic = (): boolean => {
+	// July 31st
+	// SignIn gate behavior investigation
+
+	const params = new URLSearchParams(window.location.search);
+	const value: string | null = params.get('localgatelogic');
+	return value === 'true';
+};
+
 const buildAuxiaGateDisplayData = async (
 	contributionsServiceUrl: string,
 	pageId: string,
@@ -390,7 +399,7 @@ const buildAuxiaGateDisplayData = async (
 
 	let should_show_legacy_gate_tmp;
 
-	if (isAuxiaAudience) {
+	if (!decideShouldEnforceLocalLogic() && isAuxiaAudience) {
 		should_show_legacy_gate_tmp = false;
 		// The actual value is irrelevant in this case, but we have the convention to set it to false here
 	} else {


### PR DESCRIPTION
Add a query parameter to enforce the execution of `decideShouldShowLegacyGate`, which in turn calls `canShow`, which is under investigation today ( https://github.com/guardian/dotcom-rendering/pull/14322 )