### PR TITLE
Make all `SecureSignup` inputs controlled

### DIFF
--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -274,7 +274,7 @@ export const SecureSignup = ({
 }: Props) => {
 	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
 	const [captchaSiteKey, setCaptchaSiteKey] = useState<string>();
-	const [signedInUserEmail, setSignedInUserEmail] = useState<string>();
+	const [userEmail, setUserEmail] = useState<string>();
 	const [hideEmailInput, setHideEmailInput] = useState<boolean>();
 	const [isWaitingForResponse, setIsWaitingForResponse] =
 		useState<boolean>(false);
@@ -299,7 +299,7 @@ export const SecureSignup = ({
 	useEffect(() => {
 		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
 		void resolveEmailIfSignedIn().then((email) => {
-			setSignedInUserEmail(email);
+			setUserEmail(email);
 			setHideEmailInput(isString(email));
 		});
 	}, []);
@@ -422,8 +422,8 @@ export const SecureSignup = ({
 					name="email"
 					label="Enter your email address"
 					type="email"
-					value={signedInUserEmail ?? ''}
-					onChange={(e) => setSignedInUserEmail(e.target.value)}
+					value={userEmail ?? ''}
+					onChange={(e) => setUserEmail(e.target.value)}
 				/>
 				{isSignedIn === false && (
 					<CheckboxGroup


### PR DESCRIPTION
## What does this change?

Makes all `SecureSignup` input fields controlled

## Why?

The value of the inputs is initially `undefined` making them uncontrolled, but a value may later be assigned via a state change if the reader is signed in making them controlled inputs[^1]. 

> A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component.

An additional boolean state variable has been added to manage hiding the text input when the reader is signed in. Previously this happened by checking whether `signedInUserEmail` contained a string. However, as this is now a controlled input the value of `signedInUserEmail` will be updated as the reader enters an email address causing it to be immediately hidden.

[^1]: https://react.dev/reference/react-dom/components/input#im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled