### PR TITLE
Liveblog Epic header support HTML tags fix

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ContributionsLiveblogEpic.tsx
@@ -204,6 +204,11 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 	const cleanHeading =
 		replaceNonArticleCountPlaceholders(variant.heading) ||
 		'Support the Guardian';
+	const headingElements = replaceArticleCount(
+		cleanHeading,
+		articleCounts.forTargetedWeeks,
+		'epic',
+	);
 
 	if (
 		cleanParagraphs.some(containsNonArticleCountPlaceholder) ||
@@ -220,7 +225,7 @@ export const ContributionsLiveblogEpic: ReactComponent<EpicProps> = ({
 				setNodeAt40Percent(node);
 			}}
 		>
-			{!!cleanHeading && <div css={yellowHeading}>{cleanHeading}</div>}
+			{!!cleanHeading && <div css={yellowHeading}>{headingElements}</div>}
 			<section css={container}>
 				<LiveblogEpicBody
 					paragraphs={cleanParagraphs}


### PR DESCRIPTION
## What does this change?
This change adds HTML tags support to LiveBlog Epic header text
## Why?
The header of LiveBlog Epic header text can contain HTML tags (`<s></s>, <em></em>`) but they are not displayed correctly right now. This change fixes the problem
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="731" height="500" alt="Screenshot 2026-03-18 at 10 13 18" src="https://github.com/user-attachments/assets/c1adfcd7-ee7b-4881-87c5-c13b5dd98592" /> | <img width="752" height="483" alt="Screenshot 2026-03-18 at 10 40 56" src="https://github.com/user-attachments/assets/488c3f78-219a-4993-a888-02d343f167da" /> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
