### PR TITLE
Set 'at a glance' redesign test to 0%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -88,7 +88,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-04-01",
 		type: "server",
 		status: "ON",
-		audienceSize: 80 / 100,
+		audienceSize: 0 / 100,
 		audienceSpace: "C",
 		groups: ["control", "stacked", "carousel"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?
Sets the Filter 'at a glance' redesign test to 0%

## Why?
We've finished collecting data. We'd still like to keep the zero percent test for now to do some testing on CODE to check some of our data collection.