### PR TITLE
Two step banner configurable

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "8.3.0",
+		"@guardian/support-dotcom-components": "8.3.1",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.56.1",
 		"@sentry/browser": "10.24.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "8.2.0",
+		"@guardian/support-dotcom-components": "8.3.0",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.56.1",
 		"@sentry/browser": "10.24.0",

--- a/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
@@ -94,6 +94,7 @@ const withBannerData =
 			bannerChannel,
 			abandonedBasket,
 			promoCodes,
+			isCollapsible,
 		} = bannerProps;
 
 		const [hasBeenSeen, setNode] = useIsInView({
@@ -347,6 +348,7 @@ const withBannerData =
 					submitComponentEvent,
 					design,
 					promoCodes,
+					isCollapsible,
 				};
 
 				return (

--- a/dotcom-rendering/src/components/marketing/banners/common/types.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/common/types.tsx
@@ -81,4 +81,5 @@ export interface BannerRenderProps {
 	submitComponentEvent?: (componentEvent: ComponentEvent) => void;
 	design?: ConfigurableDesign;
 	promoCodes?: string[];
+	isCollapsible?: boolean;
 }

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -145,6 +145,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 	design,
 	countryCode,
 	promoCodes,
+	isCollapsible,
 }: BannerRenderProps): JSX.Element => {
 	const isTabletOrAbove = useMatchMedia(removeMediaRulePrefix(from.tablet));
 
@@ -163,15 +164,16 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 		ChoiceCard | undefined
 	>(defaultChoiceCard);
 
-	const isCollapsableBanner =
-		tracking.abTestVariant.includes('COLLAPSABLE_V1') ||
-		tracking.abTestVariant.includes('COLLAPSABLE_V2_MAYBE_LATER');
+	const isCollapsableBanner: boolean =
+		isCollapsible ??
+		(tracking.abTestVariant.includes('COLLAPSABLE_V1') ||
+			tracking.abTestVariant.includes('COLLAPSABLE_V2_MAYBE_LATER'));
 
-	const contextClassName = tracking.abTestVariant.includes(
-		'COLLAPSABLE_V2_MAYBE_LATER',
-	)
-		? 'maybe-later'
-		: '';
+	const contextClassName =
+		isCollapsible ||
+		tracking.abTestVariant.includes('COLLAPSABLE_V2_MAYBE_LATER')
+			? 'maybe-later'
+			: '';
 
 	const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -323,16 +323,14 @@ export const CollapsableWithThreeTierChoiceCards: Story = {
 				buttonColour: stringToHexColour('F1F8FC'),
 			},
 		},
-		tracking: {
-			...tracking,
-			abTestVariant: 'COLLAPSABLE_V1',
-		},
+		tracking,
 		choiceCardAmounts: regularChoiceCardAmounts,
 		choiceCardsSettings,
 		tickerSettings,
 		separateArticleCountSettings: {
 			type: 'above',
 		},
+		isCollapsible: true,
 	},
 };
 
@@ -344,10 +342,8 @@ export const CollapsableWithMainImage: Story = {
 			...design,
 			visual: regularImage,
 		},
-		tracking: {
-			...tracking,
-			abTestVariant: 'COLLAPSABLE_V1',
-		},
+		tracking,
+		isCollapsible: true,
 	},
 };
 
@@ -359,10 +355,8 @@ export const CollapsableMaybeLaterVariant: Story = {
 			...design,
 			visual: regularImage,
 		},
-		tracking: {
-			...tracking,
-			abTestVariant: 'COLLAPSABLE_V2_MAYBE_LATER',
-		},
+		tracking,
+		isCollapsible: true,
 	},
 };
 
@@ -377,15 +371,13 @@ export const CollapsableWithThreeTierChoiceCardsMaybeLaterVariant: Story = {
 				buttonColour: stringToHexColour('F1F8FC'),
 			},
 		},
-		tracking: {
-			...tracking,
-			abTestVariant: 'COLLAPSABLE_V2_MAYBE_LATER',
-		},
+		tracking,
 		choiceCardAmounts: regularChoiceCardAmounts,
 		choiceCardsSettings,
 		tickerSettings,
 		separateArticleCountSettings: {
 			type: 'above',
 		},
