### PR TITLE
Defer apps epic until visible

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -740,7 +740,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									)}
 
 								{isApps && (
-									<Island priority="critical">
+									<Island
+										priority="critical"
+										defer={{ until: 'visible' }}
+									>
 										<AppsEpic />
 									</Island>
 								)}


### PR DESCRIPTION
The app may not have the data for the epic immediately on page load, and without this data it cannot be shown. However, the epic is at the bottom of the article, so it doesn't need to be loaded and start making Bridget calls immediately. We can instead load it when it becomes visible, which increases the likelihood that the apps will have the data available.

Suggested by @adi-gnm 
