### PR TITLE
Revert "Temporarily scale up article-rendering"

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -28,7 +28,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	stage: 'PROD',
 	domainName: 'article-rendering.guardianapis.com',
 	scaling: {
-		minimumInstances: 36,
+		minimumInstances: 24,
 		maximumInstances: 240,
 		policies: {
 			step: {


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#15143

We made it through the night 🌛