### PR TITLE
`LeftColumn` should not use `section`

### DIFF
--- a/dotcom-rendering/src/components/LeftColumn.tsx
+++ b/dotcom-rendering/src/components/LeftColumn.tsx
@@ -98,7 +98,7 @@ export const LeftColumn = ({
 	hasPageSkin = false,
 }: Props) => {
 	return (
-		<section
+		<div
 			css={[
 				positionRelative,
 				leftWidth(size, hasPageSkin),
@@ -124,6 +124,6 @@ export const LeftColumn = ({
 			>
 				{children}
 			</div>
-		</section>
+		</div>
 	);
 };


### PR DESCRIPTION
The `section` element is meant to be used for a standalone section of a document[^1]. This generally is not what this `LeftColumn` component is used to represent. For example, it's most widely used to position a heading within the `Section` component, which typically already includes a `section` itself.

https://github.com/guardian/dotcom-rendering/blob/1eac64e4b36167032657dbf882e6e0df167ea6e2/dotcom-rendering/src/components/Section.tsx#L312-L318

`LeftColumn` is for general-purpose, presentational usage, and therefore can't make assumptions about the semantics of the document in which it's used. As a result, a non-semantic element like `div`[^2] is a more appropriate choice.

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div
