### PR TITLE
Add chromatic tablet and desktop viewports for a card story

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -483,6 +483,20 @@ export const WithDifferentImagePositions = () => {
 	);
 };
 
+WithDifferentImagePositions.story = {
+	parameters: {
+		viewport: { defaultViewport: 'desktop' },
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.wide,
+			],
+		},
+	},
+};
+
 export const WithDifferentImageSizes = () => {
 	return (
 		<>


### PR DESCRIPTION
Paired with @arelra 

## What does this change?
This is to capture the hiding behaviour of trail text for tablet and desktop breakpoints
https://github.com/guardian/dotcom-rendering/blob/dd384d5a3d48d38d056fb2af2c3b2ea47951131e/dotcom-rendering/src/components/Card/Card.tsx#L596-L608
