### PR TITLE
Remove media card background colour from area where height is extended

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -255,16 +255,27 @@ export const trails: [
 	},
 	{
 		...defaultCardProps,
-		url: 'https://www.theguardian.com/world/2021/feb/16/contact-tracing-alone-has-little-impact-on-curbing-covid-spread-report-finds',
-		byline: 'Nicola Davis and Natalie Grover',
-		image: {
-			src: 'https://media.guim.co.uk/046002abfc13c8cf7f0c40454349eb0e95d842b2/0_147_3884_2331/master/3884.jpg',
-			altText: 'Dido Harding',
+		format: { design: 3, display: 0, theme: 2 },
+		url: '/football/audio/2025/feb/19/celtic-bayern-munich-champions-league-chaos-football-weekly-podcast',
+		headline: 'Celtic’s heartbreak and Champions League playoff chaos ',
+		dataLinkName: 'media | group-0 | card-@1',
+		trailText:
+			'Max Rushden is joined by Barry Glendenning, Paul Watson, Nick Ames, Ewan Murray and Jim Burke to discuss the latest Champions League playoff games, Everton’s new ground and much more',
+		webPublicationDate: '2025-02-19T14:11:54.000Z',
+		kickerText: 'Football Weekly',
+		mainMedia: {
+			type: 'Audio',
+			duration: '54:52',
+			podcastImage: {
+				src: 'https://uploads.guim.co.uk/2024/08/01/FootballWeekly_FINAL_3000_(1).jpg',
+				altText: 'Football Weekly',
+			},
 		},
-		webPublicationDate: '2021-02-16T18:22:53.000Z',
-		headline:
-			'Contact tracing alone has little impact on curbing Covid spread, report finds',
-		dataLinkName: 'news | group-0 | card-@1',
+		image: {
+			src: 'https://media.guim.co.uk/01ded462d3dd730467bdfd652decda4117d925da/0_0_2074_1244/master/2074.jpg',
+			altText:
+				"TOPSHOT-FBL-EUR-C1-MILAN-FEYENOORD<br>TOPSHOT - Polish referee Szymon Marciniak gives a red card to AC Milan's French defender #19 Theo Hernandez (R) during the UEFA Champions League knockout round play-off second leg football match between AC Milan and Feyenoord at San Siro stadium in Milan, on February 18, 2025. (Photo by Piero CRUCIATTI / AFP) (Photo by PIERO CRUCIATTI/AFP via Getty Images)",
+		},
 	},
 	{
 		...defaultCardProps,

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1209,7 +1209,6 @@ export const Card = ({
 					css`
 						${from.tablet} {
 							flex-basis: 100%;
-							background-color: ${backgroundColour};
 						}
 					`
 				}

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -549,7 +549,13 @@ export const LoopVideoCards: Story = {
 		groupedTrails: {
 			...emptyGroupedTrails,
 			splash: [loopVideoCard],
-			standard: [loopVideoCard], // Loop video is disabled at standard card size
+			standard: [
+				{
+					...loopVideoCard,
+					headline:
+						'Image fallback - the standard half-width card is too small for video',
+				},
+			],
 		},
 	},
 };


### PR DESCRIPTION
## What does this change?

Removes background colour from card where area has been extended to align with adjacent card

Add stories.

## Why?

When a horizontal (image is left or right of the text) card is adjacent to another card, the cards should have the same height, so that the meta has the same alignment. A `flex-basis: 100%` is applied to achieve this and the background colour is continued. However, this extension of background colour can lead to media cards looking a bit off in terms of the UI.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before1][] | ![after1][] |

[before]: https://github.com/user-attachments/assets/802e1c95-4d44-4468-a5ae-b70a8ce8d3ee
[after]: https://github.com/user-attachments/assets/50148309-7b45-4c7c-a751-8d5a69181efb
[before1]: https://github.com/user-attachments/assets/059e648d-a1c5-4c8d-b6d6-801be78acee3
[after1]: https://github.com/user-attachments/assets/cefbd5e0-be50-48ba-bded-26363e577449

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
