### PR TITLE
Align star ratings on highlights card with headline 

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -39,7 +39,6 @@ export type HighlightsCardProps = {
 const container = css`
 	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
 	height: 100%;
 	column-gap: ${space[2]}px;
 	/** Relative positioning is required to absolutely position the card link overlay */
@@ -72,6 +71,10 @@ const container = css`
 	${from.desktop} {
 		width: 300px;
 	}
+`;
+
+const spaceBetween = css`
+	justify-content: space-between;
 `;
 
 const hoverStyles = css`
@@ -139,9 +142,26 @@ export const HighlightsCard = ({
 }: HighlightsCardProps) => {
 	const isMediaCard = isMedia(format);
 
+	/*
+	 * We do not apply space-between to the card if it has star rating as star ratings should be aligned to the headline.
+	 * We do apply it for anything else as pills should be aligned with the bottom of the image
+	 *
+	 * We also apply it for any card not in the star rating redesign test.
+	 * This can be removed once the redesign it rolled out to production
+	 * */
+	const shouldJustifyContent =
+		!isInStarRatingVariant ||
+		(isInStarRatingVariant && isUndefined(starRating));
+
 	return (
 		<FormatBoundary format={format}>
-			<div css={[container, hoverStyles]}>
+			<div
+				css={[
+					container,
+					hoverStyles,
+					shouldJustifyContent && spaceBetween,
+				]}
+			>
 				<CardLink
 					linkTo={linkTo}
 					headlineText={headlineText}


### PR DESCRIPTION
## What does this change?
Does not apply space-between styling on highlight cards with star ratings. 

## Why?
This change has been requested by design. In the new star ratings designs, the star ratings should sit with the headline, not aligned to the bottom like the pills. The design logic for this is that, outside of highlight cards, pills bottom align with the meta, whilst stars top align with the header.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


NB for users not in the star ratings redesign test, the highlights card remains unchanges

[before]: https://github.com/user-attachments/assets/83f81589-0c16-4901-a6cf-4f1aec9ff892
[after]: https://github.com/user-attachments/assets/78e0b35c-e6c5-4e4a-810b-8cc0b23b7095

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
