### PR TITLE
Fix main media caption padding

### DIFF
--- a/dotcom-rendering/src/components/Caption.tsx
+++ b/dotcom-rendering/src/components/Caption.tsx
@@ -307,7 +307,9 @@ export const Caption = ({
 				shouldLimitWidth && limitedWidth,
 				isOverlaid ? overlaidStyles(format) : bottomMarginStyles,
 				isMainMedia &&
-					(isBlog || mediaType === 'YoutubeVideo') &&
+					(isBlog ||
+						mediaType === 'YoutubeVideo' ||
+						mediaType === 'SelfHostedVideo') &&
 					tabletCaptionPadding,
 				padCaption && captionPadding,
 				isImmersive && immersivePadding,


### PR DESCRIPTION
## What does this change?

Adds some padding to the captions of self-hosted videos when they are set as main media, when viewed on smaller screens.

We already do this for YouTube videos, so we just need to add another clause.

## Why?

We got this bug report from Daniel:

> The padding for the caption is too tight on mobile web
> 
> <img width="200"  alt="IMG_1689 (1)" src="https://github.com/user-attachments/assets/6063e1ad-4467-4df3-b6df-19b4fdef767d" />

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="376" height="470" alt="Screenshot 2025-12-12 at 13 39 24" src="https://github.com/user-attachments/assets/ddd47583-2e49-43e8-8a5b-7f8d5c256599" />  | <img width="376" height="468" alt="Screenshot 2025-12-12 at 13 39 34" src="https://github.com/user-attachments/assets/513e5f5e-ff17-42a5-b64b-02734b4bd4ea" />  |
