### PR TITLE
Preserve DCR container images with `main` tag

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -25,3 +25,4 @@ jobs:
           package-name: 'dotcom-rendering'
           package-type: 'container'
           min-versions-to-keep: ${{ env.NUM_OF_VERSIONS_TO_KEEP }}
+          ignore-versions: main


### PR DESCRIPTION
## What does this change?

Adds `ignore-versions: main` to the arguments for `actions/delete-package-versions` in the delete-old-packages workflow

## Why?

The @guardian/commercial-dev team use the latest container image from DCR in the end to end tests as part of the continuous integration for the commercial bundle.

Our CI workflows sometimes fail because there are no images available in GCR tagged as `main`
See https://github.com/guardian/commercial/pull/2332 for an example of a recent occurrence

By preserving the main tag when we run this deletion job, we should hopefully stop experiencing this issue
