### PR TITLE
Fix native ad alignment

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -71,6 +71,9 @@ const adSlotStyles = css`
 			/* iframes are inline by default, so we need to set them to block to avoid the same whitespace quirk mentioned in the above comment */
 			iframe {
 				display: block;
+				/* Centre the content within this element */
+				margin-left: auto;
+				margin-right: auto;
 			}
 		}
 


### PR DESCRIPTION
## What does this change?

Re-applies the `margin: auto` CSS for `iframe`s specifically in the `.ad-slot__content` class which was taken off in https://github.com/guardian/dotcom-rendering/pull/14665/files

## Why?

The DOM structure is different for native ads. Removing the CSS caused the a bug for the fabric ad in a top above nav slot

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/23b2dc73-08e2-4757-9276-99e5d2d8182c
[after]: https://github.com/user-attachments/assets/ebb43508-64c0-4248-85d6-2b0c56d6d47b
