### PR TITLE
Change epic view tracking threshold back to 0

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -276,7 +276,7 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();
 
-	// Used for analytics events - detects the top coming into view
+	// Used for analytics - detects the top coming into view
 	const [hasBeenSeenAtTop, setNodeAtTop] = useIsInView({
 		debounce: true,
 		threshold: 0,

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsEpic.tsx
@@ -276,15 +276,20 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } =
 		useArticleCountOptOut();
 
-	const [hasBeenSeen, setNode] = useIsInView({
+	// Used for analytics events - detects the top coming into view
+	const [hasBeenSeenAtTop, setNodeAtTop] = useIsInView({
+		debounce: true,
+		threshold: 0,
+	});
+
+	// Used for browser storage view record - detects 40% scroll depth
+	const [hasBeenSeenAt40Percent, setNodeAt40Percent] = useIsInView({
 		debounce: true,
 		threshold: 0.4,
 	});
 
 	useEffect(() => {
-		if (hasBeenSeen) {
-			// For epic view count
-			logEpicView(tracking.abTestName);
+		if (hasBeenSeenAtTop) {
 			document.dispatchEvent(
 				new CustomEvent('epic:in-view', {
 					detail: {
@@ -303,7 +308,14 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 				);
 			}
 		}
-	}, [hasBeenSeen, submitComponentEvent, countryCode, tracking]);
+	}, [hasBeenSeenAtTop, submitComponentEvent, countryCode, tracking]);
+
+	useEffect(() => {
+		if (hasBeenSeenAt40Percent) {
+			// For epic view count
+			logEpicView(tracking.abTestName);
+		}
+	}, [hasBeenSeenAt40Percent, tracking]);
 
 	useEffect(() => {
 		if (submitComponentEvent) {
@@ -355,7 +367,13 @@ const ContributionsEpic: ReactComponent<EpicProps> = ({
 	);
 
 	return (
-		<section ref={setNode} css={wrapperStyles}>
+		<section
+			ref={(node) => {
+				setNodeAtTop(node);
+				setNodeAt40Percent(node);
+			}}
+			css={wrapperStyles}
+		>
 			{showAboveArticleCount && (
 				<div css={articleCountAboveContainerStyles}>
 					<ContributionsEpicArticleCountAboveWithOptOut

--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -149,7 +149,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 }: EpicProps): JSX.Element => {
 	const { newsletterSignup, tickerSettings } = variant;
 
-	// Used for analytics events - detects the top coming into view
+	// Used for analytics - detects the top coming into view
 	const [hasBeenSeenAtTop, setNodeAtTop] = useIsInView({
 		debounce: true,
 		threshold: 0,


### PR DESCRIPTION
We use the VIEW event in the datalake for measuring performance of epic variants, for £LTV3/impression.
A [previous change](https://github.com/guardian/dotcom-rendering/pull/14820) set the VIEW event threshold for the epic at 40%.
We've now decided this is not desirable.
This has created the potential for invalid epic tests where a variant has fewer users scrolling to 40%. This can mean the variant has a lower £/INSERT but a higher £/VIEW, incorrectly making it the winner.

This PR changes the threshold back to 0 for the VIEW event.
It also adds a new view tracker, at 40%, for the epic view record in browser storage. This is used for limiting how many epics a user sees per month, and we still want this to be 40%.

Tested in CODE by observing the ophan VIEW event being sent at the top of the epic, and the local storage item (`gu.contributions.views`) updating part way down it.