### PR TITLE
Show match comment in header

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -462,9 +462,14 @@ const Scorers = (props: { scorers: string[] }) =>
 	);
 
 const Comment = (props: { match: FootballMatch }) => {
-	if (props.match.kind === 'Fixture' || props.match.comment === undefined) {
+	if (props.match.kind === 'Fixture') {
 		return null;
 	}
+
+	if (props.match.comment === undefined || props.match.comment === '') {
+		return null;
+	}
+
 	return (
 		<div
 			css={{


### PR DESCRIPTION
## What does this change?

Displays match comment if present in match data

## Why?

This comment provides additional context on the outcome of the match. ie. neither team scores and the winner is decided by penalties

## Screenshots

| Mobile | Desktop | Wide |
| ----------- | ---------- | ---------- |
| ![mobile][] | ![desktop][] | ![wide][] |

[mobile]: https://github.com/user-attachments/assets/f214eef4-fbfa-4f9a-bc55-7449d80bea0b
[desktop]: https://github.com/user-attachments/assets/4945c907-2750-4d72-9ff7-d616c2e565a2
[wide]: https://github.com/user-attachments/assets/f197bfb1-ac66-448c-b10c-7edfb9c539cd