### PR TITLE
feat: Launch Google One Tap to New Zealand

### DIFF
--- a/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.importable.tsx
@@ -121,6 +121,8 @@ const getProviders = (stage: StageType): IdentityProviderConfig[] => {
 	}
 };
 
+const ENABLED_COUNTRIES: CountryCode[] = ['IE', 'NZ'];
+
 export const initializeFedCM = async ({
 	isSignedIn,
 	countryCode,
@@ -147,7 +149,7 @@ export const initializeFedCM = async ({
 	);
 
 	// TODO: Expand Google One Tap to outside Ireland
-	if (countryCode !== 'IE') return;
+	if (!countryCode || !ENABLED_COUNTRIES.includes(countryCode)) return;
 	if (isSignedIn) return;
 
 	/**


### PR DESCRIPTION
## What does this change?

Launch Google One Tap in New Zealand at 100%.

Also cleans up some of the Ophan event handling now that we've upgraded the version of `@guardian/ophan-tracker-js`