### PR TITLE
Remove the age warning and sign in gate from The Filter US

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/displayRules.ts
+++ b/dotcom-rendering/src/components/SignInGate/displayRules.ts
@@ -34,6 +34,7 @@ export const isValidSection = (sectionId?: string): boolean => {
 		'guardian-live-australia',
 		'gnm-archive',
 		'thefilter',
+		'thefilter-us',
 	];
 
 	// we check for invalid section by reducing the above array, and then NOT the result so we know

--- a/dotcom-rendering/src/lib/age-warning.ts
+++ b/dotcom-rendering/src/lib/age-warning.ts
@@ -19,6 +19,7 @@ export const getAgeWarning = (
 		'tone/advertisement-features',
 		'gnm-archive/gnm-archive',
 		'thefilter/series/the-filter',
+		'thefilter-us/series/thefilter-us',
 	];
 	const showAge = !tags.some(({ id }) => tagsWithoutAgeWarning.includes(id));
 


### PR DESCRIPTION
## What does this change?
Removes the new section `thefilter-us` from the sign in gate
 UK equivalent -> https://github.com/guardian/dotcom-rendering/pull/14422
Removes the age-warning from series `thefilter-us/series/thefilter-us` 
UK equivalent -> https://github.com/guardian/dotcom-rendering/pull/13965

## Why?
The filter content is evergreen so does not require the age warning and as with the filter the filter us should not be behind the sign in gate.