### PR TITLE
Star rating redesign

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import {
 	between,
 	from,
@@ -28,12 +29,11 @@ import {
 } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { palette as themePalette } from '../palette';
+import type { StarRating as Rating } from '../types/content';
 import type { TagType } from '../types/tag';
 import { AgeWarning } from './AgeWarning';
 import { DesignTag } from './DesignTag';
 import { HeadlineByline } from './HeadlineByline';
-import type { StarRating as Rating } from '../types/content';
-import { isUndefined } from '@guardian/libs';
 import { StarRating } from './StarRating/StarRating';
 
 type Props = {

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -32,6 +32,9 @@ import type { TagType } from '../types/tag';
 import { AgeWarning } from './AgeWarning';
 import { DesignTag } from './DesignTag';
 import { HeadlineByline } from './HeadlineByline';
+import type { StarRating as Rating } from '../types/content';
+import { isUndefined } from '@guardian/libs';
+import { StarRating } from './StarRating/StarRating';
 
 type Props = {
 	headlineString: string;
@@ -41,6 +44,7 @@ type Props = {
 	webPublicationDateDeprecated: string;
 	hasAvatar?: boolean;
 	isMatch?: boolean;
+	starRating?: Rating;
 };
 
 const topPadding = css`
@@ -121,7 +125,6 @@ const headlineFont = (format: ArticleFormat) => {
 	if (format.design === ArticleDesign.Gallery) {
 		return css`
 			${decideMobileHeadlineFont(format)}
-
 			${from.desktop} {
 				${decideHeadlineFont(format)}
 			}
@@ -129,7 +132,6 @@ const headlineFont = (format: ArticleFormat) => {
 	}
 	return css`
 		${decideMobileHeadlineFont(format)}
-
 		${from.tablet} {
 			${decideHeadlineFont(format)}
 		}
@@ -138,6 +140,7 @@ const headlineFont = (format: ArticleFormat) => {
 
 const invertedFontLineHeight = css`
 	line-height: 2.1875rem;
+
 	${from.tablet} {
 		line-height: 2.625rem;
 	}
@@ -146,6 +149,7 @@ const invertedFontLineHeight = css`
 const labsFont = css`
 	${textSansBold28};
 	line-height: 2rem;
+
 	${from.tablet} {
 		${textSansBold34};
 		line-height: 2.375rem;
@@ -155,6 +159,7 @@ const labsFont = css`
 const labsGalleryFont = css`
 	${textSansBold34};
 	line-height: 2.1875rem;
+
 	${from.desktop} {
 		${textSansBold34};
 		font-size: 50px;
@@ -166,6 +171,7 @@ const jumboLabsFont = css`
 	${textSansBold34};
 	font-size: 3.125rem;
 	line-height: 3.5rem;
+
 	${until.desktop} {
 		${textSansBold34};
 		line-height: 2.375rem;
@@ -203,12 +209,15 @@ const immersiveStyles = css`
 	min-height: 112px;
 	padding-bottom: ${space[6]}px;
 	padding-left: ${space[1]}px;
+
 	${from.mobileLandscape} {
 		padding-left: ${space[3]}px;
 	}
+
 	${from.tablet} {
 		padding-left: ${space[1]}px;
 	}
+
 	margin-right: ${space[5]}px;
 `;
 
@@ -242,12 +251,15 @@ const immersiveWrapper = css`
         Make sure we vertically align the headline font with the body font
     */
 	margin-left: 6px;
+
 	${from.tablet} {
 		margin-left: 16px;
 	}
+
 	${from.leftCol} {
 		margin-left: 25px;
 	}
+
 	/*
         We need this grow to ensure the headline fills the main content column
     */
@@ -257,6 +269,7 @@ const immersiveWrapper = css`
         box that extends the black background to the right
     */
 	z-index: ${getZIndex('articleHeadline')};
+
 	${until.mobileLandscape} {
 		margin-right: 40px;
 	}
@@ -352,6 +365,7 @@ const decideBottomPadding = ({
 					if (format.display === ArticleDisplay.Showcase) {
 						return css`
 							padding-bottom: ${space[1]}px;
+
 							${from.tablet} {
 								padding-bottom: ${space[6]}px;
 							}
@@ -364,7 +378,8 @@ const decideBottomPadding = ({
 				case ArticleDesign.Review: {
 					if (format.display === ArticleDisplay.Showcase) {
 						return css`
-							padding-bottom: 28px;
+							padding-bottom: ${space[5]}px;
+
 							${from.tablet} {
 								padding-bottom: ${space[6]}px;
 							}
@@ -384,6 +399,7 @@ const decideBottomPadding = ({
 						? ''
 						: css`
 								padding-bottom: 28px;
+
 								${from.tablet} {
 									padding-bottom: ${space[9]}px;
 								}
@@ -396,7 +412,7 @@ const decideBottomPadding = ({
 const galleryStyles = css`
 	${grid.between('grid-start', 'centre-column-end')}
 
-	grid-row: 7/9;
+	grid-row: 7 / 9;
 	position: relative;
 
 	${from.tablet} {
@@ -413,6 +429,7 @@ export const ArticleHeadline = ({
 	webPublicationDateDeprecated,
 	hasAvatar,
 	isMatch,
+	starRating,
 }: Props) => {
 	switch (format.display) {
 		case ArticleDisplay.Immersive: {
@@ -496,6 +513,13 @@ export const ArticleHeadline = ({
 									{headlineString}
 								</span>
 							</h1>
+							{!isUndefined(starRating) && (
+								<StarRating
+									rating={starRating}
+									paddingSize={'large'}
+									size={'large'}
+								/>
+							)}
 						</WithAgeWarning>
 					);
 			}
@@ -572,6 +596,13 @@ export const ArticleHeadline = ({
 								>
 									{headlineString}
 								</h1>
+								{!isUndefined(starRating) && (
+									<StarRating
+										rating={starRating}
+										paddingSize={'medium'}
+										size={'large'}
+									/>
+								)}
 							</WithAgeWarning>
 						</div>
 					);

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { BETA_CONTAINERS } from '../../model/enhanceCollections';
 import { palette } from '../../palette';
 import type { Branding } from '../../types/branding';
-import type { RatingSizeType, StarRating as Rating } from '../../types/content';
+import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 import type {
 	AspectRatio,
 	DCRContainerPalette,

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import {
-	between,
-	from,
-	palette as sourcePalette,
-	space,
-	until,
-} from '@guardian/source/foundations';
+import { between, from, space, until } from '@guardian/source/foundations';
 import { Hide, Link, SvgCamera } from '@guardian/source/react-components';
 import {
 	ArticleDesign,
@@ -22,7 +16,7 @@ import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { BETA_CONTAINERS } from '../../model/enhanceCollections';
 import { palette } from '../../palette';
 import type { Branding } from '../../types/branding';
-import type { StarRating as Rating } from '../../types/content';
+import type { RatingSizeType, StarRating as Rating } from '../../types/content';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -163,30 +157,8 @@ export type Props = {
 	/** Determines if the headline should be positioned within the content or outside the content */
 	headlinePosition?: 'inner' | 'outer';
 	enableHls?: boolean;
+	starRatingSize?: RatingSizeType;
 };
-
-const starWrapper = (cardHasImage: boolean) => css`
-	background-color: ${sourcePalette.brandAlt[400]};
-	color: ${sourcePalette.neutral[0]};
-	margin-top: ${cardHasImage ? '2' : space[1]}px;
-	display: inline-block;
-
-	${from.tablet} {
-		margin-top: ${space[1]}px;
-	}
-`;
-
-const StarRatingComponent = ({
-	rating,
-	cardHasImage,
-}: {
-	rating: Rating;
-	cardHasImage: boolean;
-}) => (
-	<div css={starWrapper(cardHasImage)}>
-		<StarRating rating={rating} size="small" />
-	</div>
-);
 
 const waveformWrapper = (
 	mediaPositionOnMobile?: MediaPositionType,
@@ -196,13 +168,16 @@ const waveformWrapper = (
 	left: 0;
 	right: 0;
 	bottom: 0;
+
 	svg {
 		display: block;
 		width: 100%;
 		height: ${mediaPositionOnMobile === 'top' ? 50 : 29}px;
+
 		${from.mobileMedium} {
 			height: ${mediaPositionOnMobile === 'top' ? 50 : 33}px;
 		}
+
 		${from.tablet} {
 			height: ${mediaPositionOnDesktop === 'top' ? 50 : 33}px;
 		}
@@ -216,12 +191,15 @@ const HorizontalDivider = () => (
 				border-top: 1px solid ${palette('--card-border-top')};
 				height: 1px;
 				width: 50%;
+
 				${from.tablet} {
 					width: 100px;
 				}
+
 				${from.desktop} {
 					width: 140px;
 				}
+
 				margin-top: ${space[3]}px;
 			}
 		`}
@@ -236,6 +214,7 @@ const podcastImageStyles = (
 		return css`
 			width: 69px;
 			height: 69px;
+
 			${from.tablet} {
 				width: 98px;
 				height: 98px;
@@ -249,11 +228,14 @@ const podcastImageStyles = (
 	return css`
 		width: 98px;
 		height: 98px;
+
 		${from.tablet} {
 			width: 120px;
 			height: 120px;
 		}
+
 		/** The image takes the full height on desktop, so that the waveform sticks to the bottom of the card. */
+
 		${from.desktop} {
 			width: ${isHorizontalOnDesktop ? 'unset' : '120px'};
 			height: ${isHorizontalOnDesktop ? 'unset' : '120px'};
@@ -421,6 +403,7 @@ export const Card = ({
 	headlinePosition = 'inner',
 	subtitleSize = 'small',
 	enableHls = false,
+	starRatingSize = 'small',
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -579,8 +562,8 @@ export const Card = ({
 
 	/**
 -	 * Media cards have contrasting background colours. We add additional
-	 * padding to these cards to keep the text readable.
--	 */
+* padding to these cards to keep the text readable.
+-     */
 	const isMediaCardOrNewsletter = isMediaCard(format) || isNewsletter;
 
 	const showPill = isMediaCardOrNewsletter && !isGallerySecondaryOnward;
@@ -845,6 +828,7 @@ export const Card = ({
 						${until.tablet} {
 							display: none;
 						}
+
 						${from.desktop} {
 							display: none;
 						}
@@ -909,10 +893,7 @@ export const Card = ({
 						isExternalLink={isExternalLink}
 					/>
 					{!isUndefined(starRating) ? (
-						<StarRatingComponent
-							rating={starRating}
-							cardHasImage={!!image}
-						/>
+						<StarRating rating={starRating} size="small" />
 					) : null}
 				</div>
 			)}
@@ -1237,9 +1218,9 @@ export const Card = ({
 									}
 								/>
 								{!isUndefined(starRating) ? (
-									<StarRatingComponent
+									<StarRating
 										rating={starRating}
-										cardHasImage={!!image}
+										size={starRatingSize}
 									/>
 								) : null}
 							</HeadlineWrapper>

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -35,6 +35,7 @@ const cardProps: CardProps = {
 	showClock: false,
 	imageSize: 'feature',
 	collectionId: 1,
+	starRatingSize: 'medium',
 };
 
 const aBasicLink = {

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -213,14 +213,6 @@ const nonImmersivePodcastImageStyles = css`
 	left: ${space[2]}px;
 `;
 
-const starRatingWrapper = css`
-	background-color: ${palette('--star-rating-background')};
-	color: ${palette('--star-rating-fill')};
-	margin-top: ${space[1]}px;
-	display: inline-block;
-	width: fit-content;
-`;
-
 const trailTextWrapper = css`
 	margin-top: ${space[3]}px;
 
@@ -635,12 +627,10 @@ export const FeatureCard = ({
 										</div>
 
 										{starRating !== undefined ? (
-											<div css={starRatingWrapper}>
-												<StarRating
-													rating={starRating}
-													size="small"
-												/>
-											</div>
+											<StarRating
+												rating={starRating}
+												size="medium"
+											/>
 										) : null}
 
 										{!!trailText && (

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -17,7 +17,7 @@ import { getOphanComponents } from '../lib/labs';
 import { transparentColour } from '../lib/transparentColour';
 import { palette } from '../palette';
 import type { Branding } from '../types/branding';
-import type { StarRating as Rating } from '../types/content';
+import type { RatingSizeType, StarRating as Rating } from '../types/content';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -44,6 +44,7 @@ import { StarRating } from './StarRating/StarRating';
 import { SupportingContent } from './SupportingContent';
 import { WaveForm } from './WaveForm';
 import { YoutubeBlockComponent } from './YoutubeBlockComponent.importable';
+import { isUndefined } from '@guardian/libs';
 
 export type Position = 'inner' | 'outer' | 'none';
 
@@ -94,6 +95,7 @@ const hoverStyles = css`
 	}
 
 	/* Only underline the headline element we want to target (not kickers/sublink headlines) */
+
 	:hover .card-headline .show-underline {
 		text-decoration: underline;
 	}
@@ -105,6 +107,7 @@ const sublinkHoverStyles = css`
 		.card-headline .show-underline {
 			text-decoration: none;
 		}
+
 		.media-overlay {
 			background-color: transparent;
 		}
@@ -175,6 +178,7 @@ const overlayStyles = css`
 	${overlayMaskGradientStyles('180deg')};
 
 	/* Ensure the waveform is behind the other elements, e.g. headline, pill */
+
 	> :not(.waveform) {
 		z-index: 1;
 	}
@@ -351,6 +355,7 @@ export type Props = {
 	 */
 	isImmersive?: boolean;
 	showVideo?: boolean;
+	starRatingSize: RatingSizeType;
 };
 
 export const FeatureCard = ({
@@ -386,6 +391,7 @@ export const FeatureCard = ({
 	isNewsletter = false,
 	isImmersive = false,
 	showVideo = false,
+	starRatingSize,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -626,10 +632,10 @@ export const FeatureCard = ({
 											/>
 										</div>
 
-										{starRating !== undefined ? (
+										{!isUndefined(starRating) ? (
 											<StarRating
 												rating={starRating}
-												size="medium"
+												size={starRatingSize}
 											/>
 										) : null}
 

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -17,7 +18,7 @@ import { getOphanComponents } from '../lib/labs';
 import { transparentColour } from '../lib/transparentColour';
 import { palette } from '../palette';
 import type { Branding } from '../types/branding';
-import type { RatingSizeType, StarRating as Rating } from '../types/content';
+import type { StarRating as Rating, RatingSizeType } from '../types/content';
 import type {
 	AspectRatio,
 	DCRContainerPalette,
@@ -44,7 +45,6 @@ import { StarRating } from './StarRating/StarRating';
 import { SupportingContent } from './SupportingContent';
 import { WaveForm } from './WaveForm';
 import { YoutubeBlockComponent } from './YoutubeBlockComponent.importable';
-import { isUndefined } from '@guardian/libs';
 
 export type Position = 'inner' | 'outer' | 'none';
 

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -140,6 +140,7 @@ const ImmersiveCardLayout = ({
 					supportingContent={card.supportingContent}
 					isImmersive={true}
 					showVideo={card.showVideo}
+					starRatingSize={'medium'}
 				/>
 			</LI>
 		</UL>
@@ -348,6 +349,7 @@ const SplashCardLayout = ({
 					subtitleSize={subtitleSize}
 					headlinePosition={card.showLivePlayable ? 'outer' : 'inner'}
 					enableHls={enableHls}
+					starRatingSize={'medium'}
 				/>
 			</LI>
 		</UL>
@@ -503,6 +505,7 @@ const FullWidthCardLayout = ({
 					showKickerImage={card.format.design === ArticleDesign.Audio}
 					subtitleSize={subtitleSize}
 					enableHls={enableHls}
+					starRatingSize={'medium'}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -202,6 +202,7 @@ export const OneCardLayout = ({
 					headlinePosition={isSplashCard ? 'outer' : 'inner'}
 					subtitleSize={subtitleSize}
 					enableHls={enableHls}
+					starRatingSize={'medium'}
 				/>
 			</LI>
 		</UL>

--- a/dotcom-rendering/src/components/ImageBlockComponent.tsx
+++ b/dotcom-rendering/src/components/ImageBlockComponent.tsx
@@ -1,5 +1,5 @@
 import type { ArticleFormat } from '../lib/articleFormat';
-import type { ImageBlockElement, StarRating } from '../types/content';
+import type { ImageBlockElement } from '../types/content';
 import { ImageComponent } from './ImageComponent';
 
 type Props = {
@@ -8,7 +8,6 @@ type Props = {
 	hideCaption?: boolean;
 	title?: string;
 	isMainMedia?: boolean;
-	starRating?: StarRating;
 	isAvatar?: boolean;
 	isTimeline?: boolean;
 };
@@ -19,7 +18,6 @@ export const ImageBlockComponent = ({
 	hideCaption,
 	title,
 	isMainMedia,
-	starRating,
 	isAvatar,
 	isTimeline = false,
 }: Props) => {
@@ -30,7 +28,6 @@ export const ImageBlockComponent = ({
 			format={format}
 			hideCaption={hideCaption}
 			isMainMedia={isMainMedia}
-			starRating={starRating}
 			role={role}
 			title={title}
 			isAvatar={isAvatar}

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -28,7 +28,6 @@ import { Hide } from './Hide';
 import { Island } from './Island';
 import { LightboxLink } from './LightboxLink';
 import { Picture } from './Picture';
-import { StarRating } from './StarRating/StarRating';
 
 type Props = {
 	element: ImageBlockElement;
@@ -65,25 +64,6 @@ const timelineBulletStyles = css`
 		}
 	}
 `;
-
-const starsWrapper = css`
-	background-color: ${themePalette('--star-rating-background')};
-	color: ${themePalette('--star-rating-fill')};
-
-	position: absolute;
-	${until.tablet} {
-		bottom: 0;
-	}
-	${from.tablet} {
-		top: 0;
-	}
-`;
-
-const PositionStarRating = ({ rating }: { rating: Rating }) => (
-	<div css={starsWrapper}>
-		<StarRating rating={rating} size="large" />
-	</div>
-);
 
 const basicTitlePadding = css`
 	${until.tablet} {
@@ -429,9 +409,6 @@ export const ImageComponent = ({
 				{isTimeline && isMainMedia && role === 'showcase' && (
 					<div css={timelineBulletStyles} aria-hidden="true" />
 				)}
-				{!isUndefined(starRating) ? (
-					<PositionStarRating rating={starRating} />
-				) : null}
 				{!!title && <ImageTitle title={title} role={role} />}
 				{isWeb && !isUndefined(element.position) && (
 					<LightboxLink
@@ -533,9 +510,6 @@ export const ImageComponent = ({
 						</Row>
 					</Hide>
 				)}
-				{!isUndefined(starRating) ? (
-					<PositionStarRating rating={starRating} />
-				) : null}
 				{!!title && <ImageTitle title={title} role={role} />}
 
 				{isWeb && !isUndefined(element.position) && (

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -16,11 +16,7 @@ import {
 } from '../lib/articleFormat';
 import { getLargest, getMaster } from '../lib/image';
 import { palette as themePalette } from '../palette';
-import type {
-	ImageBlockElement,
-	StarRating as Rating,
-	RoleType,
-} from '../types/content';
+import type { ImageBlockElement, StarRating, RoleType } from '../types/content';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
 import { useConfig } from './ConfigContext';
@@ -35,7 +31,6 @@ type Props = {
 	format: ArticleFormat;
 	hideCaption?: boolean;
 	isMainMedia?: boolean;
-	starRating?: Rating;
 	title?: string;
 	isAvatar?: boolean;
 	isTimeline?: boolean;
@@ -241,7 +236,6 @@ export const ImageComponent = ({
 	hideCaption,
 	role,
 	isMainMedia,
-	starRating,
 	title,
 	isAvatar,
 	isTimeline = false,

--- a/dotcom-rendering/src/components/ImageComponent.tsx
+++ b/dotcom-rendering/src/components/ImageComponent.tsx
@@ -16,7 +16,7 @@ import {
 } from '../lib/articleFormat';
 import { getLargest, getMaster } from '../lib/image';
 import { palette as themePalette } from '../palette';
-import type { ImageBlockElement, StarRating, RoleType } from '../types/content';
+import type { ImageBlockElement, RoleType } from '../types/content';
 import { AppsLightboxImage } from './AppsLightboxImage.importable';
 import { Caption } from './Caption';
 import { useConfig } from './ConfigContext';

--- a/dotcom-rendering/src/components/MainMedia.tsx
+++ b/dotcom-rendering/src/components/MainMedia.tsx
@@ -9,10 +9,11 @@ import type { EditionId } from '../lib/edition';
 import { getZIndex } from '../lib/getZIndex';
 import { RenderArticleElement } from '../lib/renderElement';
 import type { ServerSideTests, Switches } from '../types/config';
-import type { FEElement, StarRating } from '../types/content';
+import type { FEElement } from '../types/content';
 
 const mainMedia = css`
 	height: 100%;
+
 	${until.tablet} {
 		margin: 0;
 		order: 2;
@@ -77,7 +78,6 @@ type Props = {
 	format: ArticleFormat;
 	elements: FEElement[];
 	hideCaption?: boolean;
-	starRating?: StarRating;
 	host?: string;
 	pageId: string;
 	webTitle: string;
@@ -96,7 +96,6 @@ export const MainMedia = ({
 	elements,
 	format,
 	hideCaption,
-	starRating,
 	host,
 	pageId,
 	webTitle,
@@ -129,7 +128,6 @@ export const MainMedia = ({
 					abTests={abTests}
 					switches={switches}
 					hideCaption={hideCaption}
-					starRating={starRating}
 					editionId={editionId}
 					shouldHideAds={shouldHideAds}
 					contentType={contentType}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -112,13 +112,6 @@ const content = css`
 	}
 `;
 
-const starWrapper = css`
-	width: fit-content;
-	margin-top: ${space[1]}px;
-	color: ${palette('--star-rating-fill')};
-	background-color: ${palette('--star-rating-background')};
-`;
-
 export const HighlightsCard = ({
 	linkTo,
 	format,
@@ -168,9 +161,7 @@ export const HighlightsCard = ({
 					/>
 
 					{!isUndefined(starRating) && (
-						<div css={starWrapper}>
-							<StarRating rating={starRating} size="small" />
-						</div>
+						<StarRating rating={starRating} size="small" />
 					)}
 
 					{!!mainMedia && isMediaCard && (

--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -41,6 +41,7 @@ interface Props {
 	contributorImage?: string;
 	isPlaceholder?: boolean; // use 'true' for server-side default prior to client-side enrichment
 }
+
 interface RichLinkImageData {
 	thumbnailUrl: string;
 	altText: string;
@@ -50,6 +51,7 @@ interface RichLinkImageData {
 
 const backgroundStyles = css`
 	background-color: ${themePalette('--rich-link-background')};
+
 	:hover {
 		background-color: ${themePalette('--rich-link-background-hover')};
 	}
@@ -97,7 +99,6 @@ const titleStyles = (parentIsBlog: boolean) => css`
 
 const labsTitleStyles = css`
 	${textSansBold15}
-
 	${from.wide} {
 		${textSansBold17}
 	}
@@ -127,12 +128,6 @@ const contributorWrapperStyles = css`
 const paidForBrandingStyles = css`
 	color: ${themePalette('--rich-link-branding-text')};
 	${textSansBold12};
-`;
-
-const starWrapperStyles = css`
-	background-color: ${themePalette('--star-rating-background')};
-	color: ${themePalette('--star-rating-fill')};
-	display: inline-block;
 `;
 
 const readMoreStyles = css`
@@ -269,12 +264,7 @@ export const RichLink = ({
 							)}
 
 							{!isUndefined(starRating) ? (
-								<div css={starWrapperStyles}>
-									<StarRating
-										rating={starRating}
-										size="small"
-									/>
-								</div>
+								<StarRating rating={starRating} size="small" />
 							) : null}
 
 							{!!(isPaidContent && sponsorName) && (

--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -257,15 +257,19 @@ export const RichLink = ({
 								)}
 
 								{linkText}
+
+								{!isUndefined(starRating) ? (
+									<StarRating
+										rating={starRating}
+										paddingSize={'medium'}
+										size="small"
+									/>
+								) : null}
 							</div>
 
 							{isOpinion && byline !== '' && (
 								<div css={[bylineStyles]}>{byline}</div>
 							)}
-
-							{!isUndefined(starRating) ? (
-								<StarRating rating={starRating} size="small" />
-							) : null}
 
 							{!!(isPaidContent && sponsorName) && (
 								<div css={paidForBrandingStyles}>

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -81,6 +81,7 @@ export const ScrollableFeature = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
+							starRatingSize={'small'}
 						/>
 					</ScrollableCarousel.Item>
 				);

--- a/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -81,18 +81,18 @@ LargeStory.storyName = 'Large stars';
 export const StarPadding = () => (
 	<>
 		<div>
-			<p>Small Padding</p>
-			<div style={{ backgroundColor: 'red' }}>
-				<StarRating rating={0} size="large" paddingSize={'small'} />
-			</div>
-			<p>Medium Padding</p>
-			<div style={{ backgroundColor: 'orange' }}>
-				<StarRating rating={1} size="large" paddingSize={'medium'} />
-			</div>
+			<span>Small Padding</span>
+			<StarRating rating={0} size="large" paddingSize={'small'} />
+			<br />
+			<br />
+			<span>Medium Padding</span>
+			<StarRating rating={1} size="large" paddingSize={'medium'} />
+			<br />
+			<br />
 			<p>Large Padding</p>
-			<div style={{ backgroundColor: 'yellow' }}>
-				<StarRating rating={2} size="large" paddingSize={'large'} />
-			</div>
+			<StarRating rating={2} size="large" paddingSize={'large'} />
+			<br />
+			<br />
 		</div>
 	</>
 );

--- a/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -78,29 +78,22 @@ export const LargeStory = () => (
 );
 LargeStory.storyName = 'Large stars';
 
-export const StarColours = () => (
+export const StarPadding = () => (
 	<>
-		<div style={{ backgroundColor: '#f6dde1' }}>
-			<p>Stars take the colour of the parent by default</p>
-			<div style={{ color: 'red' }}>
-				<StarRating rating={0} size="large" />
+		<div>
+			<p>Small Padding</p>
+			<div style={{ backgroundColor: 'red' }}>
+				<StarRating rating={0} size="large" paddingSize={'small'} />
 			</div>
-			<div style={{ color: 'orange' }}>
-				<StarRating rating={1} size="large" />
+			<p>Medium Padding</p>
+			<div style={{ backgroundColor: 'orange' }}>
+				<StarRating rating={1} size="large" paddingSize={'medium'} />
 			</div>
-			<div style={{ color: 'yellow' }}>
-				<StarRating rating={2} size="large" />
-			</div>
-			<div style={{ color: 'green' }}>
-				<StarRating rating={3} size="large" />
-			</div>
-			<div style={{ color: 'blue' }}>
-				<StarRating rating={4} size="large" />
-			</div>
-			<div style={{ color: 'purple' }}>
-				<StarRating rating={5} size="large" />
+			<p>Large Padding</p>
+			<div style={{ backgroundColor: 'yellow' }}>
+				<StarRating rating={2} size="large" paddingSize={'large'} />
 			</div>
 		</div>
 	</>
 );
-StarColours.storyName = 'Star colours';
+StarPadding.storyName = 'Star padding';

--- a/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -55,6 +55,29 @@ export const SmallStory = () => (
 );
 SmallStory.storyName = 'Small Stars';
 
+export const MediumStory = () => (
+	<>
+		<h1>0 Star</h1>
+		<StarRating rating={0} size="medium" />
+		<br />
+		<h1>1 Star</h1>
+		<StarRating rating={1} size="medium" />
+		<br />
+		<h1>2 Star</h1>
+		<StarRating rating={2} size="medium" />
+		<br />
+		<h1>3 Star</h1>
+		<StarRating rating={3} size="medium" />
+		<br />
+		<h1>4 Star</h1>
+		<StarRating rating={4} size="medium" />
+		<br />
+		<h1>5 Star</h1>
+		<StarRating rating={5} size="medium" />
+	</>
+);
+MediumStory.storyName = 'Medium stars';
+
 export const LargeStory = () => (
 	<>
 		<h1>0 Star</h1>

--- a/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.stories.tsx
@@ -20,6 +20,11 @@ export const AllSizeStars = () => (
 		<StarRating rating={3} size="small" />
 		<br />
 		<br />
+		<h1>Medium</h1>
+		<br />
+		<StarRating rating={3} size="medium" />
+		<br />
+		<br />
 		<h1>Large</h1>
 		<br />
 		<StarRating rating={3} size="large" />

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -2,8 +2,9 @@ import { css } from '@emotion/react';
 import { SvgStar, SvgStarOutline } from '@guardian/source/react-components';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 
-const padding = css`
-	padding: 0 2px;
+const flex = css`
+	display: flex;
+	flex-direction: row;
 `;
 
 const starBackground = css`
@@ -45,15 +46,15 @@ type Props = {
 };
 
 export const StarRating = ({ rating, size }: Props) => (
-	<div css={[determineSize(size), padding]}>
+	<div css={[determineSize(size), flex]}>
 		{Array.from({ length: 5 }, (_, i) =>
 			i < rating ? (
-				<div css={[starBackground, filledColor]}>
-					<SvgStar key={i} />
+				<div key={i} css={[starBackground, filledColor]}>
+					<SvgStar />
 				</div>
 			) : (
-				<div css={[starBackground, outlineColor]}>
-					<SvgStarOutline key={i} />
+				<div key={i} css={[starBackground, outlineColor]}>
+					<SvgStarOutline />
 				</div>
 			),
 		)}

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -9,15 +9,16 @@ const flex = css`
 `;
 
 const starBackground = css`
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	border-radius: 50%;
-	width: fit-content;
-	height: fit-content;
 `;
 
-const filledColor = css`
+const filledStarColor = css`
 	background-color: yellow;
 `;
-const outlineColor = css`
+const emptyStarColor = css`
 	background-color: grey;
 `;
 const determineSize = (size: RatingSizeType) => {
@@ -25,19 +26,25 @@ const determineSize = (size: RatingSizeType) => {
 		case 'small':
 			return css`
 				column-gap: 1px;
+				div {
+					width: 18px;
+					height: 18px;
+				}
 				svg {
-					width: 1.3em;
-					height: 1.3em;
-					margin: 0 -1px -2px;
+					width: 12px;
+					height: 12px;
 				}
 			`;
 		case 'large':
 			return css`
 				column-gap: 2px;
+				div {
+					width: 28px;
+					height: 28px;
+				}
 				svg {
-					width: 1.6em;
-					height: 1.6em;
-					margin: 0 -2px -2px;
+					width: 18px;
+					height: 18px;
 				}
 			`;
 	}
@@ -52,11 +59,11 @@ export const StarRating = ({ rating, size }: Props) => (
 	<div css={[determineSize(size), flex]}>
 		{Array.from({ length: 5 }, (_, i) =>
 			i < rating ? (
-				<div key={i} css={[starBackground, filledColor]}>
+				<div key={i} css={[starBackground, filledStarColor]}>
 					<SvgStar />
 				</div>
 			) : (
-				<div key={i} css={[starBackground, outlineColor]}>
+				<div key={i} css={[starBackground, emptyStarColor]}>
 					<SvgStarOutline />
 				</div>
 			),

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -6,7 +6,6 @@ import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 const flex = css`
 	display: flex;
 	flex-direction: row;
-	padding: 2px;
 `;
 
 const starBackground = css`

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { SvgStar, SvgStarOutline } from '@guardian/source/react-components';
+import { palette } from '../../palette';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 
 const flex = css`
@@ -16,10 +17,10 @@ const starBackground = css`
 `;
 
 const filledStarColor = css`
-	background-color: yellow;
+	background-color: ${palette('--star-rating-background')};
 `;
 const emptyStarColor = css`
-	background-color: grey;
+	background-color: ${palette('--star-rating-empty-background')};
 `;
 const determineSize = (size: RatingSizeType) => {
 	switch (size) {

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -3,9 +3,10 @@ import { SvgStar, SvgStarOutline } from '@guardian/source/react-components';
 import { palette } from '../../palette';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 
-const flex = css`
+const container = css`
 	display: flex;
 	flex-direction: row;
+	padding-top: 4px;
 `;
 
 const starBackground = css`
@@ -75,7 +76,7 @@ type Props = {
 };
 
 export const StarRating = ({ rating, size }: Props) => (
-	<div css={[determineSize(size), flex]}>
+	<div css={[determineSize(size), container]}>
 		{Array.from({ length: 5 }, (_, i) =>
 			i < rating ? (
 				<div key={i} css={[starBackground, filledStarColor]}>

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -5,6 +5,7 @@ import type { StarRating as Rating, RatingSizeType } from '../../types/content';
 const flex = css`
 	display: flex;
 	flex-direction: row;
+	padding: 2px;
 `;
 
 const starBackground = css`
@@ -23,6 +24,7 @@ const determineSize = (size: RatingSizeType) => {
 	switch (size) {
 		case 'small':
 			return css`
+				column-gap: 1px;
 				svg {
 					width: 1.3em;
 					height: 1.3em;
@@ -31,6 +33,7 @@ const determineSize = (size: RatingSizeType) => {
 			`;
 		case 'large':
 			return css`
+				column-gap: 2px;
 				svg {
 					width: 1.6em;
 					height: 1.6em;

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -2,11 +2,11 @@ import { css } from '@emotion/react';
 import { SvgStar, SvgStarOutline } from '@guardian/source/react-components';
 import { palette } from '../../palette';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
+import { from } from '@guardian/source/foundations';
 
 const container = css`
 	display: flex;
 	flex-direction: row;
-	padding-top: 4px;
 `;
 
 const starBackground = css`
@@ -70,13 +70,44 @@ const determineSize = (size: RatingSizeType) => {
 	}
 };
 
+type PaddingSizeType = 'small' | 'medium' | 'large';
+
+const determinePaddingTop = (size: PaddingSizeType) => {
+	switch (size) {
+		case 'small':
+			return css`
+				padding-top: 4px;
+			`;
+
+		case 'medium':
+			return css`
+				padding-top: 4px;
+
+				${from.tablet} {
+					padding-top: 8px;
+				}
+			`;
+		case 'large':
+			return css`
+				padding-top: 8px;
+
+				${from.tablet} {
+					padding-top: 12px;
+				}
+			`;
+	}
+};
+
 type Props = {
 	rating: Rating;
 	size: RatingSizeType;
+	paddingSize?: PaddingSizeType;
 };
 
-export const StarRating = ({ rating, size }: Props) => (
-	<div css={[determineSize(size), container]}>
+export const StarRating = ({ rating, size, paddingSize = 'small' }: Props) => (
+	<div
+		css={[determineSize(size), determinePaddingTop(paddingSize), container]}
+	>
 		{Array.from({ length: 5 }, (_, i) =>
 			i < rating ? (
 				<div key={i} css={[starBackground, filledStarColor]}>

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -36,6 +36,19 @@ const determineSize = (size: RatingSizeType) => {
 					height: 12px;
 				}
 			`;
+
+		case 'medium':
+			return css`
+				column-gap: 2px;
+				div {
+					width: 22px;
+					height: 22px;
+				}
+				svg {
+					width: 14px;
+					height: 14px;
+				}
+			`;
 		case 'large':
 			return css`
 				column-gap: 2px;

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -26,38 +26,44 @@ const determineSize = (size: RatingSizeType) => {
 		case 'small':
 			return css`
 				column-gap: 1px;
+
 				div {
 					width: 18px;
 					height: 18px;
 				}
+
 				svg {
-					width: 12px;
-					height: 12px;
+					width: 16px;
+					height: 16px;
 				}
 			`;
 
 		case 'medium':
 			return css`
 				column-gap: 2px;
+
 				div {
 					width: 22px;
 					height: 22px;
 				}
+
 				svg {
-					width: 14px;
-					height: 14px;
+					width: 20px;
+					height: 20px;
 				}
 			`;
 		case 'large':
 			return css`
 				column-gap: 2px;
+
 				div {
 					width: 28px;
 					height: 28px;
 				}
+
 				svg {
-					width: 18px;
-					height: 18px;
+					width: 24px;
+					height: 24px;
 				}
 			`;
 	}

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
 import { SvgStar, SvgStarOutline } from '@guardian/source/react-components';
 import { palette } from '../../palette';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
-import { from } from '@guardian/source/foundations';
 
 const container = css`
 	display: flex;

--- a/dotcom-rendering/src/components/StarRating/StarRating.tsx
+++ b/dotcom-rendering/src/components/StarRating/StarRating.tsx
@@ -6,6 +6,18 @@ const padding = css`
 	padding: 0 2px;
 `;
 
+const starBackground = css`
+	border-radius: 50%;
+	width: fit-content;
+	height: fit-content;
+`;
+
+const filledColor = css`
+	background-color: yellow;
+`;
+const outlineColor = css`
+	background-color: grey;
+`;
 const determineSize = (size: RatingSizeType) => {
 	switch (size) {
 		case 'small':
@@ -35,7 +47,15 @@ type Props = {
 export const StarRating = ({ rating, size }: Props) => (
 	<div css={[determineSize(size), padding]}>
 		{Array.from({ length: 5 }, (_, i) =>
-			i < rating ? <SvgStar key={i} /> : <SvgStarOutline key={i} />,
+			i < rating ? (
+				<div css={[starBackground, filledColor]}>
+					<SvgStar key={i} />
+				</div>
+			) : (
+				<div css={[starBackground, outlineColor]}>
+					<SvgStarOutline key={i} />
+				</div>
+			),
 		)}
 	</div>
 );

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import {
 	ArticleDesign,

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.stories.tsx
@@ -1,3 +1,5 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
 import { splitTheme } from '../../.storybook/decorators/splitThemeDecorator';
 import {
 	ArticleDesign,
@@ -13,22 +15,32 @@ const articleFormat: ArticleFormat = {
 	theme: Pillar.News,
 };
 
-export default {
+const meta = {
 	component: StarRatingBlockComponent,
 	title: 'Components/StarRatingBlockComponent',
-};
+	decorators: [splitTheme([articleFormat])],
+} satisfies Meta<typeof StarRatingBlockComponent>;
 
-export const AllSizes = () => (
-	<>
-		<h1>Small</h1>
-		<br />
-		<StarRatingBlockComponent rating={3} size="small" />
-		<br />
-		<br />
-		<h1>Large</h1>
-		<br />
-		<StarRatingBlockComponent rating={3} size="large" />
-	</>
-);
-AllSizes.storyName = 'All stars sizes';
-AllSizes.decorators = [splitTheme([articleFormat])];
+export default meta;
+type Story = StoryObj<typeof StarRatingBlockComponent>;
+
+export const AllSizes: Story = {
+	name: 'All stars sizes',
+	render: () => (
+		<>
+			<h1>Small</h1>
+			<br />
+			<StarRatingBlockComponent rating={3} size="small" />
+			<br />
+			<br />
+			<h1>medium</h1>
+			<br />
+			<StarRatingBlockComponent rating={3} size="medium" />
+			<br />
+			<br />
+			<h1>Large</h1>
+			<br />
+			<StarRatingBlockComponent rating={3} size="large" />
+		</>
+	),
+};

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
@@ -9,7 +9,6 @@ type Props = {
 };
 
 const starsWrapper = css`
-	background-color: ${palette('--star-rating-background')};
 	color: ${palette('--star-rating-fill')};
 	display: inline-block;
 `;

--- a/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/StarRatingBlockComponent.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { palette } from '../palette';
 import type { StarRating as Rating, RatingSizeType } from '../types/content';
 import { StarRating } from './StarRating/StarRating';
 
@@ -9,7 +8,6 @@ type Props = {
 };
 
 const starsWrapper = css`
-	color: ${palette('--star-rating-fill')};
 	display: inline-block;
 `;
 

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -81,6 +81,7 @@ export const StaticFeatureTwo = ({
 							isNewsletter={card.isNewsletter}
 							showQuotes={card.showQuotedHeadline}
 							showVideo={card.showVideo}
+							starRatingSize={'medium'}
 						/>
 					</LI>
 				);

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -3385,6 +3385,7 @@
         "RatingSizeType": {
             "enum": [
                 "large",
+                "medium",
                 "small"
             ],
             "type": "string"

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -37,11 +36,7 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	type ArticleFormat,
-} from '../lib/articleFormat';
+import { ArticleDisplay, type ArticleFormat } from '../lib/articleFormat';
 import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
@@ -362,13 +357,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									starRating={
-										format.design ===
-											ArticleDesign.Review &&
-										!isUndefined(article.starRating)
-											? article.starRating
-											: undefined
-									}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}
@@ -412,6 +400,7 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 											article.webPublicationDateDeprecated
 										}
 										hasAvatar={!!avatarUrl}
+										starRating={article.starRating}
 									/>
 									{/* BOTTOM */}
 									<div>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -359,12 +358,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					<MainMedia
 						format={format}
 						elements={article.mainMediaElements}
-						starRating={
-							format.design === ArticleDesign.Review &&
-							!isUndefined(article.starRating)
-								? article.starRating
-								: undefined
-						}
 						host={host}
 						hideCaption={true}
 						pageId={article.pageId}
@@ -424,6 +417,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 										webPublicationDateDeprecated={
 											article.webPublicationDateDeprecated
 										}
+										starRating={article.starRating}
 									/>
 								</Section>
 							</Box>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -44,7 +43,6 @@ import { Pagination } from '../components/Pagination';
 import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
 import { Standfirst } from '../components/Standfirst';
-import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
@@ -66,12 +64,15 @@ const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 			/* IE Fallback */
 			display: flex;
 			flex-direction: column;
+
 			${until.desktop} {
 				margin-left: 0px;
 			}
+
 			${from.desktop} {
 				margin-left: 240px;
 			}
+
 			@supports (display: grid) {
 				display: grid;
 				width: 100%;
@@ -86,12 +87,14 @@ const HeadlineGrid = ({ children }: { children: React.ReactNode }) => (
 					grid-template-columns: 220px 700px;
 					grid-template-areas: 'title	headline';
 				}
+
 				${until.desktop} {
 					grid-template-columns: 100%; /* Main content */
 					grid-template-areas:
 						'title'
 						'headline';
 				}
+
 				${until.tablet} {
 					grid-column-gap: 0px;
 				}
@@ -108,12 +111,15 @@ const StandFirstGrid = ({ children }: { children: React.ReactNode }) => (
 			/* IE Fallback */
 			display: flex;
 			flex-direction: column;
+
 			${until.desktop} {
 				margin-left: 0px;
 			}
+
 			${from.desktop} {
 				margin-left: 240px;
 			}
+
 			@supports (display: grid) {
 				display: grid;
 				width: 100%;
@@ -127,6 +133,7 @@ const StandFirstGrid = ({ children }: { children: React.ReactNode }) => (
 						'meta';
 					grid-column-gap: 0px;
 				}
+
 				${from.desktop} {
 					grid-template-columns: 220px 620px;
 					grid-template-areas: 'lastupdated standfirst';
@@ -144,12 +151,15 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 			/* IE Fallback */
 			display: flex;
 			flex-direction: column;
+
 			${until.desktop} {
 				margin-left: 0px;
 			}
+
 			${from.desktop} {
 				margin-left: 320px;
 			}
+
 			@supports (display: grid) {
 				display: grid;
 				width: 100%;
@@ -169,6 +179,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'info		media'
 						'info		body';
 				}
+
 				/* from wide define fixed body width */
 				${from.wide} {
 					grid-column-gap: 20px;
@@ -177,6 +188,7 @@ const LiveGrid = ({ children }: { children: React.ReactNode }) => (
 						'info		media		right-column'
 						'info		body		right-column';
 				}
+
 				/* until desktop define fixed body width */
 				${until.desktop} {
 					grid-template-columns: 100%; /* Main content */
@@ -203,6 +215,7 @@ const stretchLines = css`
 		margin-left: -20px;
 		margin-right: -20px;
 	}
+
 	${until.mobileLandscape} {
 		margin-left: -10px;
 		margin-right: -10px;
@@ -218,27 +231,10 @@ const sidePaddingDesktop = css`
 const bodyWrapper = css`
 	position: relative;
 	margin-bottom: ${space[3]}px;
+
 	${from.desktop} {
 		margin-bottom: 0;
 	}
-`;
-
-const starWrapper = css`
-	margin-bottom: 18px;
-	margin-top: 6px;
-	background-color: ${themePalette('--star-rating-background')};
-	color: ${themePalette('--star-rating-fill')};
-	display: inline-block;
-	${until.phablet} {
-		padding-left: 20px;
-		margin-left: -20px;
-	}
-	${until.leftCol} {
-		padding-left: 0px;
-		margin-left: -0px;
-	}
-	padding-left: 10px;
-	margin-left: -10px;
 `;
 
 interface BaseProps {
@@ -431,17 +427,10 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											webPublicationDateDeprecated={
 												article.webPublicationDateDeprecated
 											}
+											starRating={article.starRating}
 										/>
 									)}
 								</div>
-								{!isUndefined(article.starRating) ? (
-									<div css={starWrapper}>
-										<StarRating
-											rating={article.starRating}
-											size="large"
-										/>
-									</div>
-								) : null}
 							</GridItem>
 						</HeadlineGrid>
 					</Section>
@@ -903,17 +892,20 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 								<div
 									css={css`
 										height: 100%;
+
 										${from.desktop} {
 											/* above 980 */
 											margin-left: 20px;
 											margin-right: -20px;
 											display: none;
 										}
+
 										${from.leftCol} {
 											/* above 1140 */
 											margin-left: 0px;
 											margin-right: 0px;
 										}
+
 										${from.wide} {
 											display: block;
 											padding-bottom: 255px;

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -34,7 +33,7 @@ import { Standfirst } from '../components/Standfirst';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
-import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
+import type { ArticleFormat } from '../lib/articleFormat';
 import { getSoleContributor } from '../lib/byline';
 import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -399,6 +399,7 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 										webPublicationDateDeprecated={
 											article.webPublicationDateDeprecated
 										}
+										starRating={article.starRating}
 									/>
 								</div>
 							</GridItem>
@@ -414,13 +415,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									starRating={
-										format.design ===
-											ArticleDesign.Review &&
-										!isUndefined(article.starRating)
-											? article.starRating
-											: undefined
-									}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -368,13 +367,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								<MainMedia
 									format={format}
 									elements={article.mainMediaElements}
-									starRating={
-										format.design ===
-											ArticleDesign.Review &&
-										!isUndefined(article.starRating)
-											? article.starRating
-											: undefined
-									}
 									host={host}
 									pageId={article.pageId}
 									webTitle={article.webTitle}
@@ -410,6 +402,7 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 									webPublicationDateDeprecated={
 										article.webPublicationDateDeprecated
 									}
+									starRating={article.starRating}
 								/>
 							</PositionHeadline>
 						</GridItem>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isUndefined } from '@guardian/libs';
 import {
 	from,
 	palette as sourcePalette,
@@ -41,7 +40,6 @@ import { RightColumn } from '../components/RightColumn';
 import { Section } from '../components/Section';
 import { SlotBodyEnd } from '../components/SlotBodyEnd.importable';
 import { Standfirst } from '../components/Standfirst';
-import { StarRating } from '../components/StarRating/StarRating';
 import { StickyBottomBanner } from '../components/StickyBottomBanner.importable';
 import { SubMeta } from '../components/SubMeta';
 import { SubNav } from '../components/SubNav.importable';
@@ -320,21 +318,6 @@ const stretchLines = css`
 	}
 `;
 
-const starWrapper = css`
-	background-color: ${themePalette('--star-rating-background')};
-	color: ${themePalette('--star-rating-fill')};
-	display: inline-block;
-
-	${until.phablet} {
-		padding-left: 20px;
-		margin-left: -20px;
-	}
-	${until.leftCol} {
-		padding-left: 0px;
-		margin-left: -0px;
-	}
-`;
-
 interface Props {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
@@ -547,20 +530,11 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									webPublicationDateDeprecated={
 										article.webPublicationDateDeprecated
 									}
+									starRating={article.starRating}
 								/>
 							</div>
 						</GridItem>
 						<GridItem area="standfirst">
-							{!isUndefined(article.starRating) ? (
-								<div css={starWrapper}>
-									<StarRating
-										rating={article.starRating}
-										size="large"
-									/>
-								</div>
-							) : (
-								<></>
-							)}
 							<Standfirst
 								format={format}
 								standfirst={article.standfirst}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -380,7 +380,6 @@ export const renderElement = ({
 					element={element}
 					hideCaption={hideCaption}
 					isMainMedia={isMainMedia}
-					starRating={starRating ?? element.starRating}
 					title={element.title}
 					isAvatar={element.isAvatar}
 					isTimeline={isTimeline}

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2873,6 +2873,7 @@
         "RatingSizeType": {
             "enum": [
                 "large",
+                "medium",
                 "small"
             ],
             "type": "string"

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -1490,9 +1490,19 @@ const starRatingFillColourLight: PaletteFunction = () =>
 	sourcePalette.neutral[7];
 const starRatingFillColourDark: PaletteFunction = () =>
 	sourcePalette.neutral[0];
+
 const starRatingBackgroundColourLight: PaletteFunction = () =>
 	sourcePalette.brandAlt[400];
 const starRatingBackgroundColourDark: PaletteFunction = () =>
+	sourcePalette.brandAlt[200];
+const starRatingEmptyBackgroundColourLight: PaletteFunction = () =>
+	sourcePalette.neutral[86];
+const starRatingEmptyBackgroundColourDark: PaletteFunction = () =>
+	sourcePalette.neutral[60];
+
+const calloutHighlightBackgroundColourLight: PaletteFunction = () =>
+	sourcePalette.brandAlt[400];
+const calloutHighlightBackgroundColourDark: PaletteFunction = () =>
 	sourcePalette.brandAlt[200];
 
 const blockQuoteFillLight: PaletteFunction = (format: ArticleFormat) => {
@@ -6557,8 +6567,8 @@ const paletteColours = {
 		dark: bylineUnderline,
 	},
 	'--callout-highlight-background': {
-		light: starRatingBackgroundColourLight,
-		dark: starRatingBackgroundColourDark,
+		light: calloutHighlightBackgroundColourLight,
+		dark: calloutHighlightBackgroundColourDark,
 	},
 	'--callout-highlight-text': {
 		light: starRatingFillColourLight,
@@ -7952,6 +7962,10 @@ const paletteColours = {
 	'--star-rating-background': {
 		light: starRatingBackgroundColourLight,
 		dark: starRatingBackgroundColourDark,
+	},
+	'--star-rating-empty-background': {
+		light: starRatingEmptyBackgroundColourLight,
+		dark: starRatingEmptyBackgroundColourDark,
 	},
 	'--star-rating-fill': {
 		light: starRatingFillColourLight,

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -989,7 +989,7 @@ export type TimelineAtomType = {
 	expandCallback?: () => void;
 };
 
-export type RatingSizeType = 'large' | 'small';
+export type RatingSizeType = 'large' | 'medium' | 'small';
 
 export type ImageForLightbox = {
 	masterUrl: string;


### PR DESCRIPTION
## What does this change?
Updates the star rating design. 

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
