### PR TITLE
Remove keyline above date on gallery app

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.apps.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.apps.tsx
@@ -336,20 +336,22 @@ export const ArticleMetaApps = ({
 						</Island>
 					</MetaGridCommentCount>
 				)}
-				<StraightLines
-					cssOverrides={[
-						stretchLines,
-						css`
-							grid-row: 4 / -4;
-						`,
-					]}
-					count={1}
-					color={
-						isLiveBlog
-							? 'rgba(255, 255, 255, 0.4)'
-							: themePalette('--article-meta-lines')
-					}
-				/>
+				{format.design !== ArticleDesign.Gallery && (
+					<StraightLines
+						cssOverrides={[
+							stretchLines,
+							css`
+								grid-row: 4 / -4;
+							`,
+						]}
+						count={1}
+						color={
+							isLiveBlog
+								? 'rgba(255, 255, 255, 0.4)'
+								: themePalette('--article-meta-lines')
+						}
+					/>
+				)}
 				<MetaGridDateline
 					isImmersiveOrAnalysisWithMultipleAuthors={
 						isImmersiveOrAnalysisWithMultipleAuthors


### PR DESCRIPTION
## What does this change?
Requested by Rich to remove the keyline above the date in Gallery Meta section in the app to match with the existing app behaviour for galleries. 


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/dfd100d8-ab89-49e5-9cba-24ca1bfb80e1
[after]: https://github.com/user-attachments/assets/18d9f48f-4d5b-43dc-bd7b-4270c6bdbccf


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->


Fixes [#14614](https://github.com/guardian/dotcom-rendering/issues/14614)