### PR TITLE
Admiral test name fix

### DIFF
--- a/dotcom-rendering/src/components/AdmiralScript.importable.tsx
+++ b/dotcom-rendering/src/components/AdmiralScript.importable.tsx
@@ -6,6 +6,8 @@ import { getOphan } from '../client/ophan/ophan';
 import { useBetaAB } from '../lib/useAB';
 import { useConfig } from './ConfigContext';
 
+const testName = 'growth-admiral-adblock-detect';
+
 /**
  * Sends component events to Ophan with the componentType of `AD_BLOCK_RECOVERY`
  * as well as sending the AB test participation
@@ -37,7 +39,7 @@ const recordAdmiralOphanEvent = async (
 				...(value && { value }),
 				...(variantName && {
 					abTest: {
-						name: 'growth-admiral-adblock-recovery',
+						name: testName,
 						variant: variantName,
 					},
 				}),
@@ -204,8 +206,6 @@ const setUpAdmiralEventLogger = (
 		void handleCandidateDismissedEvent(variantName, event, renderingTarget);
 	});
 };
-
-const testName = 'growth-admiral-adblock-detect';
 
 export const AdmiralScript = () => {
 	const { renderingTarget } = useConfig();


### PR DESCRIPTION
## What does this change?
This change updates the test name for admiral script detection
## Why?
The admiral script was intended to be run for all users that meet the requirements, but the admiral modal should be shown to 90% of this users (for 10% only detect adblocker). There was a mismatch of test name in AdmiralScript.importable.tsx and abTests.ts and the admiral modal was shown to 100% of the users. This change fixes it
## Screenshots


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
