### PR TITLE
Football match header live styles

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
@@ -28,17 +28,19 @@ export const Fixture = {
 		},
 		tabs: {
 			selected: 'info',
+			matchKind: 'Fixture',
 		},
 		edition: 'UK',
 	},
 } satisfies Story;
 
-export const Result = {
+export const Live = {
 	args: {
-		leagueName: 'Premier League',
+		leagueName: Fixture.args.leagueName,
 		match: {
 			...Fixture.args.match,
-			kind: 'Result',
+			kind: 'Live',
+			status: '1st',
 			homeTeam: {
 				...Fixture.args.match.homeTeam,
 				score: 0,
@@ -56,7 +58,26 @@ export const Result = {
 			comment: undefined,
 		},
 		tabs: {
+			selected: 'live',
+			matchKind: 'Live',
+			infoURL: new URL(
+				'https://www.theguardian.com/football/match/2025/nov/26/arsenal-v-bayernmunich',
+			),
+		},
+		edition: 'EUR',
+	},
+} satisfies Story;
+
+export const Result = {
+	args: {
+		leagueName: Fixture.args.leagueName,
+		match: {
+			...Live.args.match,
+			kind: 'Result',
+		},
+		tabs: {
 			selected: 'info',
+			matchKind: 'Result',
 			liveURL: new URL(
 				'https://www.theguardian.com/football/live/2025/nov/26/arsenal-v-bayern-munich-champions-league-live',
 			),

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -8,6 +8,7 @@ import {
 	textSans15Object,
 	textSansBold14Object,
 	textSansBold17Object,
+	until,
 } from '@guardian/source/foundations';
 import { type ComponentProps, type ReactNode, useMemo } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
@@ -18,8 +19,10 @@ import {
 	getTimeZoneFromEdition,
 } from '../../lib/edition';
 import { palette } from '../../palette';
+import type { ColourName } from '../../paletteDeclarations';
 import { BigNumber } from '../BigNumber';
 import { FootballCrest } from '../FootballCrest';
+import { background, border, primaryText, secondaryText } from './colours';
 import { Tabs } from './Tabs';
 
 type Props = {
@@ -31,13 +34,9 @@ type Props = {
 
 export const FootballMatchHeader = (props: Props) => (
 	<section
-		css={{
-			backgroundColor: palette(
-				'--football-match-header-fixture-result-background',
-			),
-			color: palette(
-				'--football-match-header-fixture-result-primary-text',
-			),
+		style={{
+			backgroundColor: palette(background(props.match.kind)),
+			color: palette(primaryText(props.match.kind)),
 		}}
 	>
 		<div
@@ -58,9 +57,9 @@ export const FootballMatchHeader = (props: Props) => (
 				match={props.match}
 				edition={props.edition}
 			/>
-			<Hr borderStyle="dotted" />
+			<Hr borderStyle="dotted" borderColour={border(props.match.kind)} />
 			<Teams match={props.match} />
-			<Hr borderStyle="solid" />
+			<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
 			<Tabs {...props.tabs} />
 		</div>
 	</section>
@@ -75,9 +74,6 @@ const StatusLine = (props: {
 		css={{
 			...textSans14Object,
 			'&': css(grid.column.centre),
-			color: palette(
-				'--football-match-header-fixture-result-secondary-text',
-			),
 			paddingTop: space[2],
 			paddingBottom: space[1],
 			[from.leftCol]: {
@@ -85,21 +81,45 @@ const StatusLine = (props: {
 				padding: `${space[3]}px 0 0`,
 			},
 		}}
+		style={{
+			color: palette(secondaryText(props.match.kind)),
+		}}
 	>
-		<LeagueName>{props.leagueName}</LeagueName>
+		<LeagueName matchKind={props.match.kind}>{props.leagueName}</LeagueName>
 		{props.match.venue} •{' '}
 		<MatchStatus edition={props.edition} match={props.match} />
 	</p>
 );
 
-const LeagueName = (props: { children: ReactNode }) => (
+const LeagueName = (props: {
+	matchKind: FootballMatch['kind'];
+	children: ReactNode;
+}) => (
 	<>
 		<span
+			style={{
+				color: palette(primaryText(props.matchKind)),
+				'--live-circle-display':
+					props.matchKind === 'Live' ? 'inline-block' : 'none',
+			}}
 			css={{
 				...textSansBold14Object,
-				color: palette(
-					'--football-match-header-fixture-result-primary-text',
-				),
+				display: 'inline-flex',
+				alignItems: 'center',
+				[until.leftCol]: {
+					'&:before': {
+						content: '""',
+						display: 'var(--live-circle-display)',
+						borderRadius: '100%',
+						marginRight: space[1],
+						width: 12,
+						height: 12,
+						backgroundColor: palette(
+							'--football-match-header-live-primary-text',
+						),
+						opacity: 0.6,
+					},
+				},
 				[from.leftCol]: {
 					...textSansBold17Object,
 					display: 'block',
@@ -131,7 +151,7 @@ const MatchStatus = (props: { match: FootballMatch; edition: EditionId }) => {
 		case 'Fixture':
 			return kickOffFormatter.format(props.match.kickOff);
 		case 'Live':
-			return props.match.status;
+			return <span css={textSansBold14Object}>{props.match.status}</span>;
 		case 'Result':
 			return 'FT';
 	}
@@ -148,7 +168,10 @@ const kickOffFormatterForEdition = (edition: EditionId): Intl.DateTimeFormat =>
 		timeZone: getTimeZoneFromEdition(edition),
 	});
 
-const Hr = (props: { borderStyle: 'dotted' | 'solid' }) => (
+const Hr = (props: {
+	borderStyle: 'dotted' | 'solid';
+	borderColour: ColourName;
+}) => (
 	<hr
 		css={{
 			'&': css(grid.column.all),
@@ -156,14 +179,14 @@ const Hr = (props: { borderStyle: 'dotted' | 'solid' }) => (
 			width: '100%',
 			borderWidth: 0,
 			borderBottomWidth: 1,
-			borderBottomColor: palette(
-				'--football-match-header-fixture-result-border',
-			),
 			[from.leftCol]: {
 				display: 'none',
 			},
 		}}
-		style={{ borderBottomStyle: props.borderStyle }}
+		style={{
+			borderBottomColor: palette(props.borderColour),
+			borderBottomStyle: props.borderStyle,
+		}}
 	/>
 );
 
@@ -195,9 +218,6 @@ const Team = (props: {
 			flex: '1 1 50%',
 			wordBreak: 'break-word',
 			borderLeftStyle: 'solid',
-			borderLeftColor: palette(
-				'--football-match-header-fixture-result-border',
-			),
 			'&:last-of-type': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
@@ -207,6 +227,9 @@ const Team = (props: {
 				borderLeftWidth: 1,
 				paddingTop: space[3],
 			},
+		}}
+		style={{
+			borderLeftColor: palette(border(props.match.kind)),
 		}}
 	>
 		<TeamName name={props.match[props.team].name} />
@@ -222,7 +245,10 @@ const Team = (props: {
 				paID={props.match[props.team].paID}
 			/>
 			{props.match.kind !== 'Fixture' ? (
-				<Score score={props.match[props.team].score} />
+				<Score
+					score={props.match[props.team].score}
+					matchKind={props.match.kind}
+				/>
 			) : null}
 		</span>
 		{props.match.kind !== 'Fixture' ? (
@@ -273,7 +299,7 @@ const Crest = (props: { name: string; paID: string }) => (
  *
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role
  */
-const Score = (props: { score: number }) => (
+const Score = (props: { score: number; matchKind: FootballMatch['kind'] }) => (
 	<span
 		role="img"
 		aria-label={`Score: ${props.score}`}
@@ -281,15 +307,10 @@ const Score = (props: { score: number }) => (
 			...circleStyles,
 			borderWidth: 1,
 			borderStyle: 'solid',
-			borderColor: palette(
-				'--football-match-header-fixture-result-border',
-			),
 			transform: 'translateX(-10px)',
 			zIndex: 0,
 			svg: {
-				fill: palette(
-					'--football-match-header-fixture-result-primary-text',
-				),
+				fill: 'var(--svg-fill)',
 				height: 30,
 			},
 			paddingLeft: 4,
@@ -297,6 +318,10 @@ const Score = (props: { score: number }) => (
 			'& > :nth-of-type(2)': {
 				marginLeft: -10,
 			},
+		}}
+		style={{
+			borderColor: palette(border(props.matchKind)),
+			'--svg-fill': palette(primaryText(props.matchKind)),
 		}}
 	>
 		<ScoreNumber score={props.score} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const MatchInfoWhenFixture = {
 	args: {
 		selected: 'info',
+		matchKind: 'Fixture',
 	},
 	parameters: {
 		colourSchemeBackground: {
@@ -28,9 +29,16 @@ export const LiveWhenLive = {
 	...MatchInfoWhenFixture,
 	args: {
 		selected: 'live',
+		matchKind: 'Live',
 		infoURL: new URL(
 			'https://www.theguardian.com/football/match/2025/nov/26/arsenal-v-bayernmunich',
 		),
+	},
+	parameters: {
+		colourSchemeBackground: {
+			light: palette('--football-match-header-live-background'),
+			dark: palette('--football-match-header-live-background'),
+		},
 	},
 } satisfies Story;
 
@@ -38,6 +46,7 @@ export const ReportWhenResult = {
 	...MatchInfoWhenFixture,
 	args: {
 		selected: 'report',
+		matchKind: 'Result',
 		liveURL: new URL(
 			'https://www.theguardian.com/football/live/2025/nov/26/arsenal-v-bayern-munich-champions-league-live',
 		),

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -5,11 +5,15 @@ import {
 	headlineBold17Object,
 	space,
 } from '@guardian/source/foundations';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import { palette } from '../../palette';
+import { border, primaryText, selected } from './colours';
 
-type Props =
+type Props = {
+	matchKind: FootballMatch['kind'];
+} & (
 	| {
 			selected: 'info';
 			reportURL?: URL;
@@ -24,7 +28,8 @@ type Props =
 			selected: 'report';
 			liveURL?: URL;
 			infoURL: URL;
-	  };
+	  }
+);
 
 export const Tabs = (props: Props) => (
 	<nav css={[grid.column.centre]}>
@@ -36,10 +41,10 @@ export const Tabs = (props: Props) => (
 				width: '100%',
 				borderBottomWidth: 1,
 				borderStyle: 'solid',
-				borderColor: palette(
-					'--football-match-header-fixture-result-border',
-				),
 				[from.leftCol]: headlineBold17Object,
+			}}
+			style={{
+				borderColor: palette(border(props.matchKind)),
 			}}
 		>
 			<MatchReport {...props} />
@@ -51,11 +56,15 @@ export const Tabs = (props: Props) => (
 
 const MatchReport = (props: Props) => {
 	if (props.selected === 'report') {
-		return <Tab>Match report</Tab>;
+		return <Tab matchKind={props.matchKind}>Match report</Tab>;
 	}
 
 	if (props.reportURL !== undefined) {
-		return <Tab href={props.reportURL}>Match report</Tab>;
+		return (
+			<Tab matchKind={props.matchKind} href={props.reportURL}>
+				Match report
+			</Tab>
+		);
 	}
 
 	return null;
@@ -63,11 +72,15 @@ const MatchReport = (props: Props) => {
 
 const LiveFeed = (props: Props) => {
 	if (props.selected === 'live') {
-		return <Tab>Live feed</Tab>;
+		return <Tab matchKind={props.matchKind}>Live feed</Tab>;
 	}
 
 	if (props.liveURL !== undefined) {
-		return <Tab href={props.liveURL}>Live feed</Tab>;
+		return (
+			<Tab matchKind={props.matchKind} href={props.liveURL}>
+				Live feed
+			</Tab>
+		);
 	}
 
 	return null;
@@ -75,21 +88,26 @@ const LiveFeed = (props: Props) => {
 
 const MatchInfo = (props: Props) => {
 	if (props.selected === 'info') {
-		return <Tab>Match info</Tab>;
+		return <Tab matchKind={props.matchKind}>Match info</Tab>;
 	}
 
-	return <Tab href={props.infoURL}>Match info</Tab>;
+	return (
+		<Tab matchKind={props.matchKind} href={props.infoURL}>
+			Match info
+		</Tab>
+	);
 };
 
-const Tab = (props: { children: ReactNode; href?: URL }) => (
+const Tab = (props: {
+	children: ReactNode;
+	href?: URL;
+	matchKind: FootballMatch['kind'];
+}) => (
 	<li
 		css={{
 			// Ensures that if there are only two tabs they take up exactly 50%
 			flex: '1 1 50%',
 			borderLeftStyle: 'solid',
-			borderLeftColor: palette(
-				'--football-match-header-fixture-result-border',
-			),
 			'&:not(:first-of-type)': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
@@ -100,15 +118,28 @@ const Tab = (props: { children: ReactNode; href?: URL }) => (
 				flex: '0 0 auto',
 			},
 		}}
+		style={{
+			borderLeftColor: palette(border(props.matchKind)),
+		}}
 	>
-		<TabText href={props.href}>{props.children}</TabText>
+		<TabText href={props.href} matchKind={props.matchKind}>
+			{props.children}
+		</TabText>
 	</li>
 );
 
-const TabText = (props: { children: ReactNode; href?: URL }) => {
+const TabText = (props: {
+	children: ReactNode;
+	href?: URL;
+	matchKind: FootballMatch['kind'];
+}) => {
 	if (props.href !== undefined) {
 		return (
-			<a href={props.href.toString()} css={tabTextStyles}>
+			<a
+				href={props.href.toString()}
+				css={tabTextCss}
+				style={tabTextStyle(props.matchKind)}
+			>
 				{props.children}
 			</a>
 		);
@@ -116,11 +147,10 @@ const TabText = (props: { children: ReactNode; href?: URL }) => {
 
 	return (
 		<span
-			css={tabTextStyles}
+			css={tabTextCss}
 			style={{
-				borderBottomColor: palette(
-					'--football-match-header-fixture-result-selected',
-				),
+				...tabTextStyle(props.matchKind),
+				borderBottomColor: palette(selected(props.matchKind)),
 			}}
 		>
 			{props.children}
@@ -128,21 +158,23 @@ const TabText = (props: { children: ReactNode; href?: URL }) => {
 	);
 };
 
-const tabTextStyles = css({
+const tabTextCss = css({
 	display: 'block',
 	paddingBottom: space[2],
 	borderBottomWidth: space[1],
 	borderBottomStyle: 'solid',
 	borderBottomColor: 'transparent',
-	color: palette('--football-match-header-fixture-result-primary-text'),
 	textDecoration: 'none',
 	'&:hover': {
-		borderBottomColor: palette(
-			'--football-match-header-fixture-result-selected',
-		),
+		borderBottomColor: 'var(--hover-colour)',
 	},
 	[from.leftCol]: {
 		paddingRight: space[6],
 		paddingBottom: space[3],
 	},
+});
+
+const tabTextStyle = (matchKind: FootballMatch['kind']): CSSProperties => ({
+	color: palette(primaryText(matchKind)),
+	'--hover-colour': palette(selected(matchKind)),
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/colours.ts
+++ b/dotcom-rendering/src/components/FootballMatchHeader/colours.ts
@@ -1,0 +1,32 @@
+import type { FootballMatch } from '../../footballMatchV2';
+import type { ColourName } from '../../paletteDeclarations';
+
+export const primaryText = (matchKind: FootballMatch['kind']): ColourName =>
+	matchKind === 'Live'
+		? '--football-match-header-live-primary-text'
+		: '--football-match-header-fixture-result-primary-text';
+
+/**
+ * There is no secondary text colour in the live design, so we just reuse the
+ * primary colour in that case to avoid an unnecessary extra colour in the
+ * palette.
+ */
+export const secondaryText = (matchKind: FootballMatch['kind']): ColourName =>
+	matchKind === 'Live'
+		? '--football-match-header-live-primary-text'
+		: '--football-match-header-fixture-result-secondary-text';
+
+export const background = (matchKind: FootballMatch['kind']): ColourName =>
+	matchKind === 'Live'
+		? '--football-match-header-live-background'
+		: '--football-match-header-fixture-result-background';
+
+export const border = (matchKind: FootballMatch['kind']): ColourName =>
+	matchKind === 'Live'
+		? '--football-match-header-live-border'
+		: '--football-match-header-fixture-result-border';
+
+export const selected = (matchKind: FootballMatch['kind']): ColourName =>
+	matchKind === 'Live'
+		? '--football-match-header-live-selected'
+		: '--football-match-header-fixture-result-selected';

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7118,6 +7118,22 @@ const paletteColours = {
 		light: () => sourcePalette.sport[600],
 		dark: () => sourcePalette.sport[600],
 	},
+	'--football-match-header-live-background': {
+		light: () => sourcePalette.brandAlt[400],
+		dark: () => sourcePalette.brandAlt[400],
+	},
+	'--football-match-header-live-border': {
+		light: () => `${sourcePalette.neutral[7]}33`,
+		dark: () => `${sourcePalette.neutral[7]}33`,
+	},
+	'--football-match-header-live-primary-text': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
+	'--football-match-header-live-selected': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[7],
+	},
 	'--football-match-hover': {
 		light: () => sourcePalette.neutral[93],
 		dark: () => sourcePalette.neutral[38],


### PR DESCRIPTION
So far the header has only been styled to support the "fixture" and "result" variants of the design, because they look quite similar. This change adds styles to support the "live" variant.

The `Tabs` component now takes a `matchKind` prop. Note that this is different to the `selected` prop, as any tab may be selected while the match is in any state (e.g. you can view the "info" page while the match is "live", and so on).

Wherever a style has become "dynamic" (i.e. depends on a component's props) as a result of these changes, that style has been moved from the `css` prop to the `style` prop, as per Emotion's recommendations[^1].

Part of #14901.

[^1]: https://emotion.sh/docs/best-practices#use-the-style-prop-for-dynamic-styles

## Screenshots

### Mobile

![live-mobile](https://github.com/user-attachments/assets/b505e8d6-ce62-489e-8849-04615c34ee8c)

### Wide

![live-wide](https://github.com/user-attachments/assets/6a8ffd99-96a5-4052-b2f6-0b3c1f63788d)
