### PR TITLE
Remove no boosts AB test

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -48,7 +48,6 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
-	isInNoBoostsAbTestVariant?: boolean;
 };
 
 export const DecideContainer = ({
@@ -64,7 +63,6 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
-	isInNoBoostsAbTestVariant,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -270,7 +268,6 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
-					isInNoBoostsAbTestVariant={isInNoBoostsAbTestVariant}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -21,7 +21,6 @@ import type { ResponsiveFontSize } from './CardHeadline';
 import type { Loading } from './CardPicture';
 import { FeatureCard } from './FeatureCard';
 import { FrontCard } from './FrontCard';
-import { Hide } from './Hide';
 import type { Alignment } from './SupportingContent';
 
 type Props = {
@@ -33,7 +32,6 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
-	isInNoBoostsAbTestVariant?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -582,7 +580,6 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
-	isInNoBoostsAbTestVariant,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
 		...snap,
@@ -616,48 +613,7 @@ export const FlexibleGeneral = ({
 			{groupedCards.map((row, i) => {
 				switch (row.layout) {
 					case 'oneCardFullWidth':
-						return isInNoBoostsAbTestVariant ? (
-							<>
-								<Hide when="above" breakpoint="tablet">
-									<HalfWidthCardLayout
-										key={row.cards[0]?.uniqueId}
-										cards={row.cards}
-										containerPalette={containerPalette}
-										showAge={showAge}
-										absoluteServerTimes={
-											absoluteServerTimes
-										}
-										imageLoading={imageLoading}
-										isFirstRow={!splash.length && i === 0}
-										isFirstStandardRow={i === 0}
-										aspectRatio={aspectRatio}
-										isLastRow={
-											i === groupedCards.length - 1
-										}
-										containerLevel={containerLevel}
-									/>
-								</Hide>
-								<Hide when="below" breakpoint="tablet">
-									<FullWidthCardLayout
-										key={row.cards[0]?.uniqueId}
-										cards={row.cards}
-										containerPalette={containerPalette}
-										showAge={showAge}
-										absoluteServerTimes={
-											absoluteServerTimes
-										}
-										imageLoading={imageLoading}
-										aspectRatio={aspectRatio}
-										isFirstRow={!splash.length && i === 0}
-										isLastRow={
-											i === groupedCards.length - 1
-										}
-										containerLevel={containerLevel}
-										collectionId={collectionId}
-									/>
-								</Hide>
-							</>
-						) : (
+						return (
 							<FullWidthCardLayout
 								key={row.cards[0]?.uniqueId}
 								cards={row.cards}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -136,8 +136,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const { absoluteServerTimes = false } = front.config.switches;
 
-	const isInNoBoostsVariant = abTests.noBoostsVariant === 'variant';
-
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {
 			case 'scrollable/feature':
@@ -636,9 +634,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
-									isInNoBoostsAbTestVariant={
-										pageId === 'uk' && isInNoBoostsVariant
-									}
 								/>
 							</FrontSection>
 


### PR DESCRIPTION
## What does this change?

Removes the [No Boosts AB test](https://github.com/guardian/dotcom-rendering/pull/14305).

## Why?

We have reached sample sizes.