### PR TITLE
Add rel=sponsored to skimlinks in blockquotes

### DIFF
--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -103,7 +103,6 @@ const textElement =
 					key,
 					children,
 				});
-
 			case 'STRONG':
 				return jsx('strong', {
 					css: { fontWeight: 'bold' },


### PR DESCRIPTION
## What does this change?
Adds `rel="sponsored"` to anchor tags that contain skimlinks in blockquotes.

## Why?
The Filter editorial team recently added affiliate links to this piece: https://www.theguardian.com/thefilter/2026/feb/25/reader-coffee-questions-beans-machines-grinders-milk
Because the logic to add `rel="sponsored"` to links is in the text block element code, these links are not currently being tagged correctly as they're within a blockquote.

See https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
