### PR TITLE
Fix FootballMatchHeader importable 

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchHeaderWrapper.importable.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeaderWrapper.importable.tsx
@@ -11,7 +11,7 @@ type Props = {
 	matchHeaderURL: URL;
 };
 
-export const GetFootballMatchHeader = (props: Props) => (
+export const FootballMatchHeaderWrapper = (props: Props) => (
 	<FootballMatchHeaderComponent
 		leagueName={props.leagueName}
 		match={props.match}

--- a/dotcom-rendering/src/components/FootballMatchInfoPage.tsx
+++ b/dotcom-rendering/src/components/FootballMatchInfoPage.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space } from '@guardian/source/foundations';
+import { FootballMatchHeaderWrapper } from '../components/FootballMatchHeaderWrapper.importable';
 import { type FootballMatchStats } from '../footballMatchStats';
 import { type FootballMatch } from '../footballMatchV2';
 import { type FootballTableSummary } from '../footballTables';
@@ -7,7 +8,6 @@ import { grid } from '../grid';
 import { type EditionId } from '../lib/edition';
 import { palette } from '../palette';
 import { FootballMatchInfo } from './FootballMatchInfo';
-import { GetFootballMatchHeader } from './GetFootballMatchHeader.importable';
 import { Island } from './Island';
 
 export const FootballMatchInfoPage = ({
@@ -28,7 +28,7 @@ export const FootballMatchInfoPage = ({
 	return (
 		<main id="maincontent">
 			<Island priority="feature" defer={{ until: 'visible' }}>
-				<GetFootballMatchHeader
+				<FootballMatchHeaderWrapper
 					leagueName={competitionName}
 					match={matchInfo}
 					tabs={{


### PR DESCRIPTION
## What does this change?
The FootballMatchHeader importable can't seem to be found on the client, though running it locally there's no issue. 

This PR fixes the `FootballMatchHeader.importable`. It seems that the names of the importable component and the inner component being the same `FootballMatchHeader` were causing the issue. Changing the importable component name to `FootballMatchHeaderWrapper` fixed this problem