### PR TITLE
Switch PA team name Ivory Coast to Côte d’Ivoire 

### DIFF
--- a/dotcom-rendering/src/components/GetMatchNav.importable.tsx
+++ b/dotcom-rendering/src/components/GetMatchNav.importable.tsx
@@ -4,6 +4,7 @@ import { from } from '@guardian/source/foundations';
 import type { SWRConfiguration } from 'swr';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { useApi } from '../lib/useApi';
+import { cleanTeamName } from '../sportDataPage';
 import type { TeamType } from '../types/sport';
 import type { TagType } from '../types/tag';
 import { ArticleHeadline } from './ArticleHeadline';
@@ -138,11 +139,23 @@ export const GetMatchNav = ({
 
 	const isDataValid = validateMatchData(data);
 	if (isDataValid) {
+		const cleanedData = {
+			...data,
+			homeTeam: {
+				...data.homeTeam,
+				name: cleanTeamName(data.homeTeam.name),
+			},
+			awayTeam: {
+				...data.awayTeam,
+				name: cleanTeamName(data.awayTeam.name),
+			},
+		};
+
 		return (
 			<MatchNav
-				homeTeam={data.homeTeam}
-				awayTeam={data.awayTeam}
-				comments={data.comments}
+				homeTeam={cleanedData.homeTeam}
+				awayTeam={cleanedData.awayTeam}
+				comments={cleanedData.comments}
 				usage="Article"
 			/>
 		);

--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -116,6 +116,7 @@ describe('footballMatches', () => {
 		const uncleanToCleanNames: Record<string, string> = {
 			Ladies: '',
 			Holland: 'The Netherlands',
+			'Ivory Coast': 'Côte d’Ivoire',
 			'Union Saint Gilloise': 'Union Saint-Gilloise',
 		};
 

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -81,6 +81,7 @@ export const cleanTeamName = (teamName: string): string => {
 	return teamName
 		.replace('Ladies', '')
 		.replace('Holland', 'The Netherlands')
+		.replace('Ivory Coast', 'Côte d’Ivoire')
 		.replace('Bialystock', 'Białystok')
 		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
 };


### PR DESCRIPTION
## What does this change?
This PR updates football team name normalisation so PA provided Ivory Coast is rendered as Côte d’Ivoire, including in the match nav island. 
## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/15156
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/27c2affb-e453-409d-8fc4-fb4b647b4fff
[after]: https://github.com/user-attachments/assets/2644ef73-688a-4d4f-bf35-e391fb69c917

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
