### PR TITLE
Fix Gutter width so that long CTA copy remains within component bounds

### DIFF
--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -36,6 +36,7 @@ const textBlock = css`
 	align-items: flex-start;
 	padding: ${space[2]}px;
 	gap: ${space[1]}px;
+	max-width: 100%;
 `;
 const bodySection = css`
 	color: ${palette.neutral[0]};
@@ -46,6 +47,7 @@ const ctaSection = css`
 	color: ${palette.neutral[0]};
 	margin-top: ${space[3]}px;
 	margin-bottom: ${space[4]}px;
+	max-width: 100%;
 `;
 const cta = css`
 	left: ${space[2]}px;


### PR DESCRIPTION
## What does this change?

Adds max-width of 100% to the textBlock and ctaSection so that extra long CTA copy doesn't push the copy out of the gutter component bounds (see screenshot for issue).

There will also be a fix to ensure a max length on the CTA in RRCP so that the copy is limited to 14 characters.

[Trello ticket](https://trello.com/c/CL0EC5fI) 

## Screenshots

### Original issue

<img width="275" height="266" alt="Screenshot 2025-11-27 at 16 29 50" src="https://github.com/user-attachments/assets/517d8508-0727-4c3c-a211-5333018d8f5e" />

### Replicated 
<img width="322" height="385" alt="Screenshot 2025-12-01 at 15 32 10" src="https://github.com/user-attachments/assets/e714dca3-84e3-4484-ad97-fafa1b85cdb0" />

### Fix (before limitation fix in RRCP)
<img width="272" height="324" alt="Screenshot 2025-12-01 at 15 32 26" src="https://github.com/user-attachments/assets/9013a1a5-5a43-4374-8ef8-a43308b2ddff" />

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
