### PR TITLE
Right rail ad container style tweaks for interactive articles

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -160,17 +160,13 @@ const spacefinderAdSlotContainerStyles = css`
 	/*
 		To push inline2+ on desktop to the right column
 	*/
-	.ad-slot-container--right-column {
+	.ad-slot-container--right-column,
+	.ad-slot-container--offset-right {
 		${from.desktop} {
 			float: right;
 			max-width: 300px;
-			background-color: transparent;
-		}
-	}
-
-	.ad-slot-container--offset-right {
-		${from.desktop} {
 			margin-right: -330px;
+			background-color: transparent;
 		}
 
 		${from.leftCol} {


### PR DESCRIPTION
## What does this change?
Add some styles to inline ads on desktop to support certain interactives.

## Why?
Some interactives look very similar to articles, we think we can have spacefinder insert ads into them.

However they use a slightly different grid, where the article body is the full width of the article content grid.

For inline1, which is inline, we need to restrict the max-width to `620px`, the width of the paragraphs, and ensure it is left aligned by setting `margin-left` to 0, these styles do not affect regular articles.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f9ee082f-d7c4-49a7-afa5-d8eb8e7de14d
[after]: https://github.com/user-attachments/assets/6ae0cddb-d8fd-4ab5-a6b0-4a9772304728


For inline2+, width are floated into the right rail, we need them to not have a negative margin for this type of article grid, so I've moved the negative margins to a new class `ad-slot-container--offset-right` that'll only be applied on "normal" articles.

Visual of the the parent element of paragraphs to hopefully demonstrate the scenarios:

Normal articles with the body positioned using grid:
<img width="1004" height="607" alt="Screenshot 2026-02-11 at 17 02 28" src="https://github.com/user-attachments/assets/9c504bd8-c623-47d6-a13d-927556052b4f" />

Interactives with full width article body:
<img width="1440" height="657" alt="Screenshot 2026-02-11 at 17 02 34" src="https://github.com/user-attachments/assets/c90976ed-8ee8-4b07-bd2f-d0be10dbfcdd" />

## Rollout
As this involves changing a class applied to elements added via the commercial bundle, we need a phased rollout in order to not break these styles.

1. Merge this PR that applies the styles to both `.ad-slot-container--right-column` and `.ad-slot-container--offset-right`
2. Merge [commercial PR](https://github.com/guardian/commercial/pull/2408) using the new class name
3. Merge https://github.com/guardian/dotcom-rendering/pull/15387
