### PR TITLE
Follow `no-empty-object-type` lint rule

### DIFF
--- a/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialButton.tsx
@@ -2,7 +2,7 @@ import type { ButtonProps as CoreButtonProps } from '@guardian/source/react-comp
 import { Button as CoreButton } from '@guardian/source/react-components';
 import { decideBackground, decideBorder, decideFont } from './styles';
 
-export interface EditorialButtonProps extends CoreButtonProps {}
+export type EditorialButtonProps = CoreButtonProps;
 
 /**
  *

--- a/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
+++ b/dotcom-rendering/src/components/EditorialButton/EditorialLinkButton.tsx
@@ -2,7 +2,7 @@ import type { LinkButtonProps as CoreLinkButtonProps } from '@guardian/source/re
 import { LinkButton as CoreLinkButton } from '@guardian/source/react-components';
 import { decideBackground, decideBorder, decideFont } from './styles';
 
-export interface EditorialLinkButtonProps extends CoreLinkButtonProps {}
+export type EditorialLinkButtonProps = CoreLinkButtonProps;
 
 /**
  *

--- a/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
+++ b/dotcom-rendering/src/components/ManyNewslettersFormFields.tsx
@@ -45,8 +45,10 @@ const recaptchaContainerStyle = (showRecaptchaContainer: boolean) => css`
 	}
 `;
 
-export interface ManyNewslettersFormFieldsProps
-	extends Omit<FormProps, 'handleSubmitButton' | 'newsletterCount'> {}
+export type ManyNewslettersFormFieldsProps = Omit<
+	FormProps,
+	'handleSubmitButton' | 'newsletterCount'
+>;
 
 export const ManyNewslettersFormFields: FC<ManyNewslettersFormFieldsProps> = ({
 	status,


### PR DESCRIPTION
This rule comes from `typescript-eslint`[^1]. We don't have it enabled yet, but in v8 it's part of the "recommended" preset[^2].

In order to keep the upgrade to that version as small as possible, this change pre-emptively fixes code considered incorrect by that rule. The issues all relate to empty interfaces, for which the linter points out that:

```
An interface declaring no members is equivalent to its supertype
```

Solutions to this include using the supertype directly, or type aliasing the supertype to the new name. This change opts for the latter:

```ts
interface SuperType { a: string };

interface SubType extends SuperType {};
```

becomes:

```ts
interface SuperType { a: string };

type SubType = SuperType;
```

There are some differences between type aliases and interfaces[^3]. If we prefer to keep the interfaces, we can instead customise this lint rule in DCAR, setting `allowInterfaces` to `'with-single-extends'`[^4]. The cost would be diverging from our centralised linting rules, and therefore adding some complexity to DCAR.

[^1]: https://typescript-eslint.io/rules/no-empty-object-type/
[^2]: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#updated-configuration-rules
[^3]: https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces
[^4]: https://typescript-eslint.io/rules/no-empty-object-type/#allowinterfaces
