### PR TITLE
Newsletter card story

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -310,6 +310,16 @@ export const WithExternalLink = () => {
 	);
 };
 
+export const WithANewsletter = () => {
+	return (
+		<CardGroup>
+			<CardWrapper>
+				<Card {...basicCardProps} isNewsletter={true} />
+			</CardWrapper>
+		</CardGroup>
+	);
+};
+
 export const WithMediaType = () => {
 	return (
 		<>


### PR DESCRIPTION
## What does this change?
Adds a newsletter card story.

## Why?
a PR was released that erroneously removed the newsletter pill from newsletter cards . Better story coverage would have prevented this mistake.
