### PR TITLE
Product carousel navigation button issues 

### DIFF
--- a/dotcom-rendering/src/components/ScrollableProduct.importable.tsx
+++ b/dotcom-rendering/src/components/ScrollableProduct.importable.tsx
@@ -2,6 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { Breakpoint } from '@guardian/source/foundations';
 import { from, space, textSans14 } from '@guardian/source/foundations';
+import libDebounce from 'lodash.debounce';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
@@ -202,14 +203,6 @@ export const ScrollableProduct = ({ products, format }: Props) => {
 		};
 	};
 
-	const debounceEvent = (callback: () => void, delay = 200) => {
-		let timeout: ReturnType<typeof setTimeout>;
-		return () => {
-			clearTimeout(timeout);
-			timeout = setTimeout(callback, delay);
-		};
-	};
-
 	/**
 	 * Update the count of the first card / how far scrolled the carousel is
 	 *
@@ -256,8 +249,8 @@ export const ScrollableProduct = ({ products, format }: Props) => {
 		[updateCardCountOnScroll],
 	);
 
-	const throttledButtonVisibility = useMemo(
-		() => debounceEvent(updateButtonVisibilityOnScroll),
+	const debouncedButtonVisibility = useMemo(
+		() => libDebounce(updateButtonVisibilityOnScroll, 200),
 		[updateButtonVisibilityOnScroll],
 	);
 
@@ -266,16 +259,16 @@ export const ScrollableProduct = ({ products, format }: Props) => {
 		if (!carouselElement) return;
 
 		carouselElement.addEventListener('scroll', throttledCardCount);
-		carouselElement.addEventListener('scroll', throttledButtonVisibility);
+		carouselElement.addEventListener('scroll', debouncedButtonVisibility);
 
 		return () => {
 			carouselElement.removeEventListener('scroll', throttledCardCount);
 			carouselElement.removeEventListener(
 				'scroll',
-				throttledButtonVisibility,
+				debouncedButtonVisibility,
 			);
 		};
-	}, [throttledCardCount, throttledButtonVisibility]);
+	}, [throttledCardCount, debouncedButtonVisibility]);
 
 	return (
 		<>


### PR DESCRIPTION
co-authored with @oliverabrahams 

## What does this change?
Two fixes are part of this PR:

- Keeps the next navigation button until the final card is in view. This means the UI is improved because we can navigate to see the full card and button.
<img width="689" height="591" alt="image" src="https://github.com/user-attachments/assets/3ab829eb-20b1-4c5a-a589-072d34e3e701" />

- When there are only three cards enable and disable the navigation buttons depending on which card is in full view, instead of disabling them on the final card

<img width="709" height="605" alt="image" src="https://github.com/user-attachments/assets/43955b98-af47-4918-9ef3-3759767f187a" />