### PR TITLE
Fix scroll issue on mobile iOS carousels

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -80,8 +80,6 @@ const navigationStyles = (hasBackgroundColour: boolean) => css`
 	display: flex;
 	align-items: center;
 	padding-top: ${space[2]}px;
-	position: relative;
-	z-index: ${getZIndex('card-nested-link')};
 
 	${until.tablet} {
 		background-color: ${hasBackgroundColour


### PR DESCRIPTION
## What does this change?

Reinstates the container `div` element to slideshow carousels. This was removed in [this recent PR](https://github.com/guardian/dotcom-rendering/pull/14888).

## Why?

It was reported that it was no longer possible to scroll through carousels on iOS devices.

## Screenshots

iOS 18 on iPhone 16 using (a painfully slow) Browserstack.

https://github.com/user-attachments/assets/baba6ac1-bcaf-452c-9219-89c6710a2949
