### PR TITLE
Stop showing the pointer cursor when hovering over Cinemagraphs in articles

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1081,7 +1081,6 @@ export const Card = ({
 										media.mainMedia.subtitleSource
 									}
 									subtitleSize={subtitleSize}
-									letterboxed={true}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -57,7 +57,7 @@ const videoContainerStyles = (
 
 const figureStyles = (
 	aspectRatio: number,
-	letterboxed: boolean,
+	isInArticle: boolean,
 	containerAspectRatio?: number,
 	isFeatureCard?: boolean,
 ) => css`
@@ -65,7 +65,12 @@ const figureStyles = (
 	aspect-ratio: ${aspectRatio};
 	height: 100%;
 
-	${letterboxed &&
+	/**
+	 * Videos on cards (i.e. not in articles) should not exceed the viewport
+	 * height. Instead, they should be scaled and grey bars should be shown on
+	 * either side.
+	 */
+	${!isInArticle &&
 	css`
 		max-height: 100vh;
 		max-height: 100svh;
@@ -166,7 +171,7 @@ type Props = {
 	linkTo: string;
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
-	letterboxed?: boolean;
+	isInArticle?: boolean;
 	isFeatureCard?: boolean;
 };
 
@@ -187,7 +192,7 @@ export const SelfHostedVideo = ({
 	linkTo,
 	subtitleSource,
 	subtitleSize,
-	letterboxed = false,
+	isInArticle = false,
 	isFeatureCard = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
@@ -720,7 +725,7 @@ export const SelfHostedVideo = ({
 				ref={setNode}
 				css={figureStyles(
 					aspectRatio,
-					letterboxed,
+					isInArticle,
 					containerAspectRatio,
 					isFeatureCard,
 				)}
@@ -756,7 +761,7 @@ export const SelfHostedVideo = ({
 					subtitleSource={subtitleSource}
 					subtitleSize={subtitleSize}
 					activeCue={activeCue}
-					letterboxed={letterboxed}
+					isInArticle={isInArticle}
 					isFeatureCard={isFeatureCard}
 				/>
 			</figure>

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -65,6 +65,7 @@ export const SelfHostedVideoInArticle = ({
 					videoStyle={videoStyle}
 					uniqueId={element.id}
 					width={firstVideoAsset?.dimensions?.width ?? 500}
+					isInArticle={true}
 				/>
 			</Island>
 			{!!caption && (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -25,14 +25,20 @@ export type SubtitleSize = 'small' | 'medium' | 'large';
 
 const videoStyles = (
 	aspectRatio: number,
-	letterboxed: boolean,
+	isInArticle: boolean,
 	isFeatureCard: boolean,
+	isCinemagraph: boolean,
 ) => css`
 	position: relative;
 	display: block;
 	height: auto;
 	width: 100%;
-	${letterboxed &&
+	/**
+	 * Videos on cards (i.e. not in articles) should not exceed the viewport
+	 * height. Instead, they should be scaled and grey bars should be shown on
+	 * either side.
+	 */
+	${!isInArticle &&
 	css`
 		max-height: 100vh;
 		max-height: 100svh;
@@ -139,7 +145,7 @@ type Props = {
 	subtitleSize?: SubtitleSize;
 	/* used in custom subtitle overlays */
 	activeCue?: ActiveCue | null;
-	letterboxed: boolean;
+	isInArticle: boolean;
 	isFeatureCard: boolean;
 };
 
@@ -182,7 +188,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			subtitleSource,
 			subtitleSize,
 			activeCue,
-			letterboxed,
+			isInArticle,
 			isFeatureCard,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
@@ -210,7 +216,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 				<video
 					id={videoId}
 					css={[
-						videoStyles(aspectRatio, letterboxed, isFeatureCard),
+						videoStyles(aspectRatio, isInArticle, isFeatureCard),
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -43,7 +43,12 @@ const videoStyles = (
 		max-height: 100vh;
 		max-height: 100svh;
 	`}
-	cursor: pointer;
+	/**
+	 * Cinemagraphs should only show a pointer cursor when on a card (where clicking
+	 * navigates to the article). In articles, they should not show a pointer cursor
+	 * as clicking does nothing.
+	 */
+	cursor: ${isCinemagraph && isInArticle ? 'default' : 'pointer'};
 
 	/* Prevents CLS by letting the browser know the space the video will take up. */
 	aspect-ratio: ${aspectRatio};
@@ -194,11 +199,12 @@ export const SelfHostedVideoPlayer = forwardRef(
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
 		const videoId = `video-${uniqueId}`;
+		const isCinemagraph = videoStyle === 'Cinemagraph';
 		const showSubtitles =
-			videoStyle !== 'Cinemagraph' && !!subtitleSource && !!subtitleSize;
+			!isCinemagraph && !!subtitleSource && !!subtitleSize;
 
 		const showControls =
-			videoStyle !== 'Cinemagraph' &&
+			!isCinemagraph &&
 			ref &&
 			'current' in ref &&
 			ref.current &&
@@ -216,7 +222,12 @@ export const SelfHostedVideoPlayer = forwardRef(
 				<video
 					id={videoId}
 					css={[
-						videoStyles(aspectRatio, isInArticle, isFeatureCard),
+						videoStyles(
+							aspectRatio,
+							isInArticle,
+							isFeatureCard,
+							isCinemagraph,
+						),
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"


### PR DESCRIPTION
## What does this change?

Does two things:

1) https://github.com/guardian/dotcom-rendering/pull/15163/changes/cbe96ae45448ee6a55f50e2507d3355db34447da replaces the `letterboxed` prop with a more descriptive `isInArticle` prop. `isInArticle` has the opposite meaning to `letterboxed` so the logic was flipped around where appropriate. The reason for this change is that `letterboxed` was a potentially confusing term. Changing it to `isInArticle` also enabled the second thing...
2) https://github.com/guardian/dotcom-rendering/pull/15163/changes/5ea9fbc4d1cd5910836431466673b9c8a5ada16a stops showing the pointer cursor when hovering over Cinemagraphs in articles

## Why?

Feedback from Mat who rightly pointed out that clicking on a Cinemagraph in an article doesn't do anything and so we shouldn't give the user the impression it does.

## Screenshots

![no-pointer](https://github.com/user-attachments/assets/3ff48765-5959-418f-a3af-fd45fa466a87)