### PR TITLE
Add more viewports to Scrollable Highlights stories

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react';
 import { defaultCard, trails } from '../../fixtures/manual/highlights-trails';
 import { ScrollableHighlights } from './ScrollableHighlights.importable';
@@ -6,6 +7,16 @@ import { Section } from './Section';
 const meta: Meta<typeof ScrollableHighlights> = {
 	title: 'Components/Masthead/ScrollableHighlights',
 	component: ScrollableHighlights,
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.mobileLandscape,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+		},
+	},
 	render: ({ ...args }) => (
 		<Section
 			shouldCenter={true}


### PR DESCRIPTION
Includes the viewports:
```
breakpoints.mobile
breakpoints.mobileLandscape
breakpoints.tablet
breakpoints.wide
```