### PR TITLE
add AB test for integrating UID2 into prebid

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -57,6 +57,19 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-user-module-uid2",
+		description:
+			"A hold back test to measure the impact of integrating UID2 module",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: `2025-12-19`,
+		type: "client",
+		status: "ON",
+		audienceSize: 10 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
This is part of the PR: Integrate Trade Desk UID2 into prebid: [here](https://github.com/guardian/commercial/pull/2315)
Adds an A/B test to verify that the UID2 user module includes the email field in the user config when consent and email are present. This is using the new AB Beta testing framework
## Why?
The goal is to confirm that the feature correctly passes user signals (including the hashed email in the Partner Data string) to UID2 and to measure the uplift in integrating it into `prebid`
