### PR TITLE
Fix re-rendering bug in self-hosted video component

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -705,7 +705,9 @@ export const SelfHostedVideo = ({
 				playerState === 'PAUSED_BY_INTERSECTION_OBSERVER' ||
 				(hasPageBecomeActive && playerState === 'PAUSED_BY_BROWSER'))
 		) {
-			setHasPageBecomeActive(false);
+			if (hasPageBecomeActive) {
+				setHasPageBecomeActive(false);
+			}
 			void playVideo();
 		} else if (playerState === 'PLAYING' && isInView === false) {
 			void pauseVideo('PAUSED_BY_INTERSECTION_OBSERVER');


### PR DESCRIPTION
## What does this change?

Fixes a re-rendering bug in Self-hosted video component.

<hr />

_Calling setState during render unconditionally triggers another render before the current one finishes. This creates an infinite loop that crashes your app_[^1].

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7d5e8b27-9119-4fe2-ac4c-98e09433b7b7
[after]: https://github.com/user-attachments/assets/e70bdf34-dbe1-4643-bd53-ee693dac316e

[^1]: https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-render#rule-details