### PR TITLE
Fix MPU ad slot horizontal alignment

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -64,7 +64,7 @@ const adSlotStyles = css`
 			*/
 			/* stylelint-disable-next-line declaration-no-important */
 			display: block !important;
-			/* Center the content within this element */
+			/* Centre the content within this element */
 			margin-left: auto;
 			margin-right: auto;
 


### PR DESCRIPTION
## What does this change?

Fixes the horizontal alignment of MPU ads within the ad slot

Applies `margin-left: auto; margin-right: auto;` to the `ad-slot__container` itself rather than to the inner `iframe` element specifically

## Why?

To centre the advert within the available space of the ad slot

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/8d5b5816-8bb9-46e3-8feb-4b14b91a527a
[after]: https://github.com/user-attachments/assets/e2732aa3-2937-43d0-aa56-a3f2a6cf1e60
