### PR TITLE
Update EC2 instance metric granularity from 5min to 1min

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -1449,7 +1449,7 @@ exports[`The RenderingCDKStack matches the snapshot 1`] = `
             "InstanceMetadataTags": "enabled",
           },
           "Monitoring": {
-            "Enabled": false,
+            "Enabled": true,
           },
           "SecurityGroupIds": [
             {

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -208,7 +208,7 @@ export class RenderingCDKStack extends CDKStack {
 				cidrRanges: [Peer.ipv4('10.0.0.0/8')],
 				scope: AccessScope.INTERNAL,
 			},
-			instanceMetricGranularity: '5Minute',
+			instanceMetricGranularity: '1Minute',
 			applicationLogging: {
 				enabled: true,
 				systemdUnitName: guApp,


### PR DESCRIPTION
## What does this change?

Update EC2 instance metric granularity from 5min to 1min

Enables finer grained monitoring to assist in investigations

Chat thread from Apr 30th 2025: https://chat.google.com/room/AAAAWaoV0IE/6C2YLC9t4jI/6C2YLC9t4jI?cls=10

CDK v61.7.0 release notes: https://github.com/guardian/cdk/releases/tag/v61.7.0
