### PR TITLE
Football match stats summary schema and parser

### DIFF
--- a/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
@@ -81,16 +81,14 @@ export const feFootballTeamSummarySchema = object({
 	colours: string(),
 });
 
-export type FEFootballTeamSummarySchema = Output<
-	typeof feFootballTeamSummarySchema
->;
+export type FEFootballTeamSummary = Output<typeof feFootballTeamSummarySchema>;
 
 export const feFootballMatchStatsSummarySchema = object({
 	id: string(),
 	homeTeam: feFootballTeamSummarySchema,
 	awayTeam: feFootballTeamSummarySchema,
 	status: string(),
-	infoUrl: string(),
+	infoURL: string(),
 });
 
 export type FEFootballMatchStatsSummary = Output<


### PR DESCRIPTION
## What does this change?

Adds Valibot schema and parser for football match stats summary data to support the mini match stats summary component on the redesigned football live blog.

Part of #15175