### PR TITLE
Fix ab test export warning

### DIFF
--- a/ab-testing/index.ts
+++ b/ab-testing/index.ts
@@ -1,4 +1,3 @@
-// @ts-ignore - extension is required to import this as a package in DCR
-import { ABTests, activeABtests } from './abTest.ts';
+import { allABTests, activeABtests } from './abTest';
 
-export { ABTests, activeABtests };
+export { allABTests, activeABtests };


### PR DESCRIPTION
## What does this change?
Fix the warning showing in the console, the export wasn't updated in `index.ts` of `ab-testing` when changed in #14684 as there was a mysterious `@ts-ignore` there. Everything works without the ts-ignore so I've removed it, perhaps it was needed in the past?

## Why?
Annoying warning, the export is not currently used anywhere, which is why this didn't show up as a linting error. And wouldn't have any implications beyond the warning.

```
ModuleDependencyWarning: export 'ABTests' (reexported as 'ABTests') was not found in './abTest.ts' (possible exports: activeABtests, allABTests)
```