### PR TITLE
use destinationTest in url generation

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "8.4.1",
+		"@guardian/support-dotcom-components": "8.4.2",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.58.0",
 		"@sentry/browser": "10.39.0",

--- a/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
@@ -88,6 +88,24 @@ describe('getChoiceCardUrl', () => {
 			'https://support.theguardian.com/one-time-checkout',
 		);
 	});
+	it('adds destination test param for one-time checkout choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'OneOff',
+			},
+			destination: 'Checkout',
+			destinationTest: {
+				testName: 'destination-test',
+				variantName: 'variant-a',
+			},
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/one-time-checkout?force-one-time-checkout=destination-test:variant-a',
+		);
+	});
 
 	// Recurring contribution
 	it('builds landing page url for recurring contribution choice', () => {
@@ -103,6 +121,25 @@ describe('getChoiceCardUrl', () => {
 		});
 		expect(url).toEqual(
 			'https://support.theguardian.com/contribute?product=Contribution&ratePlan=Monthly',
+		);
+	});
+	it('adds destination test param for recurring landing page choice', () => {
+		const url = getChoiceCardUrl({
+			benefits: [],
+			isDefault: false,
+			label: 'label',
+			product: {
+				supportTier: 'Contribution',
+				ratePlan: 'Monthly',
+			},
+			destination: 'LandingPage',
+			destinationTest: {
+				testName: 'destination-test',
+				variantName: 'variant-b',
+			},
+		});
+		expect(url).toEqual(
+			'https://support.theguardian.com/contribute?product=Contribution&ratePlan=Monthly&force-landing-page=destination-test:variant-b',
 		);
 	});
 	it('builds checkout page url for recurring contribution choice', () => {

--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -282,6 +282,33 @@ export const addChoiceCardsProductParams = (
 	return `${url}${alreadyHasQueryString ? '&' : '?'}${newParams}`;
 };
 
+const addChoiceCardDestinationTestParam = (
+	url: string,
+	destination: ChoiceCard['destination'],
+	destinationTest: ChoiceCard['destinationTest'],
+): string => {
+	if (!destinationTest || typeof destinationTest !== 'object') {
+		return url;
+	}
+	const parsedDestinationTest = destinationTest as Record<string, unknown>;
+	if (
+		typeof parsedDestinationTest.testName !== 'string' ||
+		typeof parsedDestinationTest.variantName !== 'string'
+	) {
+		return url;
+	}
+
+	const { testName, variantName } = parsedDestinationTest;
+	const paramKey =
+		destination === 'LandingPage'
+			? 'force-landing-page'
+			: 'force-one-time-checkout';
+	const newParam = `${paramKey}=${testName}:${variantName}`;
+	const alreadyHasQueryString = url.includes('?');
+
+	return `${url}${alreadyHasQueryString ? '&' : '?'}${newParam}`;
+};
+
 export const isProfileUrl = (baseUrl: string): boolean =>
 	/\bprofile\./.test(baseUrl);
 export const addTrackingParamsToProfileUrl = (
@@ -298,19 +325,32 @@ const SupportUrl = 'https://support.theguardian.com';
 export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
 	const { product } = choiceCard;
 	const destination = choiceCard.destination ?? 'LandingPage';
+	const { destinationTest } = choiceCard;
 
 	if (product.supportTier === 'OneOff') {
 		if (destination === 'LandingPage') {
-			return addChoiceCardsOneTimeParams(`${SupportUrl}/contribute`);
+			return addChoiceCardDestinationTestParam(
+				addChoiceCardsOneTimeParams(`${SupportUrl}/contribute`),
+				destination,
+				destinationTest,
+			);
 		} else {
-			return `${SupportUrl}/one-time-checkout`;
+			return addChoiceCardDestinationTestParam(
+				`${SupportUrl}/one-time-checkout`,
+				destination,
+				destinationTest,
+			);
 		}
 	} else {
 		const path = destination === 'LandingPage' ? 'contribute' : 'checkout';
-		return addChoiceCardsProductParams(
-			`${SupportUrl}/${path}`,
-			product.supportTier,
-			product.ratePlan,
+		return addChoiceCardDestinationTestParam(
+			addChoiceCardsProductParams(
+				`${SupportUrl}/${path}`,
+				product.supportTier,
+				product.ratePlan,
+			),
+			destination,
+			destinationTest,
 		);
 	}
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,8 +341,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 8.4.1
-        version: 8.4.1(@guardian/libs@30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)
+        specifier: 8.4.2
+        version: 8.4.2(@guardian/libs@30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -2684,8 +2684,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-dotcom-components@8.4.1':
-    resolution: {integrity: sha512-2WAUNO8L6PGWT3w+TFfpTyEU7sUWeVU6poFu1bo/xPL0btZv9hMjp81qYbVzTRu1H7zg/hKGzwqMfSZYB8tG4g==}
+  '@guardian/support-dotcom-components@8.4.2':
+    resolution: {integrity: sha512-vaVnksG7epJK2TO1KvbFm4nE94iHg74qtSYS5hdFVLkk0B0ar5mvfvB9hk5jJaZ5utzNPG1KP3tEqH2SlL9LMA==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
       '@guardian/ophan-tracker-js': 2.8.0
@@ -5227,6 +5227,10 @@ packages:
 
   compression@1.8.0:
     resolution: {integrity: sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==}
+    engines: {node: '>= 0.8.0'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
@@ -7819,6 +7823,10 @@ packages:
 
   on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -12620,7 +12628,7 @@ snapshots:
       react: 18.3.1
       typescript: 5.5.3
 
-  '@guardian/support-dotcom-components@8.4.1(@guardian/libs@30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)':
+  '@guardian/support-dotcom-components@8.4.2(@guardian/libs@30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)':
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.995.0
       '@aws-sdk/client-dynamodb': 3.996.0
@@ -12631,7 +12639,7 @@ snapshots:
       '@guardian/libs': 30.1.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/ophan-tracker-js': 2.8.0
       '@okta/jwt-verifier': 4.0.2
-      compression: 1.7.4
+      compression: 1.8.1
       cors: 2.8.5
       date-fns: 2.30.0
       express: 4.22.1
@@ -15824,6 +15832,18 @@ snapshots:
       debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.0.2
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
       safe-buffer: 5.2.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -19183,6 +19203,8 @@ snapshots:
       ee-first: 1.1.1
 
   on-headers@1.0.2: {}
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:


### PR DESCRIPTION
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213615068733061)
## What does this change?
This PR updates choice card URL generation to include destination test when present.

## Why?
We need to carry destination test context into generated CTA URLs so we can force users to the intended landing/checkout destination per test variant.

Tested in CODE env. For variants with destinationTest presented, the url contains corresponding url search parameter: force-landing-page=test:variant  or force-one-time-checkout=test:variant 
## Screenshots


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
