### PR TITLE
Adjust preferred source button sizes

### DIFF
--- a/dotcom-rendering/src/components/PreferredSourceButton.tsx
+++ b/dotcom-rendering/src/components/PreferredSourceButton.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { from, space, textSans14Object } from '@guardian/source/foundations';
+import {
+	from,
+	space,
+	textSans12Object,
+	textSans14Object,
+} from '@guardian/source/foundations';
 import { LinkButton, SvgGoogleBrand } from '@guardian/source/react-components';
 import { palette } from '../palette';
 
@@ -23,13 +28,18 @@ export const PreferredSourceButton = ({ text }: Props) => (
 				flexBasis: 20,
 			},
 			[from.leftCol]: {
+				...textSans12Object,
 				textWrap: 'wrap',
 				height: 'unset',
-				padding: '4px 16px 6px',
+				padding: '4px 8px 6px 6px',
 				'.src-button-space': {
 					flexBasis: space[2],
 					flexShrink: 0,
 				},
+			},
+			[from.wide]: {
+				padding: '10px 12px',
+				height: 36,
 			},
 		})}
 		theme={{


### PR DESCRIPTION
To prevent text wrapping on the wider breakpoints.

Part of #15197.

## Screenshots

| | Before | After |
|--------|--------|--------|
| LeftCol | ![leftcol-before] | ![leftcol-after] |
| Wide | ![wide-before] | ![wide-after] | 

[wide-after]: https://github.com/user-attachments/assets/81275b76-4fe8-4b50-906c-59741425ef27
[leftcol-before]: https://github.com/user-attachments/assets/dcbe9a52-8894-4376-a51e-50f7afe4ced8
[leftcol-after]: https://github.com/user-attachments/assets/8e1237ae-1d4d-4fbd-a999-7e85a9d30ff2
[wide-before]: https://github.com/user-attachments/assets/ee97f3d6-6545-4325-8c7c-0622e0a3a9c8
