### PR TITLE
Fix main link in `DirectoryPageNav.tsx`

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -226,7 +226,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 
 	return (
 		<nav css={nav}>
-			<a href={config.title.id} css={largeLinkStyles}>
+			<a href={`/${config.title.id}`} css={largeLinkStyles}>
 				{config.title.label}
 			</a>
 			<ul css={list}>


### PR DESCRIPTION
Followup fix to #15268 which makes the main subnav link behave like the others do.