### PR TITLE
Add `ShareButton` component to `HostedArticleLayout`

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -72,7 +72,16 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 			) : null}
 			<main>
 				<header css={[grid.container, border]}>
-					<div css={[grid.column.all]}>Main media</div>
+					<div
+						css={[
+							grid.column.all,
+							css`
+								min-height: 200px;
+							`,
+						]}
+					>
+						Main media
+					</div>
 					<div
 						css={[grid.between('centre-column-start', 'grid-end')]}
 					>


### PR DESCRIPTION
## What does this change?

This PR adds the `ShareButton` component to HostedArticleLayout. There will be a follow up PR to create the ArticleDesign format for HostedArticle in order to include the required colours for the button.  Check https://github.com/guardian/dotcom-rendering/issues/12337#issuecomment-3854125983

Mobile, tablet and desktop breakpoints have the social media buttons in frontend above the standfirst which I replicated as you can see from the screenshots and from LeftCol the buttons are in the left column. 

## Why?

Hosted Content migration to DCAR

## Screenshots

#### Mobile 
<img width="360" height="474" alt="image" src="https://github.com/user-attachments/assets/59d78d29-cc1b-4d6b-953c-fca621c67cef" />

#### Tablet

<img width="767" height="474" alt="image" src="https://github.com/user-attachments/assets/fbb89aef-df4b-4fa6-be24-2c486845f877" />

#### Desktop

<img width="1004" height="474" alt="image" src="https://github.com/user-attachments/assets/9a67b059-85fb-43fd-9bdc-b9420796d855" />

#### LeftCol 

<img width="1165" height="474" alt="image" src="https://github.com/user-attachments/assets/1f0a7c9a-65df-4498-bba4-038f20417f75" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
