### PR TITLE
Fix colour scheme bug on `LabsSection`

### DIFF
--- a/dotcom-rendering/src/components/LabsSection.tsx
+++ b/dotcom-rendering/src/components/LabsSection.tsx
@@ -74,17 +74,11 @@ type Props = {
 };
 
 const leftColumnBackground = css`
-	background-color: ${sourcePalette.labs[400]};
-	@media (prefers-color-scheme: dark) {
-		background-color: ${sourcePalette.labs[200]};
-	}
+	background-color: ${palette('--labs-legacy-section-background-left')};
 `;
 
 const contentBackground = css`
-	background-color: ${sourcePalette.neutral[93]};
-	@media (prefers-color-scheme: dark) {
-		background-color: ${sourcePalette.neutral[20]};
-	}
+	background-color: ${palette('--labs-legacy-section-background')};
 `;
 
 const leftColumnWidthFromLeftCol = css`
@@ -172,10 +166,7 @@ const contentSidePaddingFromLeftCol = css`
 
 const linkStyles = css`
 	text-decoration: none;
-	color: ${sourcePalette.neutral[100]};
-	@media (prefers-color-scheme: dark) {
-		color: ${sourcePalette.neutral[97]};
-	}
+	color: ${palette('--labs-legacy-article-section-title')};
 
 	:hover {
 		text-decoration: underline;
@@ -184,11 +175,8 @@ const linkStyles = css`
 
 const headerStyles = css`
 	${textSansBold20};
-	color: ${sourcePalette.neutral[100]};
+	color: ${palette('--labs-legacy-article-section-title')};
 	overflow-wrap: break-word; /*if a single word is too long, this will break the word up rather than have the display be affected*/
-	@media (prefers-color-scheme: dark) {
-		color: ${sourcePalette.neutral[97]};
-	}
 `;
 
 const containerMargins = css`
@@ -206,12 +194,9 @@ const badgeStyles = css`
 
 const paidForByStyles = css`
 	${textSansBold12};
-	color: ${sourcePalette.neutral[46]};
+	color: ${palette('--labs-legacy-treat-text')};
 	margin-top: ${space[3]}px;
 	margin-bottom: ${space[1]}px;
-	@media (prefers-color-scheme: dark) {
-		color: ${sourcePalette.neutral[38]};
-	}
 `;
 
 const GuardianLabsTitle = ({ title, url }: { title: string; url?: string }) => {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7173,6 +7173,22 @@ const paletteColours = {
 		light: liveKickerTextLight,
 		dark: liveKickerTextDark,
 	},
+	'--labs-legacy-article-section-title': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[97],
+	},
+	'--labs-legacy-section-background': {
+		light: () => sourcePalette.neutral[93],
+		dark: () => sourcePalette.neutral[20],
+	},
+	'--labs-legacy-section-background-left': {
+		light: () => sourcePalette.labs[400],
+		dark: () => sourcePalette.labs[200],
+	},
+	'--labs-legacy-treat-text': {
+		light: () => sourcePalette.neutral[46],
+		dark: () => sourcePalette.neutral[38],
+	},
 	'--last-updated-text': {
 		light: lastUpdatedTextLight,
 		dark: lastUpdatedTextDark,


### PR DESCRIPTION
## What does this change?

Adds additional colours for `LabsSection` with light and dark themes set 

## Why?

We were previously using the "prefers-dark-mode" CSS property but since the dark mode implementation uses this behind a switch, we shouldn't be doing this directly in the code without consideration of that switch.

The easiest way to resolve this issue for now is to duplicate the colours used in the palette to ensure they are not linked to the `ContainerOverrides` component


## Screenshots
### Before

| Light  | Dark      |
| ----------- | ---------- |
| ![light1][] | ![dark1][] |

[light1]: https://github.com/user-attachments/assets/0b81e592-2d1e-4111-a9ad-321234153cba
[dark1]: https://github.com/user-attachments/assets/b0b8b608-58ee-4e51-888e-30ecc724d3a7

### After

| Light  | Dark      |
| ----------- | ---------- |
| ![light][] | ![dark][] |

[light]: https://github.com/user-attachments/assets/86a80e4b-7a6f-4e01-9b7e-827fabb0262b
[dark]: https://github.com/user-attachments/assets/1b55d708-3743-4245-ae48-00350360a7f4
