### PR TITLE
Remove ios app banner check

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -535,7 +535,10 @@ const styles = {
 		background: ${background};
 		color: ${textColor};
 		bottom: 0px;
+		/* override vh with vsh if supported */
 		max-height: 65vh;
+		/* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+		max-height: 65svh;
 
 		* {
 			box-sizing: border-box;

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -135,14 +135,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 }: BannerRenderProps): JSX.Element => {
 	const isTabletOrAbove = useMatchMedia(removeMediaRulePrefix(from.tablet));
 
-	// We can use this to shorten the banner if the "open in app" banner is present
-	const [iosAppBannerPresent, setIosAppBannerPresent] = useState(false);
-	useEffect(() => {
-		setIosAppBannerPresent(
-			window.innerHeight != window.document.documentElement.clientHeight,
-		);
-	}, []);
-
 	const bannerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -150,21 +142,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 			bannerRef.current.focus();
 		}
 	}, []);
-
-	useEffect(() => {
-		if (iosAppBannerPresent) {
-			// send ophan event
-			if (submitComponentEvent) {
-				submitComponentEvent({
-					component: {
-						componentType: 'ACQUISITIONS_OTHER',
-						id: 'safari-ios-banner-present',
-					},
-					action: 'VIEW',
-				});
-			}
-		}
-	}, [iosAppBannerPresent, submitComponentEvent]);
 
 	const choiceCards = getChoiceCards(isTabletOrAbove, choiceCardsSettings);
 	const defaultChoiceCard = choiceCards?.find((cc) => cc.isDefault);
@@ -321,7 +298,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 			tabIndex={-1}
 			css={styles.outerContainer(
 				templateSettings.containerSettings.backgroundColour,
-				iosAppBannerPresent,
 				templateSettings.containerSettings.textColor,
 			)}
 			className={contextClassName}
@@ -555,15 +531,11 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 const phabletContentMaxWidth = '492px';
 
 const styles = {
-	outerContainer: (
-		background: string,
-		limitHeight: boolean,
-		textColor: string = 'inherit',
-	) => css`
+	outerContainer: (background: string, textColor: string = 'inherit') => css`
 		background: ${background};
 		color: ${textColor};
 		bottom: 0px;
-		${limitHeight ? 'max-height: 60vh;' : ''}
+		max-height: 65vh;
 
 		* {
 			box-sizing: border-box;


### PR DESCRIPTION
## What does this change?
Currently the banner tries to detect the Safari "open in app" banner, which covers the top of the page. If detected, the height is reduced to 60%. However, this doesn't appear to be reliable.
Instead, we're reducing banner max height to 65% for all users.
This PR also introduces the `svh` unit, which in theory can do a better job of using the visible screen size. There's an existing example of this [here](https://github.com/guardian/dotcom-rendering/blob/bead368728a3c23673635184b549248cf238b282/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx#L94).

## Screenshots
I'm unable to test with the safari app banner.
![Uploading Screenshot 2025-09-18 at 13.52.14.png…]()

