### PR TITLE
Resume looping video when user returns to tab

### DIFF
--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -439,14 +439,24 @@ export const LoopVideo = ({
 	 * Handle the case where the user navigates back to the page.
 	 */
 	useEffect(() => {
-		window.addEventListener('pageshow', function (event) {
+		const handleRestoreFromCache = (event: PageTransitionEvent) => {
 			if (event.persisted) {
 				setIsAutoplayAllowed(doesUserPermitAutoplay());
 				setIsRestoredFromBFCache(true);
 			} else {
 				setIsRestoredFromBFCache(false);
 			}
+		};
+
+		window.addEventListener('pageshow', function (event) {
+			handleRestoreFromCache(event);
 		});
+
+		return () => {
+			window.removeEventListener('pageshow', function (event) {
+				handleRestoreFromCache(event);
+			});
+		};
 	}, []);
 
 	if (renderingTarget !== 'Web') return null;


### PR DESCRIPTION
## What does this change?

When the document becomes visible, trigger the play/pause useEffect.

## Why?

A browser will pause a video when the page becomes inactive. If a video was paused by the browser when the page became inactive, the looping video will resume playing if the page becomes active.

This builds on the change made in https://github.com/guardian/dotcom-rendering/pull/14324. Now we listen for an extra event to why the page might be made active.

## Screenshots

### Before

https://github.com/user-attachments/assets/821759ee-8676-4c80-a4a2-0f230a4da4ca

### After

https://github.com/user-attachments/assets/e5c232c0-26b6-4a17-822d-4ac669d030e3

