### PR TITLE
Adjust max-height and padding in Braze Banners System Wrapped Mode display

### DIFF
--- a/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
+++ b/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
@@ -935,7 +935,7 @@ export const BrazeBannersSystemDisplay = ({
 			css={
 				wrapperModeEnabled
 					? css`
-							max-height: 65svh;
+							max-height: 90svh;
 							border-top: 1px solid rgb(0, 0, 0);
 							background-color: ${wrapperModeBackgroundColor};
 							overflow-y: auto;
@@ -1043,7 +1043,7 @@ export const BrazeBannersSystemDisplay = ({
 									padding-left: 12px;
 									padding-right: 12px;
 									padding-top: 18px;
-									padding-bottom: 24px;
+									padding-bottom: 12px;
 									${until.leftCol} {
 										padding-left: 0px;
 										padding-right: 0px;


### PR DESCRIPTION
## Why?

This pull request makes minor adjustments to the styling of the `BrazeBannersSystemDisplay` component to improve its layout and appearance on Safari iOS 26.
  
## What does this change?

* Layout improvements:
  * Increased the `max-height` of the banner wrapper from `65svh` to `90svh` to allow more content to be visible within the banner.
  * Reduced the `padding-bottom` from `24px` to `12px` to create a more compact banner display.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="894" height="1944" alt="image (3)" src="https://github.com/user-attachments/assets/e8f2ef19-0b63-42cd-b341-73624fad6b37" /> | <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-03-12 at 11 24 35" src="https://github.com/user-attachments/assets/23c344e0-20db-45d8-9581-551fe28eb32a" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png

-->


<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
