### PR TITLE
Update football match stat stories

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchGoalAttempts.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchGoalAttempts.stories.tsx
@@ -9,27 +9,11 @@ import { FootballMatchGoalAttempts } from './FootballMatchStat';
 const meta = {
 	title: 'Components/Football Match Goal Attempts',
 	component: FootballMatchGoalAttempts,
-	decorators: [
-		(Story) => (
-			<div
-				css={css`
-					padding: ${space[4]}px;
-				`}
-			>
-				<Story />
-			</div>
-		),
-		splitTheme([
-			{
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.News,
-			},
-		]),
-	],
-	parameters: {
-		layout: 'padded',
-	},
+	render: (args) => (
+		<div css={{ padding: space[2] }}>
+			<FootballMatchGoalAttempts {...args} />
+		</div>
+	),
 } satisfies Meta<typeof FootballMatchGoalAttempts>;
 
 export default meta;
@@ -63,6 +47,7 @@ export const TeamColours = {
 				display: flex;
 				flex-direction: column;
 				gap: ${space[2]}px;
+				padding: ${space[2]}px;
 			`}
 		>
 			{footballTeams.map((match, index) => (
@@ -81,6 +66,15 @@ export const TeamColours = {
 			))}
 		</div>
 	),
+	decorators: [
+		splitTheme([
+			{
+				design: ArticleDesign.Standard,
+				display: ArticleDisplay.Standard,
+				theme: Pillar.Sport,
+			},
+		]),
+	],
 	args: {
 		...Default.args,
 	},

--- a/dotcom-rendering/src/components/FootballMatchStat.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchStat.stories.tsx
@@ -10,32 +10,20 @@ import { FootballMatchStat } from './FootballMatchStat';
 const meta = {
 	title: 'Components/Football Match Stat',
 	component: FootballMatchStat,
-	decorators: [
-		(Story) => (
-			<div
-				css={css`
-					padding: ${space[4]}px;
-					background-color: ${palette(
-						'--football-live-blog-background',
-					)};
-				`}
-			>
-				<Story />
-			</div>
-		),
-		splitTheme([
-			{
-				design: ArticleDesign.Standard,
-				display: ArticleDisplay.Standard,
-				theme: Pillar.News,
-			},
-		]),
-	],
 	parameters: {
 		viewport: {
 			defaultViewport: 'mobileMedium',
 		},
+		colourSchemeBackground: {
+			light: palette('--football-live-blog-background'),
+			dark: palette('--football-live-blog-background'),
+		},
 	},
+	render: (args) => (
+		<div css={{ padding: space[2] }}>
+			<FootballMatchStat {...args} />
+		</div>
+	),
 } satisfies Meta<typeof FootballMatchStat>;
 
 export default meta;
@@ -88,6 +76,7 @@ export const TeamColours = {
 				display: flex;
 				flex-direction: column;
 				gap: ${space[2]}px;
+				padding: ${space[2]}px;
 			`}
 		>
 			{footballTeams.map((match, index) => (
@@ -106,6 +95,18 @@ export const TeamColours = {
 			))}
 		</div>
 	),
+	decorators: [
+		splitTheme(
+			[
+				{
+					design: ArticleDesign.Standard,
+					display: ArticleDisplay.Standard,
+					theme: Pillar.Sport,
+				},
+			],
+			{ hideFormatHeading: true },
+		),
+	],
 	args: {
 		...ShownAsPercentage.args,
 	},


### PR DESCRIPTION
## What does this change?

Updates to football match stat and goal attempts stories:

- Removes split theme decorator as a default and only applies to team colour stories where it's most useful
  - Hides format heading as current format has no bearing on component theme
- Uses existing `colourSchemeBackground` parameter rather than a custom decorator
- Applies consistent padding around components when viewed in isolation and within split theme container so the outer border is visible
