### PR TITLE
Tweaks to design for Onward Journeys AB test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1269,6 +1269,7 @@ export const Card = ({
 						isBetaContainer,
 						isOnwardContent,
 					)}
+					isInOnwardsAbTestVariant={!!isInOnwardsAbTestVariant}
 				>
 					{/* In the storylines section on tag pages, the flex splash is used to display key stories.
 						We don't display an article headline in the conventional sense, the key stories are instead displayed as "supporting content".

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -149,6 +149,7 @@ type Props = {
 	isBetaContainer: boolean;
 	mediaPositionOnDesktop: MediaPositionType;
 	mediaPositionOnMobile: MediaPositionType;
+	isInOnwardsAbTestVariant: boolean;
 	padContent?: 'small' | 'large';
 };
 
@@ -159,6 +160,7 @@ export const ContentWrapper = ({
 	isBetaContainer,
 	mediaPositionOnDesktop,
 	mediaPositionOnMobile,
+	isInOnwardsAbTestVariant,
 	padContent,
 }: Props) => {
 	const mediaDirectionDesktop = getMediaDirection(mediaPositionOnDesktop);
@@ -176,6 +178,7 @@ export const ContentWrapper = ({
 					}),
 				padContent &&
 					!isBetaContainer &&
+					!isInOnwardsAbTestVariant &&
 					css`
 						padding: ${space[paddingSpace]}px;
 					`,

--- a/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
+++ b/dotcom-rendering/src/components/FetchOnwardsData.importable.tsx
@@ -113,17 +113,9 @@ export const FetchOnwardsData = ({
 	}
 
 	if (!data?.trails) {
-		const placeholderHeights = isInOnwardsAbTestVariant
-			? new Map<'mobile' | 'tablet' | 'desktop', number>([
-					['mobile', 900],
-					['tablet', 600],
-					['desktop', 900],
-			  ])
-			: new Map<'mobile', number>([['mobile', 340]]);
-
 		return (
 			<Placeholder
-				heights={placeholderHeights} // best guess at typical height
+				heights={new Map<'mobile', number>([['mobile', 340]])} // best guess at typical height
 				shouldShimmer={false}
 				backgroundColor={palette('--article-background')}
 			/>

--- a/dotcom-rendering/src/components/MoreGalleriesStyleOnwardsContent.importable.tsx
+++ b/dotcom-rendering/src/components/MoreGalleriesStyleOnwardsContent.importable.tsx
@@ -16,23 +16,11 @@ import { LeftColumn } from './LeftColumn';
 const standardCardListStyles = css`
 	width: 100%;
 	display: grid;
-	gap: ${space[5]}px;
+	gap: ${space[4]}px;
 	padding-top: ${space[2]}px;
 
 	${from.tablet} {
 		grid-template-columns: repeat(4, 1fr);
-	}
-
-	${from.leftCol} {
-		&::before {
-			content: '';
-			position: absolute;
-			left: -11px;
-			bottom: 0;
-			top: 8px;
-			width: 1px;
-			background-color: ${palette('--onward-content-border')};
-		}
 	}
 `;
 
@@ -48,16 +36,6 @@ const cardsContainerStyles = css`
 const splashCardStyles = css`
 	${from.leftCol} {
 		margin-top: ${space[2]}px;
-
-		&::before {
-			content: '';
-			position: absolute;
-			left: -11px;
-			top: 8px;
-			bottom: 0;
-			width: 1px;
-			background-color: ${palette('--onward-content-border')};
-		}
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Small design tweaks

- Reduce space between standard cards on mobile.
- Remove vertical line on the left on large screens. This line was misaligned with the content above it.
- Remove padding around card so that card content aligns with the image. This makes these cards similar to how they look on fronts.

## Screenshots

| <img width=100/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/564030d8-147b-4285-8c89-0241a2b431fa
[desktop-before]: https://github.com/user-attachments/assets/c516d1a7-0e9b-415b-8ab9-d172e42bd629
[mobile-after]: https://github.com/user-attachments/assets/74ecb340-b5cb-4899-be2a-4e18fdacfc58
[desktop-after]: https://github.com/user-attachments/assets/15f3a481-e90f-4ab2-9dde-015e6becb231
