### PR TITLE
BrazeBannersSystem banner:close custom event dispatching

### DIFF
--- a/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
+++ b/dotcom-rendering/src/lib/braze/BrazeBannersSystem.tsx
@@ -456,6 +456,9 @@ export const BrazeBannersSystemDisplay = ({
 	const authStatus = useAuthStatus();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [showBanner, setShowBanner] = useState(true);
+	// Tracks whether banner:open has been dispatched so we only fire banner:close if the open event was sent first.
+	const hasDispatchedOpenRef = useRef(false);
+
 	const [minHeight, setMinHeight] = useState<string>('0px');
 	const [wrapperModeEnabled, setWrapperModeEnabled] =
 		useState<boolean>(false);
@@ -591,10 +594,23 @@ export const BrazeBannersSystemDisplay = ({
 
 	/**
 	 * Dismisses the banner by setting the showBanner state to false, which will remove it from the DOM.
+	 * Also dispatches a banner:close custom event if banner:open was previously dispatched, so that
+	 * commercial code can release the mobile sticky ad slot.
 	 */
 	const dismissBanner = useCallback(() => {
 		setShowBanner(false);
-	}, []);
+		meta.braze.logBannerClick(meta.banner, 'dismiss_button');
+		if (hasDispatchedOpenRef.current) {
+			document.dispatchEvent(
+				new CustomEvent('banner:close', {
+					detail: { bannerId: meta.id },
+				}),
+			);
+		}
+		meta.braze.logCustomEvent('braze_banner_dismissed', {
+			placementId: meta.banner.placementId,
+		});
+	}, [meta.id, meta.braze, meta.banner]);
 
 	/**
 	 * Sets the background and foreground colors for wrapper mode based on a given background color.
@@ -860,11 +876,7 @@ export const BrazeBannersSystemDisplay = ({
 					}
 					break;
 				case BrazeBannersSystemMessageType.DismissBanner:
-					meta.braze.logBannerClick(meta.banner, 'dismiss_button');
 					dismissBanner();
-					meta.braze.logCustomEvent('braze_banner_dismissed', {
-						placementId: meta.banner.placementId,
-					});
 					break;
 			}
 		};
@@ -897,6 +909,7 @@ export const BrazeBannersSystemDisplay = ({
 					detail: { bannerId: meta.id },
 				}),
 			);
+			hasDispatchedOpenRef.current = true;
 
 			// Log the impression with Braze
 			meta.braze.logBannerImpressions([meta.banner.placementId]);


### PR DESCRIPTION
## What does this change?

Adds `banner:close` custom event dispatching to `BrazeBannersSystem`, the new native Braze banner system, and fixes a missing Braze SDK analytics call in its wrapper mode close button.

Specifically, in BrazeBannersSystem.tsx:

1. **Dispatches `banner:close`** from `dismissBanner()` — the single callback invoked by both dismissal paths (postMessage from the banner iframe, and the DCR-rendered wrapper mode close button).
2. **Guards the event with a `hasDispatchedOpenRef`** — `banner:close` is only dispatched if `banner:open` was previously dispatched (i.e. the banner was actually seen in the viewport), preventing orphaned close events.
3. **Fixes the `useCallback` dependency array** of `dismissBanner` — it referenced `meta.id` but had `[]` as deps, which was a stale closure.
4. **Fixes the wrapper mode close button** — it was calling `dismissBanner()` silently without any Braze SDK logging (`logBannerClick` / `logCustomEvent`). It now mirrors the postMessage `DismissBanner` path exactly.

## Why?

### Background

The mobile sticky ad slot (`mobilesticky-container`) and bottom banners occupy the same visual space on mobile. The `@guardian/commercial` code uses a custom event bus on `document` to coordinate between the two, so they never appear simultaneously:

- `banner:open` → suppress the mobile sticky ad
- `banner:close` → release the mobile sticky ad
- `banner:none` → no banner coming, show the ad immediately

This was raised in Google Chat by the @Alexguild who was informed that mobile ad units were not recovering after a Braze banner was dismissed:

> _"Mobile ad units wait for a signal from the RR banners to determine display status (e.g., banner on = don't display ad; banner closed = display ad). Is there any chance that last week's launch of the new Braze banners/CMS might be interfering with this process by not sending the expected signal?"_

### The gap

The `banner:close` event has always been dispatched by the **Reader Revenue (RRCP)** banner pipeline via the `withCloseable` HOC, which has an `onClose` callback threaded down from the banner wrapper through to the user-facing close button.

`BrazeBannersSystem` was not part of the original commit that introduced the event system (Nov 2025). When `banner:open` was later retrofitted to it (Mar 2026, `bc941e88df`), the corresponding `banner:close` was not added.

The result: `BrazeBannersSystem` correctly fires `banner:open` when a Braze banner enters the viewport, causing commercial code to suppress the mobile sticky ad — but it never fires `banner:close` when the user dismisses the banner. The mobile sticky ad slot remains suppressed for the rest of the session, silently losing ad impressions.

**This was not a regression introduced by `BrazeBannersSystem`.** The legacy Braze banner system (`braze-components` / `brazeBanner` candidate) had the same gap: its close behaviour is handled entirely inside the `@guardian/braze-components` npm package and DCR has no hook into it, so `banner:close` was never dispatched there either. Both Braze systems have always had this missing signal. The commercial team's concern, prompted by last week's launch of `BrazeBannersSystem`, correctly identified a symptom — but the underlying cause predates the new system. `BrazeBannersSystem` is fixed here because DCR owns its `dismissBanner` callback directly; the legacy system remains unfixed but is due for deprecation.

### Why `dismissBanner()` is the right place

`dismissBanner` is the single function responsible for unmounting the banner component (`setShowBanner(false)`). Both dismissal paths converge on it:
- The banner iframe sends `BRAZE_BANNERS_SYSTEM:DISMISS_BANNER` via `postMessage` → `dismissBanner()`
- The DCR-rendered wrapper mode close button → `dismissBanner()`

Adding the event dispatch there means both paths are covered with one change.

### The wrapper mode Braze logging gap

While investigating, it was also found that the wrapper mode close button was calling `dismissBanner()` directly without the Braze SDK calls (`logBannerClick`, `logCustomEvent`) that the postMessage path performs. This means wrapper mode dismissals were not tracked in Braze analytics. This is fixed in the same PR so both paths are fully consistent.

## Screenshots

No visual changes — this PR only adds event dispatching and analytics logging on close. The banner renders and dismisses identically.

| Before | After |
| ----------- | ---------- |
| Braze banner dismissed → `banner:close` never fired → mobile sticky ad stays suppressed for the session | Braze banner dismissed → `banner:close` fired → mobile sticky ad can resume |