### PR TITLE
Fix double branding on single card containers

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,7 +31,7 @@ import { StickyBottomBanner } from '../components/StickyBottomBanner.importable'
 import { SubNav } from '../components/SubNav.importable';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
-import { badgeFromBranding, isPaidContentSameBranding } from '../lib/branding';
+import { badgeFromBranding } from '../lib/branding';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
@@ -47,8 +47,6 @@ import { palette as schemePalette } from '../palette';
 import type {
 	DCRCollectionType,
 	DCRContainerType,
-	DCRFrontCard,
-	DCRGroupedTrails,
 	Front,
 } from '../types/front';
 import { pageSkinContainer } from './lib/pageSkin';
@@ -100,41 +98,6 @@ const decideLeftContent = (front: Front, collection: DCRCollectionType) => {
 
 	// show nothing!
 	return null;
-};
-
-const stripTrailBrandingIfContainerHasBranding = (
-	collection: DCRCollectionType,
-): DCRCollectionType => {
-	const shouldStripBranding = isPaidContentSameBranding(
-		collection.collectionBranding,
-	);
-	const stripBrandingFromTrails = (trails: DCRFrontCard[]): DCRFrontCard[] =>
-		trails.map((t) => ({
-			...t,
-			branding: undefined,
-		}));
-	const stripBrandingFromGroupedTrails = (
-		grouped: DCRGroupedTrails,
-	): DCRGroupedTrails => {
-		const groupedEntries = Object.entries(grouped).map(([key, value]) => [
-			key,
-			stripBrandingFromTrails(value),
-		]);
-		return Object.fromEntries(groupedEntries) as DCRGroupedTrails;
-	};
-
-	return shouldStripBranding
-		? {
-				...collection,
-				// Remove the branding from each of the cards in a paid content
-				// collection if they are the same.
-				curated: stripBrandingFromTrails(collection.curated),
-				backfill: stripBrandingFromTrails(collection.backfill),
-				// We also need to remove the branding for the cards in grouped
-				// trails for dynamic containers
-				grouped: stripBrandingFromGroupedTrails(collection.grouped),
-		  }
-		: collection;
 };
 
 export const FrontLayout = ({ front, NAV }: Props) => {
@@ -302,11 +265,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					</Island>
 				)}
 
-				{filteredCollections.map((rawCollection, index) => {
-					// Strip branding from cards if we are going to show it at the container level instead
-					const collection =
-						stripTrailBrandingIfContainerHasBranding(rawCollection);
-
+				{filteredCollections.map((collection, index) => {
 					// Backfills should be added to the end of any curated content
 					const trails = collection.curated.concat(
 						collection.backfill,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -288,6 +288,7 @@ export const enhanceCards = (
 		editionId,
 		pageId,
 		discussionApiUrl,
+		stripBranding = false,
 	}: {
 		cardInTagPage: boolean;
 		/** Used for the data link name to indicate card position in container */
@@ -295,6 +296,8 @@ export const enhanceCards = (
 		editionId: EditionId;
 		pageId?: string;
 		discussionApiUrl: string;
+		/** We strip branding from cards if the branding will appear at the collection level instead */
+		stripBranding?: boolean;
 	},
 ): DCRFrontCard[] =>
 	collections.map((faciaCard, index) => {
@@ -397,7 +400,7 @@ export const enhanceCards = (
 			mainMedia,
 			isExternalLink: faciaCard.card.cardStyle.type === 'ExternalLink',
 			embedUri: faciaCard.properties.embedUri ?? undefined,
-			branding,
+			branding: stripBranding ? undefined : branding,
 			slideshowImages: decideSlideshowImages(faciaCard),
 			showVideo:
 				!!(

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -1,5 +1,8 @@
 import type { FECollection } from '../frontend/feFront';
-import { decideCollectionBranding } from '../lib/branding';
+import {
+	decideCollectionBranding,
+	isPaidContentSameBranding,
+} from '../lib/branding';
 import type { EditionId } from '../lib/edition';
 import type { Branding } from '../types/branding';
 import type { DCRCollectionType } from '../types/front';
@@ -88,6 +91,8 @@ export const enhanceCollections = ({
 					({ type }) => type === 'Branded',
 				) ?? false,
 		});
+		const stripBrandingFromCards =
+			isPaidContentSameBranding(collectionBranding);
 
 		const containerPalette = decideContainerPalette(
 			collection.config.metadata?.map((meta) => meta.type),
@@ -127,16 +132,19 @@ export const enhanceCollections = ({
 				collection.backfill,
 				editionId,
 				discussionApiUrl,
+				stripBrandingFromCards,
 			),
 			curated: enhanceCards(collection.curated, {
 				cardInTagPage: false,
 				editionId,
 				discussionApiUrl,
+				stripBranding: stripBrandingFromCards,
 			}),
 			backfill: enhanceCards(collection.backfill, {
 				cardInTagPage: false,
 				editionId,
 				discussionApiUrl,
+				stripBranding: stripBrandingFromCards,
 			}),
 			treats: enhanceTreats(
 				collection.treats,

--- a/dotcom-rendering/src/model/groupCards.ts
+++ b/dotcom-rendering/src/model/groupCards.ts
@@ -31,6 +31,7 @@ export const groupCards = (
 	backfill: FEFrontCard[],
 	editionId: EditionId,
 	discussionApiUrl: string,
+	stripBranding: boolean = false,
 ): DCRGroupedTrails => {
 	switch (container) {
 		case 'dynamic/fast':
@@ -47,18 +48,21 @@ export const groupCards = (
 					cardInTagPage: false,
 					editionId,
 					discussionApiUrl,
+					stripBranding,
 				}),
 				veryBig: enhanceCards(veryBig, {
 					cardInTagPage: false,
 					offset: huge.length,
 					editionId,
 					discussionApiUrl,
+					stripBranding,
 				}),
 				big: enhanceCards(big, {
 					cardInTagPage: false,
 					offset: huge.length + veryBig.length,
 					editionId,
 					discussionApiUrl,
+					stripBranding,
 				}),
 				standard: enhanceCards(
 					// Backfilled cards will always be treated as 'standard' cards
@@ -91,6 +95,7 @@ export const groupCards = (
 				editionId,
 				discussionApiUrl,
 				offset,
+				stripBranding,
 			});
 
 			return {
@@ -116,6 +121,7 @@ export const groupCards = (
 				editionId,
 				discussionApiUrl,
 				offset,
+				stripBranding,
 			});
 
 			return {


### PR DESCRIPTION
## What does this change?

Ensures branding is stripped appropriately from cards if container level branding is to be used instead

Does this by moving the logic out of the rendering layer, to the data enhance layer. This should simplify rendering decisions since we have enough information at the enhancement level to do this.

## Why?

A bug was reported which resulted in branding being applied twice for a new-style container: once at the container level and once at the card level. This happened particularly for containers using grouping which contained only one card.

This bug has been fixed and the code simplified at the same time, to make it easier to spot things like this in the future.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/ca1b369d-6295-4741-a4ad-03fa258a8f66
[after]: https://github.com/user-attachments/assets/c9f8e157-e0b1-465d-8917-0011edf3288f
