### PR TITLE
Make Winter Paralympics collection heading and border-top blue

### DIFF
--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -128,7 +128,7 @@ const borderColourStyles = (
 			return schemePalette('--section-border-opinion');
 		case 'Sport':
 		case 'Sports':
-		case 'Winter Olympics 2026':
+		case 'Winter Paralympics':
 			return schemePalette('--section-border-sport');
 		case 'Lifestyle':
 			return schemePalette('--section-border-lifestyle');
@@ -154,7 +154,7 @@ const articleSectionTitleStyles = (
 			return schemePalette('--article-section-title-opinion');
 		case 'Sport':
 		case 'Sports':
-		case 'Winter Olympics 2026':
+		case 'Winter Paralympics':
 			return schemePalette('--article-section-title-sport');
 		case 'Lifestyle':
 			return schemePalette('--article-section-title-lifestyle');


### PR DESCRIPTION
## What does this change?

Changes the colour of the Winter Paralympics collection heading and top border to sport blue. Removes the custom styling for the Olympics collection and this has now been removed from the front.

## Why?

Request from editorial. We [did the same ](https://github.com/guardian/dotcom-rendering/pull/15313)for the Olympics collection a few weeks ago.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/9c17895b-1ac9-4b3f-95d0-59c2ba5ea704
[after]: https://github.com/user-attachments/assets/fa937971-5190-4733-a00f-5e04d468f085