### PR TITLE
Replace header `x-gu-xid` with `x-request-id`

### DIFF
--- a/dotcom-rendering/src/server/lib/logging-middleware.ts
+++ b/dotcom-rendering/src/server/lib/logging-middleware.ts
@@ -27,7 +27,7 @@ const hasConfig = (body: unknown): body is { config: ConfigType } => {
  */
 export const requestLoggerMiddleware: RequestHandler = (req, res, next) => {
 	const start = process.hrtime.bigint();
-	const headerValue = req.headers['x-gu-xid'];
+	const headerValue = req.headers['x-request-id'];
 	const requestId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
 	const loggerState = {
 		request: {


### PR DESCRIPTION
## What does this change?

Replace header `x-gu-xid` with `x-request-id`

`x-request-id` is a standard header name for request tracing.

The value is currently duplicated into `x-gu-xid` and `x-request-id` by the VCL layer.

Frontend PR: https://github.com/guardian/frontend/pull/28562
