### PR TITLE
Replace `serverTime` prop with context

### DIFF
--- a/dotcom-rendering/src/client/discussion.ts
+++ b/dotcom-rendering/src/client/discussion.ts
@@ -1,6 +1,7 @@
 import { doHydration } from './islands/doHydration';
 import { getEmotionCache } from './islands/emotion';
 import { getConfig } from './islands/getConfig';
+import { getDateTime } from './islands/getDateTime';
 import { getName } from './islands/getName';
 import { getProps } from './islands/getProps';
 
@@ -21,12 +22,20 @@ const forceHydration = async (): Promise<void> => {
 		// Read the props and config from where they have been serialised in the dom using an Island
 		const props = getProps(guElement);
 		const config = getConfig();
+		const dateTime = getDateTime(guElement);
 
 		// Now that we have the props as an object, tell Discussion we want it to expand itself
 		props.expanded = true;
 
 		// Force hydration
-		await doHydration(name, props, guElement, getEmotionCache(), config);
+		await doHydration(
+			name,
+			props,
+			guElement,
+			getEmotionCache(),
+			config,
+			dateTime,
+		);
 	} catch (err) {
 		// Do nothing
 	}

--- a/dotcom-rendering/src/client/islands/doHydration.tsx
+++ b/dotcom-rendering/src/client/islands/doHydration.tsx
@@ -5,6 +5,7 @@ import { isUndefined, log, startPerformanceMeasure } from '@guardian/libs';
 import { createElement } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { ConfigProvider } from '../../components/ConfigContext';
+import { DateTimeProvider } from '../../components/DateTimeContext';
 import { IslandProvider } from '../../components/IslandContext';
 import type { Config } from '../../types/configContext';
 
