### PR TITLE
update expiry date for UID2 AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -62,7 +62,7 @@ const ABTests: ABTest[] = [
 		description:
 			"A hold back test to measure the impact of integrating UID2 module",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2025-12-19`,
+		expirationDate: `2026-01-15`,
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?
A smll PR that extends the expiry date of the UID2 AB test to mid January 2026

## Why?
This will mitigate against the possibility of lack of engineers to to extend if needed around Christmas.
