### PR TITLE
Only add branding to onwards content cards for labs content

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -1344,9 +1344,12 @@ export const Card = ({
 								<>
 									{showPill ? (
 										<>
-											{!!branding && isOnwardContent && (
-												<LabsBranding />
-											)}
+											{!!branding &&
+												format.theme ===
+													ArticleSpecial.Labs &&
+												isOnwardContent && (
+													<LabsBranding />
+												)}
 											<MediaOrNewsletterPill />
 										</>
 									) : (


### PR DESCRIPTION
## What does this change?

Restricts the branding on onwards content to only appear for labs content

## Why?

A bug was introduced on https://github.com/guardian/dotcom-rendering/pull/15039 where the Guardian Org logo was showing on an onwards media card, which looks odd amongst other cards with branding

The branding should only apply for Labs content

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/83fc964c-8ae4-40bd-a5e0-3b3836bde265
[after]: https://github.com/user-attachments/assets/773868c4-4a3a-4043-a6c7-be12951e459f
