### PR TITLE
Set up product element 0% test

### DIFF
--- a/ab-testing/abTests.ts
+++ b/ab-testing/abTests.ts
@@ -44,6 +44,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: 'thefilter-product-element',
+		description:
+			'A hold back test to measure uplift of the product element',
+		owners: ['thefilter.dev@guardian.co.uk'],
+		status: 'ON',
+		expirationDate: '2025-12-30',
+		type: 'server',
+		audienceSize: 10 / 100,
+		groups: ['control', 'variant'],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");

--- a/ab-testing/abTests.ts
+++ b/ab-testing/abTests.ts
@@ -52,7 +52,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2025-12-30",
 		type: "server",
-		audienceSize: 10 / 100,
+		audienceSize: 0 / 100,
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},

--- a/ab-testing/abTests.ts
+++ b/ab-testing/abTests.ts
@@ -45,15 +45,15 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: 'thefilter-product-element',
+		name: "thefilter-product-element",
 		description:
-			'A hold back test to measure uplift of the product element',
-		owners: ['thefilter.dev@guardian.co.uk'],
-		status: 'ON',
-		expirationDate: '2025-12-30',
-		type: 'server',
+			"A hold back test to measure uplift of the product element",
+		owners: ["thefilter.dev@guardian.co.uk"],
+		status: "ON",
+		expirationDate: "2025-12-30",
+		type: "server",
 		audienceSize: 10 / 100,
-		groups: ['control', 'variant'],
+		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
 ];

--- a/ab-testing/types.ts
+++ b/ab-testing/types.ts
@@ -4,7 +4,7 @@ type AudienceSpace = Map<string, FastlyTestParams>;
 
 type AllSpace = Map<string, FastlyTestParams[]>;
 
-type Team = "commercial" | "webex";
+type Team = "commercial" | "webex" | "thefilter";
 
 type TestName = `${Team}-${string}`;
 

--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -119,7 +119,7 @@ When your PR is merged, the A/B test will be automatically deployed to Fastly an
 
 #### Naming Conventions
 
