### PR TITLE
Add server side AB test for football redesign

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -70,6 +70,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "webex-football-redesign",
+		description: "Testing the Redesign for the football pages",
+		owners: ["dotcom.platform@theguardian.com"],
+		expirationDate: `2026-02-28`,
+		type: "server",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
This PR adds a new 0% server side AB test for football redesign. This test is switched on but because it's 0% it won't affect the users unless if they opt-in for the test. 

To opt-in you'd need to run this url `/ab-tests/opt-in/webex-football-redesign:variant`. This was tested in code by using the opt-in url https://m.code.dev-theguardian.com/ab-tests/opt-in/webex-football-redesign:variant 

It was also tested locally through adding the query param `?ab-webex-football-redesign=variant` 

This PR fixes [#15170](https://github.com/guardian/dotcom-rendering/issues/15170)