### PR TITLE
Add most viewed footer to galleries

### DIFF
--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -26,6 +26,8 @@ import { Island } from '../components/Island';
 import { LabsHeader } from '../components/LabsHeader';
 import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Masthead } from '../components/Masthead/Masthead';
+import { MostViewedFooterData } from '../components/MostViewedFooterData.importable';
+import { MostViewedFooterLayout } from '../components/MostViewedFooterLayout';
 import { Section } from '../components/Section';
 import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
@@ -436,7 +438,30 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					/>
 				</Section>
 			)}
-			{/** Most Popular container goes here */}
+			{!frontendData.pageType.isPaidContent && (
+				<Section
+					title="Most viewed"
+					padContent={false}
+					verticalMargins={false}
+					element="aside"
+					data-link-name="most-popular"
+					data-component="most-popular"
+					backgroundColour={palette('--article-section-background')}
+					borderColour={palette('--article-border')}
+					fontColour={palette('--article-section-title')}
+				>
+					<MostViewedFooterLayout renderAds={isWeb && renderAds}>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<MostViewedFooterData
+								sectionId={frontendData.config.section}
+								ajaxUrl={frontendData.config.ajaxUrl}
+								edition={frontendData.editionId}
+							/>
+						</Island>
+					</MostViewedFooterLayout>
+				</Section>
+			)}
+
 			{isWeb && renderAds && !isLabs && (
 				<Section
 					fullWidth={true}


### PR DESCRIPTION
## What does this change?
Adds the most viewed footer to galleries
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/14446
## Screenshots

<img width="665" height="722" alt="image" src="https://github.com/user-attachments/assets/5caec523-8622-4568-8827-8bec3adf4441" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
