### PR TITLE
Use destination field in choice cards

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -44,7 +44,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "7.8.1",
+		"@guardian/support-dotcom-components": "7.9.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.52.0",
 		"@sentry/browser": "10.10.0",

--- a/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
@@ -338,6 +338,7 @@ const withBannerData =
 					tracking,
 					submitComponentEvent,
 					design,
+					promoCodes,
 				};
 
 				return (

--- a/dotcom-rendering/src/components/marketing/banners/common/types.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/common/types.tsx
@@ -80,4 +80,5 @@ export interface BannerRenderProps {
 	tracking: Tracking;
 	submitComponentEvent?: (componentEvent: ComponentEvent) => void;
 	design?: ConfigurableDesign;
+	promoCodes?: string[];
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -33,7 +33,7 @@ import {
 } from '../../../../lib/useMatchMedia';
 import { getChoiceCards } from '../../lib/choiceCards';
 import type { ReactComponent } from '../../lib/ReactComponent';
-import { getChoiceCardUrl } from '../../lib/tracking';
+import { enrichSupportUrl, getChoiceCardUrl } from '../../lib/tracking';
 import { ThreeTierChoiceCards } from '../../shared/ThreeTierChoiceCards';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { BannerRenderProps } from '../common/types';
@@ -132,6 +132,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 	submitComponentEvent,
 	tracking,
 	design,
+	countryCode,
+	promoCodes,
 }: BannerRenderProps): JSX.Element => {
 	const isTabletOrAbove = useMatchMedia(removeMediaRulePrefix(from.tablet));
 
@@ -480,10 +482,15 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 							)}
 							<div css={styles.ctaContainer(isCollapsed)}>
 								<LinkButton
-									href={getChoiceCardUrl(
-										selectedChoiceCard,
-										mainOrMobileContent.primaryCta.ctaUrl,
-									)}
+									href={enrichSupportUrl({
+										baseUrl:
+											getChoiceCardUrl(
+												selectedChoiceCard,
+											),
+										tracking,
+										promoCodes: promoCodes ?? [],
+										countryCode,
+									})}
 									onClick={onCtaClick}
 									priority="primary"
 									cssOverrides={styles.linkButtonStyles}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -7,8 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import lzstring from 'lz-string';
 import {
 	choiceCardsSettings,
-	choiceCardsWithDestinationUrl,
-	choiceCardsWithDestinationUrlTwoCards,
+	choiceCardsWithMixedDestinations,
 } from '../../../lib/storybook';
 import {
 	contentNoHeading,
@@ -286,7 +285,7 @@ export const NoChoiceCardOrImage: Story = {
 	},
 };
 
-export const WithDestinationUrlAllCards: Story = {
+export const WithMixedDestinations: Story = {
 	name: 'With destinationUrl on all choice cards',
 	args: {
 		...meta.args,
@@ -302,39 +301,12 @@ export const WithDestinationUrlAllCards: Story = {
 			abTestVariant: 'THREE_TIER_CHOICE_CARDS',
 		},
 		choiceCardAmounts: regularChoiceCardAmounts,
-		choiceCardsSettings: choiceCardsWithDestinationUrl,
+		choiceCardsSettings: choiceCardsWithMixedDestinations,
 	},
 	parameters: {
 		docs: {
 			description: {
-				story: 'All choice cards have a destinationUrl configured. The banner should use these custom URLs instead of constructing URLs with product parameters.',
-			},
-		},
-	},
-};
-
-export const WithDestinationUrlTwoCards: Story = {
-	name: 'With destinationUrl in two choice cards',
-	args: {
-		...meta.args,
-		design: {
-			...design,
-			visual: {
-				kind: 'ChoiceCards',
-				buttonColour: stringToHexColour('E5E5E5'),
-			},
-		},
-		tracking: {
-			...tracking,
-			abTestVariant: 'THREE_TIER_CHOICE_CARDS',
-		},
-		choiceCardAmounts: regularChoiceCardAmounts,
-		choiceCardsSettings: choiceCardsWithDestinationUrlTwoCards,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'All choice cards have a destinationUrl configured. The banner should use these custom URLs instead of constructing URLs with product parameters.',
+				story: 'Two out of three choice cards have destination set to checkout.',
 			},
 		},
 	},

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.stories.tsx
@@ -10,7 +10,7 @@ import lzstring from 'lz-string';
 import React from 'react';
 import {
 	choiceCardsSettings,
-	choiceCardsWithDestinationUrl,
+	choiceCardsWithMixedDestinations,
 } from '../lib/storybook';
 import { ContributionsEpicUnvalidated as ContributionsEpic } from './ContributionsEpic';
 import { props } from './utils/storybook';
