### PR TITLE
Set self-hosted video subtitles max width to 71%

### DIFF
--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -9,18 +9,18 @@ import { palette } from '../palette';
 import type { ControlsPosition, SubtitleSize } from './SelfHostedVideoPlayer';
 
 const subtitleOverlayStyles = (position: ControlsPosition) => css`
-	max-width: 71%;
+	width: 100%;
+	display: flex;
+	justify-content: center;
 	pointer-events: none;
 	position: absolute;
-	left: 50%;
-	transform: translateX(-50%);
 
 	${position === 'top' && `top: ${space[4]}px;`};
 	${position === 'bottom' && `bottom: ${space[4]}px;`};
 `;
 
 const cueBoxStyles = css`
-	width: 100%;
+	max-width: 71%;
 	margin: 0 auto;
 	text-align: center;
 	pointer-events: none;


### PR DESCRIPTION
## What does this change?

Subtitles should be able to take a maximum of 71% of width. There was an issue with using `left` to position the subtitles element which meant that the maximum width was actually 50%.

## Why?

This was the original intention of the code and matches designs.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/df96fa87-8d1d-496b-a8f0-ba225fd3dd72
[after]: https://github.com/user-attachments/assets/c1d4025c-1f42-4ce7-9f9a-3d252442c486
