### PR TITLE
Fix content loss by transforming legacy div and h1 tags

### DIFF
--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -160,6 +160,8 @@ const sanitiserOptions: IOptions = {
 				},
 			};
 		},
+		div: 'p',
+		h1: 'h2',
 	},
 };
 


### PR DESCRIPTION
## What does this change?
`TextBlockComponent` currently returns `null` when it encounters unknown tags like `<div>` (common in 2013/14 legacy content) or `<h1>`. This causes content loss because recursion stops and all child elements are discarded. This PR updates `sanitiserOptions` to transform `div` to `p` and `h1` to `h2` before they reach the renderer.
## Why?
-  Restores missing content
-  Fixes semantic errors
-  Reduces Log Noise

Part of https://github.com/guardian/frontend/issues/28496
