### PR TITLE
Adjust margins on product carousel

### DIFF
--- a/dotcom-rendering/src/components/ScrollableProduct.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableProduct.importable.tsx
@@ -44,11 +44,14 @@ type Props = {
 
 const baseContainerStyles = css`
 	position: relative;
+	margin-left: -10px; /* Align left card edge with edge of screen on mobile */
 	margin-right: -10px; /* Align right card edge with edge of screen on mobile */
 	${from.mobileLandscape} {
+		margin-left: -20px;
 		margin-right: -20px;
 	}
 	${from.tablet} {
+		margin-left: 0;
 		margin-right: 0;
 	}
 `;
@@ -99,6 +102,19 @@ const baseCarouselStyles = css`
 		display: none; /* Safari and Chrome */
 	}
 	scrollbar-width: none; /* Firefox */
+	scroll-padding-left: 10px;
+	padding-left: 10px;
+	padding-right: 10px;
+	${from.mobileLandscape} {
+		scroll-padding-left: 20px;
+		padding-left: 20px;
+		padding-right: 20px;
+	}
+	${from.tablet} {
+		scroll-padding-left: 0;
+		padding-left: 0;
+		padding-right: 0;
+	}
 `;
 
 const generateFixedWidthColumStyles = ({


### PR DESCRIPTION
## What does this change?
Adds a negative margin to the left of the product carousel, and padding to either side.

## Why?
Aligns the left edge of the carousel with the edge of the screen on mobile, and makes sure there's padding at the start an end of the carousel so that the edges of the carousel are aligned with the header. This makes sure the carousel displays correctly when scrolled all the way to the end.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="480" height="498" alt="Screenshot 2026-01-28 at 16 48 08" src="https://github.com/user-attachments/assets/fa4658e0-5a4c-4517-baed-6c7428f7bc66" /> | <img width="479" height="496" alt="Screenshot 2026-01-28 at 16 48 48" src="https://github.com/user-attachments/assets/350f6ce3-cee7-44c6-ae14-00e2f8677b3c" /> |

