### PR TITLE
Use correct property to get self-hosted video poster image

### DIFF
--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -176,10 +176,11 @@ const decideMediaAtomImage = (
 	videoReplace: boolean,
 	mediaAtom: FEMediaAtom,
 	cardTrailImage?: string,
+	isSelfHostedVideo?: boolean,
 ) => {
-	const largestMediaAtomImage = getLargestImageUrl(
-		mediaAtom.trailImage?.allImages,
-	);
+	const largestMediaAtomImage = isSelfHostedVideo
+		? getLargestImageUrl(mediaAtom.posterImage?.allImages)
+		: getLargestImageUrl(mediaAtom.trailImage?.allImages);
 
 	if (videoReplace) {
 		return largestMediaAtomImage ?? cardTrailImage;
@@ -213,6 +214,7 @@ export const getActiveMediaAtom = (
 			videoReplace,
 			mediaAtom,
 			cardTrailImage,
+			firstVideoAsset.platform === 'Url',
 		);
 
 		/**


### PR DESCRIPTION
## What does this change?

Use the `posterImage` field on the media atom object instead of the `trailImage field` to get the image associated with the self-hosted media atom. 

Does not affect Youtube video.

## Why?

The `trailImage` property is not populated for self-hosted video, which has led us to always using the fallback trail image instead. We now use the first frame of the video as the poster image of the self-hosted media atom, which ensures a smooth play when transitioning from the poster image to the video playing, so it's a big UX improvement to use this image over the trail image.

No `trailImage`!
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/981b5dfb-4ea0-42f3-9b52-57c6c5586788" />

## Screenshots

When fully in view

### Before

https://github.com/user-attachments/assets/9cf4e413-e6e6-4a0d-8fdc-b8f71227d2bf

### After

https://github.com/user-attachments/assets/c87bbaae-7d33-4830-97f2-5183a8cd1ab2

When scrolled into view

### Before

https://github.com/user-attachments/assets/9c744107-b14e-415a-ac6d-d46f70de7839

### After

https://github.com/user-attachments/assets/5ab66547-8788-4bac-bf30-0bbf216f8b1a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
