### PR TITLE
Fix nested `figure` elements in interactive layout atoms

### DIFF
--- a/dotcom-rendering/src/components/InteractiveLayoutAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveLayoutAtom.tsx
@@ -18,7 +18,7 @@ export const InteractiveLayoutAtom = ({
 	elementJs,
 	elementCss,
 }: InteractiveLayoutAtomType) => (
-	<figure
+	<div
 		className="interactive interactive-atom"
 		css={containerStyles}
 		data-atom-id={id}
@@ -42,5 +42,5 @@ export const InteractiveLayoutAtom = ({
 				dangerouslySetInnerHTML={{ __html: elementJs }}
 			/>
 		)}
-	</figure>
+	</div>
 );


### PR DESCRIPTION
This addresses a longstanding semantic structure issue where interactive atoms are being rendered as `<figure>` elements within `<figure>` elements. This tidies that up by removing the inner one, thereby deferring to the universal wrapper set inside `renderElement.tsx`.

Say goodbye to this:

<img width="494" height="299" alt="image" src="https://github.com/user-attachments/assets/19019f02-ba79-4b80-bc7c-698db273caca" />

And hello to this:

<img width="492" height="338" alt="image" src="https://github.com/user-attachments/assets/408b87f4-de93-4c77-b1ea-89af576c02c4" />

As with all things interactives related there's always a chance of unexpected and horrifying side effects, though looking at several pieces locally with this change applied I'm hopeful this is just a nice little improvement.
