### PR TITLE
Extend personalised highlights test

### DIFF
--- a/dotcom-rendering/src/experiments/tests/personalised-highlights.ts
+++ b/dotcom-rendering/src/experiments/tests/personalised-highlights.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const personalisedHighlights: ABTest = {
 	id: 'PersonalisedHighlights',
 	start: '2025-11-17',
-	expiry: '2025-12-01',
+	expiry: '2026-01-28',
 	author: 'Anna Beddow',
 	description:
 		'Allow user behaviour to personalise the ordering of cards in the highlights container.',


### PR DESCRIPTION
## What does this change?

Extends the Personalised Highlights test to the 28th January.

## Why?

The test was due to expire on Monday and we may want it to continue past that date. The 28th January is far enough in the future that we are unlikely to need to extend it again. Once the test has concluded, the test will be removed.
