### PR TITLE
Hide looping videos to users in control of test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -147,6 +147,8 @@ export type Props = {
 	trailTextSize?: TrailTextSize;
 	/** A kicker image is seperate to the main media and renders as part of the kicker */
 	showKickerImage?: boolean;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -250,6 +252,7 @@ const getMedia = ({
 	mainMedia,
 	canPlayInline,
 	isBetaContainer,
+	isInLoopingVideoTestControl,
 }: {
 	imageUrl?: string;
 	imageAltText?: string;
@@ -259,8 +262,13 @@ const getMedia = ({
 	mainMedia?: MainMedia;
 	canPlayInline?: boolean;
 	isBetaContainer: boolean;
+	isInLoopingVideoTestControl: boolean;
 }) => {
-	if (mainMedia?.type === 'LoopVideo' && canPlayInline) {
+	if (
+		mainMedia?.type === 'LoopVideo' &&
+		!isInLoopingVideoTestControl &&
+		canPlayInline
+	) {
 		return {
 			type: 'loop-video',
 			mainMedia,
@@ -412,6 +420,8 @@ export const Card = ({
 	showTopBarMobile = true,
 	trailTextSize,
 	showKickerImage = false,
+	isInLoopingVideoTestVariant = false,
+	isInLoopingVideoTestControl = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -564,6 +574,7 @@ export const Card = ({
 		mainMedia,
 		canPlayInline,
 		isBetaContainer,
+		isInLoopingVideoTestControl,
 	});
 
 	/**
@@ -896,6 +907,9 @@ export const Card = ({
 									fallbackImageAlt={media.imageAltText}
 									fallbackImageAspectRatio="5:4"
 									linkTo={linkTo}
+									isInLoopingVideoTestVariant={
+										isInLoopingVideoTestVariant
+									}
 								/>
 							</Island>
 						)}
@@ -1012,6 +1026,9 @@ export const Card = ({
 									loading={imageLoading}
 									roundedCorners={isOnwardContent}
 									aspectRatio={aspectRatio}
+									isInLoopingVideoTestControl={
+										isInLoopingVideoTestControl
+									}
 								/>
 								{isVideoMainMedia && mainMedia.duration > 0 && (
 									<div

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -18,6 +18,7 @@ export type Props = {
 	isCircular?: boolean;
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 /**
@@ -200,6 +201,7 @@ export const CardPicture = ({
 	isCircular,
 	aspectRatio = '5:3',
 	mobileAspectRatio,
+	isInLoopingVideoTestControl,
 }: Props) => {
 	if (mainImage === '') {
 		return null;
@@ -214,6 +216,11 @@ export const CardPicture = ({
 
 	return (
 		<picture
+			data-component={
+				isInLoopingVideoTestControl
+					? 'loop-video-player-control'
+					: undefined
+			}
 			data-size={imageSize}
 			css={[
 				block,

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -48,6 +48,8 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 export const DecideContainer = ({
@@ -63,6 +65,8 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
+	isInLoopingVideoTestVariant,
+	isInLoopingVideoTestControl,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -255,6 +259,8 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			);
 		case 'flexible/general':
@@ -268,6 +274,8 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -32,6 +32,8 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -241,6 +243,8 @@ type SplashCardLayoutProps = {
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 const SplashCardLayout = ({
@@ -253,6 +257,8 @@ const SplashCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
+	isInLoopingVideoTestVariant = false,
+	isInLoopingVideoTestControl = false,
 }: SplashCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -333,6 +339,8 @@ const SplashCardLayout = ({
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			</LI>
 		</UL>
@@ -395,6 +403,8 @@ type FullWidthCardLayoutProps = {
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 const FullWidthCardLayout = ({
@@ -408,6 +418,8 @@ const FullWidthCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
+	isInLoopingVideoTestVariant = false,
+	isInLoopingVideoTestControl = false,
 }: FullWidthCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -480,6 +492,8 @@ const FullWidthCardLayout = ({
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			</LI>
 		</UL>
@@ -580,6 +594,8 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
+	isInLoopingVideoTestVariant = false,
+	isInLoopingVideoTestControl = false,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
 		...snap,
@@ -608,6 +624,8 @@ export const FlexibleGeneral = ({
 					isLastRow={cards.length === 0}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			)}
 			{groupedCards.map((row, i) => {
@@ -626,6 +644,12 @@ export const FlexibleGeneral = ({
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
 								collectionId={collectionId}
+								isInLoopingVideoTestVariant={
+									isInLoopingVideoTestVariant
+								}
+								isInLoopingVideoTestControl={
+									isInLoopingVideoTestControl
+								}
 							/>
 						);
 

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -27,6 +27,8 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 type BoostProperties = {
@@ -117,6 +119,8 @@ type OneCardLayoutProps = {
 	isLastRow: boolean;
 	isFirstRow: boolean;
 	containerLevel: DCRContainerLevel;
+	isInLoopingVideoTestVariant?: boolean;
+	isInLoopingVideoTestControl?: boolean;
 };
 
 export const OneCardLayout = ({
@@ -129,6 +133,8 @@ export const OneCardLayout = ({
 	isLastRow,
 	isFirstRow,
 	containerLevel,
+	isInLoopingVideoTestVariant = false,
+	isInLoopingVideoTestControl = false,
 }: OneCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -177,6 +183,8 @@ export const OneCardLayout = ({
 					trailTextSize={trailTextSize}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
+					isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+					isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 				/>
 			</LI>
 		</UL>
@@ -273,6 +281,8 @@ export const FlexibleSpecial = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
+	isInLoopingVideoTestVariant,
+	isInLoopingVideoTestControl,
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1).map((snap) => ({
 		...snap,
@@ -299,6 +309,8 @@ export const FlexibleSpecial = ({
 				isFirstRow={true}
 				isLastRow={splash.length === 0 && cards.length === 0}
 				containerLevel={containerLevel}
+				isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+				isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 			/>
 			<OneCardLayout
 				cards={splash}
@@ -310,6 +322,8 @@ export const FlexibleSpecial = ({
 				isLastRow={cards.length === 0}
 				isFirstRow={!isNonEmptyArray(snaps)}
 				containerLevel={containerLevel}
+				isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
+				isInLoopingVideoTestControl={isInLoopingVideoTestControl}
 			/>
 			<TwoOrFourCardLayout
 				cards={cards}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -117,6 +117,7 @@ type Props = {
 	fallbackImageAlt: CardPictureProps['alt'];
 	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
 	linkTo: string;
+	isInLoopingVideoTestVariant?: boolean;
 };
 
 export const LoopVideo = ({
@@ -132,6 +133,7 @@ export const LoopVideo = ({
 	fallbackImageAlt,
 	fallbackImageAspectRatio,
 	linkTo,
+	isInLoopingVideoTestVariant,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -602,6 +604,7 @@ export const LoopVideo = ({
 				AudioIcon={hasAudio ? AudioIcon : null}
 				preloadPartialData={preloadPartialData}
 				showPlayIcon={showPlayIcon}
+				isInLoopingVideoTestVariant={isInLoopingVideoTestVariant}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -96,6 +96,7 @@ type Props = {
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showPlayIcon: boolean;
+	isInLoopingVideoTestVariant?: boolean;
 };
 
 /**
@@ -127,6 +128,7 @@ export const LoopVideoPlayer = forwardRef(
 			AudioIcon,
 			preloadPartialData,
 			showPlayIcon,
+			isInLoopingVideoTestVariant,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -147,6 +149,11 @@ export const LoopVideoPlayer = forwardRef(
 						showPlayIcon ? 'play' : 'pause'
 					}-${atomId}`}
 					data-chromatic="ignore"
+					data-component={
+						isInLoopingVideoTestVariant
+							? 'loop-video-player-variant'
+							: undefined
+					}
 					preload={preloadPartialData ? 'metadata' : 'none'}
 					loop={true}
 					muted={isMuted}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -107,6 +107,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			hasPageSkin: hasPageSkinConfig,
 			pageId,
 			abTests,
+			switches: { absoluteServerTimes = false },
 		},
 		editionId,
 	} = front;
@@ -134,7 +135,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
-	const { absoluteServerTimes = false } = front.config.switches;
+	const isInLoopingVideoTestVariant =
+		abTests.loopingVideoVariant === 'variant';
+	const isInLoopingVideoTestControl =
+		abTests.loopingVideoControl === 'control';
 
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {
@@ -634,6 +638,12 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
+									isInLoopingVideoTestVariant={
+										isInLoopingVideoTestVariant
+									}
+									isInLoopingVideoTestControl={
+										isInLoopingVideoTestControl
+									}
 								/>
 							</FrontSection>
 


### PR DESCRIPTION
## What does this change?

- Does not show looping videos to users in the control of the Looping Video test
- Adds `data-component` attributes to the `video` component in the variant and the `picture` element in the control

## Why?

The attribute allows us to distinguish when a looping video is being run on the page. For the purpose of analytics, we only want to consider pageviews where a looping video could be rendered on the page. There are some periods of the day where there are no looping videos on a network front. Relevant documentation [here](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#getting-the-results).
> Give each component a different data-component attribute to distinguish them. This will show up in the rendered components list on the page view table.

The test is currently set to 0%, so these changes will not have any immediate effect. There is a [PR in frontend](https://github.com/guardian/frontend/pull/28152) to update this to 5%.

## Screenshots

| <img width=120/> | |
| - | - | 
| variant | ![mobile-before] | 
| control | ![tablet-before] |
| not in test | ![desktop-before] | 

[mobile-before]: https://github.com/user-attachments/assets/01697605-1573-4a33-a8e2-e13dd0ced8f5
[tablet-before]: https://github.com/user-attachments/assets/c70d28fc-8d60-4a48-b550-e8cf1ae304b0
[desktop-before]: https://github.com/user-attachments/assets/e175f114-1f96-4ae9-8b61-00d20574c671