### PR TITLE
Share z-index value for edition switcher banner and sticky labs header

### DIFF
--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -19,7 +19,7 @@ const container = css`
 	position: relative;
 	top: 0;
 	background-color: ${palette.brand[800]};
-	z-index: ${getZIndex('editionSwitcherBanner')};
+	z-index: ${getZIndex('subNavBanner')};
 `;
 
 const content = css`

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -191,7 +191,7 @@ export const AudioLayout = (props: WebProps) => {
 			</div>
 
 			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
+				<Stuck zIndex="subNavBanner">
 					<Section
 						fullWidth={true}
 						showTopBorder={false}

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -232,7 +232,7 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 						/>
 
 						{format.theme === ArticleSpecial.Labs && (
-							<Stuck>
+							<Stuck zIndex="subNavBanner">
 								<Section
 									fullWidth={true}
 									showTopBorder={false}

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -220,7 +220,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 			)}
 
 			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
+				<Stuck zIndex="subNavBanner">
 					<Section
 						fullWidth={true}
 						showTopBorder={false}

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -333,7 +333,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 			)}
 
 			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
+				<Stuck zIndex="subNavBanner">
 					<Section
 						fullWidth={true}
 						showTopBorder={false}

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -298,7 +298,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					</div>
 
 					{format.theme === ArticleSpecial.Labs && (
-						<Stuck>
+						<Stuck zIndex="subNavBanner">
 							<Section
 								fullWidth={true}
 								showTopBorder={false}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -332,7 +332,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									/>
 								</Stuck>
 							</div>
-							<Stuck zIndex="stickyAdWrapperLabsHeader">
+							<Stuck zIndex="subNavBanner">
 								<Section
 									fullWidth={true}
 									showTopBorder={false}

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -430,7 +430,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 			)}
 
 			{format.theme === ArticleSpecial.Labs && (
-				<Stuck>
+				<Stuck zIndex="subNavBanner">
 					<Section
 						fullWidth={true}
 						showTopBorder={false}

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -71,9 +71,9 @@ const indices = [
 	'searchHeaderLink',
 	'TheGuardian',
 
-	// The edition switcher banner needs to be below the Edition selector
-	// and the myAccount dropdown in the nav
-	'editionSwitcherBanner',
+	// Banners appearing directly under the nav need to be below
+	// the Edition selector and the myAccount dropdown in the nav
+	'subNavBanner',
 
 	// Sticky table of contents element
 	'tableOfContents',


### PR DESCRIPTION
## What does this change?

- Shares z-index value for edition switcher banner and sticky labs header
- Provides this z-index value as a prop in the `Stuck` component for the `LabsHeader` on articles

## Why?

Fixes a bug where the edition dropdown menu expanded _underneath_ the sticky labs header

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a296239d-cfe9-441e-82e6-05988579c962
[after]: https://github.com/user-attachments/assets/511d72d1-8c08-41a8-b971-043e4bc53eb6
