### PR TITLE
Fix sans headline size for labs cards

### DIFF
--- a/dotcom-rendering/src/components/CardHeadline.tsx
+++ b/dotcom-rendering/src/components/CardHeadline.tsx
@@ -16,9 +16,6 @@ import {
 	textSans15,
 	textSans17,
 	textSans20,
-	textSans24,
-	textSans28,
-	textSans34,
 	textSansBold12,
 	textSansBold15,
 	textSansBold17,
@@ -124,12 +121,12 @@ const fontFamilies = {
 	 * Line height for sans style headlines for labs is overridden to match that of other headlines (1.15)
 	 */
 	textSans: {
-		xxxlarge: `${textSans34}\n\tline-height: 1.15;\n`,
-		xxlarge: `${textSans34}\n\tline-height: 1.15;\n`,
-		xlarge: `${textSans34}\n\tline-height: 1.15;\n`,
-		large: `${textSans34}\n\tline-height: 1.15;\n`,
-		medium: `${textSans28}\n\tline-height: 1.15;\n`,
-		small: `${textSans24}\n\tline-height: 1.15;\n`,
+		xxxlarge: `${textSans20}\n\tline-height: 1.15;\n`,
+		xxlarge: `${textSans20}\n\tline-height: 1.15;\n`,
+		xlarge: `${textSans20}\n\tline-height: 1.15;\n`,
+		large: `${textSans20}\n\tline-height: 1.15;\n`,
+		medium: `${textSans20}\n\tline-height: 1.15;\n`,
+		small: `${textSans20}\n\tline-height: 1.15;\n`,
 		xsmall: `${textSans20}\n\tline-height: 1.15;\n`,
 		xxsmall: `${textSans17}\n\tline-height: 1.15;\n`,
 		xxxsmall: `${textSans15}\n\tline-height: 1.15;\n`,


### PR DESCRIPTION
## What does this change?

Increases the maximum font size available for labs headlines to the largest font size available through source at the moment (34 for text sans)

## Why?

After a design review for upcoming labs changes, the headline sizes didn't seem appropriate for the splash cards and feature cards which use larger headlines than standard cards

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/ff1246e7-59f4-4494-9fe4-e9a4df711130
[after]: https://github.com/user-attachments/assets/60d5ca6e-0b92-4365-a2d8-c48baddee9ea

[before2]: https://github.com/user-attachments/assets/e34df097-0afd-4fe4-86f3-92d6a70470bc
[after2]: https://github.com/user-attachments/assets/6e602792-b91a-40a1-82be-bbdd846902b0

[before3]: https://github.com/user-attachments/assets/53fc80b6-a56c-47ca-9286-36524dfbdab9
[after3]: https://github.com/user-attachments/assets/51165ac4-a5ad-4871-ae45-dfaf6189a15a
