### PR TITLE
Add affiliates disclaimer in left column on apps

### DIFF
--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -601,6 +601,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 													article.config.shortUrlId
 												}
 											/>
+											{!!article.affiliateLinksDisclaimer && (
+												<AffiliateDisclaimer />
+											)}
 										</Hide>
 									</>
 								) : (

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -486,6 +486,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 													article.config.shortUrlId
 												}
 											/>
+											{!!article.affiliateLinksDisclaimer && (
+												<AffiliateDisclaimer />
+											)}
 										</Hide>
 									</>
 								) : (

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -645,6 +645,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 												}
 											/>
 										</div>
+										{!!article.affiliateLinksDisclaimer && (
+											<AffiliateDisclaimer />
+										)}
 									</Hide>
 								</>
 							) : (


### PR DESCRIPTION
## What does this change?
Adds the affiliates disclaimer into articles on apps at and above the leftCol (1140px) breakpoint.

## Why?
Currently the disclaimer is not shown above the leftCol breakpoint (1140px) on apps. This means some tablets won't be showing the disclaimer when in landscape view, and they should be.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1044" height="640" alt="Screenshot 2025-08-05 at 11 10 40" src="https://github.com/user-attachments/assets/44b0889b-538e-48e2-a46c-ddd39d9bd108" /> | <img width="1045" height="665" alt="Screenshot 2025-08-05 at 11 08 56" src="https://github.com/user-attachments/assets/4796df92-e212-44a2-8846-8ee04e6dba77" /> |
