### PR TITLE
Update spacing between card/container and branding labels

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -90,7 +90,7 @@ const hoverStyles = css`
 
 /** When we hover on sublinks, we want to prevent the general hover styles applying */
 const sublinkHoverStyles = css`
-	:has(ul.sublinks:hover) {
+	:has(ul.sublinks:hover, .branding-logo:hover) {
 		.card-headline .show-underline {
 			text-decoration: none;
 		}
@@ -233,10 +233,6 @@ const waveformStyles = css`
 	max-width: 100%;
 	overflow: hidden;
 	opacity: 0.3;
-`;
-
-const wrapperStyles = css`
-	padding-top: ${space[3]}px;
 `;
 
 const getMedia = ({
@@ -738,20 +734,18 @@ export const FeatureCard = ({
 						/>
 					)}
 					{isLabs && branding && showLabsRedesign && (
-						<div css={wrapperStyles}>
-							<SponsoredContentLabel
-								branding={branding}
-								containerPalette={containerPalette}
-								orientation="horizontal"
-								alignment="end"
-								ophanComponentLink={
-									labsDataAttributes?.ophanComponentLink
-								}
-								ophanComponentName={
-									labsDataAttributes?.ophanComponentName
-								}
-							/>
-						</div>
+						<SponsoredContentLabel
+							branding={branding}
+							containerPalette={containerPalette}
+							orientation="horizontal"
+							alignment="end"
+							ophanComponentLink={
+								labsDataAttributes?.ophanComponentLink
+							}
+							ophanComponentName={
+								labsDataAttributes?.ophanComponentName
+							}
+						/>
 					)}
 				</div>
 			</ContainerOverrides>

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -499,13 +499,12 @@ const sponsoredContentLabelWrapper = css`
 	grid-row: bottom-content;
 	grid-column: content;
 
-	margin: ${space[1]}px 0 0;
 	${from.tablet} {
 		/*
 		* side margins of 10px due to the -10px margins on the
 		* grid area for content, to align with the card edges
 		*/
-		margin: ${space[1]}px 10px 0;
+		margin: 0 10px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/SponsoredContentLabel.tsx
+++ b/dotcom-rendering/src/components/SponsoredContentLabel.tsx
@@ -34,9 +34,10 @@ const labelStyles = css`
 `;
 
 const wrapperStyles = css`
-	padding-top: ${space[1]}px;
+	padding-top: ${space[2]}px;
 	display: flex;
 	justify-content: end;
+	gap: ${space[1]}px;
 `;
 
 const horizontalStyles = css`


### PR DESCRIPTION
## What does this change?

Updates the spacing above the `SponsoredContentLabel` to be `${space[2]}px` (or 8px) in all scenarios

This is used in new style Labs containers (currently behind a feature flag or available via opting into an experiment)

## Why?

Requested follow-up to the design updates for Labs containers

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |

[before2]: https://github.com/user-attachments/assets/e2786894-fc69-4cc6-b170-8c7b11739753
[after2]: https://github.com/user-attachments/assets/691c2653-839a-432e-844d-ed042439e5a7
[before3]: https://github.com/user-attachments/assets/8f279e13-7f2e-4c09-89df-27ea56c76720
[after3]: https://github.com/user-attachments/assets/a2ac8ab3-848b-401f-abb8-4ee3d2391dfb
[before4]: https://github.com/user-attachments/assets/7b74fae2-b276-47f9-857e-d46c91793e67
[after4]: https://github.com/user-attachments/assets/2ebe5c5f-15d2-4c74-b967-73e5928a7079
[before5]: https://github.com/user-attachments/assets/341a4031-2d1a-4971-b137-dc491058f505
[after5]: https://github.com/user-attachments/assets/0378060c-8045-42c7-96f0-1835ee95675b


