### PR TITLE
Remove the unnecessary OnwardContainerType

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -33,7 +33,7 @@ import type {
 	DCRSupportingContent,
 } from '../../types/front';
 import type { MainMedia } from '../../types/mainMedia';
-import type { OnwardContainerType, OnwardsSource } from '../../types/onwards';
+import type { OnwardsSource } from '../../types/onwards';
 import { Avatar } from '../Avatar';
 import { CardCommentCount } from '../CardCommentCount.importable';
 import { CardHeadline, type ResponsiveFontSize } from '../CardHeadline';
@@ -124,7 +124,7 @@ export type Props = {
 	supportingContentPosition?: Position;
 	snapData?: DCRSnapType;
 	containerPalette?: DCRContainerPalette;
-	containerType?: DCRContainerType | OnwardContainerType;
+	containerType?: DCRContainerType;
 	showAge?: boolean;
 	discussionApiUrl: string;
 	discussionId?: string;
@@ -588,8 +588,6 @@ export const Card = ({
 		containerType === 'flexible/special' ||
 		containerType === 'flexible/general';
 
-	const isOnwardContainer = containerType === 'more-galleries';
-
 	const isSmallCard =
 		containerType === 'scrollable/small' ||
 		containerType === 'scrollable/medium';
@@ -624,7 +622,9 @@ export const Card = ({
 		return 'tablet';
 	};
 
-	const shouldShowTrailText = isOnwardContainer
+	const isMoreGalleriesOnwardContent =
+		isOnwardContent && onwardsSource === 'more-galleries';
+	const shouldShowTrailText = isMoreGalleriesOnwardContent
 		? media?.type !== 'podcast' && isOnwardSplash
 		: media?.type !== 'podcast';
 
@@ -1066,7 +1066,10 @@ export const Card = ({
 											imageSize={mediaSize}
 											alt={headlineText}
 											loading={imageLoading}
-											roundedCorners={isOnwardContent}
+											roundedCorners={
+												isOnwardContent &&
+												!isMoreGalleriesOnwardContent
+											}
 											aspectRatio={aspectRatio}
 											isInAllBoostsTest={
 												isInAllBoostsTest
@@ -1083,7 +1086,10 @@ export const Card = ({
 									imageSize={mediaSize}
 									alt={media.imageAltText}
 									loading={imageLoading}
-									roundedCorners={isOnwardContent}
+									roundedCorners={
+										isOnwardContent &&
+										!isMoreGalleriesOnwardContent
+									}
 									aspectRatio={aspectRatio}
 									isInAllBoostsTest={isInAllBoostsTest}
 								/>
@@ -1121,7 +1127,10 @@ export const Card = ({
 											imageSize="small"
 											alt={media.imageAltText}
 											loading={imageLoading}
-											roundedCorners={isOnwardContent}
+											roundedCorners={
+												isOnwardContent &&
+												!isMoreGalleriesOnwardContent
+											}
 											aspectRatio="1:1"
 										/>
 									</div>
@@ -1152,7 +1161,7 @@ export const Card = ({
 					padContent={determinePadContent(
 						isMediaCardOrNewsletter,
 						isBetaContainer,
-						isOnwardContent,
+						isOnwardContent && !isMoreGalleriesOnwardContent,
 					)}
 				>
 					{/* This div is needed to keep the headline and trail text justified at the start */}

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source/foundations';
-import type { ArticleFormat } from '../../../lib/articleFormat';
+import { ArticleDesign, type ArticleFormat } from '../../../lib/articleFormat';
 import { palette } from '../../../palette';
 import type { DCRContainerPalette } from '../../../types/front';
 import { ContainerOverrides } from '../../ContainerOverrides';
@@ -117,7 +117,9 @@ export const CardWrapper = ({
 						hoverStyles,
 						showTopBarDesktop && desktopTopBarStyles,
 						showTopBarMobile && mobileTopBarStyles,
-						isOnwardContent && onwardContentStyles,
+						isOnwardContent &&
+							format.design !== ArticleDesign.Gallery &&
+							onwardContentStyles,
 					]}
 				>
 					{children}

--- a/dotcom-rendering/src/components/MoreGalleries.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.tsx
@@ -109,10 +109,11 @@ const getDefaultCardProps = (
 		imageLoading: 'lazy',
 		trailText: trail.trailText,
 		showAge: false,
-		containerType: 'more-galleries',
 		showTopBarDesktop: false,
 		showTopBarMobile: false,
 		aspectRatio: '5:4',
+		isOnwardContent: true,
+		onwardsSource: 'more-galleries',
 	};
 	return defaultProps;
 };

--- a/dotcom-rendering/src/types/onwards.ts
+++ b/dotcom-rendering/src/types/onwards.ts
@@ -24,5 +24,3 @@ export type OnwardsSource =
 	| 'curated-content'
 	| 'newsletters-page'
 	| 'unknown-source'; // We should never see this in the analytics data!
-
-export type OnwardContainerType = 'more-galleries';


### PR DESCRIPTION
## What does this change?

In a previous [pull request](https://github.com/guardian/dotcom-rendering/pull/14538) I had introduced a new type `OnwardContainerType` to help determine when a `Card` component is being used within a `More Galleries` onward container.

After revisiting this, I realised that the `Card` component already includes two props — `isOnwardContent` and `onwardsSource`, which together can identify when a card is part of `More Galleries` onward content.

Therefore, the newly introduced **OnwardContainerType** is redundant and can be removed.

Fixes [#14667](https://github.com/guardian/dotcom-rendering/issues/14667)

