### PR TITLE
Reduce blur of avatars on fronts

### DIFF
--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -86,6 +86,9 @@ const decideImageWidths = (
 				{ breakpoint: breakpoints.tablet, width: 160 },
 				{ breakpoint: breakpoints.desktop, width: 190 },
 			];
+		/* Avatars on cards in the highlights container are fixed to 98px on all breakpoints */
+		case 'highlights-card':
+			return [{ breakpoint: breakpoints.mobile, width: 98 }];
 	}
 };
 

--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -64,27 +64,65 @@ const decideImageWidths = (
 ): [ImageWidthType, ...ImageWidthType[]] => {
 	switch (imageSize) {
 		case 'small':
-			return [{ breakpoint: breakpoints.mobile, width: 80 }];
+			return [
+				{
+					breakpoint: breakpoints.mobile,
+					width: 80,
+					aspectRatio: '1:1',
+				},
+			];
 
 		case 'medium':
 		default:
 			return [
-				{ breakpoint: breakpoints.mobile, width: 80 },
-				{ breakpoint: breakpoints.desktop, width: 90 },
+				{
+					breakpoint: breakpoints.mobile,
+					width: 80,
+					aspectRatio: '1:1',
+				},
+				{
+					breakpoint: breakpoints.desktop,
+					width: 90,
+					aspectRatio: '1:1',
+				},
 			];
 
 		case 'large':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 150 },
-				{ breakpoint: breakpoints.tablet, width: 130 },
-				{ breakpoint: breakpoints.desktop, width: 150 },
+				{
+					breakpoint: breakpoints.mobile,
+					width: 150,
+					aspectRatio: '1:1',
+				},
+				{
+					breakpoint: breakpoints.tablet,
+					width: 130,
+					aspectRatio: '1:1',
+				},
+				{
+					breakpoint: breakpoints.desktop,
+					width: 150,
+					aspectRatio: '1:1',
+				},
 			];
 
 		case 'jumbo':
 			return [
-				{ breakpoint: breakpoints.mobile, width: 180 },
-				{ breakpoint: breakpoints.tablet, width: 160 },
-				{ breakpoint: breakpoints.desktop, width: 190 },
+				{
+					breakpoint: breakpoints.mobile,
+					width: 180,
+					aspectRatio: '1:1',
+				},
+				{
+					breakpoint: breakpoints.tablet,
+					width: 160,
+					aspectRatio: '1:1',
+				},
+				{
+					breakpoint: breakpoints.desktop,
+					width: 190,
+					aspectRatio: '1:1',
+				},
 			];
 		/* Avatars on cards in the highlights container are fixed to 98px on all breakpoints */
 		case 'highlights-card':

--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -88,7 +88,13 @@ const decideImageWidths = (
 			];
 		/* Avatars on cards in the highlights container are fixed to 98px on all breakpoints */
 		case 'highlights-card':
-			return [{ breakpoint: breakpoints.mobile, width: 98 }];
+			return [
+				{
+					breakpoint: breakpoints.mobile,
+					width: 98,
+					aspectRatio: '1:1',
+				},
+			];
 	}
 };
 

--- a/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCardImage.tsx
@@ -10,9 +10,7 @@ const imageStyles = css`
 	position: relative;
 	align-self: flex-end;
 	flex-shrink: 0;
-	height: 98px;
 	width: 98px;
-
 	${until.tablet} {
 		margin-top: ${space[2]}px;
 	}


### PR DESCRIPTION
## What does this change?
Makes 2 adjustments to reduce blur of avatars:

1. Increase the requested image width to 98px for avatars in the highlights container as this is the rendered image width. 
2. Request a 1:1 aspect ratio crop instead of forcing a 1:1 aspect ratio via hardcoded width and height on the parent container. Avatars are not a 1:1 crop (they're ~6:5) so using a fixed 1:1 width and height stretches the image vertically.

## Why?
A step towards crisper images on the fronts. 

## Screenshots
### Highlights container
| Before      | with 98px requested width      | with 1:1 aspect ratio & 98px requested width 
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![after1][] |

[before]: https://github.com/user-attachments/assets/efe30714-ef10-4113-8440-47b512a54df0
[after]: https://github.com/user-attachments/assets/a365823e-4403-45ad-88cd-f17f01fbe796
[after1]: https://github.com/user-attachments/assets/cf5cc827-a390-4729-8e04-88f75d494dee

### Fronts

| Before      | with 1:1 aspect ratio 
| ----------- | ---------- |
| ![beforea][] | ![aftera][] |

[beforea]: https://github.com/user-attachments/assets/976c681c-1310-42c8-a972-8fea61727a39
[aftera]: https://github.com/user-attachments/assets/0054698e-1df4-47bb-8bcc-cac1bd636fa2


<!--


| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
