### PR TITLE
Update font sizes at mobile breakpoints

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -227,7 +227,7 @@ export const CardHeadline = ({
 					css={css`
 						color: ${headlineColour};
 					`}
-					className="show-underline"
+					className="show-underline headline-text"
 				>
 					{headlineText}
 					{isExternalLink && (

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -101,7 +101,10 @@ const content = css`
 		padding-bottom: 10px;
 	}
 
-	/* We're deliberately using a font-size that is not in Source at a particular breakpoint */
+	/**
+	 * We're deliberately using a font-size that is not in Source so that
+	 * the headline doesn't exceed three lines across all mobile breakpoints
+	 */
 	${between.mobileMedium.and.mobileLandscape} {
 		.headline-text {
 			font-size: 1rem;

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -100,6 +100,13 @@ const content = css`
 	${from.tablet} {
 		padding-bottom: 10px;
 	}
+
+	/* We're deliberately using a font-size that is not in Source at a particular breakpoint */
+	${between.mobileMedium.and.mobileLandscape} {
+		.headline-text {
+			font-size: 1rem;
+		}
+	}
 `;
 
 const starWrapper = css`
@@ -144,7 +151,7 @@ export const HighlightsCard = ({
 							desktop: 'xxsmall',
 							tablet: 'xxsmall',
 							mobileMedium: 'xxsmall',
-							mobile: 'tiny',
+							mobile: 'xxxsmall',
 						}}
 						showPulsingDot={
 							format.design === ArticleDesign.LiveBlog

--- a/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof ScrollableHighlights> = {
 		chromatic: {
 			viewports: [
 				breakpoints.mobile,
+				breakpoints.mobileMedium,
 				breakpoints.mobileLandscape,
 				breakpoints.tablet,
 				breakpoints.wide,


### PR DESCRIPTION
## What does this change?

Update font-size from 17px to 16px at `mobile-medium` breakpoint. Note: this new font-size is not found in Source.

Updates font-size from 14px to 15px at `mobile` breakpoint.

## Why?

Request from the Design team.

[Figma designs](https://www.figma.com/design/OBiUI7dJkso1GXfsovfzaY/%E2%97%88-Web-library?node-id=8572-13649&t=qZtMXMP96RF7IRht-0)

## Screenshots

| <img width=350/> | Before | After |
| - | - | - |
| 320px - 374px | ![mobile-before] | ![mobile-after] |
| 375px - 479px | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/e0785270-f351-431d-ad54-03c46bedc05a
[desktop-before]: https://github.com/user-attachments/assets/443f6048-9620-4494-aa4d-419fba8351bb
[mobile-after]: https://github.com/user-attachments/assets/0829af24-1e6d-42be-8a6e-6a68b410a57b
[desktop-after]: https://github.com/user-attachments/assets/4d39bd4a-0a53-4d66-851f-58a7ae7dde27

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
