### PR TITLE
Feature trail text dark mode fix

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7018,7 +7018,7 @@ const paletteColours = {
 	},
 	'--feature-card-trail-text': {
 		light: () => sourcePalette.neutral[86],
-		dark: () => sourcePalette.neutral[20],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--filter-key-events-toggle-border-top': {
 		light: () => sourcePalette.neutral[86],


### PR DESCRIPTION
## What does this change?

Adjusts the palette to make feature trail text contrast with its background in dark mode. Seems like one of those values that stays the same in light and dark mode? Only other place the `--feature-card-trail-text` variable is used is in `YoutubeAtomFeatureCardOverlay.tsx` which I wasn't able to find an example of...

## Why?

Contrast good, accessibility good, seemed like a simple enough change.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="820" height="533" alt="image" src="https://github.com/user-attachments/assets/a3bb43fe-9f66-479b-a261-d5caacb27934" /> | <img width="819" height="543" alt="image" src="https://github.com/user-attachments/assets/d6bceaa6-4ce1-46f3-8c41-f302df0af477" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
