### PR TITLE
Update AB testing notification alarm name to easily distinguish between PROD and CODE envs

### DIFF
--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -387,7 +387,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           }
         ],
         "AlarmDescription": "Something went wrong notifying test owners of upcoming AB test expiries in ab-testing-notification-lambda-CODE. Please check the logs",
-        "AlarmName": "AB Testing Notification Failures",
+        "AlarmName": "ab-testing-notification-lambda-CODE-alarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "EvaluationPeriods": 1,
@@ -941,7 +941,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           }
         ],
         "AlarmDescription": "Something went wrong notifying test owners of upcoming AB test expiries in ab-testing-notification-lambda-PROD. Please check the logs",
-        "AlarmName": "AB Testing Notification Failures",
+        "AlarmName": "ab-testing-notification-lambda-PROD-alarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 1,
         "EvaluationPeriods": 1,

--- a/ab-testing/cdk/lib/notificationLambda.ts
+++ b/ab-testing/cdk/lib/notificationLambda.ts
@@ -60,7 +60,7 @@ export class AbTestingNotificationLambda extends GuStack {
 				monitoringConfiguration: {
 					snsTopicName: snsTopic.topicName,
 					toleratedErrorPercentage: 0,
-					alarmName: "AB Testing Notification Failures",
+					alarmName: `${appName}-${props.stage}-alarm`,
 					alarmDescription: `Something went wrong notifying test owners of upcoming AB test expiries in ${appName}-${props.stage}. Please check the logs`,
 					lengthOfEvaluationPeriod: Duration.minutes(1),
 					numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 1,


### PR DESCRIPTION
## What does this change?

Update AB testing notification alarm name to easily distinguish between PROD and CODE envs
