### PR TITLE
Add nginx mapping for storybook.thegulocal.com

### DIFF
--- a/dotcom-rendering/scripts/nginx/nginx-mappings.yaml
+++ b/dotcom-rendering/scripts/nginx/nginx-mappings.yaml
@@ -3,3 +3,5 @@ domain-root: thegulocal.com
 mappings:
   - prefix: r
     port: 3030
+  - prefix: storybook
+    port: 4002

--- a/dotcom-rendering/scripts/nginx/setup.sh
+++ b/dotcom-rendering/scripts/nginx/setup.sh
@@ -8,4 +8,4 @@ brew bundle --file=${DIR}/Brewfile
 
 dev-nginx setup-app ${DIR}/nginx-mappings.yaml
 
-echo "🌎 Successfully installed config. https://r.thegulocal.com is now setup."
+echo "🌎 Successfully installed config. https://r.thegulocal.com & https://storybook.thegulocal.com is now setup."


### PR DESCRIPTION
## What does this change?
Adds a storybook prefix to thegulocal.com on port 4002.

This means storybook is accessible via https://storybook.thegulocal.com. 

## Why?
This will allow developers to proxy storybook to an allowed origin. This will allow self hosted videos - which have a cross origin requirement in order to support subtitles - to be developed in storybook 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/024723e4-4700-4f00-a069-cf6c5f5fa7fb
[after]: https://github.com/user-attachments/assets/46536927-91c6-4fc7-b560-fca93624f49a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
