### PR TITLE
Add support for videos in galleries

### DIFF
--- a/dotcom-rendering/src/components/GalleryVideo.tsx
+++ b/dotcom-rendering/src/components/GalleryVideo.tsx
@@ -1,0 +1,143 @@
+import { css } from '@emotion/react';
+import { from, space, until } from '@guardian/source/foundations';
+import { grid } from '../grid';
+import { type ArticleFormat } from '../lib/articleFormat';
+import { palette } from '../palette';
+import { type MediaAtomBlockElement } from '../types/content';
+import { GalleryCaption } from './GalleryCaption';
+import { MaintainAspectRatio } from './MaintainAspectRatio';
+import { SelfHostedVideoInArticle } from './SelfHostedVideoInArticle';
+
+type Props = {
+	format: ArticleFormat;
+	video: MediaAtomBlockElement;
+	pageId: string;
+	webTitle: string;
+};
+
+const styles = css`
+	${grid.paddedContainer}
+	grid-auto-flow: row dense;
+	background-color: ${palette('--article-inner-background')};
+
+	${until.tablet} {
+		border-top: 1px solid ${palette('--article-border')};
+		padding-top: ${space[1]}px;
+	}
+
+	${from.tablet} {
+		border-left: 1px solid ${palette('--article-border')};
+		border-right: 1px solid ${palette('--article-border')};
+	}
+
+	${from.desktop} {
+		&:first-of-type {
+			padding-top: ${space[3]}px;
+		}
+	}
+`;
+
+const galleryBodyVideoStyles = css`
+	display: inline;
+	position: relative;
+	${grid.column.all}
+
+	${from.tablet} {
+		${grid.column.centre}
+	}
+
+	${from.desktop} {
+		padding-bottom: ${space[10]}px;
+	}
+
+	${from.leftCol} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
+
+const DEFAULT_WIDTH = 460;
+const DEFAULT_HEIGHT = 259;
+
+const isLoopingVideo = (
+	videoPlayerFormat: MediaAtomBlockElement['videoPlayerFormat'],
+): videoPlayerFormat is 'Loop' | 'Cinemagraph' =>
+	videoPlayerFormat !== undefined &&
+	['Loop', 'Cinemagraph'].includes(videoPlayerFormat);
+
+export const GalleryVideo = ({ format, video, pageId, webTitle }: Props) => {
+	if (video.assets.length === 0) {
+		return null;
+	}
+
+	const poster = video.posterImage?.[0]?.url;
+
+	// Use SelfHostedVideoInArticle for looping videos (Loop/Cinemagraph)
+	if (isLoopingVideo(video.videoPlayerFormat)) {
+		return (
+			<figure css={styles}>
+				<div css={galleryBodyVideoStyles}>
+					<SelfHostedVideoInArticle
+						element={video}
+						format={format}
+						isMainMedia={false}
+						videoStyle={video.videoPlayerFormat}
+						displayCaption={false}
+					/>
+				</div>
+
+				<GalleryCaption
+					captionHtml={video.title}
+					format={format}
+					pageId={pageId}
+					webTitle={webTitle}
+				/>
+			</figure>
+		);
+	}
+
+	// Standard video player for regular videos
+	return (
+		<figure css={styles}>
+			<div css={galleryBodyVideoStyles}>
+				<MaintainAspectRatio
+					height={DEFAULT_HEIGHT}
+					width={DEFAULT_WIDTH}
+				>
+					{/* eslint-disable-next-line jsx-a11y/media-has-caption -- caption not available */}
+					<video
+						controls={true}
+						preload="metadata"
+						width={DEFAULT_WIDTH}
+						height={DEFAULT_HEIGHT}
+						poster={poster}
+						css={css`
+							width: 100%;
+							height: 100%;
+							object-fit: contain;
+						`}
+					>
+						{video.assets.map((asset) => (
+							<source
+								key={asset.url}
+								src={asset.url}
+								type={asset.mimeType}
+							/>
+						))}
+						<p>
+							{`Your browser doesn't support HTML5 video. Here is a `}
+							<a href={video.assets[0]?.url}>link to the video</a>{' '}
+							instead.
+						</p>
+					</video>
+				</MaintainAspectRatio>
+			</div>
+
+			<GalleryCaption
+				captionHtml={video.title}
+				format={format}
+				pageId={pageId}
+				webTitle={webTitle}
+			/>
+		</figure>
+	);
+};

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -16,6 +16,7 @@ type SelfHostedVideoInArticleProps = {
 	format: ArticleFormat;
 	isMainMedia: boolean;
 	videoStyle: VideoPlayerFormat;
+	displayCaption?: boolean;
 };
 
 export const SelfHostedVideoInArticle = ({
@@ -23,6 +24,7 @@ export const SelfHostedVideoInArticle = ({
 	format,
 	isMainMedia,
 	videoStyle,
+	displayCaption = true,
 }: SelfHostedVideoInArticleProps) => {
 	const posterImageUrl = element.posterImage?.[0]?.url;
 	const caption = element.title;
@@ -68,7 +70,7 @@ export const SelfHostedVideoInArticle = ({
 					enableHls={false}
 				/>
 			</Island>
-			{!!caption && (
+			{displayCaption && !!caption && (
 				<Caption
 					captionText={caption}
 					format={format}

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -21,6 +21,7 @@ import { Footer } from '../components/Footer';
 import { DesktopAdSlot, MobileAdSlot } from '../components/GalleryAdSlots';
 import { GalleryAffiliateDisclaimer } from '../components/GalleryAffiliateDisclaimer.importable';
 import { GalleryImage } from '../components/GalleryImage';
+import { GalleryVideo } from '../components/GalleryVideo';
 import { HeaderAdSlot } from '../components/HeaderAdSlot';
 import { Island } from '../components/Island';
 import { LabsHeader } from '../components/LabsHeader';
@@ -534,6 +535,16 @@ const Body = (props: {
 								pageId={props.pageId}
 								webTitle={props.webTitle}
 								renderingTarget={props.renderingTarget}
+								key={element.elementId}
+							/>
+						);
+					case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
+						return (
+							<GalleryVideo
+								video={element}
+								format={props.format}
+								pageId={props.pageId}
+								webTitle={props.webTitle}
 								key={element.elementId}
 							/>
 						);

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -25,6 +25,7 @@ import type {
 	FEElement,
 	ImageBlockElement,
 	ImageForLightbox,
+	MediaAtomBlockElement,
 } from './content';
 import { type RenderingTarget } from './renderingTarget';
 
@@ -49,7 +50,11 @@ export type ArticleFields = {
 
 export type Gallery = ArticleFields & {
 	design: ArticleDesign.Gallery;
-	bodyElements: (ImageBlockElement | AdPlaceholderBlockElement)[];
+	bodyElements: (
+		| ImageBlockElement
+		| MediaAtomBlockElement
+		| AdPlaceholderBlockElement
+	)[];
 	mainMedia?: ImageBlockElement;
 };
 
@@ -153,6 +158,8 @@ export const enhanceArticleType = (
 					(element) =>
 						element._type ===
 							'model.dotcomrendering.pageElements.ImageBlockElement' ||
+						element._type ===
+							'model.dotcomrendering.pageElements.MediaAtomBlockElement' ||
 						element._type ===
 							'model.dotcomrendering.pageElements.AdPlaceholderBlockElement',
 				),


### PR DESCRIPTION
WIP

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
