### PR TITLE
Render LiveBlogEpic only once per liveBlog

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -245,52 +245,8 @@ export const LiveBlogEpic = ({
 
 	const [pageUrl, setPageUrl] = useState<string | undefined>();
 
-	const [epicPlaceholder, setEpicPlaceholder] = useState<HTMLElement | null>(
-		null,
-	);
-
 	useEffect(() => {
 		setPageUrl(window.location.origin + window.location.pathname);
-	}, []);
-
-	useEffect(() => {
-		/**
-		 * Here we decide where to insert the epic.
-		 *
-		 * If the url contains a permalink then we
-		 * want to insert it immediately after that block to prevent any CLS issues.
-		 *
-		 * Otherwise, we choose a random position near the top of the blog
-		 */
-		const placeholder = document.createElement('article');
-		if (window.location.href.includes('#block-')) {
-			// Because we're using a permalink there's a possibility the epic will render in
-			// view. To prevent confusing layout shift we initially hide the message so that
-			// we can reveal (animate in) it once it has been rendered
-			placeholder.classList.add('pending');
-			const blockId = window.location.hash.slice(1);
-			const blockLinkedTo = document.getElementById(blockId);
-			if (blockLinkedTo) {
-				insertAfter(blockLinkedTo, placeholder);
-			}
-			placeholder.classList.add('reveal');
-			placeholder.classList.remove('pending');
-		} else {
-			// This is a simple page load so we simply insert the epic somewhere near the top
-			// of the blog
-			const randomPosition = Math.floor(Math.random() * 3) + 1; // 1, 2 or 3
-			const aBlockNearTheTop =
-				document.querySelectorAll<HTMLElement>('article.block')[
-					randomPosition
-				];
-			if (aBlockNearTheTop) {
-				insertAfter(aBlockNearTheTop, placeholder);
-			}
-		}
-		setEpicPlaceholder(placeholder);
-		return () => {
-			placeholder.remove();
-		};
 	}, []);
 
 	// First construct the payload
@@ -302,8 +258,40 @@ export const LiveBlogEpic = ({
 		pageId,
 		keywordIds,
 	});
-	if (!ophanPageViewId || !payload || !pageUrl || !epicPlaceholder) {
-		return null;
+	if (!ophanPageViewId || !payload || !pageUrl) return null;
+
+	/**
+	 * Here we decide where to insert the epic.
+	 *
+	 * If the url contains a permalink then we
+	 * want to insert it immediately after that block to prevent any CLS issues.
+	 *
+	 * Otherwise, we choose a random position near the top of the blog
+	 */
+	const epicPlaceholder = document.createElement('article');
+	if (window.location.href.includes('#block-')) {
+		// Because we're using a permalink there's a possibility the epic will render in
+		// view. To prevent confusing layout shift we initially hide the message so that
+		// we can reveal (animate in) it once it has been rendered
+		epicPlaceholder.classList.add('pending');
+		const blockId = window.location.hash.slice(1);
+		const blockLinkedTo = document.getElementById(blockId);
+		if (blockLinkedTo) {
+			insertAfter(blockLinkedTo, epicPlaceholder);
+		}
+		epicPlaceholder.classList.add('reveal');
+		epicPlaceholder.classList.remove('pending');
+	} else {
+		// This is a simple page load so we simply insert the epic somewhere near the top
+		// of the blog
+		const randomPosition = Math.floor(Math.random() * 3) + 1; // 1, 2 or 3
+		const aBlockNearTheTop =
+			document.querySelectorAll<HTMLElement>('article.block')[
+				randomPosition
+			];
+		if (aBlockNearTheTop) {
+			insertAfter(aBlockNearTheTop, epicPlaceholder);
+		}
 	}
 
 	return createPortal(

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -138,7 +138,7 @@ export const LiveBlogRenderer = ({
 				shouldHideAds={shouldHideAds}
 				serverTime={serverTime}
 			/>
-			{isWeb && blocks.length > 4 && (
+			{isWeb && blocks.length > 4 && !isLiveUpdate && (
 				<Island
 					priority="feature"
 					// this should really be deferred until visible,


### PR DESCRIPTION
## What does this change?
[Ticket link](https://trello.com/c/6VD63elu/1570-liveblog-epic-rendering-multiple-times-per-page)
## Why?
There is a bug on LiveBlog - when LiveBlog is open for a long time and it is polling a big amount of updates (5 or more blocks per update) the LiveBlogEpic appears on the page more than once (see the video attached)

This PR adds the check into LiveBlogRenderer.tsx to render  LiveBlogEpic only once during server-side rendering when isLiveUpdate === false (first upload of the page).
## Screenshots
**Video with bug**

https://github.com/user-attachments/assets/822bb3d7-72e8-4cd2-b399-f69c5a32c790


| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
