### PR TITLE
Remove curlyquotes

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -102,7 +102,6 @@
 		"constructs": "10.4.2",
 		"cpy": "11.0.0",
 		"css-loader": "7.1.2",
-		"curlyquotes": "1.5.5",
 		"dompurify": "3.2.4",
 		"dynamic-import-polyfill": "0.1.1",
 		"eslint": "8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,9 +575,6 @@ importers:
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(webpack@5.102.1)
-      curlyquotes:
-        specifier: 1.5.5
-        version: 1.5.5
       dompurify:
         specifier: 3.2.4
         version: 3.2.4
@@ -5539,9 +5536,6 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  curlyquotes@1.5.5:
-    resolution: {integrity: sha512-r1JwsUV8BJyaHP2WCfkAof8ut07bC8k1RGU/1idDqlTpUzz5e4EiOn8AsocpsYYbp0J2EWGb67aDNwdbOd9gjg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -17216,8 +17210,6 @@ snapshots:
   csstype@3.1.1: {}
 
   csstype@3.1.3: {}
-
-  curlyquotes@1.5.5: {}
 
   damerau-levenshtein@1.0.8: {}
 


### PR DESCRIPTION
It's not used. It was previously used in some AMP components, which have now been deleted (#14534).
