### PR TITLE
Add client side test for comparison with new framework

### DIFF
--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -11,6 +11,7 @@ import {
 } from '@guardian/core-web-vitals';
 import { getCookie, isString, isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
+import { compareClientTestWithNewFramework } from '../experiments/tests/compare-client-test-with-new-framework';
 import { useAB, useBetaAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useDetectAdBlock } from '../lib/useDetectAdBlock';
@@ -30,6 +31,7 @@ const willRecordCoreWebVitals = Math.random() < sampling;
 // For these tests switch off sampling and collect metrics for 100% of views
 const clientSideTestsToForceMetrics: ABTest[] = [
 	/* keep array multi-line */
+	compareClientTestWithNewFramework,
 ];
 
 const shouldCollectMetricsForBetaTests = (userTestParticipations: string[]) => {

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { auxiaSignInGate } from './tests/auxia-sign-in-gate';
+import { compareClientTestWithNewFramework } from './tests/compare-client-test-with-new-framework';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 import { userBenefitsApi } from './tests/user-benefits-api';
@@ -13,4 +14,5 @@ export const tests: ABTest[] = [
 	signInGateMainControl,
 	userBenefitsApi,
 	auxiaSignInGate,
+	compareClientTestWithNewFramework,
 ];

--- a/dotcom-rendering/src/experiments/tests/compare-client-test-with-new-framework.ts
+++ b/dotcom-rendering/src/experiments/tests/compare-client-test-with-new-framework.ts
@@ -1,0 +1,31 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const compareClientTestWithNewFramework: ABTest = {
+	id: 'CompareClientTestWithNewFramework',
+	start: '2025-10-08',
+	expiry: '2025-11-01',
+	author: 'Commercial Dev',
+	description:
+		'A test to compare the old and new AB testing frameworks in DCR',
+	audience: 10 / 100,
+	audienceOffset: 0,
+	successMeasure:
+		'No success measure, this is just to compare the two frameworks',
+	audienceCriteria: 'Everyone',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};


### PR DESCRIPTION
## Why?
So we can roughly compare pageview and metric collection rates for the old and new client side framework.
