### PR TITLE
Fix logging for comment nodes

### DIFF
--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -122,6 +122,8 @@ const textElement =
 					key,
 					children,
 				});
+			case '#comment':
+				return null;
 			default:
 				logger.warn(
 					'BlockquoteBlockComponent: Unknown element received',

--- a/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
+++ b/dotcom-rendering/src/components/SubheadingBlockComponent.tsx
@@ -54,6 +54,8 @@ export const buildElementTree =
 		} else if (node.nodeType === node.TEXT_NODE) {
 			// plain text receives no styling
 			return node.textContent;
+		} else if (node.nodeName === '#comment') {
+			return null;
 		} else {
 			logger.warn('SubheadingBlockComponent: Unknown element received', {
 				isDev: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
## What does this change?
Filters out HTML comment nodes (#comment) in SubheadingBlockComponent and BlockquoteBlockComponent to prevent unnecessary WARN level logs.

Part of https://github.com/guardian/frontend/issues/28496