### PR TITLE
Fix missing tag in article title

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -370,12 +370,6 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 
-	const abTests = useBetaAB();
-	const isInFootballRedesignVariantGroup =
-		(abTests?.isUserInTestGroup('webex-football-redesign', 'variant') &&
-			isWeb) ??
-		false;
-
 	const showBodyEndSlot =
 		isWeb &&
 		(parse(article.slotMachineFlags ?? '').showBodyEnd ||
@@ -402,6 +396,13 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 	const isMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchUrl;
+
+	const abTests = useBetaAB();
+	const isInFootballRedesignVariantGroup =
+		(isMatchReport &&
+			abTests?.isUserInTestGroup('webex-football-redesign', 'variant') &&
+			isWeb) ??
+		false;
 
 	const isMedia =
 		format.design === ArticleDesign.Video ||


### PR DESCRIPTION
## What does this change?
Fix a bug where the tag was missing in the article title. This was caused by the football redesign work. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/d562301e-2015-4519-aa88-8ac6b3883fe5
[after]: https://github.com/user-attachments/assets/b2ce3671-99d7-4d39-9d2e-e8ebaaa2d071
