### PR TITLE
Remove log fields

### DIFF
--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -24,14 +24,10 @@ const logFields = (logEvent: LoggingEvent): unknown => {
 				? process.env.GU_STAGE.toUpperCase()
 				: 'DEV',
 		'@timestamp': logEvent.startTime,
-		'@version': 1,
 		level: logEvent.level.levelStr,
-		level_value: logEvent.level.level,
 		request,
 		requestId,
 		abTests,
-		// NODE_APP_INSTANCE is set by cluster mode
-		thread_name: process.env.NODE_APP_INSTANCE ?? '0',
 	};
 	// log4js uses any[] to type data but we want to coerce it here
 	// because we now depend on the type to log the result properly


### PR DESCRIPTION
There will be less noise in the logs if we remove fields that we don't need.

- `version`: DCAR isn't versioned.
- `level_value`: We use the `level` string ("ERROR", "INFO" etc.) rather than this numeric value.
- `thread_name`: This was added for an experiment with cluster mode (#9037). We're not using cluster mode any more, so it's no longer needed.

Part of #13136.
