### PR TITLE
Track treatmentType of sign-in gates

### DIFF
--- a/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
+++ b/dotcom-rendering/src/components/SignInGateSelector.importable.tsx
@@ -455,6 +455,7 @@ const ShowSignInGateAuxia = ({
 					component: {
 						componentType: 'SIGN_IN_GATE',
 						id: treatmentId,
+						labels: [userTreatment.treatmentType],
 					},
 					action: 'VIEW',
 					abTest: buildAbTestTrackingAuxiaVariant(treatmentId),


### PR DESCRIPTION
## What does this change?
Adds the auxia `treatmentType` to the ophan view event for the sign-in gate component.

## Why?
We'll soon be testing a popup sign-in gate.
Currently if we want to know which gate views were from the popup then we have to rely on knowing the auxia treatment id, which we send in the component_id to ophan.

It would be simpler if there was an additional field with the treatment type.
This PR adds the treatment type to the labels field of the component event. This is not perfect, but we cannot change the component_type or component_id.

## Screenshots
<img width="588" height="133" alt="Screenshot 2025-10-08 at 09 18 07" src="https://github.com/user-attachments/assets/faf785d4-8488-4059-a9e9-e412acdb5f5d" />
