### PR TITLE
extends spacefinder on interactives test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -76,7 +76,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: `2026-02-28`,
 		type: "client",
-		status: "ON",
+		status: "OFF",
 		audienceSize: 20 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -61,7 +61,7 @@ const ABTests: ABTest[] = [
 		name: "commercial-enable-spacefinder-on-interactives",
 		description: "Enable spacefinder on interactive articles on mobile web",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2026-02-28`,
+		expirationDate: `2026-03-14`,
 		type: "client",
 		status: "ON",
 		audienceSize: 0 / 100,


### PR DESCRIPTION
## What does this change?
Extends `enable-spacefinder-on-interactives` AB test by 2 weeks. 

Switching off the `mobile-inline1-halfpage` AB test 
## Why?
We are extending the expiring `enable-spacefinder-on-interactives` AB test by 2 weeks to gather more data

