### PR TITLE
Default to role="inline" if undefined on interactive block

### DIFF
--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -441,7 +441,7 @@ export const renderElement = ({
 				<Island
 					priority="critical"
 					defer={{ until: 'idle' }}
-					role={element.role}
+					role={element.role ?? 'inline'}
 				>
 					<InteractiveBlockComponent
 						url={element.url}


### PR DESCRIPTION
## Why?
Spacefinder needs this role to correctly place ads, we've noticed spacefinder inserting ads too close to interactive atoms in articles, this'll be why.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cb0abf8c-14ff-4b55-bda4-1e49c99fc184
[after]: https://github.com/user-attachments/assets/2c992c18-e40e-46a3-93ba-59577b9f66b2

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
