### PR TITLE
Run AdmiralScript after CMP is booted

### DIFF
--- a/dotcom-rendering/src/components/AdmiralScript.importable.tsx
+++ b/dotcom-rendering/src/components/AdmiralScript.importable.tsx
@@ -229,82 +229,95 @@ export const AdmiralScript = () => {
 		 * Control group loads the script but the modal will not be shown.
 		 */
 		const page = window.guardian.config.page;
+		if (!window.guardian.config.switches.consentManagement) return;
 
-		const shouldRun =
-			cmp.hasInitialised() &&
-			!cmp.willShowPrivacyMessageSync() &&
-			isInUsa() &&
-			isInControlGroup &&
-			!getCookie({
-				name: 'gu_hide_support_messaging',
-				shouldMemoize: true,
-			}) &&
-			!page.shouldHideAdverts &&
-			!page.shouldHideReaderRevenue &&
-			!page.isSensitive &&
-			page.sponsorshipType !== 'paid-content' &&
-			![
-				'about',
-				'info',
-				'membership',
-				'help',
-				'guardian-live-australia',
-				'gnm-archive',
-				'guardian-labs',
-				'thefilter',
-			].includes(page.section ?? '');
-		if (!shouldRun) return;
+		let admiralScript: HTMLScriptElement | undefined;
+		let isCancelled = false;
 
-		// Record INSERT Ophan event
-		void recordAdmiralOphanEvent(
-			variantName,
-			{
-				action: 'INSERT',
-			},
-			renderingTarget,
-		);
+		const initialiseAdmiral = async () => {
+			try {
+				const willShowPrivacyMessage =
+					await cmp.willShowPrivacyMessage();
 
-		// Initialize Admiral Adblock Recovery
-		log('dotcom', '🛡️ Initialising Admiral Adblock Recovery');
+				const shouldRun =
+					!willShowPrivacyMessage &&
+					isInUsa() &&
+					isInControlGroup &&
+					!getCookie({
+						name: 'gu_hide_support_messaging',
+						shouldMemoize: true,
+					}) &&
+					!page.shouldHideAdverts &&
+					!page.shouldHideReaderRevenue &&
+					!page.isSensitive &&
+					page.sponsorshipType !== 'paid-content' &&
+					![
+						'about',
+						'info',
+						'membership',
+						'help',
+						'guardian-live-australia',
+						'gnm-archive',
+						'guardian-labs',
+						'thefilter',
+					].includes(page.section ?? '');
 
-		// Set up window.admiral stub
-		// This initializes admiral before the bootstrap script loads
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required for Admiral stub initialization
-		type AdmiralStub = Admiral & { q?: any[] };
-		const w = window as Window & { admiral?: AdmiralStub };
+				if (!shouldRun || isCancelled) return;
 
-		if (!w.admiral) {
-			// Create the Admiral stub function with queue
-			const stub = function (...args: unknown[]) {
-				if (!stub.q) stub.q = [];
-				stub.q.push(args);
-			} as AdmiralStub;
-			w.admiral = stub;
-		}
+				void recordAdmiralOphanEvent(
+					variantName,
+					{
+						action: 'INSERT',
+					},
+					renderingTarget,
+				);
 
-		log('dotcom', '🛡️ Setting up Admiral event logger');
+				log('dotcom', '🛡️ Initialising Admiral Adblock Recovery');
 
-		// Set up Admiral event logging
-		setUpAdmiralEventLogger(w.admiral, variantName, renderingTarget);
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required for Admiral stub initialization
+				type AdmiralStub = Admiral & { q?: any[] };
+				const w = window as Window & { admiral?: AdmiralStub };
 
-		// Set AB test targeting
-		if (variantName) {
-			w.admiral('targeting', 'set', 'guAbTest', variantName);
-		}
+				if (!w.admiral) {
+					const stub = function (...args: unknown[]) {
+						if (!stub.q) stub.q = [];
+						stub.q.push(args);
+					} as AdmiralStub;
+					w.admiral = stub;
+				}
 
-		// Load Admiral bootstrap script
-		const BASE_AJAX_URL = window.guardian.config.page.ajaxUrl;
+				log('dotcom', '🛡️ Setting up Admiral event logger');
+				setUpAdmiralEventLogger(
+					w.admiral,
+					variantName,
+					renderingTarget,
+				);
 
-		const admiralScript = document.createElement('script');
-		admiralScript.src = `${BASE_AJAX_URL}/commercial/admiral-bootstrap.js`;
-		admiralScript.async = true;
-		document.head.appendChild(admiralScript);
+				if (variantName) {
+					w.admiral('targeting', 'set', 'guAbTest', variantName);
+				}
 
-		log('dotcom', '🛡️ Admiral initialization complete');
+				const BASE_AJAX_URL = window.guardian.config.page.ajaxUrl;
+				admiralScript = document.createElement('script');
+				admiralScript.src = `${BASE_AJAX_URL}/commercial/admiral-bootstrap.js`;
+				admiralScript.async = true;
+				document.head.appendChild(admiralScript);
+
+				log('dotcom', '🛡️ Admiral initialization complete');
+			} catch (error) {
+				log(
+					'dotcom',
+					'🛡️ Admiral - Error waiting for CMP readiness:',
+					error,
+				);
+			}
+		};
+
+		void initialiseAdmiral();
 
 		return () => {
-			// Clean up Admiral bootstrap script
-			admiralScript.parentNode?.removeChild(admiralScript);
+			isCancelled = true;
+			admiralScript?.parentNode?.removeChild(admiralScript);
 		};
 	}, [isInControlGroup, variantName, renderingTarget]);
 


### PR DESCRIPTION
## What does this change?
This change refactors Admiral initialisation to wait on async CMP readiness via cmp.willShowPrivacyMessage() instead of relying on cmp.hasInitialised() + cmp.willShowPrivacyMessageSync().
Adds an early return when consentManagement is disabled, matching CMP boot behaviour.
Keeps existing Admiral eligibility rules intact (US only, control group, cookie/page/sponsorship/section guards).
Adds safe async cleanup with cancellation + optional script removal to avoid post-unmount side effects.

## Why?
After migrating Admiral to the new AB test framework, behavior diverged between CODE and PROD:
In CODE for users in growth-admiral-adblock-recovery:control Admiral was loaded, in PROD was not.
Root cause is a timing race: AdmiralScript can hydrate before CMP has completed async boot cmp.init, causing the one-time eligibility check to fail early.

This change removes that race by ensuring Admiral only evaluates once CMP is definitely ready.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
