### PR TITLE
Adds tracking of the checkbox state for the similar_products checkbox to the ManyNewsletterSignUp event

### DIFF
--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.importable.tsx
@@ -261,6 +261,10 @@ export const ManyNewsletterSignUp = ({
 			return undefined;
 		});
 
+		const marketingOptInType = marketingOptIn
+			? 'similar-guardian-products-optin'
+			: 'similar-guardian-products-optout';
+
 		if (!response?.ok) {
 			const responseText = response
 				? await response.text()
@@ -271,6 +275,7 @@ export const ManyNewsletterSignUp = ({
 				renderingTarget,
 				{
 					listIds,
+					...(marketingOptIn !== undefined && { marketingOptInType }),
 					// If the backend handles the failure and responds with an informative
 					// error message (E.G. "Service unavailable", "Invalid email" etc) this
 					// should be included in the event data.
@@ -289,6 +294,7 @@ export const ManyNewsletterSignUp = ({
 			renderingTarget,
 			{
 				listIds,
+				...(marketingOptIn !== undefined && { marketingOptInType }),
 			},
 		);
 		setStatus('Success');


### PR DESCRIPTION
## What does this change?

Related to https://github.com/guardian/dotcom-rendering/pull/14443
This small PR adds tracking of the Marketing Opt In checkbox to the `ManyNewsletterSignUp` tracking event (when present)

## Why?

After releasing, we realized that the tracking of the checkbox state will be useful for the marketing team to understand the usage of this feature.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
