### PR TITLE
ignore `ab-testing/**/*` in DCR CICD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
       - 'apps-rendering/**'
+      - 'ab-testing/**'
+      - '!ab-testing/config/abTests.ts'
 
 jobs:
   container:


### PR DESCRIPTION
## What does this change?
add `ab-testing` directory to `paths-ignore` for the DCR CICD workflow, except for `abTests.ts`

## Why?

It doesn't need to run on the ab-testing projects.

it does for `abTests.ts` as it's imported into `Metrics.importable.tsx` to work out which tests to bypass metrics sampling for.
