### PR TITLE
Follow `no-unused-expressions` lint rule

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -60,8 +60,10 @@ const windowGuardian = {
 // Stub global Guardian object
 // We should never be able to directly set things to the global window object.
 // But in this case we want to stub things for testing, so it's ok to ignore this rule
-// @ts-expect-error
-!isServer && (window.guardian = windowGuardian);
+if (!isServer) {
+	// @ts-expect-error
+	window.guardian = windowGuardian;
+}
 
 // Mock Local Storage
 // See: https://github.com/facebook/jest/issues/2098#issuecomment-260733457
@@ -86,10 +88,11 @@ const localStorageMock = (function () {
 	};
 })();
 
-!isServer &&
+if (!isServer) {
 	Object.defineProperty(window, 'localStorage', {
 		value: localStorageMock,
 	});
+}
 
 /**
  * This is to polyfill `TextEncoder` and `TextDecoder`.

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -57,7 +57,11 @@ export const sentryLoader = (): Promise<void> => {
 		isInBrowserVariantTest,
 		random: Math.random(),
 	});
-	canLoadSentry ? loadSentryOnError() : stubSentry();
+	if (canLoadSentry) {
+		loadSentryOnError();
+	} else {
+		stubSentry();
+	}
 	return Promise.resolve();
 };
 

--- a/dotcom-rendering/src/components/Discussion/Comments.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comments.tsx
@@ -270,7 +270,9 @@ export const Comments = ({
 			handleFilterChange(newFilterObject);
 		}
 
-		isWeb && dispatchCommentsStateChange();
+		if (isWeb) {
+			dispatchCommentsStateChange();
+		}
 	};
 
 	useEffect(() => {
@@ -302,7 +304,9 @@ export const Comments = ({
 
 	const onPageChange = (pageNumber: number) => {
 		setPage(pageNumber);
-		isWeb && dispatchCommentsStateChange();
+		if (isWeb) {
+			dispatchCommentsStateChange();
+		}
 	};
 
 	initialiseApi({ additionalHeaders, baseUrl, apiKey, idApiUrl });

--- a/dotcom-rendering/src/components/Discussion/TopPicks.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.tsx
@@ -56,9 +56,11 @@ export const TopPicks = ({
 	const leftColComments: Array<CommentType | ReplyType> = [];
 	const rightColComments: Array<CommentType | ReplyType> = [];
 	for (const [index, comment] of comments.entries()) {
-		index % 2 === 0
-			? leftColComments.push(comment)
-			: rightColComments.push(comment);
+		if (index % 2 === 0) {
+			leftColComments.push(comment);
+		} else {
+			rightColComments.push(comment);
+		}
 	}
 	return (
 		<div css={picksWrapper}>

--- a/dotcom-rendering/src/components/FollowWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FollowWrapper.importable.tsx
@@ -31,10 +31,9 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 		return !blockList.includes(tagId);
 	};
 
-	isBridgetCompatible &&
-		isMyGuardianEnabled &&
-		isNotInBlockList(id) &&
+	if (isBridgetCompatible && isMyGuardianEnabled && isNotInBlockList(id)) {
 		setShowFollowTagButton(true);
+	}
 
 	useEffect(() => {
 		const topic = new Topic({
@@ -50,12 +49,12 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 				window.guardian.modules.sentry.reportError(
 					error,
 					'bridget-getNotificationsClient-isFollowing-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getNotificationsClient.isFollowing Error:',
-						error,
-					);
+				);
+				log(
+					'dotcom',
+					'Bridget getNotificationsClient.isFollowing Error:',
+					error,
+				);
 			});
 
 		void getTagClient()
@@ -65,12 +64,8 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 				window.guardian.modules.sentry.reportError(
 					error,
 					'bridget-getTagClient-isFollowing-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getTagClient.isFollowing Error:',
-						error,
-					);
+				);
+				log('dotcom', 'Bridget getTagClient.isFollowing Error:', error);
 			});
 	}, [id, displayName]);
 
@@ -81,39 +76,41 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 			type: 'tag-contributor',
 		});
 
-		isFollowingTag
-			? void getTagClient()
-					.unfollow(topic)
-					.then((success) => {
-						success && setIsFollowingTag(false);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getTagClient-unfollow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getTagClient.unfollow Error:',
-								error,
-							);
-					})
-			: void getTagClient()
-					.follow(topic)
-					.then((success) => {
-						success && setIsFollowingTag(true);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getTagClient-follow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getTagClient.follow Error:',
-								error,
-							);
-					});
+		if (isFollowingTag) {
+			void getTagClient()
+				.unfollow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingTag(false);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'bridget-getTagClient-unfollow-error',
+					);
+					log(
+						'dotcom',
+						'Bridget getTagClient.unfollow Error:',
+						error,
+					);
+				});
+		} else {
+			void getTagClient()
+				.follow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingTag(true);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'bridget-getTagClient-follow-error',
+					);
+					log('dotcom', 'Bridget getTagClient.follow Error:', error);
+				});
+		}
 	};
 
 	const notificationsHandler = () => {
@@ -123,39 +120,45 @@ export const FollowWrapper = ({ id, displayName }: Props) => {
 			type: 'tag-contributor',
 		});
 
-		isFollowingNotifications
-			? void getNotificationsClient()
-					.unfollow(topic)
-					.then((success) => {
-						success && setIsFollowingNotifications(false);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'briidget-getNotificationsClient-unfollow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getNotificationsClient.unfollow Error:',
-								error,
-							);
-					})
-			: void getNotificationsClient()
-					.follow(topic)
-					.then((success) => {
-						success && setIsFollowingNotifications(true);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getNotificationsClient-follow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getNotificationsClient.follow Error:',
-								error,
-							);
-					});
+		if (isFollowingNotifications) {
+			void getNotificationsClient()
+				.unfollow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingNotifications(false);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'briidget-getNotificationsClient-unfollow-error',
+					);
+					log(
+						'dotcom',
+						'Bridget getNotificationsClient.unfollow Error:',
+						error,
+					);
+				});
+		} else {
+			void getNotificationsClient()
+				.follow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingNotifications(true);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'bridget-getNotificationsClient-follow-error',
+					);
+					log(
+						'dotcom',
+						'Bridget getNotificationsClient.follow Error:',
+						error,
+					);
+				});
+		}
 	};
 
 	return (

--- a/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/InteractiveContentsBlockComponent.importable.tsx
@@ -247,7 +247,9 @@ export const InteractiveContentsBlockComponent = ({
 			});
 
 			for (const item of enhancedSubheadings) {
-				item.ref && observer.observe(item.ref);
+				if (item.ref) {
+					observer.observe(item.ref);
+				}
 			}
 
 			if (endDocumentElementId) {

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -43,30 +43,45 @@ import { StickyBottomBanner } from './StickyBottomBanner.importable';
 
 const Mock = () => <>🏝️</>;
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-expressions --
+ * The expression is intentionally never used, the file is just being tested for
+ * compilation, as mentioned above. */
 () => (
 	<Island priority="critical">
 		<Mock />
 	</Island>
 );
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-expressions --
+ * The expression is intentionally never used, the file is just being tested for
+ * compilation, as mentioned above. */
 () => (
 	<Island priority="critical" defer={{ until: 'visible' }}>
 		<Mock />
 	</Island>
 );
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-expressions --
+ * The expression is intentionally never used, the file is just being tested for
+ * compilation, as mentioned above. */
 () => (
 	<Island priority="critical" defer={{ until: 'idle' }}>
 		<Mock />
 	</Island>
 );
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-expressions --
+ * The expression is intentionally never used, the file is just being tested for
+ * compilation, as mentioned above. */
 () => (
 	<Island priority="feature" defer={{ until: 'interaction' }}>
 		<Mock />
 	</Island>
 );
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-expressions --
+ * The expression is intentionally never used; the file is just being tested for
+ * compilation, as mentioned above. */
 () => (
 	// @ts-expect-error -- non-critical island must be deferred
 	<Island priority="feature">

--- a/dotcom-rendering/src/components/LightboxJavascript.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.tsx
@@ -252,7 +252,9 @@ const close = async (
 	});
 	closeLightbox(lightbox, handleKeydown);
 	history.back();
