### PR TITLE
Ensure order of mime types is correct so that mp4s are prioritised

### DIFF
--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -39,6 +39,15 @@ const isSupportedMimeType = (
 export const convertAssetsToVideoSources = (assets: VideoAssets[]): Source[] =>
 	assets
 		.filter((asset) => isSupportedMimeType(asset.mimeType))
+		.sort(
+			(a, b) =>
+				supportedVideoFileTypes.indexOf(
+					a.mimeType as SupportedVideoFileType,
+				) -
+				supportedVideoFileTypes.indexOf(
+					b.mimeType as SupportedVideoFileType,
+				),
+		)
 		.map((asset) => ({
 			src: asset.url,
 			mimeType: asset.mimeType as Source['mimeType'],


### PR DESCRIPTION
## What does this change?
Sorts assets after they have been filtered so that mp4 is always prioritised over m3u8s

## Why?
Order of the videos is preserved after filtering so we need to manually sort them as per the mimetype order so that we always prioritise m3u8s 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7b08bcf8-38a7-4f25-9c8a-2c6b47cb2cc6
[after]: https://github.com/user-attachments/assets/0cc4d948-55d0-46e4-b015-714b151cf342

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
