### PR TITLE
Set product element test to 10%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -53,7 +53,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2025-12-30",
 		type: "server",
-		audienceSize: 0 / 100,
+		audienceSize: 10 / 100,
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},


### PR DESCRIPTION
## What does this change?
Launches the product element test with 5% in the control and 5% in the variant.

## Why?
We have tested the changes and data collection using the 0% test, and we're now ready to go live.