### PR TITLE
Doml/header cls

### DIFF
--- a/dotcom-rendering/src/components/TopBar.importable.tsx
+++ b/dotcom-rendering/src/components/TopBar.importable.tsx
@@ -147,61 +147,69 @@ export const TopBar = ({
 					/>
 				</TopBarLinkContainer>
 
-				<Hide until="desktop">
-					<TopBarLinkContainer>
-						<TopBarLink
-							dataLinkName={nestedOphanComponents(
-								'header',
-								'topbar',
-								'printsubs',
-							)}
-							href={printSubscriptionsHref}
-						>
-							Print subscriptions
-						</TopBarLink>
-					</TopBarLinkContainer>
-				</Hide>
-
-				<Hide until="desktop">
-					<TopBarLinkContainer>
-						{
-							/** We replace "Search jobs" with "Newsletters" for AU and US editions */
-							['AU', 'US'].includes(editionId) ? (
+				{authStatus.kind !== 'Pending' && (
+					<>
+						<Hide until="desktop">
+							<TopBarLinkContainer>
 								<TopBarLink
 									dataLinkName={nestedOphanComponents(
 										'header',
 										'topbar',
-										'newsletters',
+										'printsubs',
 									)}
-									href="/email-newsletters"
+									href={printSubscriptionsHref}
 								>
-									Newsletters
+									Print subscriptions
 								</TopBarLink>
-							) : (
-								<TopBarLink
-									dataLinkName={nestedOphanComponents(
-										'header',
-										'topbar',
-										'job-cta',
-									)}
-									href="https://jobs.theguardian.com"
-								>
-									Search jobs
-								</TopBarLink>
-							)
-						}
-					</TopBarLinkContainer>
-				</Hide>
+							</TopBarLinkContainer>
+						</Hide>
 
-				<TopBarLinkContainer isLastChild={true}>
-					<TopBarMyAccount
-						mmaUrl={mmaUrl ?? 'https://manage.theguardian.com'}
-						idUrl={idUrl ?? 'https://profile.theguardian.com'}
-						discussionApiUrl={discussionApiUrl}
-						idApiUrl={idApiUrl}
-						authStatus={authStatus}
-					/>
-				</TopBarLinkContainer>
+						<Hide until="desktop">
+							<TopBarLinkContainer>
+								{
+									/** We replace "Search jobs" with "Newsletters" for AU and US editions */
+									['AU', 'US'].includes(editionId) ? (
+										<TopBarLink
+											dataLinkName={nestedOphanComponents(
+												'header',
+												'topbar',
+												'newsletters',
+											)}
+											href="/email-newsletters"
+										>
+											Newsletters
+										</TopBarLink>
+									) : (
+										<TopBarLink
+											dataLinkName={nestedOphanComponents(
+												'header',
+												'topbar',
+												'job-cta',
+											)}
+											href="https://jobs.theguardian.com"
+										>
+											Search jobs
+										</TopBarLink>
+									)
+								}
+							</TopBarLinkContainer>
+						</Hide>
+
+						<TopBarLinkContainer isLastChild={true}>
+							<TopBarMyAccount
+								mmaUrl={
+									mmaUrl ?? 'https://manage.theguardian.com'
+								}
+								idUrl={
+									idUrl ?? 'https://profile.theguardian.com'
+								}
+								discussionApiUrl={discussionApiUrl}
+								idApiUrl={idApiUrl}
+								authStatus={authStatus}
+							/>
+						</TopBarLinkContainer>
+					</>
+				)}
 			</div>
 		</Grid>
 	);

--- a/dotcom-rendering/src/components/TopBarMyAccount.tsx
+++ b/dotcom-rendering/src/components/TopBarMyAccount.tsx
@@ -262,9 +262,9 @@ export const TopBarMyAccount = ({
 }: MyAccountProps) => {
 	const { renderingTarget } = useConfig();
 
-	return (
-		<>
-			{authStatus.kind === 'SignedIn' ? (
+	switch (authStatus.kind) {
+		case 'SignedIn':
+			return (
 				<SignedInBraze
 					mmaUrl={mmaUrl}
 					idUrl={idUrl}
@@ -273,9 +273,10 @@ export const TopBarMyAccount = ({
 					authStatus={authStatus}
 					renderingTarget={renderingTarget}
 				/>
-			) : (
-				<SignIn idUrl={idUrl} />
-			)}
-		</>
-	);
+			);
+		case 'SignedOut':
+			return <SignIn idUrl={idUrl} />;
+		default:
+			return null;
+	}
 };


### PR DESCRIPTION
## What does this change?

Prevent flicker from 'sign in' to 'my account'
Delay showing right-hand side of the top bar on desktop until the sign-in state is known

## Why?

Fix CLS, flickering

TODO - Questions to resolve before opening PR
- What about no JS users? 
- What if it takes a really long time to get auth state? 
- What if we cant get auth state?

TODO - update stories to include sign in states

## Screenshots

#### CLS
<img width="728" height="552" alt="Screenshot 2025-08-21 at 11 10 35" src="https://github.com/user-attachments/assets/97d63f85-4ba5-4464-baa5-bd2924cbe9df" />

#### Flicker
https://github.com/user-attachments/assets/9e36da78-392d-4f4b-a046-aef2fcdf33e2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
