### PR TITLE
Onward journeys AB test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -166,6 +166,7 @@ export type Props = {
 	enableHls?: boolean;
 	isInStarRatingVariant?: boolean;
 	starRatingSize?: RatingSizeType;
+	isInOnwardsAbTestVariantStandardCard?: boolean;
 };
 
 const starWrapper = (cardHasImage: boolean) => css`
@@ -426,6 +427,7 @@ export const Card = ({
 	enableHls = false,
 	isInStarRatingVariant,
 	starRatingSize = 'small',
+	isInOnwardsAbTestVariantStandardCard,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -673,7 +675,12 @@ export const Card = ({
 	 */
 	const getGapSizes = (): GapSizes => {
 		if (isOnwardContent && !isGallerySecondaryOnward) {
-			if (isMoreGalleriesOnwardContent) {
+			if (
+				isMoreGalleriesOnwardContent ||
+				// This is untidy. If we implement the gallery-style redesign for onwards content
+				// in all articles, we can refactor how we determine gap sizes for onwards cards.
+				isInOnwardsAbTestVariantStandardCard
+			) {
 				return {
 					row: 'small',
 					column: 'small',

--- a/dotcom-rendering/src/components/MoreGalleries.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.tsx
@@ -53,10 +53,6 @@ const cardsContainerStyles = css`
 	${from.desktop} {
 		${grid.between('centre-column-start', 'right-column-end')}
 	}
-
-	${from.leftCol} {
-		${grid.between('centre-column-start', 'right-column-end')}
-	}
 `;
 
 const standardCardStyles = css`

