### PR TITLE
Fix issue of video not displaying in apps

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -506,8 +506,6 @@ export const SelfHostedVideo = ({
 		setPreloadPartialData(isAutoplayAllowed === false || !!isInView);
 	}, [isAutoplayAllowed, isInView]);
 
-	// if (renderingTarget !== 'Web') return null;
-
 	if (adapted) {
 		return FallbackImageComponent;
 	}


### PR DESCRIPTION
## What does this change?
We have an issue where the new looping video in article functionality does not display in apps.

We have demonstrated the issue through the following test:

When we invoke the apps path in the URL, the video component is not included in the DOM code:
https://www.theguardian.com/uk-news/2025/nov/06/british-military-announces-first-delivery-of-ajax-armoured-vehicles-eight-years-late?dcr=apps
<img width="1310" height="761" alt="Screenshot 2025-12-11 at 16 03 58" src="https://github.com/user-attachments/assets/3b1a93f8-7051-4117-985c-f35c92a4f746" />

When we view the article without the apps toggle, the video appears
https://www.theguardian.com/uk-news/2025/nov/06/british-military-announces-first-delivery-of-ajax-armoured-vehicles-eight-years-late
<img width="1307" height="749" alt="Screenshot 2025-12-11 at 16 03 47" src="https://github.com/user-attachments/assets/4ccef5c9-8592-4342-84ab-f74035d2c862" />

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
