### PR TITLE
Use correct class name for right rail ads

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -160,7 +160,7 @@ const spacefinderAdSlotContainerStyles = css`
 	/*
 		To push inline2+ on desktop to the right column
 	*/
-	.ad-slot-container-right-column {
+	.ad-slot-container--right-column {
 		${from.desktop} {
 			float: right;
 			max-width: 300px;


### PR DESCRIPTION
## What does this change?
Use correct class name for right rail ads
## Why?
typo in the class name
