### PR TITLE
Remove a9 use safe frames test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -57,18 +57,6 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
-	{
-		name: "commercial-a9-safe-frames",
-		description:
-			"Tests the impact of using the useSafeFrames options for A9",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2025-12-30",
-		type: "client",
-		status: "ON",
-		audienceSize: 0 / 100,
-		groups: ["variant"],
-		shouldForceMetricsCollection: false,
-	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
Remove the test

## Why?
Added in #14923, quickly validated, now we can remove the test

See https://github.com/guardian/commercial/pull/2312 for more details.