### PR TITLE
Rename makefile task `ci` to `prod-local`

### DIFF
--- a/dotcom-rendering/docs/development/run-prod-bundle-locally.md
+++ b/dotcom-rendering/docs/development/run-prod-bundle-locally.md
@@ -6,7 +6,7 @@ production build locally.
 To do this:
 
     $ make build
-    $ make ci
+    $ make prod-local
 
 The PROD server should start on its default port 9000.
 

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -42,8 +42,8 @@ prod:
 	@echo '' # just a spacer
 	NODE_ENV=production node dist/server.js
 
-ci: export DISABLE_LOGGING_AND_METRICS = true
-ci: prod
+prod-local: export DISABLE_LOGGING_AND_METRICS = true
+prod-local: prod
 
 # dev #########################################
 


### PR DESCRIPTION
## What does this change?

Rename makefile task `ci` to `prod-local`

## Why?

The old task name `ci` is a hangover from when it was used to run the prod build locally and on CI without logging and metrics reporting.

However we have been using a docker container in CI for a while now which uses the regular prod build with logging.

The only use case for this task now is to run the prod build locally, in which case running `make ci` is confusing.

Renaming this task to `make prod-local` is clearer in conveying its intended use.

