### PR TITLE
a11y Fix aria-allowed-attr

### DIFF
--- a/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/AbuseReportForm.tsx
@@ -225,7 +225,12 @@ export const AbuseReportForm = ({
 		formVariables.categoryId === legalIssueCategoryId;
 
 	return (
-		<div aria-modal="true" ref={modalRef}>
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label="Report abuse"
+			ref={modalRef}
+		>
 			<form css={formWrapper} onSubmit={onSubmit}>
 				<div
 					css={[


### PR DESCRIPTION
## What does this change?

Adds `role="dialog"` and `aria-label="Report abuse"` to the modal wrapper `<div>` in the `AbuseReportForm` component.

Resolves https://github.com/guardian/dotcom-rendering/issues/15067

## Why?

The component was using `aria-modal="true"` on a `<div>` element without a valid dialog role. According to ARIA specifications, aria-modal is only valid on elements with `role="dialog"` or `role="alertdialog"`.