### PR TITLE
Only log JSON.parse errors in InteractiveBlockComponent

### DIFF
--- a/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveBlockComponent.importable.tsx
@@ -223,26 +223,9 @@ const setupWindowListeners = (iframe: HTMLIFrameElement) => {
 			try {
 				message = JSON.parse(event.data);
 			} catch (e) {
-				if (
-					// @ts-expect-error
-					window.guardian.config.page.contentId ===
-					'politics/2025/oct/02/could-nigel-farage-really-win-the-next-election-heres-what-the-polls-say'
-				) {
-					log(
-						'dotcom',
-						getErrorMessage(e),
-						'Json parse Failed on in interactiveBlockComponent',
-					);
-				} else {
-					window.guardian.modules.sentry.reportError(
-						// @ts-expect-error
-						e,
-						'Json parse Failed on in interactiveBlockComponent',
-					);
-				}
-				window.guardian.modules.sentry.reportError(
-					// @ts-expect-error
-					e,
+				log(
+					'dotcom',
+					getErrorMessage(e),
 					'Json parse Failed on in interactiveBlockComponent',
 				);
 			}


### PR DESCRIPTION
## What does this change?

Articles with Datawrapper embeds are throwing a large number of JSON.parse errors from 'message' events which hit our Sentry quota. Until we have a long term solution we want to log these rather than report to Sentry.

