### PR TITLE
Fix ab-testing deploy workflows

### DIFF
--- a/.github/workflows/ab-testing-checks.yml
+++ b/.github/workflows/ab-testing-checks.yml
@@ -5,6 +5,12 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      save_build_artifact:
+        description: 'Whether to save the built files as an artifact'
+        required: false
+        type: boolean
+        default: false
     secrets:
       FASTLY_AB_TESTING_CONFIG:
         required: true
@@ -36,3 +42,9 @@ jobs:
 
       - name: Build
         run: deno task build
+
+      - if: ${{ inputs.save_build_artifact }}
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ab-testing-build
+          path: ab-testing/dist

--- a/.github/workflows/ab-testing-deploy-code.yml
+++ b/.github/workflows/ab-testing-deploy-code.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ab-testing-checks.yml
+    with:
+      save_build_artifact: true
     secrets:
       FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_CODE_AB_TESTING_CONFIG }}
       FASTLY_API_TOKEN: ${{ secrets.FASTLY_CODE_API_TOKEN }}

--- a/.github/workflows/ab-testing-deploy-code.yml
+++ b/.github/workflows/ab-testing-deploy-code.yml
@@ -16,15 +16,9 @@ jobs:
   deploy:
     name: Deploy CODE
     needs: ci
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ab-testing
-    steps:
-      - name: Deploy
-        uses: ./.github/workflows/ab-testing-deploy.yml
-        with:
-          stage: code
-        env:
-          FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_CODE_AB_TESTING_CONFIG }}
-          FASTLY_API_TOKEN: ${{ secrets.FASTLY_CODE_API_TOKEN }}
+    uses: ./.github/workflows/ab-testing-deploy.yml
+    with:
+      stage: code
+    secrets:
+      FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_CODE_AB_TESTING_CONFIG }}
+      FASTLY_API_TOKEN: ${{ secrets.FASTLY_CODE_API_TOKEN }}

--- a/.github/workflows/ab-testing-deploy-prod.yml
+++ b/.github/workflows/ab-testing-deploy-prod.yml
@@ -17,18 +17,13 @@ jobs:
     secrets:
       FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_PROD_AB_TESTING_CONFIG }}
       FASTLY_API_TOKEN: ${{ secrets.FASTLY_PROD_API_TOKEN }}
+
   deploy:
     name: Deploy PROD
     needs: ci
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ab-testing
-    steps:
-      - name: Deploy
-        uses: ./.github/workflows/ab-testing-deploy.yml
-        with:
-          stage: prod
-        env:
-          FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_PROD_AB_TESTING_CONFIG }}
-          FASTLY_API_TOKEN: ${{ secrets.FASTLY_PROD_API_TOKEN }}
+    uses: ./.github/workflows/ab-testing-deploy.yml
+    with:
+      stage: prod
+    secrets:
+      FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_PROD_AB_TESTING_CONFIG }}
+      FASTLY_API_TOKEN: ${{ secrets.FASTLY_PROD_API_TOKEN }}

--- a/.github/workflows/ab-testing-deploy-prod.yml
+++ b/.github/workflows/ab-testing-deploy-prod.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ab-testing-checks.yml
+    with:
+      save_build_artifact: true
     secrets:
       FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_PROD_AB_TESTING_CONFIG }}
       FASTLY_API_TOKEN: ${{ secrets.FASTLY_PROD_API_TOKEN }}

--- a/.github/workflows/ab-testing-deploy.yml
+++ b/.github/workflows/ab-testing-deploy.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Deploy
         run: deno run deploy
+        env:
+          FASTLY_AB_TESTING_CONFIG: ${{ secrets.FASTLY_AB_TESTING_CONFIG }}
+          FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}

--- a/.github/workflows/ab-testing-deploy.yml
+++ b/.github/workflows/ab-testing-deploy.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           deno-version: v2.3
 
+      - name: Download build artifact
+        uses: actions/download-artifact@v5.0.0
+        with:
+          name: ab-testing-build
+          path: ab-testing/dist
+
       - name: Deploy
         run: deno run deploy
         env:

--- a/ab-testing/abTest.ts
+++ b/ab-testing/abTest.ts
@@ -22,7 +22,7 @@ import type { ABTest } from './types';
 export const ABTests: ABTest[] = [
 	// Sample tests that will be used for testing the AB testing framework
 	{
-		name: 'commercial-client-side-test',
+		name: 'commercial-client-side-test-1',
 		description:
 			'Show new ad block ask component in ad slots when we detect ad blocker usage',
 		owners: ['commercial.dev@guardian.co.uk'],
@@ -34,7 +34,7 @@ export const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: 'commercial-server-side-test',
+		name: 'commercial-server-side-test-1',
 		description:
 			'Show new ad block ask component in ad slots when we detect ad blocker usage',
 		owners: ['commercial.dev@guardian.co.uk'],

--- a/ab-testing/deno.json
+++ b/ab-testing/deno.json
@@ -1,7 +1,7 @@
 {
 	"tasks": {
 		"validate": "deno run scripts/validation/index.ts",
-		"deploy": "deno run --allow-read=dist --allow-env=FASTLY_AB_TESTING_CONFIG --allow-net=api.fastly.com:443 scripts/deploy/index.ts --mvts=dist/mvts.json --ab-tests=dist/ab-tests.json",
+		"deploy": "deno run --allow-read=dist --allow-env=FASTLY_AB_TESTING_CONFIG,FASTLY_API_TOKEN --allow-net=api.fastly.com:443 scripts/deploy/index.ts --mvts=dist/mvts.json --ab-tests=dist/ab-tests.json",
 		"build": "deno run --allow-write=dist --allow-env=FASTLY_AB_TESTING_CONFIG,FASTLY_API_TOKEN --allow-net=api.fastly.com:443 scripts/build/index.ts --mvts=dist/mvts.json --ab-tests=dist/ab-tests.json"
 	},
 	"imports": {


### PR DESCRIPTION
## What does this change?
Quite a few fixes to get the ab-testing deploy to actually work, not sure how this got past me in #14333 ...

- The secrets weren't being passed properly to the deploy workflow
- The calling of the reusable workflow wasn't quite right
- the build wasn't saved as an artifact to deploy in a later step

Successful deploy after these changes: https://github.com/guardian/dotcom-rendering/actions/runs/18343600883