### PR TITLE
wip

### DIFF
--- a/dotcom-rendering/src/components/LoopVideoInArticle.stories.tsx
+++ b/dotcom-rendering/src/components/LoopVideoInArticle.stories.tsx
@@ -1,0 +1,121 @@
+import { breakpoints } from '@guardian/source/foundations';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { centreColumnDecorator } from '../../.storybook/decorators/gridDecorators';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import type { MediaAtomBlockElement } from '../types/content';
+import { LoopVideoInArticle } from './LoopVideoInArticle';
+
+const meta = {
+	component: LoopVideoInArticle,
+	title: 'Components/LoopVideoInArticle',
+	decorators: [centreColumnDecorator],
+	parameters: {
+		chromatic: {
+			viewports: [
+				breakpoints.mobile,
+				breakpoints.tablet,
+				breakpoints.wide,
+			],
+			// Chromatic ignores video elements by design
+			disableSnapshot: true,
+		},
+	},
+} satisfies Meta<typeof LoopVideoInArticle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultElement: MediaAtomBlockElement = {
+	_type: 'model.dotcomrendering.pageElements.MediaAtomBlockElement',
+	elementId: 'mock-element-id',
+	id: 'mock-video-id',
+	title: 'A looping video showing nature',
+	assets: [
+		{
+			url: 'https://uploads.guim.co.uk/2025%2F06%2F20%2Ftesting+only%2C+please+ignore--3cb22b60-2c3f-48d6-8bce-38c956907cce-3.mp4',
+			mimeType: 'video/mp4',
+			dimensions: {
+				width: 900,
+				height: 720,
+			},
+			aspectRatio: '5:4',
+		},
+	],
+	posterImage: [
+		{
+			url: 'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',
+			width: 1800,
+		},
+	],
+};
+
+const defaultFormat = {
+	theme: Pillar.News,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+};
+
+export const Default: Story = {
+	name: 'Default (not main media)',
+	args: {
+		element: defaultElement,
+		format: defaultFormat,
+		isMainMedia: false,
+	},
+};
+
+export const MainMedia: Story = {
+	name: 'As main media',
+	args: {
+		element: defaultElement,
+		format: defaultFormat,
+		isMainMedia: true,
+	},
+};
+
+export const WithoutCaption: Story = {
+	name: 'Without caption',
+	args: {
+		element: {
+			...defaultElement,
+			title: undefined,
+		},
+		format: defaultFormat,
+		isMainMedia: false,
+	},
+};
+
+export const MainMediaWithoutCaption: Story = {
+	name: 'Main media without caption',
+	args: {
+		element: {
+			...defaultElement,
+			title: undefined,
+		},
+		format: defaultFormat,
+		isMainMedia: true,
+	},
+};
+
+export const AspectRatio16to9: Story = {
+	name: '16:9 aspect ratio',
+	args: {
+		element: {
+			...defaultElement,
+			title: 'A widescreen looping video',
+			assets: [
+				{
+					url: 'https://uploads.guim.co.uk/2024/10/01/241001HeleneLoop_2.mp4',
+					mimeType: 'video/mp4',
+					dimensions: {
+						width: 1920,
+						height: 1080,
+					},
+					aspectRatio: '16:9',
+				},
+			],
+		},
+		format: defaultFormat,
+		isMainMedia: false,
+	},
+};

