### PR TITLE
fix restrict designable banner v2 article count to >= 5 articles

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/bannerSelectors.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/bannerSelectors.ts
@@ -14,6 +14,7 @@ type BuildBannerSelectorsArgs = {
 	tickerSettings?: BannerRenderProps['tickerSettings'];
 	separateArticleCount?: boolean;
 	separateArticleCountSettings?: BannerRenderProps['separateArticleCountSettings'];
+	articleCounts: BannerRenderProps['articleCounts'];
 };
 
 export const buildBannerSelectors = ({
@@ -26,6 +27,7 @@ export const buildBannerSelectors = ({
 	tickerSettings,
 	separateArticleCount,
 	separateArticleCountSettings,
+	articleCounts,
 }: BuildBannerSelectorsArgs): BannerSelectors => {
 	const copyForViewport = isTabletOrAbove
 		? content.mainContent
@@ -60,7 +62,8 @@ export const buildBannerSelectors = ({
 		!!settings.tickerStylingSettings;
 	const showArticleCount =
 		!isCollapsed &&
-		Boolean(separateArticleCountSettings ?? separateArticleCount);
+		Boolean(separateArticleCountSettings ?? separateArticleCount) &&
+		articleCounts.forTargetedWeeks >= 5;
 	const showBodyVisual = !!settings.imageSettings && !isCollapsed;
 	const showHeaderImage = !!settings.headerSettings?.headerImage;
 

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/tests/Banner.test.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/tests/Banner.test.tsx
@@ -233,7 +233,7 @@ describe('DesignableBanner V2', () => {
 		expect(screen.getByText('£20')).toBeInTheDocument();
 	});
 
-	it('renders article count when separateArticleCount is true', () => {
+	it('renders article count when separateArticleCount is true and >= 5 articles', () => {
 		const articleCountProps: BannerRenderProps = {
 			...mockProps,
 			separateArticleCount: true,
@@ -249,5 +249,22 @@ describe('DesignableBanner V2', () => {
 		// Usually it's something like "You've read 5 articles..."
 		expect(screen.getByText(/You've read/)).toBeInTheDocument();
 		expect(screen.getByText(/5/)).toBeInTheDocument();
+	});
+
+	it('does not render article count when separateArticleCount is true but user has read < 5 articles', () => {
+		const articleCountProps: BannerRenderProps = {
+			...mockProps,
+			separateArticleCount: true,
+			articleCounts: {
+				forTargetedWeeks: 4,
+				for52Weeks: 10,
+			},
+		};
+
+		render(<BannerComponent {...articleCountProps} />);
+
+		// Should not be in the document
+		expect(screen.queryByText(/You've read/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/4/)).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts
@@ -346,6 +346,7 @@ export const useDesignableBannerModel = ({
 			tickerSettings,
 			separateArticleCount,
 			separateArticleCountSettings,
+			articleCounts,
 		});
 
 		return {


### PR DESCRIPTION
During the recent refactoring of the designable banner into the v2 architecture, the logic that restricted the article count message to only display for users who have read at least 5 articles was inadvertently dropped. This PR restores that condition.

**Changes:**
- Updated [buildBannerSelectors](cci:1://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/bannerSelectors.ts:19:0-83:2) in [bannerSelectors.ts](cci:7://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/bannerSelectors.ts:0:0-0:0) to accept `articleCounts` and ensure `showArticleCount` is only `true` when `articleCounts.forTargetedWeeks >= 5`.
- Passed `articleCounts` into [buildBannerSelectors](cci:1://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/bannerSelectors.ts:19:0-83:2) within the [useDesignableBannerModel](cci:1://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts:105:0-403:2) hook.
- Added test cases in [Banner.test.tsx](cci:7://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/tests/Banner.test.tsx:0:0-0:0) to explicitly verify that the article count message does not render for users with fewer than 5 articles read.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213489652011371