### PR TITLE
Match lineup coming soon state

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchInfo.tsx
+++ b/dotcom-rendering/src/components/FootballMatchInfo.tsx
@@ -39,9 +39,6 @@ function teamHasStats({
 export const FootballMatchInfo = ({ matchStats, table }: Props) => {
 	const showStats =
 		teamHasStats(matchStats.homeTeam) && teamHasStats(matchStats.awayTeam);
-	const showLineups =
-		matchStats.homeTeam.players.length > 0 &&
-		matchStats.awayTeam.players.length > 0;
 	return (
 		<section aria-label={'match-info'} css={layoutCss}>
 			{showStats && (
@@ -106,7 +103,7 @@ export const FootballMatchInfo = ({ matchStats, table }: Props) => {
 					/>
 				</>
 			)}
-			{showLineups && <Lineups matchStats={matchStats} />}
+			<Lineups matchStats={matchStats} />
 			{table && <LeagueTable table={table} />}
 		</section>
 	);

--- a/dotcom-rendering/src/components/Lineups.stories.tsx
+++ b/dotcom-rendering/src/components/Lineups.stories.tsx
@@ -48,4 +48,11 @@ export const WithLineup = {
 	},
 } satisfies Story;
 
-export const ComingSoon = {} satisfies Story;
+export const ComingSoon = {
+	args: {
+		matchStats: {
+			homeTeam: { ...matchStats.homeTeam, players: [] },
+			awayTeam: { ...matchStats.awayTeam, players: [] },
+		},
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/Lineups.tsx
+++ b/dotcom-rendering/src/components/Lineups.tsx
@@ -18,13 +18,17 @@ import { palette } from '../palette';
 import Union from '../static/icons/Union.svg';
 
 type Props = {
-	matchStats?: FootballMatchStats;
+	matchStats: FootballMatchStats;
 };
 
 const lineupSectionId = 'lineups';
 const substitutesSectionId = 'substitutes';
 
 export const Lineups = ({ matchStats }: Props) => {
+	const lineupAvailable =
+		matchStats.homeTeam.players.length > 0 &&
+		matchStats.awayTeam.players.length > 0;
+
 	return (
 		<section css={sectionStyles} aria-label="Team Lineups and Substitutes">
 			<section
@@ -32,7 +36,7 @@ export const Lineups = ({ matchStats }: Props) => {
 				aria-labelledby={lineupSectionId}
 			>
 				<Title text="Lineups" id={lineupSectionId} />
-				{matchStats ? (
+				{lineupAvailable ? (
 					<>
 						<PlayerList
 							team={matchStats.homeTeam}
@@ -49,7 +53,7 @@ export const Lineups = ({ matchStats }: Props) => {
 					<span css={comingSoon}>Coming soon</span>
 				)}
 			</section>
-			{matchStats && (
+			{lineupAvailable && (
 				<section
 					css={playerListSectionGridStyles}
 					aria-labelledby={substitutesSectionId}


### PR DESCRIPTION
## What does this change?

Adds coming soon state to `Lineups` component

## Why?

The match lineup is not available until just ahead of kickoff time so we either need to hide the lineup entirely or show a placeholder

## Screenshots

| With lineup | Lineup unavailable |
| --- | --- |
| ![lineup][] | ![unavailable][] |

[lineup]: https://github.com/user-attachments/assets/608d9036-f4d5-4bd4-bdfe-b6796cf6a15a
[unavailable]: https://github.com/user-attachments/assets/60278942-7b36-485a-8bc0-fe4f0054bf31