### PR TITLE
Add `data-gu-name` attribute to pullquote and callout elements

### DIFF
--- a/dotcom-rendering/src/components/CalloutBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/CalloutBlockComponent.importable.tsx
@@ -51,7 +51,7 @@ export const CalloutBlockComponent = ({
 	const id = formId.toString();
 
 	return (
-		<>
+		<div data-gu-name="callout">
 			{!isNonCollapsible ? (
 				<aside>
 					<ExpandingWrapper
@@ -116,6 +116,6 @@ export const CalloutBlockComponent = ({
 					pageId={pageId}
 				/>
 			)}
-		</>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/PullQuoteBlockComponent.tsx
@@ -269,6 +269,7 @@ export const PullQuoteBlockComponent = ({
 				alignmentCss(role, format),
 			]}
 			data-spacefinder-role={role}
+			data-gu-name="pullquote"
 		>
 			<QuoteIcon colour={palette('--pullquote-icon')} />
 			<blockquote


### PR DESCRIPTION
## What does this change?

Since we added support for pullquotes and callouts in interactive articles (https://github.com/guardian/flexible-content/pull/5348 and https://github.com/guardian/flexible-content/pull/5341), the editorial design team have wanted a way to target them when customising interactives.

To achieve this, we're expanding the `data-gu-name` contract which was originally set out here: https://github.com/guardian/dotcom-rendering/pull/3599

## Why?

To give a way to target these elements without relying on hacks.

## Screenshots

<img width="856" height="689" alt="Screenshot 2025-08-06 at 09 03 38" src="https://github.com/user-attachments/assets/cd322a65-9323-447b-88ae-2e3917324365" />
