### PR TITLE
Don't show pointer cursor for Cinemagraphs

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -23,12 +23,15 @@ import { VideoProgressBar } from './VideoProgressBar';
 
 export type SubtitleSize = 'small' | 'medium' | 'large';
 
-const videoStyles = (aspectRatio: number) => css`
+const videoStyles = (aspectRatio: number, isCinemagraph: boolean) => css`
 	position: relative;
 	display: block;
 	height: auto;
 	width: 100%;
-	cursor: pointer;
+	${!isCinemagraph &&
+	css`
+		cursor: pointer;
+	`}
 
 	/* Prevents CLS by letting the browser know the space the video will take up. */
 	aspect-ratio: ${aspectRatio};
@@ -171,12 +174,13 @@ export const SelfHostedVideoPlayer = forwardRef(
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
+		const isCinemagraph = videoStyle === 'Cinemagraph';
 		const videoId = `video-${uniqueId}`;
 		const showSubtitles =
-			videoStyle !== 'Cinemagraph' && !!subtitleSource && !!subtitleSize;
+			!isCinemagraph && !!subtitleSource && !!subtitleSize;
 
 		const showControls =
-			videoStyle !== 'Cinemagraph' &&
+			!isCinemagraph &&
 			ref &&
 			'current' in ref &&
 			ref.current &&
@@ -194,7 +198,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 				<video
 					id={videoId}
 					css={[
-						videoStyles(aspectRatio),
+						videoStyles(aspectRatio, isCinemagraph),
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"


### PR DESCRIPTION
## What does this change?

Second attempt at not showing `cursor: pointer` when hovering over Cinemagraphs on articles.

## Why?

My [first attempt](https://github.com/guardian/dotcom-rendering/pull/15163) was overcomplicating things by distinguishing between Cinemagraphs on articles vs fronts.

Cinemagraphs on fronts have their `cursor: pointer` applied further up the tree so this change should only affect Cinemagraphs on articles.

## Screenshots

![hover](https://github.com/user-attachments/assets/71dbc153-7374-4f77-b791-d30f6eed2f5f)

