### PR TITLE
Redistribute match stat grid space

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchStat.tsx
+++ b/dotcom-rendering/src/components/FootballMatchStat.tsx
@@ -18,7 +18,7 @@ import { palette } from '../palette';
 const containerCss = css`
 	position: relative;
 	display: grid;
-	grid-template-columns: auto 1fr auto;
+	grid-template-columns: 1fr auto 1fr;
 	grid-template-areas:
 		'home-stat heading away-stat'
 		'graph     graph   graph';


### PR DESCRIPTION
## What does this change?

Redistributes space in football match stat grid

## Why?

Currently the heading column takes all of the remaining space in the layout, forcing the figures to only use as much space as required. If these are not equal width then the heading will be off-centre.

<img width="454" height="128" alt="Screenshot 2026-02-11 at 10 02 13" src="https://github.com/user-attachments/assets/fa381a18-883b-4106-93df-2bf92869abc9" />

This PR flips the spacing distribution so the figures use equal fractions of the available space, forcing the heading to remain centred.

<img width="455" height="126" alt="Screenshot 2026-02-11 at 10 04 27" src="https://github.com/user-attachments/assets/21592ea0-493e-4606-800b-7a1c3d59a14b" />

(This is a slightly contrived example as the misalignment is more extreme and noticeable when one of the stats has 3 figures which is very unlikely in practice.)
