### PR TITLE
Set max width on card logo for branded cards

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardBranding.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardBranding.tsx
@@ -21,6 +21,7 @@ type Props = {
 
 const logoImageStyle = css`
 	max-height: 60px;
+	max-width: 120px;
 	margin-left: ${space[3]}px;
 	vertical-align: middle;
 	height: auto;


### PR DESCRIPTION
## What does this change?

Sets a maximum width of 120px for the card logo on branded cards.
This is the same logo width applied at the container level.

We'll consolidate the logo logic in a future PR as we're going to be redesigning the branded containers and cards

## Why?

There was a bug reported with logo sizing on labs containers using the new _static 4_ container layout

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5f166198-dbab-47f7-afa1-af101b98978f
[after]: https://github.com/user-attachments/assets/817234cd-3d40-4a42-84cb-e3c5b2f559eb
