### PR TITLE
Extend the expiry date of the AB test to allow spacefinder to run in interactive articles

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -47,7 +47,7 @@ const ABTests: ABTest[] = [
 		name: "commercial-enable-spacefinder-on-interactives",
 		description: "Enable spacefinder on interactive articles on mobile web",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: `2026-03-25`,
+		expirationDate: "2026-04-09",
 		type: "client",
 		status: "ON",
 		audienceSize: 0 / 100,


### PR DESCRIPTION
## What does this change?

Extends the expiry date of the AB test `commercial-enable-spacefinder-on-interactives`

## Why?

This is a 0% test to enable staff to opt in to preview how spacefinder works in interactive articles. We're not ready to turn this off yet so extending it another two weeks
