### PR TITLE
Setting The Filter AAG test to 80%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -88,7 +88,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-04-01",
 		type: "server",
 		status: "ON",
-		audienceSize: 100 / 100,
+		audienceSize: 80 / 100,
 		audienceSpace: "C",
 		groups: ["control", "stacked", "carousel"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?

Updates the AAG test to be 80%.

## Why?

 On the way to turning the test off we are doing this to reduce the load on Origin as this should cover caching the most visited pages slightly less quickly than going straight to 0%

Co-authored-by: Emma Imber <emma-jo.imber@guardian.co.uk>
