### PR TITLE
Extend expiration of user benefits cookies to 30 days

### DIFF
--- a/dotcom-rendering/src/client/userFeatures/user-features.ts
+++ b/dotcom-rendering/src/client/userFeatures/user-features.ts
@@ -42,10 +42,10 @@ const USER_BENEFITS_COOKIE_EXPIRATION_IN_DAYS = 30;
 /**
  * Persist the user benefits response to cookies
  *
- * If new cookies are added/removed/edited, update the persistUserBenefitsCookie function in Gateway
- * https://github.com/guardian/gateway/blob/252b2b2f24be826da42c6e7c1b1e202594184023/src/server/lib/user-features.ts#L88
- *
+ * If new cookies are added/removed/edited, update the persistUserBenefitsCookies function in Gateway.
  * In gateway, the cookies are set after authentication.
+ *
+ * This code also exist in frontend, so any changes here should be mirrored there.
  *
  * @param {UserBenefits} userBenefitsResponse
  */


### PR DESCRIPTION
## What does this change?

This PR extends the expiration of all user benefits cookies to 30 days - `GU_AF1`, `gu_allow_reject_all`, `gu_hide_support_messaging`. The `gu_user_benefits_expiry` cookies continues to have an expiry of 1 day, so we'll recheck every day while the user is signed in.

## Why?

Previously they were short lived (1-2 days) but this resulted in edge cases where if a signed-in user didn't visit the site for more than a couple of days, when they returned their first page view wouldn't reflect their benefits (i.e. they would see ads). This is due to a race condition between the user benefits refresh and ads code. However, we don't want to delay ads until after the user benefits have been refreshed as that would impact performance. So instead, extend the expiration of the cookie.

Note: this may result in a user getting benefits they no longer have on the first returning pageview, but this will be correct from the second page view onwards. We think this is OK.

This also means we now remove cookies if the user benefits response says they no longer have the benefit, rather than simply letting the cookie expire.

Note: this logic also exists in frontend and gateway, so has been updated in both those repos too:
guardian/frontend#28352
guardian/gateway#3285