### PR TITLE
Inline gallery main media caption icon and embolden title

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -210,7 +210,19 @@ const captionLink = css`
 	}
 `;
 
+const galleryCaptionHeadingReset = css`
+	h2 {
+		display: inline;
+		font-weight: bold;
+	}
+	h2::after {
+		content: '';
+		display: block;
+	}
+`;
+
 const galleryStyles = css`
+	${galleryCaptionHeadingReset}
 	${grid.column.centre};
 	${textSans14};
 


### PR DESCRIPTION
## What does this change?
Makes gallery caption h2 inline (so camera icon and title sit on same line), adds a forced line break after the title, and applies bold weight.
## Why?
Default block h2 pushed the media icon onto its own line. This reset keeps semantic heading markup while matching desired layout and visual hierarchy.

Resolves https://github.com/guardian/dotcom-rendering/issues/14522

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/26e66f5e-c2e7-48c2-854e-5851e2059dac
[after]: https://github.com/user-attachments/assets/8a028be3-a769-4dd2-9209-19a95fe70750

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
