### PR TITLE
Update details menu spacing for Labs containers

### DIFF
--- a/dotcom-rendering/src/components/LabsSectionHeader.tsx
+++ b/dotcom-rendering/src/components/LabsSectionHeader.tsx
@@ -107,7 +107,10 @@ const positionStyles = css`
 const detailsStyles = css`
 	background-color: ${schemePalette('--labs-about-dropdown-background')};
 	color: ${schemePalette('--labs-about-dropdown-text')};
-	padding: ${space[5]}px;
+	padding: ${space[3]}px;
+	> :not(:last-child) {
+		margin-bottom: ${space[3]}px;
+	}
 `;
 
 export const LabsSectionHeader = ({ title, url, editionId }: Props) => (
@@ -137,7 +140,6 @@ export const LabsSectionHeader = ({ title, url, editionId }: Props) => (
 								advertiser and produced by the Guardian Labs
 								team.
 							</p>
-							<br />
 							<LinkButton
 								iconSide="right"
 								size="xsmall"


### PR DESCRIPTION
## What does this change?

Updates the spacing within the expanded `<details>` menu for Labs containers

## Why?

As part of the Labs redesign, this was requested post design review

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/881f5571-7763-415a-b018-68a5060e93be
[after]: https://github.com/user-attachments/assets/b3874548-69de-4cbf-a8f5-c86e8562d4b3
