### PR TITLE
Increasing 'At a glance' test to 60%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -114,7 +114,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-02-25",
 		type: "server",
 		status: "ON",
-		audienceSize: 30 / 100,
+		audienceSize: 60 / 100,
 		audienceSpace: "C",
 		groups: ["control", "stacked", "carousel"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?
Sets the audience to 60% for the At a glance test

## Why?
We're slowing increasing the audience percentage to avoid any issues with caching (especially on a hack day!). The plan is to increase to 100% later today.