### PR TITLE
Chore: Extend LiveRamp test date

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -37,7 +37,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Test measuring ad targeting from LiveRamp's identityLinkIdSystem module integration",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2026-03-01`,
+		expirationDate: `2026-03-04`,
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?

- Updates A/B test config for the liveramp integration end date

## Why?

- So we can test LiveRamp's integration in prod