### PR TITLE
Add new dispatch event for when no banner is rendered

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -406,15 +406,12 @@ export const StickyBottomBanner = ({
 		isInAuxiaControlGroup,
 	]);
 
-	//Dispatches 'banner:none' event after pickMessage completes with no banner selected.
-	//hasPickMessageCompleted distinguishes between initial state (not picked yet) and final state (picked nothing).
+	// Dispatches 'banner:none' event for mobile sticky ad integration (see @guardian/commercial-dev).
+	// Ensures ads only insert when no banner will be shown.
+	// hasPickMessageCompleted distinguishes between initial state (not picked yet) and final state (picked nothing).
 	useEffect(() => {
 		if (hasPickMessageCompleted && SelectedBanner == null) {
-			document.dispatchEvent(
-				new CustomEvent('banner:none', {
-					detail: { readerRevenue: false },
-				}),
-			);
+			document.dispatchEvent(new CustomEvent('banner:none'));
 		}
 	}, [SelectedBanner, hasPickMessageCompleted]);
 	if (SelectedBanner) {


### PR DESCRIPTION
## What does this change?
Adds custom event dispatching to the `StickyBottomBanner` component to signal banner state to the commercial bundle:

- `banner:none` - Fired when no banner is selected to display

These events are dispatched via `document.dispatchEvent()` and can be listened to by the commercial bundle to control when mobile sticky ads should show.

## Why?
The commercial team needs to coordinate mobile sticky ad placement with reader revenue banners. Mobile sticky ads should only show when:
- A banner has been closed (`banner:close`)
- No banner is due to show (`banner:none`)

This prevents ads from showing up in the DOM and going against google ad policy

Related to https://github.com/guardian/commercial/pull/2351 which implements the listening logic.

