### PR TITLE
Fix whole picture logo logic

### DIFF
--- a/dotcom-rendering/src/components/Titlepiece.importable.tsx
+++ b/dotcom-rendering/src/components/Titlepiece.importable.tsx
@@ -341,8 +341,7 @@ export const Titlepiece = ({
 }: Props) => {
 	const { showBanner } = useEditionSwitcherBanner(pageId, editionId);
 
-	const showWholePictureLogo =
-		!!wholePictureLogoSwitch && !showSlimNav && editionId === 'US';
+	const showWholePictureLogo = !!wholePictureLogoSwitch && editionId === 'US';
 
 	return (
 		<Grid


### PR DESCRIPTION
## What does this change?

Removes `!isSlimNav` from the rendering logic for the whole picture logo

## Why?

The "whole picture" logo was supposed to show on all pages but was only appearing on fronts.

This attempts to fix that issue by removing the `!isSlimNav` condition from the rendering logic

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/ec846af6-ec66-4073-9ee8-77c90d01d212
[after]: https://github.com/user-attachments/assets/93f295e6-e8fb-4585-8306-d775f92f64e5
