### PR TITLE
Add `CallToActionAtomBlockElement` for Hosted Content

### DIFF
--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -618,6 +618,9 @@
                     "$ref": "#/definitions/CalloutBlockElementV2"
                 },
                 {
+                    "$ref": "#/definitions/CallToActionAtomBlockElement"
+                },
+                {
                     "$ref": "#/definitions/ReporterCalloutBlockElement"
                 },
                 {
@@ -1557,6 +1560,46 @@
                 "name",
                 "urlPrefix",
                 "value"
+            ]
+        },
+        "CallToActionAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.CallToActionAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "trackingCode": {
+                    "type": "string"
+                },
+                "btnText": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "id",
+                "title",
+                "url"
             ]
         },
         "ReporterCalloutBlockElement": {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -100,6 +100,9 @@
                     "$ref": "#/definitions/CalloutBlockElementV2"
                 },
                 {
+                    "$ref": "#/definitions/CallToActionAtomBlockElement"
+                },
+                {
                     "$ref": "#/definitions/ReporterCalloutBlockElement"
                 },
                 {
@@ -1039,6 +1042,46 @@
                 "name",
                 "urlPrefix",
                 "value"
+            ]
+        },
+        "CallToActionAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.CallToActionAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "trackingCode": {
+                    "type": "string"
+                },
+                "btnText": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "id",
+                "title",
+                "url"
             ]
         },
         "ReporterCalloutBlockElement": {

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -112,6 +112,18 @@ export interface CalloutBlockElementV2 {
 	contacts?: CalloutContactType[];
 }
 
+export interface CallToActionAtomBlockElement {
+	_type: 'model.dotcomrendering.pageElements.CallToActionAtomBlockElement';
+	elementId: string;
+	id: string;
+	title: string;
+	url: string;
+	image?: string;
+	label?: string;
+	trackingCode?: string;
+	btnText?: string;
+}
+
 export interface ReporterCalloutBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ReporterCalloutBlockElement';
 	elementId: string;
@@ -827,6 +839,7 @@ export type FEElement =
 	| CaptionBlockElement
 	| CalloutBlockElement
 	| CalloutBlockElementV2
+	| CallToActionAtomBlockElement
 	| ReporterCalloutBlockElement
 	| CartoonBlockElement
 	| ChartAtomBlockElement


### PR DESCRIPTION
## What does this change?

This PR adds the `CallToActionAtomBlockElement` to be used for Hosted Content. This is the second PR to migrate the `CallToAction` to DCAR as part of the Hosted Content migration work. 

Here is the first PR https://github.com/guardian/frontend/pull/28653

I tested locally and we don't get the error 500 anymore that we got in the Frontend PR and the page renders as expected after the changes. 

## Why?

Migrating the `CallToAction` atom to DCAR as part of the Hosted Content migration work.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/dd511575-5e96-4121-b2d9-049cd47b484b
[after]: https://github.com/user-attachments/assets/fac5f008-6793-47a1-9710-a415d33d8c67

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
