### PR TITLE
Reduce the size of the podcast series image on feature cards

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -39,7 +39,7 @@ const decideImageWidths = (
 		// 	];
 
 		case 'podcast':
-			return [{ breakpoint: breakpoints.mobile, width: 80, aspectRatio }];
+			return [{ breakpoint: breakpoints.mobile, width: 60, aspectRatio }];
 
 		case 'highlights-card':
 			return [{ breakpoint: breakpoints.mobile, width: 98, aspectRatio }];

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -203,8 +203,8 @@ const podcastImageContainerStyles = css`
 `;
 
 const podcastImageStyles = css`
-	height: 80px;
-	width: 80px;
+	height: 60px;
+	width: 60px;
 `;
 
 const nonImmersivePodcastImageStyles = css`


### PR DESCRIPTION
## What does this change?
Reduce the size of the podcast series image on feature cards from 80x80 to 60x60

## Why?
The current UI for podcast feature cards is not suitable with podcast loops. The existing layout obscures too much of the visible video area. To support podcast video properly, we want to update the UI. 

This can be made for both podcast feature cards with videos, and podcast feature cards with images.


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/8c85b53d-d701-4ff4-84b9-796603fb6a9c
[after]: https://github.com/user-attachments/assets/8bc977b1-46b2-436c-8805-214a79e6252f

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
