### PR TITLE
Fix video unit tests

### DIFF
--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -1,27 +1,44 @@
+import type { VideoAssets } from '../types/content';
+import type { Source } from './video';
 import { convertAssetsToVideoSources } from './video';
 
-const mp4Asset = {
+const mp4Asset: VideoAssets = {
 	url: 'https://guim-example.co.uk/atomID-1.mp4',
 	mimeType: 'video/mp4',
+	dimensions: {
+		height: 720,
+		width: 1280,
+	},
 };
-
-const m3u8Asset = {
+const m3u8Asset: VideoAssets = {
 	url: 'https://guim-example.co.uk/atomID-1.m3u8',
 	mimeType: 'application/x-mpegURL',
+	dimensions: {
+		height: 720,
+		width: 1280,
+	},
 };
-const unsupportedAsset = {
+const unsupportedAsset: VideoAssets = {
 	url: 'https://guim-example.co.uk/atomID-1.mov',
 	mimeType: 'video/quicktime',
+	dimensions: {
+		height: 720,
+		width: 1280,
+	},
 };
 
-const mp4Src = {
+const mp4Src: Source = {
 	src: 'https://guim-example.co.uk/atomID-1.mp4',
 	mimeType: 'video/mp4',
+	height: 720,
+	width: 1280,
 };
 
-const m3u8Src = {
+const m3u8Src: Source = {
 	src: 'https://guim-example.co.uk/atomID-1.m3u8',
 	mimeType: 'application/x-mpegURL',
+	height: 720,
+	width: 1280,
 };
 
 describe('convertAssetsToVideoSources', () => {


### PR DESCRIPTION
## What does this change?

- Fixes a few unit tests

## Why?

They are currently broken on main:
- [PR no. 1 ](https://github.com/guardian/dotcom-rendering/pull/15556)was created and CI was run
- [PR no. 2](https://github.com/guardian/dotcom-rendering/pull/15566) was created and merged
- PR no. 1 was merged, but it had never run the new tests from PR no. 2