-	previouslyFocused && restoreFocus(previouslyFocused);
+	if (previouslyFocused) {
+		restoreFocus(previouslyFocused);
+	}
 };
 
 const toggleInfo = (
@@ -462,7 +464,9 @@ const initialiseLightbox = (lightbox: HTMLElement) => {
 					// which closes fullscreen mode but not the lightbox, so let's close it
 					closeLightbox(lightbox, handleKeydown);
 					history.back();
-					previouslyFocused && restoreFocus(previouslyFocused);
+					if (previouslyFocused) {
+						restoreFocus(previouslyFocused);
+					}
 				}
 			}
 		});
@@ -484,7 +488,9 @@ const initialiseLightbox = (lightbox: HTMLElement) => {
 			// There's no img hash so close the lightbox
 			void exitFullscreen();
 			closeLightbox(lightbox, handleKeydown);
-			previouslyFocused && restoreFocus(previouslyFocused);
+			if (previouslyFocused) {
+				restoreFocus(previouslyFocused);
+			}
 		}
 	});
 

--- a/dotcom-rendering/src/components/ListenToArticle.importable.tsx
+++ b/dotcom-rendering/src/components/ListenToArticle.importable.tsx
@@ -87,18 +87,20 @@ export const ListenToArticle = ({ articleId }: Props) => {
 			.then((success: boolean) => {
 				// hide the audio button once audio is playing until we can
 				// manage play state syncronisation across the native miniplayer and web layer
-				success && setShowButton(false);
+				if (success) {
+					setShowButton(false);
+				}
 			})
 			.catch((error: Error) => {
 				window.guardian.modules.sentry.reportError(
 					error,
 					'bridget-getListenToArticleClient-play-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getListenToArticleClient.play Error:',
-						error,
-					);
+				);
+				log(
+					'dotcom',
+					'Bridget getListenToArticleClient.play Error:',
+					error,
+				);
 			});
 	};
 	return (

--- a/dotcom-rendering/src/components/LiveblogNotifications.importable.tsx
+++ b/dotcom-rendering/src/components/LiveblogNotifications.importable.tsx
@@ -30,12 +30,12 @@ export const LiveblogNotifications = ({ id, displayName }: Props) => {
 				window.guardian.modules.sentry.reportError(
 					error,
 					'bridget-getNotificationsClient-isFollowing-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getNotificationsClient.isFollowing Error:',
-						error,
-					);
+				);
+				log(
+					'dotcom',
+					'Bridget getNotificationsClient.isFollowing Error:',
+					error,
+				);
 			});
 	}, [id, displayName]);
 
