### PR TITLE
Fix live blog toggle switch ID mismatch

### DIFF
--- a/dotcom-rendering/src/components/Card/components/CardFooter.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardFooter.tsx
@@ -22,7 +22,7 @@ const contentStyles = css`
 	> {
 		/* The dividing line is applied only to the second child. This ensures that no
 		   dividing line is added when there is only one child in the container. */
-		:nth-of-type(2) {
+		:nth-child(2) {
 			::before {
 				content: '';
 				display: block;


### PR DESCRIPTION
## What does this change?

~Replaces use of `:nth-child` and~ overrides ID for key events toggle switch

## Why?

The `ToggleSwitch` component (used for the key events toggle) generates an ID to link the `button` and `label` elements using Source's `generateSourceId` method:

```
src-component-[index]
```

The value of `index` is incremented with each render so the generated ID is not stable between renders causing an error when the page is hydrated on the client due to the mismatch.

Source was [updated to replace use of `generateSourceId` with React's `useId`](https://github.com/guardian/csnx/pull/1447) to avoid this issue, but the same fix has not yet been applied to components in the dev kitchen. For now, we can use the ID supplied to `FilterKeyEventsToggle` to override the `ToggleSwitch` ID.

### Emotion unsafe selector warnings

~`:nth-child` results in a warning when the page is server-side rendered. (Preact also warns about this, but the React warning is more prominent.) As the child elements are of the same type we can swap this out for `:nth-of-type` as the warning suggests.~

> The pseudo class `:nth-child` is potentially unsafe when doing server-side rendering. Try changing it to `:nth-of-type`.

This change has been reverted as the child elements are _not_ always the same type, so replacing with `:nth-of-type` causes a visual regression in some cases. On further investigation it seems we're not affected by the [issue of `:nth-child` (and similar selectors) being unsafe when server-side rendering](https://github.com/emotion-js/emotion/issues/1178) as we extract all CSS and inject it into the page head rather than inline with the component. Emotion does, in fact, recognise this and suppresses the warning when server-side rendering. The warning is actually being erroneously generated when the component is hydrated on the client. We should investigate if we can also suppress these warnings on the client, and whether we're using Emotion incorrectly on the client such that it believes we're server-side rendering.
