### PR TITLE
Set YouTube player `onFullscreenToggled` listener for Android

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubePlayer.ts
@@ -131,10 +131,14 @@ class YouTubePlayer {
 								onReady: onReadyListener,
 								onStateChange:
 									youtubeOptions.events?.onStateChange,
-								onFullscreenToggled:
-									youtubeOptions.events?.onFullscreenToggled,
 							},
 						});
+						if (youtubeOptions.events?.onFullscreenToggled) {
+							this.player.addEventListener(
+								'onFullscreenToggled',
+								youtubeOptions.events.onFullscreenToggled,
+							);
+						}
 						resolve({ player: this.player });
 					}
 				} catch (e) {


### PR DESCRIPTION
## What does this change?

Set YouTube player `onFullscreenToggled` listener for Android

## Why?

On Android webviews, the YouTube player does not implement fullscreen so we need to mimic fullscreen behaviour. We previously implemented this on DCAR[^1][^2] but upon testing by the Android team, who are now actively working on the native implementation, they could not enable fullscreen on DCAR rendered pages.

This PR changes the `onFullscreenToggled` listener to be added explicitly to the player rather than via player configuration.

I have tested that this event fires on fullscreen toggles in Android webviews.

There is no functional impact of merging this change as it should only effect Android and also currently the bridget method for both clients returns false for `setFullscreen` so this code path will not execute in PROD.

It is useful to merge however, to allow easier testing by Android devs on their local branches.

## References

[^1]: https://github.com/guardian/bridget/pull/169
[^2]: https://github.com/guardian/dotcom-rendering/pull/12705