### PR TITLE
Bump ophan-tracker-js

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -38,7 +38,7 @@
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
 		"@guardian/libs": "25.2.0",
-		"@guardian/ophan-tracker-js": "2.3.2",
+		"@guardian/ophan-tracker-js": "2.4.1",
 		"@guardian/react-crossword": "6.3.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,10 +327,10 @@ importers:
         version: 8.1.0(@guardian/identity-auth@6.0.1)(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/libs':
         specifier: 25.2.0
-        version: 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+        version: 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js':
-        specifier: 2.3.2
-        version: 2.3.2
+        specifier: 2.4.1
+        version: 2.4.1
       '@guardian/react-crossword':
         specifier: 6.3.0
         version: 6.3.0(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.3)
@@ -4785,7 +4785,7 @@ packages:
       react: 17.0.2 || 18.2.0
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
     dev: false
@@ -4839,7 +4839,7 @@ packages:
       '@guardian/libs': 22.5.0
     dependencies:
       '@guardian/ab-core': 8.0.0(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/googletag': 3.3.0
     dev: false
 
@@ -4919,7 +4919,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
       web-vitals: 4.2.3
@@ -4937,7 +4937,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -5012,7 +5012,7 @@ packages:
         optional: true
     dependencies:
       '@guardian/identity-auth': 6.0.1(@guardian/libs@25.2.0)(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
@@ -5027,7 +5027,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
@@ -5045,7 +5045,7 @@ packages:
       typescript: 5.5.3
     dev: false
 
-  /@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3):
+  /@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3):
     resolution: {integrity: sha512-1zwsHKRB/DjwnRyKZK6TY/r9GfZf/qK1VzUwb6EFe4CG0r94Qnz3zdEHIfF4nC8eMaua2RoCmF27b/tTEHbi5A==}
     peerDependencies:
       '@guardian/ophan-tracker-js': ^2.2.10
@@ -5055,7 +5055,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/ophan-tracker-js': 2.3.2
+      '@guardian/ophan-tracker-js': 2.4.1
       tslib: 2.6.2
       typescript: 5.5.3
     dev: false
@@ -5067,8 +5067,8 @@ packages:
       '@guardian/tsconfig': 1.0.0
     dev: false
 
-  /@guardian/ophan-tracker-js@2.3.2:
-    resolution: {integrity: sha512-JNdoCXqJSLYGiu8aWxDkYaLVtyYbWkmkEM8jq6x/3Cpo7om87qw46ycjkEOSj7zt0Kw4rXj1bdodUukVRrRmiA==}
+  /@guardian/ophan-tracker-js@2.4.1:
+    resolution: {integrity: sha512-2u/1So21U5zxkLKBwLGOJMIeKf4Y5oNqo5xYlFf84PgVMamuxYPZX1x+Gq95x2fy+qGltJW19djRvdJMp2hR9g==}
     engines: {node: '>=16'}
     dependencies:
       '@guardian/tsconfig': 1.0.0
@@ -5100,7 +5100,7 @@ packages:
         optional: true
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
       react: 18.3.1
@@ -5173,7 +5173,7 @@ packages:
         optional: true
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 10.2.0(@emotion/react@11.14.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@types/react': 18.3.1
       react: 18.3.1
@@ -5257,7 +5257,7 @@ packages:
       '@aws-sdk/client-ssm': 3.840.0
       '@aws-sdk/credential-providers': 3.840.0
       '@aws-sdk/lib-dynamodb': 3.840.0(@aws-sdk/client-dynamodb@3.840.0)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.3.2)(tslib@2.6.2)(typescript@5.5.3)
+      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js': 2.3.1
       compression: 1.7.4
       cors: 2.8.5
@@ -7400,7 +7400,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8988,8 +8988,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.101.0):
@@ -8999,8 +8999,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.1)(webpack@5.101.0):
@@ -9014,8 +9014,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-server: 5.2.1(webpack-cli@6.0.1)(webpack@5.101.0)
     dev: false
 
@@ -10685,7 +10685,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.5.4)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /css-loader@7.1.2(webpack@5.101.0):
@@ -11755,7 +11755,7 @@ packages:
       enhanced-resolve: 5.18.1
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -12750,7 +12750,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.2
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /form-data-encoder@2.1.4:
@@ -18072,7 +18072,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -18555,7 +18555,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.11.31)(@types/node@16.18.68)(typescript@5.1.6):
@@ -19300,7 +19300,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.2
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /webpack-dev-middleware@7.4.2(webpack@5.101.0):
@@ -19360,8 +19360,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-middleware: 7.4.2(webpack@5.101.0)
       ws: 8.18.1
     transitivePeerDependencies:
@@ -19406,7 +19406,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

## Why?

Bumps `ophan-tracker-js` to allow tracking of pageviews that come from `bfcache`. See release notes: https://www.npmjs.com/package/@guardian/ophan-tracker-js/v/2.4.1

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
