### PR TITLE
Disable build variant

### DIFF
--- a/dotcom-rendering/webpack/bundles.js
+++ b/dotcom-rendering/webpack/bundles.js
@@ -9,7 +9,7 @@
  *
  * @type {boolean} prevent TS from narrowing this to its current value
  */
-const BUILD_VARIANT = true;
+const BUILD_VARIANT = false;
 
 /**
  * Server-side test names for running variant test.

--- a/dotcom-rendering/webpack/webpack.config.client.js
+++ b/dotcom-rendering/webpack/webpack.config.client.js
@@ -139,20 +139,13 @@ module.exports = ({ build }) => ({
 			svgr,
 		],
 	},
-	/**
-	 * Do not alias React modules in the web build variant so React is bundled
-	 * instead of Preact
-	 */
-	resolve:
-		build === 'client.web.variant'
-			? undefined
-			: {
-					alias: {
-						react: 'preact/compat',
-						'react-dom/test-utils': 'preact/test-utils',
-						'react-dom': 'preact/compat',
-					},
-			  },
+	resolve: {
+		alias: {
+			react: 'preact/compat',
+			'react-dom/test-utils': 'preact/test-utils',
+			'react-dom': 'preact/compat',
+		},
+	},
 });
 
 module.exports.transpileExclude = {


### PR DESCRIPTION
## What does this change?

Disables building of variant client web bundle

## Why?

This was being used to test React on the client (#13736). As this is not currently being actively worked on it makes sense to remove the variant bundle for now as it is being built unnecessarily on CI.