### PR TITLE
Add aria-labels to buttons for WCAG 4.1.2 compliance

### DIFF
--- a/dotcom-rendering/src/components/AudioAtom/AudioAtom.tsx
+++ b/dotcom-rendering/src/components/AudioAtom/AudioAtom.tsx
@@ -349,6 +349,7 @@ export const AudioAtom = ({
 						data-testid={isPlaying ? 'pause-button' : 'play-button'}
 						onClick={() => (isPlaying ? pauseAudio() : playAudio())}
 						css={buttonStyle}
+						aria-label={isPlaying ? 'Pause' : 'Play'}
 					>
 						{isPlaying ? <PauseSVG /> : <PlaySVG />}
 					</button>

--- a/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
+++ b/dotcom-rendering/src/components/EditionSwitcherBanner.importable.tsx
@@ -108,6 +108,7 @@ export const EditionSwitcherBanner = ({ pageId, edition }: Props) => {
 					type="button"
 					css={closeButton}
 					data-link-name="edition-switcher-banner close-banner"
+					aria-label="Close banner"
 					onClick={() => {
 						hideEditionSwitcherBanner();
 					}}

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV1.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV1.tsx
@@ -67,6 +67,7 @@ export const SignInGateAuxiaV1 = ({
 						data-testid="sign-in-gate-main_dismiss"
 						data-ignore="global-link-styling"
 						css={dismissButtonStyles}
+						aria-label="Dismiss sign-in gate"
 						onClick={() => {
 							dismissGate();
 							trackLink(

--- a/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV2.tsx
+++ b/dotcom-rendering/src/components/SignInGate/gateDesigns/SignInGateAuxiaV2.tsx
@@ -144,6 +144,7 @@ export const SignInGateAuxiaV2 = ({
 								data-testid="sign-in-gate-main_dismiss"
 								data-ignore="global-link-styling"
 								css={dismissButtonStyles}
+								aria-label="Dismiss sign-in gate"
 								onClick={() => {
 									dismissGate();
 									trackLink(
@@ -189,6 +190,7 @@ export const SignInGateAuxiaV2 = ({
 									data-testid="sign-in-gate-main_dismiss"
 									data-ignore="global-link-styling"
 									css={signInDismissButtonStyles}
+									aria-label="Dismiss sign-in gate"
 									onClick={() => {
 										dismissGate();
 										trackLink(

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -449,12 +449,11 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									'secondary',
 								)}
 								hideLabel={true}
-								aria-label={
-									isCollapsed
-										? 'Expand banner'
-										: 'Collapse banner'
-								}
-							/>
+							>
+								{isCollapsed
+									? 'Expand banner'
+									: 'Collapse banner'}
+							</Button>
 						</div>
 					)}
 					{!isCollapsableBanner && (

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -449,6 +449,11 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									'secondary',
 								)}
 								hideLabel={true}
+								aria-label={
+									isCollapsed
+										? 'Expand banner'
+										: 'Collapse banner'
+								}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -55,7 +55,6 @@ export function DesignableBannerCloseButton({
 					icon={<SvgCross />}
 					size="small"
 					hideLabel={true}
-					aria-label="Close banner"
 				>
 					Close
 				</Button>

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -55,6 +55,7 @@ export function DesignableBannerCloseButton({
 					icon={<SvgCross />}
 					size="small"
 					hideLabel={true}
+					aria-label="Close banner"
 				>
 					Close
 				</Button>


### PR DESCRIPTION
## What does this change?
Adds aria-label attributes to buttons, fixing accessibility issues flagged by storybook a11y add-on.
## Why?
Buttons must have discernible text to meet WCAG 2.0 A success criterion [4.1.2](https://www.w3.org/WAI/WCAG22/quickref/?versions=2.1&showtechniques=412#name-role-value). Screen reader users need accessible names to understand what buttons do.

Resolves https://github.com/guardian/dotcom-rendering/issues/15063
