### PR TITLE
Handle scenarios where match stat values are zero

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchStat.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchStat.stories.tsx
@@ -62,6 +62,22 @@ export const ShownAsPercentage = {
 	},
 } satisfies Story;
 
+export const OneStatZero = {
+	args: {
+		...Default.args,
+		homeValue: 4,
+		awayValue: 0,
+	},
+} satisfies Story;
+
+export const BothStatsZero = {
+	args: {
+		...Default.args,
+		homeValue: 0,
+		awayValue: 0,
+	},
+} satisfies Story;
+
 export const CompactLayout = {
 	args: {
 		...Default.args,

--- a/dotcom-rendering/src/components/FootballMatchStat.tsx
+++ b/dotcom-rendering/src/components/FootballMatchStat.tsx
@@ -85,6 +85,7 @@ const graphCss = css`
 	display: flex;
 	gap: 10px;
 	grid-area: graph;
+	height: ${space[2]}px;
 `;
 
 const barCss = css`
@@ -126,8 +127,10 @@ export const FootballMatchStat = ({
 }: MatchStatProps) => {
 	const Heading: React.ElementType = `h${headingLevel}`;
 	const compactLayout = layout === 'compact';
-	const homePercentage = (homeValue / (homeValue + awayValue)) * 100;
-	const awayPercentage = (awayValue / (homeValue + awayValue)) * 100;
+	const homePercentage =
+		homeValue === 0 ? 0 : (homeValue / (homeValue + awayValue)) * 100;
+	const awayPercentage =
+		awayValue === 0 ? 0 : (awayValue / (homeValue + awayValue)) * 100;
 
 	return (
 		<div
@@ -159,20 +162,24 @@ export const FootballMatchStat = ({
 				{formatValue(awayValue, isPercentage)}
 			</span>
 			<div aria-hidden="true" css={graphCss}>
-				<div
-					css={barCss}
-					style={{
-						'--match-stat-percentage': `${homePercentage}%`,
-						'--match-stat-team-colour': homeTeam.colour,
-					}}
-				></div>
-				<div
-					css={barCss}
-					style={{
-						'--match-stat-percentage': `${awayPercentage}%`,
-						'--match-stat-team-colour': awayTeam.colour,
-					}}
-				></div>
+				{homePercentage > 0 && (
+					<div
+						css={barCss}
+						style={{
+							'--match-stat-percentage': `${homePercentage}%`,
+							'--match-stat-team-colour': homeTeam.colour,
+						}}
+					></div>
+				)}
+				{awayPercentage > 0 && (
+					<div
+						css={barCss}
+						style={{
+							'--match-stat-percentage': `${awayPercentage}%`,
+							'--match-stat-team-colour': awayTeam.colour,
+						}}
+					></div>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Updates football match stat component so it renders correctly in scenarios where one or both values are zero

## Why?

Currently the component renders incorrectly (and throws a JS error due to a division by zero when calculating the bar length). As this component appears on football live blogs this is a common scenario as the match stats will be zero at the beginning on the game.

## Screenshots

| One value zero | Both values zero | Both values non-zero |
| ----------- | ---------- | ---------- |
| ![onezero][] | ![bothzero][] | ![nonzero][] |

[onezero]: https://github.com/user-attachments/assets/be5d953a-8bbb-4865-b330-7c9b707160cb
[bothzero]: https://github.com/user-attachments/assets/dbd2af3b-47fa-4bb6-a7a5-c425c17850f4
[nonzero]: https://github.com/user-attachments/assets/0003e8fa-7cab-4ffe-b517-54010f2a3cf5