### PR TITLE
Add support for Cinemagraphs in articles

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -6,21 +6,24 @@ import {
 	getSubtitleAsset,
 } from '../lib/video';
 import type { MediaAtomBlockElement } from '../types/content';
+import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Caption } from './Caption';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.importable';
 
-type LoopVideoInArticleProps = {
+type SelfHostedVideoInArticleProps = {
 	element: MediaAtomBlockElement;
 	format: ArticleFormat;
 	isMainMedia: boolean;
+	videoStyle: VideoPlayerFormat;
 };
 
-export const LoopVideoInArticle = ({
+export const SelfHostedVideoInArticle = ({
 	element,
 	format,
 	isMainMedia,
-}: LoopVideoInArticleProps) => {
+	videoStyle,
+}: SelfHostedVideoInArticleProps) => {
 	const posterImageUrl = element.posterImage?.[0]?.url;
 	const caption = element.title;
 	const firstVideoAsset = getFirstVideoAsset(element.assets);
@@ -59,7 +62,7 @@ export const LoopVideoInArticle = ({
 					sources={convertAssetsToVideoSources(element.assets)}
 					subtitleSize="medium"
 					subtitleSource={getSubtitleAsset(element.assets)}
-					videoStyle="Loop"
+					videoStyle={videoStyle}
 					uniqueId={element.id}
 					width={firstVideoAsset?.dimensions?.width ?? 500}
 					enableHls={false}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -29,7 +29,6 @@ import { Island } from '../components/Island';
 import { ItemLinkBlockElement } from '../components/ItemLinkBlockElement';
 import { KeyTakeaways } from '../components/KeyTakeaways';
 import { KnowledgeQuizAtom } from '../components/KnowledgeQuizAtom.importable';
-import { LoopVideoInArticle } from '../components/LoopVideoInArticle';
 import { MainMediaEmbedBlockComponent } from '../components/MainMediaEmbedBlockComponent';
 import { MapEmbedBlockComponent } from '../components/MapEmbedBlockComponent.importable';
 import { MiniProfiles } from '../components/MiniProfiles';
@@ -44,6 +43,7 @@ import { PullQuoteBlockComponent } from '../components/PullQuoteBlockComponent';
 import { QandaAtom } from '../components/QandaAtom.importable';
 import { QAndAExplainers } from '../components/QAndAExplainers';
 import { RichLinkComponent } from '../components/RichLinkComponent.importable';
+import { SelfHostedVideoInArticle } from '../components/SelfHostedVideoInArticle';
 import { SoundcloudBlockComponent } from '../components/SoundcloudBlockComponent';
 import { SpotifyBlockComponent } from '../components/SpotifyBlockComponent.importable';
 import { StarRatingBlockComponent } from '../components/StarRatingBlockComponent';
@@ -493,22 +493,16 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
-			/*
-				- MediaAtomBlockElement is used for self-hosted videos
-				- Historically, these videos have been self-hosted for legal or sensitive reasons
-					- These videos play in the `VideoAtom` component
-				- Looping videos, introduced in July 2025, are also self-hosted
-					- Thus they are delivered as a MediaAtomBlockElement
-					- However they need to display in a different video player
-				- We need to differentiate between the two forms of video
-					- We can do this by interrogating the atom's metadata, which includes the new attribute `videoPlayerFormat`
-			*/
-			if (element.videoPlayerFormat === 'Loop') {
+			if (
+				element.videoPlayerFormat &&
+				['Loop', 'Cinemagraph'].includes(element.videoPlayerFormat)
+			) {
 				return (
-					<LoopVideoInArticle
+					<SelfHostedVideoInArticle
 						element={element}
 						format={format}
 						isMainMedia={isMainMedia}
+						videoStyle={element.videoPlayerFormat}
 					/>
 				);
 			} else {


### PR DESCRIPTION
## What does this change?

Adds support for Cinemagraphs in articles.

Follows on from: https://github.com/guardian/dotcom-rendering/pull/14843

## Screenshots

### Before

https://github.com/user-attachments/assets/2142c2e7-409e-4aa8-a8ee-44ddfaad3172

### After

https://github.com/user-attachments/assets/e6a089d0-1127-41a2-b088-2cd37e212290
