### PR TITLE
Remove `type` and `platform` from logs

### DIFF
--- a/dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts
+++ b/dotcom-rendering/src/server/handler.allEditorialNewslettersPage.web.ts
@@ -2,14 +2,12 @@ import type { RequestHandler } from 'express';
 import { enhanceNewslettersPage } from '../model/enhance-newsletters-page';
 import { validateAsAllEditorialNewslettersPageType } from '../model/validate';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderEditorialNewslettersPage } from './render.allEditorialNewslettersPage.web';
 
 export const handleAllEditorialNewslettersPage: RequestHandler = (
 	{ body },
 	res,
 ) => {
-	recordTypeAndPlatform('newsletters');
 	const feNewslettersData = validateAsAllEditorialNewslettersPageType(body);
 	const newslettersPage = enhanceNewslettersPage(feNewslettersData);
 	const { html, prefetchScripts } = renderEditorialNewslettersPage({

--- a/dotcom-rendering/src/server/handler.article.apps.ts
+++ b/dotcom-rendering/src/server/handler.article.apps.ts
@@ -5,12 +5,9 @@ import { validateAsBlock, validateAsFEArticle } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderAppsBlocks, renderArticle } from './render.article.apps';
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('article', 'apps');
-
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Apps');
 	const { html, prefetchScripts } = renderArticle(article);
@@ -20,8 +17,6 @@ export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 };
 
 export const handleAppsInteractive: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('interactive', 'app');
-
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Apps');
 	const { html, prefetchScripts } = renderArticle(article);
@@ -30,7 +25,6 @@ export const handleAppsInteractive: RequestHandler = ({ body }, res) => {
 };
 
 export const handleAppsBlocks: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('blocks', 'app');
 	const {
 		blocks,
 		format,

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -5,12 +5,9 @@ import { validateAsBlock, validateAsFEArticle } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderBlocks, renderHtml } from './render.article.web';
 
 export const handleArticle: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('article', 'web');
-
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Web');
 	const { html, prefetchScripts } = renderHtml({
@@ -21,8 +18,6 @@ export const handleArticle: RequestHandler = ({ body }, res) => {
 };
 
 export const handleInteractive: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('interactive', 'web');
-
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Web');
 	const { html, prefetchScripts } = renderHtml({
@@ -33,7 +28,6 @@ export const handleInteractive: RequestHandler = ({ body }, res) => {
 };
 
 export const handleBlocks: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('blocks');
 	const {
 		blocks,
 		format,

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -17,7 +17,6 @@ import type { Front } from '../types/front';
 import type { FETagType } from '../types/tag';
 import type { TagPage } from '../types/tagPage';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderFront, renderTagPage } from './render.front.web';
 
 const enhanceFront = (body: unknown): Front => {
@@ -161,7 +160,6 @@ const enhanceTagPage = (body: unknown): TagPage => {
 };
 
 export const handleFront: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('front');
 	const front = enhanceFront(body);
 	const { html, prefetchScripts } = renderFront({
 		front,
@@ -170,7 +168,6 @@ export const handleFront: RequestHandler = ({ body }, res) => {
 };
 
 export const handleTagPage: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('tagPage');
 	const tagPage = enhanceTagPage(body);
 	const { html, prefetchScripts } = renderTagPage({
 		tagPage,

--- a/dotcom-rendering/src/server/handler.hostedContent.web.ts
+++ b/dotcom-rendering/src/server/handler.hostedContent.web.ts
@@ -2,12 +2,9 @@ import type { RequestHandler } from 'express';
 import { validateAsFEHostedContent } from '../model/validate';
 import { enhanceHostedContentType } from '../types/hostedContent';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderHtml } from './render.hostedContent.web';
 
 export const handleHostedContent: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('article', 'web');
-
 	const frontendData = validateAsFEHostedContent(body);
 	const hostedContent = enhanceHostedContentType(frontendData);
 	const { html, prefetchScripts } = renderHtml({

--- a/dotcom-rendering/src/server/handler.sportDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.sportDataPage.web.ts
@@ -28,7 +28,6 @@ import type {
 	Region,
 } from '../sportDataPage';
 import { makePrefetchHeader } from './lib/header';
-import { recordTypeAndPlatform } from './lib/logging-store';
 import { renderSportPage } from './render.sportDataPage.web';
 
 const decideMatchListPageKind = (pageId: string): FootballMatchListPageKind => {
@@ -122,7 +121,6 @@ const parseFEFootballMatchList = (
 };
 
 export const handleFootballMatchListPage: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('footballMatchListPage', 'web');
 	const footballDataValidated: FEFootballMatchListPage =
 		validateAsFootballMatchListPage(body);
 
@@ -161,7 +159,6 @@ const parseFEFootballTables = (
 };
 
 export const handleFootballTablesPage: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('FootballTablesPage', 'web');
 	const footballTablesPageValidated: FEFootballTablesPage =
 		validateAsFootballTablesPage(body);
 
@@ -199,8 +196,6 @@ const parseFECricketMatch = (data: FECricketMatchPage): CricketMatchPage => {
 };
 
 export const handleCricketMatchPage: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('CricketMatchPage', 'web');
-
 	const cricketMatchPageValidated: FECricketMatchPage =
 		validateAsCricketMatchPageType(body);
 
@@ -241,8 +236,6 @@ const parseFEFootballMatch = (
 };
 
 export const handleFootballMatchPage: RequestHandler = ({ body }, res) => {
-	recordTypeAndPlatform('FootballMatchPage', 'web');
-
 	const footballMatchPageValidated: FEFootballMatchPage =
 		validateAsFootballMatchPageType(body);
 	const parsedFootballMatchData = parseFEFootballMatch(

--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -42,9 +42,7 @@ export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
 	};
 
 	res.on('finish', () => {
-		const { request, error } = loggingStore.getStore() ?? {};
-
-		if (!request?.type) return;
+		const { error } = loggingStore.getStore() ?? {};
 
 		const logArgs = {
 			response: {

--- a/dotcom-rendering/src/server/lib/logging-store.ts
+++ b/dotcom-rendering/src/server/lib/logging-store.ts
@@ -16,8 +16,6 @@ export type DCRLoggingStore = {
 		pageId: string;
 		path: string;
 		method: string;
-		type?: string;
-		platform?: string;
 	};
 	requestId: string;
 	abTests: string;
@@ -28,18 +26,6 @@ export type DCRLoggingStore = {
 };
 
 export const loggingStore = new AsyncLocalStorage<DCRLoggingStore>();
-
-export const recordTypeAndPlatform = (
-	type: string,
-	platform?: string,
-): void => {
-	const { request } = loggingStore.getStore() ?? {};
-
-	if (request) {
-		request.type = type;
-		request.platform = platform;
-	}
-};
 
 export const recordError = (error: unknown): void => {
 	const store = loggingStore.getStore();

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -59,13 +59,9 @@ const consoleLayout: Layout = {
 					typeof fields.response.status === 'number'
 						? fields.response.status
 						: '[status missing]';
-				const {
-					platform = '[platform missing]',
-					pageId = '[pageId missing]',
-					type: requestType = '[request type missing]',
-				} = fields.request;
+				const requestPath = fields.request.path ?? '[path missing]';
 
-				return `${status} response for ${platform} ${requestType}: ${pageId}`;
+				return `${status} response for ${requestPath}`;
 			} else {
 				return logEvent.data;
 			}


### PR DESCRIPTION
We're not using them for anything, and we're trying to reduce noise in the logs by removing fields we don't need.

In addition, these fields duplicate information that's already in the path, which is also logged. For example, a request to `/AppsArticle` would have "apps" as the platform and "article" as the type. Furthermore, an extra function call is needed to log them whenever a new handler is created, whereas the path is logged automatically for every request. This may be why they're currently logged inconsistently, with both "app" and "apps" being used, and the platform sometimes not included, although some of this could also be solved by changing the types on `recordTypeAndPlatform`.

Part of #13136.
