### PR TITLE
Set the quote colour to match the headline colour on highlight cards

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -48,6 +48,9 @@ type Props = {
 	headlineColour?: string;
 	/** Optional override of the standard card kicker colour */
 	kickerColour?: string;
+
+	/** Optional override of the standard card quote colour */
+	quoteIconColour?: string;
 	kickerImage?: PodcastSeriesImage;
 };
 
@@ -190,6 +193,7 @@ export const CardHeadline = ({
 	isExternalLink,
 	headlineColour = palette('--card-headline'),
 	kickerColour = palette('--card-kicker-text'),
+	quoteIconColour = palette('--card-kicker-text'),
 	kickerImage,
 }: Props) => {
 	// The link is only applied directly to the headline if it is a sublink
@@ -220,7 +224,7 @@ export const CardHeadline = ({
 						image={kickerImage}
 					/>
 				)}
-				{showQuotes && <QuoteIcon colour={kickerColour} />}
+				{showQuotes && <QuoteIcon colour={quoteIconColour} />}
 				<span
 					css={css`
 						color: ${headlineColour};

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -156,6 +156,7 @@ export const HighlightsCard = ({
 						isExternalLink={isExternalLink}
 						showQuotes={showQuotedHeadline}
 						headlineColour={palette('--highlights-card-headline')}
+						quoteIconColour={palette('--highlights-card-headline')}
 						kickerColour={palette('--highlights-card-kicker-text')}
 					/>
 


### PR DESCRIPTION
## What does this change?
Adds an optional quoteIconColour property  so that the consumer of card headline can adjust the quote colour if desired. 

## Why?
This allows us to match the quote to the headline colour on highlights cards where elsewhere the quotes match the kicker. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/074dfea9-95d6-4f36-a810-92f800202385
[after]: https://github.com/user-attachments/assets/8deaeb3c-bfe2-4d8c-84b0-51635f56a41f


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