--- a/dotcom-rendering/src/components/MoreGalleriesStyleOnwardsContent.importable.tsx
+++ b/dotcom-rendering/src/components/MoreGalleriesStyleOnwardsContent.importable.tsx
@@ -1,0 +1,293 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold24,
+	space,
+	until,
+} from '@guardian/source/foundations';
+import { StraightLines } from '@guardian/source-development-kitchen/react-components';
+import { grid } from '../grid';
+import { decideFormat } from '../lib/articleFormat';
+import { useApi } from '../lib/useApi';
+import { palette } from '../palette';
+import type { DCRFrontCard } from '../types/front';
+import type { FETrailType } from '../types/trails';
+import { Card } from './Card/Card';
+import type { Props as CardProps } from './Card/Card';
+import { LeftColumn } from './LeftColumn';
+import { Placeholder } from './Placeholder';
+
+type OnwardsResponse = {
+	trails: FETrailType[];
+	heading: string;
+	displayname: string;
+	description: string;
+};
+
+const standardCardListStyles = css`
+	width: 100%;
+	display: grid;
+	gap: ${space[5]}px;
+
+	${from.tablet} {
+		grid-template-columns: repeat(4, 1fr);
+		padding-top: ${space[2]}px;
+	}
+
+	${from.leftCol} {
+		&::before {
+			content: '';
+			position: absolute;
+			left: -11px;
+			bottom: 0;
+			top: 8px;
+			width: 1px;
+			background-color: ${palette('--onward-content-border')};
+		}
+	}
+`;
+
+const cardsContainerStyles = css`
+	${grid.column.centre}
+	position: relative;
+
+	${from.desktop} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
+
+const splashCardStyles = css`
+	margin-bottom: ${space[4]}px;
+	${from.leftCol} {
+		margin-top: ${space[2]}px;
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: -11px;
+			top: 8px;
+			bottom: 0;
+			width: 1px;
+			background-color: ${palette('--onward-content-border')};
+		}
+	}
+`;
+
+const standardCardStyles = css`
+	position: relative;
+	display: flex;
+
+	${from.tablet} {
+		:not(:first-child)::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			left: -11px;
+			width: 1px;
+			background: ${palette('--onward-content-border')};
+		}
+	}
+`;
+
+const containerStyles = css`
+	display: flex;
+	flex-direction: column;
+	padding-bottom: ${space[6]}px;
+
+	${from.leftCol} {
+		flex-direction: row;
+		padding-right: 80px;
+	}
+`;
+
+const headerStyles = css`
+	${headlineBold24};
+	color: ${palette('--carousel-text')};
+	padding-bottom: ${space[2]}px;
+	padding-top: ${space[1]}px;
+	margin-left: 0;
+`;
+
+const mobileHeaderStyles = css`
+	${headerStyles};
+	${from.tablet} {
+		padding-left: ${space[1]}px;
+	}
+	${from.leftCol} {
+		display: none;
+	}
+`;
+
+const convertFETrailToDcrTrail = (
+	trails: FETrailType[],
+	discussionApiUrl: string,
+): DCRFrontCard[] =>
+	trails.map((trail) => ({
+		dataLinkName: 'onwards-content-card',
+		discussionId: trail.discussion?.discussionId,
+		discussionApiUrl,
+		format: decideFormat(trail.format),
+		headline: trail.headline,
+		image: {
+			src: trail.masterImage ?? '',
+			altText: trail.linkText ?? '',
+		},
+		isExternalLink: false,
+		onwardsSource: 'related-content',
+		showLivePlayable: false,
+		showQuotedHeadline: false,
+		url: trail.url,
+		webPublicationDate: trail.webPublicationDate,
+		isImmersive: false,
+	}));
+
+const getDefaultCardProps = (
+	trail: DCRFrontCard,
+	isInOnwardsAbTestVariantStandardCard: boolean,
+) => {
+	const defaultProps: CardProps = {
+		aspectRatio: '5:4',
+		avatarUrl: trail.avatarUrl,
+		branding: trail.branding,
+		byline: trail.byline,
+		dataLinkName: `onwards-content-gallery-style ${trail.dataLinkName}`,
+		discussionApiUrl: trail.discussionApiUrl,
+		discussionId: trail.discussionId,
+		format: trail.format,
+		headlineText: trail.headline,
+		image: trail.image,
+		imageLoading: 'lazy',
+		isCrossword: trail.isCrossword,
+		isExternalLink: false,
+		isInOnwardsAbTestVariantStandardCard,
+		isOnwardContent: true,
+		kickerText: trail.kickerText,
+		linkTo: trail.url,
+		mainMedia: trail.mainMedia,
+		onwardsSource: 'related-content',
+		showAge: false,
+		showByline: trail.showByline,
+		showClock: false,
+		showPulsingDot: false,
+		showQuotedHeadline: trail.showQuotedHeadline,
+		showTopBarDesktop: false,
+		showTopBarMobile: false,
+		snapData: trail.snapData,
+		starRating: trail.starRating,
+		trailText: trail.trailText,
+		webPublicationDate: trail.webPublicationDate,
+	};
+
+	return defaultProps;
+};
+
+type Props = {
+	url: string;
+	discussionApiUrl: string;
+	isInOnwardsAbTestVariant?: boolean;
+};
+
+/**
+ * We are running an AB test to use the More Galleries style of onwards content on all articles.
+ * If the test is successful, the plan is that this component will be removed and MoreGalleries.tsx will
+ * be generalised so that is can be used for onwards content across all articles. If the
+ * test is not successful, this component will be removed.
+ */
+export const MoreGalleriesStyleOnwardsContent = ({
+	url,
+	discussionApiUrl,
+	isInOnwardsAbTestVariant,
+}: Props) => {
+	const { data, error } = useApi<OnwardsResponse>(url);
+
+	if (error) {
+		// Send the error to Sentry and then prevent the element from rendering
+		window.guardian.modules.sentry.reportError(error, 'onwards-lower');
+		return null;
+	}
+
+	if (!data?.trails) {
+		return (
+			<Placeholder
+				heights={
+					new Map([
+						['mobile', 900],
+						['tablet', 600],
+						['desktop', 900],
+					])
+				}
+				shouldShimmer={false}
+				backgroundColor={palette('--article-background')}
+			/>
+		);
+	}
+
+	const trails: DCRFrontCard[] = convertFETrailToDcrTrail(
+		data.trails,
+		discussionApiUrl,
+	);
+
+	const [firstTrail, ...standardTrails] = trails;
+	if (!firstTrail) return null;
+
+	const heading = data.heading || data.displayname;
+
+	return (
+		<div
+			data-component="onwards-content-gallery-style"
+			css={containerStyles}
+		>
+			<LeftColumn>
+				<h2 css={headerStyles}>
+					<span>{heading}</span>
+				</h2>
+			</LeftColumn>
+			<h2 css={mobileHeaderStyles}>
+				<span>{heading}</span>
+			</h2>
+			<div>
+				<div css={[cardsContainerStyles, splashCardStyles]}>
+					<Card
+						{...getDefaultCardProps(firstTrail, false)}
+						mediaPositionOnDesktop="right"
+						mediaPositionOnMobile="top"
+						mediaSize="medium"
+						headlineSizes={{
+							desktop: 'small',
+							tablet: 'small',
+							mobile: 'small',
+						}}
+					/>
+				</div>
+				<StraightLines
+					cssOverrides={[
+						cardsContainerStyles,
+						css`
+							${until.tablet} {
+								display: none;
+							}
+						`,
+					]}
+					count={1}
+					color={palette('--onward-content-border')}
+				/>
+				<ul css={[cardsContainerStyles, standardCardListStyles]}>
+					{standardTrails.slice(0, 4).map((trail) => (
+						<li key={trail.url} css={standardCardStyles}>
+							<Card
+								{...getDefaultCardProps(
+									trail,
+									!!isInOnwardsAbTestVariant,
+								)}
+								mediaPositionOnDesktop="bottom"
+								mediaPositionOnMobile="left"
+								mediaSize="small"
+							/>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+};

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -7,12 +7,14 @@ import {
 	Pillar,
 } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
+import { useAB } from '../lib/useAB';
 import { useIsHorizontalScrollingSupported } from '../lib/useIsHorizontalScrollingSupported';
 import { palette } from '../palette';
 import type { OnwardsSource } from '../types/onwards';
 import type { RenderingTarget } from '../types/renderingTarget';
 import type { TagType } from '../types/tag';
 import { FetchOnwardsData } from './FetchOnwardsData.importable';
+import { MoreGalleriesStyleOnwardsContent } from './MoreGalleriesStyleOnwardsContent.importable';
 import { Section } from './Section';
 
 type PillarForContainer =
@@ -226,8 +228,12 @@ export const OnwardsUpper = ({
 	webURL,
 	isInStarRatingVariant,
 }: Props) => {
-	const isHorizontalScrollingSupported = useIsHorizontalScrollingSupported();
+	const abTestAPI = useAB()?.api;
+	const isInOnwardsAbTestVariant =
+		renderingTarget === 'Web' &&
+		abTestAPI?.isUserInVariant('OnwardJourneys', 'variant');
 
+	const isHorizontalScrollingSupported = useIsHorizontalScrollingSupported();
 	if (!isHorizontalScrollingSupported) return null;
 
 	// Related content can be a collection of articles based on
@@ -236,7 +242,7 @@ export const OnwardsUpper = ({
 
 	// In this context, Blog tags are treated the same as Series tags
 	const seriesTag = tags.find(
-		(tag) => tag.type === 'Series' || tag.type === 'Blog',
+		({ type }) => type === 'Series' || type === 'Blog',
 	);
 
 	let url: string | undefined;
@@ -319,21 +325,29 @@ export const OnwardsUpper = ({
 	const showCuratedContainer =
 		!!curatedDataUrl && !isPaidContent && canHaveCuratedContent;
 
+	const isGalleryArticle = format.design === ArticleDesign.Gallery;
+
 	return (
 		<div css={onwardsWrapper}>
-			{!!url && (
+			{!!url && isInOnwardsAbTestVariant && (
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-section-border')}
-					padSides={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
-					showTopBorder={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
-					showSideBorders={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
+				>
+					<MoreGalleriesStyleOnwardsContent
+						url={url}
+						discussionApiUrl={discussionApiUrl}
+						isInOnwardsAbTestVariant={isInOnwardsAbTestVariant}
+					/>
+				</Section>
+			)}
+			{!!url && !isInOnwardsAbTestVariant && (
+				<Section
+					fullWidth={true}
+					borderColour={palette('--article-section-border')}
+					padSides={!isGalleryArticle}
+					showTopBorder={!isGalleryArticle}
+					showSideBorders={!isGalleryArticle}
 				>
 					<FetchOnwardsData
 						url={url}
@@ -344,7 +358,7 @@ export const OnwardsUpper = ({
 						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						isAdFreeUser={isAdFreeUser}
-						containerPosition={'first'}
+						containerPosition="first"
 						webURL={webURL}
 						isInStarRatingVariant={isInStarRatingVariant}
 					/>
@@ -354,15 +368,9 @@ export const OnwardsUpper = ({
 				<Section
 					fullWidth={true}
 					borderColour={palette('--article-section-border')}
-					showTopBorder={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
-					showSideBorders={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
-					padSides={
-						format.design === ArticleDesign.Gallery ? false : true
-					}
+					showTopBorder={!isGalleryArticle}
+					showSideBorders={!isGalleryArticle}
+					padSides={!isGalleryArticle}
 				>
 					<FetchOnwardsData
 						url={curatedDataUrl}

--- a/dotcom-rendering/src/experiments/ab-tests.ts
+++ b/dotcom-rendering/src/experiments/ab-tests.ts
@@ -1,8 +1,14 @@
 import type { ABTest } from '@guardian/ab-core';
 import { abTestTest } from './tests/ab-test-test';
 import { noAuxiaSignInGate } from './tests/no-auxia-sign-in-gate';
+import { onwardJourneys } from './tests/onward-journeys';
 import { userBenefitsApi } from './tests/user-benefits-api';
 
 // keep in sync with ab-tests in frontend
 // https://github.com/guardian/frontend/tree/main/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
-export const tests: ABTest[] = [abTestTest, userBenefitsApi, noAuxiaSignInGate];
+export const tests: ABTest[] = [
+	abTestTest,
+	userBenefitsApi,
+	noAuxiaSignInGate,
+	onwardJourneys,
+];

--- a/dotcom-rendering/src/experiments/tests/onward-journeys.ts
+++ b/dotcom-rendering/src/experiments/tests/onward-journeys.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const onwardJourneys: ABTest = {
+	id: 'OnwardJourneys',
+	start: '2025-12-11',
+	expiry: '2026-07-23',
+	author: 'fronts.and.curation@guardian.co.uk',
+	description: 'Testing the new Onward Journey component on all articles',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	successMeasure: 'Higher click-through rate',
+	audienceCriteria: 'All articles on web (excludes apps)',
+	showForSensitive: true,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Implements the logic to show the gallery-style onwards content in all articles in the AB test.

I used an amalgamation of [the previous AB test](https://github.com/guardian/dotcom-rendering/pull/12944) to implement gallery-style onwards content and the `MoreGalleries.tsx` [file](https://github.com/guardian/dotcom-rendering/blob/3eae906e801ba1beb3d46bdb46e31adc6f651ac9/dotcom-rendering/src/components/MoreGalleries.tsx#L204), which is the current way we render onwards content for gallery articles.

The top onwards content container will show the updated design. The bottom onwards content container remains the same for the purposes of this AB test.

There aren't designs for this new style of onwards content: we have [designs for this version of onwards content on gallery pages](https://www.figma.com/design/hJcX6oaYh1Pkq88CQ52My9/Galleries-Onward-Journey?node-id=11-4&p=f&t=vWkM4mA0b5eYygvf-0), but these cards look much different to standard cards. I've tried to make it look reasonable, but it would take an involved refactor of spacing within the Card component to how it handles onwards content to align everything perfectly, which I think is not worth doing until we have designs.

## Why?

The WebX team recently migrated gallery articles to DCAR and whilst doing so implemented a new design for onwards content. An example can be seen in [this gallery article](https://www.theguardian.com/global-development/gallery/2026/jan/07/women-behind-lens-six-of-our-most-striking-images-from-2025)

<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/8d15989a-8fa7-45b7-907f-f72daf19da3f" />

We would like to know whether using this type of design would lead to better user engagement (measured through click-through rate and session length) than the current design used on non-gallery articles.

<img width="800" height="300" alt="image" src="https://github.com/user-attachments/assets/ec82970d-ee9f-4541-a8cb-2dfc8a837972" />

## Screenshots

| <img width=200/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| tablet | ![tablet-before] | ![tablet-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/a0559a0a-1b61-4fde-9edc-ed35b50a6da6
[tablet-before]: https://github.com/user-attachments/assets/5d273fe3-7efb-44ac-a899-47595edb5126
[desktop-before]: https://github.com/user-attachments/assets/7829023f-8171-4be1-889e-bc735613718b
[mobile-after]: https://github.com/user-attachments/assets/918d1514-3ff5-4750-a25a-b8de58f80ed7
[tablet-after]: https://github.com/user-attachments/assets/cf8e9d8f-b98d-46b4-ab38-c2e726901a4c
[desktop-after]: https://github.com/user-attachments/assets/7d016cfa-5b0a-4364-abe7-3a9fc840e2d9