### PR TITLE
Remove the looping video CORS feature switch and 0% test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -162,8 +162,6 @@ export type Props = {
 	headlinePosition?: 'inner' | 'outer';
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -408,7 +406,6 @@ export const Card = ({
 	headlinePosition = 'inner',
 	showLabsRedesign = false,
 	subtitleSize = 'small',
-	enableLoopVideoCORS = false,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -960,7 +957,6 @@ export const Card = ({
 										media.mainMedia.subtitleSource
 									}
 									subtitleSize={subtitleSize}
-									enableLoopVideoCORS={enableLoopVideoCORS}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -49,8 +49,6 @@ type Props = {
 	containerLevel?: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS: boolean;
 };
 
 export const DecideContainer = ({
@@ -67,7 +65,6 @@ export const DecideContainer = ({
 	collectionId,
 	containerLevel,
 	showLabsRedesign = false,
-	enableLoopVideoCORS = false,
 }: Props) => {
 	switch (containerType) {
 		case 'dynamic/fast':
@@ -251,7 +248,6 @@ export const DecideContainer = ({
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			);
 		case 'flexible/general':
@@ -266,7 +262,6 @@ export const DecideContainer = ({
 					containerLevel={containerLevel}
 					collectionId={collectionId}
 					showLabsRedesign={!!showLabsRedesign}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			);
 		case 'scrollable/small':

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -35,8 +35,6 @@ type Props = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 type RowLayout = 'oneCardHalfWidth' | 'oneCardFullWidth' | 'twoCard';
@@ -256,8 +254,6 @@ type SplashCardLayoutProps = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 const SplashCardLayout = ({
@@ -271,7 +267,6 @@ const SplashCardLayout = ({
 	containerLevel,
 	collectionId,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: SplashCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -357,7 +352,6 @@ const SplashCardLayout = ({
 					subtitleSize={subtitleSize}
 					headlinePosition={card.showLivePlayable ? 'outer' : 'inner'}
 					showLabsRedesign={showLabsRedesign}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -425,8 +419,6 @@ type FullWidthCardLayoutProps = {
 	collectionId: number;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 const FullWidthCardLayout = ({
@@ -441,7 +433,6 @@ const FullWidthCardLayout = ({
 	containerLevel,
 	collectionId,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: FullWidthCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -518,7 +509,6 @@ const FullWidthCardLayout = ({
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					showLabsRedesign={showLabsRedesign}
 					subtitleSize={subtitleSize}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -538,8 +528,6 @@ type HalfWidthCardLayoutProps = {
 	containerLevel: DCRContainerLevel;
 	/** Feature flag for the labs redesign work */
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 const HalfWidthCardLayout = ({
@@ -554,7 +542,6 @@ const HalfWidthCardLayout = ({
 	isLastRow,
 	containerLevel,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: HalfWidthCardLayoutProps) => {
 	if (cards.length === 0) return null;
 
@@ -610,7 +597,6 @@ const HalfWidthCardLayout = ({
 							headlineSizes={undefined}
 							canPlayInline={false}
 							showLabsRedesign={showLabsRedesign}
-							enableLoopVideoCORS={enableLoopVideoCORS}
 						/>
 					</LI>
 				);
@@ -629,7 +615,6 @@ export const FlexibleGeneral = ({
 	containerLevel = 'Primary',
 	collectionId,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: Props) => {
 	const splash = [...groupedTrails.splash].slice(0, 1).map((snap) => ({
 		...snap,
@@ -659,7 +644,6 @@ export const FlexibleGeneral = ({
 					containerLevel={containerLevel}
 					collectionId={collectionId}
 					showLabsRedesign={showLabsRedesign}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			)}
 			{groupedCards.map((row, i) => {
@@ -679,7 +663,6 @@ export const FlexibleGeneral = ({
 								containerLevel={containerLevel}
 								collectionId={collectionId}
 								showLabsRedesign={showLabsRedesign}
-								enableLoopVideoCORS={enableLoopVideoCORS}
 							/>
 						);
 
@@ -700,7 +683,6 @@ export const FlexibleGeneral = ({
 								isLastRow={i === groupedCards.length - 1}
 								containerLevel={containerLevel}
 								showLabsRedesign={showLabsRedesign}
-								enableLoopVideoCORS={enableLoopVideoCORS}
 							/>
 						);
 				}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -32,8 +32,6 @@ type Props = {
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 type BoostProperties = {
@@ -136,8 +134,6 @@ type OneCardLayoutProps = {
 	containerLevel: DCRContainerLevel;
 	isSplashCard?: boolean;
 	showLabsRedesign?: boolean;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 export const OneCardLayout = ({
@@ -152,7 +148,6 @@ export const OneCardLayout = ({
 	containerLevel,
 	isSplashCard,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: OneCardLayoutProps) => {
 	const card = cards[0];
 	if (!card) return null;
@@ -207,7 +202,6 @@ export const OneCardLayout = ({
 					headlinePosition={isSplashCard ? 'outer' : 'inner'}
 					showLabsRedesign={showLabsRedesign}
 					subtitleSize={subtitleSize}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			</LI>
 		</UL>
@@ -311,7 +305,6 @@ export const FlexibleSpecial = ({
 	containerLevel = 'Primary',
 	collectionId,
 	showLabsRedesign,
-	enableLoopVideoCORS,
 }: Props) => {
 	const snaps = [...groupedTrails.snap].slice(0, 1).map((snap) => ({
 		...snap,
@@ -356,7 +349,6 @@ export const FlexibleSpecial = ({
 					containerLevel={containerLevel}
 					isSplashCard={true}
 					showLabsRedesign={showLabsRedesign}
-					enableLoopVideoCORS={enableLoopVideoCORS}
 				/>
 			)}
 

--- a/dotcom-rendering/src/components/LoopVideo.importable.tsx
+++ b/dotcom-rendering/src/components/LoopVideo.importable.tsx
@@ -125,8 +125,6 @@ type Props = {
 	linkTo: string;
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS?: boolean;
 };
 
 export const LoopVideo = ({
@@ -144,7 +142,6 @@ export const LoopVideo = ({
 	linkTo,
 	subtitleSource,
 	subtitleSize,
-	enableLoopVideoCORS = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -677,7 +674,6 @@ export const LoopVideo = ({
 				subtitleSource={subtitleSource}
 				subtitleSize={subtitleSize}
 				activeCue={activeCue}
-				enableLoopVideoCORS={enableLoopVideoCORS}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/components/LoopVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/LoopVideoPlayer.tsx
@@ -125,8 +125,6 @@ type Props = {
 	subtitleSize: SubtitleSize;
 	/* used in custom subtitle overlays */
 	activeCue?: ActiveCue | null;
-	/** Feature flag for the enabling CORS loading on looping video */
-	enableLoopVideoCORS: boolean;
 };
 
 /**
@@ -167,7 +165,6 @@ export const LoopVideoPlayer = forwardRef(
 			subtitleSource,
 			subtitleSize,
 			activeCue,
-			enableLoopVideoCORS,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -178,9 +175,7 @@ export const LoopVideoPlayer = forwardRef(
 				<video
 					id={loopVideoId}
 					css={videoStyles(width, height, subtitleSize)}
-					{...(enableLoopVideoCORS
-						? { crossOrigin: 'anonymous' }
-						: {})}
+					crossOrigin="anonymous"
 					ref={ref}
 					tabIndex={0}
 					data-testid="loop-video"
@@ -218,10 +213,7 @@ export const LoopVideoPlayer = forwardRef(
 						<source
 							key={source.mimeType}
 							/* The start time is set to 1ms so that Safari will autoplay the video */
-							/* Use a '?cors=enabled' cache buster so that we don't serve video from local cache*/
-							src={`${source.src}${
-								enableLoopVideoCORS ? '?cors=enabled' : ''
-							}#t=0.001`}
+							src={`${source.src}#t=0.001`}
 							type={source.mimeType}
 						/>
 					))}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -191,20 +191,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 					frontId={front.pressedPage.id}
 					collectionId={0}
-					enableLoopVideoCORS={false}
 				/>
 			)
 		);
 	};
-
-	/** We allow the video to set crossOrigin={"anonymous"} if:
-	 * - the feature switch is ON
-	 * OR
-	 * - the user is opted into the 0% server side test
-	 */
-	const enableLoopVideoCORS =
-		!!front.config.switches.enableLoopVideoCors ||
-		abTests.loopVideoLoadVariant === 'variant';
 
 	return (
 		<>
@@ -497,7 +487,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 											collection.containerLevel
 										}
 										showLabsRedesign={showLabsRedesign}
-										enableLoopVideoCORS={false}
 									/>
 								</LabsSection>
 
@@ -620,7 +609,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									collectionId={index + 1}
 									containerLevel={collection.containerLevel}
 									showLabsRedesign={showLabsRedesign}
-									enableLoopVideoCORS={enableLoopVideoCORS}
 								/>
 							</FrontSection>
 


### PR DESCRIPTION
🚨**Do not merge until Monday 10th November** 🚨

## What does this change?
Remove the looping video CORS feature switch and 0% test and release it 100% into PROD. Looping videos will now always have crossOrigin="anonymous" applied

We can also safely remove the `?cors=enabled` query param cache buster from the sources urls as this will have been active for 4 days by the time of deployment on Monday 10th November. This is because loops are short lived on fronts and do not typically return to fronts after several days meaning, by Monday, any cached assets should already carry the correct CORS headers.

## Why?
We have successfully released CORS via the feature switch into production without any issues. As such, we can remove the feature switch and 0% test as these are no longer required. 
