### PR TITLE
Directory nav responsive images

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -46,7 +46,7 @@ const configs = [
 		],
 		tagIds: [],
 		textColor: palette.neutral[7],
-		backgroundColor: '#CCCCCC',
+		backgroundColor: '#22B24B',
 		title: {
 			label: 'Winter Olympics 2026',
 			id: 'sport/winter-olympics-2026',


### PR DESCRIPTION
Switches to using the `picture` element for the background images, and the Fastly Image Optimiser for generating them. Specifying images in HTML *should* allow the browser to parse and download them earlier than when they're specified in CSS[^1]. Using the `picture` tag allows us to specify a range of images for different viewport sizes and pixel densities[^2] (this could also be achieved in CSS by adding more media queries). Using the Image Optimiser should allow for better optimised, and typically smaller, images.

[^1]: https://developer.mozilla.org/en-US/docs/Web/Performance/Guides/How_browsers_work#parsing
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images
