### PR TITLE
Temporarily scale up article-rendering

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,7 +28,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 24,
+		minimumInstances: 36,
 		maximumInstances: 240,
 		policies: {
 			step: {


### PR DESCRIPTION
## What does this change?

Scale up overnight to mitigate potential traffic elevation 
