### PR TITLE
Introduce gate_display_count

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -126,6 +126,7 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	hasConsented: boolean;
 	shouldServeDismissible: boolean; // [2]
 	showDefaultGate: ShowGateValues; // [3]
+	gateDisplayCount: number;
 }
 
 // [1]

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -1,4 +1,4 @@
-import { getCookie, isUndefined } from '@guardian/libs';
+import { getCookie, isUndefined, storage } from '@guardian/libs';
 import { useState } from 'react';
 import {
 	hasCmpConsentForBrowserId,
@@ -376,7 +376,15 @@ const decideShowDefaultGate = (): ShowGateValues => {
 
 const getGateDisplayCount = (): number => {
 	// TODO: retrieve the number of time the page has been displayed
-	return 0;
+	const count = storage.local.get('gate_display_count') as number;
+	return count;
+};
+
+const incrementGateDisplayCount = () => {
+	const count = getGateDisplayCount();
+	const now = new Date();
+	const oneYearFromNow = new Date(now.getTime() + 365 * 86400);
+	storage.local.set('gate_display_count', count + 1, oneYearFromNow);
 };
 
 const buildAuxiaGateDisplayData = async (
@@ -732,6 +740,10 @@ const ShowSignInGateAuxia = ({
 			},
 			renderingTarget,
 		);
+
+		// Once the gate is being displayed we need to update
+		// the tracking of the number of times the gate has been displayed
+		incrementGateDisplayCount();
 	}, [componentId]);
 
 	return (

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -293,6 +293,7 @@ const fetchProxyGetTreatments = async (
 	hasConsented: boolean,
 	shouldServeDismissible: boolean,
 	showDefaultGate: ShowGateValues,
+	gateDisplayCount: number,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	// pageId example: 'money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
@@ -317,6 +318,7 @@ const fetchProxyGetTreatments = async (
 		hasConsented,
 		shouldServeDismissible,
 		showDefaultGate,
+		gateDisplayCount,
 	};
 	const params = {
 		method: 'POST',
@@ -372,6 +374,11 @@ const decideShowDefaultGate = (): ShowGateValues => {
 	return undefined;
 };
 
+const getGateDisplayCount = (): number => {
+	// TODO: retrieve the number of time the page has been displayed
+	return 0;
+};
+
 const buildAuxiaGateDisplayData = async (
 	contributionsServiceUrl: string,
 	pageId: string,
@@ -410,8 +417,8 @@ const buildAuxiaGateDisplayData = async (
 	}
 
 	const shouldServeDismissible = decideShouldServeDismissible();
-
 	const showDefaultGate = decideShowDefaultGate();
+	const gateDisplayCount = getGateDisplayCount();
 
 	const response = await fetchProxyGetTreatments(
 		contributionsServiceUrl,
@@ -430,6 +437,7 @@ const buildAuxiaGateDisplayData = async (
 		readerPersonalData.hasConsented,
 		shouldServeDismissible,
 		showDefaultGate,
+		gateDisplayCount,
 	);
 
 	if (response.status && response.data) {


### PR DESCRIPTION
We introduce a new client side attribute `gate_display_count` (whose use has been cleared by data privacy), which simply keeps track of the number of times the sign-in gate has been displayed [1]. We also introduce the functions and extension of the sign-in gate GetTreatments call to pass to SDC.

[1] That number is different from the page display count. 