### PR TITLE
GutterAsk to support HTML tags in the copy

### DIFF
--- a/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
+++ b/dotcom-rendering/src/components/marketing/gutters/GutterAsk.tsx
@@ -76,7 +76,7 @@ const Copy: ReactComponent<CopyProps> = ({ paragraphs }: CopyProps) => {
 	return (
 		<>
 			{paragraphs.map((paragraph, idx) => (
-				<p key={idx}>{paragraph}</p>
+				<p key={idx} dangerouslySetInnerHTML={{ __html: paragraph }} />
 			))}
 		</>
 	);


### PR DESCRIPTION
## What does this change?
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213415387897655)
This change enables HTML tag rendering in Gutter Ask body copy.
## Why?
This PR updates the gutter copy renderer to use dangerouslySetInnerHTML, so inline markup provided in copy (for example `<strong>, <em>, <s>`) is rendered instead of shown as literal text.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
<img width="246" height="308" alt="Screenshot 2026-03-11 at 14 30 01" src="https://github.com/user-attachments/assets/1a38c0bf-b450-4971-ad45-0c2a320fd2e5" /> | <img width="255" height="314" alt="Screenshot 2026-03-11 at 14 21 21" src="https://github.com/user-attachments/assets/3fd39198-d3db-42af-a730-50ffea0fd568" />|

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
