### PR TITLE
Fix self-hosted video width for videos with non-5:4 dimensions

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -999,6 +999,7 @@ export const Card = ({
 									width={media.mainMedia.width}
 									videoStyle={media.mainMedia.videoStyle}
 									posterImage={media.mainMedia.image ?? ''}
+									containerAspectRatio={5 / 4}
 									fallbackImage={media.mainMedia.image ?? ''}
 									fallbackImageSize={mediaSize}
 									fallbackImageLoading={imageLoading}

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -30,16 +30,31 @@ import type {
 import { SelfHostedVideoPlayer } from './SelfHostedVideoPlayer';
 import { ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 
-const videoAndBackgroundStyles = (isCinemagraph: boolean) => css`
+const videoAndBackgroundStyles = (
+	isCinemagraph: boolean,
+	aspectRatio?: number,
+) => css`
 	position: relative;
 	display: flex;
 	justify-content: space-around;
 	background-color: ${palette('--video-background')};
 	${!isCinemagraph && `z-index: ${getZIndex('video-container')}`};
+
+	/**
+	 * If the video and its containing slot have different dimensions, the slot will use the aspect
+	 * ratio of the video on mobile, so that the video can take up the full width of the screen.
+	 *
+	 * From tablet breakpoints, the aspect ratio of the slot is maintained, for consistency with other content.
+	 * This will result in grey bars on either side of the video if the video is narrower than the slot.
+	 */
+	${from.tablet} {
+		${typeof aspectRatio === 'number' && `aspect-ratio: ${aspectRatio};`}
+	}
 `;
 
 const videoContainerStyles = (width: number, height: number) => css`
 	position: relative;
+	aspect-ratio: ${width} / ${height};
 	height: 100%;
 	max-height: 100vh;
 	max-height: 100svh;
@@ -113,6 +128,11 @@ type Props = {
 	width: number;
 	videoStyle: VideoPlayerFormat;
 	posterImage: string;
+	/**
+	 * The desired aspect ratio of the container of the video.
+	 * This can differ from the aspect ratio of the video itself.
+	 */
+	containerAspectRatio?: number;
 	fallbackImage: CardPictureProps['mainImage'];
 	fallbackImageSize: CardPictureProps['imageSize'];
 	fallbackImageLoading: CardPictureProps['loading'];
@@ -132,6 +152,7 @@ export const SelfHostedVideo = ({
 	width: expectedWidth,
 	videoStyle,
 	posterImage,
+	containerAspectRatio,
 	fallbackImage,
 	fallbackImageSize,
 	fallbackImageLoading,
@@ -665,7 +686,9 @@ export const SelfHostedVideo = ({
 		: undefined;
 
 	return (
-		<div css={videoAndBackgroundStyles(isCinemagraph)}>
+		<div
+			css={videoAndBackgroundStyles(isCinemagraph, containerAspectRatio)}
+		>
 			<figure
 				ref={setNode}
 				css={videoContainerStyles(width, height)}


### PR DESCRIPTION
## What does this change?

Fixes the non-5:4 video display in the Flexible container slots.

Videos with a width shorter than the width of the slot will fill the width of the slot

## Why?

Video should be rendered within a 5:4 slot above the tablet breakpoint. The progress bar should be constrained by the width of the video.

Video should be full-width up until the tablet breakpoint.

## Screenshots

| <img width=80 /> | Before | After |
| - | - | - |
| mobile - half-width | ![h-mobile-before] | ![h-mobile-after] |
| mobile - boosted | ![b-mobile-before] | ![b-mobile-after] |
| mobile - giga-boost | ![g-mobile-before] | ![g-mobile-after] |
| desktop - half-width | ![h-desktop-before] | ![h-desktop-after] |
| desktop - boosted | ![b-desktop-before] | ![b-desktop-after] |
| desktop - giga-boost | ![g-desktop-before] | ![g-desktop-after] |

[h-mobile-before]: https://github.com/user-attachments/assets/c0f638ee-fb58-4074-982f-e5a194e4692e
[h-desktop-before]: https://github.com/user-attachments/assets/42f2f8c8-850b-4d7b-a1d6-d0f111b5d724
[h-mobile-after]: https://github.com/user-attachments/assets/8f20ad79-1a8b-4a86-a31d-1d19e714ad68
[h-desktop-after]: https://github.com/user-attachments/assets/ee89d531-6dc8-4c79-b376-8942411a86b0

[b-mobile-before]: https://github.com/user-attachments/assets/eec8e663-1b8a-4077-81d1-aaa5ed2f3dda
[b-desktop-before]: https://github.com/user-attachments/assets/e0a8aa8c-52ff-47c8-a318-c61cb87217e6
[b-mobile-after]: https://github.com/user-attachments/assets/55b7dabc-e9bf-4713-bdb3-f65ce6c4883e
[b-desktop-after]: https://github.com/user-attachments/assets/33e768dd-2f23-4414-8f7b-067c620671b0

[g-mobile-before]: https://github.com/user-attachments/assets/00daa8d0-41d5-46a2-a25d-b6f9dd33293d
[g-desktop-before]: https://github.com/user-attachments/assets/5ea7c425-451d-4760-baca-3cc8686cb7ab
[g-mobile-after]: https://github.com/user-attachments/assets/8f9f5d3c-b0d0-4182-aa14-13c4d675ad04
[g-desktop-after]: https://github.com/user-attachments/assets/4a4f4892-fb3b-4339-9b23-ae556749d304

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
