### PR TITLE
Wrap very long words in card headlines

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -360,7 +360,7 @@ export const trails: [
 		...defaultCardProps,
 		url: 'https://www.theguardian.com/society/2023/may/30/trans-activists-disrupt-kathleen-stock-speech-at-oxford-union',
 		headline:
-			'Gender-critical feminist’s speech temporarily stopped after protester glues themself to floor',
+			'BBCSSO/Wigglesworth/Batsashvili review – detailed and monumental Bruckner',
 		byline: 'Matthew Weaver',
 		image: {
 			src: 'https://media.guim.co.uk/981abafa6ed4eaabdf7e743e6786aea3d9b7dbb2/0_417_901_540/500.jpg',

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -1136,6 +1136,7 @@ export const WhenVideoWithPlayButton = () => {
 		</Section>
 	);
 };
+
 export const WithLetterDesign = () => {
 	return (
 		<CardWrapper>
@@ -1152,8 +1153,6 @@ export const WithLetterDesign = () => {
 		</CardWrapper>
 	);
 };
-
-WithLetterDesign.storyName = 'WithLetterDesign';
 
 export const WithLetterDesignAndShowQuotedHeadline = () => {
 	return (
@@ -1172,9 +1171,6 @@ export const WithLetterDesignAndShowQuotedHeadline = () => {
 		</CardWrapper>
 	);
 };
-
-WithLetterDesignAndShowQuotedHeadline.storyName =
-	'WithLetterDesignAndShowQuotedHeadline';
 
 const containerPalettes = [
 	'InvestigationPalette',
@@ -1751,6 +1747,26 @@ export const WithAVerticalGapWhenScrollableSmallContainer = () => {
 						discussionId={'p/d8ex5'}
 					/>
 				</div>
+			</CardWrapper>
+		</>
+	);
+};
+
+export const WithHeadlineContainingLongWord = () => {
+	return (
+		<>
+			<CardWrapper>
+				<Card
+					{...basicCardProps}
+					format={{
+						display: ArticleDisplay.Standard,
+						design: ArticleDesign.Standard,
+						theme: Pillar.News,
+					}}
+					imagePositionOnDesktop="left"
+					imageSize="medium"
+					headlineText="BBCSSO/Wigglesworth/Batsashvili review – detailed and monumental Bruckner"
+				/>
 			</CardWrapper>
 		</>
 	);

--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -224,6 +224,7 @@ export const CardHeadline = ({
 				<span
 					css={css`
 						color: ${headlineColour};
+						overflow-wrap: anywhere;
 					`}
 					className="show-underline"
 				>

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -232,8 +232,7 @@ export const textBlockStyles = (format: ArticleFormat) => css`
 	}
 
 	${until.tablet} {
-		/* 	To stop long words going outside of the view port.
-					For compatibility */
+		/* To stop long words going outside of the view port. For compatibility */
 		overflow-wrap: anywhere;
 		word-wrap: break-word;
 	}


### PR DESCRIPTION
## What does this change?



## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
