### PR TITLE
Update sign-in gate treatmentType

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -98,9 +98,13 @@ export interface TreatmentContentDecoded {
 	second_cta_name?: string;
 }
 
+// The treatmentType is how Auxia tells the client which type of gate to display
+// The spelling of "dismissible" is inconsistent here, but this is because the treatments were set up this way in Auxia.
 export type AuxiaAPIResponseDataUserTreatmentType =
 	| 'DISMISSABLE_SIGN_IN_GATE'
-	| 'NONDISMISSIBLE_SIGN_IN_GATE';
+	| 'NONDISMISSIBLE_SIGN_IN_GATE'
+	| 'DISMISSABLE_SIGN_IN_GATE_POPUP'
+	| 'NONDISMISSIBLE_SIGN_IN_GATE_POPUP';
 
 export interface AuxiaAPIResponseDataUserTreatment {
 	treatmentId: string;

--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -258,7 +258,7 @@ export const getAuxiaGateVersion = (
 		String(version).toLowerCase().endsWith('v2') ||
 		String(userTreatment?.treatmentType)
 			.toLowerCase()
-			.includes('v2')
+			.endsWith('POPUP')
 	) {
 		return 'v2';
 	}


### PR DESCRIPTION
## What does this change?
The sign-in gate checks the `treatmentType` field to decide two things:
1. should it be dismissible?
2. should it be the popup gate?

This PR just updates the expected value for the popup gate.
This is based on the configuration in Auxia:
<img width="775" height="230" alt="Screenshot 2025-10-01 at 09 40 23" src="https://github.com/user-attachments/assets/9dd31383-300a-4502-a9eb-a25a1331437a" />
