### PR TITLE
Remove rounded corners from Onwards Content

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -844,7 +844,6 @@ export const Card = ({
 			format={format}
 			showTopBarDesktop={showTopBarDesktop}
 			showTopBarMobile={showTopBarMobile}
-			isOnwardContent={isOnwardContent}
 			containerPalette={containerPalette}
 		>
 			<CardLink
@@ -1081,10 +1080,6 @@ export const Card = ({
 											imageSize={mediaSize}
 											alt={headlineText}
 											loading={imageLoading}
-											roundedCorners={
-												isOnwardContent &&
-												!isMoreGalleriesOnwardContent
-											}
 											aspectRatio={aspectRatio}
 										/>
 									</div>
@@ -1098,10 +1093,6 @@ export const Card = ({
 									imageSize={mediaSize}
 									alt={media.imageAltText}
 									loading={imageLoading}
-									roundedCorners={
-										isOnwardContent &&
-										!isMoreGalleriesOnwardContent
-									}
 									aspectRatio={aspectRatio}
 								/>
 								{isVideoMainMedia && mainMedia.duration > 0 && (
@@ -1143,10 +1134,6 @@ export const Card = ({
 											imageSize="small"
 											alt={media.imageAltText}
 											loading={imageLoading}
-											roundedCorners={
-												isOnwardContent &&
-												!isMoreGalleriesOnwardContent
-											}
 											aspectRatio="1:1"
 										/>
 									</div>

--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, until } from '@guardian/source/foundations';
-import { ArticleDesign, type ArticleFormat } from '../../../lib/articleFormat';
+import type { ArticleFormat } from '../../../lib/articleFormat';
 import { palette } from '../../../palette';
 import type { DCRContainerPalette } from '../../../types/front';
 import { ContainerOverrides } from '../../ContainerOverrides';
@@ -11,7 +11,6 @@ type Props = {
 	format: ArticleFormat;
 	showTopBarDesktop: boolean;
 	showTopBarMobile: boolean;
-	isOnwardContent: boolean;
 	containerPalette?: DCRContainerPalette;
 };
 
@@ -93,21 +92,11 @@ const desktopTopBarStyles = css`
 	}
 `;
 
-const onwardContentStyles = css`
-	border-radius: ${space[2]}px;
-	overflow: hidden;
-
-	:hover .media-overlay {
-		border-radius: ${space[2]}px;
-	}
-`;
-
 export const CardWrapper = ({
 	children,
 	format,
 	showTopBarDesktop,
 	showTopBarMobile,
-	isOnwardContent,
 	containerPalette,
 }: Props) => {
 	return (
@@ -119,9 +108,6 @@ export const CardWrapper = ({
 						hoverStyles,
 						showTopBarDesktop && desktopTopBarStyles,
 						showTopBarMobile && mobileTopBarStyles,
-						isOnwardContent &&
-							format.design !== ArticleDesign.Gallery &&
-							onwardContentStyles,
 					]}
 				>
 					{children}

--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { breakpoints, space, until } from '@guardian/source/foundations';
+import { breakpoints, until } from '@guardian/source/foundations';
 import type { ImgHTMLAttributes } from 'react';
 import React from 'react';
 import type { AspectRatio } from '../types/front';
@@ -14,7 +14,6 @@ export type Props = {
 	mainImage: string;
 	loading: Loading;
 	alt?: string;
-	roundedCorners?: boolean;
 	isCircular?: boolean;
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
@@ -200,12 +199,6 @@ const decideAspectRatioStyles = (aspectRatio?: AspectRatio) => {
 	`;
 };
 
-const borderRadius = css`
-	& > * {
-		border-radius: ${space[2]}px;
-	}
-`;
-
 const circularStyles = css`
 	border-radius: 100%;
 	object-fit: cover;
@@ -227,7 +220,6 @@ export const CardPicture = ({
 	alt,
 	imageSize,
 	loading,
-	roundedCorners,
 	isCircular,
 	aspectRatio = '5:3',
 	mobileAspectRatio,
@@ -251,7 +243,6 @@ export const CardPicture = ({
 				decideAspectRatioStyles(aspectRatio),
 				mobileAspectRatio &&
 					decideMobileAspectRatioStyles(mobileAspectRatio),
-				roundedCorners && borderRadius,
 				isCircular && circularStyles,
 			]}
 		>


### PR DESCRIPTION
## What does this change?

Remove rounded corners from Onwards Content cards

## Why?

We are moving away from rounding the corners of images, e.g. [we no longer round corners on gallery Onwards Content](https://github.com/guardian/dotcom-rendering/commit/47624892db058c510e8d30a65cd7e7dfd3a7cff6)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/71ed0135-a253-47ea-89cc-aa3b8caf2019
[after]: https://github.com/user-attachments/assets/01c62ccb-6941-465e-9578-1e39a104266c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
