### PR TITLE
Pass newsletter and main media through to card footer in card

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -502,9 +502,9 @@ export const Card = ({
 		isOnwardContent && onwardsSource === 'more-galleries';
 
 	/**
--	 * Media cards have contrasting background colours. We add additional
-* padding to these cards to keep the text readable.
--     */
+	 * Media cards have contrasting background colours. We add additional
+	 * padding to these cards to keep the text readable.
+	 */
 	const isMediaCardOrNewsletter = isMediaCard(format) || isNewsletter;
 
 	const media = getMedia({
@@ -1226,6 +1226,7 @@ export const Card = ({
 											? mainMedia
 											: undefined
 									}
+									isNewsletter={isNewsletter}
 								/>
 							)}
 							{showLivePlayable &&


### PR DESCRIPTION
## What does this change?
Passes the isNewsletter prop to the card footer so that the footer can decide if it should show a newsletter pill.

## Why?
[PR 15285 ](https://github.com/guardian/dotcom-rendering/pull/15285) refactored the card media pill so that it exists inside the card footer. The isNewsletter prop is required by the card footer to know if it should show a pill or not. This was missed during the refactor meaning newsletter cards were not displaying the newsletter pill. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/467832d3-e7f2-4b81-adfb-6b0a490b40c9
[after]: https://github.com/user-attachments/assets/e1c97e08-2ba3-4ddb-80e3-601f6036e1b9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
