### PR TITLE
Add data-component attr to ProductLinkButton

### DIFF
--- a/dotcom-rendering/src/components/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/ProductLinkButton.tsx
@@ -8,6 +8,7 @@ import {
 type ProductLinkButtonProps = {
 	label: string;
 	url: string;
+	dataComponent?: string;
 };
 
 const linkButtonStyles = css`
@@ -19,7 +20,11 @@ const linkButtonStyles = css`
 	overflow-wrap: break-word;
 `;
 
-export const ProductLinkButton = ({ label, url }: ProductLinkButtonProps) => {
+export const ProductLinkButton = ({
+	label,
+	url,
+	dataComponent = 'in-body-product-link-button',
+}: ProductLinkButtonProps) => {
 	return (
 		<LinkButton
 			href={url}
@@ -32,6 +37,7 @@ export const ProductLinkButton = ({ label, url }: ProductLinkButtonProps) => {
 			data-link-name="in body link"
 			data-spacefinder-role="inline"
 			cssOverrides={[linkButtonStyles]}
+			data-component={dataComponent}
 		>
 			{label}
 		</LinkButton>


### PR DESCRIPTION
## What does this change?
Add data-component attribute to the Product link button to improve reporting in Ophan.

## Why?

Currently we are able to see the in body link clicks. These clicks are not distinct from other in body link clicks as the data component id is `null`. This will add the component information to the Ophan click event.

Co-authored-by: Charley Campbell <115992455+charleycampbell@users.noreply.github.com>
Co-authored-by: Emma Imber <108270776+emma-imber@users.noreply.github.com>
Co-authored-by: George Haberis <george.haberis@guardian.co.uk>