### PR TITLE
Recommend `Secure Messaging` over `SecureDrop` in callouts

### DIFF
--- a/apps-rendering/src/components/Callout/calloutComponents.tsx
+++ b/apps-rendering/src/components/Callout/calloutComponents.tsx
@@ -22,7 +22,7 @@ export const Disclaimer = () => (
 		will only use the data you provide us for the purpose of the feature and
 		we will delete any personal data when we no longer require it for this
 		purpose. For true anonymity please use our{' '}
-		<a href="https://www.theguardian.com/securedrop">SecureDrop</a> service
+		<a href="https://www.theguardian.com/tips">SecureMessaging</a> service
 		instead.
 	</div>
 );

--- a/apps-rendering/src/components/Callout/calloutComponents.tsx
+++ b/apps-rendering/src/components/Callout/calloutComponents.tsx
@@ -22,7 +22,7 @@ export const Disclaimer = () => (
 		will only use the data you provide us for the purpose of the feature and
 		we will delete any personal data when we no longer require it for this
 		purpose. For true anonymity please use our{' '}
-		<a href="https://www.theguardian.com/tips">SecureMessaging</a> service
+		<a href="https://www.theguardian.com/tips">Secure Messaging</a> service
 		instead.
 	</div>
 );

--- a/apps-rendering/src/components/Callout/calloutContact.tsx
+++ b/apps-rendering/src/components/Callout/calloutContact.tsx
@@ -79,7 +79,7 @@ const Disclaimer = ({ contacts }: { contacts: Contact[] }) => {
 	const secureMessagingText = (
 		<span css={[info, calloutLinkContainer]}>
 			For true anonymity please use our{' '}
-			<a href="https://www.theguardian.com/tips">SecureMessaging</a>{' '}
+			<a href="https://www.theguardian.com/tips">Secure Messaging</a>{' '}
 			service instead.
 		</span>
 	);

--- a/apps-rendering/src/components/Callout/calloutContact.tsx
+++ b/apps-rendering/src/components/Callout/calloutContact.tsx
@@ -76,10 +76,10 @@ const Disclaimer = ({ contacts }: { contacts: Contact[] }) => {
 		</span>
 	);
 
-	const secureDropText = (
+	const secureMessagingText = (
 		<span css={[info, calloutLinkContainer]}>
 			For true anonymity please use our{' '}
-			<a href="https://www.theguardian.com/securedrop">SecureDrop</a>{' '}
+			<a href="https://www.theguardian.com/tips">SecureMessaging</a>{' '}
 			service instead.
 		</span>
 	);
@@ -88,7 +88,7 @@ const Disclaimer = ({ contacts }: { contacts: Contact[] }) => {
 		<>
 			{contactText}
 			{contacts.some((c) => !!c.guidance) && guidanceText}{' '}
-			{secureDropText}
+			{secureMessagingText}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
@@ -221,7 +221,7 @@ export const CalloutTermsAndConditions = () => (
 			data-ignore="global-link-styling"
 			href="https://www.theguardian.com/tips"
 		>
-			SecureMessaging
+			Secure Messaging
 		</a>{' '}
 		service instead.
 	</div>

--- a/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
+++ b/dotcom-rendering/src/components/Callout/CalloutComponents.tsx
@@ -219,9 +219,9 @@ export const CalloutTermsAndConditions = () => (
 		purpose. For true anonymity please use our{' '}
 		<a
 			data-ignore="global-link-styling"
-			href="https://www.theguardian.com/securedrop"
+			href="https://www.theguardian.com/tips"
 		>
-			SecureDrop
+			SecureMessaging
 		</a>{' '}
 		service instead.
 	</div>

--- a/dotcom-rendering/src/components/Callout/MessageUs.tsx
+++ b/dotcom-rendering/src/components/Callout/MessageUs.tsx
@@ -97,7 +97,7 @@ const Disclaimer = ({ contacts }: { contacts: CalloutContactType[] }) => {
 	const secureMessagingText = (
 		<span>
 			For true anonymity please use our{' '}
-			<a href="https://www.theguardian.com/tips">SecureMessaging</a>{' '}
+			<a href="https://www.theguardian.com/tips">Secure Messaging</a>{' '}
 			service instead.
 		</span>
 	);

--- a/dotcom-rendering/src/components/Callout/MessageUs.tsx
+++ b/dotcom-rendering/src/components/Callout/MessageUs.tsx
@@ -94,10 +94,10 @@ const Disclaimer = ({ contacts }: { contacts: CalloutContactType[] }) => {
 		</span>
 	);
 
-	const secureDropText = (
+	const secureMessagingText = (
 		<span>
 			For true anonymity please use our{' '}
-			<a href="https://www.theguardian.com/securedrop">SecureDrop</a>{' '}
+			<a href="https://www.theguardian.com/tips">SecureMessaging</a>{' '}
 			service instead.
 		</span>
 	);
@@ -107,7 +107,7 @@ const Disclaimer = ({ contacts }: { contacts: CalloutContactType[] }) => {
 			{contactText}
 			<p css={[linkStyles, infoStyles]}>
 				{contacts.some((c) => !!c.guidance) && guidanceText}{' '}
-				{secureDropText}
+				{secureMessagingText}
 			</p>
 		</>
 	);


### PR DESCRIPTION
## What does this change?

Updates the secure-anonymous-submission link on Callout components (like the one on this page: https://www.theguardian.com/business/2025/oct/01/airline-industry-workers-share-your-experiences#6311788 - components which are currently used solely by the Community Team):

* From: **SecureDrop** https://www.theguardian.com/securedrop
* To: **Secure Messaging** https://www.theguardian.com/tips - detailing Secure Messaging/Coverdrop, as well as other communication options including SecureDrop (page initially setup in [January 2025](https://github.com/guardian/interactives/issues/2202)) (note from @hoyla : _In running text we use the convention "Secure Messaging" even though the logo itself is "SecureMessaging"._)

## Why?

I noticed today that callouts on www.theguardian.com still point to SecureDrop - Secure Messaging represents a generally more user-friendly way to submit tips securely & anonymously than the steps required for submitting to SecureDrop, so ideally, if readers _want_ to use high-security routes like this, we should offer them Secure Messaging for preference. Note that the new link is to a page that still lists SecureDrop as an _option_, as it is better for, eg, submitting files, photos, etc.

As these Callout components are used by the Community Team, we'll need to check they're ok with the change, and ensure they have access to read Secure Messaging messages intended for them.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="999" height="641" alt="image" src="https://github.com/user-attachments/assets/7e08b7a5-28d5-4a72-93cb-aa155e0186b3" /> | <img width="999" height="641" alt="image" src="https://github.com/user-attachments/assets/8d92090c-1c85-4c22-9242-e9518237cb1a" /> |

## Related

For subsequent/separate PRs:

* SecureDrop is also in [many footer definitions](https://github.com/search?q=repo%3Aguardian%2Fdotcom-rendering+%22https%3A%2F%2Fwww.theguardian.com%2Fsecuredrop%22&type=code) in this project (a refactor might be a good idea to reduce duplication?)
  * From @hoyla about SecureDrop footers/headers: _"Part of the convention for all SecureDrop sites is to include that info in such places"_ - so we should retain them.
* This wording is also in a mobile-apps-api template: https://github.com/guardian/mobile-apps-api/blob/3d9f47cb7bd6e0a7c9e7e1deb64bbd07121d4198/common-play/src/main/scala/views/campaigns/callouts/calloutForm.scala.html#L97


