### PR TITLE
Align On target in goal attempts for Firefox

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchStat.tsx
+++ b/dotcom-rendering/src/components/FootballMatchStat.tsx
@@ -197,6 +197,7 @@ const offTargetCss = css`
 	background-color: var(--goal-attempt-off-target-bg);
 	border: 1px solid ${palette('--football-match-stat-border')};
 	border-radius: 4px;
+	display: grid;
 	${from.desktop} {
 		${textSans15};
 	}


### PR DESCRIPTION
## What does this change?
The home team "On target" div in the goal attempts component was using `justify-self: end`, which is supposed to only work on grid items or absolutely positioned elements. Firefox was ignoring this css property, while Chrome rendered it correctly.

This PR makes the parent a grid container so that the "On target" stat aligns properly in all browsers, including Firefox.

No visual changes in Chrome, but fixes cross-browser consistency.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/931666d5-9454-4176-9128-276fe7ea2649
[after]: https://github.com/user-attachments/assets/b9ad9c13-2186-4320-bf87-1b144e7bd85a


Fixes https://github.com/guardian/dotcom-rendering/issues/15511
