### PR TITLE
Include `contentType` on the `window.guardian` object for newsletters page

### DIFF
--- a/dotcom-rendering/src/model/newsletter-page-schema.json
+++ b/dotcom-rendering/src/model/newsletter-page-schema.json
@@ -180,6 +180,9 @@
                 },
                 "googleRecaptchaSiteKeyVisible": {
                     "type": "string"
+                },
+                "contentType": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -187,6 +190,7 @@
                 "adUnit",
                 "ajaxUrl",
                 "commercialBundleUrl",
+                "contentType",
                 "dcrSentryDsn",
                 "dfpAccountId",
                 "discussionApiUrl",

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -78,6 +78,7 @@ export const renderEditorialNewslettersPage = ({
 		abTests: newslettersPage.config.abTests,
 		serverSideABTests: newslettersPage.config.serverSideABTests,
 		brazeApiKey: newslettersPage.config.brazeApiKey,
+		contentType: newslettersPage.config.contentType,
 		googleRecaptchaSiteKey: newslettersPage.config.googleRecaptchaSiteKey,
 		googleRecaptchaSiteKeyVisible:
 			newslettersPage.config.googleRecaptchaSiteKeyVisible,

--- a/dotcom-rendering/src/types/newslettersPage.ts
+++ b/dotcom-rendering/src/types/newslettersPage.ts
@@ -45,6 +45,7 @@ type FENewslettersConfigType = {
 	// isPreview?: boolean;
 	googleRecaptchaSiteKey?: string;
 	googleRecaptchaSiteKeyVisible?: string;
+	contentType: string;
 };
 
 export interface FENewslettersPageType {


### PR DESCRIPTION
## What does this change?

Similar to https://github.com/guardian/dotcom-rendering/pull/14744, this PR ensures that the `contentType` field is available on the `window.guardian.config.page` object

## Why?

This is used in ad targeting and is supplied for other page types.
We don't currently serve ads on the all newsletters page but if we decided to, we would be unlikely to spot that this was missing!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/790ad35e-f575-484d-9ae7-cdc58c414353
[after]: https://github.com/user-attachments/assets/111ccdbf-5d39-47f5-8488-eddadcc7f046