--- a/dotcom-rendering/src/components/LoopVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/LoopVideoInArticle.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import type { FEAspectRatio } from '../frontend/feFront';
 import type { ArticleFormat } from '../lib/articleFormat';
 import {
@@ -7,8 +8,57 @@ import {
 } from '../lib/video';
 import type { MediaAtomBlockElement } from '../types/content';
 import { Caption } from './Caption';
+import { Hide } from './Hide';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.importable';
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const CaptionToggle = () => (
+	<>
+		<label
+			htmlFor="the-checkbox"
+			css={css`
+				position: absolute;
+				right: 5px;
+				width: 32px;
+				height: 32px;
+				z-index: 1;
+				/* We're using rgba here for the opacity */
+				background-color: rgba(18, 18, 18, 0.6);
+				border-radius: 50%;
+				bottom: 6px;
+				border: none;
+				cursor: pointer;
+
+				svg {
+					top: 0;
+					bottom: 0;
+					right: 0;
+					left: 0;
+					margin: auto;
+					position: absolute;
+					fill: white;
+				}
+			`}
+		>
+			<svg width="6" height="14" fill="white" viewBox="0 0 6 14">
+				<path d="M4.6 12l-.4 1.4c-.7.2-1.9.6-3 .6-.7 0-1.2-.2-1.2-.9 0-.2 0-.3.1-.5l2-6.7H.7l.4-1.5 4.2-.6h.2L3 12h1.6zm-.3-9.2c-.9 0-1.4-.5-1.4-1.3C2.9.5 3.7 0 4.6 0 5.4 0 6 .5 6 1.3c0 1-.8 1.5-1.7 1.5z" />
+			</svg>
+		</label>
+		{/* Hidden input used to toggle the caption using css */}
+		<input type="checkbox" id="the-checkbox" />
+	</>
+);
 
 type LoopVideoInArticleProps = {
 	element: MediaAtomBlockElement;
@@ -31,35 +81,90 @@ export const LoopVideoInArticle = ({
 
 	return (
 		<>
-			<Island priority="critical" defer={{ until: 'visible' }}>
-				<SelfHostedVideo
-					atomId={element.id}
-					fallbackImage={posterImageUrl}
-					fallbackImageAlt={caption}
-					fallbackImageAspectRatio={
-						(firstVideoAsset?.aspectRatio ?? '5:4') as FEAspectRatio
-					}
-					fallbackImageLoading="lazy"
-					fallbackImageSize="small"
-					height={firstVideoAsset?.dimensions?.height ?? 400}
-					linkTo="Article-embed-MediaAtomBlockElement"
-					posterImage={posterImageUrl}
-					sources={convertAssetsToVideoSources(element.assets)}
-					subtitleSize="medium"
-					subtitleSource={getSubtitleAsset(element.assets)}
-					videoStyle="Loop"
-					uniqueId={element.id}
-					width={firstVideoAsset?.dimensions?.width ?? 500}
-					enableHls={false}
-				/>
-			</Island>
-			{!!caption && (
-				<Caption
-					captionText={caption}
-					format={format}
-					isMainMedia={isMainMedia}
-					mediaType="SelfHostedVideo"
-				/>
+			<div
+				css={css`
+					position: relative;
+				`}
+			>
+				<Island priority="critical" defer={{ until: 'visible' }}>
+					<SelfHostedVideo
+						atomId={element.id}
+						fallbackImage={posterImageUrl}
+						fallbackImageAlt={caption}
+						fallbackImageAspectRatio={
+							(firstVideoAsset?.aspectRatio ??
+								'5:4') as FEAspectRatio
+						}
+						fallbackImageLoading="lazy"
+						fallbackImageSize="small"
+						height={firstVideoAsset?.dimensions?.height ?? 400}
+						linkTo="Article-embed-MediaAtomBlockElement"
+						posterImage={posterImageUrl}
+						sources={convertAssetsToVideoSources(element.assets)}
+						subtitleSize="medium"
+						subtitleSource={getSubtitleAsset(element.assets)}
+						videoStyle="Loop"
+						uniqueId={element.id}
+						width={firstVideoAsset?.dimensions?.width ?? 500}
+						enableHls={false}
+					/>
+				</Island>
+
+				{isMainMedia && !!caption && (
+					// Below tablet, main media videos show an info toggle at the bottom right of
+					// the video which, when clicked, toggles the caption as an overlay
+					<Hide when="above" breakpoint="tablet">
+						<Row>
+							<div
+								css={css`
+									#the-checkbox {
+										/* Never show the input */
+										display: none;
+									}
+									#the-caption {
+										/* Hide caption by default */
+										display: none;
+									}
+									#the-checkbox:checked + #the-caption {
+										/* Show the caption if the input is checked */
+										display: block;
+									}
+								`}
+							>
+								{/* CaptionToggle contains the input with id #the-checkbox */}
+								<CaptionToggle />{' '}
+								<div id="the-caption">
+									<Caption
+										captionText={caption}
+										format={format}
+										isOverlaid={true}
+										isMainMedia={isMainMedia}
+										mediaType="SelfHostedVideo"
+									/>
+								</div>
+							</div>
+						</Row>
+					</Hide>
+				)}
+			</div>
+			{isMainMedia && !!caption ? (
+				<Hide when="below" breakpoint="tablet">
+					<Caption
+						captionText={caption}
+						format={format}
+						isMainMedia={isMainMedia}
+						mediaType="SelfHostedVideo"
+					/>
+				</Hide>
+			) : (
+				!!caption && (
+					<Caption
+						captionText={caption}
+						format={format}
+						isMainMedia={isMainMedia}
+						mediaType="SelfHostedVideo"
+					/>
+				)
 			)}
 		</>
 	);


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
