### PR TITLE
Hide old match nav and tabs when in redesign test group

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -505,41 +505,47 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 							isInFootballRedesignVariantGroup
 						}
 					>
-						<GridItem area="matchNav" element="aside">
-							<div css={maxWidth}>
-								{isMatchReport && (
-									<Island
-										priority="feature"
-										defer={{ until: 'visible' }}
-									>
-										<GetMatchNav
-											matchUrl={footballMatchUrl}
-											format={format}
-											headlineString={article.headline}
-											tags={article.tags}
-											webPublicationDateDeprecated={
-												article.webPublicationDateDeprecated
-											}
-										/>
-									</Island>
-								)}
-							</div>
-						</GridItem>
-						<GridItem area="matchtabs" element="aside">
-							<div css={maxWidth}>
-								{isMatchReport && (
-									<Island
-										priority="critical"
-										defer={{ until: 'visible' }}
-									>
-										<GetMatchTabs
-											matchUrl={footballMatchUrl}
-											format={format}
-										/>
-									</Island>
-								)}
-							</div>
-						</GridItem>
+						{!isInFootballRedesignVariantGroup && (
+							<>
+								<GridItem area="matchNav" element="aside">
+									<div css={maxWidth}>
+										{isMatchReport && (
+											<Island
+												priority="feature"
+												defer={{ until: 'visible' }}
+											>
+												<GetMatchNav
+													matchUrl={footballMatchUrl}
+													format={format}
+													headlineString={
+														article.headline
+													}
+													tags={article.tags}
+													webPublicationDateDeprecated={
+														article.webPublicationDateDeprecated
+													}
+												/>
+											</Island>
+										)}
+									</div>
+								</GridItem>
+								<GridItem area="matchtabs" element="aside">
+									<div css={maxWidth}>
+										{isMatchReport && (
+											<Island
+												priority="critical"
+												defer={{ until: 'visible' }}
+											>
+												<GetMatchTabs
+													matchUrl={footballMatchUrl}
+													format={format}
+												/>
+											</Island>
+										)}
+									</div>
+								</GridItem>
+							</>
+						)}
 						<GridItem area="media">
 							<div css={!isMedia && maxWidth}>
 								<MainMedia


### PR DESCRIPTION
## What does this change?

No longer renders the old match nav and tab components when in the redesign test group as these are replaced by the new match header component.

Currently the grid areas for these component are not created when in the test group, but the components are still rendered so they appear partially off-screen, outside of the main content area.

## Screenshots

<img width="1542" height="636" alt="Screenshot 2026-03-04 at 17 18 09" src="https://github.com/user-attachments/assets/0f5d1c94-a4de-4315-acdf-4561c690f308" />
