### PR TITLE
Revert "Increase number of instances for facia-rendering"

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -68,8 +68,8 @@ new RenderingCDKStack(cdkApp, 'FaciaRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'facia-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 48,
-		maximumInstances: 240,
+		minimumInstances: 21,
+		maximumInstances: 210,
 		policies: {
 			step: {
 				cpu: cpuScalingSteps,


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#14985

Traffic has reduced to pre-incident levels, let's scale back down