### PR TITLE
Add A/B test for ID5 user module with pd field

### DIFF
--- a/ab-testing/abTests.ts
+++ b/ab-testing/abTests.ts
@@ -31,6 +31,19 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: "commercial-user-module-ID5",
+		description:
+			"Tests whether we can get the users email, hash it and pass pd value to the userId array",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: `2025-12-19`,
+		type: "client",
+		status: "ON",
+		audienceSize: 10 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
This is part of the PR: add fetching and hashing of user email and send data to ID5 [here](https://github.com/guardian/commercial/pull/2282)
Adds an A/B test to verify that the ID5 user module includes the pd field in the user config when consent and email are present. This is using the new AB Beta testing framework

## Why?
This supports the work in commercial [PR #2282](https://github.com/guardian/commercial/pull/2282), which fetches and hashes the user’s email and sends it to ID5.
The goal is to confirm that the feature correctly passes user signals (including the hashed email in the Partner Data string) to ID5.

