### PR TITLE
Fix accidental removal of the affiliate links disclaimer in galleries

### DIFF
--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -9,6 +9,7 @@ import { Hide } from '@guardian/source/react-components';
 import { AdPlaceholder } from '../components/AdPlaceholder.apps';
 import { AdPortals } from '../components/AdPortals.importable';
 import { AdSlot } from '../components/AdSlot.web';
+import { GalleryAffiliateDisclaimer } from '../components/AffiliateDisclaimer';
 import { AppsFooter } from '../components/AppsFooter.importable';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleMetaApps } from '../components/ArticleMeta.apps';
@@ -497,6 +498,9 @@ const Meta = ({
 				shortUrlId={frontendData.config.shortUrlId}
 			/>
 		) : null}
+		{!!frontendData.affiliateLinksDisclaimer && (
+			<GalleryAffiliateDisclaimer />
+		)}
 	</div>
 );
 


### PR DESCRIPTION
## What does this change?
During the merge of main into the branch in [#14299](https://github.com/guardian/dotcom-rendering/pull/14299), the `GalleryAffiliateDisclaimer` component has been accidentally removed from the gallery layout.

This PR restores the GalleryAffiliateDisclaimer to the gallery layout to ensure the affiliate disclaimer is displayed as intended.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7dc6acb5-ed82-4c7b-b317-a1cfee66f288
[after]: https://github.com/user-attachments/assets/3a286987-4d74-4803-8a56-2e22ae85ad64

