### PR TITLE
Update expiration date for commercial-enable-spacefinder-on-interactives test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -59,7 +59,7 @@ const ABTests: ABTest[] = [
 		name: "commercial-enable-spacefinder-on-interactives",
 		description: "Enable spacefinder on interactive articles on mobile web",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2026-03-21`,
+		expirationDate: `2026-03-25`,
 		type: "client",
 		status: "ON",
 		audienceSize: 0 / 100,


### PR DESCRIPTION
## Why?
We still need the test to evaluate spacefinder on interactive articles in prod