### PR TITLE
Liveblog updates in Apps should stay in Apps

### DIFF
--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -267,6 +267,7 @@ describe('Island: server-side rendering', () => {
 					enhanceTweetsSwitch={false}
 					onFirstPage={true}
 					webURL=""
+					renderingTarget="Web"
 					mostRecentBlockId=""
 					hasPinnedPost={false}
 				/>,

--- a/dotcom-rendering/src/components/Liveness.importable.tsx
+++ b/dotcom-rendering/src/components/Liveness.importable.tsx
@@ -5,6 +5,7 @@ import { getEmotionCache } from '../client/islands/emotion';
 import { initHydration } from '../client/islands/initHydration';
 import { useApi } from '../lib/useApi';
 import type { LiveUpdateType } from '../types/liveBlog';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { Toast } from './Toast';
 
 type Props = {
@@ -17,6 +18,7 @@ type Props = {
 	webURL: string;
 	mostRecentBlockId: string;
 	hasPinnedPost: boolean;
+	renderingTarget: RenderingTarget;
 };
 
 /**
@@ -154,6 +156,7 @@ export const Liveness = ({
 	webURL,
 	mostRecentBlockId,
 	hasPinnedPost,
+	renderingTarget,
 }: Props) => {
 	const [showToast, setShowToast] = useState(false);
 	const [topOfBlogVisible, setTopOfBlogVisible] = useState<boolean>();
@@ -309,9 +312,15 @@ export const Liveness = ({
 			revealPendingBlocks();
 			setNumHiddenBlocks(0);
 		} else {
-			window.location.href = `${webURL}#${placeToScrollTo}`;
+			const url = new URL(webURL);
+			if (renderingTarget === 'Apps') {
+				url.searchParams.set('dcr', 'apps');
+			}
+			url.hash = placeToScrollTo;
+
+			window.location.href = url.href;
 		}
-	}, [hasPinnedPost, onFirstPage, webURL]);
+	}, [hasPinnedPost, onFirstPage, webURL, renderingTarget]);
 
 	if (toastRoot && showToast) {
 		/**

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -614,6 +614,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									}
 									onFirstPage={pagination.currentPage === 1}
 									webURL={article.webURL}
+									renderingTarget={renderingTarget}
 									// We default to string here because the property is optional but we
 									// know it will exist for all blogs
 									mostRecentBlockId={


### PR DESCRIPTION
Closes: https://github.com/guardian/dotcom-rendering/issues/14651

## What does this change?
* Adds `?dcr=apps` param if the liveblog is viewed in Apps.
* Uses Node URL API to add the parameter and the fragment in the liveblog url

## Why?
This fixes the following bug: When an App user is after the first page in a liveblog and they click "Updates", they currently get transferred to the web version of the liveblog.

## Videos

### Before
https://github.com/user-attachments/assets/47d2c0f8-5a5c-4f7a-bccd-4daf814fbfb1 


### After

https://github.com/user-attachments/assets/c4f2d0a1-2da7-4c0e-b674-9430cc6572aa

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
