### PR TITLE
Fix AB testing Ophan link

### DIFF
--- a/ab-testing/frontend/src/lib/components/OphanLink.svelte
+++ b/ab-testing/frontend/src/lib/components/OphanLink.svelte
@@ -8,6 +8,7 @@
 
 <a
 	href={`https://dashboard.ophan.co.uk/graph/breakdown?day=today&ab=${testName}`}
+	target="_blank"
 >
 	graph
 </a>


### PR DESCRIPTION
## What does this change?

Adds `target="_blank"` to the anchor tag to open the Ophan link for an AB test in a new tab or window

## Why?

It doesn't work at the moment as it tries to open the link in the same window

## Screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/ea262b78-f733-42eb-9fab-16c033488548
[after]:https://github.com/user-attachments/assets/dd277d30-ed2c-4862-b88d-b8b189809d53
