### PR TITLE
Stop ignoring images in Chromatic in feature cards

### DIFF
--- a/dotcom-rendering/src/components/CardPicture.tsx
+++ b/dotcom-rendering/src/components/CardPicture.tsx
@@ -269,8 +269,8 @@ export const CardPicture = ({
 				css={[block, isCircular && circularStyles]}
 				loading={loading}
 				/**
-				 * Feature cards typically have content overlaid on the image. If we ignore the image,
-				 * this content will also be ignored in Chromatic snapshots.
+				 * Feature cards typically have content overlaid on the image. In Chromatic, we don't want
+				 * to ignore the image on feature cards, as any change in card content will likely be ignored too.
 				 */
 				data-chromatic={
 					imageSize.startsWith('feature') ? undefined : 'ignore'


### PR DESCRIPTION
## What does this change?

Chromatic will no longer ignore feature cards. This change affects Chromatic only.

On standard cards, the image is separate from the card content: headline, kicker, footer, etc. When there are changes to this content on standard cards, for example, the kicker text changes to blue, Chromatic flags the change. On feature cards, the content is overlaid on top of the image. Since we ignore the area of the page covered by the image, the content is ignored too. There have been instances of accidental changes going out due to Chromatic ignoring the entire card. Not quite blue kickers, but you get the idea.

Images have often led to Chromatic false positives, which is why we have this data-attribute. If following this change we consistently receive false positives, we will reassess.