### PR TITLE
Remove all boosts AB test

### DIFF
--- a/dotcom-rendering/src/components/Avatar.tsx
+++ b/dotcom-rendering/src/components/Avatar.tsx
@@ -57,19 +57,17 @@ type Props = {
 	alt: string;
 	shape?: AvatarShape;
 	imageSize?: MediaSizeType;
-	isInAllBoostsTest?: boolean;
 };
 
 const decideImageWidths = (
 	imageSize: MediaSizeType,
-	isInAllBoostsTest = false,
 ): [ImageWidthType, ...ImageWidthType[]] => {
 	switch (imageSize) {
 		case 'small':
 			return [
 				{
 					breakpoint: breakpoints.mobile,
-					width: isInAllBoostsTest ? 150 : 80,
+					width: 80,
 					aspectRatio: '1:1',
 				},
 			];
@@ -144,15 +142,9 @@ const defaultImageSizes: [ImageWidthType, ...ImageWidthType[]] = [
 	{ breakpoint: breakpoints.tablet, width: 140 },
 ];
 
-export const Avatar = ({
-	src,
-	alt,
-	shape = 'round',
-	imageSize,
-	isInAllBoostsTest,
-}: Props) => {
+export const Avatar = ({ src, alt, shape = 'round', imageSize }: Props) => {
 	const imageWidths = imageSize
-		? decideImageWidths(imageSize, isInAllBoostsTest)
+		? decideImageWidths(imageSize)
 		: defaultImageSizes;
 
 	const sources = generateSources(getSourceImageUrl(src), imageWidths);

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -157,7 +157,6 @@ export type Props = {
 	trailTextSize?: TrailTextSize;
 	/** A kicker image is seperate to the main media and renders as part of the kicker */
 	showKickerImage?: boolean;
-	isInAllBoostsTest?: boolean;
 	fixImageWidth?: boolean;
 	/** Determines if the headline should be positioned within the content or outside the content */
 	headlinePosition?: 'inner' | 'outer';
@@ -401,7 +400,6 @@ export const Card = ({
 	trailTextSize,
 	showKickerImage = false,
 	fixImageWidth,
-	isInAllBoostsTest = false,
 	headlinePosition = 'inner',
 	showLabsRedesign = false,
 }: Props) => {
@@ -595,12 +593,18 @@ export const Card = ({
 	const mediaFixedSizeOptions = (): MediaFixedSizeOptions => {
 		if (isSmallCard) {
 			return {
-				mobile: isInAllBoostsTest ? undefined : 'tiny',
+				mobile: 'tiny',
 				tablet: 'small',
 				desktop: 'small',
 			};
 		}
-		if (isFlexibleContainer) return { mobile: 'small' };
+
+		if (isFlexibleContainer) {
+			return {
+				mobile: 'small',
+			};
+		}
+
 		return { mobile: 'medium' };
 	};
 
@@ -939,7 +943,6 @@ export const Card = ({
 								imagePositionOnMobile={mediaPositionOnMobile}
 								isBetaContainer={isBetaContainer}
 								isFlexibleContainer={isFlexibleContainer}
-								isInAllBoostsTest={isInAllBoostsTest}
 							>
 								<Avatar
 									src={media.avatarUrl}
@@ -947,7 +950,6 @@ export const Card = ({
 									imageSize={
 										isBetaContainer ? mediaSize : undefined
 									}
-									isInAllBoostsTest={isInAllBoostsTest}
 								/>
 							</AvatarContainer>
 						)}
@@ -1071,9 +1073,6 @@ export const Card = ({
 												!isMoreGalleriesOnwardContent
 											}
 											aspectRatio={aspectRatio}
-											isInAllBoostsTest={
-												isInAllBoostsTest
-											}
 										/>
 									</div>
 								)}
@@ -1091,7 +1090,6 @@ export const Card = ({
 										!isMoreGalleriesOnwardContent
 									}
 									aspectRatio={aspectRatio}
-									isInAllBoostsTest={isInAllBoostsTest}
 								/>
 								{isVideoMainMedia && mainMedia.duration > 0 && (
 									<div
@@ -1141,7 +1139,6 @@ export const Card = ({
 										alt={media.trailImage.altText}
 										loading={imageLoading}
 										aspectRatio={aspectRatio}
-										isInAllBoostsTest={isInAllBoostsTest}
 									/>
 								)}
 							</>

--- a/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
@@ -9,7 +9,6 @@ type Props = {
 	imagePositionOnMobile: MediaPositionType;
 	isBetaContainer: boolean;
 	isFlexibleContainer: boolean;
-	isInAllBoostsTest?: boolean;
 };
 
 const sideMarginStyles = css`
@@ -32,7 +31,6 @@ const sizingStyles = (
 	isFlexibleContainer: boolean,
 	isVerticalOnDesktop: boolean,
 	isVerticalOnMobile: boolean,
-	isInAllBoostsTest = false,
 ) => {
 	if (!isBetaContainer) {
 		switch (imageSize) {
@@ -83,26 +81,6 @@ const sizingStyles = (
 
 	switch (imageSize) {
 		case 'small':
-			if (isInAllBoostsTest) {
-				return isFlexibleContainer
-					? css`
-							width: 90px;
-							height: 90px;
-							${until.tablet} {
-								height: 150px;
-								width: 150px;
-							}
-					  `
-					: css`
-							width: 80px;
-							height: 80px;
-							${until.tablet} {
-								height: 150px;
-								width: 150px;
-							}
-					  `;
-			}
-
 			return isFlexibleContainer
 				? css`
 						width: 90px;
@@ -159,7 +137,6 @@ export const AvatarContainer = ({
 	imagePositionOnMobile,
 	isBetaContainer,
 	isFlexibleContainer,
-	isInAllBoostsTest,
 }: Props) => {
 	const isVerticalOnDesktop =
 		imagePositionOnDesktop === 'top' || imagePositionOnDesktop === 'bottom';
@@ -178,7 +155,6 @@ export const AvatarContainer = ({
 					isFlexibleContainer,
 					isVerticalOnDesktop,
 					isVerticalOnMobile,
-					isInAllBoostsTest,
 				),
 			]}
 		>

--- a/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
@@ -166,9 +166,12 @@ const fixMediaWidth = ({
 	tablet,
 	desktop,
 }: MediaFixedSizeOptions) => css`
-	${until.tablet} {
-		${mobile !== undefined && fixMediaWidthStyles(mediaFixedSize[mobile])}
-	}
+	${mobile &&
+	css`
+		${until.tablet} {
+			${fixMediaWidthStyles(mediaFixedSize[mobile])}
+		}
+	`}
 	${tablet &&
 	css`
 		${between.tablet.and.desktop} {

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -18,7 +18,6 @@ export type Props = {
 	isCircular?: boolean;
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
-	isInAllBoostsTest?: boolean;
 };
 
 /**
@@ -30,7 +29,6 @@ export type Props = {
 const decideImageWidths = (
 	imageSize: MediaSizeType,
 	aspectRatio: AspectRatio,
-	isInAllBoostsTest: boolean,
 ): [ImageWidthType, ...ImageWidthType[]] => {
 	switch (imageSize) {
 		// @TODO missing image size option
@@ -56,7 +54,7 @@ const decideImageWidths = (
 			return [
 				{
 					breakpoint: breakpoints.mobile,
-					width: isInAllBoostsTest ? 465 : 120,
+					width: 120,
 					aspectRatio,
 				},
 				{ breakpoint: breakpoints.tablet, width: 160, aspectRatio },
@@ -216,7 +214,6 @@ export const CardPicture = ({
 	isCircular,
 	aspectRatio = '5:3',
 	mobileAspectRatio,
-	isInAllBoostsTest = false,
 }: Props) => {
 	if (mainImage === '') {
 		return null;
@@ -224,7 +221,7 @@ export const CardPicture = ({
 
 	const sources = generateSources(
 		mainImage,
-		decideImageWidths(imageSize, aspectRatio, isInAllBoostsTest),
+		decideImageWidths(imageSize, aspectRatio),
 	);
 
 	const fallbackSource = getFallbackSource(sources);

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -46,7 +46,6 @@ type Props = {
 	sectionId: string;
 	frontId?: string;
 	collectionId: number;
-	isInAllBoostsTest?: boolean;
 	containerLevel?: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
@@ -64,7 +63,6 @@ export const DecideContainer = ({
 	sectionId,
 	frontId,
 	collectionId,
-	isInAllBoostsTest,
 	containerLevel,
 	showLabsRedesign = false,
 }: Props) => {
@@ -248,7 +246,6 @@ export const DecideContainer = ({
 					absoluteServerTimes={absoluteServerTimes}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
-					isInAllBoostsTest={!!isInAllBoostsTest}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
 				/>
@@ -263,25 +260,12 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
-					isInAllBoostsTest={!!isInAllBoostsTest}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
 				/>
 			);
 		case 'scrollable/small':
-			return isInAllBoostsTest ? (
-				<ScrollableSmall
-					trails={trails}
-					imageLoading={imageLoading}
-					containerPalette={containerPalette}
-					showAge={showAge}
-					absoluteServerTimes={absoluteServerTimes}
-					aspectRatio={aspectRatio}
-					isInAllBoostsTest={true}
-					sectionId={sectionId}
-					showLabsRedesign={!!showLabsRedesign}
-				/>
-			) : (
+			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<ScrollableSmall
 						trails={trails}
@@ -290,27 +274,13 @@ export const DecideContainer = ({
 						showAge={showAge}
 						absoluteServerTimes={absoluteServerTimes}
 						aspectRatio={aspectRatio}
-						isInAllBoostsTest={false}
 						sectionId={sectionId}
 						showLabsRedesign={!!showLabsRedesign}
 					/>
 				</Island>
 			);
 		case 'scrollable/medium':
-			return isInAllBoostsTest ? (
-				<ScrollableMedium
-					trails={trails}
-					imageLoading={imageLoading}
-					containerPalette={containerPalette}
-					showAge={showAge}
-					absoluteServerTimes={absoluteServerTimes}
-					aspectRatio={aspectRatio}
-					sectionId={sectionId}
-					showLabsRedesign={!!showLabsRedesign}
-					containerLevel={containerLevel}
-					isInAllBoostsTest={true}
-				/>
-			) : (
+			return (
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<ScrollableMedium
 						trails={trails}
@@ -321,8 +291,6 @@ export const DecideContainer = ({
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
 						showLabsRedesign={!!showLabsRedesign}
-						containerLevel={containerLevel}
-						isInAllBoostsTest={isInAllBoostsTest}
 					/>
 				</Island>
 			);
@@ -336,7 +304,6 @@ export const DecideContainer = ({
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					showLabsRedesign={!!showLabsRedesign}
-					isInAllBoostsTest={isInAllBoostsTest}
 				/>
 			);
 		case 'scrollable/feature':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -34,7 +34,6 @@ type Props = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	isInAllBoostsTest?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -513,7 +512,6 @@ type HalfWidthCardLayoutProps = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
-	isInAllBoostsTest?: boolean;
 	containerLevel: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
@@ -529,7 +527,6 @@ const HalfWidthCardLayout = ({
 	isFirstStandardRow,
 	aspectRatio,
 	isLastRow,
-	isInAllBoostsTest,
 	containerLevel,
 	showLabsRedesign,
 }: HalfWidthCardLayoutProps) => {
@@ -565,9 +562,7 @@ const HalfWidthCardLayout = ({
 							image={card.image}
 							imageLoading={imageLoading}
 							mediaPositionOnDesktop="left"
-							mediaPositionOnMobile={
-								isInAllBoostsTest ? 'bottom' : 'left'
-							}
+							mediaPositionOnMobile="left"
 							supportingContent={card.supportingContent?.slice(
 								0,
 								2,
@@ -586,18 +581,9 @@ const HalfWidthCardLayout = ({
 								(containerLevel !== 'Primary' && cardIndex > 0)
 							}
 							trailText={undefined}
-							headlineSizes={
-								isInAllBoostsTest
-									? {
-											desktop: 'xsmall',
-											tablet: 'xxsmall',
-											mobile: 'small',
-									  }
-									: undefined
-							}
+							headlineSizes={undefined}
 							canPlayInline={false}
 							showLabsRedesign={showLabsRedesign}
-							isInAllBoostsTest={isInAllBoostsTest}
 						/>
 					</LI>
 				);
@@ -614,7 +600,6 @@ export const FlexibleGeneral = ({
 	imageLoading,
 	aspectRatio,
 	containerLevel = 'Primary',
-	isInAllBoostsTest = false,
 	collectionId,
 	showLabsRedesign,
 }: Props) => {
@@ -683,7 +668,6 @@ export const FlexibleGeneral = ({
 								isFirstStandardRow={i === 0}
 								aspectRatio={aspectRatio}
 								isLastRow={i === groupedCards.length - 1}
-								isInAllBoostsTest={isInAllBoostsTest}
 								containerLevel={containerLevel}
 								showLabsRedesign={showLabsRedesign}
 							/>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -29,7 +29,6 @@ type Props = {
 	absoluteServerTimes: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
-	isInAllBoostsTest?: boolean;
 	collectionId: number;
 	showLabsRedesign?: boolean;
 };
@@ -224,7 +223,6 @@ type TwoOrFourCardLayoutProps = {
 	containerLevel: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	isInAllBoostsTest: boolean;
 };
 
 const TwoOrFourCardLayout = ({
@@ -238,7 +236,6 @@ const TwoOrFourCardLayout = ({
 	isFirstRow,
 	containerLevel,
 	showLabsRedesign,
-	isInAllBoostsTest,
 }: TwoOrFourCardLayoutProps) => {
 	if (cards.length === 0) return null;
 	const hasTwoOrFewerCards = cards.length <= 2;
@@ -266,19 +263,8 @@ const TwoOrFourCardLayout = ({
 								hasTwoOrFewerCards,
 								isMediaCard(card.format) || !!card.isNewsletter,
 							)}
-							mediaPositionOnMobile={
-								isInAllBoostsTest ? 'bottom' : 'left'
-							}
-							headlineSizes={
-								isInAllBoostsTest
-									? {
-											desktop: 'xsmall',
-											tablet: 'xxsmall',
-											mobile: 'small',
-									  }
-									: undefined
-							}
-							isInAllBoostsTest={isInAllBoostsTest}
+							mediaPositionOnMobile="left"
+							headlineSizes={undefined}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
 							mediaSize="small"
@@ -309,7 +295,6 @@ export const FlexibleSpecial = ({
 	imageLoading,
 	aspectRatio,
 	containerLevel = 'Primary',
-	isInAllBoostsTest = false,
 	collectionId,
 	showLabsRedesign,
 }: Props) => {
@@ -369,7 +354,6 @@ export const FlexibleSpecial = ({
 				isFirstRow={!isNonEmptyArray(snaps) && !isNonEmptyArray(splash)}
 				containerLevel={containerLevel}
 				showLabsRedesign={showLabsRedesign}
-				isInAllBoostsTest={isInAllBoostsTest}
 			/>
 		</>
 	);

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -1,13 +1,9 @@
 import { isMediaCard } from '../lib/cardHelpers';
-import { palette } from '../palette';
 import type {
 	AspectRatio,
-	DCRContainerLevel,
 	DCRContainerPalette,
 	DCRFrontCard,
 } from '../types/front';
-import { LI } from './Card/components/LI';
-import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
 import { ScrollableCarousel } from './ScrollableCarousel';
 
@@ -19,10 +15,8 @@ type Props = {
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	sectionId: string;
-	containerLevel?: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	isInAllBoostsTest?: boolean;
 };
 
 /**
@@ -40,66 +34,8 @@ export const ScrollableMedium = ({
 	showAge,
 	aspectRatio,
 	sectionId,
-	containerLevel,
 	showLabsRedesign,
-	isInAllBoostsTest = false,
 }: Props) => {
-	if (isInAllBoostsTest) {
-		return (
-			<UL direction="row">
-				{trails.map((trail, index) => {
-					const imagePosition = isMediaCard(trail.format)
-						? 'top'
-						: 'bottom';
-
-					return (
-						<LI
-							key={trail.url}
-							stretch={false}
-							padSides={true}
-							showDivider={true}
-							verticalDividerColour={palette(
-								'--card-border-supporting',
-							)}
-						>
-							<FrontCard
-								trail={trail}
-								imageLoading={imageLoading}
-								absoluteServerTimes={absoluteServerTimes}
-								containerPalette={containerPalette}
-								containerType="scrollable/medium"
-								showAge={showAge}
-								headlineSizes={{
-									desktop: 'xsmall',
-									tablet: 'xxsmall',
-									mobile: 'small',
-								}}
-								mediaPositionOnDesktop={imagePosition}
-								mediaPositionOnMobile={imagePosition}
-								mediaSize="small"
-								trailText={undefined}
-								supportingContent={undefined} // unsupported
-								aspectRatio={aspectRatio}
-								kickerText={trail.kickerText}
-								showLivePlayable={trail.showLivePlayable}
-								showTopBarDesktop={false}
-								showTopBarMobile={
-									// !isFirstRow ||
-									(containerLevel === 'Primary' &&
-										!isMediaCard(trail.format)) ||
-									(containerLevel !== 'Primary' && index > 0)
-								}
-								isInAllBoostsTest={isInAllBoostsTest}
-								canPlayInline={false}
-								showLabsRedesign={showLabsRedesign}
-							/>
-						</LI>
-					);
-				})}
-			</UL>
-		);
-	}
-
 	return (
 		<ScrollableCarousel
 			carouselLength={trails.length}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -1,13 +1,8 @@
-import { css } from '@emotion/react';
-import { from } from '@guardian/source/foundations';
-import { palette } from '../palette';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
 	DCRFrontCard,
 } from '../types/front';
-import { LI } from './Card/components/LI';
-import { UL } from './Card/components/UL';
 import { FrontCard } from './FrontCard';
 import { ScrollableCarousel } from './ScrollableCarousel';
 
@@ -18,7 +13,6 @@ type Props = {
 	absoluteServerTimes?: boolean;
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
-	isInAllBoostsTest?: boolean;
 	sectionId: string;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
@@ -64,122 +58,11 @@ export const ScrollableSmall = ({
 	imageLoading,
 	showAge,
 	aspectRatio,
-	isInAllBoostsTest = false,
 	sectionId,
 	showLabsRedesign,
 }: Props) => {
 	const mobileBottomCards = [1, 3];
 	const desktopBottomCards = [2, 3];
-
-	if (isInAllBoostsTest) {
-		return (
-			<>
-				<UL direction="row" padBottom={true}>
-					{trails.slice(0, 2).map((trail, index) => {
-						return (
-							<LI
-								key={trail.url}
-								stretch={false}
-								padSides={true}
-								showDivider={true}
-								verticalDividerColour={palette(
-									'--card-border-supporting',
-								)}
-							>
-								<FrontCard
-									trail={trail}
-									imageLoading={imageLoading}
-									absoluteServerTimes={!!absoluteServerTimes}
-									containerPalette={containerPalette}
-									containerType="scrollable/small"
-									showAge={showAge}
-									headlineSizes={{
-										desktop: 'xxsmall',
-										tablet: 'xxxsmall',
-										mobile: 'small',
-									}}
-									mediaPositionOnDesktop="left"
-									mediaPositionOnMobile="bottom"
-									fixImageWidth={true}
-									mediaSize="small"
-									trailText={undefined}
-									supportingContent={undefined} // unsupported
-									aspectRatio={aspectRatio}
-									kickerText={trail.kickerText}
-									showLivePlayable={trail.showLivePlayable}
-									showTopBarDesktop={desktopBottomCards.includes(
-										index,
-									)}
-									showTopBarMobile={mobileBottomCards.includes(
-										index,
-									)}
-									isInAllBoostsTest={isInAllBoostsTest}
-									canPlayInline={false}
-									showLabsRedesign={showLabsRedesign}
-								/>
-							</LI>
-						);
-					})}
-				</UL>
-				<hr
-					css={css`
-						border: 0;
-						border-top: 1px solid ${palette('--card-border-top')};
-						${from.tablet} {
-							display: none;
-						}
-					`}
-				/>
-				<UL direction="row" showTopBar={true} splitTopBar={true}>
-					{trails.slice(2, 4).map((trail, index) => {
-						return (
-							<LI
-								key={trail.url}
-								stretch={false}
-								padSides={true}
-								showDivider={true}
-								verticalDividerColour={palette(
-									'--card-border-supporting',
-								)}
-							>
-								<FrontCard
-									trail={trail}
-									imageLoading={imageLoading}
-									absoluteServerTimes={!!absoluteServerTimes}
-									containerPalette={containerPalette}
-									containerType="scrollable/small"
-									showAge={showAge}
-									headlineSizes={{
-										desktop: 'xxsmall',
-										tablet: 'xxxsmall',
-										mobile: 'small',
-									}}
-									mediaPositionOnDesktop="left"
-									mediaPositionOnMobile="bottom"
-									fixImageWidth={true}
-									mediaSize="small"
-									trailText={undefined}
-									supportingContent={undefined} // unsupported
-									aspectRatio={aspectRatio}
-									kickerText={trail.kickerText}
-									showLivePlayable={trail.showLivePlayable}
-									showTopBarDesktop={desktopBottomCards.includes(
-										index,
-									)}
-									showTopBarMobile={mobileBottomCards.includes(
-										index,
-									)}
-									isInAllBoostsTest={isInAllBoostsTest}
-									canPlayInline={false}
-									showLabsRedesign={showLabsRedesign}
-								/>
-							</LI>
-						);
-					})}
-				</UL>
-			</>
-		);
-	}
 
 	return (
 		<ScrollableCarousel

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -34,7 +34,6 @@ type Props = {
 	containerLevel?: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	isInAllBoostsTest?: boolean;
 };
 
 export const StaticMediumFour = ({
@@ -47,7 +46,6 @@ export const StaticMediumFour = ({
 	aspectRatio,
 	containerLevel = 'Primary',
 	showLabsRedesign,
-	isInAllBoostsTest = false,
 }: Props) => {
 	const cards = trails.slice(0, 4);
 
@@ -74,18 +72,8 @@ export const StaticMediumFour = ({
 								card.format,
 								!!card.isNewsletter,
 							)}
-							mediaPositionOnMobile={
-								isInAllBoostsTest ? 'bottom' : 'left'
-							}
-							headlineSizes={
-								isInAllBoostsTest
-									? {
-											desktop: 'xsmall',
-											tablet: 'xxsmall',
-											mobile: 'small',
-									  }
-									: undefined
-							}
+							mediaPositionOnMobile="left"
+							headlineSizes={undefined}
 							/* we don't want to support sublinks on standard cards here so we hard code to undefined */
 							supportingContent={undefined}
 							mediaSize="medium"
@@ -100,7 +88,6 @@ export const StaticMediumFour = ({
 							}
 							canPlayInline={false}
 							showLabsRedesign={showLabsRedesign}
-							isInAllBoostsTest={isInAllBoostsTest}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -609,10 +609,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									}
 									sectionId={ophanName}
 									collectionId={index + 1}
-									isInAllBoostsTest={
-										front.isNetworkFront &&
-										abTests.allBoostsVariant === 'variant'
-									}
 									containerLevel={collection.containerLevel}
 									showLabsRedesign={showLabsRedesign}
 								/>


### PR DESCRIPTION
## What does this change?

Removes the All Boosts AB test: https://github.com/guardian/dotcom-rendering/pull/14509

PR to remove the experiment: https://github.com/guardian/frontend/pull/28306

## Why?

The AB test has concluded and data collected.

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
