### PR TITLE
add an ab test config for allowing the  async loading of userIds

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -162,13 +162,13 @@ const ABTests: ABTest[] = [
 		description:
 			"Testing whether the asynchronous loading of userIds will alleviate any potential blocking of downstream functions",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-03-20",
+		expirationDate: "2026-03-27",
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],
-		shouldForceMetricsCollection: false,
+		shouldForceMetricsCollection: true,
 	},
 ];
 


### PR DESCRIPTION
## What does this change?
Adds an AB test configuration, for a client side commercial feature; "Allowing userIDs to be asynchronously". 
Related PR: https://github.com/guardian/commercial/pull/2429

## Why?
We would like to see if this feature has any impact on potentially blocking the loading of downstream functions.
