### PR TITLE
Make gallery captions 14px

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { between, from, space, textSans12 } from '@guardian/source/foundations';
+import { between, from, space, textSans14 } from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { type ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
@@ -19,7 +19,7 @@ type Props = {
 const styles = css`
 	${grid.column.centre}
 	color: ${palette('--caption-text')};
-	${textSans12}
+	${textSans14}
 	padding-bottom: ${space[6]}px;
 	padding-top: ${space[5]}px;
 


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/14523

## What does this change?
Increases gallery captions from 12 to 14px.

## Why?
So that it is the same as the main media caption

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1371" height="762" alt="image" src="https://github.com/user-attachments/assets/8fb5939b-b476-495c-8d03-2169b0daf4b5" /> | <img width="1404" height="784" alt="image" src="https://github.com/user-attachments/assets/4973012f-fdf4-4054-9980-e7bcd1d6b692" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
