### PR TITLE
Replace `execa` with Node.js' built in function `execFileSync`

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -129,7 +129,6 @@
 		"eslint-plugin-ssr-friendly": "1.3.0",
 		"eslint-plugin-unicorn": "48.0.1",
 		"eslint-stats": "1.0.1",
-		"execa": "5.1.1",
 		"express": "5.1.0",
 		"find": "0.3.0",
 		"he": "1.2.0",

--- a/dotcom-rendering/scripts/env/check-files.js
+++ b/dotcom-rendering/scripts/env/check-files.js
@@ -1,17 +1,23 @@
-const execa = require('execa');
+const { execFileSync } = require('node:child_process');
 const { warn } = require('../../../scripts/log');
 
-execa('find', ['src', '-type', 'f', '-name', '*index*.ts*'])
-	.then(({ stdout }) => {
-		if (stdout !== '') {
-			warn(
-				'The following files contain “index” in them and should be renamed:\n\n' +
-					stdout +
-					'\n',
-			);
-			process.exit(1);
-		}
-	})
-	.catch(() => {
+try {
+	const stdout = execFileSync(
+		'find',
+		['src', '-type', 'f', '-name', '*index*.ts*'],
+		{
+			encoding: 'utf8',
+		},
+	);
+	if (stdout !== '') {
+		warn(
+			'The following files contain "index" in them and should be renamed:\n\n' +
+				stdout +
+				'\n',
+		);
 		process.exit(1);
-	});
+	}
+} catch (error) {
+	console.log('Error finding index files', error);
+	process.exit(1);
+}

--- a/dotcom-rendering/scripts/test-data/gen-fixtures.js
+++ b/dotcom-rendering/scripts/test-data/gen-fixtures.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console -- script */
 /* eslint-disable @typescript-eslint/unbound-method -- path.resolve */
 
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs/promises');
 const { resolve } = require('node:path');
-const execa = require('execa');
 const { config } = require('../../fixtures/config');
 const { configOverrides } = require('../../fixtures/config-overrides');
 const { switchOverrides } = require('../../fixtures/switch-overrides');
