### PR TITLE
Add US masthead to articles

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Masthead.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Masthead.stories.tsx
@@ -30,6 +30,7 @@ const meta = {
 		},
 	},
 } satisfies Meta<typeof Masthead>;
+
 export default meta;
 
 export const WithoutSubnav = {};
@@ -48,4 +49,31 @@ export const WithPageSkin = {
 
 export const WithPageSkinAndContentSelfContstrain = {
 	args: { hasPageSkinContentSelfConstrain: true },
+};
+
+export const WithUsLogoAndWithoutSubnav = {
+	args: { wholePictureLogoSwitch: true, editionId: 'US' },
+};
+
+export const WithUsLogoAndSubnav = {
+	args: { ...WithUsLogoAndWithoutSubnav.args, showSubNav: true },
+};
+
+export const WithUsLogoAndSlimNav = {
+	args: {
+		...WithUsLogoAndWithoutSubnav.args,
+		showSlimNav: true,
+		displayRoundel: true,
+	},
+};
+
+export const WithUsLogoAndPageSkin = {
+	args: { ...WithUsLogoAndWithoutSubnav.args, hasPageSkin: true },
+};
+
+export const WithUsLogoAndPageSkinAndContentSelfContstrain = {
+	args: {
+		...WithUsLogoAndWithoutSubnav.args,
+		hasPageSkinContentSelfConstrain: true,
+	},
 };

--- a/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/AllEditorialNewslettersPageLayout.tsx
@@ -44,6 +44,7 @@ export const AllEditorialNewslettersPageLayout = ({
 					showSlimNav={false}
 					hasPageSkin={false}
 					hasPageSkinContentSelfConstrain={false}
+					wholePictureLogoSwitch={config.switches.wholePictureLogo}
 				/>
 			</div>
 

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -184,6 +184,9 @@ export const AudioLayout = (props: WebProps) => {
 					showSlimNav={false}
 					hasPageSkinContentSelfConstrain={true}
 					pageId={article.pageId}
+					wholePictureLogoSwitch={
+						article.config.switches.wholePictureLogo
+					}
 				/>
 			</div>
 

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -335,6 +335,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						hasPageSkin={false}
 						hasPageSkinContentSelfConstrain={false}
 						pageId={article.pageId}
+						wholePictureLogoSwitch={
+							article.config.switches.wholePictureLogo
+						}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/layouts/CrosswordLayout.tsx
+++ b/dotcom-rendering/src/layouts/CrosswordLayout.tsx
@@ -157,6 +157,9 @@ export const CrosswordLayout = (props: Props) => {
 					hasPageSkin={false}
 					hasPageSkinContentSelfConstrain={false}
 					pageId={article.pageId}
+					wholePictureLogoSwitch={
+						article.config.switches.wholePictureLogo
+					}
 				/>
 			</div>
 

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -181,6 +181,9 @@ const NavHeader = ({ article, NAV, renderAds }: HeaderProps) => {
 				hasPageSkin={false}
 				hasPageSkinContentSelfConstrain={false}
 				pageId={article.pageId}
+				wholePictureLogoSwitch={
+					article.config.switches.wholePictureLogo
+				}
 			/>
 		</section>
 	);

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -181,6 +181,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 		frontendData.isCommentable && !frontendData.config.isPaidContent;
 
 	const { absoluteServerTimes = false } = switches;
+
 	return (
 		<>
 			{isWeb && (
@@ -213,6 +214,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						hasPageSkin={false}
 						hasPageSkinContentSelfConstrain={false}
 						pageId={frontendData.pageId}
+						wholePictureLogoSwitch={switches.wholePictureLogo}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -326,6 +326,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					hasPageSkin={false}
 					hasPageSkinContentSelfConstrain={false}
 					pageId={article.pageId}
+					wholePictureLogoSwitch={
+						article.config.switches.wholePictureLogo
+					}
 				/>
 			)}
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -291,6 +291,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							hasPageSkin={false}
 							hasPageSkinContentSelfConstrain={false}
 							pageId={article.pageId}
+							wholePictureLogoSwitch={
+								article.config.switches.wholePictureLogo
+							}
 						/>
 					</div>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -327,6 +327,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						hasPageSkin={false}
 						hasPageSkinContentSelfConstrain={false}
 						pageId={article.pageId}
+						wholePictureLogoSwitch={
+							article.config.switches.wholePictureLogo
+						}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -245,6 +245,9 @@ export const NewsletterSignupLayout = ({
 					hasPageSkin={false}
 					hasPageSkinContentSelfConstrain={false}
 					pageId={article.pageId}
+					wholePictureLogoSwitch={
+						article.config.switches.wholePictureLogo
+					}
 				/>
 			</div>
 

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -309,6 +309,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						hasPageSkin={false}
 						hasPageSkinContentSelfConstrain={false}
 						pageId={article.pageId}
+						wholePictureLogoSwitch={
+							article.config.switches.wholePictureLogo
+						}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -286,6 +286,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								hasPageSkin={false}
 								hasPageSkinContentSelfConstrain={false}
 								pageId={article.pageId}
+								wholePictureLogoSwitch={
+									article.config.switches.wholePictureLogo
+								}
 							/>
 						</div>
 					) : (
@@ -322,6 +325,10 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 										hasPageSkin={false}
 										hasPageSkinContentSelfConstrain={false}
 										pageId={article.pageId}
+										wholePictureLogoSwitch={
+											article.config.switches
+												.wholePictureLogo
+										}
 									/>
 								</Stuck>
 							</div>

--- a/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/SportDataPageLayout.tsx
@@ -110,6 +110,9 @@ export const SportDataPageLayout = ({ sportData }: Props) => {
 					showSlimNav={false}
 					hasPageSkin={sportData.config.hasPageSkin}
 					pageId={sportData.config.pageId}
+					wholePictureLogoSwitch={
+						sportData.config.switches.wholePictureLogo
+					}
 				/>
 			</div>
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -422,6 +422,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						showSlimNav={false}
 						hasPageSkinContentSelfConstrain={true}
 						pageId={article.pageId}
+						wholePictureLogoSwitch={
+							article.config.switches.wholePictureLogo
+						}
 					/>
 				</div>
 			)}

--- a/dotcom-rendering/src/layouts/TagPageLayout.tsx
+++ b/dotcom-rendering/src/layouts/TagPageLayout.tsx
@@ -94,6 +94,7 @@ export const TagPageLayout = ({ tagPage, NAV }: Props) => {
 					showSlimNav={false}
 					hasPageSkin={hasPageSkin}
 					pageId={pageId}
+					wholePictureLogoSwitch={switches.wholePictureLogo}
 				/>
 			</div>
 


### PR DESCRIPTION
## What does this change?

Uses the "The Whole Picture" Guardian logo in the nav on non-front pages for users of the US edition.

The "Slim nav" logo has not been changed as the "The Whole Picture" text would be too small.

## Why?

This logo was added to front pages in [this PR](https://github.com/guardian/dotcom-rendering/pull/14527). Non-front pages were missed.