### PR TITLE
Round interactive scrolly message values

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -20,7 +20,6 @@ const iframe = css`
 		position: sticky;
 		top: 0;
 		height: 100vh;
-		height: 100dvh;
 		overflow: hidden;
 	}
 `;

--- a/dotcom-rendering/src/components/InteractiveAtomMessenger.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtomMessenger.importable.tsx
@@ -72,7 +72,7 @@ export const InteractiveAtomMessenger = ({ id }: Props) => {
 				const rect = container.getBoundingClientRect();
 				if (rect.top > 0) return setScroll(0);
 				if (rect.top < -rect.height) return setScroll(1);
-				setScroll(-rect.top);
+				setScroll(-Math.round(rect.top));
 			});
 		};
 


### PR DESCRIPTION
While testing https://github.com/guardian/dotcom-rendering/pull/14474 some odd, jittery behaviour persists on Safari/iOS. Apparently Safari has some issue with inconsistent values that `getBoundingClientRect().top` returns. We've also changed the scrolly height to use `vh` rather than `dvh`.

See: https://stackoverflow.com/questions/77831973/getboundingclientrect-top-value-is-inconsistent-on-safari-browser-on-iphone

Local testing on browser _seemed_ better though it's a bit of an eye test at the moment.  