### PR TITLE
Remove AdYouLike code

### DIFF
--- a/dotcom-rendering/fixtures/config.js
+++ b/dotcom-rendering/fixtures/config.js
@@ -48,7 +48,6 @@ module.exports = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/cricket-match.ts
+++ b/dotcom-rendering/fixtures/generated/cricket-match.ts
@@ -1317,7 +1317,6 @@ export const cricketMatchData: FECricketMatchPage = {
 			prebidOzone: true,
 			ampLiveblogSwitch: false,
 			ampAmazon: false,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abA9BidResponseWinner: true,
 			optOutAdvertising: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Analysis.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Analysis.ts
@@ -709,7 +709,6 @@ export const Analysis: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Audio.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Audio.ts
@@ -727,7 +727,6 @@ export const Audio: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Comment.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Comment.ts
@@ -677,7 +677,6 @@ export const Comment: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Dead.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Dead.ts
@@ -3086,7 +3086,6 @@ export const Dead: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Editorial.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Editorial.ts
@@ -657,7 +657,6 @@ export const Editorial: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Explainer.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Explainer.ts
@@ -1434,7 +1434,6 @@ export const Explainer: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Feature.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Feature.ts
@@ -1161,7 +1161,6 @@ export const Feature: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Gallery.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Gallery.ts
@@ -6699,7 +6699,6 @@ export const Gallery: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/GalleryLabs.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/GalleryLabs.ts
@@ -4299,7 +4299,6 @@ export const GalleryLabs: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Interview.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Interview.ts
@@ -2276,7 +2276,6 @@ export const Interview: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Labs.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Labs.ts
@@ -1655,7 +1655,6 @@ export const Labs: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Letter.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Letter.ts
@@ -553,7 +553,6 @@ export const Letter: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Live.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Live.ts
@@ -3086,7 +3086,6 @@ export const Live: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/LiveBlogSingleContributor.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/LiveBlogSingleContributor.ts
@@ -4283,7 +4283,6 @@ export const LiveBlogSingleContributor: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/MatchReport.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/MatchReport.ts
@@ -641,7 +641,6 @@ export const MatchReport: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/NewsletterSignup.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/NewsletterSignup.ts
@@ -596,7 +596,6 @@ export const NewsletterSignup: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/NumberedList.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/NumberedList.ts
@@ -5811,7 +5811,6 @@ export const NumberedList: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/PhotoEssay.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/PhotoEssay.ts
@@ -7674,7 +7674,6 @@ export const PhotoEssay: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Picture.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Picture.ts
@@ -557,7 +557,6 @@ export const Picture: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Quiz.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Quiz.ts
@@ -1157,7 +1157,6 @@ export const Quiz: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Recipe.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Recipe.ts
@@ -742,7 +742,6 @@ export const Recipe: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Review.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Review.ts
@@ -986,7 +986,6 @@ export const Review: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/SpecialReport.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/SpecialReport.ts
@@ -756,7 +756,6 @@ export const SpecialReport: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Standard.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Standard.ts
@@ -727,7 +727,6 @@ export const Standard: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/StandardWithVideo.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/StandardWithVideo.ts
@@ -727,7 +727,6 @@ export const StandardWithVideo: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/fe-articles/Video.ts
+++ b/dotcom-rendering/fixtures/generated/fe-articles/Video.ts
@@ -295,7 +295,6 @@ export const Video: FEArticle = {
 			relatedContent: true,
 			thirdPartyEmbedTracking: true,
 			prebidOzone: true,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abSignInGateMainControl: true,
 			ampPrebid: true,

--- a/dotcom-rendering/fixtures/generated/football-live.ts
+++ b/dotcom-rendering/fixtures/generated/football-live.ts
@@ -1004,7 +1004,6 @@ export const footballData: FEFootballMatchListPage = {
 			prebidOzone: true,
 			ampLiveblogSwitch: false,
 			ampAmazon: false,
-			prebidAdYouLike: true,
 			mostViewedFronts: true,
 			abA9BidResponseWinner: true,
 			optOutAdvertising: true,

--- a/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
+++ b/dotcom-rendering/scripts/perf/k6/article-nier-automata.json
@@ -1608,7 +1608,6 @@
 			"prebidOzone": true,
 			"ampLiveblogSwitch": true,
 			"ampAmazon": true,
-			"prebidAdYouLike": true,
 			"mostViewedFronts": true,
 			"optOutAdvertising": true,
 			"abSignInGateMainControl": true,


### PR DESCRIPTION
## What does this change?

This PR removes the `AdYouLike` code/references. Check related work https://github.com/guardian/commercial/pull/2142 and https://github.com/guardian/commercial/pull/2142 for more details.

## Why?

The `AdYouLike` adaptor is removed from Commercial and also the switch in Frontend. 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
