### PR TITLE
fix multiple secondary onwards on gallery

### DIFF
--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -309,7 +309,9 @@ export const OnwardsUpper = ({
 	// For galleries: they already have a "more galleries" container,
 	// so we can only allow one more onwards container
 	const canHaveCuratedContent =
-		format.design === ArticleDesign.Gallery ? isUndefined(url) : true;
+		format.design === ArticleDesign.Gallery
+			? isUndefined(url) && !hasStoryPackage
+			: true;
 
 	const hasOnwardsContainer = !!url;
 	const showCuratedContainer =


### PR DESCRIPTION
## What does this change?
This PR fixes the bug where multiple secondary onwards containers are rendered in gallery articles. 

It's a complementary fix on a previous PR https://github.com/guardian/dotcom-rendering/pull/14589

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3b000b8e-ab40-467f-be02-4d0de7055f55
[after]: https://github.com/user-attachments/assets/220f3679-1aef-42b8-b6cd-6483396e020f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

Fixes [#14763](https://github.com/guardian/dotcom-rendering/issues/14763)