### PR TITLE
Reduce blur height of blur on vertical feature cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -48,8 +48,6 @@ import { SupportingContent } from './SupportingContent';
 import { WaveForm } from './WaveForm';
 import { YoutubeBlockComponent } from './YoutubeBlockComponent.importable';
 
-export type Position = 'inner' | 'outer' | 'none';
-
 const baseCardStyles = css`
 	display: flex;
 	flex-direction: column;
@@ -162,13 +160,6 @@ const overlayMaskGradientStyles = (angle: string) => css`
 		rgba(0, 0, 0, 0.9619) 56px,
 		rgb(0, 0, 0) 64px
 	);
-`;
-
-const contentOverlayStyles = css`
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	width: 100%;
 `;
 
 const overlayStyles = css`


### PR DESCRIPTION
## What does this change?
Updates the design of feature cards

- Reduces the height of the blur on feature cards and 4:5 immersive cards from 64px to 36px. The blur on 5:4 immersive cards remains unchanged
- Reduces the height of the podcast waveform from 64px to 40px for feature card and immersive cards

To account for this reduction in padding blur, the blur has been moved into its own div so that it does not apply to the content itself. 

## Why?
Design would like to obscure less of the image in order to better serve video in these cards.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4f2fd5f1-0816-4cd0-811f-21bf99b19d43
[after]: https://github.com/user-attachments/assets/aa89c30e-f593-49fa-a443-fd77fb439e95


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
