### PR TITLE
Valibot schemas for football matches

### DIFF
--- a/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
@@ -1,83 +1,113 @@
+import {
+	boolean,
+	literal,
+	number,
+	object,
+	optional,
+	type Output,
+	string,
+	variant,
+} from 'valibot';
 import type {
 	FECompetitionSummary,
 	FEFootballCompetition,
 	FEFootballDataPage,
-	FERound,
 } from './feFootballDataPage';
 
-type FEStage = {
-	stageNumber: string;
-};
+const stageSchema = object({
+	stageNumber: string(),
+});
 
-type FEVenue = {
-	id: string;
-	name: string;
-};
+const roundSchema = object({
+	roundNumber: string(),
+	name: optional(string()),
+});
 
-type FEMatchCompetition = {
-	id: string;
-	name: string;
-};
+const venueSchema = object({
+	id: string(),
+	name: string(),
+});
 
-export type FEMatchDayTeam = {
-	id: string;
-	name: string;
-	score?: number;
-	htScore?: number;
-	aggregateScore?: number;
-	scorers?: string;
-};
+const matchCompetitionSchema = object({
+	id: string(),
+	name: string(),
+});
 
-type Official = {
-	id: string;
-	name: string;
-};
+const matchDayTeamSchema = object({
+	id: string(),
+	name: string(),
+	score: optional(number()),
+	htScore: optional(number()),
+	aggregateScore: optional(number()),
+	scorers: optional(string()),
+});
 
-type FEFootballMatchData = {
-	id: string;
-	date: string;
-	stage: FEStage;
-	round: FERound;
-	leg: string;
-	homeTeam: FEMatchDayTeam;
-	awayTeam: FEMatchDayTeam;
-	venue?: FEVenue;
-	comments?: string;
-};
+const officialSchema = object({
+	id: string(),
+	name: string(),
+});
 
-export type FELive = FEFootballMatchData & {
-	type: 'LiveMatch';
-	status: string;
-	attendance?: string;
-	referee?: Official;
-};
+const footballMatchDataSchema = object({
+	id: string(),
+	date: string(),
+	stage: stageSchema,
+	round: roundSchema,
+	leg: string(),
+	homeTeam: matchDayTeamSchema,
+	awayTeam: matchDayTeamSchema,
+	venue: optional(venueSchema),
+	comments: optional(string()),
+});
 
-export type FEFixture = FEFootballMatchData & {
-	type: 'Fixture';
-	competition?: FEMatchCompetition;
-};
+const liveSchema = object({
+	...footballMatchDataSchema.entries,
+	type: literal('LiveMatch'),
+	status: string(),
+	attendance: optional(string()),
+	referee: optional(officialSchema),
+});
 
-export type FEMatchDay = FEFootballMatchData & {
-	type: 'MatchDay';
-	liveMatch: boolean;
-	result: boolean;
-	previewAvailable: boolean;
-	reportAvailable: boolean;
-	lineupsAvailable: boolean;
-	matchStatus: string;
-	attendance?: string;
-	referee?: Official;
-	competition?: FEMatchCompetition;
-};
+const fixtureSchema = object({
+	...footballMatchDataSchema.entries,
+	type: literal('Fixture'),
+	competition: optional(matchCompetitionSchema),
+});
 
-export type FEResult = FEFootballMatchData & {
-	type: 'Result';
-	reportAvailable: boolean;
-	attendance?: string;
-	referee?: Official;
-};
+const matchDaySchema = object({
+	...footballMatchDataSchema.entries,
+	type: literal('MatchDay'),
+	liveMatch: boolean(),
+	result: boolean(),
+	previewAvailable: boolean(),
+	reportAvailable: boolean(),
+	lineupsAvailable: boolean(),
+	matchStatus: string(),
+	attendance: optional(string()),
+	referee: optional(officialSchema),
+	competition: optional(matchCompetitionSchema),
+});
 
