### PR TITLE
Reduce font size of primary container titles at mobile breakpoints

### DIFF
--- a/dotcom-rendering/src/components/ContainerTitle.tsx
+++ b/dotcom-rendering/src/components/ContainerTitle.tsx
@@ -41,7 +41,10 @@ const headerStyles = css`
 `;
 
 const primaryTitleStyles = css`
-	${headlineBold28};
+	${headlineBold24};
+	${from.tablet} {
+		${headlineBold28};
+	}
 `;
 const secondaryTitleStyles = css`
 	${textSansBold17};


### PR DESCRIPTION
## What does this change?
Reduce font size of primary container titles at mobile breakpoints from 28px -> to 24px.

## Why?
This is according to designs https://www.figma.com/design/uNL0UL65eoC80JPrglYrAx/Fairground---Flexible-Containers?node-id=5254-41049&t=TJfphF3E1MmPqMPJ-0 and aligns with apps

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/965f38f8-3e1a-42be-a67e-02a5416afe5e
[after]: https://github.com/user-attachments/assets/6673fde0-97c6-4f75-b9d1-d8aaee2042ac


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
