### PR TITLE
Rejig `color-scheme` data attribute for interactives

### DIFF
--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -173,7 +173,9 @@ window.twttr = (function(d, s, id) {
 
 	const onlyLightColourScheme =
 		isInteractive &&
-		Date.parse(webPublicationDate) < Date.parse('2026-01-13T00:00:00Z');
+		(!config.darkModeAvailable ||
+			Date.parse(webPublicationDate) <
+				Date.parse('2026-01-13T00:00:00Z'));
 
 	const maybeArticleThemeString = getArticleThemeString(theme);
 


### PR DESCRIPTION
Following up on https://github.com/guardian/dotcom-rendering/pull/14749, this adjusts the logic around the `data-color-scheme` attribute to continue rendering it on interactive articles on web for users who have not opted in to the dark mode beta.

With this approach we can continue to use existing dark mode checks in interactive atoms and it will deprecate gracefully if/when dark mode rolls out across the full site.