### PR TITLE
Fix duplicate keys in `DesignableBanner`

### DIFF
--- a/dotcom-rendering/src/components/marketing/shared/ResponsiveImage.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ResponsiveImage.tsx
@@ -21,8 +21,8 @@ type ResponsiveImageProps = {
 	cssOverrides?: SerializedStyles;
 };
 
-function createSource(image: ImageAttrs): ReactElement {
-	return <source media={image.media} srcSet={image.url} key={image.url} />;
+function createSource(image: ImageAttrs, index: number): ReactElement {
+	return <source media={image.media} srcSet={image.url} key={index} />;
 }
 
 export const ResponsiveImage: ReactComponent<ResponsiveImageProps> = ({


### PR DESCRIPTION
## What does this change?

Switches to using index rather than image URL for `key` when iterating over images

## Why?

In some cases the same image is used at different breakpoints meaning keys may not be unique when iterating through the images in `ResponsiveImage`:

<img width="490" height="228" alt="447928498-bda9a94d-3853-4d3b-8696-e8307ab1601a" src="https://github.com/user-attachments/assets/00124d6c-6a33-4bf1-9b80-e19521d2567b" />
