### PR TITLE
fix: update sign-in gate content formatting and add line-break support

### DIFF
--- a/dotcom-rendering/fixtures/manual/sign-in-gate.ts
+++ b/dotcom-rendering/fixtures/manual/sign-in-gate.ts
@@ -8,7 +8,7 @@ export const mockAuxiaResponseDismissible = {
 			treatmentContent: JSON.stringify({
 				title: 'Like uninterrupted reading?\nSo do we. Sign in.',
 				subtitle:
-					"Sign in to keep reading. It's free, and we'll bring you right back here in under a minute.",
+					"Sign in to keep reading.\n\nIt's free, and we'll bring you right back here in under a minute.",
 				body: '',
 				first_cta_name: 'Create a free account',
 				first_cta_link: 'https://profile.theguardian.com/register',

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV1.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV1.tsx
@@ -200,6 +200,7 @@ const subHeadingStyles = css`
 const descriptionText = css`
 	${textSans15};
 	padding-bottom: ${space[6]}px;
+	white-space: pre-line;
 
 	${from.phablet} {
 		${textSans17};


### PR DESCRIPTION
## What does this change?

Update sign-in gate content formatting and add line-break handling for description text

## Why?

When user input line-breaks in subtitle or body, they were not rendered.