### PR TITLE
Fix dev server logging

### DIFF
--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -11,7 +11,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-type DCRLoggingStore = {
+export type DCRLoggingStore = {
 	request: {
 		pageId: string;
 		path: string;

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -1,4 +1,4 @@
-import { type Handler, Router } from 'express';
+import { type ErrorRequestHandler, type Handler, Router } from 'express';
 import { pages } from '../devServer/routers/pages';
 import { targets } from '../devServer/routers/targets';
 import { handleAllEditorialNewslettersPage } from './handler.allEditorialNewslettersPage.web';
@@ -24,6 +24,8 @@ import {
 } from './handler.sportDataPage.web';
 import { getABTestsFromQueryParams } from './lib/get-abtests-from-query-params';
 import { getContentFromURLMiddleware } from './lib/get-content-from-url';
+import { requestLoggerMiddleware } from './lib/logging-middleware';
+import { recordError } from './lib/logging-store';
 
 /** article URLs contain a part that looks like “2022/nov/25” */
 const ARTICLE_URL = /(\/\d{4}\/[a-z]{3}\/\d{2}\/)/;
@@ -88,11 +90,17 @@ const redirects: Handler = (req, res, next) => {
 	next();
 };
 
+const logError: ErrorRequestHandler = (e, _req, _res, next) => {
+	recordError(e);
+	next(e);
+};
+
 const renderer = Router();
 // populates req.body with the content data from a production
 // URL if req.params.url is present
 renderer.use(getContentFromURLMiddleware);
 renderer.use(getABTestsFromQueryParams);
+renderer.use(requestLoggerMiddleware);
 renderer.get('/Article/*url', handleArticle);
 renderer.get('/Interactive/*url', handleInteractive);
 renderer.get('/Blocks/*url', handleBlocks);
@@ -133,6 +141,7 @@ router.use('/pages', pages);
 router.use('/targets', targets);
 router.use(renderer);
 router.use(redirects);
+renderer.use(logError);
 
 // see https://www.npmjs.com/package/webpack-hot-server-middleware
 // for more info


### PR DESCRIPTION
The dev server doesn't currently produce any request logs. This requires two changes to fix:

1. Include the logging middleware in the dev server.
2. Flip the order of the log4js `shutdown` and `configure` calls. Calling shutdown after configure means nothing gets logged.

In addition, this adds a layout to the console appender to provide clearer information in the dev server logs. It also stores any errors in context for the dev server, as we do in prod, so that any erroring requests get logged at the right level ("ERROR" rather than "INFO").

Part of #13136.

## Example Output

```
16:57:04.753 [INFO] - 200 response for web article: money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software
16:57:08.765 [ERROR] - 500 response for [platform missing] front: uk/environment
```
