### PR TITLE
Highlights scroll snap

### DIFF
--- a/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.importable.tsx
@@ -45,6 +45,7 @@ const carouselStyles = css`
 	scroll-behavior: auto;
 	overscroll-behavior-x: contain;
 	overscroll-behavior-y: auto;
+	scroll-snap-type: x mandatory;
 
 	${from.mobileLandscape} {
 		padding: 0 ${horizontalPaddingMobileLandscape}px;


### PR DESCRIPTION
## What does this change?
Reintroduce `scroll-snap-type: x mandatory;` on highlights container

## Why?
This was erroneously removed in https://github.com/guardian/dotcom-rendering/pull/14965. The highlights container requires a mandatory x scroll snap so that the cards always land in the same position on scroll. 

## Screenshots

### Before
https://github.com/user-attachments/assets/7e8e6bd2-48f8-4b10-8f7e-2637f0d4fc07
### After
https://github.com/user-attachments/assets/b10313d5-44ac-4fe5-bd91-7d293c2650aa




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
