### PR TITLE
Store a card identifier for personalised highlights

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -317,7 +317,7 @@ export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 	}, []);
 
 	useEffect(() => {
-		const personalisedHighlights = getOrderedHighlights();
+		const personalisedHighlights = getOrderedHighlights(trails);
 		if (
 			personalisedHighlights.length === 0 ||
 			personalisedHighlights.length !== trails.length ||


### PR DESCRIPTION

## What does this change?
Store a card identifier rather than the whole card to ensure editorial card updates are visible to users with stored history.

## Why?
Without this, any updates to the card itself are not being reflected for users who have had their highlights history stored
