### PR TITLE
Use new seperate project name for ab-testing UI riff-raff deploy

### DIFF
--- a/.github/workflows/ab-testing-ui.yml
+++ b/.github/workflows/ab-testing-ui.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: ui-build
-          path: ${{ github.workspace }}/ab-testing/frontend/output/ab-tests.html
+          path: ab-testing/frontend/output/ab-tests.html
           if-no-files-found: error
 
   riff-raff:
@@ -65,8 +65,8 @@ jobs:
         with:
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: dotcom:rendering-all
+          projectName: dotcom:ab-testing
           configPath: ab-testing/riff-raff.yaml
           contentDirectories: |
-            frontend-store/commercial:
+            admin/ab-testing:
               - output/ab-tests.html

--- a/ab-testing/riff-raff.yaml
+++ b/ab-testing/riff-raff.yaml
@@ -1,0 +1,13 @@
+regions: [eu-west-1]
+stacks: [frontend]
+allowedStages:
+  - CODE
+  - PROD
+deployments:
+  admin/ab-testing:
+    type: aws-s3
+    parameters:
+      bucketSsmKey: /account/services/dotcom-store.bucket
+      cacheControl: public, max-age=315360000
+      prefixStack: false
+      publicReadAcl: false


### PR DESCRIPTION
## Why?
The UI isn't being deployed at the moment.

~~Using a second riff-raff.yaml with the same project name isn't working, I've moved the ab-test UI deploy into the main CICD workflow and rif-raff.yaml~~

Update with a new riff-raff project name, and it's working now.