+		isCollapsible: true,
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,8 +399,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 8.2.0
-        version: 8.2.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)
+        specifier: 8.3.0
+        version: 8.3.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -2656,8 +2656,8 @@ packages:
   '@guardian/story-packages-model@2.2.0':
     resolution: {integrity: sha512-tZWBvoBTfR9K7AGlhsiPYAefIjfA5NsU/65OhcZjBEiFN6J+ay37D1dH6uIghYZbd+fB0mQ0I9kT/ac4Lgx0yQ==}
 
-  '@guardian/support-dotcom-components@8.2.0':
-    resolution: {integrity: sha512-XbEdBCTQ+DWPgYWNWnBa8a9xW58HrOAN8Yrzta9SbALq8YRU28DPtJdQgmeAgrX7wgtd/ZVc+1ix5U6k38K+0Q==}
+  '@guardian/support-dotcom-components@8.3.0':
+    resolution: {integrity: sha512-KWLzjp1npoWVrK4yeG94k9gkCZc2v6inBa9D8+1r+p1gibkKF/9OuxgprodXshGa/eXHAi/YbGS7Saik5q+g0g==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
       '@guardian/ophan-tracker-js': 2.6.1
@@ -10808,7 +10808,7 @@ snapshots:
       '@smithy/middleware-content-length': 4.2.5
       '@smithy/middleware-endpoint': 4.3.12
       '@smithy/middleware-retry': 4.4.12
-      '@smithy/middleware-serde': 4.2.5
+      '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
       '@smithy/node-http-handler': 4.4.5
@@ -11720,7 +11720,7 @@ snapshots:
       '@smithy/middleware-content-length': 4.2.5
       '@smithy/middleware-endpoint': 4.3.12
       '@smithy/middleware-retry': 4.4.12
-      '@smithy/middleware-serde': 4.2.5
+      '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
       '@smithy/node-http-handler': 4.4.5
@@ -13408,7 +13408,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@guardian/support-dotcom-components@8.2.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)':
+  '@guardian/support-dotcom-components@8.3.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)':
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.841.0
       '@aws-sdk/client-dynamodb': 3.840.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,8 +399,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 8.3.0
-        version: 8.3.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)
+        specifier: 8.3.1
+        version: 8.3.1(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -2656,8 +2656,8 @@ packages:
   '@guardian/story-packages-model@2.2.0':
     resolution: {integrity: sha512-tZWBvoBTfR9K7AGlhsiPYAefIjfA5NsU/65OhcZjBEiFN6J+ay37D1dH6uIghYZbd+fB0mQ0I9kT/ac4Lgx0yQ==}
 
-  '@guardian/support-dotcom-components@8.3.0':
-    resolution: {integrity: sha512-KWLzjp1npoWVrK4yeG94k9gkCZc2v6inBa9D8+1r+p1gibkKF/9OuxgprodXshGa/eXHAi/YbGS7Saik5q+g0g==}
+  '@guardian/support-dotcom-components@8.3.1':
+    resolution: {integrity: sha512-3e+BX/FTMHCXHtWqVi0LV3j6geOU0RX7vEb+c51KStsOXKLnM3wLK4eoih8AUiRSBO/Nqd42L0DWXDxaoyKUsw==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
       '@guardian/ophan-tracker-js': 2.6.1
@@ -13408,7 +13408,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@guardian/support-dotcom-components@8.3.0(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)':
+  '@guardian/support-dotcom-components@8.3.1(@guardian/libs@26.1.0(@guardian/ophan-tracker-js@2.6.3)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.6.3)(zod@4.1.12)':
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.841.0
       '@aws-sdk/client-dynamodb': 3.840.0


### PR DESCRIPTION
## What does this change?
[Ticket link](https://trello.com/c/g9c1YfSF/1557-two-step-banner-tooling)
## Why?
Before this change the decision of rendering One or Two-step banner was made based on the abVariantName property. For 2-step banner it should have contain COLLAPSABLE_V1 in the name. After this change the decision will be made based on isCollapsible boolean property of bannerVariant. This property is configurable through RRCP.

The SDC version was bumped to correspond this change and the PR link for changes in SDC can be found [here](https://github.com/guardian/support-dotcom-components/pull/1482/files) and [here](https://github.com/guardian/support-dotcom-components/pull/1480)

The SAC PR link is [here](https://github.com/guardian/support-admin-console/pull/860)
## Screenshots
<img width="1453" height="785" alt="Screenshot 2025-11-27 at 16 05 01" src="https://github.com/user-attachments/assets/5b3af31b-5f1c-49d5-96d2-0d14503aa461" />

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
