### PR TITLE
Remove Hide Trails AB test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -153,7 +153,6 @@ export type Props = {
 	showKickerImage?: boolean;
 	/** Determines if the headline should be positioned within the content or outside the content */
 	headlinePosition?: 'inner' | 'outer';
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -393,7 +392,6 @@ export const Card = ({
 	trailTextSize,
 	showKickerImage = false,
 	headlinePosition = 'inner',
-	isInHideTrailsAbTest = false,
 	showLabsRedesign = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
@@ -1097,16 +1095,14 @@ export const Card = ({
 							</HeadlineWrapper>
 						)}
 
-						{!!trailText &&
-							media?.type !== 'podcast' &&
-							!isInHideTrailsAbTest && (
-								<TrailText
-									trailText={trailText}
-									trailTextSize={trailTextSize}
-									padTop={headlinePosition === 'inner'}
-									hideUntil={hideTrailTextUntil()}
-								/>
-							)}
+						{!!trailText && media?.type !== 'podcast' && (
+							<TrailText
+								trailText={trailText}
+								trailTextSize={trailTextSize}
+								padTop={headlinePosition === 'inner'}
+								hideUntil={hideTrailTextUntil()}
+							/>
+						)}
 
 						{!isOpinionCardWithAvatar && (
 							<>

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -47,7 +47,6 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -65,7 +64,6 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
-	isInHideTrailsAbTest,
 	showLabsRedesign = false,
 }: Props) => {
 	switch (containerType) {
@@ -249,7 +247,6 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
-					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					showLabsRedesign={!!showLabsRedesign}
 				/>
 			);
@@ -264,7 +261,6 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
-					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					showLabsRedesign={!!showLabsRedesign}
 				/>
 			);
@@ -280,7 +276,6 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
-						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 						showLabsRedesign={!!showLabsRedesign}
 					/>
 				</Island>
@@ -297,7 +292,6 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
-						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 						showLabsRedesign={!!showLabsRedesign}
 					/>
 				</Island>
@@ -311,7 +305,6 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
-					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					showLabsRedesign={!!showLabsRedesign}
 				/>
 			);
@@ -325,7 +318,6 @@ export const DecideContainer = ({
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
 						collectionId={collectionId}
-						isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 					/>
 				</Island>
 			);
@@ -338,7 +330,6 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
-					isInHideTrailsAbTest={!!isInHideTrailsAbTest}
 				/>
 			);
 		default:

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -335,7 +335,6 @@ export type Props = {
 	 */
 	isImmersive?: boolean;
 	showVideo?: boolean;
-	isInHideTrailsAbTest?: boolean;
 };
 
 export const FeatureCard = ({
@@ -371,7 +370,6 @@ export const FeatureCard = ({
 	isNewsletter = false,
 	isImmersive = false,
 	showVideo = false,
-	isInHideTrailsAbTest = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -462,9 +460,6 @@ export const FeatureCard = ({
 										isImmersive={isImmersive}
 										byline={byline}
 										showByline={showByline}
-										isInHideTrailsAbTest={
-											isInHideTrailsAbTest
-										}
 									/>
 								</Island>
 							</div>
@@ -628,19 +623,18 @@ export const FeatureCard = ({
 											</div>
 										) : null}
 
-										{!!trailText &&
-											!isInHideTrailsAbTest && (
-												<div css={trailTextWrapper}>
-													<TrailText
-														trailText={trailText}
-														trailTextColour={palette(
-															'--feature-card-trail-text',
-														)}
-														trailTextSize="regular"
-														padBottom={false}
-													/>
-												</div>
-											)}
+										{!!trailText && (
+											<div css={trailTextWrapper}>
+												<TrailText
+													trailText={trailText}
+													trailTextColour={palette(
+														'--feature-card-trail-text',
+													)}
+													trailTextSize="regular"
+													padBottom={false}
+												/>
+											</div>
+										)}
 
 										<CardFooter
 											format={format}

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -32,7 +32,6 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -89,7 +88,6 @@ type ImmersiveCardLayoutProps = {
 	absoluteServerTimes: boolean;
 	imageLoading: Loading;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -104,7 +102,6 @@ const ImmersiveCardLayout = ({
 	absoluteServerTimes,
 	imageLoading,
 	collectionId,
-	isInHideTrailsAbTest,
 }: ImmersiveCardLayoutProps) => {
 	const isLoopingVideo = card.mainMedia?.type === 'LoopVideo';
 
@@ -141,7 +138,6 @@ const ImmersiveCardLayout = ({
 					supportingContent={card.supportingContent}
 					isImmersive={true}
 					showVideo={card.showVideo}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			</LI>
 		</UL>
@@ -247,7 +243,6 @@ type SplashCardLayoutProps = {
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -262,7 +257,6 @@ const SplashCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: SplashCardLayoutProps) => {
 	const card = cards[0];
@@ -277,7 +271,6 @@ const SplashCardLayout = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
-				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 		);
 	}
@@ -346,7 +339,6 @@ const SplashCardLayout = ({
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					headlinePosition={card.showLivePlayable ? 'outer' : 'inner'}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 					showLabsRedesign={showLabsRedesign}
 				/>
 			</LI>
@@ -410,7 +402,6 @@ type FullWidthCardLayoutProps = {
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -426,7 +417,6 @@ const FullWidthCardLayout = ({
 	isLastRow,
 	containerLevel,
 	collectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: FullWidthCardLayoutProps) => {
 	const card = cards[0];
@@ -453,7 +443,6 @@ const FullWidthCardLayout = ({
 				absoluteServerTimes={absoluteServerTimes}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
-				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 		);
 	}
@@ -501,7 +490,6 @@ const FullWidthCardLayout = ({
 					liveUpdatesPosition={liveUpdatesPosition}
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 					showLabsRedesign={showLabsRedesign}
 				/>
 			</LI>
@@ -520,7 +508,6 @@ type HalfWidthCardLayoutProps = {
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -536,7 +523,6 @@ const HalfWidthCardLayout = ({
 	aspectRatio,
 	isLastRow,
 	containerLevel,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: HalfWidthCardLayoutProps) => {
 	if (cards.length === 0) return null;
@@ -591,7 +577,6 @@ const HalfWidthCardLayout = ({
 							trailText={undefined}
 							headlineSizes={undefined}
 							canPlayInline={false}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 							showLabsRedesign={showLabsRedesign}
 						/>
 					</LI>
@@ -610,7 +595,6 @@ export const FlexibleGeneral = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
@@ -640,7 +624,6 @@ export const FlexibleGeneral = ({
 					isLastRow={cards.length === 0}
 					containerLevel={containerLevel}
 					collectionId={collectionId}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			)}
 			{groupedCards.map((row, i) => {
@@ -659,7 +642,6 @@ export const FlexibleGeneral = ({
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
 								collectionId={collectionId}
-								isInHideTrailsAbTest={isInHideTrailsAbTest}
 								showLabsRedesign={showLabsRedesign}
 							/>
 						);
@@ -680,7 +662,6 @@ export const FlexibleGeneral = ({
 								aspectRatio={aspectRatio}
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
-								isInHideTrailsAbTest={isInHideTrailsAbTest}
 								showLabsRedesign={showLabsRedesign}
 							/>
 						);

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -30,7 +30,6 @@ type Props = {
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 	showLabsRedesign?: boolean;
 };
 
@@ -128,7 +127,6 @@ type OneCardLayoutProps = {
 	isFirstRow: boolean;
 	containerLevel: DCRContainerLevel;
 	isSplashCard?: boolean;
-	isInHideTrailsAbTest?: boolean;
 	showLabsRedesign?: boolean;
 };
 
@@ -143,7 +141,6 @@ export const OneCardLayout = ({
 	isFirstRow,
 	containerLevel,
 	isSplashCard,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: OneCardLayoutProps) => {
 	const card = cards[0];
@@ -196,7 +193,6 @@ export const OneCardLayout = ({
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					headlinePosition={isSplashCard ? 'outer' : 'inner'}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 					showLabsRedesign={showLabsRedesign}
 				/>
 			</LI>
@@ -225,7 +221,6 @@ type TwoOrFourCardLayoutProps = {
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
 	containerLevel: DCRContainerLevel;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -240,7 +235,6 @@ const TwoOrFourCardLayout = ({
 	aspectRatio,
 	isFirstRow,
 	containerLevel,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: TwoOrFourCardLayoutProps) => {
 	if (cards.length === 0) return null;
@@ -282,7 +276,6 @@ const TwoOrFourCardLayout = ({
 									!isMediaCard(card.format))
 							}
 							canPlayInline={false}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 							showLabsRedesign={showLabsRedesign}
 						/>
 					</LI>
@@ -301,7 +294,6 @@ export const FlexibleSpecial = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	collectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1).map((snap) => ({
@@ -331,7 +323,6 @@ export const FlexibleSpecial = ({
 					isLastRow={splash.length === 0 && cards.length === 0}
 					containerLevel={containerLevel}
 					isSplashCard={false}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 					showLabsRedesign={showLabsRedesign}
 				/>
 			)}
@@ -347,7 +338,6 @@ export const FlexibleSpecial = ({
 					isFirstRow={!isNonEmptyArray(snaps)}
 					containerLevel={containerLevel}
 					isSplashCard={true}
-					isInHideTrailsAbTest={isInHideTrailsAbTest}
 				/>
 			)}
 
@@ -360,7 +350,6 @@ export const FlexibleSpecial = ({
 				aspectRatio={aspectRatio}
 				isFirstRow={!isNonEmptyArray(snaps) && !isNonEmptyArray(splash)}
 				containerLevel={containerLevel}
-				isInHideTrailsAbTest={isInHideTrailsAbTest}
 				showLabsRedesign={showLabsRedesign}
 			/>
 		</>

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -55,7 +55,6 @@ export const FrontCard = (props: Props) => {
 		showLivePlayable: trail.showLivePlayable,
 		showVideo: trail.showVideo,
 		uniqueId: trail.uniqueId,
-		isInHideTrailsAbTest: trail.isInHideTrailsAbTest,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -14,7 +14,6 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -31,7 +30,6 @@ export const ScrollableFeature = ({
 	imageLoading,
 	aspectRatio,
 	collectionId,
-	isInHideTrailsAbTest,
 }: Props) => {
 	return (
 		<ScrollableCarousel
@@ -81,7 +79,6 @@ export const ScrollableFeature = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -17,7 +17,6 @@ type Props = {
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
 	sectionId: string;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -38,7 +37,6 @@ export const ScrollableMedium = ({
 	showAge,
 	aspectRatio,
 	sectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: Props) => {
 	return (
@@ -77,7 +75,6 @@ export const ScrollableMedium = ({
 							showTopBarDesktop={false}
 							showTopBarMobile={false}
 							canPlayInline={false}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 							showLabsRedesign={showLabsRedesign}
 						/>
 					</ScrollableCarousel.Item>

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -16,7 +16,6 @@ type Props = {
 	containerType: DCRContainerType;
 	aspectRatio: AspectRatio;
 	sectionId: string;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -63,7 +62,6 @@ export const ScrollableSmall = ({
 	showAge,
 	aspectRatio,
 	sectionId,
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: Props) => {
 	const mobileBottomCards = [1, 3];
@@ -108,7 +106,6 @@ export const ScrollableSmall = ({
 							)}
 							showTopBarMobile={mobileBottomCards.includes(index)}
 							canPlayInline={false}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 							showLabsRedesign={showLabsRedesign}
 						/>
 					</ScrollableCarousel.Item>

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -16,7 +16,6 @@ type Props = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	collectionId: number;
-	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -32,7 +31,6 @@ export const StaticFeatureTwo = ({
 	imageLoading,
 	aspectRatio,
 	collectionId,
-	isInHideTrailsAbTest,
 }: Props) => {
 	const cards = trails.slice(0, 2);
 	return (
@@ -82,7 +80,6 @@ export const StaticFeatureTwo = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -32,7 +32,6 @@ type Props = {
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
-	isInHideTrailsAbTest?: boolean;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
 };
@@ -46,7 +45,6 @@ export const StaticMediumFour = ({
 	showImage = true,
 	aspectRatio,
 	containerLevel = 'Primary',
-	isInHideTrailsAbTest,
 	showLabsRedesign,
 }: Props) => {
 	const cards = trails.slice(0, 4);
@@ -87,7 +85,6 @@ export const StaticMediumFour = ({
 									!isMediaCard(card.format))
 							}
 							canPlayInline={false}
-							isInHideTrailsAbTest={isInHideTrailsAbTest}
 							showLabsRedesign={showLabsRedesign}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -64,7 +64,6 @@ export type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
-	isInHideTrailsAbTest?: boolean;
 };
 
 /**
@@ -120,7 +119,6 @@ export const YoutubeAtom = ({
 	isImmersive,
 	byline,
 	showByline,
-	isInHideTrailsAbTest,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -269,7 +267,6 @@ export const YoutubeAtom = ({
 								isImmersive={isImmersive}
 								byline={byline}
 								showByline={showByline}
-								isInHideTrailsAbTest={isInHideTrailsAbTest}
 							/>
 						) : (
 							<YoutubeAtomOverlay

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -140,7 +140,6 @@ type Props = {
 	isImmersive?: boolean;
 	byline?: string;
 	showByline?: boolean;
-	isInHideTrailsAbTest?: boolean;
 };
 
 export const YoutubeAtomFeatureCardOverlay = ({
@@ -168,7 +167,6 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	isImmersive,
 	byline,
 	showByline,
-	isInHideTrailsAbTest,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -240,7 +238,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 							showByline={showByline}
 						/>
 					)}
-					{!!trailText && !isInHideTrailsAbTest && (
+					{!!trailText && (
 						<div
 							css={css`
 								margin-top: ${space[3]}px;

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -55,7 +55,6 @@ type Props = {
 	showByline?: boolean;
 	contentType?: string;
 	contentLayout?: string;
-	isInHideTrailsAbTest?: boolean;
 };
 
 export const YoutubeBlockComponent = ({
@@ -98,7 +97,6 @@ export const YoutubeBlockComponent = ({
 	showByline,
 	contentType,
 	contentLayout,
-	isInHideTrailsAbTest,
 }: Props) => {
 	const [consentState, setConsentState] = useState<ConsentState | undefined>(
 		undefined,
@@ -224,7 +222,6 @@ export const YoutubeBlockComponent = ({
 				isImmersive={isImmersive}
 				byline={byline}
 				showByline={showByline}
-				isInHideTrailsAbTest={isInHideTrailsAbTest}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -105,7 +105,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			isPaidContent,
 			hasPageSkin: hasPageSkinConfig,
 			pageId,
-			abTests,
 			switches: { absoluteServerTimes = false },
 		},
 		editionId,
@@ -603,10 +602,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									sectionId={ophanName}
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
-									isInHideTrailsAbTest={
-										front.isNetworkFront &&
-										abTests.hideTrailsVariant === 'variant'
-									}
 									showLabsRedesign={showLabsRedesign}
 								/>
 							</FrontSection>

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -101,7 +101,6 @@ export type DCRFrontCard = {
 	slideshowImages?: DCRSlideshowImage[];
 	showVideo?: boolean;
 	uniqueId?: string;
-	isInHideTrailsAbTest?: boolean;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

Removes the [HideTrails AB test](https://github.com/guardian/dotcom-rendering/pull/14488). 

## Why?

We have collected enough data to reach significance, so the test can be removed.