### PR TITLE
Migrate dark-mode-web to new ab test framework

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -21,7 +21,7 @@ import type { ABTest } from "./types.ts";
 
 const ABTests: ABTest[] = [
 	{
-		name: "webex-dark-mode-web",
+		name: "webx-dark-mode-web",
 		description: "Dark mode accessibility feature test on web",
 		owners: ["dotcom.platform@theguardian.com"],
 		status: "ON",

--- a/ab-testing/config/types.ts
+++ b/ab-testing/config/types.ts
@@ -6,7 +6,9 @@ type AllSpace = Map<string, FastlyTestParams[]>;
 
 type Team =
 	| "commercial"
+	// WebX in the canonical name for the team, when the last test using webex expires we should remove webex from this union type
 	| "webex"
+	| "webx"
 	| "thefilter"
 	| "fronts-and-curation"
 	| "growth";

--- a/dotcom-rendering/src/components/Accessibility.importable.tsx
+++ b/dotcom-rendering/src/components/Accessibility.importable.tsx
@@ -138,7 +138,7 @@ export const Accessibility = () => {
 								You are currently participating in the dark
 								colour scheme beta.
 							</p>
-							<a href="/ab-tests/opt-out/webex-dark-mode-web:enable">
+							<a href="/ab-tests/opt-out/webx-dark-mode-web:enable">
 								Click here to opt out (this will redirect you to
 								the homepage)
 							</a>
@@ -149,7 +149,7 @@ export const Accessibility = () => {
 								You are not currently participating in the dark
 								colour scheme beta.
 							</p>
-							<a href="/ab-tests/opt-in/webex-dark-mode-web:enable">
+							<a href="/ab-tests/opt-in/webx-dark-mode-web:enable">
 								Click here to opt in (this will redirect you to
 								the homepage)
 							</a>

--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -179,7 +179,7 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 					You can{' '}
 					<a
 						style={{ color: 'inherit' }}
-						href="/ab-tests/opt-out/webex-dark-mode-web"
+						href="/ab-tests/opt-out/webx-dark-mode-web"
 					>
 						opt out anytime
 					</a>{' '}

--- a/dotcom-rendering/src/components/FrontPage.tsx
+++ b/dotcom-rendering/src/components/FrontPage.tsx
@@ -112,7 +112,7 @@ export const FrontPage = ({ front, NAV }: Props) => {
 					You can{' '}
 					<a
 						style={{ color: 'inherit' }}
-						href="/ab-tests/opt-out/webex-dark-mode-web"
+						href="/ab-tests/opt-out/webx-dark-mode-web"
 					>
 						opt out anytime
 					</a>{' '}

--- a/dotcom-rendering/src/components/SportDataPageComponent.tsx
+++ b/dotcom-rendering/src/components/SportDataPageComponent.tsx
@@ -85,7 +85,7 @@ export const SportDataPageComponent = ({ sportData }: Props) => {
 					You can{' '}
 					<a
 						style={{ color: 'inherit' }}
-						href="/ab-tests/opt-out/webex-dark-mode-web"
+						href="/ab-tests/opt-out/webx-dark-mode-web"
 					>
 						opt out anytime
 					</a>{' '}

--- a/dotcom-rendering/src/components/TagPage.tsx
+++ b/dotcom-rendering/src/components/TagPage.tsx
@@ -102,7 +102,7 @@ export const TagPage = ({ tagPage, NAV }: Props) => {
 					You can{' '}
 					<a
 						style={{ color: 'inherit' }}
-						href="/ab-tests/opt-out/webex-dark-mode-web"
+						href="/ab-tests/opt-out/webx-dark-mode-web"
 					>
 						opt out anytime
 					</a>{' '}

--- a/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
+++ b/dotcom-rendering/src/server/render.allEditorialNewslettersPage.web.tsx
@@ -24,10 +24,14 @@ export const renderEditorialNewslettersPage = ({
 	const title = newslettersPage.webTitle;
 	const NAV = extractNAV(newslettersPage.nav);
 
+	const darkModeAvailable =
+		newslettersPage.config.serverSideABTests?.['webx-dark-mode-web'] ===
+		'enable';
+
 	// The newsletters page is currently only supported on Web
 	const config = {
 		renderingTarget: 'Web',
-		darkModeAvailable: false,
+		darkModeAvailable,
 		assetOrigin: ASSET_ORIGIN,
 		editionId: newslettersPage.editionId,
 	} satisfies Config;

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -51,7 +51,7 @@ export const renderHtml = ({
 	const linkedData = frontendData.linkedData;
 
 	const darkModeAvailable =
-		frontendData.config.serverSideABTests?.['webex-dark-mode-web'] ===
+		frontendData.config.serverSideABTests?.['webx-dark-mode-web'] ===
 		'enable';
 
 	const renderingTarget = 'Web';
@@ -244,7 +244,7 @@ export const renderBlocks = ({
 	const editionId = isEditionId(edition) ? edition : 'UK';
 
 	const darkModeAvailable =
-		serverSideABTests?.['webex-dark-mode-web'] === 'enable';
+		serverSideABTests?.['webx-dark-mode-web'] === 'enable';
 
 	const config: Config = {
 		renderingTarget: 'Web',

--- a/dotcom-rendering/src/server/render.front.web.tsx
+++ b/dotcom-rendering/src/server/render.front.web.tsx
@@ -84,7 +84,7 @@ export const renderFront = ({
 	const enhancedNAV = enhanceNav(NAV);
 
 	const darkModeAvailable =
-		front.config.serverSideABTests?.['webex-dark-mode-web'] === 'enable';
+		front.config.serverSideABTests?.['webx-dark-mode-web'] === 'enable';
 
 	// Fronts are not supported in Apps
 	const config = {
@@ -185,7 +185,7 @@ export const renderTagPage = ({
 	const enhancedNAV = enhanceNav(NAV);
 
 	const darkModeAvailable =
-		tagPage.config.serverSideABTests?.['webex-dark-mode-web'] === 'enable';
+		tagPage.config.serverSideABTests?.['webx-dark-mode-web'] === 'enable';
 
 	// Fronts are not supported in Apps
 	const config: Config = {

--- a/dotcom-rendering/src/server/render.sportDataPage.web.tsx
+++ b/dotcom-rendering/src/server/render.sportDataPage.web.tsx
@@ -101,8 +101,7 @@ export const renderSportPage = (sportData: SportDataPage) => {
 	const renderingTarget = 'Web';
 
 	const darkModeAvailable =
-		sportData.config.serverSideABTests?.['webex-dark-mode-web'] ===
-		'enable';
+		sportData.config.serverSideABTests?.['webx-dark-mode-web'] === 'enable';
 	const config: Config = {
 		renderingTarget,
 		darkModeAvailable,


### PR DESCRIPTION
## What does this change?
Migrate Dark Mode on Web 0% test to the new framework. Update the accessibility page for the new opt in behaviour.

The tickbox has been replaced with opt-in links, the domain that the cookie is on didn't play nicely with `setCookie`, and there's no way to specify a domain so rather than mess around getting it working, links are fine, for this **experimental** feature.

Regardless, this means anyone opted in will need to re-opt in to retain dark mode.

## Why?
We need all tests on the legacy framework removed or migrated so we can delete it!

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/14a763b4-4139-4b31-920c-33666d3f2226

[after]: https://github.com/user-attachments/assets/5bdde7e6-299d-491c-b724-0e96baf915df

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

