### PR TITLE
Gallery image caption titles

### DIFF
--- a/dotcom-rendering/src/components/CaptionText.tsx
+++ b/dotcom-rendering/src/components/CaptionText.tsx
@@ -22,6 +22,19 @@ const renderTextElement = (node: Node, key: number): ReactNode => {
 	const children = Array.from(node.childNodes).map(renderTextElement);
 
 	switch (node.nodeName) {
+		case 'H2':
+			return text === '' ? null : (
+				<h2
+					css={css`
+						display: block;
+						${headlineMedium17}
+						padding: ${space[2]}px 0 ${space[3]}px;
+					`}
+					key={key}
+				>
+					{children}
+				</h2>
+			);
 		case 'STRONG':
 			return text === '' ? null : (
 				<strong

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -21,7 +21,6 @@ const styles = css`
 	color: ${palette('--caption-text')};
 	${textSans12}
 	padding-bottom: ${space[6]}px;
-	padding-top: ${space[5]}px;
 
 	${between.tablet.and.desktop} {
 		padding-left: ${space[5]}px;


### PR DESCRIPTION
## What does this change?
Adds support for H2 elements in CaptionText so captions can include a title. Removes the previous top padding in GalleryCaption to match frontend spacing.
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/14519
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/39dcc56f-7ef2-4c1f-9639-226670238a9d
[after]: https://github.com/user-attachments/assets/a801e56b-4030-406f-8fe6-16b187728b29

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
