### PR TITLE
Add browserId in email submission form

### DIFF
--- a/dotcom-rendering/src/components/Metrics.importable.tsx
+++ b/dotcom-rendering/src/components/Metrics.importable.tsx
@@ -9,8 +9,9 @@ import {
 	bypassCoreWebVitalsSampling,
 	initCoreWebVitals,
 } from '@guardian/core-web-vitals';
-import { getCookie, isString, isUndefined } from '@guardian/libs';
+import { isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
+import { useBrowserId } from '../lib/metrics';
 import { useAB, useBetaAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useDetectAdBlock } from '../lib/useDetectAdBlock';
@@ -39,20 +40,6 @@ const shouldCollectMetricsForBetaTests = (userTestParticipations: string[]) => {
 	return userParticipationConfigs.some(
 		(test) => test.shouldForceMetricsCollection,
 	);
-};
-
-const useBrowserId = () => {
-	const [browserId, setBrowserId] = useState<string>();
-
-	useEffect(() => {
-		const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
-
-		const id = isString(cookie) ? cookie : 'no-browser-id-available';
-
-		setBrowserId(id);
-	}, []);
-
-	return browserId;
 };
 
 const useDev = () => {

--- a/dotcom-rendering/src/components/SecureSignup.importable.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.importable.tsx
@@ -21,6 +21,7 @@ import { useEffect, useRef, useState } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
+import { useBrowserId } from '../lib/metrics';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
 import { palette } from '../palette';
@@ -136,6 +137,7 @@ const buildFormData = (
 	newsletterId: string,
 	token: string,
 	marketingOptIn?: boolean,
+	browserId?: string,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -153,6 +155,10 @@ const buildFormData = (
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (browserId !== undefined) {
+		formData.append('browserId', browserId);
 	}
 
 	return formData;
@@ -304,6 +310,7 @@ export const SecureSignup = ({
 		});
 	}, []);
 	const { renderingTarget } = useConfig();
+	const browserId = useBrowserId();
 
 	const hasResponse = typeof responseOk === 'boolean';
 
@@ -319,6 +326,7 @@ export const SecureSignup = ({
 			newsletterId,
 			token,
 			marketingOptIn,
+			browserId,
 		);
 
 		const response = await postFormData(

--- a/dotcom-rendering/src/lib/metrics.ts
+++ b/dotcom-rendering/src/lib/metrics.ts
@@ -1,0 +1,16 @@
+import { getCookie, isString } from '@guardian/libs';
+import { useEffect, useState } from 'react';
+
+export const useBrowserId = (): string | undefined => {
+	const [browserId, setBrowserId] = useState<string>();
+
+	useEffect(() => {
+		const cookie = getCookie({ name: 'bwid', shouldMemoize: true });
+
+		const id = isString(cookie) ? cookie : 'no-browser-id-available';
+
+		setBrowserId(id);
+	}, []);
+
+	return browserId;
+};


### PR DESCRIPTION
## What does this change?
Sends browserId when user subscribes to one newsletter. This flow does not require email confirmation and can be triggered in:
* Article sign-ups, e.g. https://www.theguardian.com/tv-and-radio/2026/feb/17/look-mum-no-computer-uk-entry-eurovision-2026
* Distinct article pages for each individual newsletter, e.g. https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email

## Why?
Supporter Revenue have made a request to send them the user id, the newsletter id, the browser id, and the timestamp when a user subscribes to a newsletter. Browser id is the only info we don't have. See related PRs in identity and frontend:

* https://github.com/guardian/identity/pull/2882
* https://github.com/guardian/frontend/pull/28613

## Screenshots

BrowserId is undefined in CODE so we will have to merge this to see whether we actually send it.

| Before      | After      |
| ----------- | ---------- |
| <img width="2487" height="719" alt="image" src="https://github.com/user-attachments/assets/97839b84-1f9f-4f5a-a2ff-da7bf6dd74e0" /> | <img width="2438" height="879" alt="image" src="https://github.com/user-attachments/assets/3274fe1e-b90f-4dcb-880b-c3f647a86cfa" /> |
| <img width="2437" height="691" alt="image" src="https://github.com/user-attachments/assets/6dd44dee-0f4a-42e5-998b-231e8ff68492" /> | <img width="2356" height="751" alt="image" src="https://github.com/user-attachments/assets/3db4ca19-0fa6-4f6d-a0ae-662a909ae124" /> |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
