### PR TITLE
Labs container redesign work behind 0% test

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -135,6 +135,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
+	const isInLabsContainerRedesignVariant =
+		abTests.labsContainerRedesignVariant === 'variant';
+
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {
 			case 'scrollable/feature':
@@ -425,7 +428,103 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					}
 
 					if (collection.containerPalette === 'Branded') {
-						return (
+						isInLabsContainerRedesignVariant ? (
+							<Fragment key={ophanName}>
+								<FrontSection
+									title={collection.displayName}
+									description={collection.description}
+									showTopBorder={index > 0}
+									url={
+										collection.href
+											? `https://www.theguardian.com/${collection.href}`
+											: undefined
+									}
+									ophanComponentLink={ophanComponentLink}
+									ophanComponentName={ophanName}
+									containerName={collection.collectionType}
+									containerPalette={
+										collection.containerPalette
+									}
+									toggleable={isToggleable(
+										index,
+										collection,
+										front.isNetworkFront,
+									)}
+									leftContent={decideLeftContent(
+										front,
+										collection,
+									)}
+									sectionId={ophanName}
+									collectionId={collection.id}
+									pageId={front.pressedPage.id}
+									showDateHeader={
+										collection.config.showDateHeader
+									}
+									editionId={front.editionId}
+									treats={collection.treats}
+									canShowMore={collection.canShowMore}
+									ajaxUrl={front.config.ajaxUrl}
+									isOnPaidContentFront={isPaidContent}
+									targetedTerritory={
+										collection.targetedTerritory
+									}
+									hasPageSkin={hasPageSkin}
+									discussionApiUrl={
+										front.config.discussionApiUrl
+									}
+									collectionBranding={
+										collection.collectionBranding
+									}
+									containerLevel={collection.containerLevel}
+									isNextCollectionPrimary={
+										collection.isNextCollectionPrimary
+									}
+									hasNavigationButtons={
+										collection.collectionType ===
+											'scrollable/small' ||
+										collection.collectionType ===
+											'scrollable/medium'
+									}
+									isAboveDesktopAd={desktopAdPositions.includes(
+										index + 1,
+									)}
+									isAboveMobileAd={mobileAdPositions.includes(
+										index,
+									)}
+								>
+									<DecideContainer
+										trails={trails}
+										groupedTrails={collection.grouped}
+										containerType={
+											collection.collectionType
+										}
+										containerPalette={
+											collection.containerPalette
+										}
+										showAge={
+											!hideAge.includes(
+												collection.displayName,
+											)
+										}
+										imageLoading={imageLoading}
+										absoluteServerTimes={
+											absoluteServerTimes
+										}
+										aspectRatio={
+											collection.aspectRatio ??
+											fallbackAspectRatio(
+												collection.collectionType,
+											)
+										}
+										sectionId={ophanName}
+										collectionId={index + 1}
+										containerLevel={
+											collection.containerLevel
+										}
+									/>
+								</FrontSection>
+							</Fragment>
+						) : (
 							<Fragment key={ophanName}>
 								<LabsSection
 									title={collection.displayName}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
