### PR TITLE
Add title to quote icon

### DIFF
--- a/dotcom-rendering/src/components/QuoteIcon.tsx
+++ b/dotcom-rendering/src/components/QuoteIcon.tsx
@@ -16,6 +16,7 @@ type Props = {
 export const QuoteIcon = ({ colour }: Props) => (
 	/* This viewBox is narrower than Source’s SvgQuote */
 	<svg viewBox="0 0 22 14" css={base} style={{ fill: colour }}>
+		<title>double quotation mark</title>
 		<path d="M5.255 0h4.75c-.572 4.53-1.077 8.972-1.297 13.941H0C.792 9.104 2.44 4.53 5.255 0Zm11.061 0H21c-.506 4.53-1.077 8.972-1.297 13.941h-8.686c.902-4.837 2.485-9.411 5.3-13.941Z" />
 	</svg>
 );


### PR DESCRIPTION
## What does this change?

Add title to quote icon

## Why?

_The `<title>` SVG element provides an accessible, short-text description of any SVG container element or graphics element.[^1]_

A screen reader will announce the SVG title, instead of simply "image"

[^1]: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/47fbefae-1334-4a37-b94b-22363605cffd
[after]: https://github.com/user-attachments/assets/85c1e4e4-b60d-489c-bc7a-33cc785651df

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
