### PR TITLE
Fix sign-in gate view tracking

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -1,5 +1,5 @@
 import { getCookie, isUndefined, storage } from '@guardian/libs';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { constructQuery } from '../lib/querystring';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
@@ -369,7 +369,7 @@ const ShowSignInGateAuxia = ({
 		threshold: 0,
 	});
 
-	useOnce(() => {
+	useEffect(() => {
 		if (hasBeenSeen) {
 			void auxiaLogTreatmentInteraction(
 				contributionsServiceUrl,
@@ -406,7 +406,15 @@ const ShowSignInGateAuxia = ({
 			// the tracking of the number of times the gate has been displayed
 			incrementGateDisplayCount();
 		}
-	}, [componentId, hasBeenSeen]);
+	}, [
+		componentId,
+		hasBeenSeen,
+		browserId,
+		contributionsServiceUrl,
+		renderingTarget,
+		treatmentId,
+		userTreatment,
+	]);
 
 	return (
 		<div ref={setNode}>


### PR DESCRIPTION
## What does this change?
When the sign-in gate is viewed we want to do 3 things:
- send a tracking event to Auxia
- send a tracking event to ophan
- increment the local display count

Currently this all happens when the component is rendered.
In the past this was probably good enough, as we didn't fetch the gate until the relevant part of the page scrolled into view.
We're now fetching the gate on page load, so we're incorrectly tracking views too early.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
