### PR TITLE
Remove references to beta containers

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -321,9 +321,8 @@ export const WithExternalLink = () => {
 			<CardWrapper>
 				<Card
 					{...basicCardProps}
-					mediaPositionOnDesktop="right"
+					mediaPositionOnDesktop="left"
 					kickerText="Instagram"
-					headlineSizes={{ desktop: 'medium', tablet: 'small' }}
 					headlineText="Follow The Guardian now"
 					isExternalLink={true}
 				/>
@@ -1813,7 +1812,7 @@ export const WithAVerticalGapWhenScrollableSmallContainer = () => {
 	);
 };
 
-export const WithBetaContainerAndSublinks = () => {
+export const WithinFlexibleGeneralAndSublinks = () => {
 	return (
 		<CardGroup>
 			<CardWrapper>
@@ -1828,7 +1827,7 @@ export const WithBetaContainerAndSublinks = () => {
 	);
 };
 
-export const WithBetaContainerAndSublinksNoImage = () => {
+export const WithinFlexibleGeneralAndSublinksNoImage = () => {
 	return (
 		<CardGroup>
 			<CardWrapper>

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -13,7 +13,6 @@ import { appendLinkNameMedia } from '../../lib/getDataLinkName';
 import { getZIndex } from '../../lib/getZIndex';
 import { getOphanComponents } from '../../lib/labs';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
-import { BETA_CONTAINERS } from '../../model/enhanceCollections';
 import { palette } from '../../palette';
 import type { Branding } from '../../types/branding';
 import type { StarRating as Rating, RatingSizeType } from '../../types/content';
@@ -259,7 +258,7 @@ const getMedia = ({
 	slideshowImages,
 	mainMedia,
 	canPlayInline,
-	isBetaContainer,
+	isFrontContainer,
 }: {
 	imageUrl?: string;
 	imageAltText?: string;
@@ -268,7 +267,7 @@ const getMedia = ({
 	slideshowImages?: DCRSlideshowImage[];
 	mainMedia?: MainMedia;
 	canPlayInline?: boolean;
-	isBetaContainer: boolean;
+	isFrontContainer: boolean;
 }) => {
 	if (mainMedia?.type === 'SelfHostedVideo' && canPlayInline) {
 		let type: CardMediaType;
@@ -289,20 +288,24 @@ const getMedia = ({
 			mainMedia,
 		} as const;
 	}
+
 	if (mainMedia?.type === 'YoutubeVideo' && canPlayInline) {
 		return {
 			type: 'youtube-video',
 			mainMedia,
 		} as const;
 	}
+
 	if (slideshowImages && canPlayInline) {
 		return { type: 'slideshow', slideshowImages } as const;
 	}
+
 	if (avatarUrl) return { type: 'avatar', avatarUrl } as const;
+
 	if (
 		mainMedia?.type === 'Audio' &&
 		mainMedia.podcastImage &&
-		isBetaContainer
+		isFrontContainer
 	) {
 		return {
 			...mainMedia,
@@ -310,10 +313,12 @@ const getMedia = ({
 			trailImage: { src: imageUrl, altText: imageAltText },
 		} as const;
 	}
+
 	if (imageUrl) {
 		const type = isCrossword ? 'crossword' : 'picture';
 		return { type, imageUrl, imageAltText } as const;
 	}
+
 	return undefined;
 };
 
@@ -341,6 +346,27 @@ const decideSublinkPosition = (
 	}
 
 	return alignment === 'vertical' ? 'inner' : 'outer';
+};
+
+const determinePadContent = (
+	isMediaCardOrNewsletter: boolean,
+	isFrontContainer: boolean,
+	isOnwardContent: boolean,
+	isInGalleryContext: boolean,
+): 'large' | 'small' | undefined => {
+	if (isInGalleryContext) {
+		return undefined;
+	}
+
+	if (isMediaCardOrNewsletter) {
+		return isFrontContainer ? 'large' : 'small';
+	}
+
+	if (isOnwardContent) {
+		return 'small';
+	}
+
+	return undefined;
 };
 
 export const Card = ({
@@ -420,8 +446,6 @@ export const Card = ({
 		format.design === ArticleDesign.Comment ||
 		format.design === ArticleDesign.Editorial ||
 		format.design === ArticleDesign.Letter;
-
-	const isBetaContainer = BETA_CONTAINERS.includes(containerType ?? '');
 
 	/**
 	 * A "video article" refers to standalone video content presented as the main focus of the article.
@@ -507,6 +531,8 @@ export const Card = ({
 	const isMoreGalleriesOnwardContent =
 		isOnwardContent && onwardsSource === 'more-galleries';
 
+	const isFrontContainer = containerType !== undefined && !onwardsSource;
+
 	/**
 	 * Media cards have contrasting background colours. We add additional
 	 * padding to these cards to keep the text readable.
@@ -521,7 +547,7 @@ export const Card = ({
 		slideshowImages,
 		mainMedia,
 		canPlayInline,
-		isBetaContainer,
+		isFrontContainer,
 	});
 
 	const isSelfHostedVideo =
@@ -594,7 +620,14 @@ export const Card = ({
 	 * Order matters here as the logic is based on the card properties
 	 */
 	const getGapSizes = (): GapSizes => {
-		if (isOnwardContent && !isGallerySecondaryOnward) {
+		if (isOnwardContent) {
+			if (isGallerySecondaryOnward) {
+				return {
+					row: 'medium',
+					column: 'medium',
+				};
+			}
+
 			if (isMoreGalleriesOnwardContent) {
 				return {
 					row: 'small',
@@ -608,7 +641,7 @@ export const Card = ({
 			};
 		}
 
-		if (!isBetaContainer) {
+		if (!isFrontContainer) {
 			/**
 			 * Media cards have 4px padding around the content so we have a
 			 * tiny (4px) gap to account for this and make it 8px total
@@ -620,7 +653,6 @@ export const Card = ({
 				};
 			}
 
-			// Current cards have small padding for everything
 			return { row: 'small', column: 'small' };
 		}
 
@@ -669,7 +701,7 @@ export const Card = ({
 					isMedia={isMediaCard(format)}
 					fillBackgroundOnMobile={false}
 					fillBackgroundOnDesktop={
-						isBetaContainer && isMediaCardOrNewsletter
+						isFrontContainer && isMediaCardOrNewsletter
 					}
 					isStorylines={true}
 					dataLinkName={dataLinkName}
@@ -682,13 +714,13 @@ export const Card = ({
 					isMedia={isMediaCard(format)}
 					fillBackgroundOnMobile={
 						!!isFlexSplash ||
-						(isBetaContainer &&
+						(isFrontContainer &&
 							!!image &&
 							(mediaPositionOnMobile === 'bottom' ||
 								isMediaCard(format)))
 					}
 					fillBackgroundOnDesktop={
-						isBetaContainer && isMediaCardOrNewsletter
+						isFrontContainer && isMediaCardOrNewsletter
 					}
 				/>
 			);
@@ -750,17 +782,6 @@ export const Card = ({
 		}
 
 		return <Sublinks />;
-	};
-
-	const determinePadContent = (
-		mediaCard: boolean,
-		betaContainer: boolean,
-		onwardContent: boolean,
-	): 'large' | 'small' | undefined => {
-		if (isInGalleryContext) return undefined;
-		if (mediaCard && betaContainer) return 'large';
-		if (mediaCard || onwardContent) return 'small';
-		return undefined;
 	};
 
 	/**
@@ -915,10 +936,12 @@ export const Card = ({
 						mediaPositionOnMobile={mediaPositionOnMobile}
 						padMedia={
 							isMediaCardOrNewsletter &&
-							isBetaContainer &&
+							isFrontContainer &&
 							!isGallerySecondaryOnward
 						}
-						isBetaContainer={isBetaContainer}
+						isFrontContainerOrGallerySecondaryOnward={
+							isFrontContainer || isGallerySecondaryOnward
+						}
 						isSmallCard={isSmallCard}
 					>
 						{media.type === 'slideshow' && (
@@ -943,15 +966,12 @@ export const Card = ({
 								imageSize={mediaSize}
 								imagePositionOnDesktop={mediaPositionOnDesktop}
 								imagePositionOnMobile={mediaPositionOnMobile}
-								isBetaContainer={isBetaContainer}
 								isFlexibleContainer={isFlexibleContainer}
 							>
 								<Avatar
 									src={media.avatarUrl}
 									alt={byline ?? ''}
-									imageSize={
-										isBetaContainer ? mediaSize : undefined
-									}
+									imageSize={mediaSize}
 								/>
 							</AvatarContainer>
 						)}
@@ -1150,9 +1170,9 @@ export const Card = ({
 					</MediaWrapper>
 				)}
 				<ContentWrapper
-					mediaType={media?.type}
 					mediaSize={mediaSize}
-					isBetaContainer={isBetaContainer}
+					isAvatar={media?.type === 'avatar'}
+					isFrontContainer={isFrontContainer}
 					mediaPositionOnDesktop={
 						media ? mediaPositionOnDesktop : 'none'
 					}
@@ -1161,8 +1181,9 @@ export const Card = ({
 					}
 					padContent={determinePadContent(
 						isMediaCardOrNewsletter,
-						isBetaContainer,
+						isFrontContainer,
 						isOnwardContent,
+						isInGalleryContext,
 					)}
 				>
 					{/* In the storylines section on tag pages, the flex splash is used to display key stories.
@@ -1292,7 +1313,7 @@ export const Card = ({
 				css={
 					/** We allow this area to take up more space so that cards without
 					 * sublinks next to cards with sublinks have the same meta alignment */
-					isBetaContainer &&
+					(isFrontContainer || isGallerySecondaryOnward) &&
 					(mediaPositionOnDesktop === 'left' ||
 						mediaPositionOnDesktop === 'right') &&
 					css`

--- a/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { between, from, space, until } from '@guardian/source/foundations';
+import { between, space, until } from '@guardian/source/foundations';
 import type { MediaPositionType, MediaSizeType } from './MediaWrapper';
 
 type Props = {
@@ -7,7 +7,6 @@ type Props = {
 	imageSize: MediaSizeType;
 	imagePositionOnDesktop: MediaPositionType;
 	imagePositionOnMobile: MediaPositionType;
-	isBetaContainer: boolean;
 	isFlexibleContainer: boolean;
 };
 
@@ -15,59 +14,12 @@ const sideMarginStyles = css`
 	margin-right: ${space[1]}px;
 `;
 
-const topMarginStyles = css`
-	margin-top: ${space[1]}px;
-`;
-
-const largerTopMargin = css`
-	${from.tablet} {
-		margin-top: 50px;
-	}
-`;
-
 const sizingStyles = (
 	imageSize: MediaSizeType,
-	isBetaContainer: boolean,
 	isFlexibleContainer: boolean,
 	isVerticalOnDesktop: boolean,
 	isVerticalOnMobile: boolean,
 ) => {
-	if (!isBetaContainer) {
-		switch (imageSize) {
-			case 'small':
-				return css`
-					${until.tablet} {
-						height: 73px;
-						width: 73px;
-					}
-
-					height: ${isVerticalOnDesktop ? '132px' : '73px'};
-					width: ${isVerticalOnDesktop ? '132px' : '73px'};
-				`;
-			case 'jumbo':
-				return css`
-					height: ${isVerticalOnDesktop ? '132px' : '180px'};
-					width: ${isVerticalOnDesktop ? '132px' : '180px'};
-				`;
-			default:
-				return css`
-					/* Below 980 */
-					${until.desktop} {
-						height: 108px;
-						width: 108px;
-					}
-					/* Below 740 */
-					${until.tablet} {
-						height: 73px;
-						width: 73px;
-					}
-					/* Otherwise */
-					height: 132px;
-					width: 132px;
-				`;
-		}
-	}
-
 	if (isVerticalOnDesktop && !isVerticalOnMobile) {
 		return css`
 			width: 90px;
@@ -136,7 +88,6 @@ export const AvatarContainer = ({
 	imageSize,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
-	isBetaContainer,
 	isFlexibleContainer,
 }: Props) => {
 	const isVerticalOnDesktop =
@@ -148,11 +99,8 @@ export const AvatarContainer = ({
 		<div
 			css={[
 				sideMarginStyles,
-				!isBetaContainer && topMarginStyles,
-				!isBetaContainer && isVerticalOnDesktop && largerTopMargin,
 				sizingStyles(
 					imageSize,
-					isBetaContainer,
 					isFlexibleContainer,
 					isVerticalOnDesktop,
 					isVerticalOnMobile,

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -1,7 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { between, from, space, until } from '@guardian/source/foundations';
-import type { CardMediaType } from '../../../types/layout';
 import type { MediaPositionType, MediaSizeType } from './MediaWrapper';
 
 const sizingStyles = css`
@@ -17,20 +16,20 @@ const sizingStyles = css`
  */
 const flexBasisStyles = ({
 	mediaSize,
-	mediaType,
-	isBetaContainer,
+	isAvatar,
+	isFrontContainer,
 }: {
 	mediaSize: MediaSizeType;
-	mediaType?: CardMediaType;
-	isBetaContainer: boolean;
+	isAvatar: boolean;
+	isFrontContainer: boolean;
 }): SerializedStyles => {
-	if (mediaType === 'avatar') {
+	if (isAvatar) {
 		return css`
 			flex-basis: 100%;
 		`;
 	}
 
-	if (!isBetaContainer) {
+	if (!isFrontContainer) {
 		switch (mediaSize) {
 			default:
 			case 'small':
@@ -101,7 +100,7 @@ const flexBasisStyles = ({
 /**
  * There is no padding on the side of the media where the text is.
  */
-const paddingBetaContainerStyles = (
+const paddingStyles = (
 	mediaPositionMobile: MediaPositionType,
 	mediaPositionDesktop: MediaPositionType,
 	padding: 1 | 2,
@@ -144,9 +143,9 @@ const getMediaDirection = (
 
 type Props = {
 	children: React.ReactNode;
-	mediaType?: CardMediaType;
 	mediaSize: MediaSizeType;
-	isBetaContainer: boolean;
+	isAvatar: boolean;
+	isFrontContainer: boolean;
 	mediaPositionOnDesktop: MediaPositionType;
 	mediaPositionOnMobile: MediaPositionType;
 	padContent?: 'small' | 'large';
@@ -154,9 +153,9 @@ type Props = {
 
 export const ContentWrapper = ({
 	children,
-	mediaType,
 	mediaSize,
-	isBetaContainer,
+	isAvatar,
+	isFrontContainer,
 	mediaPositionOnDesktop,
 	mediaPositionOnMobile,
 	padContent,
@@ -171,17 +170,17 @@ export const ContentWrapper = ({
 				mediaDirectionDesktop === 'horizontal' &&
 					flexBasisStyles({
 						mediaSize,
-						mediaType,
-						isBetaContainer,
+						isFrontContainer,
+						isAvatar,
 					}),
 				padContent &&
-					!isBetaContainer &&
+					!isFrontContainer &&
 					css`
 						padding: ${space[paddingSpace]}px;
 					`,
 				padContent &&
-					isBetaContainer &&
-					paddingBetaContainerStyles(
+					isFrontContainer &&
+					paddingStyles(
 						mediaPositionOnMobile,
 						mediaPositionOnDesktop,
 						paddingSpace,

--- a/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
@@ -32,7 +32,7 @@ type Props = {
 	mediaType?: CardMediaType;
 	mediaPositionOnDesktop: MediaPositionType;
 	mediaPositionOnMobile: MediaPositionType;
-	isBetaContainer: boolean;
+	isFrontContainerOrGallerySecondaryOnward: boolean;
 	isSmallCard: boolean;
 	padMedia?: boolean;
 };
@@ -77,14 +77,14 @@ const flexBasisStyles = ({
 	mediaSize,
 	mediaType,
 	isSmallCard,
-	isBetaContainer,
+	isFrontContainerOrGallerySecondaryOnward,
 }: {
 	mediaSize: MediaSizeType;
 	mediaType: CardMediaType;
 	isSmallCard: boolean;
-	isBetaContainer: boolean;
+	isFrontContainerOrGallerySecondaryOnward: boolean;
 }): SerializedStyles => {
-	if (!isBetaContainer) {
+	if (!isFrontContainerOrGallerySecondaryOnward) {
 		switch (mediaSize) {
 			default:
 			case 'small':
@@ -167,10 +167,10 @@ const fixMediaWidthStyles = (width: number) => css`
 `;
 
 const fixMobileMediaWidth = (
-	isBetaContainer: boolean,
+	isFrontContainerOrGallerySecondaryOnward: boolean,
 	isSmallCard: boolean,
 ) => {
-	if (!isBetaContainer) {
+	if (!isFrontContainerOrGallerySecondaryOnward) {
 		return css`
 			${until.tablet} {
 				${fixMediaWidthStyles(mediaFixedSize.medium)}
@@ -201,7 +201,7 @@ export const MediaWrapper = ({
 	mediaType,
 	mediaPositionOnDesktop,
 	mediaPositionOnMobile,
-	isBetaContainer,
+	isFrontContainerOrGallerySecondaryOnward,
 	isSmallCard,
 	padMedia,
 }: Props) => {
@@ -225,7 +225,7 @@ export const MediaWrapper = ({
 						mediaSize,
 						mediaType,
 						isSmallCard,
-						isBetaContainer,
+						isFrontContainerOrGallerySecondaryOnward,
 					}),
 				mediaType === 'avatar' &&
 					css`
@@ -241,7 +241,10 @@ export const MediaWrapper = ({
 					`,
 				isHorizontalOnMobile &&
 					mediaType !== 'podcast' &&
-					fixMobileMediaWidth(isBetaContainer, isSmallCard),
+					fixMobileMediaWidth(
+						isFrontContainerOrGallerySecondaryOnward,
+						isSmallCard,
+					),
 				isSmallCard && fixDesktopMediaWidth(),
 				isHorizontalOnDesktop &&
 					css`

--- a/dotcom-rendering/src/components/Card/components/UL.tsx
+++ b/dotcom-rendering/src/components/Card/components/UL.tsx
@@ -81,7 +81,7 @@ type Props = {
 	showTopBar?: boolean;
 	/** Used to add a gap in the center of the top bar */
 	splitTopBar?: boolean;
-	/** Used to give beta containers additional space */
+	/** Used to give flexible containers additional space */
 	hasLargeSpacing?: boolean;
 	/** Overrides the vertical divider colour */
 	verticalDividerColour?: string;

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -164,6 +164,6 @@ export const DecideContainer = ({
 				/>
 			);
 		default:
-			return <p>{containerType} is not yet supported</p>;
+			return null;
 	}
 };

--- a/dotcom-rendering/src/components/FrontSection.stories.tsx
+++ b/dotcom-rendering/src/components/FrontSection.stories.tsx
@@ -67,7 +67,6 @@ const PageSkinWrapper = ({ children }: { children: ReactNode }) => (
 export default {
 	component: FrontSection,
 	title: 'Components/FrontSection',
-
 	parameters: {
 		chromatic: {
 			viewports: [
@@ -79,15 +78,12 @@ export default {
 			],
 		},
 	},
-
 	args: {
 		editionId: 'UK',
 		children: <Placeholder />,
 		url: '/',
 	},
-
 	render: (args) => <FrontSection {...args} />,
-
 	globals: {
 		viewport: {
 			// This has the effect of turning off the viewports addon by default

--- a/dotcom-rendering/src/components/FrontSection.tsx
+++ b/dotcom-rendering/src/components/FrontSection.tsx
@@ -471,7 +471,7 @@ const bottomPadding = css`
 	padding-bottom: ${space[9]}px;
 `;
 
-const bottomPaddingBetaContainer = (
+const bottomPaddingFrontContainer = (
 	useLargeSpacingMobile: boolean,
 	useLargeSpacingDesktop: boolean,
 ) => css`
@@ -645,9 +645,8 @@ export const FrontSection = ({
 }: Props) => {
 	const isToggleable = toggleable && !!sectionId;
 	const showVerticalRule = !hasPageSkin;
-	const isBetaContainer = !!containerLevel;
+	const isFrontContainer = containerLevel !== undefined;
 
-	// These are for beta containers only
 	const useLargeSpacingMobile = !!isNextCollectionPrimary || isAboveMobileAd;
 	const useLargeSpacingDesktop =
 		!!isNextCollectionPrimary || isAboveDesktopAd;
@@ -685,15 +684,16 @@ export const FrontSection = ({
 					),
 				}}
 			>
-				{isBetaContainer && showTopBorder && (
+				{isFrontContainer && showTopBorder && (
 					<div
 						css={[
-							containerLevel === 'Secondary'
-								? secondaryLevelTopBorder
-								: primaryLevelTopBorder(
-										title,
-										showSectionColours,
-								  ),
+							containerLevel === 'Primary' &&
+								primaryLevelTopBorder(
+									title,
+									showSectionColours,
+								),
+							containerLevel === 'Secondary' &&
+								secondaryLevelTopBorder,
 							slimifySectionForSlimHomepageAbTest &&
 								containerLevel === 'Secondary' &&
 								css`
@@ -709,7 +709,7 @@ export const FrontSection = ({
 					css={[
 						decoration,
 						sideBorders,
-						showTopBorder && !isBetaContainer && topBorder,
+						showTopBorder && !isFrontContainer && topBorder,
 					]}
 				/>
 
@@ -737,7 +737,7 @@ export const FrontSection = ({
 								title?.toLowerCase() === 'opinion',
 							),
 							showVerticalRule &&
-								!isBetaContainer &&
+								!isFrontContainer &&
 								sectionHeadlineFromLeftCol(
 									schemePalette('--section-border'),
 								),
@@ -801,7 +801,7 @@ export const FrontSection = ({
 						sectionContentRow(toggleable),
 						topPadding,
 						showVerticalRule &&
-							isBetaContainer &&
+							isFrontContainer &&
 							sectionContentBorderFromLeftCol,
 						slimifySectionForSlimHomepageAbTest &&
 							slimHomepageRightBorderStyles,
@@ -856,8 +856,8 @@ export const FrontSection = ({
 						sectionBottomContent,
 						slimifySectionForSlimHomepageAbTest &&
 							slimSectionBottomContent,
-						isBetaContainer
-							? bottomPaddingBetaContainer(
+						isFrontContainer
+							? bottomPaddingFrontContainer(
 									useLargeSpacingMobile,
 									useLargeSpacingDesktop,
 							  )

--- a/dotcom-rendering/src/components/StorylinesSection.tsx
+++ b/dotcom-rendering/src/components/StorylinesSection.tsx
@@ -249,7 +249,7 @@ const sectionPagination = css`
 	}
 `;
 
-const bottomPaddingBetaContainer = css`
+const bottomPadding = css`
 	padding-bottom: ${space[10]}px;
 `;
 
@@ -503,7 +503,7 @@ export const StorylinesSection = ({
 							css={[
 								sectionContentHorizontalMargins,
 								sectionPagination,
-								bottomPaddingBetaContainer,
+								bottomPadding,
 							]}
 						>
 							<FrontPagination

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -99,7 +99,7 @@ const isToggleable = (
 		);
 	}
 
-	return index != 0 && !isNavList(collection) && !isLabs(collection);
+	return index !== 0 && !isNavList(collection) && !isLabs(collection);
 };
 
 const decideLeftContent = (front: Front, collection: DCRCollectionType) => {

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.test.ts
@@ -258,7 +258,7 @@ describe('Mobile Ads', () => {
 		expect(mobileAdPositions).toEqual([1, 3, 5, 7, 9]);
 	});
 
-	it('Europe Network Front, with beta containers and more than 4 collections, with thrashers in various places', () => {
+	it('Europe Network Front, with more than 4 collections and thrashers in various places', () => {
 		const testCollections: AdCandidate[] = [
 			{
 				...testCollection,

--- a/dotcom-rendering/src/model/enhanceCollections.ts
+++ b/dotcom-rendering/src/model/enhanceCollections.ts
@@ -17,17 +17,6 @@ const FORBIDDEN_CONTAINERS = [
 	'qatar treat',
 ];
 
-export const BETA_CONTAINERS = [
-	'scrollable/highlights',
-	'flexible/special',
-	'flexible/general',
-	'scrollable/small',
-	'scrollable/medium',
-	'scrollable/feature',
-	'static/feature/2',
-	'static/medium/4',
-];
-
 const PALETTE_STYLES_URI =
 	'https://content.guardianapis.com/atom/interactive/interactives/2022/03/29/fronts-container-colours/default';
 


### PR DESCRIPTION
## What does this change?

Removes references to beta containers.

This does mean replacing checks for beta containers with checks for front containers. This isn't ideal, as the props should describe behaviour of the component rather than the parent. However, I found that the Chromatic diffs were a bit unwieldy when attempting to refactor out these checks, so this will be left to a future PR.  

## Why?

Beta container are now just... containers. The old, deprecated containers have been removed and old code supporting them can be deleted. This should simplify the code and make it easier for us to make changes going forward.