### PR TITLE
adding tracking to the 'Read More' link in the product carousel card …

### DIFF
--- a/dotcom-rendering/src/components/ProductCarouselCard.tsx
+++ b/dotcom-rendering/src/components/ProductCarouselCard.tsx
@@ -111,6 +111,8 @@ export const ProductCarouselCard = ({
 							href={`#${headingId}`}
 							onFocus={(event) => event.stopPropagation()}
 							cssOverrides={readMoreCta}
+							data-component="at-a-glance-carousel-card-read-more"
+							data-link-name="product read more link"
 						>
 							Read more
 						</Link>


### PR DESCRIPTION
## What does this change?
Adds a data-component and data-link-name to the At a glance carousel `Read more` link so we can track clicks.

I've kept the names the same format as how we have it in the horizontal stacked cards.

## Screenshots
<img width="2246" height="460" alt="image" src="https://github.com/user-attachments/assets/9f5362dc-5b86-4c39-b08c-4d86f51ea4b9" />