### PR TITLE
Make it clear the ab-testing directory's Read Me is for the Beta AB test framework

### DIFF
--- a/ab-testing/README.md
+++ b/ab-testing/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the code and configuration for the new **Beta** AB Test framework, developed by commercial-dev to support both client and server side A/B tests in DCR. The goal is to eventually replace the legacy A/B testing framework with this new framework.
 
-Please reach out to commercial-dev if you're setting up a client or server side A/B tests in DCR and are interested in using this new framework whilst it's in beta (this would be helpful for the team) or if you'd like up to date information on it's state of readiness. **For now the legacy framework is still available to use, and documentation for that can be found [here](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md)**.
+Please reach out to commercial-dev if you're setting up a client or server side A/B tests in DCR and you're interested in using this new framework whilst it's in beta (this would be helpful for the team) or if you'd like up to date information on it's state of readiness. **For now the legacy framework is still available to use, and documentation for that can be found [here](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md)**.
 
 The [`abTest.ts`](./abTest.ts) module is where you should define your AB tests.
 


### PR DESCRIPTION
## What does this change?

The `/ab-testing` directory contains all the logic and documentation for the new AB test framework - which is currently in beta. The `README.md` in this directory doesn't mention this is in beta, this PR makes that clear and sign posts to the legacy framework's docs. Eventually we'll stop doing this once we move the new framework out of beta and deprecate the legacy framework.

## Why?

Make docs clearer for colleagues looking to set-up an AB test in DCR.