### PR TITLE
Follow `no-unsafe-function-type` lint rule

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ctas/EpicButton.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/EpicButton.tsx
@@ -43,8 +43,7 @@ type Props = {
 	// A function will render a <Button>
 	// A string will render a <LinkButton>
 	// Both using the same interface
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	onClickAction: Function | Url;
+	onClickAction: (() => void) | Url;
 	submitComponentEvent?: (event: ComponentEvent) => void;
 	children: React.ReactElement | string;
 	priority?: 'primary' | 'secondary';


### PR DESCRIPTION
This rule comes from `typescript-eslint`[^1]. We don't have it enabled yet, but in v8 it's part of the "recommended" preset[^2].

In order to keep the upgrade to that version as small as possible, this change pre-emptively fixes code considered incorrect by that rule. The only instance occurs in `EpicButton`, and would previously have been caught by the `ban-types` rule, if that were not disabled for this line. `ban-types` has been removed and replaced by `no-unsafe-function-type` for this particular issue, hence why the error has reappeared[^3].

We could update the `eslint-disable-next-line` comment, but there is a more specific type that can be used in this case, as mentioned in the documentation for the rule:

```ts
() => void;
```

[^1]: https://typescript-eslint.io/rules/no-unsafe-function-type/
[^2]: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#updated-configuration-rules
[^3]: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#replacement-of-ban-types
