### PR TITLE
adds ab test config for mobileInline1Halfpage

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -104,6 +104,18 @@ const ABTests: ABTest[] = [
 		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control", "prefer", "add"],
+	},
+	{
+		name: "commercial-mobile-inline1-halfpage",
+		description:
+			"To measure impact (RPM) and CLS of adding halfPage as an additional size option to mobile inline1 ad slot",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: `2026-02-28`,
+		type: "client",
+		status: "ON",
+		audienceSize: 20 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
 	{


### PR DESCRIPTION
## What does this change?
Adds the config for an AB test, enabling us to gate the feature in commercial behind an AB test

Adds a new AB test to measure the impact of enabling halfPage ad size (300x600) for the mobile inline1 ad slot.

## Why?
We want to measure the impact of displaying a 300x600 ad in mobile for the inline 1 slot:
- **RPM (Revenue)**: Does the larger ad size increase revenue?
- **CLS (Layout Shift)**: Does it cause more cumulative layout shift?


