### PR TITLE
A/B testing (beta) frontend changes

### DIFF
--- a/ab-testing/frontend/src/routes/+page.svelte
+++ b/ab-testing/frontend/src/routes/+page.svelte
@@ -31,11 +31,13 @@
 	</p>
 </section>
 <section>
-	{#if allABtests.length > 0}
+	{#if activeABtests.length > 0}
 		<AudienceBreakdown tests={activeABtests} />
+	{/if}
+	{#if allABTests.length > 0}
 		<Table tests={allABTests} />
 	{:else}
-		<p>There are <b>no active</b> A/B tests currently configured!</p>
+		<p>There are <b>ZERO</b> A/B tests currently configured!</p>
 	{/if}
 </section>
 


### PR DESCRIPTION
## What does this change?

Adds a label "Beta" to the h1 whilst we run this in parallel with the original framework, and adds a message to highlight there are no tests rather than rendering an empty table - which has been mistaken for a broken page.

## Why?

Better UX for devs using the Admin area.

## Screenshots

### Before
<img width="1429" height="468" alt="Screenshot 2025-10-27 at 15 52 18" src="https://github.com/user-attachments/assets/55f3cc5e-e243-4fc8-8faf-4ae22eb23015" />

### After
<img width="1411" height="262" alt="Screenshot 2025-10-27 at 15 52 33" src="https://github.com/user-attachments/assets/c1d89b7d-2fc5-4c81-add2-9896ea65ff48" />
