### PR TITLE
Container level paid for by and logo 

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -401,6 +401,35 @@ export const GuardianLabs = {
 	},
 };
 
+export const GuardianLabsWithContainerLevelBadge = {
+	name: 'Guardian Labs with container level badge (1 brand for all stories)',
+	args: {
+		title: 'Section',
+		collectionBranding: {
+			kind: 'paid-content',
+			isFrontBranding: false,
+			branding: {
+				brandingType: {
+					name: 'paid-content',
+				},
+				sponsorName: 'guardian.org',
+				logo,
+				aboutThisLink:
+					'https://www.theguardian.com/global-development/2021/feb/21/about-the-rights-and-freedom-series',
+			},
+			isContainerBranding: true,
+			hasMultipleBranding: false,
+		},
+		badge: {
+			imageSrc:
+				'https://static.theguardian.com/commercial/sponsor/17/Apr/2023/6c577c8c-b60f-4041-baa3-f4852219d3ff-OS_logo_strapline_colour_rgb_280.png',
+			href: 'https://www.theguardian.com/guardian-labs',
+		},
+		isLabs: true,
+		showLabsRedesign: true,
+	},
+};
+
 export const PageSkinStory = {
 	name: 'with page skin',
 	args: {

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -492,8 +492,10 @@ const labsSectionStyles = css`
 	grid-column: title;
 	margin-top: ${space[2]}px;
 	${from.leftCol} {
-		grid-row: content;
+		/* Extend the background from content area to bottom-content area to align with logo */
+		grid-row: content / bottom-content-end;
 		grid-column: title;
+		${bottomPadding};
 	}
 `;
 

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -5,6 +5,7 @@ import { pageSkinContainer } from '../layouts/lib/pageSkin';
 import { type EditionId, isNetworkFront } from '../lib/edition';
 import { hideAge } from '../lib/hideAge';
 import { palette as schemePalette } from '../palette';
+import type { DCRBadgeType } from '../types/badge';
 import type { CollectionBranding } from '../types/branding';
 import type {
 	DCRContainerLevel,
@@ -22,6 +23,7 @@ import { Island } from './Island';
 import { LabsSectionHeader } from './LabsSectionHeader';
 import { ShowHideButton } from './ShowHideButton';
 import { ShowMore } from './ShowMore.importable';
+import { SponsoredContentLabel } from './SponsoredContentLabel';
 import { Treats } from './Treats';
 
 type Props = {
@@ -94,6 +96,8 @@ type Props = {
 	hasNavigationButtons?: boolean;
 	isAboveDesktopAd?: boolean;
 	isAboveMobileAd?: boolean;
+	/** A sponsor badge can be displayed under the content cards */
+	badge?: DCRBadgeType;
 	/** Indicates whether this is a Guardian Labs container */
 	isLabs?: boolean;
 	/** Feature switch for the labs redesign work */
@@ -607,6 +611,7 @@ export const FrontSection = ({
 	hasNavigationButtons = false,
 	isAboveDesktopAd = false,
 	isAboveMobileAd = false,
+	badge,
 	isLabs = false,
 	showLabsRedesign = false,
 }: Props) => {
@@ -798,6 +803,13 @@ export const FrontSection = ({
 							/>
 						</Island>
 					) : null}
+					{collectionBranding?.kind === 'paid-content' && badge && (
+						<SponsoredContentLabel
+							imageSrc={badge.imageSrc}
+							href={badge.href}
+							ophanComponentName={ophanComponentName}
+						/>
+					)}
 					{pagination && (
 						<FrontPagination
 							sectionName={pagination.sectionName}

--- a/dotcom-rendering/src/components/SponsoredContentLabel.tsx
+++ b/dotcom-rendering/src/components/SponsoredContentLabel.tsx
@@ -6,7 +6,7 @@ import { Badge } from './Badge';
 
 type SponsoredContentLabelProps = DCRBadgeType & {
 	alignment?: 'start' | 'end';
-	ophanComponentName: string;
+	ophanComponentName?: string;
 	orientation?: 'horizontal' | 'vertical';
 };
 
@@ -20,6 +20,7 @@ const paidForByStyles = css`
 const wrapperStyles = css`
 	display: flex;
 	gap: ${space[2]}px;
+	justify-content: end;
 `;
 
 const horizontalStyles = css`

--- a/dotcom-rendering/src/components/SponsoredContentLabel.tsx
+++ b/dotcom-rendering/src/components/SponsoredContentLabel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, textSansBold12 } from '@guardian/source/foundations';
+import { from, space, textSansBold12 } from '@guardian/source/foundations';
 import { palette } from '../palette';
 import type { DCRBadgeType } from '../types/badge';
 import { Badge } from './Badge';
@@ -21,6 +21,10 @@ const wrapperStyles = css`
 	display: flex;
 	gap: ${space[2]}px;
 	justify-content: end;
+
+	${from.leftCol} {
+		padding-right: 10px;
+	}
 `;
 
 const horizontalStyles = css`

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -574,6 +574,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								isAboveMobileAd={mobileAdPositions.includes(
 									index,
 								)}
+								badge={badgeFromBranding(
+									collection.collectionBranding,
+								)}
 								isLabs={
 									collection.containerPalette === 'Branded'
 								}


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
