### PR TITLE
Prevent labs containers from being toggled

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -68,6 +68,9 @@ const isNavList = (collection: DCRCollectionType) => {
 const isHighlights = ({ collectionType }: DCRCollectionType) =>
 	collectionType === 'scrollable/highlights';
 
+const isLabs = ({ containerPalette }: DCRCollectionType) =>
+	containerPalette === 'Branded';
+
 const isToggleable = (
 	index: number,
 	collection: DCRCollectionType,
@@ -77,11 +80,12 @@ const isToggleable = (
 		return (
 			collection.displayName.toLowerCase() !== 'headlines' &&
 			!isNavList(collection) &&
-			!isHighlights(collection)
+			!isHighlights(collection) &&
+			!isLabs(collection)
 		);
 	}
 
-	return index != 0 && !isNavList(collection);
+	return index != 0 && !isNavList(collection) && !isLabs(collection);
 };
 
 const decideLeftContent = (front: Front, collection: DCRCollectionType) => {
@@ -578,9 +582,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 								isAboveMobileAd={mobileAdPositions.includes(
 									index,
 								)}
-								isLabs={
-									collection.containerPalette === 'Branded'
-								}
+								isLabs={isLabs(collection)}
 								showLabsRedesign={showLabsRedesign}
 							>
 								<DecideContainer


### PR DESCRIPTION
## What does this change?

Removes the "hide" buttons from Labs containers rendered using the `FrontSection` component. 
This happens when the Labs redesign switch is on or for users who are opted into the experiment. 
Existing Labs containers are rendered using the `LabsSection` component and are not toggleable as it is.

## Why?

When signed in, users have the ability to collapse some front containers. We do not want to allow this to happen for labs containers as this would go against the commercial contracts in place.

_N.b. Only users with non-premium account benefits will see Labs content_

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/58f10358-f43d-4848-bfdc-bdd79d60a5b7
[after]: https://github.com/user-attachments/assets/ce5e49b0-c9d3-4c09-973a-943a19dec21c
