### PR TITLE
signin gate: clean up investigation code

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/displayRules.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRules.ts
@@ -11,11 +11,7 @@ import type { CanShowGateProps } from './types';
 export const isNPageOrHigherPageView = (n = 2): boolean => {
 	// get daily read article count array from local storage
 	const [dailyCount = {} as DailyArticle] = getDailyArticleCount() ?? [];
-
 	const { count = 0 } = dailyCount;
-
-	console.log(`counter inside isNPageOrHigherPageView: ${count}`);
-
 	return count >= n;
 };
 

--- a/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
+++ b/dotcom-rendering/src/components/SignInGate/gates/main-control.ts
@@ -16,39 +16,6 @@ const canShow = ({
 	isPaidContent,
 	isPreview,
 }: CanShowGateProps): Promise<boolean> => {
-	// 31st July 2025
-	// author: Pascal
-	// Investigating broken behavior of this function
-
-	console.log('[60f7e8f7] investigation');
-	console.log(`isSignedIn: ${isSignedIn}`);
-	console.log(`!isSignedIn: ${!isSignedIn}`);
-	console.log(`currentTest.variant: ${currentTest.variant}`);
-	console.log(`currentTest.name: ${currentTest.name}`);
-	console.log(
-		`hasUserDismissedGate: ${hasUserDismissedGate(
-			currentTest.variant,
-			currentTest.name,
-		)}`,
-	);
-	console.log(
-		`!hasUserDismissedGate: ${!hasUserDismissedGate(
-			currentTest.variant,
-			currentTest.name,
-		)}`,
-	);
-	console.log(`isNPageOrHigherPageView: ${isNPageOrHigherPageView(3)}`);
-	console.log(`contentType: ${contentType}`);
-	console.log(`isValidContentType: ${isValidContentType(contentType)}`);
-	console.log(`sectionId: ${sectionId}`);
-	console.log(`isValidSection: ${isValidSection(sectionId)}`);
-	console.log(`tags: ${JSON.stringify(tags)}`);
-	console.log(`isValidTag: ${isValidTag(tags)}`);
-	console.log(`isPaidContent: ${isPaidContent}`);
-	console.log(`!isPaidContent: ${!isPaidContent}`);
-	console.log(`isPreview: ${isPreview}`);
-	console.log(`!isPreview: ${!isPreview}`);
-
 	return Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGate(currentTest.variant, currentTest.name) &&

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -372,15 +372,6 @@ const decideShowDefaultGate = (): ShowGateValues => {
 	return undefined;
 };
 
-const decideShouldEnforceLocalLogic = (): boolean => {
-	// July 31st
-	// SignIn gate behavior investigation
-
-	const params = new URLSearchParams(window.location.search);
-	const value: string | null = params.get('localgatelogic');
-	return value === 'true';
-};
-
 const buildAuxiaGateDisplayData = async (
 	contributionsServiceUrl: string,
 	pageId: string,
@@ -397,14 +388,9 @@ const buildAuxiaGateDisplayData = async (
 	const readerPersonalData = await decideAuxiaProxyReaderPersonalData();
 	const tagIds = tags.map((tag) => tag.id);
 
-	let mvtId = readerPersonalData.mvtId;
-	if (decideShouldEnforceLocalLogic()) {
-		mvtId = 350001; // to be outside the Auxia share of the Audience
-	}
-
 	let should_show_legacy_gate_tmp;
 
-	if (!decideShouldEnforceLocalLogic() && isAuxiaAudience) {
+	if (isAuxiaAudience) {
 		should_show_legacy_gate_tmp = false;
 		// The actual value is irrelevant in this case, but we have the convention to set it to false here
 	} else {
@@ -439,7 +425,7 @@ const buildAuxiaGateDisplayData = async (
 		tagIds,
 		gateDismissCount,
 		readerPersonalData.countryCode,
-		mvtId,
+		readerPersonalData.mvtId,
 		should_show_legacy_gate_tmp,
 		readerPersonalData.hasConsented,
 		shouldServeDismissible,


### PR DESCRIPTION
Clean up the code we added yesterday as part of an investigation
- https://github.com/guardian/dotcom-rendering/pull/14322
- https://github.com/guardian/dotcom-rendering/pull/14325

The outcome of that investigation was discovering incorrect specs implemented in SDC, which was corrected here: https://github.com/guardian/support-dotcom-components/pull/1404

