### PR TITLE
Updates privacy policy text in Terms component to mention email-based identifiers

### DIFF
--- a/dotcom-rendering/src/components/Terms/Terms.tsx
+++ b/dotcom-rendering/src/components/Terms/Terms.tsx
@@ -15,7 +15,9 @@ export const GuardianTerms = () => (
 		>
 			terms and conditions
 		</ExternalLink>
-		. For information about how we use your data, see our{' '}
+		. For information about how we use your data, including the generation
+		of random identifiers based on your email address for advertising and
+		marketing, visit our{' '}
 		<ExternalLink
 			href="https://www.theguardian.com/help/privacy-policy"
 			data-ignore="global-link-styling"


### PR DESCRIPTION
## What does this change?

Update privacy policy text in Terms component to mention email-based identifiers

This adds more specific information about the use of random identifiers generated from email addresses for advertising and marketing purposes, and changes "see our" to "visit our" for the privacy policy link.