### PR TITLE
Remove isVideoArticle prop from youtubeAtomFeatureCard 

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -423,8 +423,6 @@ export const FeatureCard = ({
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
-	const isVideoArticle = format.design === ArticleDesign.Video;
-
 	/**
 	 * Determine which type of media to use for the card.
 	 * For example, a video might be available, but if we don't want to show it, use an image instead.
@@ -522,7 +520,6 @@ export const FeatureCard = ({
 										altText={headlineText}
 										kickerText={kickerText}
 										trailText={trailText}
-										isVideoArticle={isVideoArticle}
 										hidePillOnMobile={false}
 										iconSizeOnDesktop="large"
 										iconSizeOnMobile="large"

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -53,7 +53,6 @@ export type Props = {
 	mobileAspectRatio?: AspectRatio;
 	trailText?: string;
 	headlineSizes?: ResponsiveFontSize;
-	isVideoArticle?: boolean;
 	webPublicationDate?: string;
 	showClock?: boolean;
 	serverTime?: number;
@@ -109,7 +108,6 @@ export const YoutubeAtom = ({
 	mobileAspectRatio,
 	trailText,
 	headlineSizes,
-	isVideoArticle,
 	webPublicationDate,
 	showClock,
 	serverTime,
@@ -259,7 +257,6 @@ export const YoutubeAtom = ({
 								aspectRatio={aspectRatio}
 								mobileAspectRatio={mobileAspectRatio}
 								trailText={trailText}
-								isVideoArticle={isVideoArticle}
 								webPublicationDate={webPublicationDate}
 								showClock={!!showClock}
 								serverTime={serverTime}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomFeatureCardOverlay.tsx
@@ -6,6 +6,7 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import type { ArticleFormat } from '../../lib/articleFormat';
+import { ArticleDesign } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { transparentColour } from '../../lib/transparentColour';
 import { palette } from '../../palette';
@@ -130,7 +131,6 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
 	trailText?: string;
-	isVideoArticle?: boolean;
 	webPublicationDate?: string;
 	showClock?: boolean;
 	serverTime?: number;
@@ -157,7 +157,6 @@ export const YoutubeAtomFeatureCardOverlay = ({
 	aspectRatio,
 	mobileAspectRatio,
 	trailText,
-	isVideoArticle,
 	webPublicationDate,
 	showClock,
 	serverTime,
@@ -170,7 +169,7 @@ export const YoutubeAtomFeatureCardOverlay = ({
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
-
+	const isVideoArticle = format.design === ArticleDesign.Video;
 	const showCardAge =
 		webPublicationDate !== undefined &&
 		showClock !== undefined &&

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.importable.tsx
@@ -41,7 +41,6 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	trailText?: string;
 	headlineSizes?: ResponsiveFontSize;
-	isVideoArticle?: boolean;
 	webPublicationDate?: string;
 	showClock?: boolean;
 	serverTime?: number;
@@ -84,7 +83,6 @@ export const YoutubeBlockComponent = ({
 	aspectRatio,
 	trailText,
 	headlineSizes,
-	isVideoArticle,
 	webPublicationDate,
 	showClock,
 	serverTime,
@@ -216,7 +214,6 @@ export const YoutubeBlockComponent = ({
 				mobileAspectRatio={mobileAspectRatio}
 				trailText={trailText}
 				headlineSizes={headlineSizes}
-				isVideoArticle={isVideoArticle}
 				webPublicationDate={webPublicationDate}
 				showClock={!!showClock}
 				serverTime={serverTime}


### PR DESCRIPTION
## What does this change?
Remove isVideoArticle prop from youtubeAtomFeatureCard  as there is access to format in this component.

This means we can decide if its a video article within the component.
## Why?
Reduce the number of props and the amount of prop drilling.
## Screenshots
This is a no-op change.