### PR TITLE
Update container branding alignment for Labs content

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -485,30 +485,18 @@ const carouselNavigationPlaceholder = css`
 	}
 `;
 
-const labsSectionStyles = css`
+const labsSectionHeaderStyles = css`
 	grid-row: headline;
 	grid-column: title;
 	margin-top: ${space[2]}px;
 	${from.leftCol} {
-		/* Extend the background from content area to bottom-content area to align with logo */
-		grid-row: content / bottom-content-end;
+		grid-row: content;
 		grid-column: title;
 	}
 `;
 
-const labsSectionPaddingBottom = css`
-	${from.leftCol} {
-		${bottomPadding}
-	}
-`;
-
 const sponsoredContentLabelWrapper = css`
-	margin-top: ${space[4]}px;
-
-	${from.leftCol} {
-		margin-top: ${space[9]}px;
-		padding-right: 10px;
-	}
+	grid-row: bottom-content;
 `;
 
 /**
@@ -698,17 +686,7 @@ export const FrontSection = ({
 				/>
 
 				{isLabs && showLabsRedesign ? (
-					<div
-						css={[
-							labsSectionStyles,
-							isBetaContainer
-								? bottomPaddingBetaContainer(
-										useLargeSpacingMobile,
-										useLargeSpacingDesktop,
-								  )
-								: labsSectionPaddingBottom,
-						]}
-					>
+					<div css={labsSectionHeaderStyles}>
 						<LabsSectionHeader title={title} />
 					</div>
 				) : (

--- a/dotcom-rendering/src/components/SponsoredContentLabel.tsx
+++ b/dotcom-rendering/src/components/SponsoredContentLabel.tsx
@@ -13,8 +13,6 @@ type SponsoredContentLabelProps = DCRBadgeType & {
 const paidForByStyles = css`
 	${textSansBold12};
 	color: ${palette('--labs-header-label-text')};
-	margin-top: ${space[3]}px;
-	margin-bottom: ${space[1]}px;
 `;
 
 const wrapperStyles = css`


### PR DESCRIPTION
## What does this change?

- Uses grid rather than offsetting by margin and padding
  - This shortens the labs header when it occupies the left column to align with the edge of the card rather than the entire container. 
    - The designs highlight two ways to do this: one was having the branding inside the bottom edge of the labs header and the other was deliberately leaving it outside. This PR implements the latter when it was previously doing the former.
    - This is easier to achieve in a consistent way so would be preferred when taking to design review
- Removes margin from sponsored content label to vertically align logo and label together

## Why?

Making small adjustments to the layouts for new designs for labs containers

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/85b2dc5a-a301-491b-86c3-f17148a9b43c
[after]: https://github.com/user-attachments/assets/b8790292-40ab-4862-9454-3769b6ecaa23

[before2]: https://github.com/user-attachments/assets/ab9ba3cb-4bd7-4fcb-9b9b-d13d932599b4
[after2]: https://github.com/user-attachments/assets/391a8b6a-9b3c-4db2-a915-be2174a9a13a

