### PR TITLE
Remove 5px bottom padding from title of rich link if its part of star rating redesign.

### DIFF
--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -80,7 +80,10 @@ const headerStyles = css`
 	color: ${themePalette('--rich-link-header')};
 `;
 
-const titleStyles = (parentIsBlog: boolean) => css`
+const titleStyles = (
+	parentIsBlog: boolean,
+	isStarRatingRedesign: boolean,
+) => css`
 	${parentIsBlog ? headlineMedium17 : headlineMedium14};
 	padding-top: 1px;
 
@@ -92,7 +95,7 @@ const titleStyles = (parentIsBlog: boolean) => css`
 		 * Please speak to your team's designer and update this to use a more appropriate preset.
 		 */
 		font-weight: 400;
-		padding-bottom: 5px;
+		${!isStarRatingRedesign && `padding-bottom: 5px`};
 	}
 `;
 
@@ -223,6 +226,8 @@ export const RichLink = ({
 
 	const isLabs = linkFormat.theme === ArticleSpecial.Labs;
 
+	const isStarRatingRedesign =
+		!isUndefined(starRating) && isInStarRatingVariant;
 	return (
 		<div
 			data-print-layout="hide"
@@ -251,7 +256,10 @@ export const RichLink = ({
 						<div css={headerStyles}>
 							<div
 								css={[
-									titleStyles(parentIsBlog),
+									titleStyles(
+										parentIsBlog,
+										!!isStarRatingRedesign,
+									),
 									isLabs && labsTitleStyles,
 								]}
 							>


### PR DESCRIPTION
## What does this change?
Reduces the padding at the bottom of rich link titles for the new star ratings. 
Once the test is over this will check just for star rating. 

Ideally, the whole of the rich link component would be refactored to use source spacing but we do not have the design resource allocated.

## Why?
This is per design request as 5px is too large and not in keeping with spacing across the site 


## Screenshots

Before 
<img width="1026" height="664" alt="Screenshot 2026-01-15 at 12 19 52" src="https://github.com/user-attachments/assets/8b0117a3-6588-4101-89eb-96a9cb83ec18" />


After
<img width="1464" height="664" alt="Screenshot 2026-01-15 at 12 00 03" src="https://github.com/user-attachments/assets/02dbbe49-77d0-48ae-88e9-a1142fa339a7" />

