### PR TITLE
Fix choice cards pill colour

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -478,7 +478,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 									choices={choiceCards}
 									id={'banner'}
 									submitComponentEvent={submitComponentEvent}
-									choiceCardSettings={choiceCardSettings}
+									choiceCardDesignSettings={
+										choiceCardSettings
+									}
 								/>
 							)}
 							<div

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -45,7 +45,7 @@ import { DesignableBannerHeader } from './components/DesignableBannerHeader';
 import { DesignableBannerVisual } from './components/DesignableBannerVisual';
 import type {
 	BannerTemplateSettings,
-	ChoiceCardSettings,
+	ChoiceCardDesignSettings,
 	CtaSettings,
 } from './settings';
 import { buttonStyles, buttonThemes } from './styles/buttonStyles';
@@ -82,7 +82,7 @@ const buildHeaderImageSettings = (
 
 const buildChoiceCardSettings = (
 	design: ConfigurableDesign,
-): ChoiceCardSettings | undefined => {
+): ChoiceCardDesignSettings | undefined => {
 	if (design.visual?.kind === 'ChoiceCards') {
 		const {
 			buttonColour,

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/settings.ts
@@ -36,7 +36,7 @@ export interface HeaderSettings {
 	headerImage?: Image;
 }
 
-export interface ChoiceCardSettings {
+export interface ChoiceCardDesignSettings {
 	buttonColour?: string;
 	buttonTextColour?: string;
 	buttonBorderColour?: string;
@@ -58,7 +58,7 @@ export interface BannerTemplateSettings {
 	articleCountTextColour?: string;
 	imageSettings?: Image;
 	alternativeVisual?: ReactNode;
-	choiceCardSettings?: ChoiceCardSettings;
+	choiceCardSettings?: ChoiceCardDesignSettings;
 	bannerId?: BannerId;
 	tickerStylingSettings?: TickerSettings['tickerStylingSettings'];
 	headerSettings?: HeaderSettings;

--- a/dotcom-rendering/src/components/marketing/lib/storybook.ts
+++ b/dotcom-rendering/src/components/marketing/lib/storybook.ts
@@ -97,6 +97,48 @@ export const choiceCardsSettings: ChoiceCardsSettings = {
 	],
 };
 
+export const choiceCardsSettingsWithDiscountPill: ChoiceCardsSettings = {
+	...choiceCardsSettings,
+	choiceCards: choiceCardsSettings.choiceCards.map((card, index) => {
+		if (index === 1) {
+			return {
+				...card,
+				label: 'Support <s>£12</s> £6/monthly',
+				pill: {
+					copy: '50% off',
+					backgroundColour: {
+						kind: 'hex',
+						r: 'BB',
+						g: '80',
+						b: '3B',
+					},
+				},
+			};
+		}
+		return card;
+	}),
+	mobileChoiceCards: choiceCardsSettings.mobileChoiceCards?.map(
+		(card, index) => {
+			if (index === 1) {
+				return {
+					...card,
+					label: 'Support <s>£12</s> £6/monthly',
+					pill: {
+						copy: '50% off',
+						backgroundColour: {
+							kind: 'hex',
+							r: 'BB',
+							g: '80',
+							b: '3B',
+						},
+					},
+				};
+			}
+			return card;
+		},
+	),
+};
+
 export const choiceCardsWithMixedDestinations: ChoiceCardsSettings = {
 	choiceCards: [
 		{

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.stories.tsx
@@ -1,0 +1,80 @@
+import { palette } from '@guardian/source/foundations';
+import type { ChoiceCard } from '@guardian/support-dotcom-components/dist/shared/types/props/choiceCards';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { useState } from 'react';
+import {
+	choiceCardsSettings,
+	choiceCardsSettingsWithDiscountPill,
+} from '../lib/storybook';
+import { ThreeTierChoiceCards } from './ThreeTierChoiceCards';
+
+const meta: Meta<typeof ThreeTierChoiceCards> = {
+	component: ThreeTierChoiceCards,
+	title: 'Components/marketing/ThreeTierChoiceCards',
+	decorators: [
+		(Story, context) => {
+			const [selectedChoiceCard, setSelectedChoiceCard] = useState<
+				ChoiceCard | undefined
+			>(choiceCardsSettings.choiceCards.find((card) => card.isDefault));
+
+			return (
+				<Story
+					args={{
+						...context.args,
+						selectedChoiceCard:
+							selectedChoiceCard ??
+							choiceCardsSettings.choiceCards[0],
+						setSelectedChoiceCard,
+					}}
+				/>
+			);
+		},
+	],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ThreeTierChoiceCards>;
+
+export const Default: Story = {
+	name: 'Default choice cards',
+	args: {
+		choices: choiceCardsSettings.choiceCards,
+		id: 'banner',
+	},
+};
+
+export const WithCustomPillColorsFromDesign: Story = {
+	name: 'Custom pill colors from design settings',
+	args: {
+		id: 'banner',
+		choiceCardDesignSettings: {
+			pillTextColour: palette.neutral[100],
+			pillBackgroundColour: palette.brand[400],
+		},
+		choices: choiceCardsSettingsWithDiscountPill.choiceCards, // overridden by design
+	},
+};
+
+export const WithCustomPillColorsFromChoiceCard: Story = {
+	name: 'Custom pill colors from choice card settings',
+	args: {
+		choices: choiceCardsSettingsWithDiscountPill.choiceCards,
+		id: 'banner',
+	},
+};
+
+export const WithCustomButtonColors: Story = {
+	name: 'Custom button and pill colors',
+	args: {
+		choices: choiceCardsSettingsWithDiscountPill.choiceCards,
+		id: 'banner',
+		choiceCardDesignSettings: {
+			buttonColour: '#F1F8FC',
+			buttonSelectColour: '#E3F6FF',
+			buttonSelectBorderColour: palette.brand[500],
+			pillTextColour: '#FFFFFF',
+			pillBackgroundColour: '#007ABC',
+		},
+	},
+};

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.stories.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.stories.tsx
@@ -44,8 +44,8 @@ export const Default: Story = {
 	},
 };
 
-export const WithCustomPillColorsFromDesign: Story = {
-	name: 'Custom pill colors from design settings',
+export const WithCustomPillColoursFromDesign: Story = {
+	name: 'Custom pill colours from design settings',
 	args: {
 		id: 'banner',
 		choiceCardDesignSettings: {
@@ -56,16 +56,16 @@ export const WithCustomPillColorsFromDesign: Story = {
 	},
 };
 
-export const WithCustomPillColorsFromChoiceCard: Story = {
-	name: 'Custom pill colors from choice card settings',
+export const WithCustomPillColoursFromChoiceCard: Story = {
+	name: 'Custom pill colours from choice card settings',
 	args: {
 		choices: choiceCardsSettingsWithDiscountPill.choiceCards,
 		id: 'banner',
 	},
 };
 
-export const WithCustomButtonColors: Story = {
-	name: 'Custom button and pill colors',
+export const WithCustomButtonColours: Story = {
+	name: 'Custom button and pill colours',
 	args: {
 		choices: choiceCardsSettingsWithDiscountPill.choiceCards,
 		id: 'banner',

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -23,7 +23,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useEffect } from 'react';
 import sanitise from 'sanitize-html';
 import { useIsInView } from '../../../lib/useIsInView';
-import type { ChoiceCardSettings } from '../banners/designableBanner/settings';
+import type { ChoiceCardDesignSettings } from '../banners/designableBanner/settings';
 
 const benefitsStyles = css`
 	${textSans15};
@@ -65,11 +65,11 @@ const supportingTextStyles = css`
 const SupportingBenefits = ({
 	benefitsLabel,
 	benefits,
-	choiceCardSettings,
+	choiceCardDesignSettings,
 }: {
 	benefitsLabel?: string;
 	benefits: ChoiceCard['benefits'];
-	choiceCardSettings?: ChoiceCardSettings;
+	choiceCardDesignSettings?: ChoiceCardDesignSettings;
 }) => {
 	const showTicks = benefits.length > 1;
 	return (
@@ -77,7 +77,7 @@ const SupportingBenefits = ({
 			{!!benefitsLabel && (
 				<span
 					css={benefitsLabelStyles(
-						choiceCardSettings?.buttonSelectTextColour,
+						choiceCardDesignSettings?.buttonSelectTextColour,
 					)}
 					dangerouslySetInnerHTML={{
 						__html: sanitise(benefitsLabel),
@@ -92,14 +92,14 @@ const SupportingBenefits = ({
 								size="xsmall"
 								theme={{
 									fill:
-										choiceCardSettings?.buttonSelectMarkerColour ??
+										choiceCardDesignSettings?.buttonSelectMarkerColour ??
 										palette.brand[400],
 								}}
 							/>
 						)}
 						<span
 							css={benefitsLabelStyles(
-								choiceCardSettings?.buttonSelectTextColour,
+								choiceCardDesignSettings?.buttonSelectTextColour,
 							)}
 							dangerouslySetInnerHTML={{
 								__html: sanitise(benefit.copy),
@@ -118,7 +118,7 @@ type ThreeTierChoiceCardsProps = {
 	choices: ChoiceCard[];
 	id: 'epic' | 'banner'; // uniquely identify this choice cards component to avoid conflicting with others
 	submitComponentEvent?: (componentEvent: ComponentEvent) => void;
-	choiceCardDesignSettings?: ChoiceCardSettings;
+	choiceCardDesignSettings?: ChoiceCardDesignSettings;
 };
 
 export const ThreeTierChoiceCards = ({
@@ -335,7 +335,7 @@ export const ThreeTierChoiceCards = ({
 															| undefined
 													}
 													benefits={benefits}
-													choiceCardSettings={
+													choiceCardDesignSettings={
 														choiceCardDesignSettings
 													}
 												/>

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -118,7 +118,7 @@ type ThreeTierChoiceCardsProps = {
 	choices: ChoiceCard[];
 	id: 'epic' | 'banner'; // uniquely identify this choice cards component to avoid conflicting with others
 	submitComponentEvent?: (componentEvent: ComponentEvent) => void;
-	choiceCardSettings?: ChoiceCardSettings;
+	choiceCardDesignSettings?: ChoiceCardSettings;
 };
 
 export const ThreeTierChoiceCards = ({
@@ -127,7 +127,7 @@ export const ThreeTierChoiceCards = ({
 	choices,
 	id,
 	submitComponentEvent,
-	choiceCardSettings,
+	choiceCardDesignSettings,
 }: ThreeTierChoiceCardsProps) => {
 	const [hasBeenSeen, setNode] = useIsInView({
 		debounce: true,
@@ -138,19 +138,20 @@ export const ThreeTierChoiceCards = ({
 		display: block;
 		border: ${selected
 			? `2px solid ${
-					choiceCardSettings?.buttonSelectBorderColour ??
+					choiceCardDesignSettings?.buttonSelectBorderColour ??
 					palette.brand['500']
 			  }`
 			: `1px solid ${
-					choiceCardSettings?.buttonBorderColour ??
+					choiceCardDesignSettings?.buttonBorderColour ??
 					palette.neutral[46]
 			  }`};
 		background-color: ${selected
-			? choiceCardSettings?.buttonSelectColour ?? palette.neutral[100]
-			: choiceCardSettings?.buttonColour ?? palette.neutral[100]};
+			? choiceCardDesignSettings?.buttonSelectColour ??
+			  palette.neutral[100]
+			: choiceCardDesignSettings?.buttonColour ?? palette.neutral[100]};
 		color: ${selected
-			? choiceCardSettings?.buttonSelectTextColour ?? 'inherit'
-			: choiceCardSettings?.buttonTextColour ?? 'inherit'};
+			? choiceCardDesignSettings?.buttonSelectTextColour ?? 'inherit'
+			: choiceCardDesignSettings?.buttonTextColour ?? 'inherit'};
 		border-radius: 10px;
 		padding: ${selected
 			? `6px ${space[5]}px 10px ${space[5]}px`
@@ -161,8 +162,8 @@ export const ThreeTierChoiceCards = ({
 		+ label div {
 			${isSelected ? 'font-weight: bold;' : ''}
 			color: ${isSelected
-				? choiceCardSettings?.buttonSelectTextColour ?? 'inherit'
-				: choiceCardSettings?.buttonTextColour ?? 'inherit'};
+				? choiceCardDesignSettings?.buttonSelectTextColour ?? 'inherit'
+				: choiceCardDesignSettings?.buttonTextColour ?? 'inherit'};
 			s {
 				font-weight: normal;
 			}
@@ -172,35 +173,52 @@ export const ThreeTierChoiceCards = ({
 	const customRadioTheme: ThemeRadio = {
 		...themeRadio,
 		borderSelected:
-			choiceCardSettings?.buttonSelectBorderColour ??
+			choiceCardDesignSettings?.buttonSelectBorderColour ??
 			palette.brandAlt[400],
 		borderUnselected:
-			choiceCardSettings?.buttonBorderColour ?? palette.neutral[46],
+			choiceCardDesignSettings?.buttonBorderColour ?? palette.neutral[46],
 		borderHover:
-			choiceCardSettings?.buttonSelectBorderColour ??
+			choiceCardDesignSettings?.buttonSelectBorderColour ??
 			palette.brandAlt[400],
 		fillSelected:
-			choiceCardSettings?.buttonSelectMarkerColour ?? palette.brand[400],
+			choiceCardDesignSettings?.buttonSelectMarkerColour ??
+			palette.brand[400],
 	};
 
-	const pillStyles = (pill: NonNullable<ChoiceCard['pill']>) => css`
-		border-radius: 4px;
-		padding: ${space[1]}px ${space[2]}px;
-		background-color: ${pill.backgroundColour
-			? hexColourToString(pill.backgroundColour as HexColour)
-			: choiceCardSettings?.pillBackgroundColour ??
-			  palette.brandAlt[400]};
-		${textSansBold14};
-		color: ${pill.textColour
-			? hexColourToString(pill.textColour as HexColour)
-			: choiceCardSettings?.pillTextColour ?? palette.neutral[7]};
-		position: absolute;
-		top: -${space[2]}px;
-		${until.phablet} {
-			right: ${space[3]}px;
-		}
-		right: ${space[5]}px;
-	`;
+	const pillStyles = (pill: NonNullable<ChoiceCard['pill']>) => {
+		const buildBackgroundColour = (): string => {
+			if (choiceCardDesignSettings?.pillBackgroundColour) {
+				return choiceCardDesignSettings.pillBackgroundColour;
+			}
+			if (pill.backgroundColour) {
+				return hexColourToString(pill.backgroundColour as HexColour);
+			}
+			return palette.brandAlt[400];
+		};
+		const buildTextColour = (): string => {
+			if (choiceCardDesignSettings?.pillTextColour) {
+				return choiceCardDesignSettings.pillTextColour;
+			}
+			if (pill.textColour) {
+				return hexColourToString(pill.textColour as HexColour);
+			}
+			return palette.neutral[7];
+		};
+
+		return css`
+			border-radius: 4px;
+			padding: ${space[1]}px ${space[2]}px;
+			background-color: ${buildBackgroundColour()};
+			${textSansBold14};
+			color: ${buildTextColour()};
+			position: absolute;
+			top: -${space[2]}px;
+			${until.phablet} {
+				right: ${space[3]}px;
+			}
+			right: ${space[5]}px;
+		`;
+	};
 
 	const ChoiceCardPill = ({
 		pill,
@@ -318,7 +336,7 @@ export const ThreeTierChoiceCards = ({
 													}
 													benefits={benefits}
 													choiceCardSettings={
-														choiceCardSettings
+														choiceCardDesignSettings
 													}
 												/>
 											)


### PR DESCRIPTION
Currently in PROD the pill is red because that's what [SDC sets](https://github.com/guardian/support-dotcom-components/blob/main/src/server/lib/choiceCards/choiceCards.ts#L72) in the choice cards settings if there's a discount:
<img width="300" height="193" alt="Screenshot 2026-01-29 at 15 34 10" src="https://github.com/user-attachments/assets/156d3fbf-0e74-44c1-9cb2-420a27a29243" />

The choice cards component "pill" colour can be configured in two ways:
1. from the banner design tool
2. from the choice card settings

Currently in the client the second overrides the first. But for banners we'd like to prioritise the banner design tool colours.
This PR changes the pill colours logic to do this.
For epics we'll still set the pill colour based on the choice card settings.

I've also added new storybook entries for the choice cards component which demonstrate this new logic

## Tested in CODE
Before:
<img width="325" height="251" alt="Screenshot 2026-01-30 at 09 18 38" src="https://github.com/user-attachments/assets/baab9aee-813b-4b6e-bbc8-a61de5e7b76b" />

After:
<img width="325" height="251" alt="Screenshot 2026-01-30 at 09 24 36" src="https://github.com/user-attachments/assets/cc219dce-85af-40ff-8718-ea31a3d032fb" />
