### PR TITLE
2-step banner: hide ticker + image when collapsed

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -345,7 +345,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 							}
 						/>
 					</div>
-					{showAboveArticleCount && (
+					{showAboveArticleCount && !isCollapsed && (
 						<div css={styles.articleCountContainer}>
 							<DesignableBannerArticleCount
 								numArticles={articleCounts.forTargetedWeeks}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -355,6 +355,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						</div>
 					)}
 					{tickerSettings?.tickerData &&
+						!isCollapsed &&
 						templateSettings.tickerStylingSettings && (
 							<div css={templateSpacing.bannerTicker}>
 								<Ticker
@@ -389,7 +390,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 					)}
 				</div>
 
-				{templateSettings.imageSettings && (
+				{templateSettings.imageSettings && !isCollapsed && (
 					<div css={styles.bannerVisualContainer}>
 						<DesignableBannerVisual
 							settings={templateSettings.imageSettings}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -358,6 +358,9 @@ export const CollapsableWithThreeTierChoiceCards: Story = {
 		choiceCardAmounts: regularChoiceCardAmounts,
 		choiceCardsSettings,
 		tickerSettings,
+		separateArticleCountSettings: {
+			type: 'above',
+		},
 	},
 };
 

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -357,5 +357,21 @@ export const CollapsableWithThreeTierChoiceCards: Story = {
 		},
 		choiceCardAmounts: regularChoiceCardAmounts,
 		choiceCardsSettings,
+		tickerSettings,
+	},
+};
+
+export const CollapsableWithMainImage: Story = {
+	name: 'Collapsable with main image',
+	args: {
+		...meta.args,
+		design: {
+			...design,
+			visual: regularImage,
+		},
+		tracking: {
+			...tracking,
+			abTestVariant: 'COLLAPSABLE_V1',
+		},
 	},
 };


### PR DESCRIPTION
## What does this change?
We recently introduced a 2-step banner, where the user must first click a "collapse" button before the "close" button appears.
We now want to hide the following when the banner is in the collapsed state:
- ticker
- main image
- article count

## Why?
The collapsed banner should be very small, and the ticker and image are too large.

## Screenshots

### Banner with ticker + article count:
<img width="1140" height="462" alt="Screenshot 2025-08-21 at 13 31 21" src="https://github.com/user-attachments/assets/ae68ce84-5ae3-4229-a562-4738157b52c4" />


<img width="1113" height="91" alt="Screenshot 2025-08-21 at 11 48 40" src="https://github.com/user-attachments/assets/223779fb-ab83-4354-8f29-e11d6619f2b5" />

### Banner with main image:
<img width="1113" height="387" alt="Screenshot 2025-08-21 at 11 53 45" src="https://github.com/user-attachments/assets/acd33018-94c7-4fd9-8dc7-641f33f68329" />

<img width="1113" height="138" alt="Screenshot 2025-08-21 at 11 48 46" src="https://github.com/user-attachments/assets/18dbddd6-cbc4-4f46-8d50-c17a3bb0b8d7" />
