### PR TITLE
Fix story package background colour in `CommentLayout`

### DIFF
--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -714,7 +714,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 				{article.storyPackage && (
 					<Section
 						fullWidth={true}
-						backgroundColour={themePalette('--article-background')}
+						backgroundColour={themePalette(
+							'--article-section-background',
+						)}
 						borderColour={themePalette('--article-border')}
 					>
 						<Island priority="feature" defer={{ until: 'visible' }}>


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/10910

## What does this change?
Fixes story package background colour in `CommentLayout` to match the section background colour rather than the article background colour.

## Why?
To match the designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1467" height="409" alt="image" src="https://github.com/user-attachments/assets/c34d6b15-fd0f-41bd-a730-1f607a32daf2" /> | <img width="1445" height="419" alt="image" src="https://github.com/user-attachments/assets/4a37b791-411f-4f9b-9c8b-de658045e499" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
