### PR TITLE
Deprecate `splitTheme` decorator

### DIFF
--- a/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
+++ b/dotcom-rendering/.storybook/decorators/splitThemeDecorator.tsx
@@ -308,6 +308,7 @@ const Theme = ({
  * mode, once for each format, and three times in dark mode, once for each
  * format.
  *
+ * @deprecated
  * The returned "splitTheme" decorator was historically used directly in story
  * files. This approach is now deprecated in favour of the "global colour
  * scheme" decorator and toolbar item, which use the "splitTheme" decorator in


### PR DESCRIPTION
It's technically still used by the `globalColourScheme` decorator, but this should prevent it being used directly in stories. When we've replaced all existing usages of `splitTheme` in stories we can move it into the `globalColourScheme` file and stop exporting it.
