### PR TITLE
Hide mostpop ad slot on liveblogs at the leftcol breakpoint

### DIFF
--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -29,38 +29,50 @@ const fixedWidthsPageSkin = css`
 	}
 `;
 
-const advertMargin = (hasHideButton: boolean, isDeeplyRead: boolean) => css`
-	margin-top: 9px;
-	${from.desktop} {
-		margin-top: 0;
-		margin-left: 10px;
+const advertMargin = (
+	hasHideButton: boolean,
+	isDeeplyRead: boolean,
+	isLiveblog: boolean,
+	hasPageskin: boolean,
+) => {
+	if (hasPageskin) {
+		return css`
+			margin: 9px 0 0 10px;
+		`;
 	}
-	${from.leftCol} {
-		margin-top: 10px;
-	}
-	${from.wide} {
-		margin-left: 16px;
-	}
-	${hasHideButton && from.leftCol} {
-		margin-top: 2px;
-	}
-	${hasHideButton && from.wide} {
-		margin-top: 36px;
-	}
-	${hasHideButton && isDeeplyRead && from.desktop} {
+	return css`
 		margin-top: 9px;
-	}
-	${hasHideButton && isDeeplyRead && from.leftCol} {
-		margin-top: 38px;
-	}
-	${hasHideButton && isDeeplyRead && from.wide} {
-		margin-top: 54px;
-	}
-`;
-
-const advertMarginWithPageSkin = css`
-	margin: 9px 0 0 10px;
-`;
+		${from.desktop} {
+			margin-top: 0;
+			margin-left: 10px;
+		}
+		${from.leftCol} {
+			margin-top: 10px;
+		}
+		${from.wide} {
+			margin-left: 16px;
+		}
+		/* Due to the larger left column on liveblogs we hide the ad slot at leftcol to prevent overflow */
+		${isLiveblog && between.leftCol.and.wide} {
+			display: none;
+		}
+		${hasHideButton && from.leftCol} {
+			margin-top: 2px;
+		}
+		${hasHideButton && from.wide} {
+			margin-top: 36px;
+		}
+		${hasHideButton && isDeeplyRead && from.desktop} {
+			margin-top: 9px;
+		}
+		${hasHideButton && isDeeplyRead && from.leftCol} {
+			margin-top: 38px;
+		}
+		${hasHideButton && isDeeplyRead && from.wide} {
+			margin-top: 54px;
+		}
+	`;
+};
 
 const frontStyles = (hasPageSkin: boolean) => css`
 	${from.wide} {
@@ -89,6 +101,7 @@ type Props = {
 	isFront?: boolean;
 	renderAds?: boolean;
 	isDeeplyRead?: boolean;
+	isLiveblog?: boolean;
 };
 
 export const MostViewedFooterLayout = ({
@@ -97,6 +110,7 @@ export const MostViewedFooterLayout = ({
 	renderAds,
 	hasPageSkin = false,
 	isDeeplyRead = false,
+	isLiveblog = false,
 }: Props) => {
 	return (
 		<div
@@ -115,11 +129,12 @@ export const MostViewedFooterLayout = ({
 			</div>
 			{renderAds && (
 				<div
-					css={
-						hasPageSkin
-							? advertMarginWithPageSkin
-							: advertMargin(!!isFront, isDeeplyRead)
-					}
+					css={advertMargin(
+						!!isFront,
+						isDeeplyRead,
+						isLiveblog,
+						hasPageSkin,
+					)}
 				>
 					<AdSlot position="mostpop" />
 				</div>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1059,6 +1059,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						>
 							<MostViewedFooterLayout
 								renderAds={isWeb && renderAds}
+								isLiveblog={true}
 							>
 								<Island
 									priority="feature"


### PR DESCRIPTION
## What does this change?

This removes the `mostpop` slot on liveblogs at the `leftCol` breakpoint.

## Why?

Due to the wider left-hand column on liveblogs compared to articles and fronts at this breakpoint, the `mostpop` ad was causing overflow due to insufficient space for the 300px ad width. Reducing the size of the left column would have a knock-on effect on many other aspects of the page, including the sticky liveblog left column support ask which has a fixed width. As this issue is exclusive to liveblogs at a single breakpoint- both `desktop` and `wide` are completely fine with no overflow issues- the least disruptive approach is to simply hide the slot.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
|  <img width="1140" height="1080" alt="Screenshot 2025-08-12 at 15-03-51 Palestine Action is a ‘violent organisation’ Downing Street says after mass arrests over the weekend – as it happened Politics The Guardian" src="https://github.com/user-attachments/assets/21203bc5-f6a9-48bb-9e8b-e4f6c11d483c" /> | <img width="1140" height="1080" alt="Screenshot 2025-08-12 at 15-02-57 Palestine Action is a ‘violent organisation’ Downing Street says after mass arrests over the weekend – as it happened Politics The Guardian" src="https://github.com/user-attachments/assets/bcd3cf99-b16b-493f-950b-62c539a55cfc" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
