### PR TITLE
Dependabot ignore `types/node` major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       - dependency-name: 'aws-cdk'
       - dependency-name: 'aws-cdk-lib'
       - dependency-name: 'constructs'
+      # The `check-node-versions` script enforces that this package is kept in
+      # sync with our Node major version, so we want dependabot to ignore major
+      # version updates, but still allow smaller updates.
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
 
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
The `check-node-versions` script enforces that this package is kept in sync with our Node major version, so we want dependabot to ignore major version updates, but still allow smaller updates.

Note that we're still enforcing updates to the major version via the aforementioned script; whenever Node is incremented by a major version, the linter will require this package to be updated to that major version too.

Note: We should technically ask dependabot to ignore 'minor' versions too. It's currently set to 'major' because the latest node release doesn't yet have types available for it (v22.18.0, latest types package is v22.17.x). When it does, we can update this to ignore both major and minor versions.

See also #14357.
