### PR TITLE
Extend podcast image size in Flexible General half-width slot

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -250,6 +250,7 @@ const podcastImageStyles = (
 			width: 120px;
 			height: 120px;
 		}
+		/** The image takes the full height on desktop, so that the waveform sticks to the bottom of the card. */
 		${from.desktop} {
 			width: ${isHorizontalOnDesktop ? 'unset' : '120px'};
 			height: ${isHorizontalOnDesktop ? 'unset' : '120px'};

--- a/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
@@ -77,9 +77,13 @@ const mediaPaddingStyles = (
  */
 const flexBasisStyles = ({
 	mediaSize,
+	mediaType,
+	isSmallCard,
 	isBetaContainer,
 }: {
 	mediaSize: MediaSizeType;
+	mediaType: CardMediaType;
+	isSmallCard: boolean;
 	isBetaContainer: boolean;
 }): SerializedStyles => {
 	if (!isBetaContainer) {
@@ -108,6 +112,15 @@ const flexBasisStyles = ({
 					flex-basis: 75%;
 				`;
 		}
+	}
+
+	if (mediaType === 'podcast' && !isSmallCard) {
+		return css`
+			flex-basis: 120px;
+			${from.desktop} {
+				flex-basis: 168px;
+			}
+		`;
 	}
 
 	switch (mediaSize) {
@@ -206,10 +219,13 @@ export const MediaWrapper = ({
 				(mediaType === 'slideshow' ||
 					mediaType === 'picture' ||
 					mediaType === 'youtube-video' ||
-					mediaType === 'loop-video') &&
+					mediaType === 'loop-video' ||
+					mediaType === 'podcast') &&
 					isHorizontalOnDesktop &&
 					flexBasisStyles({
 						mediaSize,
+						mediaType,
+						isSmallCard,
 						isBetaContainer,
 					}),
 				mediaType === 'avatar' &&
@@ -228,15 +244,6 @@ export const MediaWrapper = ({
 					mediaType !== 'podcast' &&
 					fixMobileMediaWidth(isBetaContainer, isSmallCard),
 				isSmallCard && fixDesktopMediaWidth(),
-				mediaType === 'podcast' &&
-					isHorizontalOnDesktop &&
-					!isSmallCard &&
-					css`
-						flex-basis: 120px;
-						${from.desktop} {
-							flex-basis: 168px;
-						}
-					`,
 				isHorizontalOnDesktop &&
 					css`
 						${from.tablet} {


### PR DESCRIPTION
## What does this change?

Don't fix the podcast image width when the card is horizontal on desktop and the container is not scrollable small.

Simplifies the logic of fixed-size width media including podcasts.

## Why?

So that the waveform sticks to the bottom of the card.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b20e6136-1c98-4b71-b35b-2b088c37acde
[after]: https://github.com/user-attachments/assets/fb5fd4ba-1afb-4f1e-8007-5d9abf9ddfbc

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
