### PR TITLE
Remove L2A button AB test

### DIFF
--- a/dotcom-rendering/src/components/ListenToArticle.importable.tsx
+++ b/dotcom-rendering/src/components/ListenToArticle.importable.tsx
@@ -64,18 +64,20 @@ export const ListenToArticle = ({ articleId }: Props) => {
 			.then((success: boolean) => {
 				// hide the audio button once audio is playing until we can
 				// manage play state syncronisation across the native miniplayer and web layer
-				success && setShowButton(false);
+				if (success) {
+					setShowButton(false);
+				}
 			})
 			.catch((error: Error) => {
 				window.guardian.modules.sentry.reportError(
 					error,
 					'bridget-getListenToArticleClient-play-error',
-				),
-					log(
-						'dotcom',
-						'Bridget getListenToArticleClient.play Error:',
-						error,
-					);
+				);
+				log(
+					'dotcom',
+					'Bridget getListenToArticleClient.play Error:',
+					error,
+				);
 			});
 	};
 	return (


### PR DESCRIPTION
## What does this change?

Removes the AB test from the Listen To Article button introduced in #14343

Tested locally -> L2A in article button with audio duration appears on all articles (where audio files is available)
