### PR TITLE
Hide ShowHideButton button by default

### DIFF
--- a/dotcom-rendering/src/components/ShowHideButton.tsx
+++ b/dotcom-rendering/src/components/ShowHideButton.tsx
@@ -20,12 +20,13 @@ const showHideButtonCss = css`
 
 /**
  * This component creates the styled button for showing & hiding a container,
- * The functionality for this is implemented in a single island 'ShownHideContainers.importable'
+ * The functionality for this is implemented in a single island 'ShowHideContainers.importable'
  **/
 export const ShowHideButton = ({ sectionId }: Props) => {
 	return (
 		<ButtonLink
 			priority="secondary"
+			className="hidden"
 			data-link-name="Hide"
 			cssOverrides={showHideButtonCss}
 			data-show-hide-button={sectionId}


### PR DESCRIPTION
## What does this change?

Hides the ShowHide button by default.

## Why?

Previous behaviour:
- For signed out users: the button is shown briefly, then hidden when the JS loads. Showing the button and then removing it causes CLS at the `left-col` breakpoint and sometimes a tiny amount at the `mobile` breakpoint.
- For signed in users: The button is shown immediately, but if the button is clicked before the JS has loaded, nothing happens. Now, we only display the button once the JS has loaded. However, there is more CLS than before at the two breakpoints mentioned above.
 
## Screenshots

<img width="1356" height="301" alt="Screenshot 2026-02-27 at 11 49 09" src="https://github.com/user-attachments/assets/98c3cbbf-68b6-475e-bb94-5340496a4825" />
