### PR TITLE
Don't underline headline when carousel image hovered

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -55,7 +55,11 @@ const hoverStyles = css`
 
 	/** We want to prevent the general hover styles applying when
 	    a click won't result in navigating to the main article */
-	:has(ul.sublinks:hover, .loop-video-container:hover) {
+	:has(
+			ul.sublinks:hover,
+			.loop-video-container:hover,
+			.slideshow-carousel:hover
+		) {
 		.card-headline .show-underline {
 			text-decoration: none;
 		}

--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -192,7 +192,7 @@ export const SlideshowCarousel = ({
 	const slideshowImageCount = slideshowImages.length;
 
 	return (
-		<div>
+		<div className="slideshow-carousel">
 			<ul
 				ref={carouselRef}
 				css={carouselStyles}


### PR DESCRIPTION
## What does this change?

When an image in the SlideshowCarousel is hovered over, the headline text should not be underlined

## Why?

It looks like a link, but isn't.

It would be better to add functionality to clicking the image, whether that would be clicking through to the article or going to the next image, but until that functionality is agreed on, we should remove this misleading behaviour.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
