### PR TITLE
Remove duplicate `banner:close` event

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts
@@ -159,11 +159,6 @@ export const useDesignableBannerModel = ({
 		setChannelClosedTimestamp(bannerChannel);
 		setIsOpen(false);
 		document.body.focus();
-		document.dispatchEvent(
-			new CustomEvent('banner:close', {
-				detail: { bannerId: 'designable-banner' },
-			}),
-		);
 	}, [bannerChannel]);
 
 	const handleToggleCollapse = useCallback(() => {


### PR DESCRIPTION
## What does this change?

Removes the `banner:close` event from `useDesignableBannerModel` as this seems to already be covered in `withCloseable`

## Why?

There are two `banner:close` events:
- https://github.com/guardian/dotcom-rendering/blob/8ea2760505ff298cd69926552567ddf6f9e08059/dotcom-rendering/src/components/marketing/banners/utils/withCloseable.tsx#L28
- https://github.com/guardian/dotcom-rendering/blob/8ea2760505ff298cd69926552567ddf6f9e08059/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/useDesignableBannerModel.ts#L163

When closing the reader revenue banner, the event fires twice. We don't want this behaviour ideally.

This PR addresses this so that only one event is fired when closing the reader revenue banner

## Screenshots

_The event listener is added when the reader revenue banner appears on the page view. The banner is dismissed and the console logs demonstrate the effect of this in the following screenshots:_

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3f355078-50b1-4e74-b96c-5307de4e5409
[after]: https://github.com/user-attachments/assets/302a4a5b-6623-4b27-ae8e-963bef47cfcc


