### PR TITLE
Fix hover states with loops/cinemagraphs

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardWrapper.tsx
@@ -58,7 +58,7 @@ const hoverStyles = css`
 	*/
 	:has(
 			ul.sublinks:hover,
-			.video-container.loop:hover,
+			.video-container:not(.cinemagraph):hover,
 			.slideshow-carousel-footer:hover,
 			.branding-logo:hover
 		) {

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -30,12 +30,12 @@ import type {
 import { SelfHostedVideoPlayer } from './SelfHostedVideoPlayer';
 import { ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 
-const videoAndBackgroundStyles = css`
+const videoAndBackgroundStyles = (isCinemagraph: boolean) => css`
 	position: relative;
 	display: flex;
 	justify-content: space-around;
-	z-index: ${getZIndex('video-container')};
 	background-color: ${palette('--video-background')};
+	${!isCinemagraph && `z-index: ${getZIndex('video-container')}`};
 `;
 
 const videoContainerStyles = (width: number, height: number) => css`
@@ -47,10 +47,6 @@ const videoContainerStyles = (width: number, height: number) => css`
 	${from.tablet} {
 		max-width: ${(width / height) * 80}%;
 	}
-`;
-
-const cinemagraphContainerStyles = css`
-	pointer-events: none;
 `;
 
 /**
@@ -677,13 +673,10 @@ export const SelfHostedVideo = ({
 		: undefined;
 
 	return (
-		<div css={videoAndBackgroundStyles} className="loop-video-container">
+		<div css={videoAndBackgroundStyles(isCinemagraph)}>
 			<figure
 				ref={setNode}
-				css={[
-					videoContainerStyles(width, height),
-					isCinemagraph && cinemagraphContainerStyles,
-				]}
+				css={videoContainerStyles(width, height)}
 				className={`video-container ${videoStyle.toLocaleLowerCase()}`}
 				data-component="gu-video-loop"
 			>


### PR DESCRIPTION
## What does this change?

Removes the hover styles from the headline on Looping videos.

## Why?

This was a bug introduced by https://github.com/guardian/dotcom-rendering/pull/14881/files

The headline should only be underlined on hover when a click would take a user through to the article. This is the behaviour of cinemagraphs, but not other forms of self-hosted video, e.g. loops.

## Screenshots

### Before - Looping video

https://github.com/user-attachments/assets/7e3974ee-c463-49fa-b674-17e555c6d9e6

### After - Looping video

https://github.com/user-attachments/assets/91e510d4-b5e5-4d3f-a241-2772bf9e6aa6

### After - Cinemagraph

https://github.com/user-attachments/assets/17f45d19-0719-49b4-b9c0-d559eb82cea2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
