### PR TITLE
Correctly size avatar and podcast images in Scrollable Highlights

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
@@ -45,7 +45,7 @@ export const HighlightsCardImage = ({
 					src={avatarUrl}
 					alt={byline ?? ''}
 					shape="cutout"
-					imageSize="large"
+					imageSize="highlights-card"
 				/>
 			</div>
 		);
@@ -56,7 +56,7 @@ export const HighlightsCardImage = ({
 			return (
 				<div css={[imageStyles, nonAvatarImageStyles]}>
 					<CardPicture
-						imageSize="medium"
+						imageSize="highlights-card"
 						mainImage={mainMedia.podcastImage.src}
 						alt={mainMedia.podcastImage.altText}
 						loading={imageLoading}


### PR DESCRIPTION
## What does this change?

Updates the size of images requested from Fastly for avatars and podcast images in Highlights cards.

## Why?

So that we request the correct size for the space available. We are currently requesting too large an image

## Screenshots

<img width="724" height="374" alt="Screenshot 2025-08-22 at 16 58 00" src="https://github.com/user-attachments/assets/d041ac6e-e6a0-4f7d-af11-5678dfc05c58" />

