### PR TITLE
Add accessibility add on to storybook

### DIFF
--- a/dotcom-rendering/.storybook/main.ts
+++ b/dotcom-rendering/.storybook/main.ts
@@ -29,7 +29,11 @@ const config: StorybookConfig = {
 		{ from: '../src/static', to: '/static/frontend/' },
 	],
 
-	addons: ['@storybook/addon-webpack5-compiler-swc', '@storybook/addon-docs'],
+	addons: [
+		'@storybook/addon-webpack5-compiler-swc',
+		'@storybook/addon-docs',
+		'@storybook/addon-a11y',
+	],
 
 	webpackFinal: async (config) => {
 		// Get project specific webpack options

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -47,6 +47,7 @@
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.52.0",
 		"@sentry/browser": "10.20.0",
+		"@storybook/addon-a11y": "9.1.13",
 		"@storybook/addon-docs": "9.1.13",
 		"@storybook/addon-webpack5-compiler-swc": "4.0.1",
 		"@storybook/react-webpack5": "9.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       '@sentry/browser':
         specifier: 10.20.0
         version: 10.20.0
+      '@storybook/addon-a11y':
+        specifier: 9.1.13
+        version: 9.1.13(storybook@9.1.13(@testing-library/dom@10.4.1)(prettier@3.0.3)(vite@6.4.0(@types/node@22.17.0)(terser@5.44.0)(tsx@4.6.2)))
       '@storybook/addon-docs':
         specifier: 9.1.13
         version: 9.1.13(@types/react@18.3.1)(storybook@9.1.13(@testing-library/dom@10.4.1)(prettier@3.0.3)(vite@6.4.0(@types/node@22.17.0)(terser@5.44.0)(tsx@4.6.2)))
@@ -3373,6 +3376,11 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@storybook/addon-a11y@9.1.13':
+    resolution: {integrity: sha512-4enIl1h2XSZnFKUQJJoZbp1X40lzdj7f5JE15ZhU1al4z6hHWp7i2zD7ySyDpEbMypBCz1xnLvyiyw79m1fp7w==}
+    peerDependencies:
+      storybook: ^9.1.13
 
   '@storybook/addon-docs@9.1.13':
     resolution: {integrity: sha512-V1nCo7bfC3kQ5VNVq0VDcHsIhQf507m+BxMA5SIYiwdJHljH2BXpW2fL3FFn9gv9Wp57AEEzhm+wh4zANaJgkg==}
@@ -8154,6 +8162,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -14148,6 +14157,12 @@ snapshots:
       tslib: 2.6.2
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@storybook/addon-a11y@9.1.13(storybook@9.1.13(@testing-library/dom@10.4.1)(prettier@3.0.3)(vite@6.4.0(@types/node@22.17.0)(terser@5.44.0)(tsx@4.6.2)))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.8.2
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(prettier@3.0.3)(vite@6.4.0(@types/node@22.17.0)(terser@5.44.0)(tsx@4.6.2))
 
   '@storybook/addon-docs@9.1.13(@types/react@18.3.1)(storybook@9.1.13(@testing-library/dom@10.4.1)(prettier@3.0.3)(vite@6.4.0(@types/node@22.17.0)(terser@5.44.0)(tsx@4.6.2)))':
     dependencies:


### PR DESCRIPTION
## What does this change?
Add [accessibility add on](https://storybook.js.org/docs/writing-tests/accessibility-testing) to storybook now that we have updated to storybook 9
## Why?
This allows us to see accessibility issues in the local storybook build. If this is useful we could configure this as a CI check.

## Screenshots
<img width="1012" height="569" alt="image" src="https://github.com/user-attachments/assets/57fe6cd8-c50e-41eb-b148-28092c8bdc32" />

