### PR TITLE
Extend filter AAG test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -87,7 +87,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Testing redesigned at a glance component on The Filter articles",
 		owners: ["thefilter.dev@guardian.co.uk"],
-		expirationDate: "2026-02-25",
+		expirationDate: "2026-04-01",
 		type: "server",
 		status: "ON",
 		audienceSize: 100 / 100,


### PR DESCRIPTION
## What does this change?
Extends the filter AAG test.

## Why? 
We want more data for statistical significance across commissions or split by device