@@ -46,39 +46,45 @@ export const LiveblogNotifications = ({ id, displayName }: Props) => {
 			type: 'content',
 		});
 
-		isFollowingNotifications
-			? void getNotificationsClient()
-					.unfollow(topic)
-					.then((success) => {
-						success && setIsFollowingNotifications(false);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'briidget-getNotificationsClient-unfollow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getNotificationsClient.unfollow Error:',
-								error,
-							);
-					})
-			: void getNotificationsClient()
-					.follow(topic)
-					.then((success) => {
-						success && setIsFollowingNotifications(true);
-					})
-					.catch((error) => {
-						window.guardian.modules.sentry.reportError(
-							error,
-							'bridget-getNotificationsClient-follow-error',
-						),
-							log(
-								'dotcom',
-								'Bridget getNotificationsClient.follow Error:',
-								error,
-							);
-					});
+		if (isFollowingNotifications) {
+			void getNotificationsClient()
+				.unfollow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingNotifications(false);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'briidget-getNotificationsClient-unfollow-error',
+					);
+					log(
+						'dotcom',
+						'Bridget getNotificationsClient.unfollow Error:',
+						error,
+					);
+				});
+		} else {
+			void getNotificationsClient()
+				.follow(topic)
+				.then((success) => {
+					if (success) {
+						setIsFollowingNotifications(true);
+					}
+				})
+				.catch((error) => {
+					window.guardian.modules.sentry.reportError(
+						error,
+						'bridget-getNotificationsClient-follow-error',
+					);
+					log(
+						'dotcom',
+						'Bridget getNotificationsClient.follow Error:',
+						error,
+					);
+				});
+		}
 	};
 
 	return (

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -180,8 +180,9 @@ export const Liveness = ({
 				// Insert the new blocks in the dom (but hidden)
 				if (onFirstPage) {
 					try {
-						topOfBlog &&
+						if (topOfBlog) {
 							insert(data.html, enhanceTweetsSwitch, topOfBlog);
+						}
 					} catch (e) {
 						console.log('>> failed >>', e);
 					}

--- a/dotcom-rendering/src/components/TweetBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/TweetBlockComponent.importable.tsx
@@ -65,7 +65,9 @@ const loadTweet = (element: TweetBlockElement, darkMode: boolean) => {
 		// to find the tweet on the page. We *remove* this class in
 		// enhanceTweets()
 		tweet.classList.add('twitter-tweet');
-		darkMode && tweet.setAttribute('data-theme', 'dark');
+		if (darkMode) {
+			tweet.setAttribute('data-theme', 'dark');
+		}
 
 		twttr.ready((twitter) => {
 			twitter.widgets.load(tweetContainer);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -100,7 +100,9 @@ describe('YoutubeAtom', () => {
 		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		expect(overlay).toBeInTheDocument();
 
-		overlay && fireEvent.click(overlay);
+		if (overlay) {
+			fireEvent.click(overlay);
+		}
 		expect(overlay).not.toBeInTheDocument();
 
 		const [playerDiv] = getAllByTestId(/^youtube-player-c_xtiZNDgGc-\d+$/);
@@ -309,7 +311,9 @@ describe('YoutubeAtom', () => {
 		const [overlay] = getAllByTestId(/^youtube-overlay-c_xtiZNDgGc-\d+$/);
 		expect(overlay).toBeInTheDocument();
 
-		overlay && fireEvent.click(overlay);
+		if (overlay) {
+			fireEvent.click(overlay);
+		}
 		expect(overlay).not.toBeInTheDocument();
 	});
 
@@ -377,7 +381,9 @@ describe('YoutubeAtom', () => {
 		);
 		expect(overlay1).toBeInTheDocument();
 
-		overlay1 && fireEvent.click(overlay1);
+		if (overlay1) {
+			fireEvent.click(overlay1);
+		}
 		expect(overlay1).not.toBeInTheDocument();
 
 		expect(overlay2).toBeInTheDocument();

--- a/dotcom-rendering/src/lib/discussionApi.tsx
+++ b/dotcom-rendering/src/lib/discussionApi.tsx
@@ -279,8 +279,12 @@ export const reportAbuse =
 
 		const data = new URLSearchParams();
 		data.append('categoryId', categoryId.toString());
-		email && data.append('email', email.toString());
-		reason && data.append('reason', reason);
+		if (email) {
+			data.append('email', email.toString());
+		}
+		if (reason) {
+			data.append('reason', reason);
+		}
 
 		const authOptions = authStatus
 			? getOptionsHeaders(authStatus)

--- a/dotcom-rendering/src/lib/useIsInView.ts
+++ b/dotcom-rendering/src/lib/useIsInView.ts
@@ -70,7 +70,9 @@ const useIsInView = (
 		: intersectionObserverCallback;
 
 	useEffect(() => {
-		options.node && setNode(options.node);
+		if (options.node) {
+			setNode(options.node);
+		}
 	}, [options.node]);
 
 	useEffect(() => {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5685,7 +5685,6 @@ const expandableAtomButtonFillDark: PaletteFunction = () =>
 
 const timelineAtomBulletLight: PaletteFunction = () => sourcePalette.neutral[7];
 const timelineAtomBulletDark: PaletteFunction = () => sourcePalette.neutral[93];
-sourcePalette.neutral[0];
 
 const timelineAtomHighlightText: PaletteFunction = () =>
 	sourcePalette.neutral[0];
@@ -5694,7 +5693,6 @@ const timelineAtomHighlightTextBackgroundLight: PaletteFunction = () =>
 	sourcePalette.brandAlt[400];
 const timelineAtomHighlightTextBackgroundDark: PaletteFunction = () =>
 	sourcePalette.brandAlt[200];
-sourcePalette.neutral[0];
 
 const emailSignupButtonBackgroundLight: PaletteFunction = () =>
 	sourcePalette.neutral[0];


### PR DESCRIPTION
This rule comes from `typescript-eslint`[^1]. We don't have it enabled yet, but in v8 it's part of the "recommended" preset[^2]. In order to keep the upgrade to that version as small as possible, this change pre-emptively fixes code considered incorrect by that rule. A description of these fixes follows.

**Note:** I recommend using "hide whitespace" to view the diff.

## `&&` expressions

Replaced `&&` expressions where the result isn't used with conditional statements using `if`:

```ts
a && sideEffect(a);
```

becomes:

```ts
if (a) {
    sideEffect(a);
}
```

## Ternary expressions

Replaced **ternary expressions** where the result isn't used with conditional statements using `if...else`:

```ts
a ? sideEffect(a) : otherEffect(a);
```

becomes:

```ts
if (a) {
    sideEffect(a);
} else {
    otherEffect(a);
}
```

## Comma Operator

Replaced some usages of the **comma operator**[^3] with semi-colon. The comma operator evaluates all of its operands, returns the value of the last operand, and discards all others. In the cases updated here, the results of the expressions weren't used, so these operands are better written as statements, i.e. separated with a semi-colon:

```ts
sideEffect(a), otherEffect(a);
```

becomes:

```ts
sideEffect(a); otherEffect(a);
```

## Other changes

Ignored the case in `Island.test.tsx` where unused expressions are included intentionally to test compilation. Also removed some expressions that weren't doing anything, and may therefore have been left behind in error.

[^1]: https://typescript-eslint.io/rules/no-unused-expressions/
[^2]: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#updated-configuration-rules
[^3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator
