### PR TITLE
Improve slideshow carousel accessibility to screen readers

### DIFF
--- a/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
+++ b/dotcom-rendering/src/components/SlideshowCarousel.importable.tsx
@@ -212,7 +212,13 @@ export const SlideshowCarousel = ({
 	const slideshowImageCount = slideshowImages.length;
 
 	return (
-		<div css={containerStyles}>
+		<div
+			css={containerStyles}
+			role="region"
+			aria-roledescription="carousel"
+			aria-label="Slideshow"
+			aria-live="polite"
+		>
 			<a
 				href={linkTo}
 				aria-label={linkAriaLabel}
@@ -226,7 +232,14 @@ export const SlideshowCarousel = ({
 					{slideshowImages.map((image, index) => {
 						const loading = index > 0 ? 'lazy' : 'eager';
 						return (
-							<li css={carouselItemStyles} key={image.imageSrc}>
+							<li
+								css={carouselItemStyles}
+								key={image.imageSrc}
+								role="group"
+								aria-roledescription="slide"
+								aria-label={image.imageCaption}
+								aria-hidden={index !== currentPage}
+							>
 								<figure>
 									<CardPicture
 										mainImage={image.imageSrc}
@@ -255,6 +268,8 @@ export const SlideshowCarousel = ({
 				<div
 					className="slideshow-carousel-footer"
 					css={navigationStyles(hasNavigationBackgroundColour)}
+					role="group"
+					aria-label="Slide controls"
 				>
 					<div css={scrollingDotStyles}>
 						<SlideshowCarouselScrollingDots


### PR DESCRIPTION
## What does this change?

Adds aria attributes to the Slideshow Carousel component. The container, slides and buttons are included

## Why?

So that is it easier to navigate the slideshow with a screen reader

### Sources:
- https://www.smashingmagazine.com/2023/02/guide-building-accessible-carousels
- https://www.w3.org/WAI/ARIA/apg/patterns/carousel/
- https://developer.chrome.com/blog/accessible-carousel

### Outstanding issues:

As you can see in the "After" screenshare below, the screen reader reads out the image caption three times and unfortunately I cannot find a good way around this. The three times come from: the `aria-label` on the list element, the `figcaption` and the `alt` attribute on the image. We use the same text for all three. It is important that `figcaption` remains. Removing the `alt` attribute [may not work across all screen readers](https://www.hassellinclusion.com/blog/figure-figcaption-extended-alternate-text-screen-readers/). When removing the `aria-label` on the list element, the screen reader does not announce the label for the slide initially - it takes a bit of scrolling back and forward for this to happen.

## Screenshares

### Before

https://github.com/user-attachments/assets/a11332f5-2085-4458-9df2-8e0d5804894a

### After

https://github.com/user-attachments/assets/ced4581e-c05b-4ea6-880b-26681fa259dc

