### PR TITLE
increase the gap between two buttons on the leftcol card

### DIFF
--- a/dotcom-rendering/src/components/ProductCardLeftCol.tsx
+++ b/dotcom-rendering/src/components/ProductCardLeftCol.tsx
@@ -66,7 +66,7 @@ const buttonContainer = css`
 	padding-bottom: ${space[6]}px;
 	min-width: 100%;
 	display: grid;
-	row-gap: ${space[1]}px;
+	row-gap: ${space[3]}px;
 `;
 const customAttributesContainer = css`
 	border-top: 1px solid ${palette('--section-border')};


### PR DESCRIPTION
## What does this change?
Increases the vertical gap between the two buttons in the left col product card 
## Why?
It was discussed in our Filter Design Dev sync as better UI so it is the same spacing as the two buttons in the main body content.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
<img width="248" height="560" alt="image" src="https://github.com/user-attachments/assets/3121e2d4-b5ee-4418-aadc-9fc196eeae9a" />
  
<img width="253" height="564" alt="image" src="https://github.com/user-attachments/assets/2dab74a9-92cc-4e51-9d98-bfb04b85c8d8" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
