### PR TITLE
Remove unnecessary CSS

### DIFF
--- a/dotcom-rendering/src/components/Contributor.tsx
+++ b/dotcom-rendering/src/components/Contributor.tsx
@@ -35,7 +35,6 @@ const galleryBylineStyles = css`
 	a {
 		font-style: italic;
 		:hover {
-			text-decoration: underline;
 			border-color: ${schemedPalette('--byline-anchor')};
 		}
 	}


### PR DESCRIPTION
## What does this change?
Removes unnecessary CSS that handles hover state inside the gallery byline styles.

## Why?
It was introduced in:
* https://github.com/guardian/dotcom-rendering/pull/15041

but we don't need it. Hover state is handled by the default byline styles

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1151" height="489" alt="image" src="https://github.com/user-attachments/assets/87feeb7a-5cfc-498e-8c7c-a0a588cf6a8e" /> | <img width="1248" height="488" alt="image" src="https://github.com/user-attachments/assets/85af7f3c-ca71-4810-be12-3f70444ad121" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


