### PR TITLE
Fix styling bug on highlights

### DIFF
--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -39,6 +39,7 @@ const container = css`
 	flex-direction: column;
 	height: 100%;
 	column-gap: ${space[2]}px;
+	justify-content: space-between;
 	/** Relative positioning is required to absolutely position the card link overlay */
 	position: relative;
 	padding: ${space[2]}px ${space[2]}px 0 ${space[2]}px;


### PR DESCRIPTION
## What does this change?
Adds justify-content `space-around` to the card wrapper for the highlights card. this ensures that the content and images are correctly aligned.

## Why?
This was removed in error during https://github.com/guardian/dotcom-rendering/pull/15182

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/a61e40d6-ba6e-49fd-9b7d-680b00c1b2fe
[after]: https://github.com/user-attachments/assets/6c33943a-8a83-46a4-8811-5dd43b76cc61

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
