### PR TITLE
Alter self-hosted video view tracking

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -496,7 +496,11 @@ export const SelfHostedVideo = ({
 	 * Track the first time the video comes into view.
 	 */
 	useOnce(() => {
-		const resolution = `${window.innerWidth}x${window.innerHeight}`;
+		const video = vidRef.current;
+		const resolution =
+			video === null
+				? 'unknown'
+				: `${video.offsetWidth}x${video.offsetHeight}`;
 
 		void submitComponentEvent(
 			{


### PR DESCRIPTION
## What does this change?

Alter self-hosted video tracking to be dimensions of video instead of screen.

## Why?

We would like to understand what resolution we are serving videos, for optimisation purposes.

This was initially implemented to track the users screen size in #15252, but we do not need this.