### PR TITLE
Inline main media caption galleries

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -212,6 +212,9 @@ const captionLink = css`
 
 const galleryStyles = css`
 	${grid.column.centre};
+	display: flex;
+	justify-content: center;
+	align-items: baseline;
 	${textSans14};
 
 	margin-bottom: 0;
@@ -219,6 +222,7 @@ const galleryStyles = css`
 	${from.leftCol} {
 		${grid.column.left}
 		grid-row-start: 8;
+		justify-content: flex-start;
 	}
 	${between.tablet.and.leftCol} {
 		position: relative;
@@ -239,6 +243,10 @@ const CameraIcon = ({ format }: IconProps) => {
 		<span
 			css={[
 				iconStyle,
+				format.design === ArticleDesign.Gallery &&
+					css`
+						flex-shrink: 0;
+					`,
 				(format.display === ArticleDisplay.Immersive ||
 					format.design === ArticleDesign.Gallery) &&
 					hideIconBelowLeftCol,


### PR DESCRIPTION
## What does this change?
Inlines main media caption on galleries
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/14522

<!--
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
