### PR TITLE
Add story packages to galleries

### DIFF
--- a/dotcom-rendering/fixtures/generated/story-package.ts
+++ b/dotcom-rendering/fixtures/generated/story-package.ts
@@ -11,7 +11,9 @@
  *    gen-fixtures.js directly.
  */
 
-export const storyPackage = {
+import type { FEStoryPackage } from '../../src/frontend/feArticle';
+
+export const storyPackage: FEStoryPackage = {
 	heading: 'More on this story',
 	trails: [
 		{

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -302,11 +302,10 @@ requests.push(
 		.then((res) => res.json())
 		.then((json) => {
 			// Write the new fixture data
-			const contents = `${HEADER}export const storyPackage = ${JSON.stringify(
-				json,
-				null,
-				4,
-			)}`;
+			const contents = `${HEADER}
+			import type { FEStoryPackage } from '../../src/frontend/feArticle';
+			
+			export const storyPackage: FEStoryPackage = ${JSON.stringify(json, null, 4)}`;
 			return fs.writeFile(
 				`${root}/fixtures/generated/story-package.ts`,
 				contents,

--- a/dotcom-rendering/src/frontend/feArticle.ts
+++ b/dotcom-rendering/src/frontend/feArticle.ts
@@ -84,10 +84,7 @@ export interface FEArticle {
 	hasRelated: boolean;
 	publication: string; // TODO: check who uses?
 	hasStoryPackage: boolean;
-	storyPackage?: {
-		trails: FETrailType[];
-		heading: string;
-	};
+	storyPackage?: FEStoryPackage;
 	onwards?: FEOnwards[];
 	beaconURL: string;
 	isCommentable: boolean;
@@ -196,4 +193,9 @@ export type FEFormat = {
 	design: FEDesign;
 	theme: FETheme;
 	display: FEDisplay;
+};
+
+export type FEStoryPackage = {
+	heading: string;
+	trails: FETrailType[];
 };

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -187,6 +187,7 @@ export const WebStandardLifestyleReviewLight: Story = {
 			display: WebStandardStandardNewsLight.args.article.display,
 			theme: Pillar.Lifestyle,
 			design: ArticleDesign.Review,
+			storyPackage: undefined,
 		},
 	},
 	parameters: webParameters,

--- a/dotcom-rendering/src/layouts/GalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { allModes } from '../../.storybook/modes';
 import { Gallery as GalleryFixture } from '../../fixtures/generated/fe-articles/Gallery';
+import { storyPackage } from '../../fixtures/generated/story-package';
 import { WithBranding } from '../components/ArticleMeta.web.stories';
 import { ArticleDesign } from '../lib/articleFormat';
 import { getCurrentPillar } from '../lib/layoutHelpers';
@@ -40,7 +41,13 @@ const addBrandingAndAffiliateDisclaimer = (gallery: Gallery): Gallery => ({
 	},
 });
 
-const appsArticle = enhanceArticleType(GalleryFixture, 'Apps');
+const appsArticle = enhanceArticleType(
+	{
+		...GalleryFixture,
+		storyPackage,
+	},
+	'Apps',
+);
 
 if (appsArticle.design !== ArticleDesign.Gallery) {
 	throw new Error('Expected gallery');
@@ -65,7 +72,13 @@ export const Apps = {
 	},
 } satisfies Story;
 
-const webArticle = enhanceArticleType(GalleryFixture, 'Web');
+const webArticle = enhanceArticleType(
+	{
+		...GalleryFixture,
+		storyPackage,
+	},
+	'Web',
+);
 
 if (webArticle.design !== ArticleDesign.Gallery) {
 	throw new Error('Expected gallery');

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -14,6 +14,7 @@ import { ArticleMetaApps } from '../components/ArticleMeta.apps';
 import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Caption } from '../components/Caption';
+import { Carousel } from '../components/Carousel.importable';
 import { Footer } from '../components/Footer';
 import { DesktopAdSlot, MobileAdSlot } from '../components/GalleryAdSlots';
 import { GalleryImage } from '../components/GalleryImage';
@@ -33,7 +34,7 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideMainMediaCaption } from '../lib/decide-caption';
 import { getAdPositions } from '../lib/getGalleryAdPositions';
 import type { NavType } from '../model/extract-nav';
-import { palette as themePalette } from '../palette';
+import { palette } from '../palette';
 import type { Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
@@ -54,10 +55,10 @@ interface AppProps extends Props {
 
 const headerStyles = css`
 	${grid.container}
-	background-color: ${themePalette('--article-inner-background')};
+	background-color: ${palette('--article-inner-background')};
 
 	${from.tablet} {
-		border-bottom: 1px solid ${themePalette('--article-border')};
+		border-bottom: 1px solid ${palette('--article-border')};
 	}
 `;
 
@@ -73,7 +74,7 @@ const metaAndDisclaimerContainer = css`
 			top: 0;
 			bottom: 0;
 			width: 1px;
-			background-color: ${themePalette('--article-border')};
+			background-color: ${palette('--article-border')};
 		}
 	}
 `;
@@ -81,11 +82,11 @@ const metaAndDisclaimerContainer = css`
 const galleryItemAdvertStyles = css`
 	${grid.paddedContainer}
 	grid-auto-flow: row dense;
-	background-color: ${themePalette('--article-inner-background')};
+	background-color: ${palette('--article-inner-background')};
 
 	${from.tablet} {
-		border-left: 1px solid ${themePalette('--article-border')};
-		border-right: 1px solid ${themePalette('--article-border')};
+		border-left: 1px solid ${palette('--article-border')};
+		border-right: 1px solid ${palette('--article-border')};
 	}
 `;
 
@@ -114,7 +115,7 @@ const galleryBorder = css`
 			top: 0;
 			bottom: 0;
 			width: 1px;
-			background-color: ${themePalette('--article-border')};
+			background-color: ${palette('--article-border')};
 		}
 	}
 
@@ -128,7 +129,7 @@ const galleryBorder = css`
 			top: 0;
 			bottom: 0;
 			width: 1px;
-			background-color: ${themePalette('--article-border')};
+			background-color: ${palette('--article-border')};
 		}
 	}
 `;
@@ -168,6 +169,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
 	const renderAds = canRenderAds(frontendData);
+	const showMerchandisingHigh = isWeb && renderAds && !isLabs;
 
 	const contributionsServiceUrl = getContributionsServiceUrl(frontendData);
 
@@ -228,7 +230,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 
 			<main
 				css={{
-					backgroundColor: themePalette('--article-background'),
+					backgroundColor: palette('--article-background'),
 				}}
 			>
 				<header css={headerStyles}>
@@ -362,14 +364,15 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					}
 				/>
 			</main>
-			{isWeb && renderAds && !isLabs && (
+			{/* More galleries container */}
+			{showMerchandisingHigh && (
 				<Section
 					fullWidth={true}
 					data-print-layout="hide"
 					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
-					backgroundColour={themePalette('--ad-background')}
+					backgroundColour={palette('--ad-background')}
 					element="aside"
 				>
 					<AdSlot
@@ -379,6 +382,14 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					/>
 				</Section>
 			)}
+			<StoryPackage
+				absoluteServerTimes={switches['absoluteServerTimes'] ?? false}
+				discussionApiUrl={discussionApiUrl}
+				format={format}
+				renderingTarget={renderingTarget}
+				storyPackage={gallery.storyPackage}
+				topBorder={showMerchandisingHigh}
+			/>
 			{/** Most Popular container goes here */}
 			{isWeb && renderAds && !isLabs && (
 				<Section
@@ -386,7 +397,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					padSides={false}
 					showTopBorder={false}
 					showSideBorders={false}
-					backgroundColour={themePalette('--ad-background')}
+					backgroundColour={palette('--ad-background')}
 					element="aside"
 				>
 					<AdSlot position="merchandising" display={format.display} />
@@ -441,9 +452,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 			{isApps && (
 				<div
 					css={{
-						backgroundColor: themePalette(
-							'--apps-footer-background',
-						),
+						backgroundColor: palette('--apps-footer-background'),
 					}}
 				>
 					<Island priority="critical">
@@ -454,3 +463,40 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 		</>
 	);
 };
+
+const StoryPackage = ({
+	storyPackage,
+	format,
+	discussionApiUrl,
+	absoluteServerTimes,
+	renderingTarget,
+	topBorder,
+}: {
+	storyPackage: Gallery['storyPackage'];
+	format: ArticleFormat;
+	discussionApiUrl: string;
+	absoluteServerTimes: boolean;
+	renderingTarget: RenderingTarget;
+	topBorder: boolean;
+}) =>
+	storyPackage === undefined ? null : (
+		<Section
+			fullWidth={true}
+			backgroundColour={palette('--article-section-background')}
+			borderColour={palette('--onward-content-border')}
+			showTopBorder={topBorder}
+		>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<Carousel
+					heading={storyPackage.heading}
+					trails={storyPackage.trails}
+					onwardsSource="more-on-this-story"
+					format={format}
+					leftColSize="compact"
+					discussionApiUrl={discussionApiUrl}
+					absoluteServerTimes={absoluteServerTimes}
+					renderingTarget={renderingTarget}
+				/>
+			</Island>
+		</Section>
+	);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6154,6 +6154,15 @@ const crosswordCluesHeaderBorderBottom: PaletteFunction = () =>
 const crosswordTextLight: PaletteFunction = () => sourcePalette.neutral[7];
 const crosswordTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
+const onwardContentBorderLight: PaletteFunction = (format) => {
+	switch (format.design) {
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
+		default:
+			return articleBorderLight(format);
+	}
+};
+
 // ----- Palette ----- //
 
 /**
@@ -7343,6 +7352,10 @@ const paletteColours = {
 	'--numbered-list-title': {
 		light: numberedListTitleLight,
 		dark: numberedListTitleDark,
+	},
+	'--onward-content-border': {
+		light: onwardContentBorderLight,
+		dark: () => sourcePalette.neutral[20],
 	},
 	'--pagination-text': {
 		light: paginationTextLight,

--- a/dotcom-rendering/src/storyPackage.ts
+++ b/dotcom-rendering/src/storyPackage.ts
@@ -1,0 +1,21 @@
+import type { FEStoryPackage } from './frontend/feArticle';
+import { decideTrail } from './lib/decideTrail';
+import type { TrailType } from './types/trails';
+
+export type StoryPackage = {
+	heading: string;
+	trails: TrailType[];
+};
+
+export const parse = (
+	feStoryPackage: FEStoryPackage | undefined,
+): StoryPackage | undefined => {
+	if (feStoryPackage === undefined) {
+		return undefined;
+	}
+
+	return {
+		heading: feStoryPackage.heading,
+		trails: feStoryPackage.trails.map(decideTrail),
+	};
+};

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -18,6 +18,7 @@ import {
 	type TableOfContentsItem,
 } from '../model/enhanceTableOfContents';
 import { enhancePinnedPost } from '../model/pinnedPost';
+import { parse as parseStoryPackage, type StoryPackage } from '../storyPackage';
 import type { FEElement, ImageBlockElement, ImageForLightbox } from './content';
 import { type RenderingTarget } from './renderingTarget';
 
@@ -36,6 +37,7 @@ export type ArticleFields = {
 	frontendData: ArticleDeprecated;
 	display: ArticleDisplay;
 	theme: ArticleTheme;
+	storyPackage: StoryPackage | undefined;
 };
 
 export type Gallery = ArticleFields & {
@@ -105,6 +107,8 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
+	const storyPackage = parseStoryPackage(data.storyPackage);
+
 	if (format.design === ArticleDesign.Gallery) {
 		const design = ArticleDesign.Gallery;
 
@@ -141,6 +145,7 @@ export const enhanceArticleType = (
 				mainMediaElements,
 				data.trailPicture,
 			),
+			storyPackage,
 		};
 	}
 
@@ -148,6 +153,7 @@ export const enhanceArticleType = (
 		design: format.design,
 		display: format.display,
 		theme: format.theme,
+		storyPackage,
 		frontendData: {
 			...data,
 			mainMediaElements,


### PR DESCRIPTION
The primary reason for this change is to add support for story packages to the new gallery layout.

At the moment every layout duplicates the same transformation on the frontend story package data, mapping over the trails with `decideTrail`. This change extracts the story package type definition and parsing into its own module, and calls the parsing code up front when the `Article` type is constructed (i.e. in one place rather than several). For now, we can only use this in galleries, as other layouts are still using the `ArticleDeprecated` type.

Also adds a type annotation to the story package fixtures, so that we can use them in stories without type errors.

Resolves #14424.

## Screenshots

**Note:** The grey box in the web screenshot is the "merchandising high" ad slot.

| Apps | Web |
|--------|--------|
| ![apps-story-package] | ![web-story-package] | 

[apps-story-package]: https://github.com/user-attachments/assets/ff8adeaa-5e0e-4e0a-8f95-536627b4c722
[web-story-package]: https://github.com/user-attachments/assets/0b700596-d1fb-4c5f-b783-d9a09e7b49b8
