### PR TITLE
Ensure `contentType` field is available on `window.guardian` for fronts

### DIFF
--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -135,6 +135,7 @@ export const renderFront = ({
 		abTests: front.config.abTests,
 		serverSideABTests: front.config.serverSideABTests,
 		brazeApiKey: front.config.brazeApiKey,
+		contentType: front.config.contentType,
 		googleRecaptchaSiteKey: front.config.googleRecaptchaSiteKey,
 		// Until we understand exactly what config we need to make available client-side,
 		// add everything we haven't explicitly typed as unknown config


### PR DESCRIPTION
## What does this change?

Ensures that `contentType` is available on `window.guardian.config.page` for fronts

## Why?

This is needed to set targeting for ad slots in the commercial bundle


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c7589bbf-6fa9-4396-be73-a66db406b058
[after]: https://github.com/user-attachments/assets/c7931fe9-617e-4bf7-b591-42e65729832b
