### PR TITLE
Don't float rich link on small screens

### DIFF
--- a/dotcom-rendering/src/components/Figure.tsx
+++ b/dotcom-rendering/src/components/Figure.tsx
@@ -116,6 +116,7 @@ const roleCss = {
 		@media (max-width: 23.4rem) {
 			width: 100%;
 			box-sizing: border-box;
+			float: none;
 
 			img,
 			.avatar {


### PR DESCRIPTION
## What does this change?

On small screens, rich links display at 100% width. It therefore doesn't make sense to apply `float: left` at this breakpoint.

## Why?

It's causing weirdness when the rich link is immediately followed by a list. The bullet ends up getting smooshed next to the rich link (see screenshot).

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="374" height="1035" alt="Screenshot 2025-08-21 at 13 52 39" src="https://github.com/user-attachments/assets/b7348422-0a4b-4861-9e68-598385976ce1" />   | <img width="374" height="1035" alt="Screenshot 2025-08-21 at 13 52 25" src="https://github.com/user-attachments/assets/249d838e-1870-4779-84d6-544ca1f1247f" /> |