### PR TITLE
Add auth header to banner requests

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -17,6 +17,7 @@ import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
 import type { ArticleCounts } from '../../lib/articleCount';
 import {
+	getAuthHeaders,
 	getPurchaseInfo,
 	hasOptedOutOfArticleCount,
 	recentlyClosedBanner,
@@ -248,9 +249,12 @@ export const canShowRRBanner: CanShowFunctionType<
 		pageId,
 	});
 
+	const headers = await getAuthHeaders();
+
 	const response: ModuleDataResponse<BannerProps> = await getBanner(
 		contributionsServiceUrl,
 		bannerPayload,
+		headers,
 	);
 	if (!response.data) {
 		if (engagementBannerLastClosedAt && subscriptionBannerLastClosedAt) {

--- a/dotcom-rendering/src/lib/sdcRequests.ts
+++ b/dotcom-rendering/src/lib/sdcRequests.ts
@@ -99,8 +99,9 @@ export const getLiveblogEpic = (
 export const getBanner = (
 	baseUrl: string,
 	payload: BannerPayload,
+	headers?: HeadersInit,
 ): Promise<ModuleDataResponse<BannerProps>> =>
-	getModuleData('banner', baseUrl, payload);
+	getModuleData('banner', baseUrl, payload, headers);
 
 export const getGutterLiveblog = (
 	baseUrl: string,


### PR DESCRIPTION
In a [previous PR](https://github.com/guardian/dotcom-rendering/pull/14794) we began including an Authorization header for requests to /epic. This is for signed in users with targeting consent, and enables targeting of messages using mParticle, our CDP.
This PR does the same for the /banner endpoint - as we're hoping to start using mParticle for targeting banners as well.
Here we reuse the `getAuthHeaders` function, which ensures the user has targeting consent.