### PR TITLE
Set 'At a glance' redesign test live

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -114,7 +114,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-02-25",
 		type: "server",
 		status: "ON",
-		audienceSize: 100 / 100,
+		audienceSize: 30 / 100,
 		audienceSpace: "C",
 		groups: ["control", "stacked", "carousel"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?
- Sets the audience to 30% for the at a glance redesign test
- Uses audience space C to avoid overlap with other tests that are currently running

## Why?
We would like to set the test live. We are aiming to test at 100% but will be incrementing the audience percentage gradually following Jake's recommendation (see comments).
