### PR TITLE
Container image is tagged with main on the main branch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,3 +1,5 @@
+# Commercial also use this container image for their E2E tests
+# Commercial rely on a container image built from the main branch with the tag 'main'
 on:
   workflow_call:
     outputs:
@@ -19,9 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.5.0
-
       - name: Set up Node environment
         uses: ./.github/actions/setup-node-env
 
@@ -39,7 +38,8 @@ jobs:
         uses: redhat-actions/buildah-build@v2.13
         with:
           image: dotcom-rendering
-          tags: ${{ github.sha }} ${{ env.GITHUB_REF_SLUG }}
+          # Commercial rely on a container image built from the main branch with the tag 'main'
+          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
           context: ./
           containerfiles: ./dotcom-rendering/Containerfile
 


### PR DESCRIPTION
## What does this change?

Follow up to:
#14412 
#14427 

## Why?

Removes the 3rd party action `rlespinasse/github-slug-action@v4.5.0`.

Applies the `main` tag when on the main branch.

This allows Commercial to pull the container image for their E2E tests.

