### PR TITLE
Remove `z-index` from gallery main media

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -398,7 +398,6 @@ const galleryStyles = css`
 
 	grid-row: 7/9;
 	position: relative;
-	z-index: ${getZIndex('articleHeadline')};
 
 	${from.tablet} {
 		${grid.between('centre-column-start', 'grid-end')};

--- a/dotcom-rendering/src/components/MainMediaGallery.tsx
+++ b/dotcom-rendering/src/components/MainMediaGallery.tsx
@@ -3,7 +3,6 @@ import { isUndefined } from '@guardian/libs';
 import { from } from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { type ArticleFormat } from '../lib/articleFormat';
-import { getZIndex } from '../lib/getZIndex';
 import { getImage } from '../lib/image';
 import { type ImageBlockElement } from '../types/content';
 import { type RenderingTarget } from '../types/renderingTarget';
@@ -23,7 +22,6 @@ const styles = css`
 	position: relative;
 	height: calc(80vh - 48px);
 	grid-row: 1/8;
-	z-index: ${getZIndex('mainMedia')};
 	${from.desktop} {
 		height: calc(100vh - 48px);
 	}

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -19,7 +19,6 @@ import {
 	type ArticleFormat,
 	ArticleSpecial,
 } from '../lib/articleFormat';
-import { getZIndex } from '../lib/getZIndex';
 import { palette as themePalette } from '../palette';
 import type { TagType } from '../types/tag';
 import { Hide } from './Hide';
@@ -372,7 +371,6 @@ export const SeriesSectionLink = ({
 								css`
 									display: inline-block;
 									position: relative;
-									z-index: ${getZIndex('articleHeadline')};
 								`,
 							format.display === ArticleDisplay.Immersive &&
 								css`


### PR DESCRIPTION
It isn't needed for the layout. The lightbox link is absolute positioned[^1] relative to the figure, which is itself relative positioned; this allows the link to precisely overlay the image.

Relative positioning the figure, however, causes it to be drawn over the headline and series link, because positioned elements are drawn over non-positioned ones[^2]. These elements would normally appear over the top of the image because they are a) placed in the same location with CSS grid, and b) later in the DOM. Relatively positioning these elements  too solves this problem, and allows them to overlay the image again.

In summary, this layout has already been achieved by positioning the elements, so setting additional `z-index` properties is not required.

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_without_z-index
