### PR TITLE
isMaybeLater is default for two step banner

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -291,12 +291,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 			separateArticleCount) &&
 		articleCounts.forTargetedWeeks >= 5;
 
-	// Add detection for the new "Maybe later" AB variant and pass flag to CTAs.
-	// This reuses the existing onCloseClick handler (same behaviour as the Close link).
-	const isMaybeLaterVariant = tracking.abTestVariant.includes(
-		'COLLAPSABLE_V2_MAYBE_LATER',
-	);
-
 	return (
 		<div
 			ref={bannerRef}
@@ -313,7 +307,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 					isCollapsableBanner && isCollapsed
 						? styles.collapsedLayoutOverrides(
 								cardsImageOrSpaceTemplateString,
-								isMaybeLaterVariant,
 						  )
 						: styles.layoutOverrides(
 								cardsImageOrSpaceTemplateString,
@@ -412,9 +405,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									templateSettings.secondaryCtaSettings
 								}
 								onCloseClick={
-									isMaybeLaterVariant && isCollapsed
-										? onCloseClick
-										: undefined
+									isCollapsed ? onCloseClick : undefined
 								}
 							/>
 						</div>
@@ -426,7 +417,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 						isCollapsableBanner
 							? styles.closeAndCollapseButtonContainer(
 									isCollapsed,
-									isMaybeLaterVariant,
 							  )
 							: styles.closeButtonContainer
 					}
@@ -462,14 +452,13 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 							/>
 						</div>
 					)}
-					{(!isCollapsableBanner || isCollapsed) &&
-						!isMaybeLaterVariant && (
-							<DesignableBannerCloseButton
-								onCloseClick={onCloseClick}
-								settings={templateSettings.closeButtonSettings}
-								isCollapsableBanner={isCollapsableBanner}
-							/>
-						)}
+					{(!isCollapsableBanner || isCollapsed) && (
+						<DesignableBannerCloseButton
+							onCloseClick={onCloseClick}
+							settings={templateSettings.closeButtonSettings}
+							isCollapsableBanner={isCollapsableBanner}
+						/>
+					)}
 				</div>
 
 				{choiceCards &&
@@ -521,7 +510,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 										? mainOrMobileContent.primaryCta.ctaText
 										: 'Continue'}
 								</LinkButton>
-								{isMaybeLaterVariant && isCollapsed && (
+								{isCollapsed && (
 									<div css={styles.maybeLaterButtonSizing}>
 										<LinkButton
 											onClick={onCloseClick}
@@ -637,10 +626,7 @@ const styles = {
 				'.		vert-line	cta-container	${cardsImageOrSpaceTemplateString}	.';
 		}
 	`,
-	collapsedLayoutOverrides: (
-		cardsImageOrSpaceTemplateString: string,
-		isMaybeLaterVariant: boolean,
-	) => css`
+	collapsedLayoutOverrides: (cardsImageOrSpaceTemplateString: string) => css`
 		display: grid;
 		background: inherit;
 		position: relative;
@@ -652,18 +638,11 @@ const styles = {
 			margin: 0 auto;
 			padding: ${space[2]}px ${space[3]}px 0 ${space[3]}px;
 			grid-template-columns: auto max(${phabletContentMaxWidth} auto);
-			grid-template-areas: ${isMaybeLaterVariant
-				? `
+			grid-template-areas: ${`
 				'.	.									.'
 				'.	copy-container						close-button'
 				'.	${cardsImageOrSpaceTemplateString}	${cardsImageOrSpaceTemplateString}'
 				'.	cta-container						cta-container'
-				`
-				: `
-				'.	close-button						.'
-				'.	copy-container						.'
-				'.	${cardsImageOrSpaceTemplateString}	.'
-				'.	cta-container						.';
 				`};
 		}
 		${from.phablet} {
@@ -748,10 +727,7 @@ const styles = {
 			padding-left: ${space[8]}px;
 		}
 	`,
-	closeAndCollapseButtonContainer: (
-		isCollapsed: boolean,
-		isMaybeLaterVariant: boolean,
-	) => css`
+	closeAndCollapseButtonContainer: (isCollapsed: boolean) => css`
 		/* Layout changes only here */
 		grid-area: close-button;
 		display: flex;
@@ -770,9 +746,7 @@ const styles = {
 		}
 		${from.desktop} {
 			flex-direction: ${isCollapsed ? 'row' : 'row-reverse'};
-			margin-top: ${isCollapsed && isMaybeLaterVariant
-				? space[9]
-				: space[6]}px;
+			margin-top: ${isCollapsed ? space[9] : space[6]}px;
 		}
 
 		.maybe-later & {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -452,7 +452,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 							/>
 						</div>
 					)}
-					{(!isCollapsableBanner || isCollapsed) && (
+					{!isCollapsableBanner && (
 						<DesignableBannerCloseButton
 							onCloseClick={onCloseClick}
 							settings={templateSettings.closeButtonSettings}


### PR DESCRIPTION
## What does this change?
[Ticket link](https://trello.com/c/wpCOpIci/1590-twostepbanner-needs-to-show-maybe-later-button)
This PR makes "maybe later" variant in two step banner default
## Why?
The "maybe later" button was shown up for Two step banner conditionally depending on the test variant name. Now it should show up for all Two step banners.
## Screenshots

**Before**
<img width="1492" height="119" alt="Screenshot 2025-12-12 at 15 38 10" src="https://github.com/user-attachments/assets/a7def7c8-4c1d-411f-a522-64ef5d9d9dd5" />
**After**
<img width="1051" height="112" alt="Screenshot 2025-12-12 at 16 11 25" src="https://github.com/user-attachments/assets/2df2f578-87c4-40c5-a369-2599d5c9f3f6" />



[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
