### PR TITLE
Revert "Fix AB tests admin opt-in/opt-out `CODE` routes"

### DIFF
--- a/.github/workflows/ab-testing-ci.yml
+++ b/.github/workflows/ab-testing-ci.yml
@@ -63,13 +63,8 @@ jobs:
       - name: Set up Node environment
         uses: ./.github/actions/setup-node-env
 
-      - name: Build UI for CODE
-        if: github.ref != 'refs/heads/main'
-        run: AB_TESTING_ENV=code pnpm build
-
-      - name: Build UI for PROD
-        if: github.ref == 'refs/heads/main'
-        run: AB_TESTING_ENV=production pnpm build
+      - name: Build UI
+        run: pnpm build
 
       - name: Save build
         uses: actions/upload-artifact@v5

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -1,16 +1,6 @@
 import type { ABTest } from "./types.ts";
 
 /**
- * URL for AB test opt-in/opt-out links
- * PROD: https://www.theguardian.com/
- * CODE: https://m.code.dev-theguardian.com/
- */
-const hostname =
-	process.env.AB_TESTING_ENV === "code"
-		? "https://m.code.dev-theguardian.com"
-		: "https://www.theguardian.com";
-
-/**
  * Tests are defined here. They will be assigned mvt ranges based on the
  * size of the test and the number of groups, these ranges may not be contiguous.
  *
@@ -84,4 +74,4 @@ const ABTests: ABTest[] = [
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");
 
-export { ABTests as allABTests, activeABtests, hostname };
+export { ABTests as allABTests, activeABtests };

--- a/ab-testing/config/index.ts
+++ b/ab-testing/config/index.ts
@@ -1,4 +1,4 @@
 // this file is covered by the dotcom-rendering tsconfig.json,
 // not the one in this directory (hence no need for .ts extension)
-export { activeABtests, allABTests, hostname } from "./abTests";
+export { activeABtests, allABTests } from "./abTests";
 export type { ABTest } from "./types";

--- a/ab-testing/frontend/src/lib/components/TestVariants.svelte
+++ b/ab-testing/frontend/src/lib/components/TestVariants.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { hostname } from "@guardian/ab-testing-config";
-
 	interface Props {
 		testName: string;
 		testGroups: string[];
@@ -28,7 +26,7 @@
 					</td>
 					<td>
 						<a
-							href={`${hostname}/ab-tests/opt-in/${testName}:${group}`}
+							href={`https://www.theguardian.com/ab-tests/opt-in/${testName}:${group}`}
 							target="_blank"
 						>
 							opt in
@@ -36,7 +34,7 @@
 					</td>
 					<td>
 						<a
-							href={`${hostname}/ab-tests/opt-out/${testName}:${group}`}
+							href={`https://www.theguardian.com/ab-tests/opt-out/${testName}:${group}`}
 							target="_blank"
 						>
 							opt out

--- a/ab-testing/frontend/src/routes/+page.svelte
+++ b/ab-testing/frontend/src/routes/+page.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import {
-		allABTests,
-		activeABtests,
-		hostname,
-	} from "@guardian/ab-testing-config";
+	import { allABTests, activeABtests } from "@guardian/ab-testing-config";
 	import Table from "$lib/components/TableFixed.svelte";
 	import AudienceBreakdown from "$lib/components/AudienceBreakdown.svelte";
 </script>
@@ -19,7 +15,7 @@
 	</p>
 	<p>
 		AB tests are defined in <a
-			href="https://github.com/guardian/dotcom-rendering/blob/main/ab-testing/config/abTests.ts"
+			href="https://github.com/guardian/dotcom-rendering/blob/main/ab-testing/abTest.ts"
 			>guardian/dotcom-rendering</a
 		>
 	</p>
@@ -28,7 +24,7 @@
 		this will override any cookie based test assignment.
 	</p>
 	<p>
-		<a href={`${hostname}/ab-tests/opt-out`}
+		<a href="https://www.theguardian.com/ab-tests/opt-out"
 			>Use this link to opt out of all tests you've opted into</a
 		>
 	</p>

--- a/ab-testing/frontend/vite.config.ts
+++ b/ab-testing/frontend/vite.config.ts
@@ -3,9 +3,4 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [sveltekit()],
-	define: {
-		"process.env.AB_TESTING_ENV": JSON.stringify(
-			process.env.AB_TESTING_ENV || "production",
-		),
-	},
 });

--- a/dotcom-rendering/docs/development/ab-testing-in-dcr.md
+++ b/dotcom-rendering/docs/development/ab-testing-in-dcr.md
@@ -139,7 +139,7 @@ If you want to test your changes on CODE you need to follow these steps:
 
 2. Deploy your code changes on DCR and/or Frontend to CODE as normal
 
-3. Deploy the A/B test config to CODE by deploying the `dotcom:ab-testing` riff-raff project against your branch, there will be a comment in the PR with a link to do this once the config has been validated.
+3. Deploy the A/B test config to CODE by deploying the `dotcom::ab-testing` riff-raff project against your branch, there will be a comment in the PR with a link to do this once the config has been validated.
 
 The 3rd step is crucial as Fastly buckets users into tests/cohorts and returns your A/B test participations as response headers.
 


### PR DESCRIPTION
This PR reverts guardian/dotcom-rendering#15167 after @Jakeii reported that there are errors in the console with negative values for AB tests that might break metrics collecting for tests. 