### PR TITLE
Pill refactor 

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -496,30 +496,8 @@ export const Card = ({
 			css={css`
 				margin-top: auto;
 				display: flex;
-				${isStorylines &&
-				`
-					flex-direction: column;
-					gap: ${space[1]}px;
-					align-items: flex-start;
-				`}
 			`}
 		>
-			{/* Usually, we either display the pill or the footer,
-				but if the card appears in the storylines section on tag pages
-				then we do want to display the date on these cards as well as the media pill.
-			*/}
-			{isStorylines && (
-				<CardFooter
-					format={format}
-					age={decideAge()}
-					commentCount={<CommentCount />}
-					cardBranding={
-						isOnwardContent ? <LabsBranding /> : undefined
-					}
-					showLivePlayable={showLivePlayable}
-				/>
-			)}
-
 			{mainMedia?.type === 'YoutubeVideo' && isVideoArticle && (
 				<>
 					{mainMedia.duration === 0 ? (
@@ -596,7 +574,8 @@ export const Card = ({
 -     */
 	const isMediaCardOrNewsletter = isMediaCard(format) || isNewsletter;
 
-	const showPill = isMediaCardOrNewsletter && !isGallerySecondaryOnward;
+	const showPill =
+		isMediaCardOrNewsletter && !isGallerySecondaryOnward && !isStorylines;
 
 	const media = getMedia({
 		imageUrl: image?.src,


### PR DESCRIPTION
## What does this change?
Lifts the decision to show the card footer rather than the media pill when the card is a storyline card into show pill decision logic.

## Why?
Reduce repeated logic

## Screenshots

This is a no-op change.