### PR TITLE
[StandardLinkElementButton]: Correct display logic for external links

### DIFF
--- a/dotcom-rendering/src/components/Button/utils.tsx
+++ b/dotcom-rendering/src/components/Button/utils.tsx
@@ -9,7 +9,7 @@ const platformHostnames = [
 ];
 
 export const isExternalLink = (url: string) =>
-	platformHostnames.includes(new URL(url).hostname);
+	!platformHostnames.includes(new URL(url).hostname);
 
 export const getPropsForLinkUrl = (label: string) => ({
 	rel: 'noreferrer noopener',


### PR DESCRIPTION
## What does this change?

Reverses the logic for the external links in `StandardLinkElementButton`.

## Why?

'Cos they're the wrong way round 😅 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="213" height="187" alt="Screenshot 2026-01-21 at 21 49 52" src="https://github.com/user-attachments/assets/b25f305f-7d1d-41b2-8dce-ea54294b9283" /> | <img width="282" height="227" alt="Screenshot 2026-01-21 at 21 50 41" src="https://github.com/user-attachments/assets/3326fbb0-9e30-41ee-b796-40010aacf86b" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
