### PR TITLE
Bump product element test to 40%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -53,7 +53,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2025-12-30",
 		type: "server",
-		audienceSize: 10 / 100,
+		audienceSize: 40 / 100,
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},


### PR DESCRIPTION
## What does this change?
Bumps the product element test to 40%, 20% in the control, and 20% in the variant.

## Why?
We've checked the numbers in the data lake and we'd like to increase our sample size for the test.
