### PR TITLE
AAG test - productBlock added to section ended logic

### DIFF
--- a/dotcom-rendering/src/model/enhance-product-summary.ts
+++ b/dotcom-rendering/src/model/enhance-product-summary.ts
@@ -59,11 +59,13 @@ const isAtAGlance = (element: FEElement) =>
 		'model.dotcomrendering.pageElements.SubheadingBlockElement' &&
 	generateId(element.elementId, element.html, []) === 'at-a-glance';
 
-const isSubheadingOrDivider = (element: FEElement) =>
-	// A subheading or divider signals the end of the "At a glance" section
+const isEndOfAtAGlanceSection = (element: FEElement) =>
+	// A subheading, divider, or a product block signals the end of the "At a glance" section
 	element._type ===
 		'model.dotcomrendering.pageElements.SubheadingBlockElement' ||
-	element._type === 'model.dotcomrendering.pageElements.DividerBlockElement';
+	element._type ===
+		'model.dotcomrendering.pageElements.DividerBlockElement' ||
+	element._type === 'model.dotcomrendering.pageElements.ProductBlockElement';
 
 const getAtAGlanceUrls = (elements: FEElement[]): string[] =>
 	Array.from(
@@ -124,7 +126,7 @@ const insertSummaryPlaceholder = (
 
 		// Hitting a divider or another subheading means we've reached the end
 		// of the current "At a glance" section
-		if (isSubheadingOrDivider(element)) {
+		if (isEndOfAtAGlanceSection(element)) {
 			inAtAGlanceSection = false;
 
 			const urls = getAtAGlanceUrls(atAGlanceElements);


### PR DESCRIPTION
## What does this change?
Adds in productBlock to the newly renamed `isEndOfAtAGlanceSection` so the logic knows when the At a glance (AAG) section has ended along with a divider or H2.

## Why?
When testing with a Filter article there was no divider at the end of the AAG section. This meant that the rendered section overwrites the products which are featured in the AAG, instead of leaving them in the article as it.

## Screenshots

After
<img width="723" height="658" alt="image" src="https://github.com/user-attachments/assets/3a67f10b-dbe3-4e8d-b6a6-2536e169e9bb" />

Before
<img width="682" height="772" alt="image" src="https://github.com/user-attachments/assets/9b9fbca4-9415-4903-8852-8fdf92c1a486" />

