### PR TITLE
Fix aria-prohibited-attr accessibility violations

### DIFF
--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -86,6 +86,7 @@ export const CarouselNavigationButtons = ({
 
 	return ReactDOM.createPortal(
 		<div
+			role="group"
 			aria-controls="carousel"
 			aria-label="carousel arrows"
 			css={buttonStyles}

--- a/dotcom-rendering/src/components/Contributor.tsx
+++ b/dotcom-rendering/src/components/Contributor.tsx
@@ -106,7 +106,6 @@ type Props = {
 
 export const Contributor = ({ byline, tags, format, source }: Props) => (
 	<address
-		aria-label="Contributor info"
 		data-component="meta-byline"
 		data-link-name="byline"
 		data-gu-name="byline"

--- a/dotcom-rendering/src/components/Lineups.tsx
+++ b/dotcom-rendering/src/components/Lineups.tsx
@@ -74,21 +74,22 @@ const Event = ({
 			return (
 				<span
 					css={rectangle(BackgroundRed)}
+					role="img"
 					aria-label="Red Card"
-					aria-hidden="false"
 				/>
 			);
 		case 'booking':
 			return (
 				<span
 					css={rectangle(BackgroundYellow)}
+					role="img"
 					aria-label="Yellow Card"
-					aria-hidden="false"
 				/>
 			);
 		case 'substitution':
 			return (
 				<span
+					role="img"
 					aria-label={`Substitution in ${time} minute`}
 					css={substitute}
 				>

--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -444,7 +444,7 @@ export const SecureSignup = ({
 				</Button>
 			</form>
 			{isWaitingForResponse && (
-				<div aria-label="loading">
+				<div role="status" aria-label="loading">
 					<Spinner size="small" />
 				</div>
 			)}


### PR DESCRIPTION
## What does this change?
Fixes WCAG 4.1.2 aria-prohibited-attr violations by ensuring ARIA attributes are only used on elements with roles that permit them.
See https://dequeuniversity.com/rules/axe/4.10/aria-prohibited-attr?application=axeAPI
Part of storybook add on accessibility audit https://github.com/guardian/dotcom-rendering/issues/15058

