### PR TITLE
Add an apps autoplay check

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -9,8 +9,10 @@ import {
 	submitComponentEvent,
 } from '../client/ophan/ophan';
 import type { ArticleFormat } from '../lib/articleFormat';
+import { getVideoClient } from '../lib/bridgetApi';
 import { getZIndex } from '../lib/getZIndex';
 import { generateImageURL } from '../lib/image';
+import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
@@ -269,6 +271,46 @@ type Props = {
 	role?: RoleType;
 };
 
+const doesUserPermitAutoplayOnWeb = (): boolean => {
+	/**
+	 * The user indicates a preference for reduced motion: https://web.dev/articles/prefers-reduced-motion
+	 */
+	const userPrefersReducedMotion = window.matchMedia(
+		'(prefers-reduced-motion: reduce)',
+	).matches;
+
+	/**
+	 * The user can set this on their Accessibility Settings page.
+	 * Explicitly `false` when the user has said they don't want autoplay video.
+	 */
+	const autoplayPreference = storage.local.get(
+		'gu.prefs.accessibility.autoplay-video',
+	);
+
+	return !userPrefersReducedMotion && autoplayPreference !== false;
+};
+
+const doesUserPermitAutoplayOnApps = async (): Promise<boolean> => {
+	/* isAutoplayEnabled is available on the video client from 8.8.0 onwards */
+	const isBridgetCompatible = await hasMinimumBridgetVersion('8.8.0');
+
+	if (!isBridgetCompatible) return true;
+
+	try {
+		const videoClient = getVideoClient();
+		return await videoClient.isAutoplayEnabled();
+	} catch (error) {
+		if (error instanceof Error) {
+			window.guardian.modules.sentry.reportError(
+				error,
+				'self-hosted-video',
+			);
+		}
+		log('dotcom', 'Failed to set app autoplay user preference:', error);
+		return true;
+	}
+};
+
 export const SelfHostedVideo = ({
 	sources,
 	atomId,
@@ -405,25 +447,6 @@ export const SelfHostedVideo = ({
 		/>
 	);
 
-	const doesUserPermitAutoplay = (): boolean => {
-		/**
-		 * The user indicates a preference for reduced motion: https://web.dev/articles/prefers-reduced-motion
-		 */
-		const userPrefersReducedMotion = window.matchMedia(
-			'(prefers-reduced-motion: reduce)',
-		).matches;
-
-		/**
-		 * The user can set this on their Accessibility Settings page.
-		 * Explicitly `false` when the user has said they don't want autoplay video.
-		 */
-		const autoplayPreference = storage.local.get(
-			'gu.prefs.accessibility.autoplay-video',
-		);
-
-		return !userPrefersReducedMotion && autoplayPreference !== false;
-	};
-
 	/**
 	 * Setup.
 	 *
@@ -432,7 +455,11 @@ export const SelfHostedVideo = ({
 	 * 3. Creates event listeners to control playback when there are multiple videos.
 	 */
 	useEffect(() => {
-		setIsAutoplayAllowed(doesUserPermitAutoplay());
+		if (renderingTarget === 'Apps') {
+			void doesUserPermitAutoplayOnApps().then(setIsAutoplayAllowed);
+		} else {
+			setIsAutoplayAllowed(doesUserPermitAutoplayOnWeb());
+		}
 
 		/**
 		 * Initialise Ophan attention tracking
@@ -477,7 +504,13 @@ export const SelfHostedVideo = ({
 		 */
 		const handleRestoreFromCache = (event: PageTransitionEvent) => {
 			if (event.persisted) {
-				setIsAutoplayAllowed(doesUserPermitAutoplay());
+				if (renderingTarget === 'Apps') {
+					void doesUserPermitAutoplayOnApps().then(
+						setIsAutoplayAllowed,
+					);
+				} else {
+					setIsAutoplayAllowed(doesUserPermitAutoplayOnWeb());
+				}
 				setHasPageBecomeActive(true);
 			} else {
 				setHasPageBecomeActive(false);


### PR DESCRIPTION
## What does this change?
Adds a call to check the autoplay status of the native apps. To access the isAutoplayEnabled method, the client must be on version 8.8.0 or higher. If not, DCR will continue with existing behaviour and return true for autoplay.


## Why?
So that self hosted videos in articles respect in-app accessibility settings. 
