### PR TITLE
Fix dark colors for L2A button on interactives

### DIFF
--- a/dotcom-rendering/src/components/ListenToArticleButton.tsx
+++ b/dotcom-rendering/src/components/ListenToArticleButton.tsx
@@ -12,12 +12,12 @@ import { WaveForm } from './WaveForm';
 const buttonCss = (audioDuration: string | undefined) => css`
 	display: flex;
 	align-items: center;
-	background-color: ${palette('--follow-icon-fill')};
-	color: ${palette('--follow-icon-background')};
+	background-color: ${palette('--listen-to-article-button-fill')};
+	color: ${palette('--listen-to-article-button-background')};
 	&:active,
 	&:focus,
 	&:hover {
-		background-color: ${palette('--follow-icon-fill')};
+		background-color: ${palette('--listen-to-article-button-fill')};
 	}
 	margin-bottom: ${space[4]}px;
 	margin-left: ${space[2]}px;

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7431,6 +7431,14 @@ const paletteColours = {
 		light: linkKickerTextLight,
 		dark: linkKickerTextDark,
 	},
+	'--listen-to-article-button-background': {
+		light: followIconBackgroundLight,
+		dark: followIconBackgroundDark,
+	},
+	'--listen-to-article-button-fill': {
+		light: followIconFillLight,
+		dark: followIconFillDark,
+	},
 	'--listen-to-article-waveform': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[38],


### PR DESCRIPTION
## What does this change?

L2A button colors were not rendering correctly in darkmode for some interactive articles, as the L2A button shares a colour scheme and previously a colour palette declaration with follow button icons. The latter are occasionally manipulated on interactives so separating the declarations should make this less likely to impact the L2A button 

## Why?

## Screenshots



Before:
<img width="402" height="188" alt="image" src="https://github.com/user-attachments/assets/44683f50-f1dd-4d67-9597-c9b182f89411" />


After:

<img width="363" height="756" alt="image" src="https://github.com/user-attachments/assets/0d67bd7d-bde7-4eca-9c56-201050b8585a" />


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
