### PR TITLE
Fix header grid rows for gallery

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -230,7 +230,7 @@ const galleryStyles = css`
 	padding-bottom: 6px;
 	${from.leftCol} {
 		${grid.column.left}
-		grid-row-start: 8;
+		grid-row: 8/10;
 	}
 	${between.tablet.and.leftCol} {
 		position: relative;


### PR DESCRIPTION
## What does this change?
This PR fixes the header grid in gallery. The rows were not correctly spaced out on `leftCol` size (Screens of between 1140px and 1300px). Giving the Caption item a correct grid-row-end from leftCol breakpoint, fixes row alignments. 

I tested this with several different articles, with different length of the caption text, and the behaviour is same in all of them.

## Screenshots






| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/c7945cad-9368-464e-9002-6f8ca82d08c2" controls width="200"></video> | <video src="https://github.com/user-attachments/assets/8521b2ba-cabf-4290-b594-057a4eb22d32" controls width="200"></video> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

This fixes [#14576](https://github.com/guardian/dotcom-rendering/issues/14576)