### PR TITLE
upgrade react-crossword to 11.1.0 to bring in mini crossword support

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -39,7 +39,7 @@
 		"@guardian/identity-auth-frontend": "8.1.0",
 		"@guardian/libs": "26.0.1",
 		"@guardian/ophan-tracker-js": "2.6.1",
-		"@guardian/react-crossword": "6.3.0",
+		"@guardian/react-crossword": "11.1.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -462,6 +462,7 @@
                     "enum": [
                         "cryptic",
                         "everyman",
+                        "mini",
                         "prize",
                         "quick",
                         "quick-cryptic",
@@ -4217,6 +4218,7 @@
                             "enum": [
                                 "cryptic",
                                 "everyman",
+                                "mini",
                                 "prize",
                                 "quick",
                                 "quick-cryptic",

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -3706,6 +3706,7 @@
                             "enum": [
                                 "cryptic",
                                 "everyman",
+                                "mini",
                                 "prize",
                                 "quick",
                                 "quick-cryptic",

--- a/dotcom-rendering/src/model/editions-crossword-schema.json
+++ b/dotcom-rendering/src/model/editions-crossword-schema.json
@@ -25,6 +25,7 @@
                         "enum": [
                             "cryptic",
                             "everyman",
+                            "mini",
                             "prize",
                             "quick",
                             "quick-cryptic",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       '@guardian/react-crossword':
-        specifier: 6.3.0
-        version: 6.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.0.1(@guardian/ophan-tracker-js@2.6.1)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+        specifier: 11.1.0
+        version: 11.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.0.1(@guardian/ophan-tracker-js@2.6.1)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -2424,12 +2424,12 @@ packages:
       prettier: ^3.0.0
       tslib: ^2.5.3
 
-  '@guardian/react-crossword@6.3.0':
-    resolution: {integrity: sha512-6CVNzY+yZrrUYOLpaAu7KSlyU23LBiZTFNJACI935iyjYuWEtyROoOwza82h1XconuqyEd9S8iG8CjtLb+j9Ig==}
+  '@guardian/react-crossword@11.1.0':
+    resolution: {integrity: sha512-GfkyqCHCajiyuMdK8s/s8TH+LhADTcJeIXFEqbesCYp0wQO/DdTR27tRtaFhKqVRCgzRIKFyxd68HcAy+Z7eBQ==}
     peerDependencies:
-      '@emotion/react': ^11.11.3
-      '@guardian/libs': ^22.0.0
-      '@guardian/source': ^9.0.0
+      '@emotion/react': ^11.11.4
+      '@guardian/libs': ^26.0.0
+      '@guardian/source': ^11.0.0
       '@types/react': ^18.2.79
       react: ^18.2.0
       typescript: ~5.5.2
@@ -8373,7 +8373,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -12958,7 +12957,7 @@ snapshots:
       prettier: 3.0.3
       tslib: 2.6.2
 
-  '@guardian/react-crossword@6.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.0.1(@guardian/ophan-tracker-js@2.6.1)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@guardian/react-crossword@11.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.0.1(@guardian/ophan-tracker-js@2.6.1)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
       '@guardian/libs': 26.0.1(@guardian/ophan-tracker-js@2.6.1)(tslib@2.6.2)(typescript@5.5.3)


### PR DESCRIPTION
## What does this change?

Updates the crossword player lib to the latest version, which among other upgrades includes support for the upcoming mini crossword. 

The crossword page may want some tweaks to the layout to better support these smaller grids, but that can happen in a separate change before publish if agreed. 

## Why?

## Screenshots

<img width="1295" height="716" alt="image" src="https://github.com/user-attachments/assets/6ffd31cd-85c1-4f13-a180-2c087893b99a" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
