### PR TITLE
Testing Sourcepoint Australia Migration

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -37,7 +37,7 @@
 		"@guardian/eslint-config-typescript": "9.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
-		"@guardian/libs": "25.2.0",
+		"@guardian/libs": "0.0.0-canary-20250812112542",
 		"@guardian/ophan-tracker-js": "2.3.2",
 		"@guardian/react-crossword": "6.3.0",
 		"@guardian/shimport": "1.0.2",

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -14,7 +14,8 @@
 			/* Aliases should also be added to the webpack and jest configurations */
 			"*": ["node_modules/@types/*", "*"] // Make sure that package linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
 		},
-		"preserveConstEnums": true
+		"preserveConstEnums": true,
+		"skipLibCheck": true // Temporary fix for canary version testing - skip type checking of dependency .d.ts files
 	},
 	"include": ["**/*", ".storybook/mocks/bridgetApi.ts"],
 	"exclude": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         version: 8.0.0(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/braze-components':
         specifier: 22.2.0
-        version: 22.2.0(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(react@18.3.1)
+        version: 22.2.0(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(react@18.3.1)
       '@guardian/bridget':
         specifier: 8.6.0
         version: 8.6.0
@@ -309,10 +309,10 @@ importers:
         version: 61.4.0(aws-cdk-lib@2.189.0)(aws-cdk@2.1007.0)(constructs@10.4.2)
       '@guardian/commercial-core':
         specifier: 27.1.0
-        version: 27.1.0(@guardian/ab-core@8.0.0)(@guardian/libs@25.2.0)
+        version: 27.1.0(@guardian/ab-core@8.0.0)(@guardian/libs@0.0.0-canary-20250812112542)
       '@guardian/core-web-vitals':
         specifier: 7.0.0
-        version: 7.0.0(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)(web-vitals@4.2.3)
+        version: 7.0.0(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3)(web-vitals@4.2.3)
       '@guardian/eslint-config':
         specifier: 7.0.1
         version: 7.0.1(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(tslib@2.6.2)
@@ -321,19 +321,19 @@ importers:
         version: 9.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/identity-auth':
         specifier: 6.0.1
-        version: 6.0.1(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)
+        version: 6.0.1(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/identity-auth-frontend':
         specifier: 8.1.0
-        version: 8.1.0(@guardian/identity-auth@6.0.1)(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)
+        version: 8.1.0(@guardian/identity-auth@6.0.1)(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/libs':
-        specifier: 25.2.0
-        version: 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+        specifier: 0.0.0-canary-20250812112542
+        version: 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js':
         specifier: 2.3.2
         version: 2.3.2
       '@guardian/react-crossword':
         specifier: 6.3.0
-        version: 6.3.0(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
+        version: 6.3.0(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -342,10 +342,10 @@ importers:
         version: 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source-development-kitchen':
         specifier: 18.1.1
-        version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
+        version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
         specifier: 7.7.0
-        version: 7.7.0(@guardian/libs@25.2.0)(zod@3.22.4)
+        version: 7.7.0(@guardian/libs@0.0.0-canary-20250812112542)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -4712,7 +4712,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/braze-components@22.2.0(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(react@18.3.1):
+  /@guardian/braze-components@22.2.0(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(react@18.3.1):
     resolution: {integrity: sha512-uSkHd6mBVTAD+BrvJZNt+oSipYHQXBdVt9Pu/VTvkliXHzT8OUsep7ObIWM1lkf3znWbqLDhoXtwS5apX2AEWQ==}
     engines: {node: ^18.15 || ^20.8}
     peerDependencies:
@@ -4722,7 +4722,7 @@ packages:
       react: 17.0.2 || 18.2.0
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
     dev: false
@@ -4769,14 +4769,14 @@ packages:
       yargs: 17.7.2
     dev: false
 
-  /@guardian/commercial-core@27.1.0(@guardian/ab-core@8.0.0)(@guardian/libs@25.2.0):
+  /@guardian/commercial-core@27.1.0(@guardian/ab-core@8.0.0)(@guardian/libs@0.0.0-canary-20250812112542):
     resolution: {integrity: sha512-uA7bA1YzvjgbyO5qkwKzuxgYZqw0PjqCz4YYsOeDj7Zq2Xeehrjwz30m8sJurA6pQmap7C4ZJIY62pJP+W7KEw==}
     peerDependencies:
       '@guardian/ab-core': 8.0.1
       '@guardian/libs': 22.5.0
     dependencies:
       '@guardian/ab-core': 8.0.0(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@types/googletag': 3.3.0
     dev: false
 
@@ -4845,7 +4845,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/core-web-vitals@7.0.0(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)(web-vitals@4.2.3):
+  /@guardian/core-web-vitals@7.0.0(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3)(web-vitals@4.2.3):
     resolution: {integrity: sha512-1JLUQjkLY8SXYJqcy0TiE9/9hCcmyIlmMpRoW8Ygn/qGtyNxG+zzwkwsgtJIP+B0ZjtDqfukra2IV9l7wX5A0g==}
     peerDependencies:
       '@guardian/libs': ^18.0.0
@@ -4856,7 +4856,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
       web-vitals: 4.2.3
@@ -4937,7 +4937,7 @@ packages:
       - supports-color
     dev: false
 
-  /@guardian/identity-auth-frontend@8.1.0(@guardian/identity-auth@6.0.1)(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3):
+  /@guardian/identity-auth-frontend@8.1.0(@guardian/identity-auth@6.0.1)(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-2GzIsUBp8uiP+fRsKUpMrqJYSqokUCDo4q9WByi143CN0LRRWj2tVt23Y/+cZxWUuwDfRBxp1qbRnsy4QSMVLQ==}
     peerDependencies:
       '@guardian/identity-auth': ^6.0.0
@@ -4948,13 +4948,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/identity-auth': 6.0.1(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/identity-auth': 6.0.1(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
 
-  /@guardian/identity-auth@6.0.1(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3):
+  /@guardian/identity-auth@6.0.1(@guardian/libs@0.0.0-canary-20250812112542)(tslib@2.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-x6X7/+0w2ZLYZERUbkO69AjHJ7Jq2IDA5UJP8SrQPhJoTlSxKAl+13w77TcVX75IK7L8KldZscHMfOW1tSnq9g==}
     peerDependencies:
       '@guardian/libs': ^21.0.0
@@ -4964,7 +4964,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      tslib: 2.6.2
+      typescript: 5.5.3
+    dev: false
+
+  /@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3):
+    resolution: {integrity: sha512-3waUYoreQDqac9SwCG6alXp3vb3/Tg0EXP287FySMexO/D7Y1U0wbwvuknm0+v4Y4+nlCs87z0HB6Q9xMNDcHQ==}
+    peerDependencies:
+      '@guardian/ophan-tracker-js': ^2.2.10
+      tslib: ^2.6.2
+      typescript: ~5.5.2
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@guardian/ophan-tracker-js': 2.3.2
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
@@ -4978,21 +4993,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      tslib: 2.6.2
-      typescript: 5.5.3
-    dev: false
-
-  /@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3):
-    resolution: {integrity: sha512-1zwsHKRB/DjwnRyKZK6TY/r9GfZf/qK1VzUwb6EFe4CG0r94Qnz3zdEHIfF4nC8eMaua2RoCmF27b/tTEHbi5A==}
-    peerDependencies:
-      '@guardian/ophan-tracker-js': ^2.2.10
-      tslib: ^2.6.2
-      typescript: ~5.5.2
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@guardian/ophan-tracker-js': 2.3.2
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
@@ -5021,7 +5021,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@guardian/react-crossword@6.3.0(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
+  /@guardian/react-crossword@6.3.0(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3):
     resolution: {integrity: sha512-6CVNzY+yZrrUYOLpaAu7KSlyU23LBiZTFNJACI935iyjYuWEtyROoOwza82h1XconuqyEd9S8iG8CjtLb+j9Ig==}
     peerDependencies:
       '@emotion/react': ^11.11.3
@@ -5037,7 +5037,7 @@ packages:
         optional: true
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
       react: 18.3.1
@@ -5089,7 +5089,7 @@ packages:
       typescript: 5.5.3
     dev: false
 
-  /@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3):
+  /@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0)(@guardian/libs@0.0.0-canary-20250812112542)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-wuMULnVjValyEz6YjrOPt054tXJkutkAbPdeV/KQHoSCSjAJnd0Cp3SZeoVog77HE/iZ0mnKaiVkK+QXpRVtCQ==}
     peerDependencies:
       '@emotion/react': ^11.11.4
@@ -5110,7 +5110,7 @@ packages:
         optional: true
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
       react: 18.3.1
@@ -5182,7 +5182,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@7.7.0(@guardian/libs@25.2.0)(zod@3.22.4):
+  /@guardian/support-dotcom-components@7.7.0(@guardian/libs@0.0.0-canary-20250812112542)(zod@3.22.4):
     resolution: {integrity: sha512-yVDJ//dFSIZtU8vuR07iHhco8+cCp6ClYUHBIPpXgljXUBhkURcLIEYgccUssKylrWu5HfbzWuEGH5hOi1eXDw==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
@@ -5194,7 +5194,7 @@ packages:
       '@aws-sdk/client-ssm': 3.840.0
       '@aws-sdk/credential-providers': 3.840.0
       '@aws-sdk/lib-dynamodb': 3.840.0(@aws-sdk/client-dynamodb@3.840.0)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js': 2.3.1
       compression: 1.7.4
       cors: 2.8.5


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
