### PR TITLE
Add padding top on the first image of the gallery

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -54,7 +54,7 @@ const styles = css`
 			content: '';
 			position: absolute;
 			right: -10px;
-			top: 0;
+			top: -12px;
 			bottom: 0;
 			width: 1px;
 			background-color: ${palette('--article-border')};

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -35,6 +35,12 @@ const styles = css`
 		border-left: 1px solid ${palette('--article-border')};
 		border-right: 1px solid ${palette('--article-border')};
 	}
+
+	${from.desktop} {
+		&:first-of-type {
+			padding-top: ${space[3]}px;
+		}
+	}
 `;
 
 const galleryBodyImageStyles = css`


### PR DESCRIPTION
## What does this change?
Adds padding top to the first image of the gallery

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/60468cf8-62e3-4b2d-a083-88b14ce38d2e
[after]: https://github.com/user-attachments/assets/2f22c570-7ae5-4dfe-befd-8705b015dc24

This PR fixes [#14613](https://github.com/guardian/dotcom-rendering/issues/14613)
