### PR TITLE
Use Sport colours for Winter Olympics container

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -118,6 +118,7 @@ const borderColourStyles = (
 			return schemePalette('--section-border-opinion');
 		case 'Sport':
 		case 'Sports':
+		case 'Winter Olympics 2026':
 			return schemePalette('--section-border-sport');
 		case 'Lifestyle':
 			return schemePalette('--section-border-lifestyle');
@@ -143,6 +144,7 @@ const articleSectionTitleStyles = (
 			return schemePalette('--article-section-title-opinion');
 		case 'Sport':
 		case 'Sports':
+		case 'Winter Olympics 2026':
 			return schemePalette('--article-section-title-sport');
 		case 'Lifestyle':
 			return schemePalette('--article-section-title-lifestyle');


### PR DESCRIPTION
## What does this change?

The section title and top border line of the Winter Olympics section on network fronts is now the same blue colour used in the Sport section

## Why?

Following request from editorial.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/04da92e5-cb86-4c5b-9706-d3714dc4d0b4
[after]: https://github.com/user-attachments/assets/0b5b2bdc-381c-49ce-a261-fce1e2029985

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
