### PR TITLE
Add links to sports pages to dev index

### DIFF
--- a/dotcom-rendering/src/server/dev-index.html
+++ b/dotcom-rendering/src/server/dev-index.html
@@ -73,6 +73,30 @@
 					>📧 Email Newsletters</a
 				>
 			</li>
+			<li>
+				<a
+					href="/FootballTablesPage/https://www.theguardian.com/football/tables"
+					>⚽️ Football Tables</a
+				>
+			</li>
+			<li>
+				<a
+					href="/FootballMatchListPage/https://www.theguardian.com/football/fixtures"
+					>📋 Football Match List</a
+				>
+			</li>
+			<li>
+				<a
+					href="/FootballMatchSummaryPage/https://www.theguardian.com/football/match/2025/nov/18/austria-v-bosnia-herzegovina"
+					>📊 Football Match Summary</a
+				>
+			</li>
+			<li>
+				<a
+					href="/CricketMatchPage/https://www.theguardian.com/sport/cricket/match/2025-11-06/australia-cricket-team"
+					>🏏 Cricket Match Page</a
+				>
+			</li>
 		</ul>
 		<form name="url-form">
 			<input


### PR DESCRIPTION
## What does this change?

Adds the following links to the dev index (dev server homepage)

- Football tables
- Football match list (i.e. live scores, results, fixtures)
- Football match summary (match stats when no story was written for a particular match)
- Cricket match (cricket match stats)

## Why?

Makes it easier to find examples of these pages

## Screenshots

<img width="283" height="302" alt="Screenshot 2025-11-19 at 09 30 51" src="https://github.com/user-attachments/assets/966f6c7a-c2d5-477f-98b3-5120622ee946" />


