### PR TITLE
Implements All Newsletters visible reCAPTCHA design changes

### DIFF
--- a/dotcom-rendering/src/components/ManyNewslettersForm.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersForm.tsx
@@ -37,7 +37,10 @@ export interface FormProps {
 const CARD_CONTAINER_WIDTH = 240;
 const CARD_CONTAINER_PADDING = 10;
 
-const formFrameStyle = css`
+const formFrameStyle = (visibleRecaptcha: boolean) => css`
+	background-color: ${visibleRecaptcha
+		? palette.neutral[100]
+		: 'transparent'};
 	border: ${palette.brand[400]} 2px dashed;
 	border-radius: 12px;
 	padding: ${space[2]}px;
@@ -53,7 +56,7 @@ const formFrameStyle = css`
 	}
 `;
 
-const formFieldsStyle = css`
+const formFieldsStyle = (visibleRecaptcha: boolean) => css`
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
@@ -61,9 +64,9 @@ const formFieldsStyle = css`
 
 	${from.desktop} {
 		flex-basis: ${2 * CARD_CONTAINER_WIDTH - CARD_CONTAINER_PADDING * 2}px;
-		flex-direction: row;
+		flex-direction: ${visibleRecaptcha ? 'column' : 'row'};
 		flex-shrink: 0;
-		align-items: last baseline;
+		align-items: ${visibleRecaptcha ? 'stretch' : 'last baseline'};
 	}
 `;
 
@@ -85,13 +88,14 @@ const formAsideStyle = (hideOnMobile: boolean) => css`
 	}
 `;
 
-const signUpButtonStyle = css`
+const signUpButtonStyle = (visibleRecaptcha: boolean) => css`
 	justify-content: center;
 	background-color: ${palette.neutral[0]};
 	border-color: ${palette.neutral[0]};
 
 	${from.desktop} {
-		flex-basis: 110px;
+		margin-right: ${visibleRecaptcha ? space[2] : 0}px;
+		flex-basis: ${visibleRecaptcha ? 'unset' : '110px'};
 	}
 
 	&:hover {
@@ -139,7 +143,7 @@ export const ManyNewslettersForm = ({
 		<form
 			aria-label="sign-up confirmation form"
 			aria-live="polite"
-			css={formFrameStyle}
+			css={formFrameStyle(visibleRecaptcha)}
 			onSubmit={(submitEvent) => {
 				submitEvent.preventDefault();
 			}}
@@ -159,7 +163,7 @@ export const ManyNewslettersForm = ({
 				</InlineSkipToWrapper>
 			</aside>
 
-			<div css={formFieldsStyle}>
+			<div css={formFieldsStyle(visibleRecaptcha)}>
 				{status !== 'Success' ? (
 					<>
 						<ManyNewslettersFormFields
@@ -181,7 +185,7 @@ export const ManyNewslettersForm = ({
 							onClick={() => {
 								void handleSubmitButton();
 							}}
-							cssOverrides={signUpButtonStyle}
+							cssOverrides={signUpButtonStyle(visibleRecaptcha)}
 						>
 							Sign up
 						</Button>

--- a/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
@@ -33,6 +33,23 @@ const optInCheckboxTextSmall = css`
 	}
 `;
 
+const recaptchaContainerStyle = (
+	visibleRecaptcha: boolean,
+	firstInteractionOccurred: boolean,
+) => css`
+	margin-bottom: ${visibleRecaptcha && firstInteractionOccurred
+		? space[3]
+		: 0}px;
+	padding: ${visibleRecaptcha && firstInteractionOccurred ? space[2] : 0}px;
+	background-color: ${visibleRecaptcha && firstInteractionOccurred
+		? palette.neutral[93]
+		: 'transparent'};
+
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+`;
+
 export interface ManyNewslettersFormFieldsProps
 	extends Omit<FormProps, 'handleSubmitButton' | 'newsletterCount'> {}
 
@@ -96,23 +113,10 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 			)}
 			{useReCaptcha && !!captchaSiteKey && (
 				<div
-					css={css`
-						margin-bottom: ${visibleRecaptcha &&
-						firstInteractionOccurred
-							? space[3]
-							: 0}px;
-						padding: ${visibleRecaptcha && firstInteractionOccurred
-							? space[2]
-							: 0}px;
-						background-color: ${visibleRecaptcha &&
-						firstInteractionOccurred
-							? palette.neutral[93]
-							: 'transparent'};
-
-						.grecaptcha-badge {
-							visibility: hidden;
-						}
-					`}
+					css={recaptchaContainerStyle(
+						visibleRecaptcha,
+						firstInteractionOccurred,
+					)}
 				>
 					{(!visibleRecaptcha || firstInteractionOccurred) && (
 						<ReactGoogleRecaptcha

--- a/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
@@ -19,9 +19,9 @@ const inputWrapperStyle = css`
 	}
 `;
 
-const inputAndOptInWrapperStyle = css`
+const inputAndOptInWrapperStyle = (visibleRecaptcha: boolean) => css`
 	${from.desktop} {
-		flex-basis: 296px;
+		flex-basis: ${visibleRecaptcha ? 'unset' : '296px'};
 		margin-right: ${space[2]}px;
 	}
 `;
@@ -44,7 +44,7 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 	setMarketingOptIn,
 	useReCaptcha,
 	captchaSiteKey,
-	visibleRecaptcha,
+	visibleRecaptcha = false,
 	reCaptchaRef,
 	handleCaptchaError,
 }) => {
@@ -61,7 +61,7 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 			: undefined;
 
 	return (
-		<div css={inputAndOptInWrapperStyle}>
+		<div css={inputAndOptInWrapperStyle(visibleRecaptcha)}>
 			<span css={inputWrapperStyle}>
 				<TextInput
 					label="Enter your email"
@@ -97,6 +97,18 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 			{useReCaptcha && !!captchaSiteKey && (
 				<div
 					css={css`
+						margin-bottom: ${visibleRecaptcha &&
+						firstInteractionOccurred
+							? space[3]
+							: 0}px;
+						padding: ${visibleRecaptcha && firstInteractionOccurred
+							? space[2]
+							: 0}px;
+						background-color: ${visibleRecaptcha &&
+						firstInteractionOccurred
+							? palette.neutral[93]
+							: 'transparent'};
+
 						.grecaptcha-badge {
 							visibility: hidden;
 						}
@@ -109,6 +121,13 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 							onError={handleCaptchaError}
 							size={visibleRecaptcha ? 'normal' : 'invisible'}
 						/>
+					)}
+					{visibleRecaptcha && firstInteractionOccurred && (
+						<span css={[textSans14]}>
+							By ticking this box, you agree to let Google perform
+							a security check to confirm you are a human. Please
+							refer to their terms and privacy policies.
+						</span>
 					)}
 				</div>
 			)}

--- a/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
@@ -33,15 +33,10 @@ const optInCheckboxTextSmall = css`
 	}
 `;
 
-const recaptchaContainerStyle = (
-	visibleRecaptcha: boolean,
-	firstInteractionOccurred: boolean,
-) => css`
-	margin-bottom: ${visibleRecaptcha && firstInteractionOccurred
-		? space[3]
-		: 0}px;
-	padding: ${visibleRecaptcha && firstInteractionOccurred ? space[2] : 0}px;
-	background-color: ${visibleRecaptcha && firstInteractionOccurred
+const recaptchaContainerStyle = (showRecaptchaContainer: boolean) => css`
+	margin-bottom: ${showRecaptchaContainer ? space[3] : 0}px;
+	padding: ${showRecaptchaContainer ? space[2] : 0}px;
+	background-color: ${showRecaptchaContainer
 		? palette.neutral[93]
 		: 'transparent'};
 
@@ -114,8 +109,7 @@ export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 			{useReCaptcha && !!captchaSiteKey && (
 				<div
 					css={recaptchaContainerStyle(
-						visibleRecaptcha,
-						firstInteractionOccurred,
+						visibleRecaptcha && firstInteractionOccurred,
 					)}
 				>
 					{(!visibleRecaptcha || firstInteractionOccurred) && (


### PR DESCRIPTION
## What does this change?

Related to https://github.com/guardian/dotcom-rendering/pull/14443

Implements the missing design aspects of the visible reCAPTCHA on the All Newsletters page.
- Controlled via the new feature switch (ManyNewsletterVisibleRecaptcha).
- The switch is currently off, so these changes are not visible. It will be turned on and monitored for a period of time, comparing its impact against historical data. 

## Why?

We want to study how/if the visible reCAPTCHA reduces the number of bots that opt in for newsletters, while understanding the impact that it may have on actual users.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![B][] | ![I][] |
| ![B][] | ![M][] |
| ![C][] | ![H][] |
| ![C][] | ![N][] |
| ![A][] | ![G][] |
| ![D][] | ![J][] |
| ![E][] | ![K][] |
| ![F][] | ![L][] |

[A]: https://github.com/user-attachments/assets/5be47a47-8dd6-4229-add1-1efd548f6b57
[B]: https://github.com/user-attachments/assets/ea1cf4b1-13f7-49c0-8fb8-736c26eca6fc
[C]: https://github.com/user-attachments/assets/bde19201-02ba-4840-bf61-5bb0a50f6eba
[D]: https://github.com/user-attachments/assets/6e1caec3-23c6-4464-9840-681cfde556af
[E]: https://github.com/user-attachments/assets/2659c7a7-4555-4c3f-9ca4-3df5fa84a53b
[F]: https://github.com/user-attachments/assets/2a1b1cf9-8b27-417e-94d7-a1bdd0c568cf

[G]: https://github.com/user-attachments/assets/a139ec7d-14da-4c53-b73c-da569d56dbf4
[H]: https://github.com/user-attachments/assets/ee426aeb-2992-4582-868a-ba0577dfdb58
[I]: https://github.com/user-attachments/assets/1a015ebb-b333-458b-be8b-17f1ab7c8d61
[J]: https://github.com/user-attachments/assets/2e53d91c-05fa-4168-817b-0c71d7262a40
[K]: https://github.com/user-attachments/assets/c0c74690-9f21-4ab3-a662-cc7176293bdf
[L]: https://github.com/user-attachments/assets/524115e4-942b-486e-8c2f-ed1caa2a7825
[M]: https://github.com/user-attachments/assets/70ce2789-f45e-4e5e-a913-8042b4393eb4
[N]: https://github.com/user-attachments/assets/a1265bcc-4c06-4a5f-9bce-fe17c8bd649b

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
