### PR TITLE
Personalised container tracking

### DIFF
--- a/dotcom-rendering/src/components/PersonalisedMediumFour.importable.tsx
+++ b/dotcom-rendering/src/components/PersonalisedMediumFour.importable.tsx
@@ -1,5 +1,6 @@
 import { isUndefined } from '@guardian/libs';
 import { useEffect, useState } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { isMediaCard } from '../lib/cardHelpers';
 import { getDemotedState, trackView } from '../lib/personalisationHistory';
@@ -108,6 +109,18 @@ export const PersonalisedMediumFour = ({
 		if (curatedTrails.length > 0) {
 			setOrderedTrails(curatedTrails);
 		}
+
+		/* Fire a view event only if the container has been personalised */
+		void submitComponentEvent(
+			{
+				component: {
+					componentType: 'CONTAINER',
+					id: `reordered-container`,
+				},
+				action: 'VIEW',
+			},
+			'Web',
+		);
 
 		setShouldShowCards(true);
 	}, [trails, pillarBuckets, isInPersonalisationVariant]);


### PR DESCRIPTION
## What does this change?
Fire a view event only if the container has been reordered.

## Why?
So that d&i can understand when a container in the variant has or has not changed.
