### PR TITLE
Fix failing playwright test

### DIFF
--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe('Affiliate links', () => {
 			await expect(disclaimerLocator).toContainText('affiliate link');
 		});
 
-		test('skimlinks should have the attribute rel="sponsored"', async ({
+		test('skimlinks should have the attribute rel="sponsored noreferrer noopener"', async ({
 			page,
 		}) => {
 			await loadPage({


### PR DESCRIPTION
## What does this change?
Updates the expected value in the `skimlinks should have the attribute rel="sponsored noreferrer noopener"` test

## Why?
We think this test failure has been caused by editorial updating the article to use the new link button which contains these new fields
