### PR TITLE
Add `.element-video-immersive` to immersive self-hosted videos

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -21,6 +21,7 @@ import {
 	customYoutubePlayEventName,
 } from '../lib/video';
 import { palette } from '../palette';
+import type { RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Caption } from './Caption';
 import { CardPicture, type Props as CardPictureProps } from './CardPicture';
@@ -250,6 +251,7 @@ type Props = {
 	caption?: string;
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
+	role?: RoleType;
 };
 
 export const SelfHostedVideo = ({
@@ -277,6 +279,7 @@ export const SelfHostedVideo = ({
 	caption,
 	format,
 	isMainMedia,
+	role,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -766,7 +769,9 @@ export const SelfHostedVideo = ({
 
 	return (
 		<figure
-			className={`video-container ${videoStyle.toLocaleLowerCase()}`}
+			className={`video-container ${videoStyle.toLocaleLowerCase()} ${
+				role === 'immersive' ? 'element-video-immersive' : ''
+			}`}
 			data-component="gu-video-loop"
 		>
 			<div

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -5,7 +5,7 @@ import {
 	getFirstVideoAsset,
 	getSubtitleAsset,
 } from '../lib/video';
-import type { MediaAtomBlockElement } from '../types/content';
+import type { MediaAtomBlockElement, RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.importable';
@@ -15,6 +15,7 @@ type SelfHostedVideoInArticleProps = {
 	format: ArticleFormat;
 	isMainMedia: boolean;
 	videoStyle: VideoPlayerFormat;
+	role?: RoleType;
 };
 
 export const SelfHostedVideoInArticle = ({
@@ -22,6 +23,7 @@ export const SelfHostedVideoInArticle = ({
 	format,
 	isMainMedia,
 	videoStyle,
+	role = 'inline',
 }: SelfHostedVideoInArticleProps) => {
 	const posterImageUrl = element.posterImage?.[0]?.url;
 	const caption = element.title;
@@ -54,6 +56,7 @@ export const SelfHostedVideoInArticle = ({
 				caption={caption}
 				format={format}
 				isMainMedia={isMainMedia}
+				role={role}
 			/>
 		</Island>
 	);

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -2809,6 +2809,9 @@
                 },
                 "videoPlayerFormat": {
                     "$ref": "#/definitions/VideoPlayerFormat"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -513,6 +513,7 @@ export const renderElement = ({
 						format={format}
 						isMainMedia={isMainMedia}
 						videoStyle={element.videoPlayerFormat}
+						role={element.role}
 					/>
 				);
 			} else {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2297,6 +2297,9 @@
                 },
                 "videoPlayerFormat": {
                     "$ref": "#/definitions/VideoPlayerFormat"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -456,6 +456,7 @@ export interface MediaAtomBlockElement {
 	title?: string;
 	duration?: number;
 	videoPlayerFormat?: VideoPlayerFormat;
+	role?: RoleType;
 }
 
 export interface MultiImageBlockElement {


### PR DESCRIPTION
## What does this change?

Adds `.element-video-immersive` to self-hosted videos with `role = immersive`

Relies on https://github.com/guardian/frontend/pull/28616

## Why?

Requested by Harry Fischer. We already do it for immersive images.

## How to test

Deploy this branch and https://github.com/guardian/frontend/pull/28616 to CODE. Create an article containing a self-hosted video with weighting set to "Immersive". Preview the article. The `figure` containing the video should have class `element-video-immersive`.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="615" height="205" alt="Screenshot 2026-02-19 at 13 14 39" src="https://github.com/user-attachments/assets/d5bfc985-dc84-48fb-92b0-5f38c6b7fd4d" /> | <img width="631" height="189" alt="Screenshot 2026-02-19 at 15 33 27" src="https://github.com/user-attachments/assets/6c8f6dd9-01a5-438a-8f76-bb91ee3e9e8e" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
