### PR TITLE
Add `WritingStories` docs to Storybook

### DIFF
--- a/dotcom-rendering/src/WritingStories.mdx
+++ b/dotcom-rendering/src/WritingStories.mdx
@@ -1,4 +1,6 @@
-import { Source } from '@storybook/addon-docs/blocks';
+import { Meta, Source } from '@storybook/addon-docs/blocks';
+
+<Meta title="Writing Stories" />
 
 # Writing Stories
 


### PR DESCRIPTION
To explain the basics of writing stories, describe the conventions we use, and detail the custom tooling we've built around Storybook.

The resulting built docs can be seen in the [published storybook for this branch](https://63e251470cfbe61776b0ef19-glohsyoemw.chromatic.com/?path=/docs/writing-stories--docs).
