### PR TITLE
Reinstate Sentry sample rate of 1%

### DIFF
--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.test.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.test.ts
@@ -34,7 +34,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 			}),
 		).toEqual(true);
 	});
-	it('does enable Sentry for 0.1% of users', () => {
+	it('does enable Sentry for 1% of users', () => {
 		expect(
 			isSentryEnabled({
 				isDev: false,
@@ -56,7 +56,7 @@ describe('Enable Sentry when it passes loading conditions', () => {
 				isDev: false,
 				enableSentryReporting: true,
 				isInBrowserVariantTest: false,
-				random: 99.9001 / 100,
+				random: 99.0001 / 100,
 			}),
 		).toEqual(true);
 		expect(

--- a/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
+++ b/dotcom-rendering/src/client/sentryLoader/sentryLoader.ts
@@ -24,11 +24,11 @@ const isSentryEnabled = ({
 	if (isInBrowserVariantTest) return true;
 	// Sentry lets you configure sampleRate to reduce the volume of events sent
 	// but this filter only happens _after_ the library is loaded. The Guardian
-	// measures page views in the billions so we only want to log 0.1% of errors that
+	// measures page views in the billions so we only want to log 1% of errors that
 	// happen but if we used sampleRate to do this we'd be needlessly downloading
-	// Sentry 99.9% of the time. So instead we just do some math here and use that
+	// Sentry 99% of the time. So instead we just do some math here and use that
 	// to prevent the Sentry script from ever loading.
-	if (random <= 999 / 1000) return false;
+	if (random <= 99 / 100) return false;
 	return true;
 };
 


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#14782

Now that we're not running a high number of Sentry requests and the billing period has reset, we can once again increase the sample rate.