### PR TITLE
Add `top-above-nav` grey background width for tablet

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -135,11 +135,16 @@ const topAboveNavContainerVariantStyles = css`
 			content: '';
 			position: absolute;
 			height: 250px;
-			width: 970px;
+			width: 728px;
 			top: ${labelHeight}px;
 			left: 50%;
 			transform: translateX(-50%);
 			background-color: ${palette.neutral[93]};
+		}
+		${from.desktop} {
+			::before {
+				width: 970px;
+			}
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

This PR updates the `top-above-nav` background colour width for tablet to be `728px` as previously we had just a width size of `970px` that accommodates desktop. Previous work https://github.com/guardian/dotcom-rendering/pull/14320

## Why?

Improve UI for tablet breakpoint when we show the `top-above-nav` background grey.

## Screenshots

**Before**

https://github.com/user-attachments/assets/8e45d946-361b-44e9-a886-e3452cf069ea

**After**

https://github.com/user-attachments/assets/8f0112d9-ea55-4c0c-a4f7-c9587097e0ff

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
