### PR TITLE
Upgrade Facia Rendering CODE instances to T4g.medium

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -21,7 +21,7 @@ new RenderingCDKStack(cdkApp, 'ArticleRendering-CODE', {
 	stage: 'CODE',
 	domainName: 'article-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 3 },
-	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
 });
 new RenderingCDKStack(cdkApp, 'ArticleRendering-PROD', {
 	guApp: 'article-rendering',


### PR DESCRIPTION
## What does this change?
The Facia Rendering CODE environment has been experiencing periodic high CPU usage resulting in low availability. We should test if this is improved by increasing the instance size.

Part of https://github.com/guardian/platform/issues/2145
