### PR TITLE
Remove Opinion no avatar AB test

### DIFF
--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -47,7 +47,6 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
-	isInOpinionNoAvatarVariant?: boolean;
 	isInHideTrailsAbTest?: boolean;
 };
 
@@ -64,7 +63,6 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
-	isInOpinionNoAvatarVariant,
 	isInHideTrailsAbTest,
 }: Props) => {
 	switch (containerType) {
@@ -262,7 +260,6 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
-					isInOpinionNoAvatarVariant={isInOpinionNoAvatarVariant}
 					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
@@ -294,7 +291,6 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
-						isInOpinionNoAvatarVariant={isInOpinionNoAvatarVariant}
 						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					/>
 				</Island>

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -32,7 +32,6 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
-	isInOpinionNoAvatarVariant?: boolean;
 	isInHideTrailsAbTest?: boolean;
 };
 
@@ -597,7 +596,6 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
-	isInOpinionNoAvatarVariant,
 	isInHideTrailsAbTest,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
@@ -610,9 +608,6 @@ export const FlexibleGeneral = ({
 		.map((standard, i) => ({
 			...standard,
 			uniqueId: `collection-${collectionId}-standard-${i}`,
-			avatarUrl: isInOpinionNoAvatarVariant
-				? undefined
-				: standard.avatarUrl,
 		}));
 
 	const groupedCards = decideCardPositions(cards);

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -17,7 +17,6 @@ type Props = {
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
 	sectionId: string;
-	isInOpinionNoAvatarVariant?: boolean;
 	isInHideTrailsAbTest?: boolean;
 };
 
@@ -37,7 +36,6 @@ export const ScrollableMedium = ({
 	showAge,
 	aspectRatio,
 	sectionId,
-	isInOpinionNoAvatarVariant,
 	isInHideTrailsAbTest,
 }: Props) => {
 	return (
@@ -55,12 +53,7 @@ export const ScrollableMedium = ({
 				return (
 					<ScrollableCarousel.Item key={trail.url}>
 						<FrontCard
-							trail={{
-								...trail,
-								avatarUrl: isInOpinionNoAvatarVariant
-									? undefined
-									: trail.avatarUrl,
-							}}
+							trail={trail}
 							imageLoading={imageLoading}
 							absoluteServerTimes={!!absoluteServerTimes}
 							containerPalette={containerPalette}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -135,15 +135,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
-	/**
-	 * We are running an AB test which replaces the avatar for the card image
-	 * in the Opinion and More opinion collections on network fronts.
-	 */
-	const isInOpinionNoAvatarVariant = (collectionName: string) =>
-		abTests.opinionNoAvatarVariant === 'variant' &&
-		front.isNetworkFront &&
-		(collectionName === 'Opinion' || collectionName === 'More opinion');
-
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {
 			case 'scrollable/feature':
@@ -600,9 +591,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
-									isInOpinionNoAvatarVariant={isInOpinionNoAvatarVariant(
-										collection.displayName,
-									)}
 									isInHideTrailsAbTest={
 										front.isNetworkFront &&
 										abTests.hideTrailsVariant === 'variant'


### PR DESCRIPTION
## What does this change?

Removes the [OpinionNoAvatar AB test](https://github.com/guardian/dotcom-rendering/pull/14369). 

## Why?

We have collected enough data to reach significance, so the test can be removed. It has been switched off this morning via the switchboard.