### PR TITLE
Refactor `htmlPageTemplate` to take data attributes as props

### DIFF
--- a/dotcom-rendering/src/lib/articleFormat.ts
+++ b/dotcom-rendering/src/lib/articleFormat.ts
@@ -230,3 +230,12 @@ export const formatToString = ({
 		`${ArticleDisplay[display]} Display`,
 		`and ${Pillar[theme] ?? ArticleSpecial[theme]} Theme`,
 	].join(', ');
+
+export const getArticleThemeString = (
+	articleTheme: ArticleTheme | undefined,
+): string | undefined => {
+	if (articleTheme === undefined) {
+		return undefined;
+	}
+	return Pillar[articleTheme] ?? ArticleSpecial[articleTheme];
+};

--- a/dotcom-rendering/src/server/htmlPageTemplate.ts
+++ b/dotcom-rendering/src/server/htmlPageTemplate.ts
@@ -2,11 +2,6 @@ import { isUndefined } from '@guardian/libs';
 import { resets, palette as sourcePalette } from '@guardian/source/foundations';
 import CleanCSS from 'clean-css';
 import he from 'he';
-import {
-	ArticleSpecial,
-	type ArticleTheme,
-	Pillar,
-} from '../lib/articleFormat';
 import { ASSET_ORIGIN } from '../lib/assets';
 import { escapeData } from '../lib/escapeData';
 import { rawFontsCss } from '../lib/fonts-css';
@@ -30,10 +25,8 @@ type BaseProps = {
 	hasLiveBlogTopAd?: boolean;
 	hasSurveyAd?: boolean;
 	weAreHiring: boolean;
-	onlyLightColourScheme?: boolean;
-	isInteractive?: boolean;
 	rssFeedUrl?: string;
-	articleTheme?: ArticleTheme;
+	dataAttributes?: { [key: string]: string };
 };
 
 interface WebProps extends BaseProps {
@@ -65,15 +58,6 @@ const fontPreloadTags = fontFiles
 
 const minifiedFontsCss = new CleanCSS().minify(rawFontsCss).styles;
 
-const getArticleThemeString = (
-	theme: ArticleTheme | undefined,
-): string | undefined => {
-	if (theme === undefined) {
-		return undefined;
-	}
-	return Pillar[theme] ?? ArticleSpecial[theme];
-};
-
 export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 	const {
 		css,
@@ -89,15 +73,11 @@ export const htmlPageTemplate = (props: WebProps | AppProps): string => {
 		canonicalUrl,
 		renderingTarget,
 		hasPageSkin = false,
-		onlyLightColourScheme = false,
 		weAreHiring,
 		config,
-		isInteractive = false,
 		rssFeedUrl,
-		articleTheme,
+		dataAttributes,
 	} = props;
-
-	const maybeArticleThemeString = getArticleThemeString(articleTheme);
 
 	const doNotIndex = (): boolean => {
 		if (process.env.GU_STAGE !== 'PROD') return true;
@@ -233,12 +213,10 @@ https://workforus.theguardian.com/careers/product-engineering/
 
 	return `<!doctype html>
         <html lang="en" ${
-			maybeArticleThemeString && isInteractive
-				? `data-article-theme="${maybeArticleThemeString}"`
-				: ''
-		} ${onlyLightColourScheme ? 'data-color-scheme="light"' : ''} ${
-			renderingTarget === 'Apps' && isInteractive
-				? 'data-rendering-target="apps"'
+			dataAttributes
+				? Object.entries(dataAttributes)
+						.map(([key, value]) => `data-${key}="${value}"`)
+						.join(' ')
 				: ''
 		}>
             <head>

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -6,6 +6,7 @@ import {
 	ArticleDesign,
 	type ArticleFormat,
 	decideFormat,
+	getArticleThemeString,
 } from '../lib/articleFormat';
 import {
 	ASSET_ORIGIN,
@@ -123,11 +124,12 @@ window.twttr = (function(d, s, id) {
 				? initTwitter
 				: undefined,
 		config,
-		onlyLightColourScheme: false,
-		isInteractive:
-			design === ArticleDesign.FullPageInteractive ||
-			design === ArticleDesign.Interactive,
-		articleTheme: theme,
+		dataAttributes: {
+			'rendering-target': 'apps',
+			...(getArticleThemeString(theme) && {
+				'article-theme': getArticleThemeString(theme)!,
+			}),
+		},
 	});
 
 	return {

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -6,6 +6,7 @@ import {
 	ArticleDesign,
 	type ArticleFormat,
 	decideFormat,
+	getArticleThemeString,
 	Pillar,
 } from '../lib/articleFormat';
 import {
@@ -170,8 +171,11 @@ window.twttr = (function(d, s, id) {
 		design === ArticleDesign.FullPageInteractive ||
 		design === ArticleDesign.Interactive;
 
-	const isBeforeInteractiveDarkModeSupport =
+	const onlyLightColourScheme =
+		isInteractive &&
 		Date.parse(webPublicationDate) < Date.parse('2026-01-13T00:00:00Z');
+
+	const maybeArticleThemeString = getArticleThemeString(theme);
 
 	const pageHtml = htmlPageTemplate({
 		linkedData,
@@ -194,10 +198,14 @@ window.twttr = (function(d, s, id) {
 		config,
 		hasLiveBlogTopAd: !!frontendData.config.hasLiveBlogTopAd,
 		hasSurveyAd: !!frontendData.config.hasSurveyAd,
-		isInteractive,
-		onlyLightColourScheme:
-			isInteractive && isBeforeInteractiveDarkModeSupport,
-		articleTheme: theme,
+		dataAttributes: {
+			...(maybeArticleThemeString && {
+				'article-theme': maybeArticleThemeString,
+			}),
+			...(onlyLightColourScheme && {
+				'color-scheme': 'light',
+			}),
+		},
 	});
 
 	return { html: pageHtml, prefetchScripts };


### PR DESCRIPTION
[As discussed](https://github.com/guardian/dotcom-rendering/pull/15144#pullrequestreview-3670729378) while working on #15144, there are enough data attributes being affixed to the core HTML template for articles specifically that the code should be abstracted out.

This makes the change suggested by @JamieB-gu and certainly makes things feel cleaner and more intuitive. 