### PR TITLE
Deduplicate onward containers and story packages

### DIFF
--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { isNonNullable } from '@guardian/libs';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
-import { decideTrail } from '../lib/decideTrail';
+import { decideTrail, dedupeTrail } from '../lib/decideTrail';
 import { useApi } from '../lib/useApi';
 import { addDiscussionIds } from '../lib/useCommentCount';
 import { palette } from '../palette';
@@ -20,6 +20,7 @@ type Props = {
 	absoluteServerTimes: boolean;
 	renderingTarget: RenderingTarget;
 	isAdFreeUser: boolean;
+	webURL: string;
 };
 
 type OnwardsResponse = {
@@ -40,9 +41,11 @@ const buildTrails = (
 	trails: FETrailType[],
 	trailLimit: number,
 	isAdFreeUser: boolean,
+	webURL: string,
 ): TrailType[] => {
 	return trails
 		.filter((trailType) => !(isTrailPaidContent(trailType) && isAdFreeUser))
+		.filter((trailType) => dedupeTrail(trailType, webURL))
 		.slice(0, trailLimit)
 		.map(decideTrail);
 };
@@ -56,6 +59,7 @@ export const FetchOnwardsData = ({
 	absoluteServerTimes,
 	renderingTarget,
 	isAdFreeUser,
+	webURL,
 }: Props) => {
 	const { data, error } = useApi<OnwardsResponse>(url);
 
@@ -81,11 +85,13 @@ export const FetchOnwardsData = ({
 			.filter(isNonNullable),
 	);
 
+	const trails = buildTrails(data.trails, limit, isAdFreeUser, webURL);
+
 	return (
 		<div css={minHeight}>
 			<Carousel
 				heading={data.heading || data.displayname} // Sometimes the api returns heading as 'displayName'
-				trails={buildTrails(data.trails, limit, isAdFreeUser)}
+				trails={trails}
 				description={data.description}
 				onwardsSource={onwardsSource}
 				format={format}

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -217,6 +217,7 @@ describe('Island: server-side rendering', () => {
 						discussionApiUrl=""
 						absoluteServerTimes={true}
 						renderingTarget="Web"
+						webURL={''}
 					/>
 				</WithConfig>,
 			),

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -186,6 +186,7 @@ type Props = {
 	discussionApiUrl: string;
 	absoluteServerTimes: boolean;
 	renderingTarget: RenderingTarget;
+	webURL: string;
 };
 
 /**
@@ -221,6 +222,7 @@ export const OnwardsUpper = ({
 	discussionApiUrl,
 	absoluteServerTimes,
 	renderingTarget,
+	webURL,
 }: Props) => {
 	const isHorizontalScrollingSupported = useIsHorizontalScrollingSupported();
 
@@ -325,6 +327,7 @@ export const OnwardsUpper = ({
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
 						isAdFreeUser={isAdFreeUser}
+						webURL={webURL}
 					/>
 				</Section>
 			)}
@@ -342,6 +345,7 @@ export const OnwardsUpper = ({
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
 						isAdFreeUser={isAdFreeUser}
+						webURL={webURL}
 					/>
 				</Section>
 			)}

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -38,7 +38,7 @@ import { type ArticleFormat, ArticleSpecial } from '../lib/articleFormat';
 import { getAudioData } from '../lib/audio-data';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -484,8 +484,9 @@ export const AudioLayout = (props: WebProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -519,6 +520,7 @@ export const AudioLayout = (props: WebProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 				{showComments && (

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -45,7 +45,7 @@ import {
 import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -725,8 +725,9 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -760,6 +761,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -339,6 +339,7 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					discussionApiUrl={frontendData.config.discussionApiUrl}
 					absoluteServerTimes={absoluteServerTimes}
 					renderingTarget={renderingTarget}
+					webURL={frontendData.webURL}
 				/>
 			</Island>
 

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -50,7 +50,7 @@ import {
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideMainMediaCaption } from '../lib/decide-caption';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import { parse } from '../lib/slot-machine-flags';
@@ -806,8 +806,9 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -841,6 +842,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -43,7 +43,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { type ArticleFormat, ArticleSpecial } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
 import type { ArticleDeprecated } from '../types/article';
@@ -650,8 +650,9 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -685,6 +686,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -51,7 +51,7 @@ import { SubNav } from '../components/SubNav.importable';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -970,8 +970,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							>
 								<Carousel
 									heading={article.storyPackage.heading}
-									trails={article.storyPackage.trails.map(
-										decideTrail,
+									trails={decideStoryPackageTrails(
+										article.storyPackage.trails,
+										article.webURL,
 									)}
 									onwardsSource="more-on-this-story"
 									format={format}
@@ -1007,6 +1008,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							discussionApiUrl={article.config.discussionApiUrl}
 							absoluteServerTimes={absoluteServerTimes}
 							renderingTarget={renderingTarget}
+							webURL={article.webURL}
 						/>
 					</Island>
 

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -36,7 +36,7 @@ import { Standfirst } from '../components/Standfirst';
 import { ArticleDisplay, type ArticleFormat } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
 import type { ArticleDeprecated } from '../types/article';
@@ -429,8 +429,9 @@ export const NewsletterSignupLayout = ({
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -464,6 +465,7 @@ export const NewsletterSignupLayout = ({
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 			</main>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -38,7 +38,7 @@ import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -583,8 +583,9 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -621,6 +622,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							discussionApiUrl={article.config.discussionApiUrl}
 							absoluteServerTimes={absoluteServerTimes}
 							renderingTarget={renderingTarget}
+							webURL={article.webURL}
 						/>
 					</Island>
 				)}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -46,7 +46,7 @@ import {
 } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { decideLanguage, decideLanguageDirection } from '../lib/lang';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
@@ -690,8 +690,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -725,6 +726,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -52,7 +52,7 @@ import {
 } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
-import { decideTrail } from '../lib/decideTrail';
+import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { parse } from '../lib/slot-machine-flags';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -873,8 +873,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<Carousel
 								heading={article.storyPackage.heading}
-								trails={article.storyPackage.trails.map(
-									decideTrail,
+								trails={decideStoryPackageTrails(
+									article.storyPackage.trails,
+									article.webURL,
 								)}
 								onwardsSource="more-on-this-story"
 								format={format}
@@ -908,6 +909,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						discussionApiUrl={article.config.discussionApiUrl}
 						absoluteServerTimes={absoluteServerTimes}
 						renderingTarget={renderingTarget}
+						webURL={article.webURL}
 					/>
 				</Island>
 				{showComments && (

--- a/dotcom-rendering/src/lib/decideTrail.ts
+++ b/dotcom-rendering/src/lib/decideTrail.ts
@@ -3,6 +3,19 @@ import type { FETrailType, TrailType } from '../types/trails';
 import { type ArticleFormat, decideFormat } from './articleFormat';
 import { getDataLinkNameCard } from './getDataLinkName';
 
+export const dedupeTrail = (trail: FETrailType, webURL: string): boolean => {
+	return trail.url !== webURL;
+};
+
+export const decideStoryPackageTrails = (
+	trails: FETrailType[],
+	webURL: string,
+): TrailType[] => {
+	return trails
+		.filter((trail) => dedupeTrail(trail, webURL))
+		.map(decideTrail);
+};
+
 export const decideTrail = (trail: FETrailType, index = 0): TrailType => {
 	const format: ArticleFormat = decideFormat(trail.format);
 	const image: DCRFrontImage | undefined = trail.image


### PR DESCRIPTION
## What does this change?
Adds a filter when constructing trails in story packages and onwards container to remove a trail if it matches the article a user is currently on. This is achieved by comparing the trail URL from the article webURL.
## Why?
The article that a user is on can appear in its own onwards containers or story packages which is not desired. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0f99b892-2728-42ca-ac84-b2419c8a81db
[after]: https://github.com/user-attachments/assets/6e8bad96-1fc2-4570-9712-0f9f807850f9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
