### PR TITLE
Double click to full screen on video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -321,6 +321,8 @@ export const SelfHostedVideo = ({
 	 */
 	const isCinemagraph = videoStyle === 'Cinemagraph';
 
+	const isLoop = videoStyle === 'Loop';
+
 	const singleClickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
@@ -651,8 +653,12 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleFullscreenClick = (event: React.SyntheticEvent) => {
-		if (singleClickTimerRef.current) {
-			clearTimeout(singleClickTimerRef.current);
+		if (isCinemagraph || isLoop) return;
+
+		{
+			if (singleClickTimerRef.current) {
+				clearTimeout(singleClickTimerRef.current);
+			}
 		}
 
 		void submitClickComponentEvent(event.currentTarget, renderingTarget);

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -870,7 +870,6 @@ export const SelfHostedVideo = ({
 						preloadPartialData={preloadPartialData}
 						showPlayIcon={showPlayIcon}
 						showProgressBar={showProgressBar}
-						showFullscreenIcon={videoStyle === 'Default'}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}
 						controlsPosition={controlsPosition}

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -655,13 +655,12 @@ export const SelfHostedVideo = ({
 	const handleFullscreenClick = (event: React.SyntheticEvent) => {
 		if (isCinemagraph || isLoop) return;
 
-		{
-			if (singleClickTimerRef.current) {
-				clearTimeout(singleClickTimerRef.current);
-			}
+		if (singleClickTimerRef.current) {
+			clearTimeout(singleClickTimerRef.current);
 		}
 
 		void submitClickComponentEvent(event.currentTarget, renderingTarget);
+
 		event.stopPropagation(); // Don't pause the video
 		const video = vidRef.current;
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.importable.tsx
@@ -870,6 +870,7 @@ export const SelfHostedVideo = ({
 						preloadPartialData={preloadPartialData}
 						showPlayIcon={showPlayIcon}
 						showProgressBar={showProgressBar}
+						showFullscreenIcon={videoStyle === 'Default'}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}
 						controlsPosition={controlsPosition}

--- a/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
@@ -152,9 +152,9 @@ export const InteractionObserver: Story = {
 	},
 } satisfies Story;
 
-export const FullscreenOpen: Story = {
+export const FullscreenButtonOpen: Story = {
 	...Loop5to4,
-	name: 'Open fullscreen',
+	name: 'Open fullscreen with button',
 	args: {
 		...Loop5to4.args,
 		videoStyle: 'Default',
@@ -181,9 +181,48 @@ export const FullscreenOpen: Story = {
 			'requestFullscreen',
 		);
 
-		await canvas.findByTestId('fullscreen-icon');
+		const fullscreenIcon = await canvas.findByTestId('fullscreen-icon');
 
-		await userEvent.click(canvas.getByTestId('fullscreen-icon'));
+		await userEvent.click(fullscreenIcon);
+
+		await expect(requestFullscreenSpy).toHaveBeenCalled();
+	},
+} satisfies Story;
+
+export const FullscreenDoubleClickOpen: Story = {
+	...Loop5to4,
+	name: 'Open fullscreen with a double click',
+	args: {
+		...Loop5to4.args,
+		videoStyle: 'Default',
+	},
+	parameters: {
+		test: {
+			// The following error is received without this flag: "TypeError: ophan.trackClickComponentEvent is not a function"
+			dangerouslyIgnoreUnhandledErrors: true,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		/**
+		 * Ideally, this interaction test would open and close fullscreen.
+		 * However, the Fullscreen API is not implemented in jsdom, so
+		 * document.fullscreenElement will always be null regardless of what the
+		 * component does. Instead, we spy on requestFullscreen to ensure
+		 * that the correct handler is invoked when the fullscreen button is clicked.
+		 */
+
+		const canvas = within(canvasElement);
+
+		const requestFullscreenSpy = spyOn(
+			HTMLElement.prototype,
+			'requestFullscreen',
+		);
+
+		const selfHostedPlayer = await canvas.findByTestId(
+			'self-hosted-video-player',
+		);
+
+		await userEvent.dblClick(selfHostedPlayer);
 
 		await expect(requestFullscreenSpy).toHaveBeenCalled();
 	},

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -245,6 +245,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					}}
 					onPause={handlePause}
 					onClick={handlePlayPauseClick}
+					onDoubleClick={handleFullscreenClick}
 					onKeyDown={handleKeyDown}
 					onError={onError}
 				>


### PR DESCRIPTION
## What does this change? 
Adds the ability to double-click on a video to go to fullscreen. This is currently guarded so that this functionality only works on self hosted default videos, not loops or cinemagraphs. This works by using reacts onDoubleClick handler to call handleFullscreenClick.

## Why does this require a delay to play/pause? 
clicks are registered as click -> click -> double click. This means our existing single-click play/pause handler would fire twice before the dblclick event is emitted (eg pause -> play -> fullscreen).

To prevent this, a 250ms delay has been introduced to the single-click play/pause handler. 250ms is roughly the threshold for a double click. 

### How it works

On first click start a 250ms timer.
1. If a second click occurs within that window:
- The timer is cancelled.
- Play/pause is never triggered.
- The onDoubleClick handler runs and enters fullscreen.
2. If no second click occurs:
- The timer completes.
- Play/pause executes as normal.


## Why? 
This aligns the video experience more closely with common desktop video player behaviour (e.g. YouTube).

## Screenshots

### Without the delay to single click
https://github.com/user-attachments/assets/75f2accd-ab2f-422f-a04c-10950428570a

### With the delay to single click
https://github.com/user-attachments/assets/0d60862b-6e7d-41bc-b3da-2825bccfbb61

## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
