### PR TITLE
Move Spacefinder role to correct div in Product Element

### DIFF
--- a/dotcom-rendering/src/components/ProductElement.tsx
+++ b/dotcom-rendering/src/components/ProductElement.tsx
@@ -98,12 +98,12 @@ const Content = ({
 		? subheadingHtml.textContent.trim().length > 0
 		: false;
 	return (
-		<div data-spacefinder-role="nested">
+		<div>
 			{isSubheading &&
 				Array.from(subheadingHtml.childNodes).map(
 					buildElementTree(format),
 				)}
-			<div css={contentContainer}>
+			<div css={contentContainer} data-spacefinder-role="nested">
 				{showLeftCol && (
 					<LeftColProductCardContainer>
 						<ProductCardLeftCol


### PR DESCRIPTION
## What does this change?
Moves `data-spacefinder-role="nested"` to the content container div in the product element.

## Why?
This allows ads to be inserted into the content of the product element.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="646" height="768" alt="Screenshot 2025-11-12 at 16 20 17" src="https://github.com/user-attachments/assets/5fbbd720-c4a1-4356-9bff-caeb11141cd7" /> | <img width="646" height="765" alt="Screenshot 2025-11-12 at 16 19 53" src="https://github.com/user-attachments/assets/774a0bce-a90a-4476-ae0f-362f538fdae5" /> |
