### PR TITLE
`guardian/eslint-config-typescript` v10

### DIFF
--- a/apps-rendering/package.json
+++ b/apps-rendering/package.json
@@ -46,7 +46,7 @@
 		"@guardian/cdk": "61.4.0",
 		"@guardian/content-api-models": "31.0.0",
 		"@guardian/content-atom-model": "6.1.0",
-		"@guardian/eslint-config-typescript": "9.0.1",
+		"@guardian/eslint-config-typescript": "10.0.1",
 		"@guardian/libs": "22.0.0",
 		"@guardian/renditions": "0.2.0",
 		"@guardian/source": "9.0.0",

--- a/apps-rendering/src/atoms.ts
+++ b/apps-rendering/src/atoms.ts
@@ -21,9 +21,13 @@ interface TimelineEvent {
 }
 
 function formatOptionalDate(date: Int64 | undefined): string | undefined {
-	if (date === undefined) return undefined;
+	if (date === undefined) {
+		return undefined;
+	}
 	const d = new Date(date.toNumber());
-	if (!isValidDate(d)) return undefined;
+	if (!isValidDate(d)) {
+		return undefined;
+	}
 	return d.toDateString();
 }
 

--- a/apps-rendering/src/client/article.ts
+++ b/apps-rendering/src/client/article.ts
@@ -78,7 +78,9 @@ function followToggle(
 	bridgetClient: NotificationsClient<void> | TagClient<void>,
 ): void {
 	const followStatus = document.querySelector(querySelector);
-	if (!followStatus) return;
+	if (!followStatus) {
+		return;
+	}
 	void bridgetClient.isFollowing(topic).then((isFollowing) => {
 		if (isFollowing) {
 			void bridgetClient.unfollow(topic).then((unfollow) => {

--- a/apps-rendering/src/client/callouts.ts
+++ b/apps-rendering/src/client/callouts.ts
@@ -120,8 +120,12 @@ const makeArticleFormat = (theme: ArticleTheme): ArticleFormatProps => ({
 const themeParser: Parser<ArticleTheme> = pipe(
 	numberParser,
 	andThen((num) => {
-		if (Pillar[num]) return succeed(num);
-		if (ArticleSpecial[num]) return succeed(num);
+		if (Pillar[num]) {
+			return succeed(num);
+		}
+		if (ArticleSpecial[num]) {
+			return succeed(num);
+		}
 		return fail(`I was not able to parse '${num}' as a valid theme`);
 	}),
 );

--- a/apps-rendering/src/client/editions.ts
+++ b/apps-rendering/src/client/editions.ts
@@ -33,7 +33,9 @@ const adjustGalleryImages = (): void => {
 	const figures: NodeListOf<HTMLElement> = document.querySelectorAll(
 		'.editions-gallery-figure',
 	);
-	if (figures.length === 0) return;
+	if (figures.length === 0) {
+		return;
+	}
 
 	Array.from(figures).forEach((figure) => {
 		const imageEl = figure.querySelector('img');

--- a/apps-rendering/src/client/nativeCommunication.ts
+++ b/apps-rendering/src/client/nativeCommunication.ts
@@ -29,7 +29,9 @@ function areRectsEqual(rectA: IRect, rectB: IRect): boolean {
 }
 
 function positionChanged(slotsA: Slot[], slotsB: Slot[]): boolean {
-	if (slotsA.length !== slotsB.length) return true;
+	if (slotsA.length !== slotsB.length) {
+		return true;
+	}
 	return !slotsA.every((slot, index) =>
 		areRectsEqual(slot.rect, slotsB[index].rect),
 	);

--- a/apps-rendering/src/client/newsletterSignupForm.ts
+++ b/apps-rendering/src/client/newsletterSignupForm.ts
@@ -14,10 +14,10 @@ interface FormBundle {
 }
 
 // ----- Constants ----- //
-const SIGNUP_CONTAINER_CLASSNAME = 'js-signup-form-container' as const;
-const FALLBACK_CONTENT_CLASSNAME = 'js-signup-form-fallback-container' as const;
-const LOADING_CONTENT_CLASSNAME = 'js-signup-form-loading-content' as const;
-const SIGNUP_COMPONENT_BASE_CLASSNAME = 'js-signup-form' as const;
+const SIGNUP_CONTAINER_CLASSNAME = 'js-signup-form-container';
+const FALLBACK_CONTENT_CLASSNAME = 'js-signup-form-fallback-container';
+const LOADING_CONTENT_CLASSNAME = 'js-signup-form-loading-content';
+const SIGNUP_COMPONENT_BASE_CLASSNAME = 'js-signup-form';
 const MODIFIER_CLASSNAME = {
 	waiting: `${SIGNUP_COMPONENT_BASE_CLASSNAME}--waiting`,
 	success: `${SIGNUP_COMPONENT_BASE_CLASSNAME}--success`,

--- a/apps-rendering/src/components/Callout/calloutContact.tsx
+++ b/apps-rendering/src/components/Callout/calloutContact.tsx
@@ -31,7 +31,9 @@ export const formatContactNumbers = (contacts: Contact[]): string => {
 
 	// Group each contact by its value, so we can display multiple names for the same number.
 	contacts.forEach(({ name, value }) => {
-		if (!contactNumbers.has(value)) contactNumbers.set(value, []);
+		if (!contactNumbers.has(value)) {
+			contactNumbers.set(value, []);
+		}
 		contactNumbers.get(value)?.push(name);
 	});
 

--- a/apps-rendering/src/components/Callout/calloutForm.tsx
+++ b/apps-rendering/src/components/Callout/calloutForm.tsx
@@ -94,7 +94,9 @@ const CalloutForm = ({ id, fields }: CalloutFormProps) => {
 		// Reset error for new submission attempt
 		setSubmissionError('');
 		const isValid = validateForm();
-		if (!isValid) return;
+		if (!isValid) {
+			return;
+		}
 
 		// need to add prefix `field_` to all keys in form (as is required by formstack api)
 		const formDataWithFieldPrefix = Object.keys(formData).reduce(

--- a/apps-rendering/src/components/Callout/formFields.tsx
+++ b/apps-rendering/src/components/Callout/formFields.tsx
@@ -62,7 +62,9 @@ export const FormField = ({
 		);
 	}
 
-	if (formField.hidden) return <input type="hidden" />;
+	if (formField.hidden) {
+		return <input type="hidden" />;
+	}
 
 	switch (type) {
 		case 'text':

--- a/apps-rendering/src/components/Callout/shareLink.tsx
+++ b/apps-rendering/src/components/Callout/shareLink.tsx
@@ -23,7 +23,9 @@ export const ShareLink = ({
 	const onShare = async (): Promise<void> => {
 		const url = window.location.href;
 		let shareTitle = `Share your experience`;
-		if (title) shareTitle += `: ${title}`;
+		if (title) {
+			shareTitle += `: ${title}`;
+		}
 
 		const shareText = `
 I saw this callout in an article: ${url}#${urlAnchor}

--- a/apps-rendering/src/components/Callout/theme.ts
+++ b/apps-rendering/src/components/Callout/theme.ts
@@ -85,7 +85,9 @@ export const darkTheme = {
 };
 
 const getPrefersDark = (): boolean => {
-	if (typeof window === 'undefined') return false;
+	if (typeof window === 'undefined') {
+		return false;
+	}
 	return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
 

--- a/apps-rendering/src/components/Deadline/index.tsx
+++ b/apps-rendering/src/components/Deadline/index.tsx
@@ -22,16 +22,26 @@ export const getDeadlineText = (
 ): string | undefined => {
 	const maxDays = 7;
 	const daysBetween = getDaysBetween(date1, date2);
-	if (daysBetween <= 0 || daysBetween > maxDays) return;
-	if (daysBetween <= 1) return 'Closing today';
-	if (Math.round(daysBetween) === 1) return 'Open for 1 more day';
+	if (daysBetween <= 0 || daysBetween > maxDays) {
+		return;
+	}
+	if (daysBetween <= 1) {
+		return 'Closing today';
+	}
+	if (Math.round(daysBetween) === 1) {
+		return 'Open for 1 more day';
+	}
 	return `Open for ${Math.round(daysBetween)} more days`;
 };
 
 function formatOptionalDate(date: number | undefined): Date | undefined {
-	if (date === undefined) return undefined;
+	if (date === undefined) {
+		return undefined;
+	}
 	const d = new Date(date);
-	if (!isValidDate(d)) return undefined;
+	if (!isValidDate(d)) {
+		return undefined;
+	}
 	return d;
 }
 
@@ -44,10 +54,14 @@ function isCalloutActive(until?: number): boolean {
 
 const DeadlineDate = ({ until }: { until?: number }) => {
 	const untilDate = formatOptionalDate(until);
-	if (!untilDate) return null;
+	if (!untilDate) {
+		return null;
+	}
 	const now = new Date();
 	const deadlineText = getDeadlineText(now, untilDate);
-	if (!deadlineText) return null;
+	if (!deadlineText) {
+		return null;
+	}
 	return (
 		<Highlight>
 			<SvgClockFilled size="xsmall" />

--- a/apps-rendering/src/renderer.ts
+++ b/apps-rendering/src/renderer.ts
@@ -118,8 +118,12 @@ const TweetStyles = css`
 `;
 
 const allowsDropCaps = (format: ArticleFormat): boolean => {
-	if (format.theme === ArticleSpecial.Labs) return false;
-	if (format.display === ArticleDisplay.Immersive) return true;
+	if (format.theme === ArticleSpecial.Labs) {
+		return false;
+	}
+	if (format.display === ArticleDisplay.Immersive) {
+		return true;
+	}
 	switch (format.design) {
 		case ArticleDesign.Feature:
 		case ArticleDesign.Comment:
@@ -396,7 +400,9 @@ const calloutDescriptionText = (
 	format: ArticleFormat,
 	doc?: DocumentFragment,
 ): ReactNode[] => {
-	if (!doc) return [];
+	if (!doc) {
+		return [];
+	}
 	const nodes = Array.from(doc.childNodes);
 	const filteredNodes = nodes.filter(
 		(node) => !['A'].includes(node.nodeName),

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -34,7 +34,7 @@
 		"@guardian/cdk": "61.4.0",
 		"@guardian/commercial-core": "28.0.0",
 		"@guardian/core-web-vitals": "7.0.0",
-		"@guardian/eslint-config-typescript": "9.0.1",
+		"@guardian/eslint-config-typescript": "10.0.1",
 		"@guardian/identity-auth": "6.0.1",
 		"@guardian/identity-auth-frontend": "8.1.0",
 		"@guardian/libs": "26.0.0",

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -219,7 +219,7 @@ export const getActiveMediaAtom = (
 			/**
 			 * Take one source for each supported video file type.
 			 */
-			const sources = supportedVideoFileTypes.reduce(
+			const sources = supportedVideoFileTypes.reduce<typeof assets>(
 				(acc, type) => {
 					const source = assets.find(
 						({ mimeType }) => mimeType === type,
@@ -227,7 +227,7 @@ export const getActiveMediaAtom = (
 					if (source) acc.push(source);
 					return acc;
 				},
-				[] as typeof assets,
+				[],
 			);
 			if (!sources.length) return undefined;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       '@guardian/eslint-config-typescript':
-        specifier: 9.0.1
-        version: 9.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3)
+        specifier: 10.0.1
+        version: 10.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/libs':
         specifier: 22.0.0
         version: 22.0.0(tslib@2.6.2)(typescript@5.5.3)
@@ -316,8 +316,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(@guardian/libs@26.0.0)(tslib@2.6.2)(typescript@5.5.3)(web-vitals@4.2.3)
       '@guardian/eslint-config-typescript':
-        specifier: 9.0.1
-        version: 9.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3)
+        specifier: 10.0.1
+        version: 10.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/identity-auth':
         specifier: 6.0.1
         version: 6.0.1(@guardian/libs@26.0.0)(tslib@2.6.2)(typescript@5.5.3)
@@ -4890,19 +4890,19 @@ packages:
       web-vitals: 4.2.3
     dev: false
 
-  /@guardian/eslint-config-typescript@9.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3):
-    resolution: {integrity: sha512-m6DZbfZGLSgObkQWhz0aKKGSKd3UqDsTZPeIDS8AEHqMjsn6DerOe6Pn1wH8939D2rW/c2RsrdmJxkHo/OF5+w==}
+  /@guardian/eslint-config-typescript@10.0.1(eslint@8.56.0)(tslib@2.6.2)(typescript@5.5.3):
+    resolution: {integrity: sha512-Y9QBfonXbiILuifudDOb96nYN+lwFhejPHda4ZzbGqRjcQbALQAmT/RMl0gubZTbIuXbRH+RZ7mWHGs/wxOuog==}
     peerDependencies:
       eslint: ^8.56.0
       tslib: ^2.6.2
       typescript: ~5.3.3
     dependencies:
-      '@guardian/eslint-config': 7.0.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)(tslib@2.6.2)
-      '@typescript-eslint/eslint-plugin': 6.18.0(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
+      '@guardian/eslint-config': 8.0.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)(tslib@2.6.2)
+      '@typescript-eslint/eslint-plugin': 7.3.1(@typescript-eslint/parser@7.3.1)(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.3.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -4911,8 +4911,8 @@ packages:
       - supports-color
     dev: false
 
-  /@guardian/eslint-config@7.0.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)(tslib@2.6.2):
-    resolution: {integrity: sha512-9MX0Xj2vaXWLQvjnk0QJKYXaCABwkaZx6ZAOGiGOb4KiadN5guFOgV2ki+YuDqcd5k/R1F3bUyBh/L3+gk0ouQ==}
+  /@guardian/eslint-config@8.0.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)(tslib@2.6.2):
+    resolution: {integrity: sha512-pvXXJhtRqsBW7RxeWIFcXro0Y7hV7rQ4wJYiNiTtBRHo1cmML9lHLFNkIuAncVcc6YodgqCRWAeljaAJrGJJLQ==}
     peerDependencies:
       eslint: ^8.56.0
       tslib: ^2.6.2
@@ -4920,7 +4920,7 @@ packages:
       eslint: 8.56.0
       eslint-config-prettier: 9.1.0(eslint@8.56.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -8188,23 +8188,23 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin@6.18.0(@typescript-eslint/parser@6.18.0)(eslint@8.56.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-3lqEvQUdCozi6d1mddWqd+kf8KxmGq2Plzx36BlkjuQe3rSTm/O98cLf0A4uDO+a5N1KD2SeEEl6fW97YHY+6w==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/eslint-plugin@7.3.1(@typescript-eslint/parser@7.3.1)(eslint@8.56.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
-      eslint: ^7.0.0 || ^8.0.0
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.10.1
-      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/scope-manager': 6.18.0
-      '@typescript-eslint/type-utils': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/utils': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 6.18.0
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/scope-manager': 7.3.1
+      '@typescript-eslint/type-utils': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 7.3.1
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.56.0
       graphemer: 1.4.0
@@ -8250,20 +8250,20 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@6.18.0(eslint@8.56.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-v6uR68SFvqhNQT41frCMCQpsP+5vySy6IdgjlzUWoo7ALCnpaWYcz/Ij2k4L8cEsL0wkvOviCMpjmtRtHNOKzA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/parser@7.3.1(eslint@8.56.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.18.0
-      '@typescript-eslint/types': 6.18.0
-      '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 6.18.0
+      '@typescript-eslint/scope-manager': 7.3.1
+      '@typescript-eslint/types': 7.3.1
+      '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 7.3.1
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.56.0
       typescript: 5.5.3
@@ -8279,12 +8279,12 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/scope-manager@6.18.0:
-    resolution: {integrity: sha512-o/UoDT2NgOJ2VfHpfr+KBY2ErWvCySNUIX/X7O9g8Zzt/tXdpfEU43qbNk8LVuWUT2E0ptzTWXh79i74PP0twA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/scope-manager@7.3.1:
+    resolution: {integrity: sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.18.0
-      '@typescript-eslint/visitor-keys': 6.18.0
+      '@typescript-eslint/types': 7.3.1
+      '@typescript-eslint/visitor-keys': 7.3.1
     dev: false
 
   /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@5.5.3):
@@ -8307,18 +8307,18 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils@6.18.0(eslint@8.56.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-ZeMtrXnGmTcHciJN1+u2CigWEEXgy1ufoxtWcHORt5kGvpjjIlK9MUhzHm4RM8iVy6dqSaZA/6PVkX6+r+ChjQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/type-utils@7.3.1(eslint@8.56.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.5.3)
-      '@typescript-eslint/utils': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
@@ -8332,9 +8332,9 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/types@6.18.0:
-    resolution: {integrity: sha512-/RFVIccwkwSdW/1zeMx3hADShWbgBxBnV/qSrex6607isYjj05t36P6LyONgqdUrNLl5TYU8NIKdHUYpFvExkA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/types@7.3.1:
+    resolution: {integrity: sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.3):
@@ -8358,17 +8358,17 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@6.18.0(typescript@5.5.3):
-    resolution: {integrity: sha512-klNvl+Ql4NsBNGB4W9TZ2Od03lm7aGvTbs0wYaFYsplVPhr+oeXjlPZCDI4U9jgJIDK38W1FKhacCFzCC+nbIg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/typescript-estree@7.3.1(typescript@5.5.3):
+    resolution: {integrity: sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.18.0
-      '@typescript-eslint/visitor-keys': 6.18.0
+      '@typescript-eslint/types': 7.3.1
+      '@typescript-eslint/visitor-keys': 7.3.1
       debug: 4.4.1(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
@@ -8400,18 +8400,18 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@6.18.0(eslint@8.56.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-wiKKCbUeDPGaYEYQh1S580dGxJ/V9HI7K5sbGAVklyf+o5g3O+adnS4UNJajplF4e7z2q0uVBaTdT/yLb4XAVA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/utils@7.3.1(eslint@8.56.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
+      eslint: ^8.56.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
-      '@typescript-eslint/scope-manager': 6.18.0
-      '@typescript-eslint/types': 6.18.0
-      '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.5.3)
+      '@typescript-eslint/scope-manager': 7.3.1
+      '@typescript-eslint/types': 7.3.1
+      '@typescript-eslint/typescript-estree': 7.3.1(typescript@5.5.3)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -8427,11 +8427,11 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
-  /@typescript-eslint/visitor-keys@6.18.0:
-    resolution: {integrity: sha512-1wetAlSZpewRDb2h9p/Q8kRjdGuqdTAQbkJIOUMLug2LBLG+QOjiWoSj6/3B/hA9/tVTFFdtiKvAYoYnSRW/RA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  /@typescript-eslint/visitor-keys@7.3.1:
+    resolution: {integrity: sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.18.0
+      '@typescript-eslint/types': 7.3.1
       eslint-visitor-keys: 3.4.3
     dev: false
 
@@ -11330,7 +11330,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.3.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -11340,8 +11340,8 @@ packages:
       debug: 4.4.1(supports-color@8.1.1)
       enhanced-resolve: 5.18.1
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -11382,7 +11382,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.12.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-module-utils@2.12.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11403,40 +11403,11 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
-      debug: 3.2.7
-      eslint: 8.56.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.18.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.3.1)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -11460,7 +11431,7 @@ packages:
       ignore: 5.3.2
     dev: false
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11470,7 +11441,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.18.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.3.1(eslint@8.56.0)(typescript@5.5.3)
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -11479,7 +11450,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.3.1)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
It now requires curly braces, which have been added where needed in this change using `--fix`. This also resulted in some small changes to how types are defined in a few places.

Release notes:

- https://github.com/guardian/csnx/releases/tag/%40guardian%2Feslint-config-typescript%4010.0.0
- https://github.com/guardian/csnx/releases/tag/%40guardian%2Feslint-config-typescript%4010.0.1
