### PR TITLE
Add AB test for L2A button in Apps Article 

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -102,6 +102,14 @@ export const getListenToArticleClient: BridgetApi<
 	isAvailable: async () => true,
 	isPlaying: async () => false,
 });
+
+export const getNativeABTestingClient: BridgetApi<
+	'getNativeABTestingClient'
+> = () => ({
+	getParticipations: async () =>
+		new Map(Object.entries({ 'test-id': 'variant' })),
+});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -119,6 +127,7 @@ export const ensure_all_exports_are_present = {
 	getInteractionClient,
 	getInteractivesClient,
 	getListenToArticleClient,
+	getNativeABTestingClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -1,3 +1,4 @@
+import * as AbTesting from '@guardian/bridget/AbTesting';
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Analytics from '@guardian/bridget/Analytics';
 import * as Commercial from '@guardian/bridget/Commercial';
@@ -203,4 +204,16 @@ export const getListenToArticleClient = (): ListenToArticle.Client<void> => {
 		);
 	}
 	return listenToArticleClient;
+};
+
+let nativeAbTestingClient: AbTesting.Client<void> | undefined = undefined;
+export const getNativeABTestingClient = (): AbTesting.Client<void> => {
+	if (!nativeAbTestingClient) {
+		nativeAbTestingClient = createAppClient<AbTesting.Client<void>>(
+			AbTesting.Client,
+			'buffered',
+			'compact',
+		);
+	}
+	return nativeAbTestingClient;
 };


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
