### PR TITLE
Add main media component to hosted article layout

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -90,6 +90,12 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 								css`
 									overflow: hidden;
 									max-height: 400px;
+									${from.leftCol} {
+										${grid.between(
+											'left-column-start',
+											'right-column-end',
+										)}
+									}
 								`,
 							]}
 						>


### PR DESCRIPTION
## What does this change?

Adds main media to hosted article layouts

This doesn't look right yet due to aspect ratio issues with the underlying grid images and low resolution appearance but we'll come back to that later

## Why?

As part of the hosted content migration, we are developing the new page layouts for these pages.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b44e9c46-c84e-4e8c-a4be-5cd4072ad898
[after]: https://github.com/user-attachments/assets/822158d0-16c8-4a4b-b18c-7df608b69192
