### PR TITLE
Don't throw when main media is not image

### DIFF
--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -76,6 +76,7 @@ export const getGalleryMainMedia = (
 		'model.dotcomrendering.pageElements.ImageBlockElement'
 	) {
 		logger.warn('Main media is not an image');
+		return;
 	}
 
 	return mainMedia;


### PR DESCRIPTION
## What does this change?

When main media is not an image, we should log a warning but we should still try to render the page. 

## Why?

A number of old galleries appear to have data that doesn't confirm to DCAR's expectations. While not perfect, it is better to try to render the content DCAR can understand, rather than returning a 500.

This is a follow-on from #14738

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/9183ab34-df85-460d-bb79-d5188253a34a
[after]: https://github.com/user-attachments/assets/9fdfd5bf-3682-4ec0-ae8a-973dc34d1c9b

