### PR TITLE
Set expiry of 2 days for the ad free cookie

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -53,8 +53,10 @@ const persistResponse = (userBenefitsResponse: UserBenefits) => {
 	if (userBenefitsResponse.allowRejectAll) {
 		createOrRenewCookie(ALLOW_REJECT_ALL_COOKIE);
 	}
+	// Ad free cookie has an expiry of 2 days from now
+	// See https://github.com/guardian/gateway/blob/52f810a88fa9ce23c6a794916251748718742c3d/src/server/lib/user-features.ts#L111-L115
 	if (userBenefitsResponse.adFree) {
-		createOrRenewCookie(AD_FREE_USER_COOKIE);
+		createOrRenewCookie(AD_FREE_USER_COOKIE, 2);
 	}
 };
 


### PR DESCRIPTION
## What does this change?

Updates the expiry date of the ad free cookie to be two days rather than one.

## Why?

This matches the [logic in gateway](https://github.com/guardian/gateway/blob/252b2b2f24be826da42c6e7c1b1e202594184023/src/server/lib/user-features.ts#L111-L115)

Also see https://github.com/guardian/frontend/pull/28232
