### PR TITLE
extend fronts-and-curation-personalised-container to 25th to ensure w…

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -47,9 +47,9 @@ const ABTests: ABTest[] = [
 	},
 	{
 		name: "fronts-and-curation-personalised-container",
-		description: "Testing the a personalised container component on fronts",
+		description: "Testing the personalised container component on fronts",
 		owners: ["fronts.and.curation@guardian.co.uk"],
-		expirationDate: `2026-02-19`,
+		expirationDate: `2026-02-25`,
 		type: "server",
 		status: "ON",
 		audienceSize: 5 / 100,


### PR DESCRIPTION
## What does this change?
Extend fronts-and-curation-personalised-container to 25th Feb.
## Why?
To ensure we have statistical significance whilst D&I resource are unavailable to check today. 

