### PR TITLE
Add an opt in 0% test for enabling CORS on looping videos

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -160,6 +160,8 @@ export type Props = {
 	headlinePosition?: 'inner' | 'outer';
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -403,6 +405,7 @@ export const Card = ({
 	showKickerImage = false,
 	headlinePosition = 'inner',
 	showLabsRedesign = false,
+	enableLoopVideoCORS = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -950,6 +953,7 @@ export const Card = ({
 									fallbackImageAlt={media.imageAltText}
 									fallbackImageAspectRatio="5:4"
 									linkTo={linkTo}
+									enableLoopVideoCORS={enableLoopVideoCORS}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -49,6 +49,8 @@ type Props = {
 	containerLevel?: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS: boolean;
 };
 
 export const DecideContainer = ({
@@ -65,6 +67,7 @@ export const DecideContainer = ({
 	collectionId,
 	containerLevel,
 	showLabsRedesign = false,
+	enableLoopVideoCORS = false,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -248,6 +251,7 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			);
 		case 'flexible/general':
@@ -262,6 +266,7 @@ export const DecideContainer = ({
 					containerLevel={containerLevel}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -34,6 +34,8 @@ type Props = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -248,6 +250,8 @@ type SplashCardLayoutProps = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 const SplashCardLayout = ({
@@ -261,6 +265,7 @@ const SplashCardLayout = ({
 	containerLevel,
 	collectionId,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: SplashCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -344,6 +349,7 @@ const SplashCardLayout = ({
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					headlinePosition={card.showLivePlayable ? 'outer' : 'inner'}
 					showLabsRedesign={showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -408,6 +414,8 @@ type FullWidthCardLayoutProps = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 const FullWidthCardLayout = ({
@@ -422,6 +430,7 @@ const FullWidthCardLayout = ({
 	containerLevel,
 	collectionId,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: FullWidthCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -496,6 +505,7 @@ const FullWidthCardLayout = ({
 					canPlayInline={true}
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					showLabsRedesign={showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -515,6 +525,8 @@ type HalfWidthCardLayoutProps = {
 	containerLevel: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 const HalfWidthCardLayout = ({
@@ -529,6 +541,7 @@ const HalfWidthCardLayout = ({
 	isLastRow,
 	containerLevel,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: HalfWidthCardLayoutProps) => {
 	if (cards.length === 0) return null;
 
@@ -584,6 +597,7 @@ const HalfWidthCardLayout = ({
 							headlineSizes={undefined}
 							canPlayInline={false}
 							showLabsRedesign={showLabsRedesign}
+							enableLoopVideoCORS={enableLoopVideoCORS}
 						/>
 					</LI>
 				);
@@ -602,6 +616,7 @@ export const FlexibleGeneral = ({
 	containerLevel = 'Primary',
 	collectionId,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
 		...snap,
@@ -631,6 +646,7 @@ export const FlexibleGeneral = ({
 					containerLevel={containerLevel}
 					collectionId={collectionId}
 					showLabsRedesign={showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			)}
 			{groupedCards.map((row, i) => {
@@ -650,6 +666,7 @@ export const FlexibleGeneral = ({
 								containerLevel={containerLevel}
 								collectionId={collectionId}
 								showLabsRedesign={showLabsRedesign}
+								enableLoopVideoCORS={enableLoopVideoCORS}
 							/>
 						);
 
@@ -670,6 +687,7 @@ export const FlexibleGeneral = ({
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
 								showLabsRedesign={showLabsRedesign}
+								enableLoopVideoCORS={enableLoopVideoCORS}
 							/>
 						);
 				}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -31,6 +31,8 @@ type Props = {
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 type BoostProperties = {
@@ -128,6 +130,8 @@ type OneCardLayoutProps = {
 	containerLevel: DCRContainerLevel;
 	isSplashCard?: boolean;
 	showLabsRedesign?: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 export const OneCardLayout = ({
@@ -142,6 +146,7 @@ export const OneCardLayout = ({
 	containerLevel,
 	isSplashCard,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: OneCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -194,6 +199,7 @@ export const OneCardLayout = ({
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					headlinePosition={isSplashCard ? 'outer' : 'inner'}
 					showLabsRedesign={showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -297,6 +303,7 @@ export const FlexibleSpecial = ({
 	containerLevel = 'Primary',
 	collectionId,
 	showLabsRedesign,
+	enableLoopVideoCORS,
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1).map((snap) => ({
 		...snap,
@@ -341,6 +348,7 @@ export const FlexibleSpecial = ({
 					containerLevel={containerLevel}
 					isSplashCard={true}
 					showLabsRedesign={showLabsRedesign}
+					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -117,6 +117,8 @@ type Props = {
 	fallbackImageAlt: CardPictureProps['alt'];
 	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
 	linkTo: string;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS?: boolean;
 };
 
 export const LoopVideo = ({
@@ -132,6 +134,7 @@ export const LoopVideo = ({
 	fallbackImageAlt,
 	fallbackImageAspectRatio,
 	linkTo,
+	enableLoopVideoCORS = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -635,6 +638,7 @@ export const LoopVideo = ({
 				AudioIcon={hasAudio ? AudioIcon : null}
 				preloadPartialData={preloadPartialData}
 				showPlayIcon={showPlayIcon}
+				enableLoopVideoCORS={enableLoopVideoCORS}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -97,6 +97,8 @@ type Props = {
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showPlayIcon: boolean;
+	/** Feature flag for the enabling CORS loading on looping video */
+	enableLoopVideoCORS: boolean;
 };
 
 /**
@@ -128,6 +130,7 @@ export const LoopVideoPlayer = forwardRef(
 			AudioIcon,
 			preloadPartialData,
 			showPlayIcon,
+			enableLoopVideoCORS,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -138,6 +141,9 @@ export const LoopVideoPlayer = forwardRef(
 				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Captions will be considered later. */}
 				<video
 					id={loopVideoId}
+					{...(enableLoopVideoCORS
+						? { crossOrigin: 'anonymous' }
+						: {})}
 					css={videoStyles(width, height)}
 					ref={ref}
 					tabIndex={0}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -191,10 +191,16 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 					frontId={front.pressedPage.id}
 					collectionId={0}
+					enableLoopVideoCORS={false}
 				/>
 			)
 		);
 	};
+
+	/** We allow the video to set crossOrigin={"anonymous"} CORS redesign
+	 * if the user is opted into the 0% server side test
+	 */
+	const enableLoopVideoCORS = abTests.loopVideoLoadVariant === 'variant';
 
 	return (
 		<>
@@ -487,6 +493,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.containerLevel
 										}
 										showLabsRedesign={showLabsRedesign}
+										enableLoopVideoCORS={false}
 									/>
 								</LabsSection>
 
@@ -609,6 +616,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
 									showLabsRedesign={showLabsRedesign}
+									enableLoopVideoCORS={enableLoopVideoCORS}
 								/>
 							</FrontSection>
 


### PR DESCRIPTION
## What does this change?
We need to enable CORS on looping videos so that we can work a side-car VTT file. This PR introduces the crossOrigin: anonymous header behind a 0% opt in flag so that we can test how this interacts with the fastly cache. It has only been drilled through container and container card sizes that support looping video.   
## Why?
We released this change into the wild and found some users were receiving CORS errors. We would like to debug and fix this before we re-release this change.
## Screenshots

| Flag set to false - no origin request header      | Flag set to true - origin request header present       | 
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5c5cb580-3176-414b-8531-56d1d6a6374f
[after]: https://github.com/user-attachments/assets/2b58ff3d-d8ad-43f9-9b3e-b8b00fe6382f

<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
