### PR TITLE
Increase number of instances for facia-rendering

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -68,8 +68,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 21,
-		maximumInstances: 210,
+		minimumInstances: 48,
+		maximumInstances: 240,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
This is due to an increase in number of requests facia-rendering is experiencing. We're investigating this, but for now, we're increasing the number of instances to avoid failure
