### PR TITLE
Place front container stories into folders within storybook

### DIFF
--- a/dotcom-rendering/src/components/DynamicFast.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: DynamicFast,
-	title: 'Components/DynamicFast',
+	title: 'Front Containers/Deprecated Containers/DynamicFast',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicPackage.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.stories.tsx
@@ -22,7 +22,7 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 
 const meta = {
 	component: DynamicPackage,
-	title: 'Components/DynamicPackage',
+	title: 'Front Containers/Deprecated Containers/DynamicPackage',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicSlow.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.stories.tsx
@@ -23,7 +23,7 @@ const defaultGroupedTrails: DCRGroupedTrails = {
 
 export default {
 	component: DynamicSlow,
-	title: 'Components/DynamicSlow',
+	title: 'Front Containers/Deprecated Containers/DynamicSlow',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
+++ b/dotcom-rendering/src/components/DynamicSlowMPU.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: DynamicSlowMPU,
-	title: 'Components/DynamicSlowMPU',
+	title: 'Front Containers/Deprecated Containers/DynamicSlowMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedLargeSlowXIV,
-	title: 'Components/FixedLargeSlowXIV',
+	title: 'Front Containers/Deprecated Containers/FixedLargeSlowXIV',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumFastXI,
-	title: 'Components/FixedMediumFastXI',
+	title: 'Front Containers/Deprecated Containers/FixedMediumFastXI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumFastXII,
-	title: 'Components/FixedMediumFastXII',
+	title: 'Front Containers/Deprecated Containers/FixedMediumFastXII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowVI,
-	title: 'Components/FixedMediumSlowVI',
+	title: 'Front Containers/Deprecated Containers/FixedMediumSlowVI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowVII,
-	title: 'Components/FixedMediumSlowVII',
+	title: 'Front Containers/Deprecated Containers/FixedMediumSlowVII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedMediumSlowXIIMPU,
-	title: 'Components/FixedMediumSlowXIIMPU',
+	title: 'Front Containers/Deprecated Containers/FixedMediumSlowXIIMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallFastVIII,
-	title: 'Components/FixedSmallFastVIII',
+	title: 'Front Containers/Deprecated Containers/FixedSmallFastVIII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowI,
-	title: 'Components/FixedSmallSlowI',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowI',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowIII,
-	title: 'Components/FixedSmallSlowIII',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowIII',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowIV,
-	title: 'Components/FixedSmallSlowIV',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowIV',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVHalf,
-	title: 'Components/FixedSmallSlowVHalf',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowVHalf',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVMPU,
-	title: 'Components/FixedSmallSlowVMPU',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowVMPU',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.stories.tsx
@@ -6,7 +6,7 @@ import { FrontSection } from './FrontSection';
 
 export default {
 	component: FixedSmallSlowVThird,
-	title: 'Components/FixedSmallSlowVThird',
+	title: 'Front Containers/Deprecated Containers/FixedSmallSlowVThird',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -138,7 +138,7 @@ type FlexibleGeneralArgsAndCustomArgs = React.ComponentProps<
 
 const meta = {
 	component: FlexibleGeneral,
-	title: 'Components/FlexibleGeneral',
+	title: 'Front Containers/FlexibleGeneral',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.stories.tsx
@@ -68,7 +68,7 @@ const liveUpdatesCard = {
 
 const meta = {
 	component: FlexibleSpecial,
-	title: 'Components/FlexibleSpecial',
+	title: 'Front Containers/FlexibleSpecial',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -61,7 +61,7 @@ const trails = new Array(6)
 
 const meta = {
 	component: ScrollableFeature,
-	title: 'Components/ScrollableFeature',
+	title: 'Front Containers/ScrollableFeature',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
@@ -5,7 +5,7 @@ import { ScrollableHighlights } from './ScrollableHighlights.importable';
 import { Section } from './Section';
 
 const meta: Meta<typeof ScrollableHighlights> = {
-	title: 'Components/Masthead/ScrollableHighlights',
+	title: 'Front Containers/ScrollableHighlights',
 	component: ScrollableHighlights,
 	parameters: {
 		chromatic: {

--- a/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 import { ScrollableMedium } from './ScrollableMedium.importable';
 
 const meta = {
-	title: 'Components/ScrollableMedium',
+	title: 'Front Containers/ScrollableMedium',
 	component: ScrollableMedium,
 	parameters: {
 		chromatic: {

--- a/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.stories.tsx
@@ -7,7 +7,7 @@ import { FrontSection } from './FrontSection';
 import { ScrollableSmall } from './ScrollableSmall.importable';
 
 const meta = {
-	title: 'Components/ScrollableSmall',
+	title: 'Front Containers/ScrollableSmall',
 	component: ScrollableSmall,
 	parameters: {
 		chromatic: {

--- a/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
@@ -13,7 +13,7 @@ import { StaticFeatureTwo } from './StaticFeatureTwo';
 
 const meta = {
 	component: StaticFeatureTwo,
-	title: 'Components/StaticFeatureTwo',
+	title: 'Front Containers/StaticFeatureTwo',
 	parameters: {
 		chromatic: {
 			viewports: [

--- a/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.stories.tsx
@@ -8,7 +8,7 @@ import { StaticMediumFour } from './StaticMediumFour';
 
 const meta = {
 	component: StaticMediumFour,
-	title: 'Components/StaticMediumFour',
+	title: 'Front Containers/StaticMediumFour',
 	parameters: {
 		chromatic: {
 			viewports: [


### PR DESCRIPTION
## What does this change?
Places front container stories in storybook in its own directory
Within `Front Containers`, deprecated container have been separated into its own `Deprecated Containers` folder.

## Why?
To help reduce overwhelm when working with fronts. 
