### PR TITLE
Apply news.800 for both the kicker and the quote on News Feature cards

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6134,6 +6134,7 @@ const featureCardKickerText: PaletteFunction = ({ theme }) => {
 		case ArticleSpecial.SpecialReportAlt:
 			return sourcePalette.neutral[86];
 		case Pillar.News:
+			return sourcePalette.news[800];
 		case Pillar.Opinion:
 		case Pillar.Sport:
 		case Pillar.Culture:
@@ -6148,6 +6149,7 @@ const featureCardQuoteIcon: PaletteFunction = ({ theme }) => {
 		case ArticleSpecial.SpecialReportAlt:
 			return sourcePalette.neutral[86];
 		case Pillar.News:
+			return sourcePalette.news[800];
 		case Pillar.Opinion:
 		case Pillar.Sport:
 		case Pillar.Culture:


### PR DESCRIPTION
## What does this change?
Apply news.800 for both the kicker and the quote on News Feature cards. Continue using the .600 shades for all other pillars.

## Why?
The kicker colours on Feature cards are currently set to the .600 shades of their respective pillar colours. However, news.600 and lifestyle.600 are visually similar, which can create confusion when identifying whether the content is News or Lifestyle. 

A clear distinction between the News and Lifestyle pillars is essential for maintaining editorial clarity.
 
Because of the darker background, we use lighter shades of the pillar colours. While the differences are more noticeable when viewed side by side, some colours remain difficult to distinguish when seen in isolation.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a94c0d62-32aa-4e8a-bfde-0cf914920c73
[after]: https://github.com/user-attachments/assets/70fa3555-29b2-4c78-b0c7-25c255aa699f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
