### PR TITLE
Tick and hightlighted color fix

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerBody.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerBody.tsx
@@ -41,7 +41,8 @@ export const BannerBody = ({
 }: {
 	bannerData: BannerData;
 }): JSX.Element | null => {
-	const textColour = bannerData.settings.containerSettings.textColor ?? '';
+	const textColour =
+		bannerData.settings.highlightedTextSettings.textColour ?? '';
 	const highlightColour =
 		bannerData.settings.highlightedTextSettings.highlightColour;
 

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerBody.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerBody.tsx
@@ -3,7 +3,10 @@ import { from, space, textSans15 } from '@guardian/source/foundations';
 import { createBannerBodyCopy } from '../../components/BannerText';
 import type { BannerData } from '../BannerProps';
 
-const getStyles = (textColour: string, highlightColour?: string) => ({
+const getStyles = (
+	highlightedTextColour: string,
+	highlightColour?: string,
+) => ({
 	container: css`
 		margin-bottom: ${space[4]}px;
 
@@ -24,7 +27,7 @@ const getStyles = (textColour: string, highlightColour?: string) => ({
 	`,
 	highlightedText: css`
 		display: inline;
-		color: ${textColour};
+		color: ${highlightedTextColour};
 
 		${highlightColour
 			? `
@@ -41,12 +44,12 @@ export const BannerBody = ({
 }: {
 	bannerData: BannerData;
 }): JSX.Element | null => {
-	const textColour =
+	const highlightedTextColour =
 		bannerData.settings.highlightedTextSettings.textColour ?? '';
 	const highlightColour =
 		bannerData.settings.highlightedTextSettings.highlightColour;
 
-	const styles = getStyles(textColour, highlightColour);
+	const styles = getStyles(highlightedTextColour, highlightColour);
 	const { copyForViewport, showBody } = bannerData.selectors;
 
 	return (

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -67,10 +67,12 @@ const supportingTextStyles = css`
 const SupportingBenefits = ({
 	benefitsLabel,
 	benefits,
+	benefitsTickColour,
 	choiceCardDesignSettings,
 }: {
 	benefitsLabel?: string;
 	benefits: ChoiceCard['benefits'];
+	benefitsTickColour?: string;
 	choiceCardDesignSettings?: ChoiceCardDesignSettings;
 }) => {
 	const showTicks = benefits.length > 1;
@@ -94,6 +96,7 @@ const SupportingBenefits = ({
 								size="xsmall"
 								theme={{
 									fill:
+										benefitsTickColour ??
 										choiceCardDesignSettings?.buttonSelectMarkerColour ??
 										palette.brand[400],
 								}}
@@ -187,16 +190,19 @@ export const ThreeTierChoiceCards = ({
 			palette.brand[400],
 	};
 
+	const getPillBackgroundColour = (
+		pill: NonNullable<ChoiceCard['pill']>,
+	): string => {
+		if (choiceCardDesignSettings?.pillBackgroundColour) {
+			return choiceCardDesignSettings.pillBackgroundColour;
+		}
+		if (pill.backgroundColour) {
+			return hexColourToString(pill.backgroundColour as HexColour);
+		}
+		return palette.brandAlt[400];
+	};
+
 	const pillStyles = (pill: NonNullable<ChoiceCard['pill']>) => {
-		const buildBackgroundColour = (): string => {
-			if (choiceCardDesignSettings?.pillBackgroundColour) {
-				return choiceCardDesignSettings.pillBackgroundColour;
-			}
-			if (pill.backgroundColour) {
-				return hexColourToString(pill.backgroundColour as HexColour);
-			}
-			return palette.brandAlt[400];
-		};
 		const buildTextColour = (): string => {
 			if (choiceCardDesignSettings?.pillTextColour) {
 				return choiceCardDesignSettings.pillTextColour;
@@ -210,7 +216,7 @@ export const ThreeTierChoiceCards = ({
 		return css`
 			border-radius: 4px;
 			padding: ${space[1]}px ${space[2]}px;
-			background-color: ${buildBackgroundColour()};
+			background-color: ${getPillBackgroundColour(pill)};
 			${textSansBold14};
 			color: ${buildTextColour()};
 			position: absolute;
@@ -343,6 +349,13 @@ export const ThreeTierChoiceCards = ({
 															| undefined
 													}
 													benefits={benefits}
+													benefitsTickColour={
+														pill
+															? getPillBackgroundColour(
+																	pill,
+															  )
+															: undefined
+													}
 													choiceCardDesignSettings={
 														choiceCardDesignSettings
 													}


### PR DESCRIPTION
## What does this change?
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213620147951668)
This changes fix colour bugs in benefits tick bullet points and in highlighted text colour for "mid teal" colour theme.
## Why?
There is a bug in displaying background colour in benefit ticks. It should be the same colour as a pill background (if presented). Also for Colour theme "Mid teal" the Highlighted text colour should be white.
## Screenshots
**BEFORE**
<img width="500" height="197" alt="Screenshot 2026-03-11 at 15 54 57" src="https://github.com/user-attachments/assets/ceee4164-d518-4d31-a6ae-94bc80a1d62e" />
<img width="623" height="131" alt="Screenshot 2026-03-11 at 15 54 52" src="https://github.com/user-attachments/assets/d84327fc-d7bb-4d6e-b088-feae7d93282c" />
**AFTER**
<img width="1052" height="420" alt="Screenshot 2026-03-17 at 09 13 24" src="https://github.com/user-attachments/assets/eb54f90d-5a07-410b-a5f5-105b120b42ff" />
<img width="1115" height="385" alt="Screenshot 2026-03-17 at 09 36 20" src="https://github.com/user-attachments/assets/98d4b3cd-1e76-4f62-a1a9-4c1f81887c4b" />

**EPIC**
<img width="617" height="663" alt="Screenshot 2026-03-17 at 09 38 35" src="https://github.com/user-attachments/assets/f51c5350-69dc-4fd8-acd1-8142f006680f" />
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
