### PR TITLE
Add ab test for amazon A9 use safe frames option 0% test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -57,6 +57,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-a9-safe-frames",
+		description:
+			"Tests the impact of using the useSafeFrames options for A9",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2025-12-30",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		groups: ["variant"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
Add 0% test which we will put a change to the Amazon A9 ads init configuration

it can have a single variant as this is for manual testing in prod, not actual ab testing.

## Why?
We need to share this change with amazon for testing.