### PR TITLE
Rename Slim homepage AB test variants

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -109,14 +109,14 @@ const ABTests: ABTest[] = [
 	{
 		name: "fronts-and-curation-slim-homepage",
 		description:
-			"Test slimming content and placing Most Popular components on the right-hand side on the UK front.",
+			"Test slimming content on the UK front and placing Most Popular components on the right-hand side.",
 		owners: ["fronts.and.curation@guardian.co.uk"],
 		status: "ON",
 		expirationDate: "2026-04-28",
 		type: "server",
 		audienceSize: 0 / 100,
 		audienceSpace: "A",
-		groups: ["control", "variant-one", "variant-two"],
+		groups: ["control", "variant-slim-empty", "variant-slim-content"],
 		shouldForceMetricsCollection: false,
 	},
 	{

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -165,22 +165,23 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 			pageId,
 			hasPageSkin,
 		);
-	const isInSlimHomepageAbTestVariantOne =
+	const isInSlimHomepageAbTestVariantEmpty =
 		(pageQualifiesForSlimHomepageAbTest &&
 			abTests?.isUserInTestGroup(
 				'fronts-and-curation-slim-homepage',
-				'variant-one',
+				'variant-slim-empty',
 			)) ??
 		false;
-	const isInSlimHomepageAbTestVariantTwo =
+	const isInSlimHomepageAbTestVariantContent =
 		(pageQualifiesForSlimHomepageAbTest &&
 			abTests?.isUserInTestGroup(
 				'fronts-and-curation-slim-homepage',
-				'variant-two',
+				'variant-slim-content',
 			)) ??
 		false;
 	const isInEitherSlimHomepageAbTestVariant =
-		isInSlimHomepageAbTestVariantOne || isInSlimHomepageAbTestVariantTwo;
+		isInSlimHomepageAbTestVariantEmpty ||
+		isInSlimHomepageAbTestVariantContent;
 
 	const fallbackAspectRatio = (collectionType: DCRContainerType) => {
 		switch (collectionType) {
@@ -506,7 +507,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									index,
 									collection,
 									front.isNetworkFront,
-									isInSlimHomepageAbTestVariantTwo,
+									isInSlimHomepageAbTestVariantContent,
 								)}
 								leftContent={decideLeftContent(
 									front,
@@ -550,7 +551,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 									isInEitherSlimHomepageAbTestVariant
 								}
 								showRightContentForSlimHomepageAbTest={
-									isInSlimHomepageAbTestVariantTwo
+									isInSlimHomepageAbTestVariantContent
 								}
 								mostViewed={front.mostViewed}
 								deeplyRead={front.deeplyRead}


### PR DESCRIPTION
## What does this change?

- Rename [Slim homepage AB test](https://github.com/guardian/dotcom-rendering/pull/15430) variants to be more descriptive