### PR TITLE
Allow loop video cors via switch

### DIFF
--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -198,9 +198,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	};
 
 	/** We allow the video to set crossOrigin={"anonymous"} if:
-	 *- the user is opted into the 0% server side test
+	 * - the feature switch is ON
+	 * OR
+	 * - the user is opted into the 0% server side test
 	 */
-	const enableLoopVideoCORS = abTests.loopVideoLoadVariant === 'variant';
+	const enableLoopVideoCORS =
+		!!front.config.switches.enableLoopVideoCors ||
+		abTests.loopVideoLoadVariant === 'variant';
 
 	return (
 		<>


### PR DESCRIPTION
## What?
Allow a feature switch to control enabling CORS on looping video with a cache buster. 

The switch is added in Frontend here https://github.com/guardian/frontend/pull/28347

## Why?
So that we can have a more controlled rollout for this feature.