### PR TITLE
Ophan tracking for preferred source button

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.web.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.web.tsx
@@ -519,7 +519,7 @@ export const ArticleMeta = ({
 					</div>
 				</div>
 				{preferredSource.hasButton ? (
-					<PreferredSourceButton text={preferredSource.copy} />
+					<PreferredSourceButton kind={preferredSource.kind} />
 				) : null}
 			</div>
 		</div>

--- a/dotcom-rendering/src/components/PreferredSourceButton.stories.tsx
+++ b/dotcom-rendering/src/components/PreferredSourceButton.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 
 export const VariantA = {
 	args: {
-		text: 'Prefer the Guardian on Google',
+		kind: 'prefer',
 	},
 	parameters: {
 		chromatic: {
@@ -27,7 +27,7 @@ export const VariantA = {
 
 export const VariantB = {
 	args: {
-		text: 'Add the Guardian on Google',
+		kind: 'add',
 	},
 	parameters: {
 		chromatic: {

--- a/dotcom-rendering/src/components/PreferredSourceButton.tsx
+++ b/dotcom-rendering/src/components/PreferredSourceButton.tsx
@@ -6,18 +6,21 @@ import {
 	textSans14Object,
 } from '@guardian/source/foundations';
 import { LinkButton, SvgGoogleBrand } from '@guardian/source/react-components';
+import type { ButtonKind } from '../experiments/preferredSource';
 import { palette } from '../palette';
 
 type Props = {
-	text: string;
+	kind: ButtonKind;
 };
 
-export const PreferredSourceButton = ({ text }: Props) => (
+export const PreferredSourceButton = ({ kind }: Props) => (
 	<LinkButton
 		priority="tertiary"
 		icon={<SvgGoogleBrand />}
 		size="small"
 		href="https://www.google.com/preferences/source?q=theguardian.com"
+		data-component={`preferred-source-button-${kind}`}
+		data-link-name={`preferred-source-button-${kind}`}
 		cssOverrides={css({
 			...textSans14Object,
 			padding: '8px 12px 10px',
@@ -49,6 +52,15 @@ export const PreferredSourceButton = ({ text }: Props) => (
 			backgroundTertiaryHover: palette('--preferred-source-button-hover'),
 		}}
 	>
-		{text}
+		{copy(kind)}
 	</LinkButton>
 );
+
+const copy = (kind: Props['kind']): string => {
+	switch (kind) {
+		case 'prefer':
+			return 'Prefer the Guardian on Google';
+		case 'add':
+			return 'Add the Guardian on Google';
+	}
+};

--- a/dotcom-rendering/src/experiments/preferredSource.ts
+++ b/dotcom-rendering/src/experiments/preferredSource.ts
@@ -9,11 +9,13 @@ import type { BetaABTestAPI } from './lib/beta-ab-tests';
 type PreferredSourceExperiment =
 	| {
 			hasButton: true;
-			copy: string;
+			kind: ButtonKind;
 	  }
 	| {
 			hasButton: false;
 	  };
+
+export type ButtonKind = 'prefer' | 'add';
 
 export const preferredSourceExperiment = (
 	renderingTarget: RenderingTarget,
@@ -58,12 +60,12 @@ export const preferredSourceExperiment = (
 		case 'prefer':
 			return {
 				hasButton: true,
-				copy: 'Prefer the Guardian on Google',
+				kind: 'prefer',
 			};
 		case 'add':
 			return {
 				hasButton: true,
-				copy: 'Add the Guardian on Google',
+				kind: 'add',
 			};
 		case 'control':
 		default:


### PR DESCRIPTION
This adds `data-component` so that Ophan can track its presence on a page, and `data-link-name` so that it can track usage. The name is the same for both attributes and depends on which variant of the button appears:

- `preferred-source-button-prefer`
- `preferred-source-button-add`