-A/B tests should be prefixed with the team associated with the test, for example `webex-example-test`. This helps to identify the team responsible for the test and is enforce by typescript validation, you can inspect & edit the allowed team name definitions [here](https://github.com/guardian/dotcom-rendering/blob/main/ab-testing/types.ts#L9).
+A/B tests should be prefixed with the team associated with the test, for example `webex-example-test`. This helps to identify the team responsible for the test and is enforced by typescript validation, you can inspect & edit the allowed team name definitions [here](https://github.com/guardian/dotcom-rendering/blob/main/ab-testing/types.ts#L9).
 
 #### Test Size and Groups
 
@@ -135,7 +135,7 @@ All requests are processed by Fastly at the edge, however, A/B testing of server
 
 Ensure that the `type` field is set to either `client` or `server` to indicate the type of test so that server side tests can be cached correctly, and client side tests are not splitting the cache unnecessarily.
 
-There's a limit of the number of concurrent server-side tests that can be run, enforce by the validation script, so it's important to use client-side tests where possible.
+There's a limit of the number of concurrent server-side tests that can be run, enforced by the validation script, so it's important to use client-side tests where possible.
 
 #### Test Expiration
 
@@ -178,13 +178,13 @@ const someComponent = () => {
 	const abTests = useBetaAB();
 
 	// Am I in the test at all?
-	const isInTest = abTests?.isUserInTest('AbTestTest') ?? false;
+	const isInTest = abTests?.isUserInTest('webex-example-test') ?? false;
 
 	const isInControlGroup =
-		(abTests?.isUserInTestGroup('AbTestTest', 'control') ?? false);
+		(abTests?.isUserInTestGroup('webex-example-test', 'control') ?? false);
 
 	const isInVariantGroup =
-	abTests?.isUserInTestGroup('AbTestTest', 'variant') ?? false;
+	abTests?.isUserInTestGroup('webex-example-test', 'variant') ?? false;
 
 	if (isInControlGroup) {
 		return (
@@ -224,15 +224,15 @@ const abTests = useBetaAB();
 const abTestParticipations = abTests?.getParticipations(); // EG. { commercial-dev-client-side-test: 'variant', commercial-dev-server-side-test: 'variant' }
 
 // Is user in the AbTestTest test (any cohort)
-const isInTest = abTests?.isUserInTest('AbTestTest') ?? false;
+const isInTest = abTests?.isUserInTest('webex-example-test') ?? false;
 
 // Is user in the AbTestTest test (control cohort)
 const isInControlGroup =
-	abTests?.isUserInTestGroup('AbTestTest', 'control') ?? false;
+	abTests?.isUserInTestGroup('webex-example-test', 'control') ?? false;
 
 // Is user in the AbTestTest test (variant cohort)
 const isInVariantGroup =
-	abTests?.isUserInTestGroup('AbTestTest', 'variant') ?? false;
+	abTests?.isUserInTestGroup('webex-example-test', 'variant') ?? false;
 ```
 
 #### On the Client

--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -223,14 +223,14 @@ const abTests = useBetaAB();
 // Get all of the user's server/client-side A/B test participations
 const abTestParticipations = abTests?.getParticipations(); // EG. { commercial-dev-client-side-test: 'variant', commercial-dev-server-side-test: 'variant' }
 
-// Is user in the AbTestTest test (any cohort)
+// Is user in the webex-example-test test (any cohort)
 const isInTest = abTests?.isUserInTest('webex-example-test') ?? false;
 
-// Is user in the AbTestTest test (control cohort)
+// Is user in the webex-example-test test (control cohort)
 const isInControlGroup =
 	abTests?.isUserInTestGroup('webex-example-test', 'control') ?? false;
 
-// Is user in the AbTestTest test (variant cohort)
+// Is user in the webex-example-test test (variant cohort)
 const isInVariantGroup =
 	abTests?.isUserInTestGroup('webex-example-test', 'variant') ?? false;
 ```

--- a/dotcom-rendering/src/components/ProductElement.tsx
+++ b/dotcom-rendering/src/components/ProductElement.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { parseHtml } from '../lib/domUtils';
 import type { NestedArticleElement } from '../lib/renderElement';
+import { useBetaAB } from '../lib/useAB';
 import type { ProductBlockElement } from '../types/content';
 import { ProductCardInline } from './ProductCardInline';
 import { ProductCardLeftCol } from './ProductCardLeftCol';
@@ -39,12 +40,22 @@ export const ProductElement = ({
 	format: ArticleFormat;
 	shouldShowLeftColCard: boolean;
 }) => {
+	const abTests = useBetaAB();
+	const isInHoldBackTestVariant =
+		abTests?.isUserInTestGroup('thefilter-product-element', 'variant') ??
+		false;
+
 	const showContent =
 		product.displayType === 'InlineOnly' ||
 		product.displayType === 'InlineWithProductCard';
+	// In the hold back test variant, if the product element has a display type of ProductCardOnly,
+	// we should still render the product card. This is because there may not be any suitable
+	// nested content to render, which could result in some unintended display issues. For the
+	// InlineWithProductCard display type, we won't render the cards in the hold back test.
 	const showProductCard =
 		product.displayType === 'ProductCardOnly' ||
-		product.displayType === 'InlineWithProductCard';
+		(!isInHoldBackTestVariant &&
+			product.displayType === 'InlineWithProductCard');
 	return (
 		<>
 			{showContent && (
@@ -52,7 +63,9 @@ export const ProductElement = ({
 					product={product}
 					format={format}
 					ArticleElementComponent={ArticleElementComponent}
-					shouldShowLeftColCard={shouldShowLeftColCard}
+					shouldShowLeftColCard={
+						shouldShowLeftColCard && !isInHoldBackTestVariant
+					}
 				/>
 			)}
 			{showProductCard && (


### PR DESCRIPTION
## What does this change?
Adds a 0% test to measure the impact of the Product Element on click through rate. Also makes some changes to the ab testing docs to update the example test name being used to be kebab case, to make it clearer to future users.

## Why?
We want to test the impact of the Product Element on click through rate using a 'hold back' test. The audience in the control will see the Product Element as it was designed, the same as anyone not in the test. The audience in the variant will see the Product Element rendered without the additional left col or inline product cards. This is to mock a page experience very close to that of pages without the Product Element. We then want to measure the difference in click through rate between the control and variant to see if there's a measurable benefit to the new Product Element designs.

We're setting this test up as a 0% test to start so that we can check that the test data is coming through correctly.

## Screenshots
### Desktop
| Control      | Variant      |
| ----------- | ---------- |
| <img width="806" height="719" alt="Screenshot 2025-11-19 at 16 24 23" src="https://github.com/user-attachments/assets/e9c8e469-5e3a-4d39-b6c9-4246ac6fb331" /> | <img width="805" height="716" alt="Screenshot 2025-11-19 at 16 26 01" src="https://github.com/user-attachments/assets/dff5d81a-70dd-409e-851b-5a4175dd7385" /> |

### Mobile
| Control      | Variant      |
| ----------- | ---------- |
| <img width="314" height="674" alt="Screenshot 2025-11-19 at 16 27 54" src="https://github.com/user-attachments/assets/23948bb0-3f2e-46e5-8150-4bac4dea4574" /> | <img width="309" height="664" alt="Screenshot 2025-11-19 at 16 28 32" src="https://github.com/user-attachments/assets/2213eb0b-19e8-47de-9a89-9ea94430b775" /> |