@@ -304,7 +304,7 @@ requests.push(
 			// Write the new fixture data
 			const contents = `${HEADER}
 			import type { FEStoryPackage } from '../../src/frontend/feArticle';
-			
+
 			export const storyPackage: FEStoryPackage = ${JSON.stringify(json, null, 4)}`;
 			return fs.writeFile(
 				`${root}/fixtures/generated/story-package.ts`,
@@ -427,19 +427,19 @@ Promise.allSettled(requests)
 		}
 
 		console.log('Generation complete, formatting successful fixtures...');
-		execa('prettier', [
-			'./fixtures/**/*',
-			'--write',
-			'--log-level',
-			'error',
-		])
-			.then(() => {
-				console.log('✅ Formatting complete.');
-			})
-			.catch((err) => {
-				console.error('\n❌ Failed to format fixtures:\n', err);
-				process.exitCode = 1;
-			});
+
+		try {
+			execFileSync('prettier', [
+				'./fixtures/**/*',
+				'--write',
+				'--log-level',
+				'error',
+			]);
+			console.log('✅ Formatting complete.');
+		} catch (err) {
+			console.error('\n❌ Failed to format fixtures:\n', err);
+			process.exitCode = 1;
+		}
 	})
 	.catch((err) => {
 		console.error('❌ Unexpected error occurred:\n', err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,9 +603,6 @@ importers:
       eslint-stats:
         specifier: 1.0.1
         version: 1.0.1
-      execa:
-        specifier: 5.1.1
-        version: 5.1.1
       express:
         specifier: 5.1.0
         version: 5.1.0
@@ -698,7 +695,7 @@ importers:
         version: 0.7.4
       storybook:
         specifier: 8.6.14
-        version: 8.6.14(prettier@3.0.3)
+        version: 8.6.14
       stylelint:
         specifier: 16.5.0
         version: 16.5.0(typescript@5.5.3)
@@ -4942,7 +4939,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -7038,7 +7035,7 @@ packages:
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       uuid: 9.0.1
     dev: false
 
@@ -7049,7 +7046,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7060,7 +7057,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7075,7 +7072,7 @@ packages:
       '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -7095,7 +7092,7 @@ packages:
       '@storybook/addon-outline': 8.6.14(storybook@8.6.14)
       '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14)
       '@storybook/addon-viewport': 8.6.14(storybook@8.6.14)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -7107,7 +7104,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/addon-interactions@8.6.14(storybook@8.6.14):
@@ -7119,7 +7116,7 @@ packages:
       '@storybook/instrumenter': 8.6.14(storybook@8.6.14)
       '@storybook/test': 8.6.14(storybook@8.6.14)
       polished: 4.3.1
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7129,7 +7126,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       tiny-invariant: 1.3.3
     dev: false
 
@@ -7139,7 +7136,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7148,7 +7145,7 @@ packages:
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/addon-viewport@8.6.14(storybook@8.6.14):
@@ -7157,7 +7154,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/addon-webpack5-compiler-babel@3.0.6(webpack@5.101.0):
@@ -7197,7 +7194,7 @@ packages:
       '@storybook/icons': 1.4.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7224,7 +7221,7 @@ packages:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.4
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       style-loader: 3.3.4(webpack@5.101.0)
       terser-webpack-plugin: 5.3.14(@swc/core@1.11.31)(esbuild@0.25.5)(webpack@5.101.0)
       ts-dedent: 2.2.0
@@ -7292,7 +7289,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/core-events@8.6.14(storybook@8.6.14):
@@ -7300,7 +7297,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/core-webpack@8.6.14(storybook@8.6.14):
@@ -7308,7 +7305,7 @@ packages:
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       ts-dedent: 2.2.0
     dev: false
 
@@ -7339,12 +7336,38 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@storybook/core@8.6.14(storybook@8.6.14):
+    resolution: {integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==}
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      '@storybook/theming': 8.6.14(storybook@8.6.14)
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.25.5
+      esbuild-register: 3.6.0(esbuild@0.25.5)
+      jsdoc-type-pratt-parser: 4.1.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.2
+      util: 0.12.5
+      ws: 8.18.2
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@storybook/csf-plugin@8.6.14(storybook@8.6.14):
     resolution: {integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==}
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       unplugin: 1.16.1
     dev: false
 
@@ -7370,7 +7393,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/manager-api@8.6.14(storybook@8.6.14):
@@ -7378,7 +7401,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14)(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)(webpack-cli@6.0.1):
@@ -7404,7 +7427,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
       semver: 7.5.4
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       tsconfig-paths: 4.2.0
       typescript: 5.5.3
       webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
@@ -7458,7 +7481,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.101.0):
@@ -7475,7 +7498,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7489,7 +7512,7 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/react-webpack5@8.6.14(@storybook/test@8.6.14)(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)(webpack-cli@6.0.1):
@@ -7509,7 +7532,7 @@ packages:
       '@storybook/react': 8.6.14(@storybook/test@8.6.14)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       typescript: 5.5.3
     transitivePeerDependencies:
       - '@rspack/core'
@@ -7574,7 +7597,7 @@ packages:
       '@storybook/theming': 8.6.14(storybook@8.6.14)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
       typescript: 5.5.3
     dev: false
 
@@ -7590,7 +7613,7 @@ packages:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@storybook/theming@8.6.14(storybook@8.6.14):
@@ -7598,7 +7621,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14(prettier@3.0.3)
+      storybook: 8.6.14
     dev: false
 
   /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0):
@@ -9063,8 +9086,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.101.0):
@@ -9074,8 +9097,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.1)(webpack@5.101.0):
@@ -9089,8 +9112,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-server: 5.2.1(webpack-cli@6.0.1)(webpack@5.101.0)
     dev: false
 
@@ -10764,7 +10787,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.5.4)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /css-loader@7.1.2(webpack@5.101.0):
@@ -11834,7 +11857,7 @@ packages:
       enhanced-resolve: 5.18.1
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -12829,7 +12852,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.2
       typescript: 5.5.3
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /form-data-encoder@2.1.4:
@@ -13486,7 +13509,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /htmlparser2@6.1.0:
@@ -17913,6 +17936,22 @@ packages:
       internal-slot: 1.1.0
     dev: false
 
+  /storybook@8.6.14:
+    resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      '@storybook/core': 8.6.14(storybook@8.6.14)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /storybook@8.6.14(prettier@3.0.3):
     resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
     hasBin: true
@@ -18151,7 +18190,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -18634,7 +18673,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.11.31)(@types/node@16.18.68)(typescript@5.1.6):
@@ -19379,7 +19418,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.2
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /webpack-dev-middleware@7.4.2(webpack@5.101.0):
@@ -19439,8 +19478,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-middleware: 7.4.2(webpack@5.101.0)
       ws: 8.18.1
     transitivePeerDependencies:
@@ -19485,7 +19524,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

Replaces usages of [execa](https://github.com/sindresorhus/execa) with Node.js' built in function [execFileSync](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options)

## Why?

Mo dependencies mo problems

## Screenshots

I tested both scripts and they work as expected after the update