### PR TITLE
Enhance message picker & fire new event for `banner:sign-in-gate`

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -18,11 +18,7 @@ import {
 	BrazeBannersSystemPlacementId,
 	buildBrazeBannersSystemConfig,
 } from '../lib/braze/BrazeBannersSystem';
-import type {
-	CandidateConfig,
-	MaybeFC,
-	SlotConfig,
-} from '../lib/messagePicker';
+import type { CandidateConfig, SlotConfig } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
 import { useBetaAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
@@ -205,7 +201,13 @@ export const SlotBodyEnd = ({
 			name: 'slotBodyEnd',
 		};
 		pickMessage(epicConfig, renderingTarget)
-			.then((PickedEpic: () => MaybeFC) => setSelectedEpic(PickedEpic))
+			.then((result) => {
+				if (result.type === 'MessageSelected') {
+					setSelectedEpic(() => result.SelectedMessage);
+				} else {
+					setSelectedEpic(() => null);
+				}
+			})
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),
 			);

--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -61,7 +61,7 @@ const buildReaderRevenueEpicConfig = (
 		candidate: {
 			id: 'reader-revenue-banner',
 			canShow: () => canShowReaderRevenueEpic(canShowData),
-			show: (data: ModuleData<EpicProps>) => () => {
+			show: (data: ModuleData<EpicProps>) => {
 				return <ReaderRevenueEpic {...data} />;
 			},
 		},
@@ -89,7 +89,7 @@ const buildBrazeEpicConfig = (
 					tags,
 					shouldHideReaderRevenue,
 				),
-			show: (meta: any) => () => (
+			show: (meta: any) => (
 				<MaybeBrazeEpic
 					meta={meta}
 					countryCode={countryCode}
@@ -203,7 +203,7 @@ export const SlotBodyEnd = ({
 		pickMessage(epicConfig, renderingTarget)
 			.then((result) => {
 				if (result.type === 'MessageSelected') {
-					setSelectedEpic(() => result.SelectedMessage);
+					setSelectedEpic(result.SelectedMessage);
 				} else {
 					setSelectedEpic(() => null);
 				}

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -435,15 +435,21 @@ export const StickyBottomBanner = ({
 		abTests,
 	]);
 
-	// Dispatches 'banner:none' event for commercial to handle for the mobile sticky ad integration (@guardian/commercial-dev)
-	// Ensures the mobile-sticky ad slots only render when no banner will be shown.
+	/**
+	 * Custom events for commercial purposes to avoid the mobile-sticky ad slot clashing with these banners
+	 * Dispatches events when no banner is due to appear and when the sign in gate is the chosen banner
+	 * Please talk to @guardian/commercial-dev before changing this logic
+	 */
 	useEffect(() => {
-		if (
-			pickMessageResult?.type === 'NoMessageSelected' ||
-			// Explicitly ignore the sign in gate for this
-			pickMessageResult?.messageId === 'sign-in-gate-portal'
-		) {
+		if (pickMessageResult?.type === 'NoMessageSelected') {
 			document.dispatchEvent(new CustomEvent('banner:none'));
+		}
+
+		if (
+			pickMessageResult?.type === 'MessageSelected' &&
+			pickMessageResult.messageId === 'sign-in-gate-portal'
+		) {
+			document.dispatchEvent(new CustomEvent('banner:sign-in-gate'));
 		}
 	}, [pickMessageResult]);
 

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -177,9 +177,9 @@ const buildRRBannerConfigWith = ({
 						pageId,
 						inHoldbackGroup,
 					}),
-				show:
-					({ name, props }: ModuleData<BannerProps>) =>
-					() => <BannerComponent name={name} props={props} />,
+				show: ({ name, props }: ModuleData<BannerProps>) => (
+					<BannerComponent name={name} props={props} />
+				),
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 		};
@@ -195,7 +195,7 @@ const buildSignInGateConfig = (
 		canShow: async () => {
 			return await canShowSignInGatePortal(canShowProps);
 		},
-		show: (meta: AuxiaGateDisplayData) => () => (
+		show: (meta: AuxiaGateDisplayData) => (
 			<SignInGatePortal
 				host={host}
 				isPaidContent={canShowProps.isPaidContent}
@@ -233,7 +233,7 @@ const buildBrazeBanner = (
 				tags,
 				shouldHideReaderRevenue,
 			),
-		show: (meta: BrazeMeta) => () => (
+		show: (meta: BrazeMeta) => (
 			<BrazeBanner meta={meta} idApiUrl={idApiUrl} />
 		),
 	},
@@ -445,7 +445,7 @@ export const StickyBottomBanner = ({
 
 	if (pickMessageResult?.type === 'MessageSelected') {
 		const { SelectedMessage } = pickMessageResult;
-		return SelectedMessage();
+		return <SelectedMessage />;
 	}
 
 	return null;

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -15,7 +15,7 @@ import {
 } from '../lib/braze/BrazeBannersSystem';
 import type {
 	CandidateConfig,
-	MaybeFC,
+	PickMessageResult,
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
@@ -282,9 +282,9 @@ export const StickyBottomBanner = ({
 		'control',
 	);
 
-	const [SelectedBanner, setSelectedBanner] = useState<MaybeFC | null>(null);
-	const [hasPickMessageCompleted, setHasPickMessageCompleted] =
-		useState<boolean>(false);
+	const [pickMessageResult, setPickMessageResult] =
+		useState<PickMessageResult | null>(null);
+
 	const [asyncArticleCounts, setAsyncArticleCounts] =
 		useState<Promise<ArticleCounts | undefined>>();
 
@@ -396,9 +396,9 @@ export const StickyBottomBanner = ({
 		};
 
 		pickMessage(bannerConfig, renderingTarget)
-			.then((PickedBanner: () => MaybeFC) => {
-				setSelectedBanner(PickedBanner);
-				setHasPickMessageCompleted(true);
+			.then((result) => {
+				setPickMessageResult(result);
+				// setHasPickMessageCompleted(true);
 			})
 			.catch((e) => {
 				// Report error to Sentry
@@ -409,7 +409,7 @@ export const StickyBottomBanner = ({
 					new Error(msg),
 					'sticky-bottom-banner',
 				);
-				setHasPickMessageCompleted(true);
+				// setHasPickMessageCompleted(true);
 			});
 	}, [
 		isSignedIn,
@@ -441,12 +441,15 @@ export const StickyBottomBanner = ({
 	// Ensures ads only insert when no banner will be shown.
 	// hasPickMessageCompleted distinguishes between initial state (not picked yet) and final state (picked nothing).
 	useEffect(() => {
-		if (hasPickMessageCompleted && SelectedBanner == null) {
+		if (pickMessageResult?.type === 'NoMessageSelected') {
 			document.dispatchEvent(new CustomEvent('banner:none'));
 		}
-	}, [SelectedBanner, hasPickMessageCompleted]);
-	if (SelectedBanner) {
-		return <SelectedBanner />;
+	}, [pickMessageResult]);
+	if (pickMessageResult?.type === 'MessageSelected') {
+		const { SelectedMessage } = pickMessageResult;
+		if (SelectedMessage) {
+			return <SelectedMessage />;
+		}
 	}
 
 	return null;

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -435,10 +435,14 @@ export const StickyBottomBanner = ({
 		abTests,
 	]);
 
-	// Dispatches 'banner:none' event for mobile sticky ad integration (see @guardian/commercial-dev).
-	// Ensures ads only insert when no banner will be shown.
+	// Dispatches 'banner:none' event for commercial to handle for the mobile sticky ad integration (@guardian/commercial-dev)
+	// Ensures the mobile-sticky ad slots only render when no banner will be shown.
 	useEffect(() => {
-		if (pickMessageResult?.type === 'NoMessageSelected') {
+		if (
+			pickMessageResult?.type === 'NoMessageSelected' ||
+			// Explicitly ignore the sign in gate for this
+			pickMessageResult?.messageId === 'sign-in-gate-portal'
+		) {
 			document.dispatchEvent(new CustomEvent('banner:none'));
 		}
 	}, [pickMessageResult]);

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -398,7 +398,6 @@ export const StickyBottomBanner = ({
 		pickMessage(bannerConfig, renderingTarget)
 			.then((result) => {
 				setPickMessageResult(result);
-				// setHasPickMessageCompleted(true);
 			})
 			.catch((e) => {
 				// Report error to Sentry
@@ -409,7 +408,6 @@ export const StickyBottomBanner = ({
 					new Error(msg),
 					'sticky-bottom-banner',
 				);
-				// setHasPickMessageCompleted(true);
 			});
 	}, [
 		isSignedIn,
@@ -439,17 +437,15 @@ export const StickyBottomBanner = ({
 
 	// Dispatches 'banner:none' event for mobile sticky ad integration (see @guardian/commercial-dev).
 	// Ensures ads only insert when no banner will be shown.
-	// hasPickMessageCompleted distinguishes between initial state (not picked yet) and final state (picked nothing).
 	useEffect(() => {
 		if (pickMessageResult?.type === 'NoMessageSelected') {
 			document.dispatchEvent(new CustomEvent('banner:none'));
 		}
 	}, [pickMessageResult]);
+
 	if (pickMessageResult?.type === 'MessageSelected') {
 		const { SelectedMessage } = pickMessageResult;
-		if (SelectedMessage) {
-			return <SelectedMessage />;
-		}
+		return SelectedMessage();
 	}
 
 	return null;

--- a/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
+++ b/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
@@ -273,7 +273,7 @@ export const buildBrazeBannersSystemConfig = (
 					tags,
 				);
 			},
-			show: (meta: BrazeBannersSystemMeta) => () => (
+			show: (meta: BrazeBannersSystemMeta) => (
 				<BrazeBannersSystemDisplay
 					meta={meta}
 					idApiUrl={idApiUrl}

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -56,9 +56,12 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const got = await pickMessage(config, 'Web');
+		const result = await pickMessage(config, 'Web');
 
-		expect(got()).toEqual(ChosenMockComponent);
+		expect(result.type).toEqual('MessageSelected');
+		if (result.type === 'MessageSelected') {
+			expect(result.SelectedMessage).toEqual(ChosenMockComponent);
+		}
 	});
 
 	it('resolves with null if no messages can show', async () => {
@@ -86,9 +89,9 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const got = await pickMessage(config, 'Web');
+		const result = await pickMessage(config, 'Web');
 
-		expect(got()).toEqual(null);
+		expect(result.type).toEqual('NoMessageSelected');
 	});
 
 	it('falls through to a lower priority message when a higher one times out', async () => {
@@ -129,9 +132,12 @@ describe('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
-		const got = await messagePromise;
+		const result = await messagePromise;
 
-		expect(got()).toEqual(ChosenMockComponent);
+		expect(result.type).toEqual('MessageSelected');
+		if (result.type === 'MessageSelected') {
+			expect(result.SelectedMessage).toEqual(ChosenMockComponent);
+		}
 	});
 
 	it('resolves with null if all messages time out', async () => {
@@ -182,9 +188,9 @@ describe('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
-		const got = await messagePromise;
+		const result = await messagePromise;
 
-		expect(got()).toEqual(null);
+		expect(result.type).toEqual('NoMessageSelected');
 
 		clearTimeout(timer1);
 		clearTimeout(timer2);
@@ -211,8 +217,7 @@ describe('pickMessage', () => {
 			],
 		};
 
-		const show = await pickMessage(config, 'Web');
-		show();
+		await pickMessage(config, 'Web');
 
 		expect(renderComponent).toHaveBeenCalledWith(meta);
 	});
@@ -246,9 +251,9 @@ describe('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(250);
-		const got = await messagePromise;
+		const result = await messagePromise;
 
-		expect(got()).toEqual(null);
+		expect(result.type).toEqual('NoMessageSelected');
 
 		expect(ophanRecordSpy).toHaveBeenCalledWith({
 			component: 'banner-picker-timeout-dcr',

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -31,7 +31,7 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-1',
 						canShow: () => Promise.resolve({ show: false }),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -40,7 +40,7 @@ describe('pickMessage', () => {
 						id: 'banner-2',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: () => ChosenMockComponent,
+						show: ChosenMockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -49,7 +49,7 @@ describe('pickMessage', () => {
 						id: 'banner-3',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -74,7 +74,7 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-1',
 						canShow: () => Promise.resolve({ show: false }),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -82,7 +82,7 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-2',
 						canShow: () => Promise.resolve({ show: false }),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -114,7 +114,7 @@ describe('pickMessage', () => {
 									500,
 								),
 							),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -123,7 +123,7 @@ describe('pickMessage', () => {
 						id: 'banner-2',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: () => ChosenMockComponent,
+						show: ChosenMockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -161,7 +161,7 @@ describe('pickMessage', () => {
 									500,
 								);
 							}),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -179,7 +179,7 @@ describe('pickMessage', () => {
 									500,
 								);
 							}),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -197,7 +197,7 @@ describe('pickMessage', () => {
 	});
 
 	it('passes metadata returned by canShow to show', async () => {
-		const renderComponent = jest.fn(() => () => <div />);
+		const renderComponent = jest.fn(() => <div />);
 		const meta = { extra: 'info' };
 		const config: SlotConfig = {
 			name: 'banner',
@@ -242,7 +242,7 @@ describe('pickMessage', () => {
 									300,
 								);
 							}),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: 200,
 				},
@@ -283,7 +283,7 @@ describe('pickMessage', () => {
 									120,
 								);
 							}),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 					reportTiming: true,
@@ -302,7 +302,7 @@ describe('pickMessage', () => {
 									100,
 								);
 							}),
-						show: () => MockComponent,
+						show: MockComponent,
 					},
 					timeoutMillis: null,
 				},

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -20,10 +20,10 @@ afterEach(async () => {
 	jest.clearAllMocks();
 });
 
-describe.skip('pickMessage', () => {
+describe('pickMessage', () => {
 	it('resolves with the highest priority message which can show', async () => {
 		const MockComponent = () => <div />;
-		const ChosenMockComponent = () => <div />;
+		const ChosenMockComponent = () => <div id="chosen" />;
 		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
@@ -56,11 +56,12 @@ describe.skip('pickMessage', () => {
 			],
 		};
 
-		const result = await pickMessage(config, 'Web');
-
-		expect(result.type).toEqual('MessageSelected');
-		if (result.type === 'MessageSelected') {
-			expect(result.SelectedMessage).toEqual(ChosenMockComponent);
+		const pickMessageResult = await pickMessage(config, 'Web');
+		expect(pickMessageResult.type).toEqual('MessageSelected');
+		if (pickMessageResult.type === 'MessageSelected') {
+			expect(pickMessageResult.SelectedMessage()).toEqual(
+				ChosenMockComponent(),
+			);
 		}
 	});
 
@@ -89,14 +90,14 @@ describe.skip('pickMessage', () => {
 			],
 		};
 
-		const result = await pickMessage(config, 'Web');
+		const pickMessageResult = await pickMessage(config, 'Web');
 
-		expect(result.type).toEqual('NoMessageSelected');
+		expect(pickMessageResult.type).toEqual('NoMessageSelected');
 	});
 
 	it('falls through to a lower priority message when a higher one times out', async () => {
 		const MockComponent = () => <div />;
-		const ChosenMockComponent = () => <div />;
+		const ChosenMockComponent = () => <div id="chosen" />;
 		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
@@ -132,11 +133,13 @@ describe.skip('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
-		const result = await messagePromise;
 
-		expect(result.type).toEqual('MessageSelected');
-		if (result.type === 'MessageSelected') {
-			expect(result.SelectedMessage).toEqual(() => ChosenMockComponent);
+		const pickMessageResult = await messagePromise;
+		expect(pickMessageResult.type).toEqual('MessageSelected');
+		if (pickMessageResult.type === 'MessageSelected') {
+			expect(pickMessageResult.SelectedMessage()).toEqual(
+				ChosenMockComponent(),
+			);
 		}
 	});
 
@@ -188,15 +191,15 @@ describe.skip('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
-		const result = await messagePromise;
+		const got = await messagePromise;
 
-		expect(result.type).toEqual('NoMessageSelected');
+		expect(got.type).toEqual('NoMessageSelected');
 
 		clearTimeout(timer1);
 		clearTimeout(timer2);
 	});
 
-	it.skip('passes metadata returned by canShow to show', async () => {
+	it('passes metadata returned by canShow to show', async () => {
 		const renderComponent = jest.fn(() => <div />);
 		const meta = { extra: 'info' };
 		const config: SlotConfig = {
@@ -217,7 +220,11 @@ describe.skip('pickMessage', () => {
 			],
 		};
 
-		await pickMessage(config, 'Web');
+		const show = await pickMessage(config, 'Web');
+		expect(show.type).toEqual('MessageSelected');
+		if (show.type === 'MessageSelected') {
+			expect(show.SelectedMessage()).toEqual(renderComponent());
+		}
 
 		expect(renderComponent).toHaveBeenCalledWith(meta);
 	});
@@ -251,9 +258,9 @@ describe.skip('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(250);
-		const result = await messagePromise;
+		const got = await messagePromise;
 
-		expect(result.type).toEqual('NoMessageSelected');
+		expect(got.type).toEqual('NoMessageSelected');
 
 		expect(ophanRecordSpy).toHaveBeenCalledWith({
 			component: 'banner-picker-timeout-dcr',

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -20,7 +20,7 @@ afterEach(async () => {
 	jest.clearAllMocks();
 });
 
-describe('pickMessage', () => {
+describe.skip('pickMessage', () => {
 	it('resolves with the highest priority message which can show', async () => {
 		const MockComponent = () => <div />;
 		const ChosenMockComponent = () => <div />;
@@ -136,7 +136,7 @@ describe('pickMessage', () => {
 
 		expect(result.type).toEqual('MessageSelected');
 		if (result.type === 'MessageSelected') {
-			expect(result.SelectedMessage).toEqual(ChosenMockComponent);
+			expect(result.SelectedMessage).toEqual(() => ChosenMockComponent);
 		}
 	});
 
@@ -196,7 +196,7 @@ describe('pickMessage', () => {
 		clearTimeout(timer2);
 	});
 
-	it('passes metadata returned by canShow to show', async () => {
+	it.skip('passes metadata returned by canShow to show', async () => {
 		const renderComponent = jest.fn(() => <div />);
 		const meta = { extra: 'info' };
 		const config: SlotConfig = {

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -129,6 +129,7 @@ interface NoMessageSelected {
 }
 interface MessageSelected {
 	type: 'MessageSelected';
+	messageId: string;
 	// The react component is optional because sometimes we selected a message for this slot, but there is nothing to render
 	SelectedMessage: () => MaybeFC;
 }
@@ -194,6 +195,7 @@ export const pickMessage = (
 					const { candidate, meta } = winner;
 					resolve({
 						type: 'MessageSelected',
+						messageId: candidate.id,
 						SelectedMessage: () => candidate.show(meta),
 					});
 				}

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -2,7 +2,7 @@ import { isUndefined, log, startPerformanceMeasure } from '@guardian/libs';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
 
-export type MaybeFC = React.FC | null;
+export type MaybeFC = React.ReactNode | null;
 type ShowMessage<T> = (meta: T) => MaybeFC;
 
 interface ShouldShow<T> {

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -1,4 +1,4 @@
-import { isUndefined, log, startPerformanceMeasure } from '@guardian/libs';
+import { isUndefined, startPerformanceMeasure } from '@guardian/libs';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
 
@@ -140,11 +140,6 @@ export const pickMessage = (
 	renderingTarget: RenderingTarget,
 ): Promise<PickMessageResult> =>
 	new Promise((resolve) => {
-		// Temporary variable to filter messages from the StickyBottomBanner only
-		const allowConsoleLog = candidates.some(
-			(c) => c.candidate.id === 'cmpUi',
-		);
-
 		const candidateConfigsWithTimeout = candidates.map((c) =>
 			timeoutify(c, name, renderingTarget),
 		);
@@ -154,14 +149,6 @@ export const pickMessage = (
 				canShow: candidateConfig.candidate.canShow(),
 			}),
 		);
-
-		if (allowConsoleLog) {
-			log(
-				'commercial',
-				'☑️ [pick] possible messages:',
-				results.map((_) => _.candidateConfig.candidate.id),
-			);
-		}
 
 		const winnerResult = results.reduce<
 			Promise<WinningMessage<any> | null>
@@ -184,9 +171,6 @@ export const pickMessage = (
 
 		winnerResult
 			.then((winner) => {
-				if (allowConsoleLog) {
-					log('commercial', '☑️ [pick] picked message:', winner);
-				}
 				clearAllTimeouts(candidateConfigsWithTimeout);
 
 				if (winner === null) {

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -184,7 +184,8 @@ export const pickMessage = (
 					});
 				}
 			})
-			.catch((e) =>
-				console.error(`pickMessage winner - error: ${String(e)}`),
-			);
+			.catch((e) => {
+				console.error(`pickMessage winner - error: ${String(e)}`);
+				resolve({ type: 'NoMessageSelected' });
+			});
 	});


### PR DESCRIPTION
## What does this change?

- Reworks the `messagePicker` return type to include metadata on _which_ message was picked and which type of message was picked. 
  The return type was previously just the component to be rendered but it now includes the following:
  ```typescript
  /** Acts as discriminator to distinguish which type of event was returned */
  type: "MessageSelected" | "NoMessageSelected"; 
  /** The ID of the picked message */
  messageId: string;
  /** The resulting component to render ie. the picked message itself */
  SelectedMessage: () => MaybeFC
  ```

  This allows us to remove the `defaultShow` (which is a function that returns null) in favour of the type `NoMessageSelected` which is much more explicit about what is happening under the hood. 
  It also allows us to safely distinguish between the CMP result (which returns null because it's handled by a separate process) and the `defaultShow` result, which happens when no message has been picked.

- Updates the expected type of picked message to render to be `ReactNode` rather than `FC` to be more flexible with the rest of the codebase

- Updates the logic for firing the custom event within `StickyBottomBanner` to use the discriminated union to check which type of message has been picked.
Also fires a new custom event when the picked message is the sign in gate, since we have decided to explicitly ignore this in the commercial code.

> [!NOTE]
> Companion PR in commercial https://github.com/guardian/commercial/pull/2421

## Why?

The mobile-sticky slot can sometimes launch at the same time as the CMP and supporter revenue banners. When this happens, the slot is present in the DOM but sits underneath these elements. We can't continue to allow this to happen as impressions are counted against the advert in the slot even though it can't be seen by the end user

We have decided to only allow the mobile-sticky to launch after certain events as well as the existing page conditions.

It is worth noting that we deliberately allow display of the mobile-sticky slot when the sign in gate is the chosen message from the `StickyBottomBanner` component. The sign in gate currently appears most often obscuring the article body and does not look like a banner or a modal. Another version of the sign in gate appears as a modal and we may want to look into preventing ads running when this is present on the screen.

<hr />

_Co-authored by: @tomrf1_

[Document link for extra information](https://docs.google.com/document/d/1Z8fhVC_Ugy7Lk4GiPe6ZXROQ968SfcyPS6sYF0xhXU0/edit?usp=sharing)