### PR TITLE
Fix the broken headline due to main media bug

### DIFF
--- a/dotcom-rendering/src/components/MainMediaGallery.tsx
+++ b/dotcom-rendering/src/components/MainMediaGallery.tsx
@@ -19,7 +19,6 @@ type Props = {
 
 const styles = css`
 	${grid.column.all}
-	position: relative;
 	height: calc(80vh - 48px);
 	grid-row: 1/8;
 	${from.desktop} {


### PR DESCRIPTION
Co-authored-by: Dina Hafez <dina.hafez@guardian.co.uk>

## What does this change?
This PR fixes a bug that was introduced in the previous gallery PR https://github.com/guardian/dotcom-rendering/pull/14163

We don't need a `position: relative` for the parent of `LightboxLink` in main media because the button will be invisible for main media in Galleries. 
## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/140cbd32-9607-4c08-be2c-8daefe1273ec
[after]: https://github.com/user-attachments/assets/2cb69706-6d8f-4f55-a673-65f36c1af6d6