### PR TITLE
Remove temporary body copy colour override on DCAR interactive articles

### DIFF
--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -27,7 +27,6 @@ import type { ArticleDeprecated } from '../types/article';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
-import { temporaryBodyCopyColourOverride } from './InteractiveLayout';
 import { interactiveGlobalStyles } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
@@ -210,7 +209,6 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 					<Island priority="critical">
 						<InteractivesDisableArticleSwipe />
 					</Island>
-					<Global styles={temporaryBodyCopyColourOverride} />
 				</>
 			)}
 			{isWeb && (

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -201,13 +201,6 @@ const starWrapper = css`
 	margin-left: -10px;
 `;
 
-export const temporaryBodyCopyColourOverride = css`
-	.content__main-column--interactive p {
-		/* stylelint-disable-next-line declaration-no-important */
-		color: ${themePalette('--article-text')} !important;
-	}
-`;
-
 interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
@@ -253,7 +246,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					<Island priority="critical">
 						<InteractivesDisableArticleSwipe />
 					</Island>
-					<Global styles={temporaryBodyCopyColourOverride} />
 				</>
 			)}
 			{article.isLegacyInteractive && (


### PR DESCRIPTION
Now the dust has settled on the DCAR migration of interactive articles, this follows up on https://github.com/guardian/dotcom-rendering/pull/14049 and https://github.com/guardian/dotcom-rendering/pull/14074 by rolling back enforced body copy colour responsiveness. 

See the original PRs for more context but essentially a hardcoded colour value in the interactive templates was keeping body copy black regardless of whether the page was in dark mode or not. This overrode that as a temporary measure - the long term fix being to tidy up the old interactives then roll back the override.