### PR TITLE
Preload self-hosted video metadata when video is expected to play

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -178,7 +178,6 @@ export const SelfHostedVideo = ({
 	const [isMuted, setIsMuted] = useState(true);
 	const [hasAudio, setHasAudio] = useState(true);
 	const [showPlayIcon, setShowPlayIcon] = useState(false);
-	const [preloadPartialData, setPreloadPartialData] = useState(false);
 	const [showPosterImage, setShowPosterImage] = useState<boolean>(false);
 	const [currentTime, setCurrentTime] = useState(0);
 	const [playerState, setPlayerState] =
@@ -526,15 +525,6 @@ export const SelfHostedVideo = ({
 		}
 	}, [isAutoplayAllowed, isInView, hasBeenInView]);
 
-	/**
-	 * We almost always want to preload some of the video data. If a user has prefers-reduced-motion
-	 * enabled, then the video will only be partially preloaded (metadata + small amount of video)
-	 * when it comes into view.
-	 */
-	useEffect(() => {
-		setPreloadPartialData(isAutoplayAllowed === false || !!isInView);
-	}, [isAutoplayAllowed, isInView]);
-
 	if (adapted) {
 		return FallbackImageComponent;
 	}
@@ -692,6 +682,12 @@ export const SelfHostedVideo = ({
 	const optimisedPosterImage = showPosterImage
 		? getOptimisedPosterImage(posterImage)
 		: undefined;
+
+	/**
+	 * We almost always want to preload some of the video data. The exception
+	 * is when autoplay is off and the video is only partially in view.
+	 */
+	const preloadPartialData = !!isAutoplayAllowed || !!isInView;
 
 	return (
 		<div


### PR DESCRIPTION
## What does this change?

Preload partial data (metadata and also part of the video) when the video is expected to play. 

Improves comment.

## Why?

Fixes a bug with preloading metadata. The comment was correct but the code was wrong.

Simplifies the code and removes an unnecessary `useEffect`.

## Notes

The preload attribute is [sometimes ignored by browsers](https://web.dev/articles/fast-playback-with-preload#video_preload_attribute). I was finding this to be true when testing a HLS video on Chrome on Macbook.

