### PR TITLE
Google One Tap: New Client IDs, Ophan Tracking, and Email-only redirect

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -14,7 +14,7 @@ import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { EnhanceAffiliateLinks } from './EnhanceAffiliateLinks.importable';
 import { FocusStyles } from './FocusStyles.importable';
-import { GoogleOneTap, isInGoogleOneTapTest } from './GoogleOneTap.importable';
+import { GoogleOneTap, isGoogleOneTapEnabled } from './GoogleOneTap.importable';
 import { Island } from './Island';
 import { Lightbox } from './Lightbox';
 import { Metrics } from './Metrics.importable';
@@ -140,7 +140,10 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							}
 						/>
 					</Island>
-					{isInGoogleOneTapTest(frontendData.config.abTests) && (
+					{isGoogleOneTapEnabled(
+						frontendData.config.abTests,
+						frontendData.config.switches,
+					) && (
 						<Island
 							priority="enhancement"
 							defer={{ until: 'idle' }}

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -14,6 +14,7 @@ import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { EnhanceAffiliateLinks } from './EnhanceAffiliateLinks.importable';
 import { FocusStyles } from './FocusStyles.importable';
+import { GoogleOneTap, isInGoogleOneTapTest } from './GoogleOneTap.importable';
 import { Island } from './Island';
 import { Lightbox } from './Lightbox';
 import { Metrics } from './Metrics.importable';
@@ -139,6 +140,14 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 							}
 						/>
 					</Island>
+					{isInGoogleOneTapTest(frontendData.config.abTests) && (
+						<Island
+							priority="enhancement"
+							defer={{ until: 'idle' }}
+						>
+							<GoogleOneTap />
+						</Island>
+					)}
 				</>
 			)}
 			{renderingTarget === 'Web' ? (

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -12,7 +12,7 @@ import { BrazeMessaging } from './BrazeMessaging.importable';
 import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
-import { GoogleOneTap, isInGoogleOneTapTest } from './GoogleOneTap.importable';
+import { GoogleOneTap, isGoogleOneTapEnabled } from './GoogleOneTap.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { ReaderRevenueDev } from './ReaderRevenueDev.importable';
@@ -93,7 +93,10 @@ export const FrontPage = ({ front, NAV }: Props) => {
 			<Island priority="feature" defer={{ until: 'idle' }}>
 				<ReaderRevenueDev shouldHideReaderRevenue={false} />
 			</Island>
-			{isInGoogleOneTapTest(front.config.abTests) && (
+			{isGoogleOneTapEnabled(
+				front.config.abTests,
+				front.config.switches,
+			) && (
 				<Island priority="enhancement" defer={{ until: 'idle' }}>
 					<GoogleOneTap />
 				</Island>

--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -6,7 +6,7 @@ import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useConsent } from '../lib/useConsent';
 import { useCountryCode } from '../lib/useCountryCode';
 import { useOnce } from '../lib/useOnce';
-import type { ServerSideTests, StageType } from '../types/config';
+import type { ServerSideTests, StageType, Switches } from '../types/config';
 
 type IdentityProviderConfig = {
 	configURL: string;
@@ -23,8 +23,12 @@ type CredentialsProvider = {
 	}) => Promise<{ token: string }>;
 };
 
-export const isInGoogleOneTapTest = (tests: ServerSideTests): boolean =>
-	tests['googleOneTapVariant'] === 'variant';
+export const isGoogleOneTapEnabled = (
+	tests: ServerSideTests,
+	switches: Switches,
+): boolean =>
+	tests['googleOneTapVariant'] === 'variant' ||
+	switches['googleOneTapSwitch'] === true;
 
 /**
  * Detect the current stage of the application based on the hostname.

--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -64,14 +64,14 @@ export const getRedirectUrl = ({
 	return `${profileDomain}/signin/google?${queryParams.toString()}`;
 };
 
-// TODO: Do we want to use different Google Client IDs for One Tap than we use for social sign in?
 const getProviders = (stage: StageType): IdentityProviderConfig[] => {
 	switch (stage) {
 		case 'PROD':
 			return [
 				{
 					configURL: 'https://accounts.google.com/gsi/fedcm.json',
-					clientId: '774465807556.apps.googleusercontent.com',
+					clientId:
+						'774465807556-4d50ur6svcjj90l7fe6i0bnp4t4qhkga.apps.googleusercontent.com',
 				},
 			];
 		case 'CODE':
@@ -79,9 +79,8 @@ const getProviders = (stage: StageType): IdentityProviderConfig[] => {
 			return [
 				{
 					configURL: 'https://accounts.google.com/gsi/fedcm.json',
-					// TODO: m.code.dev-theguardian.com is not a supported origin for this Client ID
 					clientId:
-						'774465807556-pkevncqpfs9486ms0bo5q1f2g9vhpior.apps.googleusercontent.com',
+						'774465807556-h24eigcs027mj7sunatfem926c4310jo.apps.googleusercontent.com',
 				},
 			];
 	}

--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -1,8 +1,10 @@
+import type { CountryCode } from '@guardian/libs';
 import { log } from '@guardian/libs';
 import type { TAction, TComponentType } from '@guardian/ophan-tracker-js';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useConsent } from '../lib/useConsent';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useOnce } from '../lib/useOnce';
 import type { ServerSideTests, StageType } from '../types/config';
 
@@ -108,9 +110,10 @@ const getProviders = (stage: StageType): IdentityProviderConfig[] => {
 
 export const initializeFedCM = async ({
 	isSignedIn,
+	countryCode,
 }: {
 	isSignedIn?: boolean;
-	isInTest?: boolean;
+	countryCode?: CountryCode;
 }): Promise<void> => {
 	const isSupported = 'IdentityCredential' in window;
 
@@ -131,6 +134,8 @@ export const initializeFedCM = async ({
 		'Web',
 	);
 
+	// TODO: Expand Google One Tap to outside Ireland
+	if (countryCode !== 'IE') return;
 	if (isSignedIn) return;
 
 	/**
@@ -256,6 +261,7 @@ export const GoogleOneTap = () => {
 	// TODO: FedCM doesn't require cookies? Do we need to check consent?
 	const consent = useConsent();
 	const isSignedIn = useIsSignedIn();
+	const countryCode = useCountryCode('google-one-tap');
 	// useIsSignedIn returns 'Pending' until the auth status is known.
 	// We don't want to initialize FedCM until we know the auth status, so we pass `undefined` to `useOnce` if it is 'Pending'
 	// to stop it from initializing.
@@ -265,6 +271,7 @@ export const GoogleOneTap = () => {
 	useOnce(() => {
 		void initializeFedCM({
 			isSignedIn: isSignedInWithoutPending,
+			countryCode,
 		});
 	}, [isSignedInWithoutPending, consent]);
 

--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -119,7 +119,12 @@ export const initializeFedCM = async ({
 	isSignedIn?: boolean;
 	countryCode?: CountryCode;
 }): Promise<void> => {
-	const isSupported = 'IdentityCredential' in window;
+	// If the window doesn't support "hover" interactions we assume its a touch only device (e.g. mobile)
+	// and we don't show Google One Tap. This is because mobile browsers render Google One Tap differently
+	// which can potentially cover the reader revenue banner and lead to a poor user experience.
+	const isSupported =
+		'IdentityCredential' in window &&
+		window.matchMedia('(any-hover: hover)').matches;
 
 	void submitComponentEvent(
 		{

--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -255,10 +255,8 @@ export const initializeFedCM = async ({
 	}
 };
 
-// TODO: GoogleOneTap is currently only used on the front page, but we do probably want to use it on other pages in the future.
 export const GoogleOneTap = () => {
 	// We don't care what consent we get, we just want to make sure Google One Tap is not shown above the consent banner.
-	// TODO: FedCM doesn't require cookies? Do we need to check consent?
 	const consent = useConsent();
 	const isSignedIn = useIsSignedIn();
 	const countryCode = useCountryCode('google-one-tap');

--- a/dotcom-rendering/src/components/GoogleOneTap.test.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.test.tsx
@@ -106,7 +106,8 @@ describe('GoogleOneTap', () => {
 				context: 'continue',
 				providers: [
 					{
-						clientId: '774465807556.apps.googleusercontent.com',
+						clientId:
+							'774465807556-4d50ur6svcjj90l7fe6i0bnp4t4qhkga.apps.googleusercontent.com',
 						configURL: 'https://accounts.google.com/gsi/fedcm.json',
 					},
 				],
@@ -139,7 +140,8 @@ describe('GoogleOneTap', () => {
 				context: 'continue',
 				providers: [
 					{
-						clientId: '774465807556.apps.googleusercontent.com',
+						clientId:
+							'774465807556-4d50ur6svcjj90l7fe6i0bnp4t4qhkga.apps.googleusercontent.com',
 						configURL: 'https://accounts.google.com/gsi/fedcm.json',
 					},
 				],

--- a/dotcom-rendering/src/components/GoogleOneTap.test.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.test.tsx
@@ -94,7 +94,7 @@ describe('GoogleOneTap', () => {
 			replace: locationReplace,
 		});
 
-		await initializeFedCM({ isSignedIn: false });
+		await initializeFedCM({ isSignedIn: false, countryCode: 'IE' });
 
 		expect(navigatorGet).toHaveBeenCalledWith({
 			identity: {
@@ -150,7 +150,7 @@ describe('GoogleOneTap', () => {
 			replace: locationReplace,
 		});
 
-		await initializeFedCM({ isSignedIn: false });
+		await initializeFedCM({ isSignedIn: false, countryCode: 'IE' });
 
 		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
 			1,
@@ -205,9 +205,9 @@ describe('GoogleOneTap', () => {
 			replace: locationReplace,
 		});
 
-		await expect(initializeFedCM({ isSignedIn: false })).rejects.toThrow(
-			'window.navigator.credentials.get failed',
-		);
+		await expect(
+			initializeFedCM({ isSignedIn: false, countryCode: 'IE' }),
+		).rejects.toThrow('window.navigator.credentials.get failed');
 
 		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
 			1,
@@ -249,7 +249,7 @@ describe('GoogleOneTap', () => {
 			enableFedCM: false,
 		});
 
-		await initializeFedCM({ isSignedIn: false });
+		await initializeFedCM({ isSignedIn: false, countryCode: 'IE' });
 
 		expect(submitComponentEventMock).toHaveBeenCalledTimes(1);
 		expect(submitComponentEventMock).toHaveBeenCalledWith(
@@ -276,13 +276,13 @@ describe('GoogleOneTap', () => {
 			replace: locationReplace,
 		});
 
-		await initializeFedCM({ isSignedIn: true });
+		await initializeFedCM({ isSignedIn: true, countryCode: 'IE' });
 
 		expect(navigatorGet).not.toHaveBeenCalled();
 		expect(locationReplace).not.toHaveBeenCalled();
 	});
 
-	it('should not initializeFedCM when user is not in test', async () => {
+	it('should not initializeFedCM when user is not in Ireland', async () => {
 		const navigatorGet = jest.fn();
 		const locationReplace = jest.fn();
 
@@ -291,7 +291,7 @@ describe('GoogleOneTap', () => {
 			replace: locationReplace,
 		});
 
-		await initializeFedCM({ isSignedIn: true });
+		await initializeFedCM({ isSignedIn: false, countryCode: 'GB' });
 
 		expect(submitComponentEventMock).toHaveBeenCalledTimes(1);
 		expect(submitComponentEventMock).toHaveBeenCalledWith(

--- a/dotcom-rendering/src/components/GoogleOneTap.test.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.test.tsx
@@ -1,4 +1,5 @@
 import { submitComponentEvent as submitComponentEventMock } from '../client/ophan/ophan';
+import { error, ok } from '../lib/result';
 import {
 	extractEmailFromToken,
 	getRedirectUrl,
@@ -79,11 +80,11 @@ describe('GoogleOneTap', () => {
 			extractEmailFromToken(
 				'NULL.eyJlbWFpbCI6InZhbGlkQGVtYWlsLmNvbSJ9.NULL',
 			),
-		).toEqual('valid@email.com');
+		).toEqual(ok('valid@email.com'));
 	});
 
 	it('should return undefined from a malformed JWT token', () => {
-		expect(extractEmailFromToken('NULL')).toEqual(undefined);
+		expect(extractEmailFromToken('NULL')).toEqual(error('ParsingError'));
 	});
 
 	it('should initializeFedCM and redirect to Gateway with token on success', async () => {
@@ -144,10 +145,10 @@ describe('GoogleOneTap', () => {
 	});
 
 	it('should initializeFedCM and not redirect to Gateway with token on failure', async () => {
-		const error = new Error('Network Error');
-		error.name = 'NetworkError';
+		const e = new Error('Network Error');
+		e.name = 'NetworkError';
 
-		const navigatorGet = jest.fn(() => Promise.reject(error));
+		const navigatorGet = jest.fn(() => Promise.reject(e));
 		const locationReplace = jest.fn();
 
 		mockWindow({
@@ -199,10 +200,10 @@ describe('GoogleOneTap', () => {
 	});
 
 	it('should initializeFedCM and throw error when unexpected', async () => {
-		const error = new Error('window.navigator.credentials.get failed');
-		error.name = 'DOMException';
+		const e = new Error('window.navigator.credentials.get failed');
+		e.name = 'DOMException';
 
-		const navigatorGet = jest.fn(() => Promise.reject(error));
+		const navigatorGet = jest.fn(() => Promise.reject(e));
 		const locationReplace = jest.fn();
 
 		mockWindow({

--- a/dotcom-rendering/src/components/GoogleOneTap.test.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.test.tsx
@@ -1,4 +1,9 @@
+import { submitComponentEvent as submitComponentEventMock } from '../client/ophan/ophan';
 import { getRedirectUrl, initializeFedCM } from './GoogleOneTap.importable';
+
+jest.mock('../client/ophan/ophan', () => ({
+	submitComponentEvent: jest.fn(),
+}));
 
 const mockWindow = ({
 	replace,
@@ -23,6 +28,10 @@ const mockWindow = ({
 	});
 
 describe('GoogleOneTap', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('should return the correct signin URL after constructing it with the provided stage and token', () => {
 		expect(
 			getRedirectUrl({
@@ -85,6 +94,29 @@ describe('GoogleOneTap', () => {
 		expect(locationReplace).toHaveBeenCalledWith(
 			'https://profile.theguardian.com/signin/google?token=test-token&returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fuk',
 		);
+
+		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
+			1,
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'DETECT',
+				value: 'SUPPORTED',
+			},
+			'Web',
+		);
+
+		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
+			2,
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'SIGN_IN',
+			},
+			'Web',
+		);
 	});
 
 	it('should initializeFedCM and not redirect to Gateway with token on failure', async () => {
@@ -100,6 +132,29 @@ describe('GoogleOneTap', () => {
 		});
 
 		await initializeFedCM({ isSignedIn: false });
+
+		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
+			1,
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'DETECT',
+				value: 'SUPPORTED',
+			},
+			'Web',
+		);
+
+		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
+			2,
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'CLOSE',
+			},
+			'Web',
+		);
 
 		expect(navigatorGet).toHaveBeenCalledWith({
 			identity: {
@@ -135,6 +190,18 @@ describe('GoogleOneTap', () => {
 			'window.navigator.credentials.get failed',
 		);
 
+		expect(submitComponentEventMock).toHaveBeenNthCalledWith(
+			1,
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'DETECT',
+				value: 'SUPPORTED',
+			},
+			'Web',
+		);
+
 		expect(navigatorGet).toHaveBeenCalledWith({
 			identity: {
 				context: 'continue',
@@ -165,6 +232,18 @@ describe('GoogleOneTap', () => {
 
 		await initializeFedCM({ isSignedIn: false });
 
+		expect(submitComponentEventMock).toHaveBeenCalledTimes(1);
+		expect(submitComponentEventMock).toHaveBeenCalledWith(
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'DETECT',
+				value: 'NOT_SUPPORTED',
+			},
+			'Web',
+		);
+
 		expect(navigatorGet).not.toHaveBeenCalled();
 		expect(locationReplace).not.toHaveBeenCalled();
 	});
@@ -194,6 +273,18 @@ describe('GoogleOneTap', () => {
 		});
 
 		await initializeFedCM({ isSignedIn: true });
+		
+		expect(submitComponentEventMock).toHaveBeenCalledTimes(1);
+		expect(submitComponentEventMock).toHaveBeenCalledWith(
+			{
+				component: {
+					componentType: 'SIGN_IN_GOOGLE_ONE_TAP',
+				},
+				action: 'DETECT',
+				value: 'SUPPORTED',
+			},
+			'Web',
+		);
 
 		expect(navigatorGet).not.toHaveBeenCalled();
 		expect(locationReplace).not.toHaveBeenCalled();

--- a/dotcom-rendering/src/components/TagPage.tsx
+++ b/dotcom-rendering/src/components/TagPage.tsx
@@ -11,6 +11,7 @@ import { AlreadyVisited } from './AlreadyVisited.importable';
 import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
+import { GoogleOneTap, isInGoogleOneTapTest } from './GoogleOneTap.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { SetABTests } from './SetABTests.importable';
@@ -82,6 +83,11 @@ export const TagPage = ({ tagPage, NAV }: Props) => {
 			<Island priority="critical">
 				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
+			{isInGoogleOneTapTest(tagPage.config.abTests) && (
+				<Island priority="enhancement" defer={{ until: 'idle' }}>
+					<GoogleOneTap />
+				</Island>
+			)}
 			{darkModeAvailable && (
 				<DarkModeMessage>
 					Dark mode is a work-in-progress.

--- a/dotcom-rendering/src/components/TagPage.tsx
+++ b/dotcom-rendering/src/components/TagPage.tsx
@@ -11,7 +11,7 @@ import { AlreadyVisited } from './AlreadyVisited.importable';
 import { useConfig } from './ConfigContext';
 import { DarkModeMessage } from './DarkModeMessage';
 import { FocusStyles } from './FocusStyles.importable';
-import { GoogleOneTap, isInGoogleOneTapTest } from './GoogleOneTap.importable';
+import { GoogleOneTap, isGoogleOneTapEnabled } from './GoogleOneTap.importable';
 import { Island } from './Island';
 import { Metrics } from './Metrics.importable';
 import { SetABTests } from './SetABTests.importable';
@@ -83,7 +83,10 @@ export const TagPage = ({ tagPage, NAV }: Props) => {
 			<Island priority="critical">
 				<SetAdTargeting adTargeting={adTargeting} />
 			</Island>
-			{isInGoogleOneTapTest(tagPage.config.abTests) && (
+			{isGoogleOneTapEnabled(
+				tagPage.config.abTests,
+				tagPage.config.switches,
+			) && (
 				<Island priority="enhancement" defer={{ until: 'idle' }}>
 					<GoogleOneTap />
 				</Island>


### PR DESCRIPTION
## What does this change?

- **Use Google One Tap specific Client IDs**
  
  We don't need to use the same client IDs as we use for Google Social Sign in, so we may aswell separate concerns a bit and have a client ID specifically for Google One Tap.

- **Only include the users email the URL when redirecting to Gateway**

  This PR changes the Google One Tap redirect to only include the email field in the redirect, instead of the full Google ID token. This is because we only need the users email address to sign them in and we don't need to verify their ID token.
  
  The flow for Google One Tap is described in https://github.com/guardian/gateway/blob/7f40d65a5cda534b47e266e5f2f2a7f4255c46d0/docs/google-one-tap.md#enhanced-social-sign-in-approach

- **Limit experiment scope to Ireland**

- **Add Ophan tracking**

  We'll be using the following actions to track users interactions with Google One Tap:

  - `DETECT` - Whether or not the browser supports Google One Tap, stored in the `value`. If the browser does support Google One Tap we show the prompt and record one of the 2 following actions.
  - `CLOSE` - We've requested that the browser shows the prompt, but for various reasons its declined. Due to privacy concerns the browser does not reveal why the prompt was declined, which could be that the user was not logged into a google account, or they pressed the "X" to close the prompt, or an error occured trying to show the prompt.
  - `SIGN_IN` - The reader accepts the Google One Tap prompt and is redirected to https://profile.theguardian.com to finish their login.

## Screenshots


https://github.com/user-attachments/assets/53d19ae0-c7ed-44cd-b05f-5688cd4f725c



