### PR TITLE
clarify and ensure sign-in gate specs

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/displayRules.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRules.ts
@@ -58,6 +58,18 @@ export const hasRequiredConsents = (): Promise<boolean> =>
 		.then(({ canTarget }: ConsentState) => canTarget)
 		.catch(() => false);
 
+export const pageMetaDataMakesItEligibleForGateDisplay = (
+	contentType: string,
+	sectionId: string | undefined,
+	tags: TagType[],
+): boolean => {
+	return (
+		isValidContentType(contentType) &&
+		isValidSection(sectionId) &&
+		isValidTag(tags)
+	);
+};
+
 export const canShowSignInGate = ({
 	isSignedIn,
 	currentTest,
@@ -66,8 +78,17 @@ export const canShowSignInGate = ({
 	tags,
 	isPaidContent,
 	isPreview,
-}: CanShowGateProps): Promise<boolean> =>
-	Promise.resolve(
+}: CanShowGateProps): Promise<boolean> => {
+	// This check is functionally identical to the same check in SDC
+	// This logically ensures that SDC will get a subset of the pages for which
+	// pageMetaDataMakesItEligibleForGateDisplay return true
+	if (
+		!pageMetaDataMakesItEligibleForGateDisplay(contentType, sectionId, tags)
+	) {
+		return Promise.resolve(false);
+	}
+
+	return Promise.resolve(
 		!isSignedIn &&
 			!hasUserDismissedGateMoreThanCount(
 				currentTest.variant,
@@ -75,14 +96,12 @@ export const canShowSignInGate = ({
 				5,
 			) &&
 			isNPageOrHigherPageView(3) &&
-			isValidContentType(contentType) &&
-			isValidSection(sectionId) &&
-			isValidTag(tags) &&
 			// hide the sign in gate on isPaidContent
 			!isPaidContent &&
 			// hide the sign in gate on internal tools preview &&
 			!isPreview,
 	);
+};
 
 export const canShowSignInGateMandatory: ({
 	isSignedIn,


### PR DESCRIPTION
Small refactoring companion PR for this: https://github.com/guardian/support-dotcom-components/pull/1414
(Which also serves as a step towards moving some of the gate logic to SDC)