### PR TITLE
Fix hover in galleries contributor

### DIFF
--- a/dotcom-rendering/src/components/Contributor.tsx
+++ b/dotcom-rendering/src/components/Contributor.tsx
@@ -35,7 +35,7 @@ const galleryBylineStyles = css`
 	a {
 		font-style: italic;
 		:hover {
-			text-decoration: none;
+			text-decoration: underline;
 			border-color: ${schemedPalette('--byline-anchor')};
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/guardian/dotcom-rendering/issues/15036

## What does this change?
Makes byline underlined on hover

## Why?
To match the designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1198" height="574" alt="image" src="https://github.com/user-attachments/assets/848a1c5f-05c0-4d7c-975a-0cdcd2deba87" /> | <img width="1260" height="566" alt="image" src="https://github.com/user-attachments/assets/0ac805bc-b961-4643-b3ca-df3d218697cb" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


