### PR TITLE
Ensure borders on hosted content pages display behind main page elements

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -85,11 +85,6 @@ const headlineStyles = css`
 const metaStyles = css`
 	${grid.column.centre}
 	grid-row-start: 3;
-`;
-
-const shareButtonStyles = css`
-	margin-top: ${space[4]}px;
-	padding: ${space[1]}px;
 
 	${from.desktop} {
 		grid-row-start: 2;
@@ -98,6 +93,11 @@ const shareButtonStyles = css`
 	${from.leftCol} {
 		${grid.column.left}
 	}
+`;
+
+const shareButtonStyles = css`
+	margin-top: ${space[4]}px;
+	padding: ${space[1]}px;
 `;
 
 const standfirstStyles = css`


### PR DESCRIPTION
## What does this change?

- Uses one grid container rather than two to lay out the content
  - This makes it much easier to understand 

- Reworks the side borders from desktop to ensure they don't block interaction with the main article content. See before/after video clips for examples of this

## Why?

The side borders were covering all content between the start and end of the grid area it was placed in instead of only occupying the 1px space either side of the content they needed. This was interfering with the hover/focus state of the share button, making it difficult to click it


> [!TIP]
> Toggle "hide whitespace" when reviewing the changes in this PR

## Video Clips

### Before
https://github.com/user-attachments/assets/5373ace4-7575-4c5b-8f74-e317256597f7

### After
https://github.com/user-attachments/assets/88b232de-e305-4695-a965-bc747feaecc4


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/34756e0b-da88-447b-80b4-97a203deb04c
[after]: https://github.com/user-attachments/assets/4bfada8a-1f37-4170-8cb1-1b825f5e9f60

