### PR TITLE
Reduce log noise for newsletter insertion

### DIFF
--- a/dotcom-rendering/docs/logging.md
+++ b/dotcom-rendering/docs/logging.md
@@ -4,12 +4,13 @@ We use log4js to handle application logs, which can be found in the logs/ direct
 or in /var/log/dotcom-rendering/ in production. At the moment these logs do not contain uncaught exceptions - these
 are logged by the frontend article app at present when dotcom-rendering fails to render a page.
 
-Logs are shipped from the appplication instance to the central elk stack, you can find them [here](<https://logs.gutools.co.uk/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,interval:auto,query:(language:lucene,query:'app:dotcom-rendering'),sort:!('@timestamp',desc))>).
+Logs are shipped from the application instance to the central elk stack, you can find them [here](<https://logs.gutools.co.uk/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:a35a6090-59d7-11e8-bbe4-cbb5b151b19c,interval:auto,query:(language:lucene,query:'app:dotcom-rendering'),sort:!('@timestamp',desc))>).
 
 To log something:
 
     import { logger } from './logging';
 
+    logger.debug('Enabled in local and CODE environments only');
     logger.info('Logging can be useful');
     logger.warn('But also expensive');
     logger.error('Help someone put me in a wood burner');

--- a/dotcom-rendering/src/model/insertPromotedNewsletter.ts
+++ b/dotcom-rendering/src/model/insertPromotedNewsletter.ts
@@ -202,7 +202,7 @@ const tryToInsert = (
 	const insertPosition = findInsertPosition(elements);
 
 	if (insertPosition === null) {
-		logger.warn(
+		logger.debug(
 			`Unable to find suitable place for NewsletterSignupBlockElement`,
 			blockId,
 		);


### PR DESCRIPTION
## What does this change?
This log is currently generating significant noise. Failing to find a suitable position for a newsletter is a common and expected scenario for certain article structures and does not indicate an operational failure requiring intervention. Moving this to debug cleans up our production logs while keeping the information available for local/CODE debugging.


## Why?
Part of https://github.com/guardian/frontend/issues/28496
