### PR TITLE
Fix z-index on immersive feature cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -117,6 +117,7 @@ const overlayContainerStyles = css`
 	bottom: 0;
 	left: 0;
 	width: 100%;
+	cursor: pointer;
 `;
 
 const immersiveOverlayContainerStyles = css`
@@ -129,8 +130,16 @@ const immersiveOverlayContainerStyles = css`
 		* 48px is to ensure the gradient does not render the content inaccessible.
 		*/
 		width: 268px;
-		z-index: ${getZIndex('feature-card-overlay')};
+		z-index: 1;
 	}
+`;
+
+const cinemagraphOverlayStyles = css`
+	/* Needs to be above the video player */
+	z-index: ${getZIndex('mediaOverlay')};
+
+	/* The whole card is clickable on cinemagraphs */
+	pointer-events: none;
 `;
 
 /**
@@ -155,6 +164,7 @@ const overlayMaskGradientStyles = (angle: string) => css`
 		rgb(0, 0, 0) 64px
 	);
 `;
+
 const overlayStyles = css`
 	position: relative;
 	display: flex;
@@ -162,8 +172,6 @@ const overlayStyles = css`
 	text-align: start;
 	gap: ${space[1]}px;
 	padding: 64px ${space[2]}px ${space[2]}px;
-	/* Needs to be above self-hosted video  */
-	z-index: ${getZIndex('feature-card-overlay')};
 	backdrop-filter: blur(12px) brightness(0.5);
 	@supports not (backdrop-filter: blur(12px)) {
 		background-color: ${transparentColour(sourcePalette.neutral[10], 0.7)};
@@ -621,11 +629,8 @@ export const FeatureCard = ({
 										overlayContainerStyles,
 										isImmersive &&
 											immersiveOverlayContainerStyles,
-										// The whole card is clickable on cinemagraphs
 										media.type === 'cinemagraph' &&
-											css`
-												pointer-events: none;
-											`,
+											cinemagraphOverlayStyles,
 									]}
 								>
 									{mainMedia?.type === 'Audio' &&

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -89,9 +89,6 @@ const indices = [
 	// Media overlay
 	'mediaOverlay',
 
-	// Feature card overlay
-	'feature-card-overlay',
-
 	// Self-hosted video
 	'video-progress-bar-foreground',
 	'video-progress-bar-background',


### PR DESCRIPTION
## What does this change?

Fixes an issue where the overlay on immersive feature cards was not clickable. This bug was introduced [here](https://github.com/guardian/dotcom-rendering/pull/14933/changes#diff-7bdcbda8b4039b530d8ad3dd4b4324cb5d105d53d81dd65339f857e2d1193c78R132).

Moves the z-index updates to `cinemagraphOverlayStyles` so that non-cinemagraph feature cards are unaffected.

Reuses `mediaOverlay` as the z-index value rather than create a superfluous new one for `mediaOverlay`.

Adds `cursor:pointer` to the overlay. The overlay on feature cards is always a link, so use a pointer to indicate this.

## Why?

Bug fix

