### PR TITLE
Fix Latest Links unique `key` prop warning

### DIFF
--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -7,6 +7,7 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { DottedLines } from '@guardian/source-development-kitchen/react-components';
+import { Fragment } from 'react';
 import { revealStyles } from '../lib/revealStyles';
 import { useApi } from '../lib/useApi';
 import { palette as themePalette } from '../palette';
@@ -179,21 +180,12 @@ export const LatestLinks = ({
 						.filter((block) => block.body.trim() !== '')
 						.slice(0, 3)
 						.map((block, index) => (
-							<>
+							<Fragment key={block.id}>
 								<ContainerOverrides
 									containerPalette={containerPalette}
 								>
-									{index > 0 && (
-										<li
-											key={block.id + ' : divider'}
-											css={dividerStyles}
-										></li>
-									)}
-									<li
-										key={block.id}
-										css={linkStyles}
-										className={'reveal'}
-									>
+									{index > 0 && <li css={dividerStyles}></li>}
+									<li css={linkStyles} className={'reveal'}>
 										<WithLink
 											linkTo={`${id}?page=with:block-${block.id}#block-${block.id}`}
 										>
@@ -228,7 +220,7 @@ export const LatestLinks = ({
 										</WithLink>
 									</li>
 								</ContainerOverrides>
-							</>
+							</Fragment>
 						))
 				) : (
 					<>


### PR DESCRIPTION
## What does this change?

Adds a unique `key` prop to the fragment elements wrapping each link in the `LatestLinks` component.

## Why?

When rendering with React on the client we get a warning that the child list elements do not have a unique key.

Whilst the child `li` elements _do_ have unique keys applied, it's actually the wrapping fragment elements that are the direct children and therefore require a unique key. As the keys on the `li` elements are not necessary they have been removed.

<img width="1128" height="376" alt="Screenshot 2025-10-08 at 11 52 57" src="https://github.com/user-attachments/assets/2afd3e1f-fe67-46e2-bf47-8130edb79228" />
