### PR TITLE
Improve list item text wrapping

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -187,7 +187,6 @@ export const textBlockStyles = (format: ArticleFormat) => css`
 	li {
 		margin-bottom: ${remSpace[1]};
 		padding-left: ${remSpace[5]};
-		display: flow-root;
 
 		p {
 			margin: -1.5rem 0 0 0;


### PR DESCRIPTION
## What does this change?

Ensures list elements in the article body wrap around elements floating on the left (e.g. rich links or image thumbnails)

## Why?

We got this report from user help:

> Summary of issue - a reader reported that the text is aligned to the right instead of being wrapped around the 'The Guardian view on Ukraine's protests' box. 
> 
> Expected behaviour vs actual behaviour - text should wrap around the 'The Guardian view on Ukraine's protests' box.
> 
> https://www.theguardian.com/world/2025/jul/25/ukraine-war-briefing-anti-corruption-agencies-endorse-bill-restoring-their-independence

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="617" height="933" alt="Screenshot 2025-08-06 at 11 48 55" src="https://github.com/user-attachments/assets/00e221f7-72a7-426d-aedb-bb9730bff967" />  | <img width="617" height="932" alt="Screenshot 2025-08-06 at 11 49 10" src="https://github.com/user-attachments/assets/8df7a79b-ed82-4a3e-97cb-aeaf53bfc7f9" /> |


