### PR TITLE
Use dimensions from video element in self-hosted video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -529,14 +529,17 @@ export const SelfHostedVideo = ({
 				cue.line = percentFromTop;
 			}
 		}
-
-		setWidth(video.videoWidth);
-		setHeight(video.videoHeight);
 	};
 
 	const handleLoadedData = () => {
-		if (vidRef.current) {
-			setHasAudio(doesVideoHaveAudio(vidRef.current));
+		const video = vidRef.current;
+		if (!video) return;
+
+		setHasAudio(doesVideoHaveAudio(video));
+
+		if (video.videoWidth > 0 && video.videoHeight > 0) {
+			setWidth(video.videoWidth);
+			setHeight(video.videoHeight);
 		}
 	};
 


### PR DESCRIPTION
## What does this change?

Uses the width and height from the video element instead of relying on the values from the atom. These values are used for sizing the video, including calculating aspect ratio.

## Why?

Width and height are not always available on the atom. We have been using a default of `width: 500px` and `height: 400px` as all videos were 5:4 and the actual values were not too important. Now we want to support videos of different aspect ratios, we need the correct dimensions.