### PR TITLE
Add initial type for hosted content to the DCR model

### DIFF
--- a/dotcom-rendering/src/types/hostedContent.ts
+++ b/dotcom-rendering/src/types/hostedContent.ts
@@ -1,10 +1,6 @@
 import type { FEHostedContent } from '../frontend/feHostedContent';
 
-enum HostedContentType {
-	Article,
-	Video,
-	Gallery,
-}
+type HostedContentType = 'article' | 'video' | 'gallery';
 
 export type HostedContent = {
 	frontendData: FEHostedContent;
@@ -14,12 +10,12 @@ export type HostedContent = {
 export const enhanceHostedContentType = (
 	data: FEHostedContent,
 ): HostedContent => {
-	let type = HostedContentType.Article;
+	let type: HostedContentType = 'article';
 
 	if (data.video) {
-		type = HostedContentType.Video;
+		type = 'video';
 	} else if (data.images.length) {
-		type = HostedContentType.Gallery;
+		type = 'gallery';
 	}
 
 	return {


### PR DESCRIPTION
## What does this change?

This adds a very basic type for hosted content to the DCR model, as part of a piece of ongoing work to migrate hosted content to DCR.

## Why?

This is purposefully a very basic starting point- I spent a decent amount of time building something more complex but decided to revert it. I fully expect this type to change as we build out the DCR implementation for this content, but to begin with I think it's better not to be overly deterministic about what we actually need from this type. We can and should iterate this based on what the implementation actually requires.