### PR TITLE
Update gallery byline colour in dark mode

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -619,6 +619,8 @@ const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 
 const bylineAnchorDark: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
+		case ArticleDesign.Gallery:
+			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
 				case Pillar.News:


### PR DESCRIPTION
## What does this change?
Update the byline colour in dark mode in gallery. This was requested after design review


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fddb2686-97b5-47c5-9859-82da86f7c540
[after]: https://github.com/user-attachments/assets/5ea01403-be85-471e-892f-66139aab7b2c

This PR fixes [#14617](https://github.com/guardian/dotcom-rendering/issues/14617)