### PR TITLE
Reduce presence of Winter Olympics 2026 subnav

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -41,7 +41,7 @@ const configs = [
 			'sport/ng-interactive/2026/feb/04/winter-olympics-results-milano-cortina-2026',
 			'sport/ng-interactive/2026/feb/04/winter-olympics-2026-latest-medal-table-milano-cortina',
 		],
-		tagIds: ['sport/winter-olympics-2026'],
+		tagIds: [],
 		textColor: palette.neutral[7],
 		backgroundColor: '#CCCCCC',
 		title: {


### PR DESCRIPTION
This tweaks the subnav config so that it appears just on specific pages rather than on all pages tagged with the 2026 Winter Olympics.