### PR TITLE
Support full-width looping videos in articles

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1013,7 +1013,7 @@ export const Card = ({
 									}
 									subtitleSize={subtitleSize}
 									enableHls={enableHls}
-									fullWidth={false}
+									letterboxed={true}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1013,6 +1013,7 @@ export const Card = ({
 									}
 									subtitleSize={subtitleSize}
 									enableHls={enableHls}
+									fullWidth={false}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/LoopVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/LoopVideoInArticle.tsx
@@ -29,6 +29,17 @@ export const LoopVideoInArticle = ({
 		return null;
 	}
 
+	const calculateAspectRatio = (): number => {
+		const dimensions = firstVideoAsset?.dimensions;
+
+		if (dimensions) {
+			return dimensions.width / dimensions.height;
+		}
+
+		// Default aspect ratio if dimensions are not available
+		return 5 / 4;
+	};
+
 	return (
 		<>
 			<Island priority="critical" defer={{ until: 'visible' }}>
@@ -39,6 +50,7 @@ export const LoopVideoInArticle = ({
 					fallbackImageAspectRatio={
 						(firstVideoAsset?.aspectRatio ?? '5:4') as FEAspectRatio
 					}
+					containerAspectRatio={calculateAspectRatio()}
 					fallbackImageLoading="lazy"
 					fallbackImageSize="small"
 					height={firstVideoAsset?.dimensions?.height ?? 400}

--- a/dotcom-rendering/src/components/LoopVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/LoopVideoInArticle.tsx
@@ -63,6 +63,7 @@ export const LoopVideoInArticle = ({
 					uniqueId={element.id}
 					width={firstVideoAsset?.dimensions?.width ?? 500}
 					enableHls={false}
+					fullWidth={true}
 				/>
 			</Island>
 			{!!caption && (

--- a/dotcom-rendering/src/components/LoopVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/LoopVideoInArticle.tsx
@@ -63,7 +63,6 @@ export const LoopVideoInArticle = ({
 					uniqueId={element.id}
 					width={firstVideoAsset?.dimensions?.width ?? 500}
 					enableHls={false}
-					fullWidth={true}
 				/>
 			</Island>
 			{!!caption && (

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -55,20 +55,23 @@ const videoContainerStyles = (
 	}
 `;
 
-const figureStyles = (aspectRatio: number) => css`
+const figureStyles = (aspectRatio: number, fullWidth: boolean) => css`
 	position: relative;
 	aspect-ratio: ${aspectRatio};
 	height: 100%;
-	max-height: 100vh;
-	max-height: 100svh;
-	max-width: 100%;
-	${from.tablet} {
-		/**
-		 * The value "80" is derived from the aspect ratio of the 5:4 slot.
-		 * When other slots are used for self-hosted videos, this will need to be adjusted.
-		 */
-		max-width: ${aspectRatio * 80}%;
-	}
+	${!fullWidth &&
+	css`
+		max-height: 100vh;
+		max-height: 100svh;
+		max-width: 100%;
+		${from.tablet} {
+			/**
+			 * The value "80" is derived from the aspect ratio of the 5:4 slot.
+			 * When other slots are used for self-hosted videos, this will need to be adjusted.
+			 */
+			max-width: ${aspectRatio * 80}%;
+		}
+	`}
 `;
 
 /**
@@ -150,6 +153,7 @@ type Props = {
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
 	enableHls: boolean;
+	fullWidth: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -170,6 +174,7 @@ export const SelfHostedVideo = ({
 	subtitleSource,
 	subtitleSize,
 	enableHls,
+	fullWidth,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -703,7 +708,7 @@ export const SelfHostedVideo = ({
 		>
 			<figure
 				ref={setNode}
-				css={figureStyles(aspectRatio)}
+				css={figureStyles(aspectRatio, fullWidth)}
 				className={`video-container ${videoStyle.toLocaleLowerCase()}`}
 				data-component="gu-video-loop"
 			>
@@ -737,6 +742,7 @@ export const SelfHostedVideo = ({
 					subtitleSize={subtitleSize}
 					activeCue={activeCue}
 					enableHls={enableHls}
+					fullWidth={fullWidth}
 				/>
 			</figure>
 		</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -55,11 +55,11 @@ const videoContainerStyles = (
 	}
 `;
 
-const figureStyles = (aspectRatio: number, fullWidth: boolean) => css`
+const figureStyles = (aspectRatio: number, letterboxed: boolean) => css`
 	position: relative;
 	aspect-ratio: ${aspectRatio};
 	height: 100%;
-	${!fullWidth &&
+	${letterboxed &&
 	css`
 		max-height: 100vh;
 		max-height: 100svh;
@@ -153,7 +153,7 @@ type Props = {
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
 	enableHls: boolean;
-	fullWidth: boolean;
+	letterboxed?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -174,7 +174,7 @@ export const SelfHostedVideo = ({
 	subtitleSource,
 	subtitleSize,
 	enableHls,
-	fullWidth,
+	letterboxed = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -708,7 +708,7 @@ export const SelfHostedVideo = ({
 		>
 			<figure
 				ref={setNode}
-				css={figureStyles(aspectRatio, fullWidth)}
+				css={figureStyles(aspectRatio, letterboxed)}
 				className={`video-container ${videoStyle.toLocaleLowerCase()}`}
 				data-component="gu-video-loop"
 			>
@@ -742,7 +742,7 @@ export const SelfHostedVideo = ({
 					subtitleSize={subtitleSize}
 					activeCue={activeCue}
 					enableHls={enableHls}
-					fullWidth={fullWidth}
+					letterboxed={letterboxed}
 				/>
 			</figure>
 		</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -23,13 +23,16 @@ import { VideoProgressBar } from './VideoProgressBar';
 
 export type SubtitleSize = 'small' | 'medium' | 'large';
 
-const videoStyles = (aspectRatio: number) => css`
+const videoStyles = (aspectRatio: number, fullWidth: boolean) => css`
 	position: relative;
 	display: block;
 	height: auto;
 	width: 100%;
-	max-height: 100vh;
-	max-height: 100svh;
+	${!fullWidth &&
+	css`
+		max-height: 100vh;
+		max-height: 100svh;
+	`}
 	cursor: pointer;
 	/* Prevents CLS by letting the browser know the space the video will take up. */
 	aspect-ratio: ${aspectRatio};
@@ -127,6 +130,7 @@ type Props = {
 	/* used in custom subtitle overlays */
 	activeCue?: ActiveCue | null;
 	enableHls: boolean;
+	fullWidth: boolean;
 };
 
 /**
@@ -169,6 +173,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			subtitleSize,
 			activeCue,
 			enableHls,
+			fullWidth,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -199,7 +204,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 				<video
 					id={videoId}
 					css={[
-						videoStyles(aspectRatio),
+						videoStyles(aspectRatio, fullWidth),
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -23,12 +23,12 @@ import { VideoProgressBar } from './VideoProgressBar';
 
 export type SubtitleSize = 'small' | 'medium' | 'large';
 
-const videoStyles = (aspectRatio: number, fullWidth: boolean) => css`
+const videoStyles = (aspectRatio: number, letterboxed: boolean) => css`
 	position: relative;
 	display: block;
 	height: auto;
 	width: 100%;
-	${!fullWidth &&
+	${letterboxed &&
 	css`
 		max-height: 100vh;
 		max-height: 100svh;
@@ -130,7 +130,7 @@ type Props = {
 	/* used in custom subtitle overlays */
 	activeCue?: ActiveCue | null;
 	enableHls: boolean;
-	fullWidth: boolean;
+	letterboxed: boolean;
 };
 
 /**
@@ -173,7 +173,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			subtitleSize,
 			activeCue,
 			enableHls,
-			fullWidth,
+			letterboxed,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -204,7 +204,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 				<video
 					id={videoId}
 					css={[
-						videoStyles(aspectRatio, fullWidth),
+						videoStyles(aspectRatio, letterboxed),
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"


### PR DESCRIPTION
## What does this change?

Does two things:

1) sets the aspect ratio of the container for looping videos in articles by passing in `containerAspectRatio`. This follows on from https://github.com/guardian/dotcom-rendering/pull/15029
2) adds support for full-width self-hosted videos. Looping videos in articles should display at full-width. Looping videos on fronts should continue to display in a fixed-size box with letterboxing (i.e. not full-width)

## Why?

Editorial have requested it. There is a precedent because this is how images currently behave in articles.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="328" height="370" alt="Screenshot 2025-12-23 at 12 06 51" src="https://github.com/user-attachments/assets/fc8c8650-dab8-4906-b677-af9173eeb42e" /> | <img width="336" height="671" alt="Screenshot 2025-12-23 at 12 00 12" src="https://github.com/user-attachments/assets/be4f1edf-2b25-45ab-9e39-3e290456f5a9" /> |


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
