### PR TITLE
amend audience for uid2 size to 0%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -65,7 +65,7 @@ const ABTests: ABTest[] = [
 		expirationDate: `2026-01-15`,
 		type: "client",
 		status: "ON",
-		audienceSize: 10 / 100,
+		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,


### PR DESCRIPTION
## What does this change?
Reduces the `commercial-user-module-uid2` AB test audience size to 0% to enable opt-in only testing.

## Why?
We're investigating why `pbjs.getUserIds().uid2` returns `undefined` instead of a valid UID2 token as expected per The Trade Desk.

To debug this issue in production, we need to:
1. Test the UID2 module without the storage property ([commercial#2335](https://github.com/guardian/commercial/pull/2335))
2. Limit exposure to opt-in users only (via `?ab-commercial-user-module-uid2=variant`)
3. Validate token generation in the production environment

Setting `audienceSize: 0%` allows us to safely test the module configuration with real production data while controlling exactly who is exposed to the test via query parameters.

## Testing
- Verify test can be activated via `?ab-commercial-user-module-uid2=variant`
- Confirm `pbjs.getUserIds().uid2` returns a valid token with the updated configuration
- Validate no users are automatically enrolled (0% audience)