### PR TITLE
Check node types match node version

### DIFF
--- a/dotcom-rendering/scripts/check-node-versions.mjs
+++ b/dotcom-rendering/scripts/check-node-versions.mjs
@@ -4,6 +4,8 @@ import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { log, warn } from '../../scripts/log.js';
+import semverParse from 'semver/functions/parse.js';
+import semverSatisfies from 'semver/functions/satisfies.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -27,36 +29,101 @@ if (!nodeVersion) {
 	log(`Found node version ${nodeVersion} in \`.nvmrc\``);
 }
 
+/**
+ * @typedef {'major' | 'minor' | 'patch'} MatchLevel
+ */
 const requiredNodeVersionMatches =
-	/** @type {const} @satisfies {ReadonlyArray<{filepath: string, pattern: RegExp}>}*/ ([
+	/** @type {const} @satisfies {ReadonlyArray<{filepath: string, pattern: RegExp, matchLevel: MatchLevel}>}*/ ([
 		{
 			filepath: 'Containerfile',
 			pattern: /^FROM node:(.+)-alpine$/m,
+			matchLevel: 'patch',
 		},
 		{
 			filepath: 'scripts/deploy/riff-raff.yaml',
 			pattern: /^ +Recipe: dotcom-rendering.*-node-(\d+\.\d+\.\d+).*?$/m,
+			matchLevel: 'patch',
 		},
 		{
 			filepath: '../apps-rendering/riff-raff.yaml',
 			pattern: /^ +Recipe: apps-rendering.*-node-(\d+\.\d+\.\d+).*?$/m,
+			matchLevel: 'patch',
+		},
+		{
+			filepath: 'package.json',
+			pattern: /^\t+"@types\/node"\: "(.+)",$/m,
+			/*
+			Definitely Typed packages only match the major and minor
+			versions of the corresponding library/node release.
+			https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+
+			Note: Given this rule, this should be set to 'minor'. It's currently
+			set to 'major' because the latest node release doesn't yet have
+			types available for it (v22.18.0, latest types package is v22.17.x).
+			*/
+			matchLevel: 'major',
+		},
+		{
+			filepath: '../apps-rendering/package.json',
+			pattern: /^\t+"@types\/node"\: "(.+)",$/m,
+			/*
+			Definitely Typed packages only match the major and minor
+			versions of the corresponding library/node release.
+			https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+
+			Note: Given this rule, this should be set to 'minor'. It's currently
+			set to 'major' because the latest node release doesn't yet have
+			types available for it (v22.18.0, latest types package is v22.17.x).
+			*/
+			matchLevel: 'major',
 		},
 	]);
 
+/**
+ *
+ * @param {string} a
+ * @param {string} b
+ * @param {MatchLevel} matchLevel
+ * @returns boolean
+ */
+const versionMatches = (a, b, matchLevel) => {
+	const semverA = semverParse(a);
+
+	switch (matchLevel) {
+		case 'major':
+			return semverSatisfies(b, `${semverA?.major}.x.x`);
+		case 'minor':
+			return semverSatisfies(b, `${semverA?.major}.${semverA?.minor}.x`);
+		case 'patch':
+			return semverSatisfies(b, a);
+	}
+};
+
 const problems = (
 	await Promise.all(
-		requiredNodeVersionMatches.map(async ({ filepath, pattern }) => {
-			const fileContents = await readFile(
-				resolve(...filepath.split('/')),
-				'utf-8',
-			);
-			const foundNodeVersion =
-				fileContents.match(pattern)?.[1] ?? undefined;
+		requiredNodeVersionMatches.map(
+			async ({ filepath, pattern, matchLevel }) => {
+				const fileContents = await readFile(
+					resolve(...filepath.split('/')),
+					'utf-8',
+				);
+				const foundNodeVersion =
+					fileContents.match(pattern)?.[1] ?? undefined;
 
-			return foundNodeVersion === nodeVersion
-				? undefined
-				: `Node version in ${filepath} (${foundNodeVersion}) does not match \`.nvmrc\` (${nodeVersion})`;
-		}),
+				const matches =
+					foundNodeVersion === undefined
+						? false
+						: versionMatches(
+								nodeVersion,
+								foundNodeVersion,
+								matchLevel,
+						  );
+
+				return matches
+					? undefined
+					: `Node version in ${filepath} (${foundNodeVersion}) does not match \`.nvmrc\` (${nodeVersion}), expected them to match versions to the ${matchLevel} level`;
+			},
+		),
 	)
 ).filter(
 	/** @type {(problem?: string) => problem is string} */


### PR DESCRIPTION
The TS types for the Node APIs come from the "types/node" package, published from the Definitely Typed project. Both Node and the types package use semver versions ("major.minor.patch"). The types package for a particular Node version will have matching "major" and "minor" numbers, but not necessarily a matching "patch" number: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library

We should ensure that the types package we install matches the Node version. We have a `check-node-versions` script to ensure this in other places (riff-raff config, for example), but it currently only supports matching exact versions (major, minor and patch). This change updates the script to allow specifying a "level" to which a given Node version should be matched, and adds the DCAR and AR types packages to these checks.

Note: the "match level" for the types package should be "minor", but there isn't yet a package available for the version of Node that we're currently on (v22.18.0, latest types package is v22.17.x). Therefore this change sets the "level" to "major", to at least ensure that we're always on the correct major version. This can be updated once a new types package is released.

## Relevant PRs

The types package in AR was previously out of sync with the Node version, as demonstrated in #14336. In addition, dependabot is currently attempting to update the types package too far in #14340.
