### PR TITLE
fix(google-one-tap): Use browser supported `atob` function to parse Base64

### DIFF
--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -67,7 +67,7 @@ export const extractEmailFromToken = (
 	const payload = token.split('.')[1];
 	if (!payload) return error('ParsingError');
 	try {
-		const decoded = Buffer.from(payload, 'base64').toString();
+		const decoded = atob(payload);
 		const parsed = JSON.parse(decoded) as unknown;
 		if (!isObject(parsed) || typeof parsed.email !== 'string') {
 			return error('ParsingError');
@@ -222,9 +222,7 @@ export const initializeFedCM = async ({
 		});
 
 	if (credentials) {
-		log('identity', 'FedCM credentials received', {
-			credentials,
-		});
+		log('identity', 'FedCM credentials received');
 
 		const signInEmail = okOrThrow(
 			extractEmailFromToken(credentials.token),


### PR DESCRIPTION
## What does this change?

 - I switched to using `Buffer.from` instead of `atob` in https://github.com/guardian/dotcom-rendering/pull/14438 to parse base64 as VSCode suggested it:
 
   > This function is only provided for compatibility with legacy web platform APIs and should never be used in new code, because they use strings to represent binary data and predate the introduction of typed arrays in JavaScript. For code running using Node.js APIs, converting between base64-encoded strings and binary data should be performed using Buffer.from(str, 'base64') and buf.toString('base64')
   
   But I guess I didn't test it thoroughly enough as `Buffer.from` doesn't exist in the Browser environment and Webpack doesn't polyfill it. Annoyingly the tests didn't catch it as Jest doesn't run in a browser environment.
  - Don't log `token` after receiving it, theres no reason for us to log it and it contains user data.