### PR TITLE
Make interactives support dark mode across platforms after January 2026

### DIFF
--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -166,8 +166,7 @@ window.twttr = (function(d, s, id) {
 
 	const { canonicalUrl, webPublicationDate } = frontendData;
 
-	// Interactive dark mode support launched with full DCAR on June 25th 2025
-	const isBeforeInteractiveDarkModeSupportLaunch =
+	const isBeforeInteractiveDarkModeSupport =
 		Date.parse(webPublicationDate) < Date.parse('2026-01-13T00:00:00Z');
 
 	const pageHtml = htmlPageTemplate({
@@ -192,9 +191,9 @@ window.twttr = (function(d, s, id) {
 		hasLiveBlogTopAd: !!frontendData.config.hasLiveBlogTopAd,
 		hasSurveyAd: !!frontendData.config.hasSurveyAd,
 		onlyLightColourScheme:
-			design === ArticleDesign.FullPageInteractive ||
-			(design === ArticleDesign.Interactive &&
-				isBeforeInteractiveDarkModeSupportLaunch),
+			(design === ArticleDesign.FullPageInteractive ||
+				design === ArticleDesign.Interactive) &&
+			isBeforeInteractiveDarkModeSupport,
 	});
 
 	return { html: pageHtml, prefetchScripts };


### PR DESCRIPTION
This adjusts the check for forcing light mode only on interactive articles, adjusting it to only apply on pieces before January 2026. Following the migration to DCAR this felt like a natural, low friction opportunity to further align web and apps.

Signed off by the Interactives crew and good to go.