### PR TITLE
Refactor function names and logic in Metrics

### DIFF
--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 const sampling = 1 / 100;
 /** defining this here allows to share this with other metrics */
-const willRecordCoreWebVitals = Math.random() < sampling;
+const isInSample = Math.random() < sampling;
 
 // For these tests switch off sampling and collect metrics for 100% of views
 const clientSideTestsToForceMetrics: ABTest[] = [
@@ -90,7 +90,6 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 
 	const shouldBypassSampling = useCallback(
 		(api: ABTestAPI) =>
-			willRecordCoreWebVitals ||
 			userInServerSideTest ||
 			clientSideTestsToForceMetrics.some((test) =>
 				api.runnableTest(test),
@@ -105,7 +104,7 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 			if (isUndefined(isDev)) return;
 			if (isUndefined(pageViewId)) return;
 
-			const bypassSampling = shouldBypassSampling(abTestApi);
+			const recordMetrics = isInSample || shouldBypassSampling(abTestApi);
 
 			/**
 			 * We rely on `bypassSampling` rather than the built-in sampling,
@@ -121,7 +120,7 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 				team: 'dotcom',
 			});
 
-			if (bypassSampling || isDev) {
+			if (recordMetrics || isDev) {
 				void bypassCoreWebVitalsSampling('commercial');
 			}
 		},
@@ -139,7 +138,7 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 			if (isUndefined(isDev)) return;
 			if (isUndefined(pageViewId)) return;
 
-			const bypassSampling = shouldBypassSampling(abTestApi);
+			const recordMetrics = isInSample || shouldBypassSampling(abTestApi);
 
 			// This is a new detection method we are trying, so we want to record it separately to `adBlockerInUse`
 			EventTimer.get().setProperty(
@@ -154,7 +153,7 @@ export const Metrics = ({ commercialMetricsEnabled, tests }: Props) => {
 				adBlockerInUse,
 			})
 				.then(() => {
-					if (bypassSampling || isDev) {
+					if (recordMetrics || isDev) {
 						void bypassCommercialMetricsSampling();
 					}
 				})


### PR DESCRIPTION
## What does this change?

Renames `bypassSampling` to `recordMetrics` as this better represents what this value means. 

Introduces another value `isInSample` to replace `willRecordCoreWebVitals` since this is used for both commercial metrics and core web vitals, and represents whether the request is in the sample or not.

Additionally takes this value `isInSample` out of the `bypassSampling` decision seeing as these are two distinct things - in order to record metrics, you should either be in the sample or if not, the sampling should be bypassed in order to record all metrics

 

## Why?

Making the code more easy to understand for future developers

