### PR TITLE
Add resolution to component event when self-hosted video viewed

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -496,12 +496,14 @@ export const SelfHostedVideo = ({
 	 * Track the first time the video comes into view.
 	 */
 	useOnce(() => {
+		const resolution = `${window.innerWidth}x${window.innerHeight}`;
+
 		void submitComponentEvent(
 			{
 				component: {
 					componentType: 'LOOP_VIDEO',
 					id: `gu-video-loop-${atomId}`,
-					labels: [linkTo],
+					labels: [linkTo, resolution],
 				},
 				action: 'VIEW',
 			},


### PR DESCRIPTION
## What does this change?

Adds the users window resolution to the component event that we send to Ophan when a self-hosted video is viewed

## Why?

To surface a useful piece of data.
