### PR TITLE
Show the correct image size in mega-boosted Opinion cards in Flexible General

### DIFF
--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -88,6 +88,7 @@ const decideImageWidths = (
 			];
 
 		case 'large':
+		case 'xlarge':
 			return [
 				{
 					breakpoint: breakpoints.mobile,

--- a/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
@@ -95,6 +95,7 @@ const sizingStyles = (
 						height: 80px;
 				  `;
 		case 'large':
+		case 'xlarge':
 			return css`
 				width: 150px;
 				height: 150px;


### PR DESCRIPTION
## What does this change?

Add avatar sizes for the `xlarge` image size.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/73440379-685d-416a-b0dd-d027f0842220
[after]: https://github.com/user-attachments/assets/c88f60b6-57f2-429a-9048-4010adef835e

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
