### PR TITLE
Implement handling for `bfcache` in Ophan tracking

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "10.2.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "7.7.0",
+		"@guardian/support-dotcom-components": "7.8.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.52.0",
 		"@sentry/browser": "10.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,8 +344,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@25.2.0)(@guardian/source@10.2.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 7.7.0
-        version: 7.7.0(@guardian/libs@25.2.0)(zod@3.22.4)
+        specifier: 7.8.0
+        version: 7.8.0(@guardian/libs@25.2.0)(@guardian/ophan-tracker-js@2.4.4)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -5060,13 +5060,6 @@ packages:
       typescript: 5.5.3
     dev: false
 
-  /@guardian/ophan-tracker-js@2.3.1:
-    resolution: {integrity: sha512-AvxBTQMe2MC2ssLSuxCxEA8+1lAK3IEZaVOsjsZeX0l0orIc6tBmpuENFjdhd+NV61p0BJQRWqw7b8EQY2HfSA==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@guardian/tsconfig': 1.0.0
-    dev: false
-
   /@guardian/ophan-tracker-js@2.4.4:
     resolution: {integrity: sha512-7Nd9p1cuEaXSkisxTQuR6VUX9yxYvEeBMv9HBwAJ/BFUMDprPQhnr5oDGZVnAyd6iVzvCPoH4BN5hkICYP60cg==}
     engines: {node: '>=16'}
@@ -5245,10 +5238,11 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@7.7.0(@guardian/libs@25.2.0)(zod@3.22.4):
-    resolution: {integrity: sha512-yVDJ//dFSIZtU8vuR07iHhco8+cCp6ClYUHBIPpXgljXUBhkURcLIEYgccUssKylrWu5HfbzWuEGH5hOi1eXDw==}
+  /@guardian/support-dotcom-components@7.8.0(@guardian/libs@25.2.0)(@guardian/ophan-tracker-js@2.4.4)(zod@3.22.4):
+    resolution: {integrity: sha512-IC/a2Pc+zvMsyVBxjZhgTy7sT6VoRJSLgjEyRihGTS+IsdrQYDSbsk0WUsW+jNv8WnXpdsUbH4LeUHuZoT5WHg==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
+      '@guardian/ophan-tracker-js': ^2.4.1
       zod: ^3.22.4
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.841.0
@@ -5258,7 +5252,7 @@ packages:
       '@aws-sdk/credential-providers': 3.840.0
       '@aws-sdk/lib-dynamodb': 3.840.0(@aws-sdk/client-dynamodb@3.840.0)
       '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.4)(tslib@2.6.2)(typescript@5.5.3)
-      '@guardian/ophan-tracker-js': 2.3.1
+      '@guardian/ophan-tracker-js': 2.4.4
       compression: 1.7.4
       cors: 2.8.5
       date-fns: 2.30.0


### PR DESCRIPTION
## What does this change?

Bumps the version of @guardian/ophan-tracker-js which handles the `bfcache` browser feature in Ophan tracking by regenerating the page view ID on backwards/forwards navigation when the page is served from cache.

See Ophan [changelog](https://github.com/guardian/ophan/blob/main/tracker-js/CHANGELOG.md#244) and PRs:
- https://github.com/guardian/ophan/pull/7178
- https://github.com/guardian/ophan/pull/7197
- https://github.com/guardian/ophan/pull/7203
- https://github.com/guardian/ophan/pull/7208

Also bumps the version of `@guardian/support-dotcom-components` to allow one version of Ophan to exist in dotcom-rendering at a time. Without this, we install two different versions of tracker-js which results in build errors

See https://github.com/guardian/support-dotcom-components/pull/1348


## Why?

Before the `bfcache` feature in browsers was introduced, pages were re-fetched on back/forwards navigation. This meant we used a fresh page view ID each time. 

Since then, when a user navigated back and forwards in their browser history we re-used the same page view ID as the first time the page loaded.
This is due to the `bfcache` feature where browsers cache the page and pause any javascript currently in execution when users navigate away from the page. If a user then re-visits that page via their browser history (ie clicking back/forwards buttons), the page is loaded instantly from memory instead of re-fetching via network calls and the javascript is resumed from the point it stopped.

This PR sets a new page view ID when the page is loaded from cache, to revert back to the previous behaviour seen before the roll out of `bfcache` support.

## Screenshots

Both examples below show the behaviour for cached pages. A function `logPageViewIds` was set on the pages ahead of the video recording and does not need to be re-defined since the videos show the cached page result.

### Before

Page views do not change on back/forwards navigation for cached pages

https://github.com/user-attachments/assets/c119160e-0818-446d-bd3e-66289a707d6f


### After

Page views are updated on back/forwards navigation for cached pages

https://github.com/user-attachments/assets/2a570c02-d9a8-4a01-9fc5-14a882c937e6


--------------------

*Useful docs*
- *[Bfcache impact on page views](https://docs.google.com/document/d/17rkbQIkyJWvADms3wTcSfG123vDMAJX8xA5aHIEsGLg/edit?usp=sharing)*
- *[Commercial assessment of bfcache](https://docs.google.com/document/d/1aeqMeEyycNrboEUkOjXrOW19rmDYSSYH3qVQZ-hGWhM/edit?usp=sharing)*