@@ -30,6 +31,7 @@ declare global {
  * @param element The location on the DOM where the component to hydrate exists
  * @param emotionCache An instance of an emotion cache to use for the island
  * @param config Application configuration to be passed to the config context for the hydrated component
+ * @param dateTime Datetime value to be passed to DateTime context for the hydrated component
  */
 export const doHydration = async (
 	name: string,
@@ -37,6 +39,7 @@ export const doHydration = async (
 	element: HTMLElement,
 	emotionCache: EmotionCache,
 	config: Config,
+	dateTime?: number,
 ): Promise<void> => {
 	// If this function has already been run for an element then don't try to
 	// run it a second time
@@ -61,13 +64,15 @@ export const doHydration = async (
 			hydrateRoot(
 				element,
 				<ConfigProvider value={config}>
-					<CacheProvider value={emotionCache}>
-						{/* Child islands should not be hydrated separately */}
-						<IslandProvider value={{ isChild: true }}>
-							{/* The component to hydrate must be a single JSX Element */}
-							{createElement(module[name], data)}
-						</IslandProvider>
-					</CacheProvider>
+					<DateTimeProvider value={dateTime}>
+						<CacheProvider value={emotionCache}>
+							{/* Child islands should not be hydrated separately */}
+							<IslandProvider value={{ isChild: true }}>
+								{/* The component to hydrate must be a single JSX Element */}
+								{createElement(module[name], data)}
+							</IslandProvider>
+						</CacheProvider>
+					</DateTimeProvider>
 				</ConfigProvider>,
 			);
 

--- a/dotcom-rendering/src/client/islands/getDateTime.ts
+++ b/dotcom-rendering/src/client/islands/getDateTime.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns `datetime` attribute from given HTML element.
+ *
+ * We expect the element to always be a `gu-*` custom element
+ */
+export const getDateTime = (marker: HTMLElement): number | undefined => {
+	const dateTime = marker.getAttribute('datetime');
+	if (dateTime) return parseInt(dateTime);
+	return;
+};

--- a/dotcom-rendering/src/client/islands/initHydration.ts
+++ b/dotcom-rendering/src/client/islands/initHydration.ts
@@ -3,6 +3,7 @@ import { isUndefined } from '@guardian/libs';
 import { schedule } from '../../lib/scheduler';
 import { doHydration } from './doHydration';
 import { getConfig } from './getConfig';
+import { getDateTime } from './getDateTime';
 import { getName } from './getName';
 import { getPriority } from './getPriority';
 import { getProps } from './getProps';
@@ -41,6 +42,7 @@ export const initHydration = async (
 	const props = getProps(element);
 	const config = getConfig();
 	const priority = getPriority(element);
+	const dateTime = getDateTime(element);
 
 	if (!name) return;
 	if (isUndefined(priority)) return;
@@ -48,7 +50,15 @@ export const initHydration = async (
 	const scheduleHydration = () =>
 		schedule(
 			name,
-			() => doHydration(name, props, element, emotionCache, config),
+			() =>
+				doHydration(
+					name,
+					props,
+					element,
+					emotionCache,
+					config,
+					dateTime,
+				),
 			{ priority },
 		);
 

--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -54,7 +54,6 @@ type Props = {
 	lang?: string;
 	isRightToLeftLang?: boolean;
 	shouldHideAds: boolean;
-	serverTime?: number;
 	idApiUrl?: string;
 };
 
@@ -139,7 +138,6 @@ export const ArticleBody = ({
 	isRightToLeftLang = false,
 	editionId,
 	shouldHideAds,
-	serverTime,
 	idApiUrl,
 }: Props) => {
 	const isInteractiveContent =
@@ -209,7 +207,6 @@ export const ArticleBody = ({
 					keywordIds={keywordIds}
 					editionId={editionId}
 					shouldHideAds={shouldHideAds}
-					serverTime={serverTime}
 					idApiUrl={idApiUrl}
 				/>
 			</div>

--- a/dotcom-rendering/src/components/ArticleMeta.web.test.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.web.test.tsx
@@ -3,6 +3,7 @@ import { interactiveLegacyClasses } from '../layouts/lib/interactiveLegacyStylin
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { ArticleMeta, shouldShowContributor } from './ArticleMeta.web';
 import { ConfigProvider } from './ConfigContext';
+import { DateTimeProvider } from './DateTimeContext';
 
 jest.mock('../lib/bridgetApi', () => jest.fn());
 jest.mock('../lib/useMatchMedia', () => ({
@@ -25,24 +26,26 @@ describe('ArticleMeta', () => {
 					editionId: 'UK',
 				}}
 			>
-				<ArticleMeta
-					format={format}
-					pageId="1234"
-					webTitle="A title"
-					byline="Observer writers"
-					tags={[
-						{
-							id: 'lifeandstyle/series/observer-design',
-							type: 'Series',
-							title: 'Observer Design',
-						},
-					]}
-					primaryDateline="primary date line"
-					secondaryDateline="secondary date line"
-					isCommentable={false}
-					discussionApiUrl=""
-					shortUrlId=""
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<ArticleMeta
+						format={format}
+						pageId="1234"
+						webTitle="A title"
+						byline="Observer writers"
+						tags={[
+							{
+								id: 'lifeandstyle/series/observer-design',
+								type: 'Series',
+								title: 'Observer Design',
+							},
+						]}
+						primaryDateline="primary date line"
+						secondaryDateline="secondary date line"
+						isCommentable={false}
+						discussionApiUrl=""
+						shortUrlId=""
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -72,24 +75,26 @@ describe('ArticleMeta', () => {
 					editionId: 'UK',
 				}}
 			>
-				<ArticleMeta
-					format={format}
-					pageId="1234"
-					webTitle="A title"
-					byline="Observer writers"
-					tags={[
-						{
-							id: 'lifeandstyle/series/observer-design',
-							type: 'Series',
-							title: 'Observer Design',
-						},
-					]}
-					primaryDateline="primary date line"
-					secondaryDateline="secondary date line"
-					isCommentable={false}
-					discussionApiUrl=""
-					shortUrlId=""
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<ArticleMeta
+						format={format}
+						pageId="1234"
+						webTitle="A title"
+						byline="Observer writers"
+						tags={[
+							{
+								id: 'lifeandstyle/series/observer-design',
+								type: 'Series',
+								title: 'Observer Design',
+							},
+						]}
+						primaryDateline="primary date line"
+						secondaryDateline="secondary date line"
+						isCommentable={false}
+						discussionApiUrl=""
+						shortUrlId=""
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -76,7 +76,6 @@ export type Props = {
 	format: ArticleFormat;
 	/** The format of the article holding the card */
 	contextFormat?: ArticleFormat;
-	serverTime?: number;
 	headlineText: string;
 	headlineSizes?: ResponsiveFontSize;
 	showQuotedHeadline?: boolean;
@@ -383,7 +382,6 @@ export const Card = ({
 	liveUpdatesPosition = 'inner',
 	onwardsSource,
 	showVideo = true,
-	serverTime,
 	isTagPage = false,
 	aspectRatio,
 	index = 0,
@@ -444,7 +442,6 @@ export const Card = ({
 					isWithinTwelveHours: withinTwelveHours,
 				}}
 				showClock={showClock}
-				serverTime={serverTime}
 				isTagPage={isTagPage}
 			/>
 		);
@@ -1244,7 +1241,6 @@ export const Card = ({
 													: supportingContentAlignment
 											}
 											containerPalette={containerPalette}
-											serverTime={serverTime}
 											displayHeader={isFlexibleContainer}
 											directionOnMobile={
 												isFlexibleContainer
@@ -1303,7 +1299,6 @@ export const Card = ({
 									: supportingContentAlignment
 							}
 							containerPalette={containerPalette}
-							serverTime={serverTime}
 							displayHeader={isFlexibleContainer}
 							directionOnMobile={'horizontal'}
 						></LatestLinks>

--- a/dotcom-rendering/src/components/Card/components/CardAge.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardAge.tsx
@@ -22,7 +22,6 @@ const ageStyles = (colour: string) => {
 };
 
 type Props = {
-	serverTime?: number;
 	webPublication: {
 		date: string;
 		isWithinTwelveHours: boolean;
@@ -34,7 +33,6 @@ type Props = {
 };
 
 export const CardAge = ({
-	serverTime,
 	webPublication,
 	isTagPage,
 	showClock,
@@ -60,7 +58,6 @@ export const CardAge = ({
 				<DateTime
 					date={new Date(webPublication.date)}
 					display={'relative'}
-					serverTime={serverTime}
 					showWeekday={false}
 					showDate={true}
 					showTime={false}

--- a/dotcom-rendering/src/components/Carousel.importable.tsx
+++ b/dotcom-rendering/src/components/Carousel.importable.tsx
@@ -43,7 +43,6 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	leftColSize: LeftColSize;
 	discussionApiUrl: string;
-	serverTime?: number;
 	renderingTarget: RenderingTarget;
 };
 
@@ -449,7 +448,6 @@ type CarouselCardProps = {
 	linkTo: string;
 	headlineText: string;
 	webPublicationDate: string;
-	serverTime?: number;
 	imageLoading: Loading;
 	kickerText?: string;
 	image?: DCRFrontImage;
@@ -483,7 +481,6 @@ const CarouselCard = ({
 	imageLoading,
 	discussionApiUrl,
 	isOnwardContent,
-	serverTime,
 	starRating,
 	index,
 }: CarouselCardProps) => {
@@ -527,7 +524,6 @@ const CarouselCard = ({
 				isOnwardContent={isOnwardContent}
 				mediaPositionOnDesktop={cardImagePosition}
 				mediaPositionOnMobile={cardImagePosition}
-				serverTime={serverTime}
 				starRating={starRating}
 				index={index}
 				showTopBarDesktop={!isOnwardContent}
@@ -751,7 +747,6 @@ export const Carousel = ({
 	leftColSize,
 	discussionApiUrl,
 	isOnwardContent = true,
-	serverTime,
 	renderingTarget,
 	...props
 }: ArticleProps | FrontProps) => {
@@ -973,7 +968,6 @@ export const Carousel = ({
 									linkTo={linkTo}
 									headlineText={headlineText}
 									webPublicationDate={webPublicationDate}
-									serverTime={serverTime}
 									image={image}
 									kickerText={kickerText}
 									dataLinkName={`carousel-small-card-position-${i}`}

--- a/dotcom-rendering/src/components/DateTime.tsx
+++ b/dotcom-rendering/src/components/DateTime.tsx
@@ -1,6 +1,7 @@
-import { isString, isUndefined } from '@guardian/libs';
+import { isString } from '@guardian/libs';
 import { getEditionFromId } from '../lib/edition';
 import { useConfig } from './ConfigContext';
+import { useDateTime } from './DateTimeContext';
 import { Island } from './Island';
 import { RelativeTime } from './RelativeTime.importable';
 
@@ -14,11 +15,9 @@ type Props = {
 type DisplayProps =
 	| {
 			display?: 'absolute';
-			serverTime?: never;
 	  }
 	| {
 			display: 'relative';
-			serverTime?: number;
 	  };
 
 const formatWeekday = (date: Date, locale: string, timeZone: string) =>
@@ -57,10 +56,10 @@ export const DateTime = ({
 	showDate,
 	showTime,
 	display = 'absolute',
-	serverTime,
 }: Props & DisplayProps) => {
 	const { editionId } = useConfig();
 	const { dateLocale, timeZone } = getEditionFromId(editionId);
+	const serverTime = useDateTime();
 
 	/**
 	 * Server time (if set) is rounded down to the previous minute to ensure
@@ -70,9 +69,9 @@ export const DateTime = ({
 	 *
 	 * [1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
 	 */
-	const now = isUndefined(serverTime)
-		? MAX_DATE
-		: Math.floor(serverTime / ONE_MINUTE) * ONE_MINUTE;
+	const now = serverTime
+		? Math.floor(serverTime / ONE_MINUTE) * ONE_MINUTE
+		: MAX_DATE;
 	const then = date.getTime();
 
 	return display === 'relative' ? (

--- a/dotcom-rendering/src/components/DateTimeContext.tsx
+++ b/dotcom-rendering/src/components/DateTimeContext.tsx
@@ -1,0 +1,42 @@
+import { isUndefined } from '@guardian/libs';
+import { createContext, useContext } from 'react';
+
+/**
+ * Context to store current date and time when page is rendered on server.
+ *
+ * It is deliberately set with a default value of `undefined` to better
+ * surface errors relating to incorrect usage and is not exported.
+ *
+ * @see https://kentcdodds.com/blog/how-to-use-react-context-effectively
+ */
+const DateTimeContext = createContext<number | undefined>(undefined);
+
+/**
+ * DateTimeProvider should be included at a high level to ensure child
+ * components can access the current date and time
+ */
+export const DateTimeProvider = ({
+	value,
+	children,
+}: {
+	value: number | undefined;
+	children: React.ReactNode;
+}) => (
+	<DateTimeContext.Provider value={value}>
+		{children}
+	</DateTimeContext.Provider>
+);
+
+/**
+ * Hook to safely fetch current date and time from context and ensure it is
+ * used correctly within an instance of `DateTimeProvider`
+ */
+export const useDateTime = () => {
+	const context = useContext(DateTimeContext);
+
+	if (isUndefined(context)) {
+		throw Error('useDateTime must be used within DateTimeProvider');
+	}
+
+	return context;
+};

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -43,7 +43,6 @@ type Props = {
 	containerType: DCRContainerType;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	sectionId: string;
 	frontId?: string;
@@ -58,7 +57,6 @@ export const DecideContainer = ({
 	containerType,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	sectionId,
@@ -74,7 +72,6 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -84,7 +81,6 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -94,7 +90,6 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -104,7 +99,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -114,7 +108,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -124,7 +117,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -134,7 +126,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -144,7 +135,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -154,7 +144,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -164,7 +153,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -174,7 +162,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -184,7 +171,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -194,7 +180,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -204,7 +189,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -214,7 +198,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -224,7 +207,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			);
@@ -244,7 +226,6 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}
@@ -256,7 +237,6 @@ export const DecideContainer = ({
 					groupedTrails={groupedTrails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					containerLevel={containerLevel}
@@ -271,7 +251,6 @@ export const DecideContainer = ({
 						imageLoading={imageLoading}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
 					/>
@@ -285,7 +264,6 @@ export const DecideContainer = ({
 						imageLoading={imageLoading}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						aspectRatio={aspectRatio}
 						sectionId={sectionId}
 					/>
@@ -299,7 +277,6 @@ export const DecideContainer = ({
 							trails={trails}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 							aspectRatio={aspectRatio}
 							pillarBuckets={pillarBuckets}
@@ -312,7 +289,6 @@ export const DecideContainer = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 				/>
@@ -324,7 +300,6 @@ export const DecideContainer = ({
 						trails={trails}
 						imageLoading={imageLoading}
 						containerPalette={containerPalette}
-						serverTime={serverTime}
 						aspectRatio={aspectRatio}
 						collectionId={collectionId}
 					/>
@@ -335,7 +310,6 @@ export const DecideContainer = ({
 				<StaticFeatureTwo
 					trails={trails}
 					containerPalette={containerPalette}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					collectionId={collectionId}

--- a/dotcom-rendering/src/components/DynamicFast.tsx
+++ b/dotcom-rendering/src/components/DynamicFast.tsx
@@ -35,7 +35,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 /* ._________________.________.________.
@@ -48,14 +47,12 @@ type Props = {
 const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -71,7 +68,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -90,7 +86,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										serverTime={serverTime}
 										imageLoading={imageLoading}
 									/>
 								) : (
@@ -98,7 +93,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 										trail={card}
 										containerPalette={containerPalette}
 										showAge={showAge}
-										serverTime={serverTime}
 									/>
 								)}
 							</LI>
@@ -119,7 +113,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);
@@ -133,14 +126,12 @@ const Card50_ColumnOfThreeCards25_ColumnOfFiveCards = ({
 const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -154,7 +145,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -180,7 +170,6 @@ const Card50_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);
@@ -195,12 +184,10 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 	({
 		cards,
 		showAge,
-		serverTime,
 		containerPalette,
 	}: {
 		cards: DCRFrontCard[];
 		showAge?: boolean;
-		serverTime?: number;
 		containerPalette?: DCRContainerPalette;
 	}) => {
 		if (cards.length === 0) return null;
@@ -226,7 +213,6 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 							/>
 						</LI>
 					);
@@ -238,14 +224,12 @@ const ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThr
 const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (!cards[0]) return null;
@@ -259,7 +243,6 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 					trail={big}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			</LI>
@@ -285,7 +268,6 @@ const Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);
@@ -301,12 +283,10 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
-	serverTime,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 0) return null;
@@ -328,7 +308,6 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -357,7 +336,6 @@ const Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);
@@ -373,12 +351,10 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
-	serverTime,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 3) return null;
@@ -400,7 +376,6 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -422,7 +397,6 @@ const Card25_Card25_Card25_ColumnOfThreeCards25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);
@@ -437,7 +411,6 @@ export const DynamicFast = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
@@ -570,7 +543,6 @@ export const DynamicFast = ({
 					<Card100PictureTop
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -580,7 +552,6 @@ export const DynamicFast = ({
 					<Card100PictureRight
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -590,7 +561,6 @@ export const DynamicFast = ({
 					<Card75_Card25
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -600,7 +570,6 @@ export const DynamicFast = ({
 					<Card25_Card75
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -610,7 +579,6 @@ export const DynamicFast = ({
 					<Card50_Card50
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -627,7 +595,6 @@ export const DynamicFast = ({
 					<Card50_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -637,7 +604,6 @@ export const DynamicFast = ({
 					<Card50_ColumnOfThreeCards25_ColumnOfFiveCards
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -647,7 +613,6 @@ export const DynamicFast = ({
 					<ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 					/>
 				);
@@ -656,7 +621,6 @@ export const DynamicFast = ({
 					<Card25_ColumnOfCards25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -666,7 +630,6 @@ export const DynamicFast = ({
 					<Card25_Card25_ColumnOfThreeCards25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -676,7 +639,6 @@ export const DynamicFast = ({
 					<Card25_Card25_Card25_ColumnOfThreeCards25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -686,7 +648,6 @@ export const DynamicFast = ({
 					<Card25_Card25_Card25_Card25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/DynamicPackage.tsx
+++ b/dotcom-rendering/src/components/DynamicPackage.tsx
@@ -14,7 +14,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 /*ø
@@ -32,14 +31,12 @@ const Snap100 = ({
 	snaps,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	snaps: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	if (!snaps[0]) return null;
 	return (
@@ -50,7 +47,6 @@ const Snap100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
-					serverTime={serverTime}
 					headlineSizes={{
 						desktop: 'small',
 						tablet: 'xxsmall',
@@ -71,14 +67,12 @@ const Card100 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	if (!cards[0]) return null;
 
@@ -90,7 +84,6 @@ const Card100 = ({
 					containerPalette={containerPalette}
 					containerType="dynamic/package"
 					showAge={showAge}
-					serverTime={serverTime}
 					headlineSizes={
 						cards[0].isBoosted
 							? {
@@ -117,14 +110,12 @@ const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	if (cards.length < 2) return null;
 	const card75 = cards.slice(0, 1);
@@ -139,7 +130,6 @@ const Card75_Card25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
-						serverTime={serverTime}
 						headlineSizes={{ desktop: 'small' }}
 						mediaPositionOnDesktop="right"
 						mediaPositionOnMobile="bottom"
@@ -161,7 +151,6 @@ const Card75_Card25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -174,7 +163,6 @@ const Card25_Card25_Card25_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	showImage = true,
 	padBottom,
 	imageLoading,
@@ -183,7 +171,6 @@ const Card25_Card25_Card25_Card25 = ({
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	showImage?: boolean;
 	padBottom?: boolean;
 }) => {
@@ -201,7 +188,6 @@ const Card25_Card25_Card25_Card25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
-							serverTime={serverTime}
 							supportingContent={limitSupportingContent(card)}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
@@ -217,14 +203,12 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const bigs = cards.slice(0, 3);
 	const remaining = cards.slice(3);
@@ -244,7 +228,6 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
-							serverTime={serverTime}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -265,7 +248,6 @@ const Card25_Card25_Card25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
-									serverTime={serverTime}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -285,14 +267,12 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const bigs = cards.slice(0, 2);
 	const remaining = cards.slice(2, 6);
@@ -312,7 +292,6 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
-							serverTime={serverTime}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -339,7 +318,6 @@ const Card25_Card25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
-									serverTime={serverTime}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -359,14 +337,12 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const bigs = cards.slice(0, 1);
 	const remaining = cards.slice(1, 7);
@@ -381,7 +357,6 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 							containerPalette={containerPalette}
 							containerType="dynamic/package"
 							showAge={showAge}
-							serverTime={serverTime}
 							supportingContent={limitSupportingContent(card)}
 							imageLoading={imageLoading}
 						/>
@@ -408,7 +383,6 @@ const Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
-									serverTime={serverTime}
 									supportingContent={limitSupportingContent(
 										card,
 									)}
@@ -428,14 +402,12 @@ const Card75_ColumnOfCards25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const card75 = cards.slice(0, 1);
 	const remaining = cards.slice(1, 4);
@@ -449,7 +421,6 @@ const Card75_ColumnOfCards25 = ({
 						containerPalette={containerPalette}
 						containerType="dynamic/package"
 						showAge={showAge}
-						serverTime={serverTime}
 						headlineSizes={{ desktop: 'medium', tablet: 'small' }}
 						mediaPositionOnDesktop="bottom"
 						mediaPositionOnMobile="bottom"
@@ -481,7 +452,6 @@ const Card75_ColumnOfCards25 = ({
 									containerPalette={containerPalette}
 									containerType="dynamic/package"
 									showAge={showAge}
-									serverTime={serverTime}
 									image={
 										shouldShowImage ? card.image : undefined
 									}
@@ -512,7 +482,6 @@ export const DynamicPackage = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	let layout:
@@ -603,14 +572,12 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -622,7 +589,6 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					{/* Card75_Card25 does not support the first card being boosted - on Frontend the 75% card would
@@ -632,7 +598,6 @@ export const DynamicPackage = ({
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -644,21 +609,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -670,14 +632,12 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card75_ColumnOfCards25
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -689,21 +649,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -715,21 +672,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -741,21 +695,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -767,21 +718,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_ColumnOfTwo25_ColumnOfTwo25_ColumnOfTwo25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</>
@@ -793,21 +741,18 @@ export const DynamicPackage = ({
 						snaps={firstSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card100
 						cards={secondSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 					<Card25_Card25_Card25_Card25
 						cards={thirdSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						padBottom={true}
 						imageLoading={imageLoading}
 					/>
@@ -815,7 +760,6 @@ export const DynamicPackage = ({
 						cards={fourthSlice}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						showImage={false}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/DynamicSlow.tsx
+++ b/dotcom-rendering/src/components/DynamicSlow.tsx
@@ -27,7 +27,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 const ColumnOfCards50_Card50 = ({
@@ -35,12 +34,10 @@ const ColumnOfCards50_Card50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
-	serverTime,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const big = cards.slice(0, 1);
@@ -58,7 +55,6 @@ const ColumnOfCards50_Card50 = ({
 					<Card50Media50
 						trail={card}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -77,7 +73,6 @@ const ColumnOfCards50_Card50 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 									imageLoading={imageLoading}
 								/>
 							</LI>
@@ -94,12 +89,10 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 	showAge,
 	containerPalette,
 	imageLoading,
-	serverTime,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	return (
@@ -122,7 +115,6 @@ const ColumnOfCards50_ColumnOfCards50 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -141,7 +133,6 @@ export const DynamicSlow = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	let firstSliceLayout:
@@ -225,7 +216,6 @@ export const DynamicSlow = ({
 					<Card100PictureTop
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -235,7 +225,6 @@ export const DynamicSlow = ({
 					<Card100PictureRight
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -245,7 +234,6 @@ export const DynamicSlow = ({
 					<Card75_Card25
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -255,7 +243,6 @@ export const DynamicSlow = ({
 					<Card25_Card75
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -265,7 +252,6 @@ export const DynamicSlow = ({
 					<Card50_Card50
 						cards={firstSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -282,7 +268,6 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_ColumnOfCards50
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -292,7 +277,6 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_Card50
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -302,7 +286,6 @@ export const DynamicSlow = ({
 					<ColumnOfCards50_Card25_Card25
 						cards={secondSliceCards}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -330,7 +330,6 @@ const renderPodcastImage = (
 export type Props = {
 	linkTo: string;
 	format: ArticleFormat;
-	serverTime?: number;
 	headlineText: string;
 	headlineSizes?: ResponsiveFontSize;
 	byline?: string;
@@ -412,7 +411,6 @@ export const FeatureCard = ({
 	discussionApiUrl,
 	discussionId,
 	isExternalLink,
-	serverTime,
 	aspectRatio,
 	mobileAspectRatio,
 	starRating,
@@ -529,7 +527,6 @@ export const FeatureCard = ({
 										headlineSizes={headlineSizes}
 										webPublicationDate={webPublicationDate}
 										showClock={!!showClock}
-										serverTime={serverTime}
 										linkTo={linkTo}
 										discussionId={discussionId}
 										discussionApiUrl={discussionApiUrl}
@@ -779,7 +776,6 @@ export const FeatureCard = ({
 															webPublicationDate
 														}
 														showClock={!!showClock}
-														serverTime={serverTime}
 														isStorylines={
 															isStorylines
 														}

--- a/dotcom-rendering/src/components/FeatureCardCardAge.tsx
+++ b/dotcom-rendering/src/components/FeatureCardCardAge.tsx
@@ -4,14 +4,12 @@ import { CardAge } from './Card/components/CardAge';
 
 type Props = {
 	showClock: boolean;
-	serverTime?: number;
 	webPublicationDate: string;
 	isStorylines?: boolean;
 };
 
 export const FeatureCardCardAge = ({
 	showClock,
-	serverTime,
 	webPublicationDate,
 	isStorylines,
 }: Props) => {
@@ -24,7 +22,6 @@ export const FeatureCardCardAge = ({
 					isWithinTwelveHours: true,
 				}}
 				showClock={showClock}
-				serverTime={serverTime}
 				isTagPage={false}
 				colour={palette('--feature-card-footer-text')}
 			/>

--- a/dotcom-rendering/src/components/FetchMoreGalleriesData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchMoreGalleriesData.importable.tsx
@@ -12,7 +12,6 @@ import { Placeholder } from './Placeholder';
 
 type Props = {
 	discussionApiUrl: string;
-	serverTime?: number;
 	isAdFreeUser: boolean;
 	ajaxUrl: string;
 	guardianBaseUrl: string;
@@ -87,7 +86,6 @@ const fetchJson = async (ajaxUrl: string): Promise<MoreGalleriesResponse> => {
 
 export const FetchMoreGalleriesData = ({
 	discussionApiUrl,
-	serverTime,
 	isAdFreeUser,
 	ajaxUrl,
 	guardianBaseUrl,
@@ -149,7 +147,6 @@ export const FetchMoreGalleriesData = ({
 
 	return (
 		<MoreGalleries
-			serverTime={serverTime}
 			trails={buildTrails(data.trails, 5, isAdFreeUser)}
 			discussionApiUrl={discussionApiUrl}
 			guardianBaseUrl={guardianBaseUrl}

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -27,7 +27,6 @@ type Props = {
 	onwardsSource: OnwardsSource;
 	format: ArticleFormat;
 	discussionApiUrl: string;
-	serverTime?: number;
 	renderingTarget: RenderingTarget;
 	isAdFreeUser: boolean;
 	containerPosition: string;
@@ -76,7 +75,6 @@ export const FetchOnwardsData = ({
 	onwardsSource,
 	format,
 	discussionApiUrl,
-	serverTime,
 	renderingTarget,
 	isAdFreeUser,
 	containerPosition,
@@ -152,7 +150,6 @@ export const FetchOnwardsData = ({
 		<div ref={setIsInViewRef} css={minHeight(format.design)}>
 			{format.design === ArticleDesign.Gallery ? (
 				<ScrollableSmallOnwards
-					serverTime={serverTime}
 					trails={trails({
 						withMasterImage: true,
 						permitFallbackImage: false,
@@ -179,7 +176,6 @@ export const FetchOnwardsData = ({
 							: 'compact'
 					}
 					discussionApiUrl={discussionApiUrl}
-					serverTime={serverTime}
 					renderingTarget={renderingTarget}
 				/>
 			)}

--- a/dotcom-rendering/src/components/FirstPublished.tsx
+++ b/dotcom-rendering/src/components/FirstPublished.tsx
@@ -22,7 +22,6 @@ type Props = {
 	blockId: string;
 	isPinnedPost: boolean;
 	isOriginalPinnedPost: boolean;
-	serverTime?: number;
 };
 
 const href = (blockId: string, renderingTarget: RenderingTarget): string => {
@@ -43,7 +42,6 @@ const FirstPublished = ({
 	blockId,
 	isPinnedPost,
 	isOriginalPinnedPost,
-	serverTime,
 }: Props) => {
 	const publishedDate = new Date(firstPublished);
 	const { renderingTarget } = useConfig();
@@ -81,7 +79,6 @@ const FirstPublished = ({
 						<DateTime
 							date={new Date(firstPublished)}
 							display="relative"
-							serverTime={serverTime}
 							showWeekday={false}
 							showDate={true}
 							showTime={false}

--- a/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
+++ b/dotcom-rendering/src/components/FixedLargeSlowXIV.tsx
@@ -15,14 +15,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedLargeSlowXIV = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
@@ -39,7 +37,6 @@ export const FixedLargeSlowXIV = ({
 							<Card75Media50Right
 								trail={card}
 								showAge={showAge}
-								serverTime={serverTime}
 								containerPalette={containerPalette}
 								imageLoading={imageLoading}
 							/>
@@ -57,7 +54,6 @@ export const FixedLargeSlowXIV = ({
 							<Card25Media25
 								trail={card}
 								showAge={showAge}
-								serverTime={serverTime}
 								containerPalette={containerPalette}
 								imageLoading={imageLoading}
 							/>
@@ -78,7 +74,6 @@ export const FixedLargeSlowXIV = ({
 								trail={card}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 								imageLoading={imageLoading}
 							/>
 						</LI>
@@ -103,7 +98,6 @@ export const FixedLargeSlowXIV = ({
 							<CardDefault
 								trail={card}
 								showAge={showAge}
-								serverTime={serverTime}
 								containerPalette={containerPalette}
 							/>
 						</LI>

--- a/dotcom-rendering/src/components/FixedMediumFastXI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXI.tsx
@@ -10,7 +10,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 const decideOffset = ({
@@ -44,7 +43,6 @@ export const FixedMediumFastXI = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
@@ -55,7 +53,6 @@ export const FixedMediumFastXI = ({
 				cards={firstSlice}
 				containerPalette={containerPalette}
 				showAge={showAge}
-				serverTime={serverTime}
 				imageLoading={imageLoading}
 			/>
 			{/*
@@ -85,7 +82,6 @@ export const FixedMediumFastXI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedMediumFastXII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumFastXII.tsx
@@ -9,14 +9,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedMediumFastXII = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
@@ -37,7 +35,6 @@ export const FixedMediumFastXII = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 								imageLoading={imageLoading}
 							/>
 						</LI>
@@ -57,7 +54,6 @@ export const FixedMediumFastXII = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 							/>
 						</LI>
 					);

--- a/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVI.tsx
@@ -13,7 +13,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedMediumSlowVI = ({
@@ -21,7 +20,6 @@ export const FixedMediumSlowVI = ({
 	containerPalette,
 	showAge,
 	imageLoading,
-	serverTime,
 }: Props) => {
 	const firstSlice75 = trails.slice(0, 1);
 	const firstSlice25 = trails.slice(1, 2);
@@ -36,7 +34,6 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -52,7 +49,6 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -65,7 +61,6 @@ export const FixedMediumSlowVI = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowVII.tsx
@@ -13,14 +13,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedMediumSlowVII = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -41,7 +39,6 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -58,7 +55,6 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -71,7 +67,6 @@ export const FixedMediumSlowVII = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
+++ b/dotcom-rendering/src/components/FixedMediumSlowXIIMPU.tsx
@@ -14,7 +14,6 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	imageLoading: Loading;
-	serverTime?: number;
 	showAge?: boolean;
 };
 
@@ -29,11 +28,9 @@ const Card33_Card33_Card33 = ({
 	showAge,
 	padBottom,
 	imageLoading,
-	serverTime,
 }: {
 	trails: DCRFrontCard[];
 	imageLoading: Loading;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -49,7 +46,6 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -65,7 +61,6 @@ const Card33_Card33_Card33 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -85,11 +80,9 @@ const Card50_Card50 = ({
 	showAge,
 	padBottom,
 	imageLoading,
-	serverTime,
 }: {
 	trails: DCRFrontCard[];
 	imageLoading: Loading;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
 	padBottom?: boolean;
@@ -104,7 +97,6 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -120,7 +112,6 @@ const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -138,7 +129,6 @@ export const FixedMediumSlowXIIMPU = ({
 	containerPalette,
 	showAge,
 	imageLoading,
-	serverTime,
 }: Props) => {
 	const firstSlice = trails.slice(0, 3);
 	const remaining = trails.slice(3, 9);
@@ -152,7 +142,6 @@ export const FixedMediumSlowXIIMPU = ({
 								trail={trail}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 								key={trail.url}
 								imageLoading={imageLoading}
 							/>
@@ -164,7 +153,6 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={trails}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 				/>
 			) : (
@@ -172,7 +160,6 @@ export const FixedMediumSlowXIIMPU = ({
 					trails={firstSlice}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					padBottom={true}
 					imageLoading={imageLoading}
 				/>
@@ -196,7 +183,6 @@ export const FixedMediumSlowXIIMPU = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 						/>
 					</LI>
 				))}

--- a/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallFastVIII.tsx
@@ -10,14 +10,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallFastVIII = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	if (!trails[0]) return null;
@@ -38,7 +36,6 @@ export const FixedSmallFastVIII = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -66,7 +63,6 @@ export const FixedSmallFastVIII = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 								/>
 							</LI>
 						);

--- a/dotcom-rendering/src/components/FixedSmallSlowI.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowI.tsx
@@ -9,14 +9,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallSlowI = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice100 = trails.slice(0, 1);
@@ -29,7 +27,6 @@ export const FixedSmallSlowI = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIII.tsx
@@ -9,14 +9,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallSlowIII = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -30,7 +28,6 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -46,7 +43,6 @@ export const FixedSmallSlowIII = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowIV.tsx
@@ -9,14 +9,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallSlowIV = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 4);
@@ -30,7 +28,6 @@ export const FixedSmallSlowIV = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVHalf.tsx
@@ -9,14 +9,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallSlowVHalf = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice50 = trails.slice(0, 1);
@@ -36,7 +34,6 @@ export const FixedSmallSlowVHalf = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -51,7 +48,6 @@ export const FixedSmallSlowVHalf = ({
 									trail={trail}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 									imageLoading={imageLoading}
 								/>
 							</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVMPU.tsx
@@ -9,7 +9,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 /**
@@ -20,7 +19,6 @@ export const FixedSmallSlowVMPU = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => (
 	<UL direction="row" padBottom={true}>
@@ -36,7 +34,6 @@ export const FixedSmallSlowVMPU = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
+++ b/dotcom-rendering/src/components/FixedSmallSlowVThird.tsx
@@ -10,14 +10,12 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 };
 
 export const FixedSmallSlowVThird = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: Props) => {
 	const firstSlice25 = trails.slice(0, 2);
@@ -37,7 +35,6 @@ export const FixedSmallSlowVThird = ({
 							trail={trail}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -52,7 +49,6 @@ export const FixedSmallSlowVThird = ({
 									trail={trail}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 									headlineSizes={{ desktop: 'xxsmall' }}
 									mediaPositionOnDesktop="left"
 									mediaPositionOnMobile="none"

--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -29,7 +29,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
@@ -86,7 +85,6 @@ export const decideCardPositions = (cards: DCRFrontCard[]): GroupedCards => {
 type ImmersiveCardLayoutProps = {
 	card: DCRFrontCard;
 	containerPalette?: DCRContainerPalette;
-	serverTime?: number;
 	imageLoading: Loading;
 	collectionId: number;
 	isStorylines?: boolean;
@@ -101,7 +99,6 @@ type ImmersiveCardLayoutProps = {
 const ImmersiveCardLayout = ({
 	card,
 	containerPalette,
-	serverTime,
 	imageLoading,
 	collectionId,
 	isStorylines,
@@ -131,7 +128,6 @@ const ImmersiveCardLayout = ({
 				branding={card.branding}
 				containerPalette={containerPalette}
 				trailText={card.trailText}
-				serverTime={serverTime}
 				imageLoading={imageLoading}
 				aspectRatio="5:3"
 				mobileAspectRatio="4:5"
@@ -250,7 +246,6 @@ type SplashCardLayoutProps = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
@@ -262,7 +257,6 @@ const SplashCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	isLastRow,
@@ -279,7 +273,6 @@ const SplashCardLayout = ({
 			<ImmersiveCardLayout
 				card={card}
 				containerPalette={containerPalette}
-				serverTime={serverTime}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
 			/>
@@ -325,7 +318,6 @@ const SplashCardLayout = ({
 					containerPalette={containerPalette}
 					containerType="flexible/general"
 					showAge={showAge}
-					serverTime={serverTime}
 					headlineSizes={headlineSizes}
 					mediaPositionOnDesktop={mediaPositionOnDesktop}
 					mediaPositionOnMobile={mediaPositionOnMobile}
@@ -414,7 +406,6 @@ type FullWidthCardLayoutProps = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
 	isLastRow: boolean;
@@ -427,7 +418,6 @@ const FullWidthCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	isFirstRow,
@@ -458,7 +448,6 @@ const FullWidthCardLayout = ({
 			<ImmersiveCardLayout
 				card={card}
 				containerPalette={containerPalette}
-				serverTime={serverTime}
 				imageLoading={imageLoading}
 				collectionId={collectionId}
 				isStorylines={isStorylines}
@@ -481,7 +470,6 @@ const FullWidthCardLayout = ({
 					containerPalette={containerPalette}
 					containerType="flexible/general"
 					showAge={showAge}
-					serverTime={serverTime}
 					headlineSizes={headlineSizes}
 					mediaPositionOnDesktop="right"
 					mediaPositionOnMobile={
@@ -525,7 +513,6 @@ type HalfWidthCardLayoutProps = {
 	isFirstStandardRow?: boolean;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
 	containerLevel: DCRContainerLevel;
@@ -536,7 +523,6 @@ const HalfWidthCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	isFirstRow,
 	isFirstStandardRow,
@@ -573,7 +559,6 @@ const HalfWidthCardLayout = ({
 							containerPalette={containerPalette}
 							containerType="flexible/general"
 							showAge={showAge}
-							serverTime={serverTime}
 							image={card.image}
 							imageLoading={imageLoading}
 							mediaPositionOnDesktop="left"
@@ -611,7 +596,6 @@ export const FlexibleGeneral = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	containerLevel = 'Primary',
@@ -639,7 +623,6 @@ export const FlexibleGeneral = ({
 					cards={splash}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					isLastRow={cards.length === 0}
@@ -657,7 +640,6 @@ export const FlexibleGeneral = ({
 								cards={row.cards}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 								imageLoading={imageLoading}
 								aspectRatio={aspectRatio}
 								isFirstRow={!splash.length && i === 0}
@@ -677,7 +659,6 @@ export const FlexibleGeneral = ({
 								cards={row.cards}
 								containerPalette={containerPalette}
 								showAge={showAge}
-								serverTime={serverTime}
 								imageLoading={imageLoading}
 								isFirstRow={!splash.length && i === 0}
 								isFirstStandardRow={i === 0}

--- a/dotcom-rendering/src/components/FlexibleSpecial.tsx
+++ b/dotcom-rendering/src/components/FlexibleSpecial.tsx
@@ -27,7 +27,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
 	collectionId: number;
@@ -132,7 +131,6 @@ type OneCardLayoutProps = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	isLastRow: boolean;
 	isFirstRow: boolean;
@@ -144,7 +142,6 @@ export const OneCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	isLastRow,
@@ -180,7 +177,6 @@ export const OneCardLayout = ({
 					containerPalette={containerPalette}
 					containerType="flexible/special"
 					showAge={showAge}
-					serverTime={serverTime}
 					headlineSizes={headlineSizes}
 					mediaSize={mediaSize}
 					mediaPositionOnDesktop={mediaPositionOnDesktop}
@@ -228,7 +224,6 @@ type TwoOrFourCardLayoutProps = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	isFirstRow: boolean;
@@ -239,7 +234,6 @@ const TwoOrFourCardLayout = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	showImage = true,
 	imageLoading,
 	aspectRatio,
@@ -265,7 +259,6 @@ const TwoOrFourCardLayout = ({
 							containerPalette={containerPalette}
 							containerType="flexible/special"
 							showAge={showAge}
-							serverTime={serverTime}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
 							mediaPositionOnDesktop={getImagePosition(
@@ -299,7 +292,6 @@ export const FlexibleSpecial = ({
 	groupedTrails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	containerLevel = 'Primary',
@@ -325,7 +317,6 @@ export const FlexibleSpecial = ({
 					cards={snaps}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					isFirstRow={true}
@@ -339,7 +330,6 @@ export const FlexibleSpecial = ({
 					cards={splash}
 					containerPalette={containerPalette}
 					showAge={showAge}
-					serverTime={serverTime}
 					imageLoading={imageLoading}
 					aspectRatio={aspectRatio}
 					isLastRow={cards.length === 0}
@@ -353,7 +343,6 @@ export const FlexibleSpecial = ({
 				cards={cards}
 				containerPalette={containerPalette}
 				showAge={showAge}
-				serverTime={serverTime}
 				imageLoading={imageLoading}
 				aspectRatio={aspectRatio}
 				isFirstRow={!isNonEmptyArray(snaps) && !isNonEmptyArray(splash)}

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -6,7 +6,7 @@ import { Card } from './Card/Card';
 type Props = {
 	trail: DCRFrontCard;
 } & Partial<CardProps> &
-	Pick<CardProps, 'imageLoading' | 'serverTime'>;
+	Pick<CardProps, 'imageLoading'>;
 
 /**
  * A wrapper around the normal Card component providing sensible defaults for Cards on front containers.
@@ -25,7 +25,7 @@ type Props = {
  */
 export const FrontCard = (props: Props) => {
 	const { trail, ...cardProps } = props;
-	const defaultProps: Omit<CardProps, 'imageLoading' | 'serverTime'> = {
+	const defaultProps: Omit<CardProps, 'imageLoading'> = {
 		linkTo: trail.url,
 		format: trail.format,
 		headlineText: trail.headline,

--- a/dotcom-rendering/src/components/Island.test.tsx
+++ b/dotcom-rendering/src/components/Island.test.tsx
@@ -12,6 +12,7 @@ import { BrazeMessaging } from './BrazeMessaging.importable';
 import { CardCommentCount } from './CardCommentCount.importable';
 import { CommentCount } from './CommentCount.importable';
 import { ConfigProvider } from './ConfigContext';
+import { DateTimeProvider } from './DateTimeContext';
 import { DiscussionLayout } from './DiscussionLayout';
 import { DiscussionMeta } from './DiscussionMeta.importable';
 import { EnhanceAffiliateLinks } from './EnhanceAffiliateLinks.importable';
@@ -102,7 +103,7 @@ describe('Island: server-side rendering', () => {
 				editionId: 'UK',
 			}}
 		>
-			{children}
+			<DateTimeProvider value={Date.now()}>{children}</DateTimeProvider>
 		</ConfigProvider>
 	);
 

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 import type { ScheduleOptions, SchedulePriority } from '../lib/scheduler';
+import { useDateTime } from './DateTimeContext';
 import { IslandContext, IslandProvider } from './IslandContext';
 
 type DeferredProps = {
@@ -62,6 +63,11 @@ export const Island = ({ priority, defer, children, role }: IslandProps) => {
 	 */
 	const island = useContext(IslandContext);
 
+	/**
+	 * Datetime from server render
+	 */
+	const dateTime = useDateTime();
+
 	return (
 		<IslandProvider value={{ isChild: true }}>
 			{/* Child islands defer to nearest parent island for hydration */}
@@ -74,6 +80,7 @@ export const Island = ({ priority, defer, children, role }: IslandProps) => {
 					deferUntil={defer?.until}
 					props={JSON.stringify(children.props)}
 					rootMargin={rootMargin}
+					dateTime={dateTime}
 					data-spacefinder-role={role}
 				>
 					{children}
@@ -92,6 +99,7 @@ export type GuIsland = {
 	priority: ScheduleOptions['priority'];
 	deferUntil?: NonNullable<IslandProps['defer']>['until'];
 	rootMargin?: string;
+	dateTime?: number;
 	props: string;
 	children: React.ReactNode;
 };

--- a/dotcom-rendering/src/components/IslandContext.test.tsx
+++ b/dotcom-rendering/src/components/IslandContext.test.tsx
@@ -1,12 +1,16 @@
 import { render } from '@testing-library/react';
+import { DateTimeProvider } from './DateTimeContext';
 import { Island } from './Island';
 
 describe('IslandContext tracks nesting of islands', () => {
 	test('Single island', () => {
 		const { container } = render(
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<span>🏝️</span>
-			</Island>,
+			<DateTimeProvider value={Date.now()}>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<span>🏝️</span>
+				</Island>
+				,
+			</DateTimeProvider>,
 		);
 		const islands = container.querySelectorAll('gu-island');
 		expect(islands.length).toBe(1);
@@ -14,13 +18,16 @@ describe('IslandContext tracks nesting of islands', () => {
 
 	test('Nested island', () => {
 		const { container } = render(
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<div>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<span>🏝️</span>
-					</Island>
-				</div>
-			</Island>,
+			<DateTimeProvider value={Date.now()}>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<div>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<span>🏝️</span>
+						</Island>
+					</div>
+				</Island>
+				,
+			</DateTimeProvider>,
 		);
 		const islands = container.querySelectorAll('gu-island');
 		expect(islands.length).toBe(1);
@@ -28,20 +35,23 @@ describe('IslandContext tracks nesting of islands', () => {
 
 	test('Multiple nested islands', () => {
 		const { container } = render(
-			<Island priority="critical">
-				<div>
-					<Island priority="critical">
-						<div>
-							<Island priority="critical">
-								<span>🏝️</span>
-							</Island>
-							<Island priority="critical">
-								<span>🏝️</span>
-							</Island>
-						</div>
-					</Island>
-				</div>
-			</Island>,
+			<DateTimeProvider value={Date.now()}>
+				<Island priority="critical">
+					<div>
+						<Island priority="critical">
+							<div>
+								<Island priority="critical">
+									<span>🏝️</span>
+								</Island>
+								<Island priority="critical">
+									<span>🏝️</span>
+								</Island>
+							</div>
+						</Island>
+					</div>
+				</Island>
+				,
+			</DateTimeProvider>,
 		);
 		const islands = container.querySelectorAll('gu-island');
 		expect(islands.length).toBe(1);
@@ -49,13 +59,16 @@ describe('IslandContext tracks nesting of islands', () => {
 
 	test('Parent island includes props for child islands', () => {
 		const { container } = render(
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<div>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<span className="archipelago">🏝️</span>
-					</Island>
-				</div>
-			</Island>,
+			<DateTimeProvider value={Date.now()}>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<div>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<span className="archipelago">🏝️</span>
+						</Island>
+					</div>
+				</Island>
+				,
+			</DateTimeProvider>,
 		);
 		const island = container.querySelector('gu-island');
 		expect(island).toHaveAttribute(

--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -16,7 +16,6 @@ interface Props {
 	title: string;
 	isSummary: boolean;
 	filterKeyEvents: boolean;
-	serverTime?: number;
 	cardPosition?: string;
 	renderingTarget: RenderingTarget;
 }
@@ -139,7 +138,6 @@ export const KeyEventCard = ({
 	title,
 	filterKeyEvents,
 	cardPosition = 'unknown position',
-	serverTime,
 	renderingTarget,
 }: Props) => {
 	const url = getUrl({ filterKeyEvents, renderingTarget, id });
@@ -156,7 +154,6 @@ export const KeyEventCard = ({
 					<DateTime
 						date={new Date(blockFirstPublished)}
 						display="relative"
-						serverTime={serverTime}
 						showWeekday={false}
 						showDate={true}
 						showTime={false}

--- a/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/KeyEventsCarousel.importable.tsx
@@ -17,7 +17,6 @@ interface Props {
 	keyEvents: Block[];
 	filterKeyEvents: boolean;
 	id: 'key-events-carousel-desktop' | 'key-events-carousel-mobile';
-	serverTime?: number;
 	renderingTarget: RenderingTarget;
 }
 type ValidBlock = Block & {
@@ -110,7 +109,6 @@ export const KeyEventsCarousel = ({
 	keyEvents,
 	filterKeyEvents,
 	id,
-	serverTime,
 	renderingTarget,
 }: Props) => {
 	const carousel = useRef<HTMLDivElement | null>(null);
@@ -162,7 +160,6 @@ export const KeyEventsCarousel = ({
 								isSummary={keyEvent.attributes.summary}
 								title={keyEvent.title}
 								cardPosition={`${index} of ${carouselLength}`}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						);

--- a/dotcom-rendering/src/components/LatestLinks.importable.tsx
+++ b/dotcom-rendering/src/components/LatestLinks.importable.tsx
@@ -20,7 +20,6 @@ import type { Alignment } from './SupportingContent';
 type Props = {
 	id: string;
 	direction: Alignment;
-	serverTime?: number;
 	isDynamo?: boolean;
 	containerPalette?: DCRContainerPalette;
 	displayHeader?: boolean;
@@ -118,7 +117,6 @@ export const LatestLinks = ({
 	direction,
 	isDynamo = false,
 	containerPalette,
-	serverTime,
 	displayHeader = false,
 	directionOnMobile,
 }: Props) => {
@@ -204,7 +202,6 @@ export const LatestLinks = ({
 														)
 													}
 													display="relative"
-													serverTime={serverTime}
 													showWeekday={false}
 													showDate={true}
 													showTime={false}

--- a/dotcom-rendering/src/components/LiveBlock.tsx
+++ b/dotcom-rendering/src/components/LiveBlock.tsx
@@ -26,7 +26,6 @@ type Props = {
 	pinnedPostId?: string;
 	editionId: EditionId;
 	shouldHideAds: boolean;
-	serverTime?: number;
 	idApiUrl?: string;
 };
 
@@ -46,7 +45,6 @@ export const LiveBlock = ({
 	pinnedPostId,
 	editionId,
 	shouldHideAds,
-	serverTime,
 	idApiUrl,
 }: Props) => {
 	if (block.elements.length === 0) return null;
@@ -72,7 +70,6 @@ export const LiveBlock = ({
 			contributors={block.contributors}
 			isPinnedPost={isPinnedPost}
 			isOriginalPinnedPost={isOriginalPinnedPost}
-			serverTime={serverTime}
 		>
 			{block.elements.map((element, index) => (
 				<RenderArticleElement

--- a/dotcom-rendering/src/components/LiveBlockContainer.tsx
+++ b/dotcom-rendering/src/components/LiveBlockContainer.tsx
@@ -25,7 +25,6 @@ type Props = {
 	isLiveUpdate?: boolean;
 	contributors?: BlockContributor[];
 	isPinnedPost: boolean;
-	serverTime?: number;
 	isOriginalPinnedPost?: boolean;
 };
 
@@ -137,7 +136,6 @@ export const LiveBlockContainer = ({
 	contributors,
 	isPinnedPost,
 	isOriginalPinnedPost = false,
-	serverTime,
 }: Props) => {
 	return (
 		<article
@@ -170,7 +168,6 @@ export const LiveBlockContainer = ({
 						blockId={blockId}
 						isPinnedPost={isPinnedPost}
 						isOriginalPinnedPost={isOriginalPinnedPost}
-						serverTime={serverTime}
 					/>
 				)}
 				{blockTitle ? <BlockTitle title={blockTitle} /> : null}

--- a/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
+++ b/dotcom-rendering/src/components/LiveBlogBlocksAndAdverts.tsx
@@ -24,7 +24,6 @@ type Props = {
 	isSensitive: boolean;
 	isLiveUpdate?: boolean;
 	shouldHideAds: boolean;
-	serverTime?: number;
 	idApiUrl?: string;
 };
 /**
@@ -50,7 +49,6 @@ export const LiveBlogBlocksAndAdverts = ({
 	isLiveUpdate,
 	editionId,
 	shouldHideAds,
-	serverTime,
 	idApiUrl,
 }: Props) => {
 	const { renderingTarget } = useConfig();
@@ -75,7 +73,6 @@ export const LiveBlogBlocksAndAdverts = ({
 				pinnedPostId={pinnedPost?.id}
 				editionId={editionId}
 				shouldHideAds={shouldHideAds}
-				serverTime={serverTime}
 				idApiUrl={idApiUrl}
 			/>
 		);

--- a/dotcom-rendering/src/components/LiveBlogRenderer.tsx
+++ b/dotcom-rendering/src/components/LiveBlogRenderer.tsx
@@ -38,7 +38,6 @@ type Props = {
 	keyEvents: Block[];
 	filterKeyEvents: boolean;
 	shouldHideAds: boolean;
-	serverTime?: number;
 	idApiUrl?: string;
 };
 
@@ -66,7 +65,6 @@ export const LiveBlogRenderer = ({
 	filterKeyEvents = false,
 	editionId,
 	shouldHideAds,
-	serverTime,
 	idApiUrl,
 }: Props) => {
 	const { renderingTarget } = useConfig();
@@ -79,7 +77,7 @@ export const LiveBlogRenderer = ({
 					<Island defer={{ until: 'idle' }} priority="feature">
 						<EnhancePinnedPost />
 					</Island>
-					<PinnedPost pinnedPost={pinnedPost} serverTime={serverTime}>
+					<PinnedPost pinnedPost={pinnedPost}>
 						<LiveBlock
 							format={format}
 							block={pinnedPost}
@@ -95,7 +93,6 @@ export const LiveBlogRenderer = ({
 							isPinnedPost={true}
 							editionId={editionId}
 							shouldHideAds={shouldHideAds}
-							serverTime={serverTime}
 							idApiUrl={idApiUrl}
 						/>
 					</PinnedPost>
@@ -109,7 +106,6 @@ export const LiveBlogRenderer = ({
 							filterKeyEvents={filterKeyEvents}
 							id={'key-events-carousel-mobile'}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					</Island>
 					<Island priority="feature" defer={{ until: 'visible' }}>
@@ -139,7 +135,6 @@ export const LiveBlogRenderer = ({
 				pinnedPost={pinnedPost}
 				editionId={editionId}
 				shouldHideAds={shouldHideAds}
-				serverTime={serverTime}
 				idApiUrl={idApiUrl}
 			/>
 			{isWeb && blocks.length > 4 && !isLiveUpdate && (

--- a/dotcom-rendering/src/components/MoreGalleries.tsx
+++ b/dotcom-rendering/src/components/MoreGalleries.tsx
@@ -15,7 +15,6 @@ import { Card } from './Card/Card';
 import type { Props as CardProps } from './Card/Card';
 
 type Props = {
-	serverTime?: number;
 	trails: TrailType[];
 	discussionApiUrl: string;
 	guardianBaseUrl: string;
@@ -160,7 +159,6 @@ const getDefaultCardProps = (
 	trail: TrailType,
 	discussionApiUrl: string,
 	format: ArticleFormat,
-	serverTime?: number,
 ) => {
 	const defaultProps: CardProps = {
 		linkTo: trail.url,
@@ -187,7 +185,6 @@ const getDefaultCardProps = (
 		mainMedia: trail.mainMedia,
 		isExternalLink: false,
 		branding: trail.branding,
-		serverTime,
 		imageLoading: 'lazy',
 		trailText: trail.trailText,
 		showAge: false,
@@ -235,7 +232,6 @@ export const MoreGalleries = (props: Props) => {
 						firstTrail,
 						props.discussionApiUrl,
 						props.format,
-						props.serverTime,
 					)}
 				/>
 				<StraightLines
@@ -258,7 +254,6 @@ export const MoreGalleries = (props: Props) => {
 									trail,
 									props.discussionApiUrl,
 									props.format,
-									props.serverTime,
 								)}
 								mediaSize="medium"
 							/>

--- a/dotcom-rendering/src/components/MostViewedFooter.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooter.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { useApi as useApi_ } from '../lib/useApi';
 import { ConfigProvider } from './ConfigContext';
+import { DateTimeProvider } from './DateTimeContext';
 import { responseWithTwoTabs } from './MostViewed.mocks';
 import { MostViewedFooterData } from './MostViewedFooterData.importable';
 
@@ -30,11 +31,13 @@ describe('MostViewedFooterData', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedFooterData
-					sectionId="Section Name"
-					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					edition="UK"
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedFooterData
+						sectionId="Section Name"
+						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+						edition="UK"
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -73,11 +76,13 @@ describe('MostViewedFooterData', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedFooterData
-					sectionId="Section Name"
-					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					edition="UK"
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedFooterData
+						sectionId="Section Name"
+						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+						edition="UK"
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -135,11 +140,13 @@ describe('MostViewedFooterData', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedFooterData
-					sectionId="Section Name"
-					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					edition="UK"
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedFooterData
+						sectionId="Section Name"
+						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+						edition="UK"
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -182,11 +189,13 @@ describe('MostViewedFooterData', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedFooterData
-					sectionId="Section Name"
-					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					edition="UK"
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedFooterData
+						sectionId="Section Name"
+						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+						edition="UK"
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -205,11 +214,13 @@ describe('MostViewedFooterData', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedFooterData
-					sectionId="Section Name"
-					ajaxUrl="https://api.nextgen.guardianapps.co.uk"
-					edition="UK"
-				/>
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedFooterData
+						sectionId="Section Name"
+						ajaxUrl="https://api.nextgen.guardianapps.co.uk"
+						edition="UK"
+					/>
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 

--- a/dotcom-rendering/src/components/MostViewedRight.test.tsx
+++ b/dotcom-rendering/src/components/MostViewedRight.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { useApi as useApi_ } from '../lib/useApi';
 import { ConfigProvider } from './ConfigContext';
+import { DateTimeProvider } from './DateTimeContext';
 import { responseWithTwoTabs } from './MostViewed.mocks';
 import { MostViewedRight } from './MostViewedRight';
 
@@ -27,7 +28,9 @@ describe('MostViewedList', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedRight />
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedRight />
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -77,7 +80,9 @@ describe('MostViewedList', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedRight limitItems={3} />
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedRight limitItems={3} />
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 
@@ -106,7 +111,9 @@ describe('MostViewedList', () => {
 					editionId: 'UK',
 				}}
 			>
-				<MostViewedRight />
+				<DateTimeProvider value={Date.now()}>
+					<MostViewedRight />
+				</DateTimeProvider>
 			</ConfigProvider>,
 		);
 

--- a/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.importable.tsx
@@ -184,7 +184,6 @@ type Props = {
 	pillar: ArticleTheme;
 	shortUrlId: string;
 	discussionApiUrl: string;
-	serverTime?: number;
 	renderingTarget: RenderingTarget;
 	webURL: string;
 };
@@ -220,7 +219,6 @@ export const OnwardsUpper = ({
 	editionId,
 	shortUrlId,
 	discussionApiUrl,
-	serverTime,
 	renderingTarget,
 	webURL,
 }: Props) => {
@@ -334,7 +332,6 @@ export const OnwardsUpper = ({
 						onwardsSource={onwardsSource}
 						format={format}
 						discussionApiUrl={discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						isAdFreeUser={isAdFreeUser}
 						containerPosition="first"
@@ -356,7 +353,6 @@ export const OnwardsUpper = ({
 						onwardsSource="curated-content"
 						format={format}
 						discussionApiUrl={discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						isAdFreeUser={isAdFreeUser}
 						containerPosition={

--- a/dotcom-rendering/src/components/PersonalisedMediumFour.importable.tsx
+++ b/dotcom-rendering/src/components/PersonalisedMediumFour.importable.tsx
@@ -36,7 +36,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
@@ -68,7 +67,6 @@ export const PersonalisedMediumFour = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	showImage = true,
 	aspectRatio,
@@ -155,7 +153,6 @@ export const PersonalisedMediumFour = ({
 								containerPalette={containerPalette}
 								containerType="static/medium/4"
 								showAge={showAge}
-								serverTime={serverTime}
 								image={showImage ? card.image : undefined}
 								imageLoading={imageLoading}
 								mediaPositionOnDesktop={getMediaPositionOnDesktop(

--- a/dotcom-rendering/src/components/PinnedPost.tsx
+++ b/dotcom-rendering/src/components/PinnedPost.tsx
@@ -140,10 +140,9 @@ const buttonIcon = css`
 type Props = {
 	pinnedPost: Block;
 	children: React.ReactNode;
-	serverTime?: number;
 };
 
-export const PinnedPost = ({ pinnedPost, children, serverTime }: Props) => {
+export const PinnedPost = ({ pinnedPost, children }: Props) => {
 	return (
 		<div
 			id="pinned-post"
@@ -170,7 +169,6 @@ export const PinnedPost = ({ pinnedPost, children, serverTime }: Props) => {
 						<DateTime
 							date={new Date(pinnedPost.blockFirstPublished)}
 							display="relative"
-							serverTime={serverTime}
 							showWeekday={false}
 							showDate={true}
 							showTime={false}

--- a/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.importable.tsx
@@ -10,7 +10,6 @@ import { ScrollableCarousel } from './ScrollableCarousel';
 type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
-	serverTime?: number;
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	collectionId: number;
@@ -26,7 +25,6 @@ type Props = {
 export const ScrollableFeature = ({
 	trails,
 	containerPalette,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	collectionId,
@@ -63,7 +61,6 @@ export const ScrollableFeature = ({
 						isExternalLink={card.isExternalLink}
 						branding={card.branding}
 						containerPalette={containerPalette}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 						aspectRatio={aspectRatio}
 						imageSize="feature"

--- a/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableMedium.importable.tsx
@@ -11,7 +11,6 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	sectionId: string;
@@ -27,7 +26,6 @@ type Props = {
 export const ScrollableMedium = ({
 	trails,
 	containerPalette,
-	serverTime,
 	imageLoading,
 	showAge,
 	aspectRatio,
@@ -50,7 +48,6 @@ export const ScrollableMedium = ({
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}
-							serverTime={serverTime}
 							containerPalette={containerPalette}
 							containerType="scrollable/medium"
 							showAge={!!showAge}

--- a/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmall.importable.tsx
@@ -10,7 +10,6 @@ type Props = {
 	trails: DCRFrontCard[];
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	imageLoading: 'lazy' | 'eager';
 	aspectRatio: AspectRatio;
 	sectionId: string;
@@ -52,7 +51,6 @@ type Props = {
 export const ScrollableSmall = ({
 	trails,
 	containerPalette,
-	serverTime,
 	imageLoading,
 	showAge,
 	aspectRatio,
@@ -79,7 +77,6 @@ export const ScrollableSmall = ({
 						<FrontCard
 							trail={trail}
 							imageLoading={imageLoading}
-							serverTime={serverTime}
 							containerPalette={containerPalette}
 							containerType="scrollable/small"
 							showAge={!!showAge}

--- a/dotcom-rendering/src/components/ScrollableSmallOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallOnwards.stories.tsx
@@ -14,7 +14,6 @@ type Story = StoryObj<typeof meta>;
 
 export const ScrollableSmallOnwardsStory = {
 	args: {
-		serverTime: new Date('2022-09-01T20:00:25.000Z').getTime(),
 		discussionApiUrl:
 			'https://discussion.code.dev-theguardian.com/discussion-api',
 		heading: 'More on this story',

--- a/dotcom-rendering/src/components/ScrollableSmallOnwards.tsx
+++ b/dotcom-rendering/src/components/ScrollableSmallOnwards.tsx
@@ -18,7 +18,6 @@ import type { Props as CardProps } from './Card/Card';
 import { ScrollableCarousel } from './ScrollableCarousel';
 
 type Props = {
-	serverTime?: number;
 	trails: TrailType[];
 	discussionApiUrl: string;
 	heading: string;
@@ -119,7 +118,6 @@ export const ScrollableSmallOnwards = (props: Props) => {
 										props.discussionApiUrl,
 										props.onwardsSource,
 										props.format,
-										props.serverTime,
 									)}
 									showTopBarDesktop={desktopBottomCards.includes(
 										index,
@@ -190,12 +188,10 @@ const getDefaultCardProps = (
 	discussionApiUrl: string,
 	onwardsSource: OnwardsSource,
 	format: ArticleFormat,
-	serverTime?: number,
 ) => {
 	const defaultProps: CardProps = {
 		linkTo: trail.url,
 		imageLoading: 'lazy',
-		serverTime,
 		format: trail.format,
 		contextFormat: format,
 		containerType: 'scrollable/small',

--- a/dotcom-rendering/src/components/StaticFeatureTwo.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.tsx
@@ -13,7 +13,6 @@ type Props = {
 	trails: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
-	serverTime?: number;
 	aspectRatio: AspectRatio;
 	collectionId: number;
 };
@@ -27,7 +26,6 @@ type Props = {
 export const StaticFeatureTwo = ({
 	trails,
 	containerPalette,
-	serverTime,
 	imageLoading,
 	aspectRatio,
 	collectionId,
@@ -68,7 +66,6 @@ export const StaticFeatureTwo = ({
 							isExternalLink={card.isExternalLink}
 							branding={card.branding}
 							containerPalette={containerPalette}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 							aspectRatio={aspectRatio}
 							imageSize="feature-large"

--- a/dotcom-rendering/src/components/StaticMediumFour.tsx
+++ b/dotcom-rendering/src/components/StaticMediumFour.tsx
@@ -28,7 +28,6 @@ type Props = {
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 	showImage?: boolean;
 	aspectRatio: AspectRatio;
 	containerLevel?: DCRContainerLevel;
@@ -38,7 +37,6 @@ export const StaticMediumFour = ({
 	trails,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 	showImage = true,
 	aspectRatio,
@@ -62,7 +60,6 @@ export const StaticMediumFour = ({
 							containerPalette={containerPalette}
 							containerType="static/medium/4"
 							showAge={showAge}
-							serverTime={serverTime}
 							image={showImage ? card.image : undefined}
 							imageLoading={imageLoading}
 							mediaPositionOnDesktop={getMediaPositionOnDesktop(

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -55,7 +55,6 @@ export type Props = {
 	headlineSizes?: ResponsiveFontSize;
 	webPublicationDate?: string;
 	showClock?: boolean;
-	serverTime?: number;
 	linkTo?: string;
 	discussionApiUrl?: string;
 	discussionId?: string;
@@ -110,7 +109,6 @@ export const YoutubeAtom = ({
 	headlineSizes,
 	webPublicationDate,
 	showClock,
-	serverTime,
 	linkTo,
 	discussionApiUrl,
 	discussionId,
@@ -259,7 +257,6 @@ export const YoutubeAtom = ({
 								trailText={trailText}
 								webPublicationDate={webPublicationDate}
 								showClock={!!showClock}
-								serverTime={serverTime}
 								linkTo={linkTo}
 								discussionId={discussionId}
 								discussionApiUrl={discussionApiUrl}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -133,7 +133,6 @@ type Props = {
 	trailText?: string;
 	webPublicationDate?: string;
 	showClock?: boolean;
-	serverTime?: number;
 	linkTo?: string;
 	discussionApiUrl?: string;
 	discussionId?: string;
@@ -159,7 +158,6 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	trailText,
 	webPublicationDate,
 	showClock,
-	serverTime,
 	linkTo,
 	discussionId,
 	discussionApiUrl,
@@ -171,9 +169,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	const hasDuration = !isUndefined(duration) && duration > 0;
 	const isVideoArticle = format.design === ArticleDesign.Video;
 	const showCardAge =
-		webPublicationDate !== undefined &&
-		showClock !== undefined &&
-		serverTime === undefined;
+		webPublicationDate !== undefined && showClock !== undefined;
 
 	const showCommentCount =
 		linkTo !== undefined &&
@@ -272,7 +268,6 @@ export const YoutubeAtomFeatureCardOverlay = ({
 									<FeatureCardCardAge
 										webPublicationDate={webPublicationDate}
 										showClock={!!showClock}
-										serverTime={serverTime}
 									/>
 								) : undefined
 							}

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -43,7 +43,6 @@ type Props = {
 	headlineSizes?: ResponsiveFontSize;
 	webPublicationDate?: string;
 	showClock?: boolean;
-	serverTime?: number;
 	linkTo?: string;
 	discussionApiUrl?: string;
 	discussionId?: string;
@@ -85,7 +84,6 @@ export const YoutubeBlockComponent = ({
 	headlineSizes,
 	webPublicationDate,
 	showClock,
-	serverTime,
 	linkTo,
 	discussionApiUrl,
 	discussionId,
@@ -216,7 +214,6 @@ export const YoutubeBlockComponent = ({
 				headlineSizes={headlineSizes}
 				webPublicationDate={webPublicationDate}
 				showClock={!!showClock}
-				serverTime={serverTime}
 				linkTo={linkTo}
 				discussionId={discussionId}
 				discussionApiUrl={discussionApiUrl}

--- a/dotcom-rendering/src/layouts/AudioLayout.tsx
+++ b/dotcom-rendering/src/layouts/AudioLayout.tsx
@@ -126,7 +126,6 @@ interface Props {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends Props {
@@ -135,7 +134,7 @@ interface WebProps extends Props {
 }
 
 export const AudioLayout = (props: WebProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const audioData = getAudioData(article.mainMediaElements);
 
 	const {
@@ -491,7 +490,6 @@ export const AudioLayout = (props: WebProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -515,7 +513,6 @@ export const AudioLayout = (props: WebProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/CommentLayout.tsx
+++ b/dotcom-rendering/src/layouts/CommentLayout.tsx
@@ -260,7 +260,6 @@ interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends CommonProps {
@@ -273,7 +272,7 @@ interface AppsProps extends CommonProps {
 }
 
 export const CommentLayout = (props: WebProps | AppsProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 	const {
@@ -741,7 +740,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -765,7 +763,6 @@ export const CommentLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -41,8 +41,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 		theme: article.theme,
 	};
 
-	const serverTime = article.serverTime;
-
 	switch (article.display) {
 		case ArticleDisplay.Immersive: {
 			switch (article.design) {
@@ -61,7 +59,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				}
@@ -77,7 +74,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Comment:
@@ -88,7 +84,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Picture:
@@ -97,7 +92,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				default:
@@ -106,7 +100,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 			}
@@ -120,7 +113,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 
@@ -140,7 +132,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Comment:
@@ -151,7 +142,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.NewsletterSignup:
@@ -162,7 +152,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 						<GalleryLayout
 							gallery={article}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.HostedArticle:
@@ -188,7 +177,6 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 							article={article.frontendData}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 			}
@@ -202,8 +190,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 		display: article.display,
 		theme: article.theme,
 	};
-
-	const serverTime = article.serverTime;
 
 	switch (article.display) {
 		case ArticleDisplay.Immersive: {
@@ -225,7 +211,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							format={format}
 							NAV={NAV}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				}
@@ -242,7 +227,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Comment:
@@ -254,7 +238,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Picture:
@@ -264,7 +247,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				default:
@@ -274,7 +256,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 			}
@@ -289,7 +270,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.FullPageInteractive: {
@@ -310,7 +290,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Comment:
@@ -322,7 +301,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.NewsletterSignup:
@@ -332,7 +310,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Audio:
@@ -342,7 +319,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							format={format}
 							NAV={NAV}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.Crossword:
@@ -359,7 +335,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							gallery={article}
 							NAV={NAV}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 				case ArticleDesign.HostedArticle:
@@ -386,7 +361,6 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 							NAV={NAV}
 							format={format}
 							renderingTarget={renderingTarget}
-							serverTime={serverTime}
 						/>
 					);
 			}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -113,8 +113,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		editionId,
 	} = front;
 
-	const serverTime = front.serverTime;
-
 	const renderAds = canRenderAds(front);
 
 	const hasPageSkin = renderAds && hasPageSkinConfig;
@@ -170,7 +168,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					]}
 					groupedTrails={highlightsCollection.grouped}
 					showAge={false}
-					serverTime={serverTime}
 					imageLoading="eager"
 					aspectRatio={
 						highlightsCollection.aspectRatio ??
@@ -510,7 +507,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 										)
 									}
 									imageLoading={imageLoading}
-									serverTime={serverTime}
 									aspectRatio={
 										collection.aspectRatio ??
 										fallbackAspectRatio(

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -55,7 +55,6 @@ import { BannerWrapper, Stuck } from './lib/stickiness';
 interface Props {
 	gallery: Gallery;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends Props {
@@ -77,7 +76,7 @@ const headerStyles = css`
 `;
 
 export const GalleryLayout = (props: WebProps | AppProps) => {
-	const { gallery, renderingTarget, serverTime } = props;
+	const { gallery, renderingTarget } = props;
 
 	const {
 		config: {
@@ -201,7 +200,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 						ajaxUrl={gallery.frontendData.config.ajaxUrl}
 						guardianBaseUrl={gallery.frontendData.guardianBaseURL}
 						discussionApiUrl={discussionApiUrl}
-						serverTime={serverTime}
 						isAdFreeUser={frontendData.isAdFreeUser}
 						format={format}
 					/>
@@ -214,7 +212,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 				display={format.display}
 			/>
 			<ScrollableSmallOnwards
-				serverTime={serverTime}
 				trails={gallery.storyPackage?.trails ?? []}
 				discussionApiUrl={discussionApiUrl}
 				format={format}
@@ -238,7 +235,6 @@ export const GalleryLayout = (props: WebProps | AppProps) => {
 					editionId={frontendData.editionId}
 					shortUrlId={frontendData.config.shortUrlId}
 					discussionApiUrl={frontendData.config.discussionApiUrl}
-					serverTime={serverTime}
 					renderingTarget={renderingTarget}
 					webURL={frontendData.webURL}
 				/>

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -186,7 +186,6 @@ const stretchLines = css`
 interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
-	serverTime?: number;
 }
 
 interface WebProps extends CommonProps {
@@ -230,7 +229,7 @@ const Box = ({ children }: { children: React.ReactNode }) => (
 );
 
 export const ImmersiveLayout = (props: WebProps | AppProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
@@ -828,7 +827,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -852,7 +850,6 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -192,7 +192,6 @@ interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends CommonProps {
@@ -205,7 +204,7 @@ interface AppsProps extends CommonProps {
 }
 
 export const InteractiveLayout = (props: WebProps | AppsProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
 		editionId,
@@ -644,7 +643,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -668,7 +666,6 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -235,7 +235,6 @@ interface BaseProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface AppsProps extends BaseProps {
@@ -248,7 +247,7 @@ interface WebProps extends BaseProps {
 }
 
 export const LiveLayout = (props: WebProps | AppsProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host, hasLiveBlogTopAd, hasSurveyAd },
 	} = article;
@@ -546,7 +545,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									keyEvents={article.keyEvents}
 									filterKeyEvents={article.filterKeyEvents}
 									id={'key-events-carousel-desktop'}
-									serverTime={serverTime}
 									renderingTarget={renderingTarget}
 								/>
 							</Island>
@@ -816,7 +814,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 											shouldHideAds={
 												article.shouldHideAds
 											}
-											serverTime={serverTime}
 											idApiUrl={article.config.idApiUrl}
 										/>
 										{pagination.totalPages > 1 && (
@@ -948,7 +945,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									discussionApiUrl={
 										article.config.discussionApiUrl
 									}
-									serverTime={serverTime}
 									renderingTarget={renderingTarget}
 								/>
 							</Island>
@@ -974,7 +970,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
-							serverTime={serverTime}
 							renderingTarget={renderingTarget}
 							webURL={article.webURL}
 						/>

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -48,7 +48,6 @@ type Props = {
 	NAV: NavType;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 };
 
 const mainColWrapperStyle = css`
@@ -191,7 +190,6 @@ export const NewsletterSignupLayout = ({
 	NAV,
 	format,
 	renderingTarget,
-	serverTime,
 }: Props) => {
 	const {
 		promotedNewsletter,
@@ -436,7 +434,6 @@ export const NewsletterSignupLayout = ({
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -460,7 +457,6 @@ export const NewsletterSignupLayout = ({
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/PictureLayout.tsx
+++ b/dotcom-rendering/src/layouts/PictureLayout.tsx
@@ -239,7 +239,6 @@ interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends CommonProps {
@@ -252,7 +251,7 @@ interface AppsProps extends CommonProps {
 }
 
 export const PictureLayout = (props: WebProps | AppsProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
@@ -584,7 +583,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -611,7 +609,6 @@ export const PictureLayout = (props: WebProps | AppsProps) => {
 							editionId={article.editionId}
 							shortUrlId={article.config.shortUrlId}
 							discussionApiUrl={article.config.discussionApiUrl}
-							serverTime={serverTime}
 							renderingTarget={renderingTarget}
 							webURL={article.webURL}
 						/>

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -210,7 +210,6 @@ interface CommonProps {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends CommonProps {
@@ -223,7 +222,7 @@ interface AppsProps extends CommonProps {
 }
 
 export const ShowcaseLayout = (props: WebProps | AppsProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
 		editionId,
@@ -712,7 +711,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -736,7 +734,6 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -325,7 +325,6 @@ interface Props {
 	article: ArticleDeprecated;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
-	serverTime?: number;
 }
 
 interface WebProps extends Props {
@@ -338,7 +337,7 @@ interface AppProps extends Props {
 }
 
 export const StandardLayout = (props: WebProps | AppProps) => {
-	const { article, format, renderingTarget, serverTime } = props;
+	const { article, format, renderingTarget } = props;
 	const {
 		config: { isPaidContent, host, hasSurveyAd },
 		editionId,
@@ -887,7 +886,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								discussionApiUrl={
 									article.config.discussionApiUrl
 								}
-								serverTime={serverTime}
 								renderingTarget={renderingTarget}
 							/>
 						</Island>
@@ -911,7 +909,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						editionId={article.editionId}
 						shortUrlId={article.config.shortUrlId}
 						discussionApiUrl={article.config.discussionApiUrl}
-						serverTime={serverTime}
 						renderingTarget={renderingTarget}
 						webURL={article.webURL}
 					/>

--- a/dotcom-rendering/src/lib/cardWrappers.tsx
+++ b/dotcom-rendering/src/lib/cardWrappers.tsx
@@ -10,7 +10,6 @@ import type {
 type TrailProps = {
 	trail: DCRFrontCard;
 	imageLoading: Loading;
-	serverTime?: number;
 	showAge?: boolean;
 	containerPalette?: DCRContainerPalette;
 	isTagPage?: boolean;
@@ -55,7 +54,6 @@ export const Card100Media50 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -65,7 +63,6 @@ export const Card100Media50 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			headlineSizes={{ desktop: 'medium', tablet: 'xxsmall' }}
 			image={trail.image}
 			mediaSize="medium"
@@ -109,7 +106,6 @@ export const Card100Media75 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -117,7 +113,6 @@ export const Card100Media75 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			headlineSizes={{ desktop: 'medium', tablet: 'xsmall' }}
 			image={trail.image}
 			mediaSize="jumbo"
@@ -164,7 +159,6 @@ export const Card100Media100 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -172,7 +166,6 @@ export const Card100Media100 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			headlineSizes={{ desktop: 'medium', tablet: 'xsmall' }}
 			image={trail.image}
 			mediaPositionOnDesktop="top"
@@ -208,7 +201,6 @@ export const Card100Media100Tall = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -216,7 +208,6 @@ export const Card100Media100Tall = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xsmall' }}
 			image={trail.image}
 			mediaPositionOnDesktop="top"
@@ -251,7 +242,6 @@ export const Card75Media50Right = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -259,7 +249,6 @@ export const Card75Media50Right = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment={
@@ -298,7 +287,6 @@ export const Card75Media50Left = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -306,7 +294,6 @@ export const Card75Media50Left = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment={
@@ -345,7 +332,6 @@ export const Card25Media25 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -355,7 +341,6 @@ export const Card25Media25 = ({
 			supportingContentAlignment="vertical"
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
 			mediaSize="small"
@@ -388,7 +373,6 @@ export const Card25Media25SmallHeadline = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -398,7 +382,6 @@ export const Card25Media25SmallHeadline = ({
 			supportingContentAlignment="vertical"
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
 			mediaSize="small"
@@ -432,7 +415,6 @@ export const Card25Media25Tall = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -440,7 +422,6 @@ export const Card25Media25Tall = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
 			mediaSize="small"
@@ -481,7 +462,6 @@ export const Card25Media25TallNoTrail = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -489,7 +469,6 @@ export const Card25Media25TallNoTrail = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
 			mediaSize="small"
@@ -523,7 +502,6 @@ export const Card25Media25TallSmallHeadline = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -531,7 +509,6 @@ export const Card25Media25TallSmallHeadline = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
 			mediaSize="small"
@@ -565,7 +542,6 @@ export const Card50Media50 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -579,7 +555,6 @@ export const Card50Media50 = ({
 			imageLoading={imageLoading}
 			isTagPage={isTagPage}
 			showAge={showAge}
-			serverTime={serverTime}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
 			aspectRatio={aspectRatio}
@@ -608,7 +583,6 @@ export const Card50Media50Tall = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -616,7 +590,6 @@ export const Card50Media50Tall = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			supportingContent={trail.supportingContent?.slice(0, 3)}
 			supportingContentAlignment="horizontal"
@@ -651,7 +624,6 @@ export const Card66Media66 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -659,7 +631,6 @@ export const Card66Media66 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			headlineSizes={{ desktop: 'xsmall', tablet: 'xxsmall' }}
 			mediaPositionOnDesktop="top"
@@ -692,7 +663,6 @@ export const Card33Media33 = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -700,7 +670,6 @@ export const Card33Media33 = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			mediaSize="medium"
 			mediaPositionOnDesktop="top"
@@ -732,7 +701,6 @@ export const Card33Media33Tall = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -740,7 +708,6 @@ export const Card33Media33Tall = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaSize="medium"
 			mediaPositionOnDesktop="top"
 			mediaPositionOnMobile="left"
@@ -774,7 +741,6 @@ export const Card33Media33MobileTopTall = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -782,7 +748,6 @@ export const Card33Media33MobileTopTall = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			trailText={trail.trailText}
 			mediaSize="medium"
 			mediaPositionOnDesktop="top"
@@ -813,7 +778,6 @@ export const CardDefault = ({
 	trail,
 	showAge,
 	containerPalette,
-	serverTime,
 	isTagPage,
 	aspectRatio,
 }: Omit<TrailProps, 'imageLoading'>) => {
@@ -822,7 +786,6 @@ export const CardDefault = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			image={undefined}
 			imageLoading={'lazy'}
 			avatarUrl={undefined}
@@ -852,7 +815,6 @@ export const CardDefaultMedia = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -860,7 +822,6 @@ export const CardDefaultMedia = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaSize="small"
 			mediaPositionOnDesktop="left"
 			mediaPositionOnMobile="none"
@@ -891,7 +852,6 @@ export const CardDefaultMediaMobile = ({
 	containerPalette,
 	imageLoading,
 	isTagPage,
-	serverTime,
 	aspectRatio,
 }: TrailProps) => {
 	return (
@@ -899,7 +859,6 @@ export const CardDefaultMediaMobile = ({
 			trail={trail}
 			containerPalette={containerPalette}
 			showAge={showAge}
-			serverTime={serverTime}
 			mediaSize="small"
 			mediaPositionOnDesktop="left"
 			mediaPositionOnMobile="left"

--- a/dotcom-rendering/src/lib/dynamicSlices.tsx
+++ b/dotcom-rendering/src/lib/dynamicSlices.tsx
@@ -36,14 +36,12 @@ export const Card50_Card50 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const cards50 = cards.slice(0, 2);
 
@@ -60,7 +58,6 @@ export const Card50_Card50 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -78,14 +75,12 @@ export const Card75_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const card75 = cards.slice(0, 1);
 	const card25 = cards.slice(1, 2);
@@ -97,7 +92,6 @@ export const Card75_Card25 = ({
 					<Card75Media50Right
 						trail={trail}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -113,7 +107,6 @@ export const Card75_Card25 = ({
 					<Card25Media25
 						trail={trail}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -132,14 +125,12 @@ export const Card25_Card75 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const card25 = cards.slice(0, 1);
 	const card75 = cards.slice(1, 2);
@@ -151,7 +142,6 @@ export const Card25_Card75 = ({
 					<Card25Media25
 						trail={trail}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -167,7 +157,6 @@ export const Card25_Card75 = ({
 					<Card75Media50Left
 						trail={trail}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -186,14 +175,12 @@ export const Card50_Card25_Card25 = ({
 	cards,
 	containerPalette,
 	showAge,
-	serverTime,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	containerPalette?: DCRContainerPalette;
 	showAge?: boolean;
-	serverTime?: number;
 }) => {
 	const card50 = cards.slice(0, 1);
 	const cards25 = cards.slice(1, 3);
@@ -206,7 +193,6 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -223,7 +209,6 @@ export const Card50_Card25_Card25 = ({
 						trail={trail}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>
@@ -243,12 +228,10 @@ export const Card100PictureTop = ({
 	showAge,
 	containerPalette,
 	imageLoading,
-	serverTime,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const card100 = cards.slice(0, 1);
@@ -260,7 +243,6 @@ export const Card100PictureTop = ({
 					<Card100Media100
 						trail={card}
 						showAge={showAge}
-						serverTime={serverTime}
 						containerPalette={containerPalette}
 						imageLoading={imageLoading}
 					/>
@@ -273,14 +255,12 @@ export const Card100PictureTop = ({
 export const Card25_Card25_Card25_Card25 = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	if (cards.length < 4) return null;
@@ -301,7 +281,6 @@ export const Card25_Card25_Card25_Card25 = ({
 							trail={card}
 							containerPalette={containerPalette}
 							showAge={showAge}
-							serverTime={serverTime}
 							imageLoading={imageLoading}
 						/>
 					</LI>
@@ -314,14 +293,12 @@ export const Card25_Card25_Card25_Card25 = ({
 export const ColumnOfCards50_Card25_Card25 = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const bigs = cards.slice(0, 2).reverse();
@@ -340,7 +317,6 @@ export const ColumnOfCards50_Card25_Card25 = ({
 						<Card25Media25Tall
 							trail={big}
 							showAge={showAge}
-							serverTime={serverTime}
 							containerPalette={containerPalette}
 							imageLoading={imageLoading}
 						/>
@@ -360,7 +336,6 @@ export const ColumnOfCards50_Card25_Card25 = ({
 									trail={card}
 									containerPalette={containerPalette}
 									showAge={showAge}
-									serverTime={serverTime}
 									imageLoading={imageLoading}
 								/>
 							</LI>
@@ -381,14 +356,12 @@ export const ColumnOfCards50_Card25_Card25 = ({
 export const Card100PictureRight = ({
 	cards,
 	showAge,
-	serverTime,
 	containerPalette,
 	imageLoading,
 }: {
 	cards: DCRFrontCard[];
 	imageLoading: Loading;
 	showAge?: boolean;
-	serverTime?: number;
 	containerPalette?: DCRContainerPalette;
 }) => {
 	const card100 = cards.slice(0, 1);
@@ -401,7 +374,6 @@ export const Card100PictureRight = ({
 						trail={card}
 						containerPalette={containerPalette}
 						showAge={showAge}
-						serverTime={serverTime}
 						imageLoading={imageLoading}
 					/>
 				</LI>

--- a/dotcom-rendering/src/server/handler.front.web.ts
+++ b/dotcom-rendering/src/server/handler.front.web.ts
@@ -23,8 +23,6 @@ import { renderFront, renderTagPage } from './render.front.web';
 const enhanceFront = (body: unknown): Front => {
 	const data: FEFront = validateAsFEFront(body);
 
-	const serverTime = Date.now();
-
 	const isInPersonalisedContainerTest =
 		data.config.serverSideABTests[
 			`fronts-and-curation-personalised-container`
@@ -86,7 +84,6 @@ const enhanceFront = (body: unknown): Front => {
 		),
 		deeplyRead: data.deeplyRead?.map((trail) => decideTrail(trail)),
 		canonicalUrl: data.canonicalUrl,
-		serverTime,
 	};
 };
 

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -1,5 +1,6 @@
 import { AllEditorialNewslettersPage } from '../components/AllEditorialNewslettersPage';
 import { ConfigProvider } from '../components/ConfigContext';
+import { DateTimeProvider } from '../components/DateTimeContext';
 import {
 	ASSET_ORIGIN,
 	generateScriptTags,
@@ -32,12 +33,16 @@ export const renderEditorialNewslettersPage = ({
 		editionId: newslettersPage.editionId,
 	} satisfies Config;
 
+	const serverTime = Date.now();
+
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<AllEditorialNewslettersPage
-				newslettersPage={newslettersPage}
-				NAV={NAV}
-			/>
+			<DateTimeProvider value={serverTime}>
+				<AllEditorialNewslettersPage
+					newslettersPage={newslettersPage}
+					NAV={NAV}
+				/>
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -1,6 +1,7 @@
 import { isString } from '@guardian/libs';
 import { ArticlePage } from '../components/ArticlePage';
 import { ConfigProvider } from '../components/ConfigContext';
+import { DateTimeProvider } from '../components/DateTimeContext';
 import { LiveBlogRenderer } from '../components/LiveBlogRenderer';
 import {
 	ArticleDesign,
@@ -36,10 +37,16 @@ export const renderArticle = (
 		assetOrigin: ASSET_ORIGIN,
 		editionId: frontendData.editionId,
 	};
+	const serverTime = Date.now();
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<ArticlePage article={article} renderingTarget={renderingTarget} />
+			<DateTimeProvider value={serverTime}>
+				<ArticlePage
+					article={article}
+					renderingTarget={renderingTarget}
+				/>
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 
@@ -171,33 +178,37 @@ export const renderAppsBlocks = ({
 		editionId,
 	};
 
+	const serverTime = Date.now();
+
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<LiveBlogRenderer
-				blocks={blocks}
-				format={format}
-				host={host}
-				pageId={pageId}
-				webTitle={webTitle}
-				ajaxUrl={ajaxUrl}
-				isSensitive={isSensitive}
-				isAdFreeUser={isAdFreeUser}
-				abTests={abTests}
-				switches={switches}
-				isLiveUpdate={true}
-				sectionId={section}
-				// The props below are never used because isLiveUpdate is true but, typescript...
-				shouldHideReaderRevenue={false}
-				tags={[]}
-				isPaidContent={false}
-				contributionsServiceUrl=""
-				keywordIds={keywordIds}
-				editionId={editionId}
-				onFirstPage={false}
-				keyEvents={[]}
-				filterKeyEvents={false}
-				shouldHideAds={shouldHideAds}
-			/>
+			<DateTimeProvider value={serverTime}>
+				<LiveBlogRenderer
+					blocks={blocks}
+					format={format}
+					host={host}
+					pageId={pageId}
+					webTitle={webTitle}
+					ajaxUrl={ajaxUrl}
+					isSensitive={isSensitive}
+					isAdFreeUser={isAdFreeUser}
+					abTests={abTests}
+					switches={switches}
+					isLiveUpdate={true}
+					sectionId={section}
+					// The props below are never used because isLiveUpdate is true but, typescript...
+					shouldHideReaderRevenue={false}
+					tags={[]}
+					isPaidContent={false}
+					contributionsServiceUrl=""
+					keywordIds={keywordIds}
+					editionId={editionId}
+					onFirstPage={false}
+					keyEvents={[]}
+					filterKeyEvents={false}
+					shouldHideAds={shouldHideAds}
+				/>
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -1,6 +1,7 @@
 import { isString } from '@guardian/libs';
 import { ArticlePage } from '../components/ArticlePage';
 import { ConfigProvider } from '../components/ConfigContext';
+import { DateTimeProvider } from '../components/DateTimeContext';
 import { LiveBlogRenderer } from '../components/LiveBlogRenderer';
 import {
 	ArticleDesign,
@@ -58,14 +59,17 @@ export const renderHtml = ({
 		assetOrigin: ASSET_ORIGIN,
 		editionId: frontendData.editionId,
 	};
+	const serverTime = Date.now();
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<ArticlePage
-				article={article}
-				NAV={NAV}
-				renderingTarget={renderingTarget}
-			/>
+			<DateTimeProvider value={serverTime}>
+				<ArticlePage
+					article={article}
+					NAV={NAV}
+					renderingTarget={renderingTarget}
+				/>
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 
@@ -246,33 +250,37 @@ export const renderBlocks = ({
 		editionId,
 	};
 
+	const serverTime = Date.now();
+
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<LiveBlogRenderer
-				blocks={blocks}
-				format={format}
-				host={host}
-				pageId={pageId}
-				webTitle={webTitle}
-				ajaxUrl={ajaxUrl}
-				isSensitive={isSensitive}
-				isAdFreeUser={isAdFreeUser}
-				abTests={abTests}
-				switches={switches}
-				isLiveUpdate={true}
-				sectionId={section}
-				// The props below are never used because isLiveUpdate is true but, typescript...
-				shouldHideReaderRevenue={false}
-				tags={[]}
-				isPaidContent={false}
-				contributionsServiceUrl=""
-				keywordIds={keywordIds}
-				editionId={editionId}
-				onFirstPage={false}
-				keyEvents={[]}
-				filterKeyEvents={false}
-				shouldHideAds={shouldHideAds}
-			/>
+			<DateTimeProvider value={serverTime}>
+				<LiveBlogRenderer
+					blocks={blocks}
+					format={format}
+					host={host}
+					pageId={pageId}
+					webTitle={webTitle}
+					ajaxUrl={ajaxUrl}
+					isSensitive={isSensitive}
+					isAdFreeUser={isAdFreeUser}
+					abTests={abTests}
+					switches={switches}
+					isLiveUpdate={true}
+					sectionId={section}
+					// The props below are never used because isLiveUpdate is true but, typescript...
+					shouldHideReaderRevenue={false}
+					tags={[]}
+					isPaidContent={false}
+					contributionsServiceUrl=""
+					keywordIds={keywordIds}
+					editionId={editionId}
+					onFirstPage={false}
+					keyEvents={[]}
+					filterKeyEvents={false}
+					shouldHideAds={shouldHideAds}
+				/>
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -1,5 +1,6 @@
 import { isString } from '@guardian/libs';
 import { ConfigProvider } from '../components/ConfigContext';
+import { DateTimeProvider } from '../components/DateTimeContext';
 import { FrontPage } from '../components/FrontPage';
 import { TagPage } from '../components/TagPage';
 import { Pillar } from '../lib/articleFormat';
@@ -92,9 +93,13 @@ export const renderFront = ({
 		editionId: front.editionId,
 	} satisfies Config;
 
+	const serverTime = Date.now();
+
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<FrontPage front={front} NAV={enhancedNAV} />
+			<DateTimeProvider value={serverTime}>
+				<FrontPage front={front} NAV={enhancedNAV} />
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 
@@ -191,9 +196,13 @@ export const renderTagPage = ({
 		editionId: tagPage.editionId,
 	};
 
+	const serverTime = Date.now();
+
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<TagPage tagPage={tagPage} NAV={enhancedNAV} />
+			<DateTimeProvider value={serverTime}>
+				<TagPage tagPage={tagPage} NAV={enhancedNAV} />
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/server/render.sportDataPage.web.tsx
+++ b/dotcom-rendering/src/server/render.sportDataPage.web.tsx
@@ -1,5 +1,6 @@
 import { isString } from '@guardian/libs';
 import { ConfigProvider } from '../components/ConfigContext';
+import { DateTimeProvider } from '../components/DateTimeContext';
 import { SportDataPageComponent } from '../components/SportDataPageComponent';
 import type { FootballMatch } from '../footballMatch';
 import {
@@ -106,13 +107,16 @@ export const renderSportPage = (sportData: SportDataPage) => {
 		assetOrigin: ASSET_ORIGIN,
 		editionId: sportData.editionId,
 	};
+	const serverTime = Date.now();
 
 	const title = decideTitle(sportData);
 	const description = decideDescription(sportData.kind);
 
 	const { html, extractedCss } = renderToStringWithEmotion(
 		<ConfigProvider value={config}>
-			<SportDataPageComponent sportData={sportData} />
+			<DateTimeProvider value={serverTime}>
+				<SportDataPageComponent sportData={sportData} />
+			</DateTimeProvider>
 		</ConfigProvider>,
 	);
 

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -44,7 +44,6 @@ export type ArticleFields = {
 	display: ArticleDisplay;
 	theme: ArticleTheme;
 	storyPackage: StoryPackage | undefined;
-	serverTime?: number | undefined;
 };
 
 export type Gallery = ArticleFields & {
@@ -88,8 +87,6 @@ export const enhanceArticleType = (
 	renderingTarget: RenderingTarget,
 ): Article => {
 	const format = decideFormat(data.format);
-
-	const serverTime = Date.now();
 
 	const imagesForLightbox = data.config.switches.lightbox
 		? buildLightboxImages(data.format, data.blocks, data.mainMediaElements)
@@ -150,7 +147,6 @@ export const enhanceArticleType = (
 			design,
 			display: format.display,
 			theme: format.theme,
-			serverTime,
 			bodyElements: blocks.flatMap((block) =>
 				block.elements.filter(
 					(element) =>
@@ -173,7 +169,6 @@ export const enhanceArticleType = (
 		display: format.display,
 		theme: format.theme,
 		storyPackage,
-		serverTime,
 		frontendData: {
 			...data,
 			mainMediaElements,

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -38,7 +38,6 @@ export interface Front {
 	pageId: string;
 	webURL: string;
 	guardianBaseURL: string;
-	serverTime?: number;
 }
 
 interface PressedPage {
@@ -102,7 +101,6 @@ export type DCRFrontCard = {
 	slideshowImages?: DCRSlideshowImage[];
 	showVideo?: boolean;
 	uniqueId?: string;
-	serverTime?: number;
 };
 
 export type DCRSlideshowImage = {


### PR DESCRIPTION
## What does this change?

Removes `serverTime` prop (used to prop drill current date and time down to the `DateTime` component) and moves to context instead

## Why?

This prop adds a lot of extra noise to the codebase due to having to be drilled through numerous components so it is available where needed. We also found it difficult to make the prop required (#14776) as in some cases the data is not easily available (ie. when doing partial rendering of components).

`DateTime` already relies on context from `ConfigProvider` so by also including `DateTimeProvider` wherever this is used we can ensure that it is available where needed.