### PR TITLE
Update match info page data model

### DIFF
--- a/dotcom-rendering/scripts/jsonSchema/schema.mjs
+++ b/dotcom-rendering/scripts/jsonSchema/schema.mjs
@@ -18,7 +18,7 @@ const program = TJS.getProgramFromFiles(
 		path.resolve(`${root}/src/frontend/feCricketMatchPage.ts`),
 		path.resolve(`${root}/src/frontend/feFootballMatchListPage.ts`),
 		path.resolve(`${root}/src/frontend/feFootballTablesPage.ts`),
-		path.resolve(`${root}/src/frontend/feFootballMatchPage.ts`),
+		path.resolve(`${root}/src/frontend/feFootballMatchInfoPage.ts`),
 		path.resolve(`${root}/src/frontend/feHostedContent.ts`),
 	],
 	{
@@ -75,8 +75,8 @@ const schemas = [
 		file: `${root}/src/frontend/schemas/feCricketMatchPage.json`,
 	},
 	{
-		typeName: 'FEFootballMatchPage',
-		file: `${root}/src/frontend/schemas/feFootballMatchPage.json`,
+		typeName: 'FEFootballMatchInfoPage',
+		file: `${root}/src/frontend/schemas/feFootballMatchInfoPage.json`,
 	},
 	{
 		typeName: 'FEHostedContent',

--- a/dotcom-rendering/src/footballMatch.ts
+++ b/dotcom-rendering/src/footballMatch.ts
@@ -5,7 +5,7 @@ import type {
 	FEFootballPlayer,
 	FEFootballPlayerEvent,
 	FEFootballTeam,
-} from './frontend/feFootballMatchPage';
+} from './frontend/feFootballMatchInfoPage';
 import type { Result } from './lib/result';
 import { error, ok } from './lib/result';
 import { cleanTeamName } from './sportDataPage';

--- a/dotcom-rendering/src/footballMatchStats.ts
+++ b/dotcom-rendering/src/footballMatchStats.ts
@@ -6,7 +6,7 @@ import type {
 	FEFootballPlayer,
 	FEFootballPlayerEvent,
 	FEFootballTeam,
-} from './frontend/feFootballMatchPage';
+} from './frontend/feFootballMatchInfoPage';
 import { parseIntResult } from './lib/parse';
 import type { Result } from './lib/result';
 import { error, ok } from './lib/result';

--- a/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
@@ -42,7 +42,7 @@ export type FEFootballMatchStats = {
 	comments?: string;
 };
 
-export type FEFootballMatchPage = FEFootballDataPage & {
+export type FEFootballMatchInfoPage = FEFootballDataPage & {
 	// This field name will need to get changed to matchStats in the future PRs.
 	// Since this change needs to happen in both frontend and DCAR, and it also
 	// needs to be backward compatible for a temprary duration, we will handle
@@ -51,4 +51,5 @@ export type FEFootballMatchPage = FEFootballDataPage & {
 	matchInfo: FEFootballMatch;
 	group?: FEGroupSummary;
 	competitionName: string;
+	matchUrl: string;
 };

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
@@ -479,12 +479,16 @@
                 },
                 "competitionName": {
                     "type": "string"
+                },
+                "matchUrl": {
+                    "type": "string"
                 }
             },
             "required": [
                 "competitionName",
                 "footballMatch",
-                "matchInfo"
+                "matchInfo",
+                "matchUrl"
             ]
         }
     ],

--- a/dotcom-rendering/src/model/validate.ts
+++ b/dotcom-rendering/src/model/validate.ts
@@ -4,16 +4,16 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import type { FEArticle } from '../frontend/feArticle';
 import type { FECricketMatchPage } from '../frontend/feCricketMatchPage';
+import type { FEFootballMatchInfoPage } from '../frontend/feFootballMatchInfoPage';
 import type { FEFootballMatchListPage } from '../frontend/feFootballMatchListPage';
-import type { FEFootballMatchPage } from '../frontend/feFootballMatchPage';
 import type { FEFootballTablesPage } from '../frontend/feFootballTablesPage';
 import type { FEFront } from '../frontend/feFront';
 import type { FEHostedContent } from '../frontend/feHostedContent';
 import type { FETagPage } from '../frontend/feTagPage';
 import articleSchema from '../frontend/schemas/feArticle.json';
 import cricketMatchPageSchema from '../frontend/schemas/feCricketMatchPage.json';
+import footballMatchInfoPageSchema from '../frontend/schemas/feFootballMatchInfoPage.json';
 import footballMatchListPageSchema from '../frontend/schemas/feFootballMatchListPage.json';
-import footballMatchPageSchema from '../frontend/schemas/feFootballMatchPage.json';
 import footballTablesPageSchema from '../frontend/schemas/feFootballTablesPage.json';
 import frontSchema from '../frontend/schemas/feFront.json';
 import hostedContentSchema from '../frontend/schemas/feHostedContent.json';