-export type FEFootballMatch = FEFixture | FEMatchDay | FEResult | FELive;
+const resultSchema = object({
+	...footballMatchDataSchema.entries,
+	type: literal('Result'),
+	reportAvailable: boolean(),
+	attendance: optional(string()),
+	referee: optional(officialSchema),
+});
+
+export const feFootballMatchSchema = variant('type', [
+	fixtureSchema,
+	matchDaySchema,
+	resultSchema,
+	liveSchema,
+]);
+
+export type FELive = Output<typeof liveSchema>;
+export type FEFixture = Output<typeof fixtureSchema>;
+export type FEMatchDay = Output<typeof matchDaySchema>;
+export type FEResult = Output<typeof resultSchema>;
+export type FEFootballMatch = Output<typeof feFootballMatchSchema>;
+export type FEMatchDayTeam = Output<typeof matchDayTeamSchema>;
 
 export type FECompetitionMatch = {
 	competitionSummary: FECompetitionSummary;

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
@@ -296,7 +296,20 @@
                     ]
                 },
                 "matchInfo": {
-                    "$ref": "#/definitions/FEFootballMatch"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"LiveMatch\";status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                        },
+                        {
+                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Fixture\";venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
+                        },
+                        {
+                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}"
+                        },
+                        {
+                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Result\";reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                        }
+                    ]
                 },
                 "group": {
                     "type": "object",
@@ -1058,680 +1071,341 @@
                 "url"
             ]
         },
-        "FEFootballMatch": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/FELive"
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"LiveMatch\";status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
-                {
-                    "$ref": "#/definitions/FEFixture"
+                "id": {
+                    "type": "string"
                 },
-                {
-                    "$ref": "#/definitions/FEMatchDay"
+                "date": {
+                    "type": "string"
                 },
-                {
-                    "$ref": "#/definitions/FEResult"
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "LiveMatch"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "status",
+                "type"
             ]
         },
-        "FELive": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "LiveMatch"
-                        },
-                        "status": {
-                            "type": "string"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "type"
-                    ]
+        "{stageNumber:string;}": {
+            "type": "object",
+            "properties": {
+                "stageNumber": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "stageNumber"
             ]
         },
-        "FEFixture": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{roundNumber:string;name?:string;}": {
+            "type": "object",
+            "properties": {
+                "roundNumber": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "Fixture"
-                        },
-                        "competition": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ]
+                "name": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "roundNumber"
             ]
         },
-        "FEMatchDay": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "MatchDay"
-                        },
-                        "liveMatch": {
-                            "type": "boolean"
-                        },
-                        "result": {
-                            "type": "boolean"
-                        },
-                        "previewAvailable": {
-                            "type": "boolean"
-                        },
-                        "reportAvailable": {
-                            "type": "boolean"
-                        },
-                        "lineupsAvailable": {
-                            "type": "boolean"
-                        },
-                        "matchStatus": {
-                            "type": "string"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "competition": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "lineupsAvailable",
-                        "liveMatch",
-                        "matchStatus",
-                        "previewAvailable",
-                        "reportAvailable",
-                        "result",
-                        "type"
-                    ]
+                "id": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "htScore": {
+                    "type": "number"
+                },
+                "aggregateScore": {
+                    "type": "number"
+                },
+                "scorers": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
-        "FEResult": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{name:string;id:string;}": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "Result"
-                        },
-                        "reportAvailable": {
-                            "type": "boolean"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "reportAvailable",
-                        "type"
-                    ]
+                "id": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{name:string;id:string;}_1": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Fixture\";venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "Fixture"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "competition": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "type"
+            ]
+        },
+        "{name:string;id:string;}_2": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "MatchDay"
+                },
+                "liveMatch": {
+                    "type": "boolean"
+                },
+                "result": {
+                    "type": "boolean"
+                },
+                "previewAvailable": {
+                    "type": "boolean"
+                },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "lineupsAvailable": {
+                    "type": "boolean"
+                },
+                "matchStatus": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                },
+                "competition": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "lineupsAvailable",
+                "liveMatch",
+                "matchStatus",
+                "previewAvailable",
+                "reportAvailable",
+                "result",
+                "round",
+                "stage",
+                "type"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Result\";reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "Result"
+                },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "reportAvailable",
+                "round",
+                "stage",
+                "type"
             ]
         }
     },

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
@@ -94,7 +94,20 @@
                                         "matches": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/FEFootballMatch"
+                                                "anyOf": [
+                                                    {
+                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"LiveMatch\";status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                                                    },
+                                                    {
+                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Fixture\";venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
+                                                    },
+                                                    {
+                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}"
+                                                    },
+                                                    {
+                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Result\";reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                                                    }
+                                                ]
                                             }
                                         }
                                     },
