### PR TITLE
Choice cards tracking

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -479,6 +479,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									}
 									choices={choiceCards}
 									id={'banner'}
+									submitComponentEvent={submitComponentEvent}
 								/>
 							)}
 							<div css={styles.ctaContainer(isCollapsed)}>

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -55,6 +55,7 @@ export const ContributionsEpicCtasContainer: ReactComponent<Props> = ({
 					setSelectedChoiceCard={setSelectedChoiceCard}
 					choices={choiceCards}
 					id={'epic'}
+					submitComponentEvent={submitComponentEvent}
 				/>
 			)}
 			<ContributionsEpicButtons

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -155,7 +155,7 @@ type ThreeTierChoiceCardsProps = {
 	setSelectedChoiceCard: Dispatch<SetStateAction<ChoiceCard | undefined>>;
 	choices: ChoiceCard[];
 	id: 'epic' | 'banner'; // uniquely identify this choice cards component to avoid conflicting with others
-	submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
+	submitComponentEvent?: (componentEvent: ComponentEvent) => void;
 };
 
 export const ThreeTierChoiceCards = ({


### PR DESCRIPTION
PR review tip - select "hide whitespace" to make it easier to see the actual changes.

## What does this change?
The RR epic + banner have a "choice cards" component, which allows the user to select a product.
Currently we do not have tracking on this component.
This PR adds INSERT + VIEW ophan events, for both epic + banner.

The component_id will be `epic-choice-cards` or `banner-choice-cards`

## Why?
Currently we only track VIEW events for the very start of the epic, and the CTA at the end.
This will help MRR to understand what proportion of users make it further down the epic.
It can also give us a sense of what proportion of epics + banners have the choice cards component.

## Screenshots
<img width="736" height="122" alt="Screenshot 2025-09-04 at 10 03 51" src="https://github.com/user-attachments/assets/b36590cb-dee2-47c8-a0b4-06842802d81b" />
