### PR TITLE
Reorder the privacy settings link so it appears at the bottom of the …

### DIFF
--- a/dotcom-rendering/src/components/Footer.tsx
+++ b/dotcom-rendering/src/components/Footer.tsx
@@ -41,7 +41,7 @@ const footer = css`
 `;
 
 const pillarWrap = css`
-	${clearFix}
+	${clearFix};
 	border-left: ${footerBorders};
 	border-right: ${footerBorders};
 	padding-top: ${space[2]}px;
@@ -192,7 +192,7 @@ const acknowledgments = css`
 const copyright = css`
 	${textSans12};
 	padding: ${space[3]}px;
-	padding-left: 20px;
+	padding-left: ${space[5]}px;
 
 	${until.tablet} {
 		margin-top: 11px;
@@ -222,7 +222,7 @@ const footerGrid = css`
 	border: ${footerBorders};
 
 	${from.mobileLandscape} {
-		padding: 0 20px;
+		padding: 0 ${space[5]}px;
 	}
 `;
 
@@ -231,7 +231,7 @@ const bttPosition = css`
 	padding: 0 5px;
 	position: absolute;
 	bottom: -21px;
-	right: 20px;
+	right: ${space[5]}px;
 `;
 
 const FooterLinks = ({
@@ -241,22 +241,10 @@ const FooterLinks = ({
 	pageFooter: FooterType;
 	urls: ReaderRevenueCategories;
 }) => {
-	const linkGroups = pageFooter.footerLinks.map((linkGroup) => {
+	const linkGroups = pageFooter.footerLinks.map((linkGroup, index) => {
 		const linkList = linkGroup.flatMap(
 			({ url, extraClasses, dataLinkName, text }) =>
 				[
-					dataLinkName === 'privacy' ? (
-						<li key="privacy-settings-link">
-							<Island
-								priority="critical"
-								defer={{ until: 'visible' }}
-							>
-								<PrivacySettingsLink
-									extraClasses={extraClasses}
-								/>
-							</Island>
-						</li>
-					) : null,
 					<li key={url}>
 						<a
 							className={extraClasses}
@@ -269,6 +257,21 @@ const FooterLinks = ({
 					</li>,
 				].filter(isNonNullable),
 		);
+		const privacyClasses = linkGroup.find(
+			(link) => link.dataLinkName === 'privacy',
+		)?.extraClasses;
+
+		const isFinalColumn = index === pageFooter.footerLinks.length - 1;
+
+		if (isFinalColumn) {
+			linkList.push(
+				<li key="privacy-settings-link">
+					<Island priority="critical" defer={{ until: 'visible' }}>
+						<PrivacySettingsLink extraClasses={privacyClasses} />
+					</Island>
+				</li>,
+			);
+		}
 		const key = linkGroup.reduce((acc, { text }) => `${acc}-${text}`, '');
 		return <ul key={key}>{linkList}</ul>;
 	});


### PR DESCRIPTION
…final column in the footer.

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
