### PR TITLE
Revert "Enhance message picker & fire new event for `banner:sign-in-gate`"

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.importable.tsx
@@ -18,7 +18,11 @@ import {
 	BrazeBannersSystemPlacementId,
 	buildBrazeBannersSystemConfig,
 } from '../lib/braze/BrazeBannersSystem';
-import type { CandidateConfig, SlotConfig } from '../lib/messagePicker';
+import type {
+	CandidateConfig,
+	MaybeFC,
+	SlotConfig,
+} from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
 import { useBetaAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
@@ -61,7 +65,7 @@ const buildReaderRevenueEpicConfig = (
 		candidate: {
 			id: 'reader-revenue-banner',
 			canShow: () => canShowReaderRevenueEpic(canShowData),
-			show: (data: ModuleData<EpicProps>) => {
+			show: (data: ModuleData<EpicProps>) => () => {
 				return <ReaderRevenueEpic {...data} />;
 			},
 		},
@@ -89,7 +93,7 @@ const buildBrazeEpicConfig = (
 					tags,
 					shouldHideReaderRevenue,
 				),
-			show: (meta: any) => (
+			show: (meta: any) => () => (
 				<MaybeBrazeEpic
 					meta={meta}
 					countryCode={countryCode}
@@ -201,13 +205,7 @@ export const SlotBodyEnd = ({
 			name: 'slotBodyEnd',
 		};
 		pickMessage(epicConfig, renderingTarget)
-			.then((result) => {
-				if (result.type === 'MessageSelected') {
-					setSelectedEpic(result.SelectedMessage);
-				} else {
-					setSelectedEpic(() => null);
-				}
-			})
+			.then((PickedEpic: () => MaybeFC) => setSelectedEpic(PickedEpic))
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),
 			);

--- a/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.importable.tsx
@@ -15,7 +15,7 @@ import {
 } from '../lib/braze/BrazeBannersSystem';
 import type {
 	CandidateConfig,
-	PickMessageResult,
+	MaybeFC,
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
@@ -177,9 +177,9 @@ const buildRRBannerConfigWith = ({
 						pageId,
 						inHoldbackGroup,
 					}),
-				show: ({ name, props }: ModuleData<BannerProps>) => (
-					<BannerComponent name={name} props={props} />
-				),
+				show:
+					({ name, props }: ModuleData<BannerProps>) =>
+					() => <BannerComponent name={name} props={props} />,
 			},
 			timeoutMillis: DEFAULT_BANNER_TIMEOUT_MILLIS,
 		};
@@ -195,7 +195,7 @@ const buildSignInGateConfig = (
 		canShow: async () => {
 			return await canShowSignInGatePortal(canShowProps);
 		},
-		show: (meta: AuxiaGateDisplayData) => (
+		show: (meta: AuxiaGateDisplayData) => () => (
 			<SignInGatePortal
 				host={host}
 				isPaidContent={canShowProps.isPaidContent}
@@ -233,7 +233,7 @@ const buildBrazeBanner = (
 				tags,
 				shouldHideReaderRevenue,
 			),
-		show: (meta: BrazeMeta) => (
+		show: (meta: BrazeMeta) => () => (
 			<BrazeBanner meta={meta} idApiUrl={idApiUrl} />
 		),
 	},
@@ -282,9 +282,9 @@ export const StickyBottomBanner = ({
 		'control',
 	);
 
-	const [pickMessageResult, setPickMessageResult] =
-		useState<PickMessageResult | null>(null);
-
+	const [SelectedBanner, setSelectedBanner] = useState<MaybeFC | null>(null);
+	const [hasPickMessageCompleted, setHasPickMessageCompleted] =
+		useState<boolean>(false);
 	const [asyncArticleCounts, setAsyncArticleCounts] =
 		useState<Promise<ArticleCounts | undefined>>();
 
@@ -396,8 +396,9 @@ export const StickyBottomBanner = ({
 		};
 
 		pickMessage(bannerConfig, renderingTarget)
-			.then((result) => {
-				setPickMessageResult(result);
+			.then((PickedBanner: () => MaybeFC) => {
+				setSelectedBanner(PickedBanner);
+				setHasPickMessageCompleted(true);
 			})
 			.catch((e) => {
 				// Report error to Sentry
@@ -408,6 +409,7 @@ export const StickyBottomBanner = ({
 					new Error(msg),
 					'sticky-bottom-banner',
 				);
+				setHasPickMessageCompleted(true);
 			});
 	}, [
 		isSignedIn,
@@ -435,27 +437,16 @@ export const StickyBottomBanner = ({
 		abTests,
 	]);
 
-	/**
-	 * Custom events for commercial purposes to avoid the mobile-sticky ad slot clashing with these banners
-	 * Dispatches events when no banner is due to appear and when the sign in gate is the chosen banner
-	 * Please talk to @guardian/commercial-dev before changing this logic
-	 */
+	// Dispatches 'banner:none' event for mobile sticky ad integration (see @guardian/commercial-dev).
+	// Ensures ads only insert when no banner will be shown.
+	// hasPickMessageCompleted distinguishes between initial state (not picked yet) and final state (picked nothing).
 	useEffect(() => {
-		if (pickMessageResult?.type === 'NoMessageSelected') {
+		if (hasPickMessageCompleted && SelectedBanner == null) {
 			document.dispatchEvent(new CustomEvent('banner:none'));
 		}
-
-		if (
-			pickMessageResult?.type === 'MessageSelected' &&
-			pickMessageResult.messageId === 'sign-in-gate-portal'
-		) {
-			document.dispatchEvent(new CustomEvent('banner:sign-in-gate'));
-		}
-	}, [pickMessageResult]);
-
-	if (pickMessageResult?.type === 'MessageSelected') {
-		const { SelectedMessage } = pickMessageResult;
-		return <SelectedMessage />;
+	}, [SelectedBanner, hasPickMessageCompleted]);
+	if (SelectedBanner) {
+		return <SelectedBanner />;
 	}
 
 	return null;

--- a/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
+++ b/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
@@ -273,7 +273,7 @@ export const buildBrazeBannersSystemConfig = (
 					tags,
 				);
 			},
-			show: (meta: BrazeBannersSystemMeta) => (
+			show: (meta: BrazeBannersSystemMeta) => () => (
 				<BrazeBannersSystemDisplay
 					meta={meta}
 					idApiUrl={idApiUrl}

--- a/dotcom-rendering/src/lib/messagePicker.test.tsx
+++ b/dotcom-rendering/src/lib/messagePicker.test.tsx
@@ -23,7 +23,7 @@ afterEach(async () => {
 describe('pickMessage', () => {
 	it('resolves with the highest priority message which can show', async () => {
 		const MockComponent = () => <div />;
-		const ChosenMockComponent = () => <div id="chosen" />;
+		const ChosenMockComponent = () => <div />;
 		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
@@ -31,7 +31,7 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-1',
 						canShow: () => Promise.resolve({ show: false }),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -40,7 +40,7 @@ describe('pickMessage', () => {
 						id: 'banner-2',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: ChosenMockComponent,
+						show: () => ChosenMockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -49,20 +49,16 @@ describe('pickMessage', () => {
 						id: 'banner-3',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 				},
 			],
 		};
 
-		const pickMessageResult = await pickMessage(config, 'Web');
-		expect(pickMessageResult.type).toEqual('MessageSelected');
-		if (pickMessageResult.type === 'MessageSelected') {
-			expect(pickMessageResult.SelectedMessage()).toEqual(
-				ChosenMockComponent(),
-			);
-		}
+		const got = await pickMessage(config, 'Web');
+
+		expect(got()).toEqual(ChosenMockComponent);
 	});
 
 	it('resolves with null if no messages can show', async () => {
@@ -75,7 +71,7 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-1',
 						canShow: () => Promise.resolve({ show: false }),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -83,21 +79,21 @@ describe('pickMessage', () => {
 					candidate: {
 						id: 'banner-2',
 						canShow: () => Promise.resolve({ show: false }),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 				},
 			],
 		};
 
-		const pickMessageResult = await pickMessage(config, 'Web');
+		const got = await pickMessage(config, 'Web');
 
-		expect(pickMessageResult.type).toEqual('NoMessageSelected');
+		expect(got()).toEqual(null);
 	});
 
 	it('falls through to a lower priority message when a higher one times out', async () => {
 		const MockComponent = () => <div />;
-		const ChosenMockComponent = () => <div id="chosen" />;
+		const ChosenMockComponent = () => <div />;
 		const config: SlotConfig = {
 			name: 'banner',
 			candidates: [
@@ -115,7 +111,7 @@ describe('pickMessage', () => {
 									500,
 								),
 							),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -124,7 +120,7 @@ describe('pickMessage', () => {
 						id: 'banner-2',
 						canShow: () =>
 							Promise.resolve({ show: true, meta: undefined }),
-						show: ChosenMockComponent,
+						show: () => ChosenMockComponent,
 					},
 					timeoutMillis: null,
 				},
@@ -133,14 +129,9 @@ describe('pickMessage', () => {
 
 		const messagePromise = pickMessage(config, 'Web');
 		jest.advanceTimersByTime(260);
+		const got = await messagePromise;
 
-		const pickMessageResult = await messagePromise;
-		expect(pickMessageResult.type).toEqual('MessageSelected');
-		if (pickMessageResult.type === 'MessageSelected') {
-			expect(pickMessageResult.SelectedMessage()).toEqual(
-				ChosenMockComponent(),
-			);
-		}
+		expect(got()).toEqual(ChosenMockComponent);
 	});
 
 	it('resolves with null if all messages time out', async () => {
@@ -164,7 +155,7 @@ describe('pickMessage', () => {
 									500,
 								);
 							}),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -182,7 +173,7 @@ describe('pickMessage', () => {
 									500,
 								);
 							}),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: 250,
 				},
@@ -193,14 +184,14 @@ describe('pickMessage', () => {
 		jest.advanceTimersByTime(260);
 		const got = await messagePromise;
 
-		expect(got.type).toEqual('NoMessageSelected');
+		expect(got()).toEqual(null);
 
 		clearTimeout(timer1);
 		clearTimeout(timer2);
 	});
 
 	it('passes metadata returned by canShow to show', async () => {
-		const renderComponent = jest.fn(() => <div />);
+		const renderComponent = jest.fn(() => () => <div />);
 		const meta = { extra: 'info' };
 		const config: SlotConfig = {
 			name: 'banner',
@@ -221,10 +212,7 @@ describe('pickMessage', () => {
 		};
 
 		const show = await pickMessage(config, 'Web');
-		expect(show.type).toEqual('MessageSelected');
-		if (show.type === 'MessageSelected') {
-			expect(show.SelectedMessage()).toEqual(renderComponent());
-		}
+		show();
 
 		expect(renderComponent).toHaveBeenCalledWith(meta);
 	});
@@ -249,7 +237,7 @@ describe('pickMessage', () => {
 									300,
 								);
 							}),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: 200,
 				},
@@ -260,7 +248,7 @@ describe('pickMessage', () => {
 		jest.advanceTimersByTime(250);
 		const got = await messagePromise;
 
-		expect(got.type).toEqual('NoMessageSelected');
+		expect(got()).toEqual(null);
 
 		expect(ophanRecordSpy).toHaveBeenCalledWith({
 			component: 'banner-picker-timeout-dcr',
@@ -290,7 +278,7 @@ describe('pickMessage', () => {
 									120,
 								);
 							}),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 					reportTiming: true,
@@ -309,7 +297,7 @@ describe('pickMessage', () => {
 									100,
 								);
 							}),
-						show: MockComponent,
+						show: () => MockComponent,
 					},
 					timeoutMillis: null,
 				},

--- a/dotcom-rendering/src/lib/messagePicker.ts
+++ b/dotcom-rendering/src/lib/messagePicker.ts
@@ -2,7 +2,7 @@ import { isUndefined, startPerformanceMeasure } from '@guardian/libs';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
 
-export type MaybeFC = React.ReactNode | null;
+export type MaybeFC = React.FC | null;
 type ShowMessage<T> = (meta: T) => MaybeFC;
 
 interface ShouldShow<T> {
@@ -114,6 +114,8 @@ const timeoutify = <T>(
 const clearAllTimeouts = (messages: CandidateConfigWithTimeout<any>[]) =>
 	messages.map((m) => m.cancelTimeout());
 
+const defaultShow = () => null;
+
 interface PendingMessage<T> {
 	candidateConfig: CandidateConfigWithTimeout<T>;
 	canShow: Promise<CanShowResult<T>>;
@@ -124,21 +126,10 @@ interface WinningMessage<T> {
 	candidate: Candidate<T>;
 }
 
-interface NoMessageSelected {
-	type: 'NoMessageSelected';
-}
-interface MessageSelected {
-	type: 'MessageSelected';
-	messageId: string;
-	// The react component is optional because sometimes we selected a message for this slot, but there is nothing to render
-	SelectedMessage: () => MaybeFC;
-}
-export type PickMessageResult = NoMessageSelected | MessageSelected;
-
 export const pickMessage = (
 	{ candidates, name }: SlotConfig,
 	renderingTarget: RenderingTarget,
-): Promise<PickMessageResult> =>
+): Promise<() => MaybeFC> =>
 	new Promise((resolve) => {
 		const candidateConfigsWithTimeout = candidates.map((c) =>
 			timeoutify(c, name, renderingTarget),
@@ -174,18 +165,13 @@ export const pickMessage = (
 				clearAllTimeouts(candidateConfigsWithTimeout);
 
 				if (winner === null) {
-					resolve({ type: 'NoMessageSelected' });
+					resolve(defaultShow);
 				} else {
 					const { candidate, meta } = winner;
-					resolve({
-						type: 'MessageSelected',
-						messageId: candidate.id,
-						SelectedMessage: () => candidate.show(meta),
-					});
+					resolve(() => candidate.show(meta));
 				}
 			})
-			.catch((e) => {
-				console.error(`pickMessage winner - error: ${String(e)}`);
-				resolve({ type: 'NoMessageSelected' });
-			});
+			.catch((e) =>
+				console.error(`pickMessage winner - error: ${String(e)}`),
+			);
 	});


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#15380 due to reported lack of epics being displayed on the site