### PR TITLE
Ensure galleries only render one secondary onward container

### DIFF
--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
-import { joinUrl } from '@guardian/libs';
+import { isUndefined, joinUrl } from '@guardian/libs';
 import {
+	ArticleDesign,
 	type ArticleFormat,
 	type ArticleTheme,
 	Pillar,
@@ -303,6 +304,11 @@ export const OnwardsUpper = ({
 		? getContainerDataUrl(pillar, editionId, ajaxUrl)
 		: undefined;
 
+	// For galleries: they already have a "more galleries" container,
+	// so we can only allow one more onwards container
+	const canHaveCuratedContent =
+		format.design === ArticleDesign.Gallery ? isUndefined(url) : true;
+
 	return (
 		<div css={onwardsWrapper}>
 			{!!url && (
@@ -322,7 +328,7 @@ export const OnwardsUpper = ({
 					/>
 				</Section>
 			)}
-			{!!curatedDataUrl && !isPaidContent && (
+			{!!curatedDataUrl && !isPaidContent && canHaveCuratedContent && (
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-section-border')}

--- a/dotcom-rendering/src/layouts/GalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.stories.tsx
@@ -44,6 +44,7 @@ const addBrandingAndAffiliateDisclaimer = (gallery: Gallery): Gallery => ({
 const appsArticle = enhanceArticleType(
 	{
 		...GalleryFixture,
+		hasStoryPackage: true,
 		storyPackage,
 	},
 	'Apps',
@@ -75,6 +76,7 @@ export const Apps = {
 const webArticle = enhanceArticleType(
 	{
 		...GalleryFixture,
+		hasStoryPackage: true,
 		storyPackage,
 	},
 	'Web',


### PR DESCRIPTION
## What does this change?
This PR Restrict galleries to a single secondary onward container. This is because galleries already have a "more galleries" container. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/16951cae-edaf-4261-a95c-4d157a7c0cf9
[after]: https://github.com/user-attachments/assets/471e1272-399b-4201-b86e-b28d7e03d06f


This PR fixes [#14588](https://github.com/guardian/dotcom-rendering/issues/14588)