### PR TITLE
extend UID2 ab test expiry date

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -37,7 +37,7 @@ const ABTests: ABTest[] = [
 		description:
 			"A hold back test to measure the impact of integrating UID2 module",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2026-01-15`,
+		expirationDate: `2026-01-29`,
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?
This PR extends the UID2 expiry date in the AB test configuaration.
## Why?
The AB test for UID2 is about to expire, and we want to extend this until further notice. 
