### PR TITLE
Add more galleries container

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -30,7 +30,7 @@ import type {
 	DCRSupportingContent,
 } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
-import type { OnwardsSource } from '../../types/onwards';
+import type { OnwardContainerType, OnwardsSource } from '../../types/onwards';
 import { Avatar } from '../Avatar';
 import { CardCommentCount } from '../CardCommentCount.importable';
 import { CardHeadline, type ResponsiveFontSize } from '../CardHeadline';
@@ -120,7 +120,7 @@ export type Props = {
 	supportingContentPosition?: Position;
 	snapData?: DCRSnapType;
 	containerPalette?: DCRContainerPalette;
-	containerType?: DCRContainerType;
+	containerType?: DCRContainerType | OnwardContainerType;
 	showAge?: boolean;
 	discussionApiUrl: string;
 	discussionId?: string;
@@ -574,6 +574,8 @@ export const Card = ({
 		containerType === 'flexible/special' ||
 		containerType === 'flexible/general';
 
+	const isOnwardContainer = containerType === 'more-galleries';
+
 	const isSmallCard = containerType === 'scrollable/small';
 
 	const imageFixedSizeOptions = (): ImageFixedSizeOptions => {
@@ -591,6 +593,8 @@ export const Card = ({
 	const hideTrailTextUntil = () => {
 		if (isFlexibleContainer) {
 			return undefined;
+		} else if (isOnwardContainer && isFlexSplash) {
+			return 'mobile';
 		} else if (
 			imageSize === 'large' &&
 			imagePositionOnDesktop === 'right' &&
@@ -601,6 +605,10 @@ export const Card = ({
 			return 'tablet';
 		}
 	};
+
+	const shouldShowTrailText = isOnwardContainer
+		? media?.type !== 'podcast' && isFlexSplash
+		: media?.type !== 'podcast';
 
 	/**
 	 * Determines the gap of between card components based on card properties
@@ -1090,7 +1098,7 @@ export const Card = ({
 							</HeadlineWrapper>
 						)}
 
-						{!!trailText && media?.type !== 'podcast' && (
+						{!!trailText && shouldShowTrailText && (
 							<TrailText
 								trailText={trailText}
 								trailTextSize={trailTextSize}

--- a/dotcom-rendering/src/components/Card/components/TrailText.tsx
+++ b/dotcom-rendering/src/components/Card/components/TrailText.tsx
@@ -11,14 +11,16 @@ import { palette } from '../../../palette';
 
 export type TrailTextSize = 'regular' | 'large';
 
-const trailTextStyles = css`
-	display: flex;
-	flex-direction: column;
+const trailTextStyles = (hideUntil?: 'tablet' | 'desktop' | 'mobile') => {
+	return css`
+		display: flex;
+		flex-direction: column;
 
-	${until.tablet} {
-		display: none;
-	}
-`;
+		${hideUntil === 'mobile' ? until.mobile : until.tablet} {
+			display: none;
+		}
+	`;
+};
 
 const bottomPadding = css`
 	padding-bottom: ${space[2]}px;
@@ -44,7 +46,7 @@ type Props = {
 	/** Optionally overrides the trail text colour */
 	trailTextColour?: string;
 	/** Controls visibility of trail text on various breakpoints */
-	hideUntil?: 'tablet' | 'desktop';
+	hideUntil?: 'tablet' | 'desktop' | 'mobile';
 	/** Defaults to `true`. Adds padding to the bottom of the trail text */
 	padBottom?: boolean;
 	/** Adds padding to the top of the trail text */
@@ -62,7 +64,7 @@ export const TrailText = ({
 	const trailText = (
 		<div
 			css={[
-				trailTextStyles,
+				trailTextStyles(hideUntil),
 				css`
 					color: ${trailTextColour};
 				`,

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -880,6 +880,8 @@ export const Carousel = ({
 		return null;
 	}
 
+	console.log('*************************** rendering related contents');
+
 	return (
 		<CarouselColours props={props}>
 			<div

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { isNonNullable } from '@guardian/libs';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
-import { decideTrail } from '../lib/decideTrail';
+import { decideTrail, decideTrailWithMasterImage } from '../lib/decideTrail';
 import { useApi } from '../lib/useApi';
 import { addDiscussionIds } from '../lib/useCommentCount';
 import { palette } from '../palette';
@@ -9,6 +9,7 @@ import type { OnwardsSource } from '../types/onwards';
 import type { RenderingTarget } from '../types/renderingTarget';
 import type { FETrailType, TrailType } from '../types/trails';
 import { Carousel } from './Carousel.importable';
+import { MoreGalleries } from './MoreGalleries';
 import { Placeholder } from './Placeholder';
 
 type Props = {
@@ -40,11 +41,12 @@ const buildTrails = (
 	trails: FETrailType[],
 	trailLimit: number,
 	isAdFreeUser: boolean,
+	withMasterImage = false,
 ): TrailType[] => {
 	return trails
 		.filter((trailType) => !(isTrailPaidContent(trailType) && isAdFreeUser))
 		.slice(0, trailLimit)
-		.map(decideTrail);
+		.map(withMasterImage ? decideTrailWithMasterImage : decideTrail);
 };
 
 export const FetchOnwardsData = ({
@@ -83,22 +85,32 @@ export const FetchOnwardsData = ({
 
 	return (
 		<div css={minHeight}>
-			<Carousel
-				heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
-				trails={buildTrails(data.trails, limit, isAdFreeUser)}
-				description={data.description}
-				onwardsSource={onwardsSource}
-				format={format}
-				leftColSize={
-					format.design === ArticleDesign.LiveBlog ||
-					format.design === ArticleDesign.DeadBlog
-						? 'wide'
-						: 'compact'
-				}
-				discussionApiUrl={discussionApiUrl}
-				absoluteServerTimes={absoluteServerTimes}
-				renderingTarget={renderingTarget}
-			/>
+			{onwardsSource === 'more-galleries' ? (
+				<MoreGalleries
+					absoluteServerTimes={absoluteServerTimes}
+					trails={buildTrails(data.trails, limit, isAdFreeUser, true)}
+					discussionApiUrl={discussionApiUrl}
+					heading={'More Galleries'}
+					onwardsSource={onwardsSource}
+				/>
+			) : (
+				<Carousel
+					heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
+					trails={buildTrails(data.trails, limit, isAdFreeUser)}
+					description={data.description}
+					onwardsSource={onwardsSource}
+					format={format}
+					leftColSize={
+						format.design === ArticleDesign.LiveBlog ||
+						format.design === ArticleDesign.DeadBlog
+							? 'wide'
+							: 'compact'
+					}
+					discussionApiUrl={discussionApiUrl}
+					absoluteServerTimes={absoluteServerTimes}
+					renderingTarget={renderingTarget}
+				/>
+			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/MoreGalleries.stories.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { getDataLinkNameCard } from '../lib/getDataLinkName';
 import { MoreGalleries as MoreGalleriesComponent } from './MoreGalleries';
-import { getDataLinkNameCard } from 'src/lib/getDataLinkName';
 
 const meta = {
 	title: 'Components/MoreGalleries',
@@ -14,14 +14,12 @@ type Story = StoryObj<typeof meta>;
 
 export const MoreGalleries = {
 	args: {
-		format: {
-			theme: Pillar.News,
-			design: ArticleDesign.Gallery,
-			display: ArticleDisplay.Standard,
-		},
 		absoluteServerTimes: false,
 		discussionApiUrl:
 			'https://discussion.code.dev-theguardian.com/discussion-api',
+		heading: 'More galleries',
+		url: 'http://localhost:9000/more-galleries',
+		onwardsSource: 'more-galleries',
 		trails: [
 			{
 				url: 'http://localhost:9000/environment/gallery/2025/aug/22/week-in-wildlife-a-clumsy-fox-swinging-orangutang-and-rescued-jaguarundi-cub',
@@ -56,6 +54,10 @@ export const MoreGalleries = {
 					'0',
 					0,
 				),
+				trailText:
+					'Guinness World Records is looking back at the extraordinary feats achieved since its inception - as well as unveiling 70 whacky and unclaimed records ',
+				kickerText: 'Politics', // Get data for this
+				mainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for this
 			},
 			{
 				url: 'http://localhost:9000/money/gallery/2025/aug/22/characterful-cottages-for-sale-in-england-in-pictures',
@@ -63,31 +65,36 @@ export const MoreGalleries = {
 					'Characterful cottages for sale in England – in pictures',
 				showByline: false,
 				byline: 'Anna White',
-				masterImage:
-					'https://media.guim.co.uk/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg',
-				image: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=35fb647440143717424928ec795146e7',
-				carouselImages: {
-					300: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=35fb647440143717424928ec795146e7',
-					460: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=460&quality=85&auto=format&fit=max&s=372ea9d012b1d9d96d0ab0a74aa9f4cf',
+				image: {
+					src: 'https://media.guim.co.uk/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg',
+					altText: '',
 				},
-				isLiveBlog: false,
-				pillar: 'lifestyle',
-				designType: 'Media',
 				format: {
-					design: 'GalleryDesign',
-					theme: 'LifestylePillar',
-					display: 'StandardDisplay',
+					design: ArticleDesign.Gallery,
+					theme: Pillar.Lifestyle,
+					display: ArticleDisplay.Standard,
 				},
 				webPublicationDate: '2025-08-22T06:00:24.000Z',
 				headline:
 					'Characterful cottages for sale in England – in pictures',
-				mediaType: 'Gallery',
 				shortUrl: 'https://www.theguardian.com/p/x32gqj',
 				discussion: {
 					isCommentable: false,
 					isClosedForComments: true,
 					discussionId: '/p/x32gqj',
 				},
+				dataLinkName: getDataLinkNameCard(
+					{
+						design: ArticleDesign.Gallery,
+						theme: Pillar.Lifestyle,
+						display: ArticleDisplay.Standard,
+					},
+					'0',
+					1,
+				),
+				trailText:
+					'Picked from a record 60,636 entries, the first images from the Natural History Museum’s wildlife photographer of the year competition have been released. The photographs, which range from a lion facing down a cobra to magnified mould spores, show the diversity, beauty and complexity of the natural world and humanity’s relationship with it',
+				mainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for this
 			},
 			{
 				url: 'http://localhost:9000/news/gallery/2025/aug/22/sunsets-aid-parachutes-and-giant-pandas-photos-of-the-day-friday',
@@ -95,92 +102,107 @@ export const MoreGalleries = {
 					'Sunsets, aid parachutes and giant pandas: photos of the day – Friday ',
 				showByline: false,
 				byline: 'Eithne Staunton',
-				masterImage:
-					'https://media.guim.co.uk/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png',
-				image: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=300&quality=85&auto=format&fit=max&s=0fe5f2cd010943be553fef6725d4b617',
-				carouselImages: {
-					300: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=300&quality=85&auto=format&fit=max&s=0fe5f2cd010943be553fef6725d4b617',
-					460: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=460&quality=85&auto=format&fit=max&s=966e5c2a61465aa333a1e3efa4851bfc',
+				image: {
+					src: 'https://media.guim.co.uk/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png',
+					altText: '',
 				},
-				isLiveBlog: false,
-				pillar: 'news',
-				designType: 'Media',
 				format: {
-					design: 'GalleryDesign',
-					theme: 'NewsPillar',
-					display: 'StandardDisplay',
+					design: ArticleDesign.Gallery,
+					theme: Pillar.News,
+					display: ArticleDisplay.Standard,
 				},
 				webPublicationDate: '2025-08-22T12:49:42.000Z',
 				headline:
 					'Sunsets, aid parachutes and giant pandas: photos of the day – Friday ',
-				mediaType: 'Gallery',
 				shortUrl: 'https://www.theguardian.com/p/x3359z',
 				discussion: {
 					isCommentable: false,
 					isClosedForComments: true,
 					discussionId: '/p/x3359z',
 				},
+				dataLinkName: getDataLinkNameCard(
+					{
+						design: ArticleDesign.Gallery,
+						theme: Pillar.News,
+						display: ArticleDisplay.Standard,
+					},
+					'0',
+					2,
+				),
+				trailText:
+					'From the mock-Tudor fad of the 1920s to drivers refuelling on a roundabout, each era produces its own distinctive petrol stations – as photographer Philip Butler discovered',
+				mainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for this
 			},
 			{
 				url: 'http://localhost:9000/fashion/gallery/2025/aug/22/what-to-wear-to-notting-hill-carnival',
 				linkText: 'On parade: what to wear to Notting Hill carnival',
 				showByline: false,
 				byline: 'Melanie Wilkinson',
-				masterImage:
-					'https://media.guim.co.uk/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg',
-				image: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=300&quality=85&auto=format&fit=max&s=552a5c40f2dbe4ec5e41eb7ce38cc51b',
-				carouselImages: {
-					300: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=300&quality=85&auto=format&fit=max&s=552a5c40f2dbe4ec5e41eb7ce38cc51b',
-					460: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=460&quality=85&auto=format&fit=max&s=92465638ffbcf894d49bdcb033b9ddfd',
+				image: {
+					src: 'https://media.guim.co.uk/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg',
+					altText: '',
 				},
-				isLiveBlog: false,
-				pillar: 'lifestyle',
-				designType: 'Media',
 				format: {
-					design: 'GalleryDesign',
-					theme: 'LifestylePillar',
-					display: 'StandardDisplay',
+					design: ArticleDesign.Gallery,
+					theme: Pillar.Lifestyle,
+					display: ArticleDisplay.Standard,
 				},
 				webPublicationDate: '2025-08-22T05:00:23.000Z',
 				headline: 'On parade: what to wear to Notting Hill carnival',
-				mediaType: 'Gallery',
 				shortUrl: 'https://www.theguardian.com/p/x32mte',
 				discussion: {
 					isCommentable: false,
 					isClosedForComments: true,
 					discussionId: '/p/x32mte',
 				},
+				dataLinkName: getDataLinkNameCard(
+					{
+						design: ArticleDesign.Gallery,
+						theme: Pillar.Lifestyle,
+						display: ArticleDisplay.Standard,
+					},
+					'0',
+					1,
+				),
+				trailText:
+					'The Guardian’s picture editors select photographs from around the world',
+				mainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for thismainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for this
 			},
 			{
 				url: 'http://localhost:9000/artanddesign/gallery/2025/aug/21/psychedelic-rock-glass-mountain-michael-lundgren',
 				linkText:
 					'Psychedelic rock! Formations that mess with your mind – in pictures ',
 				showByline: false,
-				masterImage:
-					'https://media.guim.co.uk/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg',
-				image: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=300&quality=85&auto=format&fit=max&s=3105a2cb22c9aa1c4247cb1d373c449d',
-				carouselImages: {
-					300: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=300&quality=85&auto=format&fit=max&s=3105a2cb22c9aa1c4247cb1d373c449d',
-					460: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=460&quality=85&auto=format&fit=max&s=59f834675fd82a57db4d61ffe76ac759',
+				image: {
+					src: 'https://media.guim.co.uk/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg',
+					altText: '',
 				},
-				isLiveBlog: false,
-				pillar: 'culture',
-				designType: 'Media',
 				format: {
-					design: 'GalleryDesign',
-					theme: 'CulturePillar',
-					display: 'StandardDisplay',
+					design: ArticleDesign.Gallery,
+					theme: Pillar.Culture,
+					display: ArticleDisplay.Standard,
 				},
 				webPublicationDate: '2025-08-21T06:01:01.000Z',
 				headline:
 					'Psychedelic rock! Formations that mess with your mind – in pictures ',
-				mediaType: 'Gallery',
 				shortUrl: 'https://www.theguardian.com/p/x2p663',
 				discussion: {
 					isCommentable: false,
 					isClosedForComments: true,
 					discussionId: '/p/x2p663',
 				},
+				dataLinkName: getDataLinkNameCard(
+					{
+						design: ArticleDesign.Gallery,
+						theme: Pillar.Culture,
+						display: ArticleDisplay.Standard,
+					},
+					'0',
+					1,
+				),
+				trailText:
+					'Politicians and their partners put on their best show at this year’s Midwinter Ball, an annual dinner hosted by the Federal Parliamentary Press Gallery in Canberra',
+				mainMedia: { type: 'Gallery', count: '6' }, // TODO: get data for this
 			},
 		],
 	},

--- a/dotcom-rendering/src/components/MoreGalleries.stories.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.stories.tsx
@@ -1,0 +1,187 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { MoreGalleries as MoreGalleriesComponent } from './MoreGalleries';
+import { getDataLinkNameCard } from 'src/lib/getDataLinkName';
+
+const meta = {
+	title: 'Components/MoreGalleries',
+	component: MoreGalleriesComponent,
+} satisfies Meta<typeof MoreGalleriesComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MoreGalleries = {
+	args: {
+		format: {
+			theme: Pillar.News,
+			design: ArticleDesign.Gallery,
+			display: ArticleDisplay.Standard,
+		},
+		absoluteServerTimes: false,
+		discussionApiUrl:
+			'https://discussion.code.dev-theguardian.com/discussion-api',
+		trails: [
+			{
+				url: 'http://localhost:9000/environment/gallery/2025/aug/22/week-in-wildlife-a-clumsy-fox-swinging-orangutang-and-rescued-jaguarundi-cub',
+				linkText:
+					'Week in wildlife: a clumsy fox, a swinging orangutan and a rescued jaguarundi cub',
+				showByline: false,
+				byline: 'Pejman Faratin',
+				image: {
+					src: 'https://media.guim.co.uk/a81e974ffee6c8c88fa280c2d02eaf5dc2af863e/151_292_1020_816/master/1020.jpg',
+					altText: '',
+				},
+				format: {
+					theme: Pillar.News,
+					design: ArticleDesign.Gallery,
+					display: ArticleDisplay.Standard,
+				},
+				webPublicationDate: '2025-08-22T06:00:25.000Z',
+				headline:
+					'Week in wildlife: a clumsy fox, a swinging orangutan and a rescued jaguarundi cub',
+				shortUrl: 'https://www.theguardian.com/p/x32n89',
+				discussion: {
+					isCommentable: false,
+					isClosedForComments: true,
+					discussionId: '/p/x32n89',
+				},
+				dataLinkName: getDataLinkNameCard(
+					{
+						theme: Pillar.News,
+						design: ArticleDesign.Gallery,
+						display: ArticleDisplay.Standard,
+					},
+					'0',
+					0,
+				),
+			},
+			{
+				url: 'http://localhost:9000/money/gallery/2025/aug/22/characterful-cottages-for-sale-in-england-in-pictures',
+				linkText:
+					'Characterful cottages for sale in England – in pictures',
+				showByline: false,
+				byline: 'Anna White',
+				masterImage:
+					'https://media.guim.co.uk/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg',
+				image: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=35fb647440143717424928ec795146e7',
+				carouselImages: {
+					300: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=300&quality=85&auto=format&fit=max&s=35fb647440143717424928ec795146e7',
+					460: 'https://i.guim.co.uk/img/media/58cd9356e6d68e8efa6028162bb959f9798307d5/515_0_5000_4000/master/5000.jpg?width=460&quality=85&auto=format&fit=max&s=372ea9d012b1d9d96d0ab0a74aa9f4cf',
+				},
+				isLiveBlog: false,
+				pillar: 'lifestyle',
+				designType: 'Media',
+				format: {
+					design: 'GalleryDesign',
+					theme: 'LifestylePillar',
+					display: 'StandardDisplay',
+				},
+				webPublicationDate: '2025-08-22T06:00:24.000Z',
+				headline:
+					'Characterful cottages for sale in England – in pictures',
+				mediaType: 'Gallery',
+				shortUrl: 'https://www.theguardian.com/p/x32gqj',
+				discussion: {
+					isCommentable: false,
+					isClosedForComments: true,
+					discussionId: '/p/x32gqj',
+				},
+			},
+			{
+				url: 'http://localhost:9000/news/gallery/2025/aug/22/sunsets-aid-parachutes-and-giant-pandas-photos-of-the-day-friday',
+				linkText:
+					'Sunsets, aid parachutes and giant pandas: photos of the day – Friday ',
+				showByline: false,
+				byline: 'Eithne Staunton',
+				masterImage:
+					'https://media.guim.co.uk/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png',
+				image: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=300&quality=85&auto=format&fit=max&s=0fe5f2cd010943be553fef6725d4b617',
+				carouselImages: {
+					300: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=300&quality=85&auto=format&fit=max&s=0fe5f2cd010943be553fef6725d4b617',
+					460: 'https://i.guim.co.uk/img/media/4ce0b080206fe9b65b976c1acf219d81072cc814/0_0_2113_1690/master/2113.png?width=460&quality=85&auto=format&fit=max&s=966e5c2a61465aa333a1e3efa4851bfc',
+				},
+				isLiveBlog: false,
+				pillar: 'news',
+				designType: 'Media',
+				format: {
+					design: 'GalleryDesign',
+					theme: 'NewsPillar',
+					display: 'StandardDisplay',
+				},
+				webPublicationDate: '2025-08-22T12:49:42.000Z',
+				headline:
+					'Sunsets, aid parachutes and giant pandas: photos of the day – Friday ',
+				mediaType: 'Gallery',
+				shortUrl: 'https://www.theguardian.com/p/x3359z',
+				discussion: {
+					isCommentable: false,
+					isClosedForComments: true,
+					discussionId: '/p/x3359z',
+				},
+			},
+			{
+				url: 'http://localhost:9000/fashion/gallery/2025/aug/22/what-to-wear-to-notting-hill-carnival',
+				linkText: 'On parade: what to wear to Notting Hill carnival',
+				showByline: false,
+				byline: 'Melanie Wilkinson',
+				masterImage:
+					'https://media.guim.co.uk/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg',
+				image: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=300&quality=85&auto=format&fit=max&s=552a5c40f2dbe4ec5e41eb7ce38cc51b',
+				carouselImages: {
+					300: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=300&quality=85&auto=format&fit=max&s=552a5c40f2dbe4ec5e41eb7ce38cc51b',
+					460: 'https://i.guim.co.uk/img/media/49a9656cd10c4f64f8bdd54380afb915c7a3648b/207_0_1500_1200/master/1500.jpg?width=460&quality=85&auto=format&fit=max&s=92465638ffbcf894d49bdcb033b9ddfd',
+				},
+				isLiveBlog: false,
+				pillar: 'lifestyle',
+				designType: 'Media',
+				format: {
+					design: 'GalleryDesign',
+					theme: 'LifestylePillar',
+					display: 'StandardDisplay',
+				},
+				webPublicationDate: '2025-08-22T05:00:23.000Z',
+				headline: 'On parade: what to wear to Notting Hill carnival',
+				mediaType: 'Gallery',
+				shortUrl: 'https://www.theguardian.com/p/x32mte',
+				discussion: {
+					isCommentable: false,
+					isClosedForComments: true,
+					discussionId: '/p/x32mte',
+				},
+			},
+			{
+				url: 'http://localhost:9000/artanddesign/gallery/2025/aug/21/psychedelic-rock-glass-mountain-michael-lundgren',
+				linkText:
+					'Psychedelic rock! Formations that mess with your mind – in pictures ',
+				showByline: false,
+				masterImage:
+					'https://media.guim.co.uk/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg',
+				image: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=300&quality=85&auto=format&fit=max&s=3105a2cb22c9aa1c4247cb1d373c449d',
+				carouselImages: {
+					300: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=300&quality=85&auto=format&fit=max&s=3105a2cb22c9aa1c4247cb1d373c449d',
+					460: 'https://i.guim.co.uk/img/media/2810af61b2d2d2d5f71ec01e56e6555e0a6d4635/55_0_2813_2250/master/2813.jpg?width=460&quality=85&auto=format&fit=max&s=59f834675fd82a57db4d61ffe76ac759',
+				},
+				isLiveBlog: false,
+				pillar: 'culture',
+				designType: 'Media',
+				format: {
+					design: 'GalleryDesign',
+					theme: 'CulturePillar',
+					display: 'StandardDisplay',
+				},
+				webPublicationDate: '2025-08-21T06:01:01.000Z',
+				headline:
+					'Psychedelic rock! Formations that mess with your mind – in pictures ',
+				mediaType: 'Gallery',
+				shortUrl: 'https://www.theguardian.com/p/x2p663',
+				discussion: {
+					isCommentable: false,
+					isClosedForComments: true,
+					discussionId: '/p/x2p663',
+				},
+			},
+		],
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/MoreGalleries.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.tsx
@@ -1,0 +1,29 @@
+import { type ArticleFormat } from '../lib/articleFormat';
+import { type TrailType } from '../types/trails';
+import { Card } from './Card/Card';
+
+type Props = {
+	format: ArticleFormat;
+	absoluteServerTimes: boolean;
+	trails: TrailType[];
+	discussionApiUrl: string;
+};
+
+export const MoreGalleries = (props: Props) => {
+	return (
+		<section>
+			{props.trails.map((trail) => (
+				<Card
+					key={trail.url}
+					linkTo={trail.url}
+					format={props.format}
+					absoluteServerTimes={props.absoluteServerTimes}
+					headlineText={trail.headline}
+					imageLoading="lazy"
+					discussionApiUrl={props.discussionApiUrl}
+					isExternalLink={false}
+				/>
+			))}
+		</section>
+	);
+};

--- a/dotcom-rendering/src/components/MoreGalleries.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.tsx
@@ -1,29 +1,270 @@
-import { type ArticleFormat } from '../lib/articleFormat';
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold24,
+	headlineBold28,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import { formatAttrString } from '../lib/formatAttrString';
+import { palette as themePalette } from '../palette';
+import { type OnwardsSource } from '../types/onwards';
 import { type TrailType } from '../types/trails';
 import { Card } from './Card/Card';
+import type { Props as CardProps } from './Card/Card';
+import { Hide } from './Hide';
+import { LeftColumn } from './LeftColumn';
+import { Section } from './Section';
 
 type Props = {
-	format: ArticleFormat;
 	absoluteServerTimes: boolean;
 	trails: TrailType[];
 	discussionApiUrl: string;
+	heading: string;
+	onwardsSource: OnwardsSource;
+	url?: string;
+};
+
+const wrapperStyle = css`
+	display: flex;
+	justify-content: space-between;
+	overflow: hidden;
+	${from.desktop} {
+		padding-right: 40px;
+	}
+`;
+
+const containerStyles = css`
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	overflow: hidden; /* Needed for scrolling to work */
+
+	margin-top: ${space[2]}px;
+	padding-bottom: ${space[6]}px;
+
+	margin-left: 0px;
+	margin-right: 0px;
+
+	border-bottom: 1px solid ${themePalette('--onward-content-border')};
+
+	${from.leftCol} {
+		margin-left: 10px;
+		margin-right: 100px;
+	}
+`;
+
+const standardCardStyles = css`
+	flex: 1;
+
+	position: relative;
+	display: flex;
+	padding: ${space[2]}px;
+	background-color: ${themePalette('--onward-card-background')};
+
+	:not(:first-child)::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: -10px; /* shift into the gap */
+		width: 1px;
+		background: ${themePalette('--onward-content-border')};
+	}
+`;
+
+const standardCardsListStyles = css`
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	gap: 20px;
+
+	${from.tablet} {
+		padding-top: ${space[2]}px;
+	}
+
+	${until.tablet} {
+		flex-direction: column;
+		width: 100%;
+	}
+`;
+
+const headerStyles = css`
+	color: ${themePalette('--carousel-text')};
+	${headlineBold24};
+	padding-bottom: ${space[3]}px;
+	padding-top: ${space[1]}px;
+	margin-left: 0;
+
+	${from.tablet} {
+		${headlineBold28};
+	}
+`;
+
+const headerStylesWithUrl = css`
+	:hover {
+		text-decoration: underline;
+	}
+`;
+
+const titleStyle = css`
+	color: ${themePalette('--onward-text')};
+	display: inline-block;
+	&::first-letter {
+		text-transform: capitalize;
+	}
+`;
+
+const getDefaultCardProps = (
+	trail: TrailType,
+	absoluteServerTimes: boolean,
+	discussionApiUrl: string,
+) => {
+	const defaultProps: CardProps = {
+		linkTo: trail.url,
+		format: trail.format,
+		headlineText: trail.headline,
+		byline: trail.byline,
+		showByline: trail.showByline,
+		showQuotedHeadline: trail.showQuotedHeadline,
+		webPublicationDate: trail.webPublicationDate,
+		kickerText: trail.kickerText,
+		showPulsingDot: false,
+		showClock: false,
+		image: trail.image,
+		isCrossword: trail.isCrossword,
+		starRating: trail.starRating,
+		dataLinkName: trail.dataLinkName,
+		snapData: trail.snapData,
+		discussionApiUrl,
+		discussionId: trail.discussionId,
+		avatarUrl: trail.avatarUrl,
+		mainMedia: trail.mainMedia,
+		isExternalLink: false,
+		branding: trail.branding,
+		absoluteServerTimes,
+		imageLoading: 'lazy',
+		trailText: trail.trailText,
+		showAge: false, // TODO
+		containerType: 'more-galleries',
+		showTopBarDesktop: false,
+		showTopBarMobile: false,
+		aspectRatio: '5:4',
+	};
+	return defaultProps;
 };
 
 export const MoreGalleries = (props: Props) => {
+	const [firstTrail, ...standardCards] = props.trails;
+	if (!firstTrail) return null;
+
+	const defaultProps = getDefaultCardProps(
+		firstTrail,
+		props.absoluteServerTimes,
+		props.discussionApiUrl,
+	);
+
 	return (
-		<section>
-			{props.trails.map((trail) => (
-				<Card
-					key={trail.url}
-					linkTo={trail.url}
-					format={props.format}
-					absoluteServerTimes={props.absoluteServerTimes}
-					headlineText={trail.headline}
-					imageLoading="lazy"
-					discussionApiUrl={props.discussionApiUrl}
-					isExternalLink={false}
-				/>
-			))}
-		</section>
+		<Section
+			fullWidth={true}
+			borderColour={themePalette('--onward-content-border')}
+			backgroundColour={themePalette('--onward-background')}
+			showTopBorder={false}
+		>
+			<div
+				css={wrapperStyle}
+				data-link-name={formatAttrString(props.heading)}
+			>
+				<LeftColumn
+					size={'compact'}
+					borderColour={themePalette('--onward-content-border')}
+					hasPageSkin={false} // TODO
+				>
+					<Title title={props.heading} url={props.url} />
+				</LeftColumn>
+
+				<div
+					css={containerStyles}
+					data-component={props.onwardsSource}
+					data-link={formatAttrString(props.heading)}
+				>
+					<Hide when="above" breakpoint="leftCol">
+						<Title title={props.heading} url={props.url} />
+					</Hide>
+
+					<MoreGalleriesSplashCard defaultProps={defaultProps} />
+					<Hide when="below" breakpoint="tablet">
+						<StraightLines
+							count={1}
+							color={themePalette('--onward-content-border')}
+						/>
+					</Hide>
+
+					<ul css={standardCardsListStyles}>
+						{standardCards.map((trail) => (
+							<li key={trail.url} css={standardCardStyles}>
+								{Card({
+									...getDefaultCardProps(
+										trail,
+										props.absoluteServerTimes,
+										props.discussionApiUrl,
+									),
+									imageSize: 'medium',
+								})}
+							</li>
+						))}
+					</ul>
+				</div>
+			</div>
+		</Section>
 	);
 };
+
+const MoreGalleriesSplashCard = ({
+	defaultProps,
+}: {
+	defaultProps: CardProps;
+}) => {
+	const cardProps: Partial<CardProps> = {
+		headlineSizes: {
+			desktop: 'medium',
+			tablet: 'medium',
+			mobile: 'medium',
+		},
+		imagePositionOnDesktop: 'right',
+		imagePositionOnMobile: 'top',
+		imageSize: 'large',
+		isFlexSplash: true,
+	};
+	return (
+		<div
+			css={css`
+				margin-bottom: ${space[6]}px;
+				background-color: ${themePalette('--onward-card-background')};
+				padding: ${space[2]}px;
+			`}
+		>
+			{Card({ ...defaultProps, ...cardProps })}
+		</div>
+	);
+};
+
+const Title = ({ title, url }: { title: string; url?: string }) =>
+	url ? (
+		<a
+			css={css`
+				text-decoration: none;
+			`}
+			href={url}
+			data-link-name="section heading" // TODO
+		>
+			<h2 css={headerStyles}>
+				<span css={[headerStylesWithUrl, titleStyle]}>{title}</span>
+			</h2>
+		</a>
+	) : (
+		<h2 css={headerStyles}>
+			<span css={titleStyle}>{title}</span>
+		</h2>
+	);

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -303,6 +303,9 @@ export const OnwardsUpper = ({
 		? getContainerDataUrl(pillar, editionId, ajaxUrl)
 		: undefined;
 
+	console.log(`url: ${url}`);
+	console.log(`curatedDataUrl: ${curatedDataUrl}`);
+
 	return (
 		<div css={onwardsWrapper}>
 			{!!url && (

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -18,6 +18,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { Caption } from '../components/Caption';
 import { Carousel } from '../components/Carousel.importable';
 import { DiscussionLayout } from '../components/DiscussionLayout';
+import { FetchOnwardsData } from '../components/FetchOnwardsData.importable';
 import { Footer } from '../components/Footer';
 import { DesktopAdSlot, MobileAdSlot } from '../components/GalleryAdSlots';
 import { GalleryImage } from '../components/GalleryImage';
@@ -379,6 +380,20 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						frontendData.showBottomSocialButtons && isWeb
 					}
 				/>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<FetchOnwardsData
+						url={`${gallery.frontendData.config.ajaxUrl}/gallery/most-viewed.json?dcr=true`} // TODO: Fix the url for the app version too
+						limit={5}
+						onwardsSource={'more-galleries'}
+						format={format}
+						discussionApiUrl={discussionApiUrl}
+						absoluteServerTimes={
+							switches['absoluteServerTimes'] ?? false
+						}
+						renderingTarget={renderingTarget}
+						isAdFreeUser={frontendData.isAdFreeUser}
+					/>
+				</Island>
 			</main>
 			{/* More galleries container */}
 			{showMerchandisingHigh && (

--- a/dotcom-rendering/src/lib/decideTrail.ts
+++ b/dotcom-rendering/src/lib/decideTrail.ts
@@ -1,4 +1,5 @@
 import type { DCRFrontImage } from '../types/front';
+import { type MainMedia } from '../types/mainMedia';
 import type { FETrailType, TrailType } from '../types/trails';
 import { type ArticleFormat, decideFormat } from './articleFormat';
 import { getDataLinkNameCard } from './getDataLinkName';
@@ -18,4 +19,32 @@ export const decideTrail = (trail: FETrailType, index = 0): TrailType => {
 		format,
 		dataLinkName: getDataLinkNameCard(format, '0', index),
 	};
+};
+
+export const decideTrailWithMasterImage = (
+	trail: FETrailType,
+	index = 0,
+): TrailType => {
+	const format: ArticleFormat = decideFormat(trail.format);
+	const image: DCRFrontImage | undefined = trail.masterImage
+		? {
+				src: trail.masterImage,
+				altText: '', // TODO: Do we get this from frontend?
+		  }
+		: undefined;
+
+	return {
+		...trail,
+		image,
+		format,
+		dataLinkName: getDataLinkNameCard(format, '0', index),
+		mainMedia: getMedia(trail.galleryCount),
+	};
+};
+
+const getMedia = (galleryCount: number | undefined): MainMedia | undefined => {
+	if (typeof galleryCount === 'number') {
+		return { type: 'Gallery', count: galleryCount.toString() };
+	}
+	return undefined;
 };

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -59,6 +59,7 @@ export const generateImageURL = ({
 	aspectRatio?: string;
 	cropOffset?: { x: number; y: number };
 }): string => {
+	console.log(`mainImage: ${mainImage}`);
 	const url = new URL(mainImage);
 	const offset = cropOffset
 		? `,offset-x${cropOffset.x},offset-y${cropOffset.y}`
@@ -74,9 +75,12 @@ export const generateImageURL = ({
 
 	const domain = isCodeGridUrl(url) ? 'i.guimcode.co.uk' : 'i.guim.co.uk';
 
-	return `https://${domain}/img/${getServiceFromUrl(url)}${
+	const res = `https://${domain}/img/${getServiceFromUrl(url)}${
 		url.pathname
 	}?${params.toString()}`;
+
+	console.log(`res url: ${res}`);
+	return res;
 };
 
 export const isSupported = (imageUrl: string): boolean => {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7361,9 +7361,21 @@ const paletteColours = {
 		light: numberedListTitleLight,
 		dark: numberedListTitleDark,
 	},
+	'--onward-background': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[0],
+	},
+	'--onward-card-background': {
+		light: () => sourcePalette.neutral[97],
+		dark: () => sourcePalette.neutral[20],
+	},
 	'--onward-content-border': {
 		light: onwardContentBorderLight,
 		dark: () => sourcePalette.neutral[20],
+	},
+	'--onward-text': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--pagination-text': {
 		light: paginationTextLight,

--- a/dotcom-rendering/src/types/onwards.ts
+++ b/dotcom-rendering/src/types/onwards.ts
@@ -24,3 +24,5 @@ export type OnwardsSource =
 	| 'curated-content'
 	| 'newsletters-page'
 	| 'unknown-source'; // We should never see this in the analytics data!
+
+export type OnwardContainerType = 'more-galleries';

--- a/dotcom-rendering/src/types/trails.ts
+++ b/dotcom-rendering/src/types/trails.ts
@@ -30,6 +30,8 @@ interface BaseTrailType {
 		discussionId?: string;
 	};
 	mainMedia?: MainMedia;
+	trailText?: string;
+	galleryCount?: number;
 }
 
 export interface TrailType extends BaseTrailType {


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
