### PR TITLE
Add headline, standfirst and main media caption to hosted article page

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -4,12 +4,16 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
+import { ArticleHeadline } from '../components/ArticleHeadline';
+import { Caption } from '../components/Caption';
 import { HostedContentHeader } from '../components/HostedContentHeader';
 import { Island } from '../components/Island';
 import { Section } from '../components/Section';
 import { ShareButton } from '../components/ShareButton.importable';
+import { Standfirst } from '../components/Standfirst';
 import { grid } from '../grid';
 import type { ArticleFormat } from '../lib/articleFormat';
+import { decideMainMediaCaption } from '../lib/decide-caption';
 import type { Article } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
@@ -41,7 +45,6 @@ const metaFlex = css`
 
 const shareButtonWrapper = css`
 	${grid.column.centre}
-	grid-row: 1 / -2;
 
 	${from.leftCol} {
 		${grid.column.left}
@@ -50,11 +53,12 @@ const shareButtonWrapper = css`
 
 export const HostedArticleLayout = (props: WebProps | AppProps) => {
 	const {
-		content: {
-			frontendData: { headline, standfirst, pageId, webTitle },
-		},
+		content: { frontendData },
 		format,
 	} = props;
+
+	const mainMedia = frontendData.mainMediaElements[0];
+	const mainMediaCaptionText = decideMainMediaCaption(mainMedia);
 
 	return (
 		<>
@@ -77,65 +81,108 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			) : null}
 			<main>
-				<header css={[grid.container, border]}>
+				<article>
+					<header css={grid.container}>
+						<div
+							css={[
+								grid.column.all,
+								css`
+									min-height: 200px;
+								`,
+							]}
+						>
+							Main media
+						</div>
+						<div
+							css={[
+								grid.between('centre-column-start', 'grid-end'),
+							]}
+						>
+							<ArticleHeadline
+								format={format}
+								headlineString={frontendData.headline}
+								tags={frontendData.tags}
+								byline={frontendData.byline}
+								webPublicationDateDeprecated={
+									frontendData.webPublicationDateDeprecated
+								}
+							/>
+						</div>
+					</header>
 					<div
 						css={[
-							grid.column.all,
+							grid.container,
 							css`
-								min-height: 200px;
+								padding-top: ${space[12]}px;
+
+								${from.leftCol} {
+									padding-top: ${space[5]}px;
+								}
 							`,
 						]}
 					>
-						Main media
-					</div>
-					<div
-						css={[grid.between('centre-column-start', 'grid-end')]}
-					>
-						{/** @todo Use ArticleHeadline component */}
-						{headline}
-					</div>
-				</header>
-				<div
-					css={[
-						grid.container,
-						css`
-							padding-top: ${space[12]}px;
-
-							${from.leftCol} {
-								padding-top: ${space[5]}px;
-							}
-						`,
-					]}
-				>
-					<div css={shareButtonWrapper}>
-						<div data-print-layout="hide" css={metaFlex}>
+						<div
+							data-print-layout="hide"
+							css={[
+								shareButtonWrapper,
+								metaFlex,
+								css`
+									grid-row: 1;
+								`,
+							]}
+						>
 							{props.renderingTarget === 'Web' && (
 								<Island
 									priority="feature"
 									defer={{ until: 'visible' }}
 								>
 									<ShareButton
-										pageId={pageId}
-										webTitle={webTitle}
+										pageId={frontendData.pageId}
+										webTitle={frontendData.webTitle}
 										format={format}
 										context="ArticleMeta"
 									/>
 								</Island>
 							)}
 						</div>
+						<div
+							css={[
+								grid.column.right,
+								css`
+									grid-row: 1;
+								`,
+							]}
+						>
+							<Caption
+								captionText={mainMediaCaptionText}
+								format={format}
+								isMainMedia={true}
+							/>
+
+							{'Onward content'}
+						</div>
+						<div
+							css={[
+								grid.column.centre,
+								css`
+									grid-row: 1;
+								`,
+							]}
+						>
+							<Standfirst
+								format={format}
+								standfirst={frontendData.standfirst}
+							/>
+						</div>
+						<div id="maincontent" css={[grid.column.centre]}>
+							{'body'}
+						</div>
 					</div>
-					<div css={[grid.column.right, 'grid-row: 1']}>
-						Onward content
+
+					<div css={[grid.container, border]}>
+						<div css={[grid.column.all]}>Footer</div>
 					</div>
-					<div css={[border, grid.column.centre, 'grid-row: 1']}>
-						{standfirst}
-					</div>
-					<div css={[border, grid.column.centre]}>Meta</div>
-					<article css={[border, grid.column.centre]}>Body</article>
-				</div>
-				<div css={[grid.container, border]}>
-					<div css={[grid.column.all]}>Footer</div>
-				</div>
+				</article>
 			</main>
 		</>
 	);


### PR DESCRIPTION
## What does this change?

As described in title, adds headline, standfirst and main media caption components to the Hosted Article page layout

Also reworks the HTML slightly by including the `article` element at the top level around the entire article data and reducing the number of nested divs for the share button component

Removes some of the borders used to divide content as placeholders since the page is starting to take shape now

## Why?

As part of the Hosted Content migration from frontend, we're working on developing the new page layouts in DCR

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/67e5db29-b49f-414e-9d9b-42edc5bf19f3
[after]: https://github.com/user-attachments/assets/8bbcfa21-569b-4121-8b6a-367af8b97120
