### PR TITLE
`data-article-theme` also rendered for web

### DIFF
--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -166,6 +166,10 @@ window.twttr = (function(d, s, id) {
 
 	const { canonicalUrl, webPublicationDate } = frontendData;
 
+	const isInteractive =
+		design === ArticleDesign.FullPageInteractive ||
+		design === ArticleDesign.Interactive;
+
 	const isBeforeInteractiveDarkModeSupport =
 		Date.parse(webPublicationDate) < Date.parse('2026-01-13T00:00:00Z');
 
@@ -190,10 +194,9 @@ window.twttr = (function(d, s, id) {
 		config,
 		hasLiveBlogTopAd: !!frontendData.config.hasLiveBlogTopAd,
 		hasSurveyAd: !!frontendData.config.hasSurveyAd,
+		isInteractive,
 		onlyLightColourScheme:
-			(design === ArticleDesign.FullPageInteractive ||
-				design === ArticleDesign.Interactive) &&
-			isBeforeInteractiveDarkModeSupport,
+			isInteractive && isBeforeInteractiveDarkModeSupport,
 		articleTheme: theme,
 	});
 


### PR DESCRIPTION
Fix for silly mistake made in https://github.com/guardian/dotcom-rendering/pull/15144. Ensures the `data-article-theme` attribute is rendered for web as well as apps.