### PR TITLE
Update personalise highlights test details

### DIFF
--- a/dotcom-rendering/src/experiments/tests/personalised-highlights.ts
+++ b/dotcom-rendering/src/experiments/tests/personalised-highlights.ts
@@ -2,12 +2,12 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const personalisedHighlights: ABTest = {
 	id: 'PersonalisedHighlights',
-	start: '2025-10-29',
-	expiry: '2025-12-04',
+	start: '2025-11-17',
+	expiry: '2025-12-01',
 	author: 'Anna Beddow',
 	description:
 		'Allow user behaviour to personalise the ordering of cards in the highlights container.',
-	audience: 0,
+	audience: 0.75,
 	audienceOffset: 0,
 	successMeasure: '',
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?
Update personalise highlights test details to the following
	start: '2025-11-17',
	expiry: '2025-12-01',
	audience: 0.75,
	
The expiry date is for 2 weeks time. Its possible this test will be turned off after 1 week, depending on when significance is reached. 

**This increases the audience share from 0% to 75%**

## Why?
We would like to turn this test live for up to 2 weeks.

Frontend companion PR is available https://github.com/guardian/frontend/pull/28335