### PR TITLE
Add `cdk` group to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
     schedule:
       interval: 'daily'
     ignore:
-      # The version of the aws-cdk[-lib] & constructs dependencies should match
-      # exactly the version specified by @guardian/cdk
-      - dependency-name: 'aws-cdk'
-      - dependency-name: 'aws-cdk-lib'
-      - dependency-name: 'constructs'
       # The `check-node-versions` script enforces that this package is kept in
       # sync with our Node major version, so we want dependabot to ignore major
       # version updates, but still allow smaller updates.
@@ -29,6 +24,12 @@ updates:
       babel:
         patterns:
           - '*babel*'
+      cdk:
+        patterns:
+          - '@guardian/cdk'
+          - 'aws-cdk'
+          - 'aws-cdk-lib'
+          - 'constructs'
       eslint:
         patterns:
           - '*eslint*'


### PR DESCRIPTION
Historically `guardian/cdk` has specified exact versions of the CDK libraries (`aws-cdk`, `aws-cdk-lib` and `constructs`) as peer dependencies. This has made it difficult to rely on dependabot for updates, because it will try to update past these versions. It's possible npm 7's default peer dependency behaviour or pnpm's `strictPeerDependencies` could be used to mitigate this, but not all projects (including this one) are configured this way. As a consequence, we've typically had to ignore those dependencies, and update them manually instead.

However, `guardian/cdk` has recently relaxed its requirements, instead specifying minimum versions of the CDK libraries that it's compatible with: https://github.com/guardian/cdk/pull/2698

This allows us to create a dependabot group to have all three CDK libraries and `guardian/cdk` updated together. Whenever a new version of `guardian/cdk` is published, the minimum versions of the CDK libraries that it depends on should already exist, so grouped PRs should always contain at least the minimum versions required.
