### PR TITLE
Allow experiment participation to preview labs redesigns

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -134,7 +134,14 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 
 	const contributionsServiceUrl = getContributionsServiceUrl(front);
 
-	const showLabsRedesign = !!front.config.switches.guardianLabsRedesign;
+	/** We allow the labs redesign to be shown if:
+	 * - the feature switch is ON
+	 * OR
+	 * - the user is opted into the 0% server side test
+	 */
+	const showLabsRedesign =
+		!!front.config.switches.guardianLabsRedesign ||
+		abTests.labsRedesignVariant === 'variant';
 
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {


### PR DESCRIPTION
## What does this change?

Adds an `OR` condition to the `showLabsRedesign` value to include the option of participating in the 0% server side experiment as well as the environment-level feature switch.

## Why?

The `CODE` environment is not very stable, so for previewing new designs it is better to use `PROD`, though we aren't totally ready to release yet. Putting these behind a server side test allows us to share preview links with designers

_Frontend PR adding the experiment: https://github.com/guardian/frontend/pull/28275_
