### PR TITLE
Fix issue with opt-in links on A/B test reporting page

### DIFF
--- a/ab-testing/frontend/src/lib/components/TestVariants.svelte
+++ b/ab-testing/frontend/src/lib/components/TestVariants.svelte
@@ -20,6 +20,7 @@
 			<li>
 				<a
 					href={`https://www.theguardian.com/ab-tests/opt/in/${testName}:${group}`}
+					target="_blank"
 				>
 					{group} ({formatter.format(
 						((1 / testGroups.length) * size) / 100,


### PR DESCRIPTION
## What does this change?

This adds `target="_blank"` to make the links for opting into an A/B test variant open in a new tab.

## Why?

Attempting to open the link in the current page causes an error as the page is loaded via an iframe; opening in a new tab avoids this.