### PR TITLE
Remove unecessary storybook commands from outer package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,6 @@
 	"private": true,
 	"scripts": {
 		"postinstall": "./scripts/postinstall.sh",
-		"storybook": "pnpm '/^storybook:.*/'",
-		"storybook:dcr": "pnpm --filter @guardian/dotcom-rendering storybook --no-open --quiet",
-		"build-storybook": "pnpm '/^build-storybook:.*/'",
-		"build-storybook:dcr": "pnpm --filter @guardian/dotcom-rendering build-storybook",
 		"build:dcr": "cd dotcom-rendering && make build",
 		"chromatic": "chromatic --build-script-name=build-storybook --exit-zero-on-changes",
 		"prepare": "husky",


### PR DESCRIPTION
After apps-rendering was removed, we don't need them: 
* https://github.com/guardian/dotcom-rendering/pull/14966.  

We can run storybook from the [makefile](https://github.com/guardian/dotcom-rendering/blob/2b6e23fa25afbb4020ee81b3a921c9afbcc39720/dotcom-rendering/makefile#L69).