@@ -55,8 +55,8 @@ const validateFootballTablesPage = ajv.compile<FEFootballTablesPage>(
 const validateCricketMatchPage = ajv.compile<FECricketMatchPage>(
 	cricketMatchPageSchema,
 );
-const validateFootballMatchPage = ajv.compile<FEFootballMatchPage>(
-	footballMatchPageSchema,
+const validateFootballMatchInfoPage = ajv.compile<FEFootballMatchInfoPage>(
+	footballMatchInfoPageSchema,
 );
 const validateHostedContent = ajv.compile<FEHostedContent>(hostedContentSchema);
 
@@ -176,8 +176,8 @@ export const validateAsCricketMatchPageType = (
 
 export const validateAsFootballMatchPageType = (
 	data: unknown,
-): FEFootballMatchPage => {
-	if (validateFootballMatchPage(data)) return data;
+): FEFootballMatchInfoPage => {
+	if (validateFootballMatchInfoPage(data)) return data;
 
 	const url =
 		isObject(data) && isObject(data.config) && isString(data.config.pageId)
@@ -186,7 +186,7 @@ export const validateAsFootballMatchPageType = (
 
 	throw new TypeError(
 		`Unable to validate request body for url ${url}.\n
-            ${JSON.stringify(validateFootballMatchPage.errors, null, 2)}`,
+            ${JSON.stringify(validateFootballMatchInfoPage.errors, null, 2)}`,
 	);
 };
 

--- a/dotcom-rendering/src/server/handler.sportDataPage.web.ts
+++ b/dotcom-rendering/src/server/handler.sportDataPage.web.ts
@@ -13,8 +13,8 @@ import {
 } from '../footballTables';
 import type { FECricketMatchPage } from '../frontend/feCricketMatchPage';
 import type { FEFootballCompetition } from '../frontend/feFootballDataPage';
+import type { FEFootballMatchInfoPage } from '../frontend/feFootballMatchInfoPage';
 import type { FEFootballMatchListPage } from '../frontend/feFootballMatchListPage';
-import type { FEFootballMatchPage } from '../frontend/feFootballMatchPage';
 import type { FEFootballTablesPage } from '../frontend/feFootballTablesPage';
 import { Pillar } from '../lib/articleFormat';
 import { extractNAV } from '../model/extract-nav';
@@ -26,9 +26,9 @@ import {
 } from '../model/validate';
 import type {
 	CricketMatchPage,
+	FootballMatchInfoPage,
 	FootballMatchListPage,
 	FootballMatchListPageKind,
-	FootballMatchSummaryPage,
 	FootballTablesPage,
 	Region,
 } from '../sportDataPage';
@@ -213,8 +213,8 @@ export const handleCricketMatchPage: RequestHandler = ({ body }, res) => {
 };
 
 const parseFEFootballMatch = (
-	data: FEFootballMatchPage,
-): FootballMatchSummaryPage => {
+	data: FEFootballMatchInfoPage,
+): FootballMatchInfoPage => {
 	const parsedFootballMatch = parseFootballMatch(data.footballMatch);
 
 	if (!parsedFootballMatch.ok) {
@@ -253,6 +253,7 @@ const parseFEFootballMatch = (
 		matchInfo: matchInfo.value,
 		competitionName: data.competitionName,
 		group: group?.value,
+		matchUrl: data.matchUrl,
 		kind: 'FootballMatchSummary',
 		nav: {
 			...extractNAV(data.nav),
@@ -269,7 +270,7 @@ const parseFEFootballMatch = (
 };
 
 export const handleFootballMatchPage: RequestHandler = ({ body }, res) => {
-	const footballMatchPageValidated: FEFootballMatchPage =
+	const footballMatchPageValidated: FEFootballMatchInfoPage =
 		validateAsFootballMatchPageType(body);
 	const parsedFootballMatchData = parseFEFootballMatch(
 		footballMatchPageValidated,

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -51,12 +51,13 @@ export type CricketMatchPage = SportPageConfig & {
 	kind: 'CricketMatch';
 };
 
-export type FootballMatchSummaryPage = SportPageConfig & {
+export type FootballMatchInfoPage = SportPageConfig & {
 	match: FootballMatch;
 	matchStats: FootballMatchStats;
 	matchInfo: FootballMatchV2;
 	group?: FootballTableSummary;
 	competitionName: string;
+	matchUrl: string;
 	kind: 'FootballMatchSummary';
 };
 
@@ -71,7 +72,7 @@ export type FootballPageWithRegionsKind = FootballDataWithRegionsPage['kind'];
 export type SportDataPage =
 	| FootballDataWithRegionsPage
 	| CricketMatchPage
-	| FootballMatchSummaryPage;
+	| FootballMatchInfoPage;
 
 export type SportPageKind = SportDataPage['kind'];
 


### PR DESCRIPTION
Paired with @JamieB-gu & @jamesmockett 
## What does this change?
Update match info page data model: 
- Added the new `matchUrl` to the match info page
- Consolidated the names of the match info page model

This PR fixes part of https://github.com/guardian/dotcom-rendering/issues/15265