### PR TITLE
add getGateDismissedCount function for dismissed gate logic

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/dismissGate.test.ts
+++ b/dotcom-rendering/src/components/SignInGate/dismissGate.test.ts
@@ -1,8 +1,8 @@
 import {
-	getGateDismissedCount,
 	hasUserDismissedGate,
 	hasUserDismissedGateMoreThanCount,
 	incrementUserDismissedGateCount,
+	retrieveLastGateDismissedCount,
 	setUserDismissedGate,
 	unsetUserDismissedGate,
 } from './dismissGate';
@@ -210,7 +210,7 @@ describe('SignInGate - dismissGate methods', () => {
 
 	describe('getGateDismissedCount', () => {
 		test('returns 0 when no treatmentId has been saved yet (first visit)', () => {
-			const count = getGateDismissedCount('AuxiaSignInGate');
+			const count = retrieveLastGateDismissedCount('AuxiaSignInGate');
 			expect(count).toBe(0);
 		});
 
@@ -219,7 +219,7 @@ describe('SignInGate - dismissGate methods', () => {
 			incrementUserDismissedGateCount('14414017', 'AuxiaSignInGate');
 			incrementUserDismissedGateCount('14414017', 'AuxiaSignInGate');
 
-			const count = getGateDismissedCount('AuxiaSignInGate');
+			const count = retrieveLastGateDismissedCount('AuxiaSignInGate');
 			expect(count).toBe(2);
 		});
 
@@ -234,22 +234,22 @@ describe('SignInGate - dismissGate methods', () => {
 				'AuxiaSignInGate',
 			);
 
-			expect(getGateDismissedCount('AuxiaSignInGate')).toBe(2);
+			expect(retrieveLastGateDismissedCount('AuxiaSignInGate')).toBe(2);
 
 			// Later visit with treatmentId '14414017'
 			incrementUserDismissedGateCount('14414017', 'AuxiaSignInGate');
 
 			// Should now return count for '14414017' since it's the last one saved
-			expect(getGateDismissedCount('AuxiaSignInGate')).toBe(1);
+			expect(retrieveLastGateDismissedCount('AuxiaSignInGate')).toBe(1);
 		});
 
 		test('handles different gate names independently', () => {
 			incrementUserDismissedGateCount('variant-1', 'GateA');
 			incrementUserDismissedGateCount('variant-2', 'GateB');
 
-			expect(getGateDismissedCount('GateA')).toBe(1);
-			expect(getGateDismissedCount('GateB')).toBe(1);
-			expect(getGateDismissedCount('GateC')).toBe(0);
+			expect(retrieveLastGateDismissedCount('GateA')).toBe(1);
+			expect(retrieveLastGateDismissedCount('GateB')).toBe(1);
+			expect(retrieveLastGateDismissedCount('GateC')).toBe(0);
 		});
 	});
 });

--- a/dotcom-rendering/src/components/SignInGate/dismissGate.ts
+++ b/dotcom-rendering/src/components/SignInGate/dismissGate.ts
@@ -136,7 +136,7 @@ export const incrementUserDismissedGateCount = (
  * Get the dismissed count using the last known treatmentId if available.
  * Returns 0 if no treatmentId has been saved yet (first visit).
  */
-export const getGateDismissedCount = (name: string): number => {
+export const retrieveLastGateDismissedCount = (name: string): number => {
 	const prefs = getSigninGatePrefsSafely();
 	const lastTreatmentId = prefs[`last-treatment-id-${name}`];
 

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -23,7 +23,6 @@ import { usePageViewId } from '../lib/usePageViewId';
 import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { useConfig } from './ConfigContext';
-import { retrieveDismissedCount } from './SignInGate/dismissGate';
 import type { AuxiaGateDisplayData } from './SignInGate/types';
 import {
 	BrazeBanner,
@@ -204,7 +203,6 @@ const buildSignInGateConfig = (
 				contentType,
 				sectionId,
 				tags,
-				retrieveDismissedCount,
 			);
 		},
 		show: (meta: AuxiaGateDisplayData) => () => (

--- a/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.test.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.test.tsx
@@ -93,7 +93,6 @@ describe('SignInGatePortal', () => {
 				'Article', // contentType (must be a valid content type)
 				'section', // sectionId
 				[], // tags
-				() => 0, // retrieveDismissedCount
 			);
 
 			expect(result).toEqual({ show: true, meta: auxiaReturn });
@@ -134,7 +133,6 @@ describe('SignInGatePortal', () => {
 				'Article',
 				'section',
 				[],
-				() => 0,
 			);
 
 			expect(result).toEqual({ show: true, meta: auxiaReturn });

--- a/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.tsx
@@ -6,7 +6,7 @@ import type { CanShowResult } from '../../lib/messagePicker';
 import { useAuthStatus } from '../../lib/useAuthStatus';
 import type { TagType } from '../../types/tag';
 import { Island } from '../Island';
-import { getGateDismissedCount } from '../SignInGate/dismissGate';
+import { retrieveLastGateDismissedCount } from '../SignInGate/dismissGate';
 import { pageIdIsAllowedForGating } from '../SignInGate/displayRules';
 import type { AuxiaGateDisplayData } from '../SignInGate/types';
 import {
@@ -150,7 +150,6 @@ export const canShowSignInGatePortal = async (
 	contentType?: string,
 	sectionId?: string,
 	tags?: TagType[],
-	retrieveDismissedCount?: (variant: string, name: string) => number,
 ): Promise<CanShowResult<AuxiaGateDisplayData>> => {
 	// Check if the sign-in gate placeholder exists in the DOM
 	const targetElement = document.getElementById('sign-in-gate');
@@ -172,8 +171,7 @@ export const canShowSignInGatePortal = async (
 		editionId === undefined ||
 		contentType === undefined ||
 		sectionId === undefined ||
-		tags === undefined ||
-		retrieveDismissedCount === undefined
+		tags === undefined
 	) {
 		return Promise.resolve({ show: false });
 	}
@@ -186,7 +184,7 @@ export const canShowSignInGatePortal = async (
 			contentType,
 			sectionId,
 			tags,
-			getGateDismissedCount('AuxiaSignInGate'),
+			retrieveLastGateDismissedCount('AuxiaSignInGate'),
 		);
 
 		return {


### PR DESCRIPTION
## What does this change?

Saves the last treatment type ID in local storage to send the correct sign-in gate dismissed count to the get-treatments API.