@@ -696,680 +709,341 @@
         "Record<string,FEFootballCompetition[]>": {
             "type": "object"
         },
-        "FEFootballMatch": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/FELive"
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"LiveMatch\";status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
-                {
-                    "$ref": "#/definitions/FEFixture"
+                "id": {
+                    "type": "string"
                 },
-                {
-                    "$ref": "#/definitions/FEMatchDay"
+                "date": {
+                    "type": "string"
                 },
-                {
-                    "$ref": "#/definitions/FEResult"
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "LiveMatch"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "status",
+                "type"
             ]
         },
-        "FELive": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "LiveMatch"
-                        },
-                        "status": {
-                            "type": "string"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "type"
-                    ]
+        "{stageNumber:string;}": {
+            "type": "object",
+            "properties": {
+                "stageNumber": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "stageNumber"
             ]
         },
-        "FEFixture": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{roundNumber:string;name?:string;}": {
+            "type": "object",
+            "properties": {
+                "roundNumber": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "Fixture"
-                        },
-                        "competition": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ]
+                "name": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "roundNumber"
             ]
         },
-        "FEMatchDay": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "MatchDay"
-                        },
-                        "liveMatch": {
-                            "type": "boolean"
-                        },
-                        "result": {
-                            "type": "boolean"
-                        },
-                        "previewAvailable": {
-                            "type": "boolean"
-                        },
-                        "reportAvailable": {
-                            "type": "boolean"
-                        },
-                        "lineupsAvailable": {
-                            "type": "boolean"
-                        },
-                        "matchStatus": {
-                            "type": "string"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "competition": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "lineupsAvailable",
-                        "liveMatch",
-                        "matchStatus",
-                        "previewAvailable",
-                        "reportAvailable",
-                        "result",
-                        "type"
-                    ]
+                "id": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "htScore": {
+                    "type": "number"
+                },
+                "aggregateScore": {
+                    "type": "number"
+                },
+                "scorers": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
-        "FEResult": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "date": {
-                            "type": "string"
-                        },
-                        "stage": {
-                            "type": "object",
-                            "properties": {
-                                "stageNumber": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "stageNumber"
-                            ]
-                        },
-                        "round": {
-                            "type": "object",
-                            "properties": {
-                                "roundNumber": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "roundNumber"
-                            ]
-                        },
-                        "leg": {
-                            "type": "string"
-                        },
-                        "homeTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "awayTeam": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "score": {
-                                    "type": "number"
-                                },
-                                "htScore": {
-                                    "type": "number"
-                                },
-                                "aggregateScore": {
-                                    "type": "number"
-                                },
-                                "scorers": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "venue": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        },
-                        "comments": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "awayTeam",
-                        "date",
-                        "homeTeam",
-                        "id",
-                        "leg",
-                        "round",
-                        "stage"
-                    ]
+        "{name:string;id:string;}": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "const": "Result"
-                        },
-                        "reportAvailable": {
-                            "type": "boolean"
-                        },
-                        "attendance": {
-                            "type": "string"
-                        },
-                        "referee": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "id",
-                                "name"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "reportAvailable",
-                        "type"
-                    ]
+                "id": {
+                    "type": "string"
                 }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{name:string;id:string;}_1": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Fixture\";venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "Fixture"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "competition": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "type"
+            ]
+        },
+        "{name:string;id:string;}_2": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "MatchDay"
+                },
+                "liveMatch": {
+                    "type": "boolean"
+                },
+                "result": {
+                    "type": "boolean"
+                },
+                "previewAvailable": {
+                    "type": "boolean"
+                },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "lineupsAvailable": {
+                    "type": "boolean"
+                },
+                "matchStatus": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                },
+                "competition": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "lineupsAvailable",
+                "liveMatch",
+                "matchStatus",
+                "previewAvailable",
+                "reportAvailable",
+                "result",
+                "round",
+                "stage",
+                "type"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;};type:\"Result\";reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;}"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "Result"
+                },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "reportAvailable",
+                "round",
+                "stage",
+                "type"
             ]
         }
     },


### PR DESCRIPTION
Allows us to request and validate this data from frontend client-side, which we'll want to do for the new match header to poll for scores and other data.

Part of #14901, paired with @marjisound @jamesmockett 