### PR TITLE
Add quadrule and border bottom in galleries submeta

### DIFF
--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -138,8 +138,7 @@ const syndicationButtonOverrides = css`
 `;
 
 const straightLinesStyles = css`
-	display: inline;
-	position: relative;
+	display: block;
 
 	${grid.column.all}
 
@@ -237,16 +236,12 @@ export const SubMeta = ({
 				<Fragment>
 					<div css={galleryBorder}></div>
 
-					<div css={straightLinesStyles}>
-						<StraightLines
-							data-print-layout="hide"
-							count={4}
-							cssOverrides={css`
-								display: block;
-							`}
-							color={palette('--straight-lines')}
-						/>
-					</div>
+					<StraightLines
+						data-print-layout="hide"
+						count={4}
+						cssOverrides={straightLinesStyles}
+						color={palette('--straight-lines')}
+					/>
 				</Fragment>
 			)}
 			{hasLinks && (

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -84,22 +84,19 @@ const listStyles = css`
 	background-repeat: no-repeat;
 `;
 
-const listWrapper = (design: ArticleDesign): SerializedStyles => {
-	if (design === ArticleDesign.Gallery) {
-		return css`
-			${grid.column.centre}
-			padding-bottom: 0.75rem;
-			margin-bottom: 6px;
-			border-bottom: 1px solid ${palette('--article-border')};
-		`;
-	}
+const listWrapper = css`
+	padding-bottom: 0.75rem;
+	margin-bottom: 6px;
+	border-bottom: 1px solid ${palette('--article-border')};
+`;
 
-	return css`
-		padding-bottom: 0.75rem;
-		margin-bottom: 6px;
-		border-bottom: 1px solid ${palette('--article-border')};
-	`;
-};
+const galleryWrapperStyles = css`
+	${grid.column.centre}
+
+	${from.leftCol} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
 
 const listItemStyles = css`
 	${textSans14};
@@ -257,7 +254,13 @@ export const SubMeta = ({
 					<span css={labelStyles(format.design)}>
 						Explore more on these topics
 					</span>
-					<div css={listWrapper(format.design)}>
+					<div
+						css={[
+							listWrapper,
+							format.design == ArticleDesign.Gallery &&
+								galleryWrapperStyles,
+						]}
+					>
 						<ul css={listStyles}>
 							{links.map((link) => (
 								<li css={listItemStyles} key={link.url}>

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -88,6 +88,7 @@ const listWrapper = (design: ArticleDesign): SerializedStyles => {
 			${grid.column.centre}
 			padding-bottom: 0.75rem;
 			margin-bottom: 6px;
+			border-bottom: 1px solid ${palette('--article-border')};
 		`;
 	}
 

--- a/dotcom-rendering/src/components/SubMeta.tsx
+++ b/dotcom-rendering/src/components/SubMeta.tsx
@@ -8,6 +8,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { LinkButton } from '@guardian/source/react-components';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import { Fragment } from 'react';
 import { grid } from '../grid';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import type { BaseLinkType } from '../model/extract-nav';
@@ -138,6 +140,21 @@ const syndicationButtonOverrides = css`
 	}
 `;
 
+const straightLinesStyles = css`
+	display: inline;
+	position: relative;
+
+	${grid.column.all}
+
+	${from.tablet} {
+		${grid.column.centre}
+	}
+
+	${from.leftCol} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
+
 const galleryStyles = css`
 	${grid.paddedContainer};
 	background-color: ${palette('--article-inner-background')};
@@ -220,7 +237,20 @@ export const SubMeta = ({
 			]}
 		>
 			{format.design === ArticleDesign.Gallery && (
-				<div css={galleryBorder}></div>
+				<Fragment>
+					<div css={galleryBorder}></div>
+
+					<div css={straightLinesStyles}>
+						<StraightLines
+							data-print-layout="hide"
+							count={4}
+							cssOverrides={css`
+								display: block;
+							`}
+							color={palette('--straight-lines')}
+						/>
+					</div>
+				</Fragment>
 			)}
 			{hasLinks && (
 				<>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -6,6 +6,7 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
 import { Fragment } from 'react';
 import { AdPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
@@ -280,6 +281,15 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						</Fragment>
 					);
 				})}
+
+				<StraightLines
+					data-print-layout="hide"
+					count={4}
+					cssOverrides={css`
+						display: block;
+					`}
+					color={palette('--straight-lines')}
+				/>
 
 				<SubMeta
 					format={format}

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -6,7 +6,6 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { Hide } from '@guardian/source/react-components';
-import { StraightLines } from '@guardian/source-development-kitchen/react-components';
 import { Fragment } from 'react';
 import { AdPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
@@ -281,15 +280,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						</Fragment>
 					);
 				})}
-
-				<StraightLines
-					data-print-layout="hide"
-					count={4}
-					cssOverrides={css`
-						display: block;
-					`}
-					color={palette('--straight-lines')}
-				/>
 
 				<SubMeta
 					format={format}


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/14615

## What does this change?
Adds quadrule and border in Galleries submet

## Why?
Requested by design

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="927" height="217" alt="image" src="https://github.com/user-attachments/assets/8758bb50-6c59-4d44-b5ff-21f927bad7c6" /> | <img width="973" height="227" alt="image" src="https://github.com/user-attachments/assets/2f9efea4-77f5-4550-9872-3b9ee7e91634" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
