### PR TITLE
Add accent colour to CTA button

### DIFF
--- a/dotcom-rendering/src/components/CallToActionAtom.stories.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.stories.tsx
@@ -25,7 +25,7 @@ export const WithAccentColour = () => {
 			backgroundImage="https://media.guim.co.uk/2c2ad59a167c43496ff709d0d9a83e8d46c30674/0_0_1300_375/1300.jpg"
 			text="Proactive security starts here"
 			buttonText="Explore more"
-			accentColour="#d71920"
+			accentColor="#d71920"
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/CallToActionAtom.test.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.test.tsx
@@ -3,7 +3,20 @@ import '@testing-library/jest-dom';
 import { CallToActionAtom } from './CallToActionAtom';
 
 describe('CallToActionAtom', () => {
-	it('should render with url and button text', () => {
+	it('should render with url and a default button text when not provided', () => {
+		const { getByRole } = render(
+			<CallToActionAtom
+				linkUrl="https://example.com"
+				backgroundImage="https://example.com/image.jpg"
+			/>,
+		);
+
+		const link = getByRole('link', { name: 'Learn more' });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', 'https://example.com');
+	});
+
+	it('should display custom button text when provided', () => {
 		const { getByRole } = render(
 			<CallToActionAtom
 				linkUrl="https://example.com"
@@ -12,12 +25,9 @@ describe('CallToActionAtom', () => {
 			/>,
 		);
 
-		const link = getByRole('link');
+		const link = getByRole('link', { name: 'Click here' });
 		expect(link).toBeInTheDocument();
 		expect(link).toHaveAttribute('href', 'https://example.com');
-
-		const button = getByRole('button', { name: 'Click here' });
-		expect(button).toBeInTheDocument();
 	});
 
 	it('should display the label when provided', () => {
@@ -47,21 +57,34 @@ describe('CallToActionAtom', () => {
 		expect(heading).not.toBeInTheDocument();
 	});
 
-	it('should have correct link wrapping the entire component', () => {
+	it('should apply the accent colour to the button when provided', () => {
 		const { getByRole } = render(
 			<CallToActionAtom
 				linkUrl="https://example.com"
-				buttonText="Learn more"
-				text="Important Info"
 				backgroundImage="https://example.com/image.jpg"
+				buttonText="Click here"
+				accentColor="#d71920"
 			/>,
 		);
 
-		const link = getByRole('link');
-		expect(link).toHaveAttribute('href', 'https://example.com');
+		const link = getByRole('link', { name: 'Click here' });
+		const computedStyle = window.getComputedStyle(link);
+		expect(computedStyle.color).toBe('rgb(255, 255, 255)');
+		expect(computedStyle.backgroundColor).toBe('rgb(215, 25, 32)');
+	});
 
-		// Check that the button is within the link
-		const button = getByRole('button', { name: 'Learn more' });
-		expect(link).toContainElement(button);
+	it('should apply the default theme to the button when no accent colour is provided', () => {
+		const { getByRole } = render(
+			<CallToActionAtom
+				linkUrl="https://example.com"
+				backgroundImage="https://example.com/image.jpg"
+				buttonText="Click here"
+			/>,
+		);
+
+		const link = getByRole('link', { name: 'Click here' });
+		const computedStyle = window.getComputedStyle(link);
+		expect(computedStyle.color).toBe('rgb(0, 0, 0)');
+		expect(computedStyle.backgroundColor).toBe('rgb(255, 255, 255)');
 	});
 });

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -14,7 +14,7 @@ type CallToActionProps = {
 	backgroundImage?: string;
 	text?: string;
 	buttonText?: string;
-	accentColour?: string;
+	accentColor?: string;
 };
 
 const overlayMaskGradientStyles = (angle: string, startPosition: number) => {
@@ -117,7 +117,7 @@ export const CallToActionAtom = ({
 	backgroundImage,
 	text,
 	buttonText,
-	accentColour,
+	accentColor,
 }: CallToActionProps) => {
 	return (
 		<picture
@@ -151,18 +151,18 @@ export const CallToActionAtom = ({
 					icon={<SvgExternal />}
 					theme={{
 						// We also still need to implement the dark mode based on the provided designs which should be the same as not providing an accent colour.
-						textPrimary: accentColour
+						textPrimary: accentColor
 							? sourcePalette.neutral[100]
 							: sourcePalette.neutral[0],
 						backgroundPrimary:
-							accentColour ?? sourcePalette.neutral[100],
-						backgroundPrimaryHover: transparentColour(
-							accentColour ?? sourcePalette.neutral[100],
-							0.8,
-						),
+							accentColor ?? sourcePalette.neutral[100],
+						// This should be changed with `calculateHoverColour()` once we have the function available as DCR needs to upgrade Source to 12.1.0 to use it.
+						// Check https://github.com/guardian/csnx/blob/857116cf826dc700742f14c5a5f005bd6d39f1be/libs/%40guardian/source/CHANGELOG.md?plain=1#L20
+						backgroundPrimaryHover:
+							accentColor ?? sourcePalette.neutral[100],
 					}}
 				>
-					{buttonText}
+					{buttonText ?? 'Learn more'}
 				</LinkButton>
 			</div>
 		</picture>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -361,9 +361,7 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 								backgroundImage={cta.image}
 								text={cta.label}
 								buttonText={cta.btnText}
-									accentColour={
-										branding?.hostedCampaignColour
-									}
+								accentColor={branding?.hostedCampaignColour}
 							/>
 						</div>
 					)}


### PR DESCRIPTION
## What does this change?

This PR adds the accent colour to `CallToActionAtom` button and if there is no accent colour provided it defaults to a neutral colour. This work implements the light mode from the provided designs but the dark mode requires a neutral colour which is the same as the light mode without accent colour. It will be implemented in another PR. 

The changes are:
- Removed the anchor that wraps all the data for CTA and just have the button as a link based on the designs.
- Added a default neutral colour if no accent colour is provided. 
- Replaced `CallToActionAtom` data in storybook with a CTA with more vibrant accent colour.
- Added a new story for `CallToActionAtom` to include accent colour.
- Updated unit tests and included tests for accent colour.

Next to be done in CTA button is the hovering and the dark mode which I already created tickets for.

## Why?

Part of the Hosted Content migration work. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a77b623d-a58a-45c5-80db-eb5937d8aed4
[after]: https://github.com/user-attachments/assets/01e47c88-71c3-4035-8271-df4d44ac7d16

| Before without accent colour      | After without accent colour     |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before2]: https://github.com/user-attachments/assets/48ade972-bd79-438b-9fcb-803af07250f1
[after2]: https://github.com/user-attachments/assets/4729dced-289d-4552-91bd-c86e6c88f087

There is no visual difference between the before and after without accent colour.
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213692022876566