@@ -385,8 +385,8 @@ export const WithParagraphLinks: Story = {
 	},
 };
 
-export const WithThreeTierChoiceCardsAndCustomDestinationUrl: Story = {
-	name: 'ContributionsEpic with three tier choice cards and custom destination URL',
+export const WithThreeTierChoiceCardsAndMixedDestinations: Story = {
+	name: 'ContributionsEpic with three tier choice cards and mixed destinations',
 	args: {
 		...meta.args,
 		variant: {
@@ -394,7 +394,7 @@ export const WithThreeTierChoiceCardsAndCustomDestinationUrl: Story = {
 			name: 'THREE_TIER_CHOICE_CARDS',
 			secondaryCta: undefined,
 			showChoiceCards: true,
-			choiceCardsSettings: choiceCardsWithDestinationUrl,
+			choiceCardsSettings: choiceCardsWithMixedDestinations,
 		},
 	},
 };

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicButtons.tsx
@@ -184,7 +184,7 @@ export const ContributionsEpicButtons = ({
 
 		return {
 			text: cta.text,
-			baseUrl: getChoiceCardUrl(threeTierSelectedChoiceCard, cta.baseUrl),
+			baseUrl: getChoiceCardUrl(threeTierSelectedChoiceCard),
 		};
 	};
 

--- a/dotcom-rendering/src/components/marketing/lib/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/lib/storybook.ts
@@ -97,7 +97,7 @@ export const choiceCardsSettings: ChoiceCardsSettings = {
 	],
 };
 
-export const choiceCardsWithDestinationUrl: ChoiceCardsSettings = {
+export const choiceCardsWithMixedDestinations: ChoiceCardsSettings = {
 	choiceCards: [
 		{
 			product: {
@@ -106,8 +106,7 @@ export const choiceCardsWithDestinationUrl: ChoiceCardsSettings = {
 			},
 			label: 'Support £5/month',
 			isDefault: false,
-			destinationUrl:
-				'https://support.theguardian.com/contribute/monthly?custom-destination=contribution',
+			destination: 'LandingPage',
 			benefits: [
 				{
 					copy: 'Give to the Guardian every month with Support',
@@ -121,8 +120,7 @@ export const choiceCardsWithDestinationUrl: ChoiceCardsSettings = {
 			},
 			label: 'Support £12/month',
 			isDefault: true,
-			destinationUrl:
-				'https://support.theguardian.com/subscribe/monthly?custom-destination=supporter-plus',
+			destination: 'Checkout',
 			benefitsLabel:
 				'Unlock <strong>All-access digital</strong> benefits:',
 			benefits: [
@@ -142,63 +140,7 @@ export const choiceCardsWithDestinationUrl: ChoiceCardsSettings = {
 			},
 			label: 'One-time support',
 			isDefault: false,
-			destinationUrl:
-				'https://support.theguardian.com/contribute/one-time?custom-destination=one-off',
-			benefits: [
-				{
-					copy: 'Support the Guardian with a one-time contribution',
-				},
-			],
-		},
-	],
-};
-
-export const choiceCardsWithDestinationUrlTwoCards: ChoiceCardsSettings = {
-	choiceCards: [
-		{
-			product: {
-				supportTier: 'Contribution',
-				ratePlan: 'Monthly',
-			},
-			label: 'Support £5/month',
-			isDefault: false,
-			destinationUrl: null,
-			benefits: [
-				{
-					copy: 'Give to the Guardian every month with Support',
-				},
-			],
-		},
-		{
-			product: {
-				supportTier: 'SupporterPlus',
-				ratePlan: 'Monthly',
-			},
-			label: 'Support £12/month',
-			isDefault: true,
-			destinationUrl:
-				'https://support.theguardian.com/subscribe/monthly?custom-destination=supporter-plus',
-			benefitsLabel:
-				'Unlock <strong>All-access digital</strong> benefits:',
-			benefits: [
-				{
-					copy: '<strong>Unlimited</strong> access to the Guardian app',
-				},
-				{ copy: 'Unlimited access to our new Feast App' },
-				{ copy: 'Ad-free reading on all your devices' },
-				{
-					copy: 'Exclusive newsletters for subscribers',
-				},
-			],
-		},
-		{
-			product: {
-				supportTier: 'OneOff',
-			},
-			label: 'One-time support',
-			isDefault: false,
-			destinationUrl:
-				'https://support.theguardian.com/contribute/one-time?custom-destination=one-off',
+			destination: 'Checkout',
 			benefits: [
 				{
 					copy: 'Support the Guardian with a one-time contribution',

--- a/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
@@ -90,7 +90,7 @@ describe('getChoiceCardUrl', () => {
 	});
 
 	// Recurring contribution
-	it('builds landing page url for one-time choice', () => {
+	it('builds landing page url for recurring contribution choice', () => {
 		const url = getChoiceCardUrl({
 			benefits: [],
 			isDefault: false,
@@ -105,7 +105,7 @@ describe('getChoiceCardUrl', () => {
 			'https://support.theguardian.com/contribute?product=Contribution&ratePlan=Monthly',
 		);
 	});
-	it('builds checkout page url for one-time choice', () => {
+	it('builds checkout page url for recurring contribution choice', () => {
 		const url = getChoiceCardUrl({
 			benefits: [],
 			isDefault: false,
@@ -122,7 +122,7 @@ describe('getChoiceCardUrl', () => {
 	});
 
 	// SupporterPlus
-	it('builds landing page url for one-time choice', () => {
+	it('builds landing page url for Supporter Plus choice', () => {
 		const url = getChoiceCardUrl({
 			benefits: [],
 			isDefault: false,
@@ -137,7 +137,7 @@ describe('getChoiceCardUrl', () => {
 			'https://support.theguardian.com/contribute?product=SupporterPlus&ratePlan=Annual',
 		);
 	});
-	it('builds checkout page url for one-time choice', () => {
+	it('builds checkout page url for Supporter Plus choice', () => {
 		const url = getChoiceCardUrl({
 			benefits: [],
 			isDefault: false,

--- a/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
@@ -1,29 +1,5 @@
 import type { Tracking } from '@guardian/support-dotcom-components/dist/shared/types';
-import { addChoiceCardsParams, enrichSupportUrl } from './tracking';
-
-describe('addChoiceCardsParams', () => {
-	it('adds choice cards params to url without existing querystring', () => {
-		const result = addChoiceCardsParams(
-			'https://support.theguardian.com/contribute',
-			'ONE_OFF',
-			5,
-		);
-		expect(result).toEqual(
-			'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF&selected-amount=5',
-		);
-	});
-
-	it('adds choice cards params to url with existing querystring', () => {
-		const result = addChoiceCardsParams(
-			'https://support.theguardian.com/contribute?test=test',
-			'ONE_OFF',
-			5,
-		);
-		expect(result).toEqual(
-			'https://support.theguardian.com/contribute?test=test&selected-contribution-type=ONE_OFF&selected-amount=5',
-		);
-	});
-});
+import { enrichSupportUrl, getChoiceCardUrl } from './tracking';
 
 describe('enrichSupportUrl', () => {
 	const tracking: Tracking = {
@@ -78,6 +54,102 @@ describe('enrichSupportUrl', () => {
 		});
 		expect(result).toEqual(
 			'https://support.theguardian.com/uk/contribute?REFPVID=123&INTCMP=test&acquisitionData=%7B%22source%22%3A%22WEB%22%2C%22componentId%22%3A%22test%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22test%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%22test%22%2C%22variant%22%3A%22control%22%7D%5D%2C%22referrerPageviewId%22%3A%22123%22%2C%22referrerUrl%22%3A%22https%3A%2F%2Ftheguardian.com%22%2C%22isRemote%22%3Atrue%7D&promoCode=PROMO1&promoCode=PROMO2',
+		);
+	});
+});
+
+describe('getChoiceCardUrl', () => {
+	// One-time
+	it('builds landing page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'OneOff',
+			},
+			destination: 'LandingPage',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/contribute?oneTime',
+		);
+	});
+	it('builds checkout page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'OneOff',
+			},
+			destination: 'Checkout',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/one-time-checkout',
+		);
+	});
+
+	// Recurring contribution
+	it('builds landing page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'Contribution',
+				ratePlan: 'Monthly',
+			},
+			destination: 'LandingPage',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/contribute?product=Contribution&ratePlan=Monthly',
+		);
+	});
+	it('builds checkout page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'Contribution',
+				ratePlan: 'Monthly',
+			},
+			destination: 'Checkout',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/checkout?product=Contribution&ratePlan=Monthly',
+		);
+	});
+
+	// SupporterPlus
+	it('builds landing page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'SupporterPlus',
+				ratePlan: 'Annual',
+			},
+			destination: 'LandingPage',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/contribute?product=SupporterPlus&ratePlan=Annual',
+		);
+	});
+	it('builds checkout page url for one-time choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'SupporterPlus',
+				ratePlan: 'Annual',
+			},
+			destination: 'Checkout',
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/checkout?product=SupporterPlus&ratePlan=Annual',
 		);
 	});
 });

--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -10,7 +10,6 @@ import type {
 	AbandonedBasket,
 	BannerTest,
 	BannerVariant,
-	ContributionFrequency,
 	EpicTest,
 	EpicVariant,
 	TargetingAbTest,
@@ -263,18 +262,6 @@ export const addProfileTrackingParams = (
 	)}`;
 };
 
-export const addChoiceCardsParams = (
-	url: string,
-	frequency: ContributionFrequency,
-	amount?: number | 'other',
-): string => {
-	const newParams = `selected-contribution-type=${frequency}${
-		amount !== undefined ? `&selected-amount=${amount}` : ''
-	}`;
-	const alreadyHasQueryString = url.includes('?');
-	return `${url}${alreadyHasQueryString ? '&' : '?'}${newParams}`;
-};
-
 export const addChoiceCardsOneTimeParams = (url: string): string => {
 	const newParams = `oneTime`;
 	const alreadyHasQueryString = url.includes('?');
@@ -313,9 +300,11 @@ export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
 	const destination = choiceCard.destination ?? 'LandingPage';
 
 	if (product.supportTier === 'OneOff') {
-		const path =
-			destination === 'LandingPage' ? 'contribute' : 'one-time-checkout';
-		return addChoiceCardsOneTimeParams(`${SupportUrl}/${path}`);
+		if (destination === 'LandingPage') {
+			return addChoiceCardsOneTimeParams(`${SupportUrl}/contribute`);
+		} else {
+			return `${SupportUrl}/one-time-checkout`;
+		}
 	} else {
 		const path = destination === 'LandingPage' ? 'contribute' : 'checkout';
 		return addChoiceCardsProductParams(

--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -306,26 +306,24 @@ export const addTrackingParamsToProfileUrl = (
 		: baseUrl;
 };
 
-export const getChoiceCardUrl = (
-	choiceCard: ChoiceCard,
-	baseUrl: string,
-): string => {
-	const { destinationUrl, product } = choiceCard;
+const SupportUrl = 'https://support.theguardian.com';
 
-	const url: string =
-		destinationUrl && destinationUrl.trim() !== ''
-			? destinationUrl.trim()
-			: baseUrl;
+export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
+	const { product } = choiceCard;
+	const destination = choiceCard.destination ?? 'LandingPage';
 
 	if (product.supportTier === 'OneOff') {
-		return addChoiceCardsOneTimeParams(url);
+		const path =
+			destination === 'LandingPage' ? 'contribute' : 'one-time-checkout';
+		return addChoiceCardsOneTimeParams(`${SupportUrl}/${path}`);
+	} else {
+		const path = destination === 'LandingPage' ? 'contribute' : 'checkout';
+		return addChoiceCardsProductParams(
+			`${SupportUrl}/${path}`,
+			product.supportTier,
+			product.ratePlan,
+		);
 	}
-
-	return addChoiceCardsProductParams(
-		url,
-		product.supportTier,
-		product.ratePlan,
-	);
 };
 
 // SHARED TRACKING

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,8 +349,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0)(@guardian/libs@26.0.0)(@guardian/source@11.3.0)(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 7.8.1
-        version: 7.8.1(@guardian/libs@26.0.0)(@guardian/ophan-tracker-js@2.6.1)(zod@3.22.4)
+        specifier: 7.9.0
+        version: 7.9.0(@guardian/libs@26.0.0)(@guardian/ophan-tracker-js@2.6.1)(zod@3.22.4)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -680,7 +680,7 @@ importers:
         version: 0.7.4
       storybook:
         specifier: 8.6.14
-        version: 8.6.14
+        version: 8.6.14(prettier@3.0.3)
       stylelint:
         specifier: 16.5.0
         version: 16.5.0(typescript@5.5.3)
@@ -4921,7 +4921,7 @@ packages:
       '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -5222,8 +5222,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@guardian/support-dotcom-components@7.8.1(@guardian/libs@26.0.0)(@guardian/ophan-tracker-js@2.6.1)(zod@3.22.4):
-    resolution: {integrity: sha512-lBMvk6o87RufobXt73TU8eCci0zSax4Z2MmPFb2vZNHDLMErfQoa8uor4FuOwbG8ECRuN2zSHCf9yG+oSCAh4Q==}
+  /@guardian/support-dotcom-components@7.9.0(@guardian/libs@26.0.0)(@guardian/ophan-tracker-js@2.6.1)(zod@3.22.4):
+    resolution: {integrity: sha512-3TUG6Ah8l/0WcwG2KKQohstfxmXS9Ghm3hm/oTuCoNlYsHzEoMtZcHEoBe/H/d3xmQq4chMuiVdnb7j3U1B/Zg==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
       '@guardian/ophan-tracker-js': 2.6.1
@@ -6636,7 +6636,7 @@ packages:
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       uuid: 9.0.1
     dev: false
 
@@ -6647,7 +6647,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6658,7 +6658,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6673,7 +6673,7 @@ packages:
       '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -6693,7 +6693,7 @@ packages:
       '@storybook/addon-outline': 8.6.14(storybook@8.6.14)
       '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14)
       '@storybook/addon-viewport': 8.6.14(storybook@8.6.14)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -6705,7 +6705,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/addon-interactions@8.6.14(storybook@8.6.14):
@@ -6717,7 +6717,7 @@ packages:
       '@storybook/instrumenter': 8.6.14(storybook@8.6.14)
       '@storybook/test': 8.6.14(storybook@8.6.14)
       polished: 4.3.1
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6727,7 +6727,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       tiny-invariant: 1.3.3
     dev: false
 
@@ -6737,7 +6737,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6746,7 +6746,7 @@ packages:
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/addon-viewport@8.6.14(storybook@8.6.14):
@@ -6755,7 +6755,7 @@ packages:
       storybook: ^8.6.14
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/addon-webpack5-compiler-babel@3.0.6(webpack@5.101.0):
@@ -6795,7 +6795,7 @@ packages:
       '@storybook/icons': 1.4.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6822,7 +6822,7 @@ packages:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.4
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       style-loader: 3.3.4(webpack@5.101.0)
       terser-webpack-plugin: 5.3.14(@swc/core@1.11.31)(esbuild@0.25.5)(webpack@5.101.0)
       ts-dedent: 2.2.0
@@ -6890,7 +6890,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/core-events@8.6.14(storybook@8.6.14):
@@ -6898,7 +6898,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/core-webpack@8.6.14(storybook@8.6.14):
@@ -6906,7 +6906,7 @@ packages:
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       ts-dedent: 2.2.0
     dev: false
 
@@ -6937,38 +6937,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@storybook/core@8.6.14(storybook@8.6.14):
-    resolution: {integrity: sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==}
-    peerDependencies:
-      prettier: ^2 || ^3
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-    dependencies:
-      '@storybook/theming': 8.6.14(storybook@8.6.14)
-      better-opn: 3.0.2
-      browser-assert: 1.2.1
-      esbuild: 0.25.5
-      esbuild-register: 3.6.0(esbuild@0.25.5)
-      jsdoc-type-pratt-parser: 4.1.0
-      process: 0.11.10
-      recast: 0.23.11
-      semver: 7.7.2
-      util: 0.12.5
-      ws: 8.18.2
-    transitivePeerDependencies:
-      - bufferutil
-      - storybook
-      - supports-color
-      - utf-8-validate
-    dev: false
-
   /@storybook/csf-plugin@8.6.14(storybook@8.6.14):
     resolution: {integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==}
     peerDependencies:
       storybook: ^8.6.14
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       unplugin: 1.16.1
     dev: false
 
@@ -6994,7 +6968,7 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/manager-api@8.6.14(storybook@8.6.14):
@@ -7002,7 +6976,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14)(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)(webpack-cli@6.0.1):
@@ -7028,7 +7002,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
       semver: 7.5.4
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       tsconfig-paths: 4.2.0
       typescript: 5.5.3
       webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
@@ -7082,7 +7056,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.101.0):
@@ -7099,7 +7073,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7113,7 +7087,7 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/react-webpack5@8.6.14(@storybook/test@8.6.14)(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)(webpack-cli@6.0.1):
@@ -7133,7 +7107,7 @@ packages:
       '@storybook/react': 8.6.14(@storybook/test@8.6.14)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.14)(typescript@5.5.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       typescript: 5.5.3
     transitivePeerDependencies:
       - '@rspack/core'
@@ -7198,7 +7172,7 @@ packages:
       '@storybook/theming': 8.6.14(storybook@8.6.14)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
       typescript: 5.5.3
     dev: false
 
@@ -7214,7 +7188,7 @@ packages:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@storybook/theming@8.6.14(storybook@8.6.14):
@@ -7222,7 +7196,7 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.6.14
+      storybook: 8.6.14(prettier@3.0.3)
     dev: false
 
   /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0):
@@ -8681,8 +8655,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.101.0):
@@ -8692,8 +8666,8 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
     dev: false
 
   /@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.1)(webpack@5.101.0):
@@ -8707,8 +8681,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-server: 5.2.1(webpack-cli@6.0.1)(webpack@5.101.0)
     dev: false
 
@@ -10364,7 +10338,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.5.4)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /css-loader@7.1.2(webpack@5.101.0):
@@ -11434,7 +11408,7 @@ packages:
       enhanced-resolve: 5.18.1
       eslint: 8.56.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -12429,7 +12403,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.2
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /form-data-encoder@2.1.4:
@@ -13086,7 +13060,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /htmlparser2@6.1.0:
@@ -17497,22 +17471,6 @@ packages:
       internal-slot: 1.1.0
     dev: false
 
-  /storybook@8.6.14:
-    resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
-    hasBin: true
-    peerDependencies:
-      prettier: ^2 || ^3
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-    dependencies:
-      '@storybook/core': 8.6.14(storybook@8.6.14)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
   /storybook@8.6.14(prettier@3.0.3):
     resolution: {integrity: sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==}
     hasBin: true
@@ -17751,7 +17709,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /stylelint-config-recommended@14.0.0(stylelint@16.5.0):
@@ -18234,7 +18192,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /ts-node@10.9.2(@swc/core@1.11.31)(@types/node@16.18.68)(typescript@5.1.6):
@@ -18979,7 +18937,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.2
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
     dev: false
 
   /webpack-dev-middleware@7.4.2(webpack@5.101.0):
@@ -19039,8 +18997,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.1)(webpack@5.101.0)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.1)(webpack@5.101.0)
       webpack-dev-middleware: 7.4.2(webpack@5.101.0)
       ws: 8.18.1
     transitivePeerDependencies:
@@ -19085,7 +19043,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.101.0(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.101.0(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-sources: 2.3.1
     dev: false
     patched: true


### PR DESCRIPTION
## What does this change?

The choice cards config from SDC now includes a `destination` field instead of `destinationUrl`: https://github.com/guardian/support-dotcom-components/pull/1431
The `destination` field will simply be `LandingPage` or `Checkout`, and DCR builds the url.

This is because we've changed our mind about how this should be configured from the tool. It simplifies things for MRR users of the tool, and also in the client (DCR).

The main change here is to the `getChoiceCardUrl` function, which no longer takes a `baseUrl` parameter. It builds the right Support site url based on the given choice card settings.

## Testing
In addition to the new unit tests, I configured some choice cards in the CODE RRCP and tested both landing page and checkout links work
