### PR TITLE
Revert banner:none event dispatch

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -107,6 +107,19 @@ const ABTests: ABTest[] = [
 		groups: ["control", "stacked", "carousel"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-banner-ad-coordination",
+		description:
+			"Dispatches events to coordinate mobile sticky ad placement with banners. Currently disabled due to CMP banner incorrectly blocking ads.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-03-01",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
Gates the banner:none event dispatch behind a 0% A/B test (commercial-banner-ad-coordination) using the new beta AB testing framework.

The event logic is preserved but disabled. Uses useBetaAB() to check if users are in the test variant before dispatching events.

## Why?
The CMP banner currently blocks mobile sticky ads even though it renders "outside of react's world" and doesn't occupy the banner space. This may be causing incorrect ad suppression and impacts revenue.

By gating behind a 0% test, we:
- 100% of users (not in test) → **will** get banner:none event (current production behavior)
- 0% in variant → do **not** get banner:none event (disabled for testing)
Related to: [guardian/commercial#2351](https://github.com/guardian/commercial/pull/2351)
