### PR TITLE
Add `linkTo` prop to LoopVideo for navigation tracking

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -895,6 +895,7 @@ export const Card = ({
 									fallbackImageLoading={imageLoading}
 									fallbackImageAlt={media.imageAltText}
 									fallbackImageAspectRatio="5:4"
+									linkTo={linkTo}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -116,6 +116,7 @@ type Props = {
 	fallbackImageLoading: CardPictureProps['loading'];
 	fallbackImageAlt: CardPictureProps['alt'];
 	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
+	linkTo: string;
 };
 
 export const LoopVideo = ({
@@ -130,6 +131,7 @@ export const LoopVideo = ({
 	fallbackImageLoading,
 	fallbackImageAlt,
 	fallbackImageAspectRatio,
+	linkTo,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -333,6 +335,7 @@ export const LoopVideo = ({
 					component: {
 						componentType: 'LOOP_VIDEO',
 						id: `gu-video-loop-${atomId}`,
+						labels: [linkTo],
 					},
 					action: 'VIEW',
 				},
@@ -341,7 +344,7 @@ export const LoopVideo = ({
 
 			setHasBeenInView(true);
 		}
-	}, [isInView, hasBeenInView, atomId]);
+	}, [isInView, hasBeenInView, atomId, linkTo]);
 
 	/**
 	 * Handle play/pause, when instigated by the browser.


### PR DESCRIPTION
## What does this change?
When a loop video is first in view we fire an event to ophan. This PR adds the path that the card, for which the looping video is embedded within, links to. The path is added within the labels array.

## Why?
This is to allow Data and Insight to more easily marry up card/article data. 

## Screenshots
EG the documentary card of https://www.theguardian.com/us would send the following

```
{
  "componentType": "LOOP_VIDEO",
  "id": "gu-video-loop-3e3ac527-8dab-4d9a-9ca5-311a8fe53324",
  "labels": [
    "/world/video/2025/jul/30/the-oath-to-be-a-palestinian-doctor-in-israels-healthcare-system"
  ]
}
```

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
