### PR TITLE
Use eager loading for gallery images

### DIFF
--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -113,7 +113,7 @@ export const GalleryImage = ({
 						master={asset.url}
 						width={width}
 						height={height}
-						loading="lazy"
+						loading="eager"
 					/>
 				)}
 				{renderingTarget === 'Web' && !isUndefined(image.position) && (


### PR DESCRIPTION
## What does this change?
Use eager loading for gallery images

Currently the images in a DCAR Gallery article are loading with delay and this is affecting the user experience. 

In current Production (frontend), the images are loading eagerly, so probably we would need the same behaviour in DCAR as well?!