### PR TITLE
Fix repeating newsletter sign up in the product element

### DIFF
--- a/dotcom-rendering/src/components/ProductElement.tsx
+++ b/dotcom-rendering/src/components/ProductElement.tsx
@@ -124,7 +124,6 @@ const Content = ({
 						key={index}
 						index={index}
 						format={format}
-						isProduct={true}
 						isMainMedia={false}
 					/>
 				))}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -93,7 +93,6 @@ type Props = {
 	editionId: EditionId;
 	forceDropCap?: 'on' | 'off';
 	isTimeline?: boolean;
-	isProduct?: boolean;
 	totalElements?: number;
 	isListElement?: boolean;
 	isSectionedMiniProfilesArticle?: boolean;
@@ -165,7 +164,6 @@ export const renderElement = ({
 	editionId,
 	forceDropCap,
 	isTimeline = false,
-	isProduct = false,
 	totalElements = 0,
 	isListElement = false,
 	isSectionedMiniProfilesArticle = false,
@@ -555,7 +553,7 @@ export const renderElement = ({
 				successDescription: element.newsletter.successDescription,
 				theme: element.newsletter.theme,
 			};
-			if (isListElement || isTimeline || isProduct) return null;
+			if (isListElement || isTimeline) return null;
 			return <EmailSignUpWrapper {...emailSignUpProps} />;
 		case 'model.dotcomrendering.pageElements.AdPlaceholderBlockElement':
 			return renderAds && <AdPlaceholder />;
@@ -987,7 +985,6 @@ export const RenderArticleElement = ({
 	editionId,
 	forceDropCap,
 	isTimeline,
-	isProduct,
 	totalElements,
 	isListElement,
 	isSectionedMiniProfilesArticle,
@@ -1016,7 +1013,6 @@ export const RenderArticleElement = ({
 		editionId,
 		forceDropCap,
 		isTimeline,
-		isProduct,
 		totalElements,
 		isListElement,
 		isSectionedMiniProfilesArticle,
@@ -1057,7 +1053,6 @@ type ElementLevelPropNames =
 	| 'hideCaption'
 	| 'format'
 	| 'isTimeline'
-	| 'isProduct'
 	| 'isListElement'
 	| 'isMainMedia';
 type ArticleLevelProps = Omit<Props, ElementLevelPropNames>;


### PR DESCRIPTION
## What does this change?
In the enhancers, don't insert a newsletter signup block if we're in nested content.

## Why?
At the moment the newsletter sign up is being inserted into most Product Elements on a page as we're rendering elements inside the nested content of each Product. This means a lot of repetition on the page, which we want to fix.

I noticed when testing with the existing fix that it still inserts the newsletter sign up block, but the block returns nothing. This looks fine but it means the (empty!) newsletter sign up block is considered blocking by Spacefinder, which means inline1 gets pushed down, impacting ad revenue. (See below)

With this in mind, I think it's preferable to not add the block into nested content at all. This should result in the page looking the same, but with a cleaner DOM.

<img width="335" height="449" alt="Screenshot 2025-11-12 at 15 27 19" src="https://github.com/user-attachments/assets/add83aec-88b3-4bff-b611-112a1a4b3d62" />

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="428" height="766" alt="Screenshot 2025-11-12 at 14 47 46" src="https://github.com/user-attachments/assets/70043e4a-361f-4d67-adc0-f246fb92d3f6" /> | <img width="446" height="765" alt="Screenshot 2025-11-12 at 14 48 14" src="https://github.com/user-attachments/assets/e0f99a7e-9ed4-4e68-a000-c22227f97e3f" /> |




