### PR TITLE
Move looping video caption inside island

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -8,6 +8,7 @@ import {
 	submitClickComponentEvent,
 	submitComponentEvent,
 } from '../client/ophan/ophan';
+import type { ArticleFormat } from '../lib/articleFormat';
 import { getZIndex } from '../lib/getZIndex';
 import { generateImageURL } from '../lib/image';
 import { useIsInView } from '../lib/useIsInView';
@@ -21,6 +22,7 @@ import {
 } from '../lib/video';
 import { palette } from '../palette';
 import type { VideoPlayerFormat } from '../types/mainMedia';
+import { Caption } from './Caption';
 import { CardPicture, type Props as CardPictureProps } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import type {
@@ -245,6 +247,9 @@ type Props = {
 	 */
 	containerAspectRatioMobile?: number;
 	containerAspectRatioDesktop?: number;
+	caption?: string;
+	format?: ArticleFormat;
+	isMainMedia?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -269,6 +274,9 @@ export const SelfHostedVideo = ({
 	maxAspectRatio,
 	containerAspectRatioMobile,
 	containerAspectRatioDesktop,
+	caption,
+	format,
+	isMainMedia,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -757,64 +765,75 @@ export const SelfHostedVideo = ({
 	const preloadPartialData = !!isAutoplayAllowed || !!isInView;
 
 	return (
-		<div
-			css={[
-				videoContainerStyles(
-					isCinemagraph,
-					aspectRatioOfVisibleVideo,
-					containerAspectRatioMobile,
-					containerAspectRatioDesktop,
-				),
-			]}
+		<figure
+			className={`video-container ${videoStyle.toLocaleLowerCase()}`}
+			data-component="gu-video-loop"
 		>
-			<figure
+			<div
 				ref={setNode}
-				css={figureStyles(
-					aspectRatio,
-					aspectRatioOfVisibleVideo,
-					isGreyBarsAtSidesOnDesktop,
-					isGreyBarsAtTopAndBottomOnDesktop,
-					isVideoCroppedAtTopBottom,
-					isVideoCroppedAtLeftRight,
-					containerAspectRatioDesktop,
-				)}
-				className={`video-container ${videoStyle.toLocaleLowerCase()}`}
-				data-component="gu-video-loop"
+				css={[
+					videoContainerStyles(
+						isCinemagraph,
+						aspectRatioOfVisibleVideo,
+						containerAspectRatioMobile,
+						containerAspectRatioDesktop,
+					),
+				]}
 			>
-				<SelfHostedVideoPlayer
-					sources={sources}
-					atomId={atomId}
-					uniqueId={uniqueId}
-					width={width}
-					height={height}
-					videoStyle={videoStyle}
-					posterImage={optimisedPosterImage}
-					FallbackImageComponent={FallbackImageComponent}
-					currentTime={currentTime}
-					setCurrentTime={setCurrentTime}
-					ref={vidRef}
-					isPlayable={isPlayable}
-					playerState={playerState}
-					isMuted={isMuted}
-					handleLoadedMetadata={handleLoadedMetadata}
-					handleLoadedData={handleLoadedData}
-					handleCanPlay={handleCanPlay}
-					handlePlaying={handlePlaying}
-					handlePlayPauseClick={handlePlayPauseClick}
-					handleAudioClick={handleAudioClick}
-					handleKeyDown={handleKeyDown}
-					handlePause={handlePause}
-					onError={onError}
-					AudioIcon={hasAudio ? AudioIcon : null}
-					preloadPartialData={preloadPartialData}
-					showPlayIcon={showPlayIcon}
-					showProgressBar={showProgressBar}
-					subtitleSource={subtitleSource}
-					subtitleSize={subtitleSize}
-					controlsPosition={controlsPosition}
-					activeCue={activeCue}
+				<div
+					css={figureStyles(
+						aspectRatio,
+						aspectRatioOfVisibleVideo,
+						isGreyBarsAtSidesOnDesktop,
+						isGreyBarsAtTopAndBottomOnDesktop,
+						isVideoCroppedAtTopBottom,
+						isVideoCroppedAtLeftRight,
+						containerAspectRatioDesktop,
+					)}
+				>
+					<SelfHostedVideoPlayer
+						sources={sources}
+						atomId={atomId}
+						uniqueId={uniqueId}
+						width={width}
+						height={height}
+						videoStyle={videoStyle}
+						posterImage={optimisedPosterImage}
+						FallbackImageComponent={FallbackImageComponent}
+						currentTime={currentTime}
+						setCurrentTime={setCurrentTime}
+						ref={vidRef}
+						isPlayable={isPlayable}
+						playerState={playerState}
+						isMuted={isMuted}
+						handleLoadedMetadata={handleLoadedMetadata}
+						handleLoadedData={handleLoadedData}
+						handleCanPlay={handleCanPlay}
+						handlePlaying={handlePlaying}
+						handlePlayPauseClick={handlePlayPauseClick}
+						handleAudioClick={handleAudioClick}
+						handleKeyDown={handleKeyDown}
+						handlePause={handlePause}
+						onError={onError}
+						AudioIcon={hasAudio ? AudioIcon : null}
+						preloadPartialData={preloadPartialData}
+						showPlayIcon={showPlayIcon}
+						showProgressBar={showProgressBar}
+						subtitleSource={subtitleSource}
+						subtitleSize={subtitleSize}
+						controlsPosition={controlsPosition}
+						activeCue={activeCue}
+					/>
+				</div>
+			</div>
+			{!!caption && format && (
+				<Caption
+					captionText={caption}
+					format={format}
+					isMainMedia={isMainMedia}
+					mediaType="SelfHostedVideo"
 				/>
-			</figure>
-		</div>
+			)}
+		</figure>
 	);
 };

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -7,7 +7,6 @@ import {
 } from '../lib/video';
 import type { MediaAtomBlockElement } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
-import { Caption } from './Caption';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.importable';
 
@@ -33,36 +32,29 @@ export const SelfHostedVideoInArticle = ({
 	}
 
 	return (
-		<>
-			<Island priority="critical" defer={{ until: 'visible' }}>
-				<SelfHostedVideo
-					atomId={element.id}
-					fallbackImage={posterImageUrl}
-					fallbackImageAlt={caption}
-					fallbackImageAspectRatio={
-						(firstVideoAsset?.aspectRatio ?? '5:4') as FEAspectRatio
-					}
-					fallbackImageLoading="lazy"
-					fallbackImageSize="small"
-					height={firstVideoAsset?.dimensions?.height ?? 400}
-					linkTo="Article-embed-MediaAtomBlockElement"
-					posterImage={posterImageUrl}
-					sources={convertAssetsToVideoSources(element.assets)}
-					subtitleSize="medium"
-					subtitleSource={getSubtitleAsset(element.assets)}
-					videoStyle={videoStyle}
-					uniqueId={element.id}
-					width={firstVideoAsset?.dimensions?.width ?? 500}
-				/>
-			</Island>
-			{!!caption && (
-				<Caption
-					captionText={caption}
-					format={format}
-					isMainMedia={isMainMedia}
-					mediaType="SelfHostedVideo"
-				/>
-			)}
-		</>
+		<Island priority="critical" defer={{ until: 'visible' }}>
+			<SelfHostedVideo
+				atomId={element.id}
+				fallbackImage={posterImageUrl}
+				fallbackImageAlt={caption}
+				fallbackImageAspectRatio={
+					(firstVideoAsset?.aspectRatio ?? '5:4') as FEAspectRatio
+				}
+				fallbackImageLoading="lazy"
+				fallbackImageSize="small"
+				height={firstVideoAsset?.dimensions?.height ?? 400}
+				linkTo="Article-embed-MediaAtomBlockElement"
+				posterImage={posterImageUrl}
+				sources={convertAssetsToVideoSources(element.assets)}
+				subtitleSize="medium"
+				subtitleSource={getSubtitleAsset(element.assets)}
+				videoStyle={videoStyle}
+				uniqueId={element.id}
+				width={firstVideoAsset?.dimensions?.width ?? 500}
+				caption={caption}
+				format={format}
+				isMainMedia={isMainMedia}
+			/>
+		</Island>
 	);
 };


### PR DESCRIPTION
## What does this change?

Moves the looping video caption inside the island.

This changes the structure slightly. 

#### Before

```
<gu-island>
    <div>
        <figure><!-- video player --></figure>
    </div>
</gu-island>
<figcaption><!-- caption --></figcaption>
```

#### After

```
<gu-island>
    <figure>
        <div><!-- video player --></div>
        <figcaption><!-- caption --></figcaption>
    </figure>
</gu-island>
```

## Why?

We got this request from Pip:

> would it be a lot of work to keep the figcaption for any video elements inside the figure element when it is rendered into the page?
> 
> At the moment with Cinemagraphs they render the video & caption separately into the DOM, e.g.
> `<gu-island></gu-island>`
> `<figcaption></figcaption>`
> 
> I'm sure this has been considered – just flagging it makes it harder to handle in interactives and means that the figcaption isn't semantically linked to the figure

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="313" height="279" alt="Screenshot 2026-02-19 at 12 46 23" src="https://github.com/user-attachments/assets/ac7630f6-cc74-4891-b603-e675e726e224" /> | <img width="311" height="279" alt="Screenshot 2026-02-23 at 11 26 31" src="https://github.com/user-attachments/assets/b893094e-48ab-48e3-831c-9c6bbf2f436f" /> |
| <img width="643" height="313" alt="Screenshot 2026-02-19 at 12 46 04" src="https://github.com/user-attachments/assets/83e0bf34-8368-481b-97b0-71c3c35f7940" /> | <img width="638" height="326" alt="Screenshot 2026-02-23 at 11 26 58" src="https://github.com/user-attachments/assets/bb60118f-5566-4af3-b5cb-5a470ea27d75" />  |

## Testing

Tested on CODE.
