### PR TITLE
Fix scores red background

### DIFF
--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -360,7 +360,9 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 				{footballMatchUrl ? (
 					<Section
 						showTopBorder={false}
-						backgroundColour={'red'}
+						backgroundColour={themePalette(
+							'--match-nav-background',
+						)}
 						borderColour={themePalette('--headline-border')}
 						leftContent={
 							<ArticleTitle


### PR DESCRIPTION
Introduced accidentally in #14944.

## Screenshots

### Before

![scores-before](https://github.com/user-attachments/assets/1a401033-8402-43c8-b93d-82ae2e639a18)

### After

![scores-after](https://github.com/user-attachments/assets/3f2b8716-e42c-4d7d-8478-a321fa7f153e)
