### PR TITLE
Add 0% test for hosted content preview

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -158,6 +158,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-hosted-content",
+		description: "Preview the Hosted Content pages using dotcom-rendering",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-07-01",
+		type: "server",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["preview"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?

Adds an AB test to allow previewing the Hosted Content pages in dotcom-rendering

## Why?

We are migrating the rendering of the Hosted Content pages over from frontend to dotcom-rendering and need a way to preview live content before launch
