### PR TITLE
Fix display of boosted podcast slideshows

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -932,6 +932,7 @@ export const Card = ({
 					<MediaWrapper
 						mediaSize={mediaSize}
 						mediaType={media.type}
+						articleMedia={articleMedia}
 						mediaPositionOnDesktop={mediaPositionOnDesktop}
 						mediaPositionOnMobile={mediaPositionOnMobile}
 						padMedia={

--- a/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/MediaWrapper.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { between, from, space, until } from '@guardian/source/foundations';
 import { getZIndex } from '../../../lib/getZIndex';
 import type { CardMediaType } from '../../../types/layout';
+import type { ArticleMedia } from '../../../types/mainMedia';
 
 const mediaFixedSize = {
 	tiny: 86,
@@ -30,6 +31,7 @@ type Props = {
 	children: React.ReactNode;
 	mediaSize: MediaSizeType;
 	mediaType?: CardMediaType;
+	articleMedia?: ArticleMedia;
 	mediaPositionOnDesktop: MediaPositionType;
 	mediaPositionOnMobile: MediaPositionType;
 	isFrontContainerOrGallerySecondaryOnward: boolean;
@@ -199,6 +201,7 @@ export const MediaWrapper = ({
 	children,
 	mediaSize,
 	mediaType,
+	articleMedia,
 	mediaPositionOnDesktop,
 	mediaPositionOnMobile,
 	isFrontContainerOrGallerySecondaryOnward,
@@ -265,6 +268,14 @@ export const MediaWrapper = ({
 						mediaPositionOnDesktop,
 						mediaPositionOnMobile,
 					),
+				// Edge case: The slideshow carousel buttons and the podcast waveform overlap
+				mediaType === 'slideshow' &&
+					articleMedia?.type === 'Audio' &&
+					css`
+						${from.tablet} {
+							padding-bottom: ${space[10]}px;
+						}
+					`,
 			]}
 		>
 			<>

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -15,6 +15,7 @@ import {
 	trails,
 	youtubeVideoTrails,
 } from '../../fixtures/manual/trails';
+import type { ArticleFormat } from '../lib/articleFormat';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import { customMockFetch } from '../lib/mockRESTCalls';
 import type { BoostLevel } from '../types/content';
@@ -24,6 +25,7 @@ import type {
 	DCRGroupedTrails,
 	DCRSupportingContent,
 } from '../types/front';
+import type { ArticleMedia, MainMedia } from '../types/mainMedia';
 import { FlexibleGeneral } from './FlexibleGeneral';
 import { FrontSection } from './FrontSection';
 
@@ -625,7 +627,6 @@ export const StandardBoostedMediaCardWithSublinks: Story = {
 export const SplashWithSlideshow: Story = {
 	name: 'Splash with a slideshow',
 	args: {
-		frontSectionTitle: 'Flexible General Splash card with a slideshow',
 		groupedTrails: {
 			...emptyGroupedTrails,
 			splash: [
@@ -638,13 +639,79 @@ export const SplashWithSlideshow: Story = {
 		},
 		collectionId: 1,
 	},
+	render: (args) => {
+		const Section = ({
+			title,
+			format,
+			mainMedia,
+			articleMedia,
+		}: {
+			title: string;
+			format: ArticleFormat;
+			mainMedia?: MainMedia;
+			articleMedia?: ArticleMedia;
+		}) => (
+			<FrontSection title={title} editionId="UK" showTopBorder={true}>
+				<FlexibleGeneral
+					{...args}
+					groupedTrails={{
+						...emptyGroupedTrails,
+						splash: [
+							{
+								...slideshowCard,
+								boostLevel: 'default',
+								headline:
+									'Default splash card with a slideshow',
+								format,
+								mainMedia,
+								articleMedia,
+							},
+						],
+					}}
+				/>
+			</FrontSection>
+		);
+
+		return (
+			<>
+				<Section
+					title="Slideshow"
+					format={{
+						design: ArticleDesign.Standard,
+						display: ArticleDisplay.Standard,
+						theme: Pillar.News,
+					}}
+				/>
+				<Section
+					title="Slideshow podcast"
+					format={{
+						design: ArticleDesign.Audio,
+						display: ArticleDisplay.Standard,
+						theme: Pillar.Sport,
+					}}
+					mainMedia={{
+						type: 'Audio',
+						duration: '46:12',
+						podcastImage: {
+							src: 'https://uploads.guim.co.uk/2021/01/22/AudioLongReadJan2021.jpg',
+							altText: 'The Audio Long Read',
+						},
+					}}
+					articleMedia={{
+						type: 'Audio',
+						duration: '46:12',
+					}}
+				/>
+			</>
+		);
+	},
 };
 
-export const StandardCardWithSlideshow: Story = {
-	name: 'Standard card with a slideshow',
+export const StandardCardsWithSlideshow: Story = {
+	name: 'Standard cards with a slideshow',
 	args: {
 		frontSectionTitle:
-			'Flexible General standard card with a slideshow at each boost level',
+			'Standard cards with a slideshow at each boost level',
 		groupedTrails: {
 			...emptyGroupedTrails,
 			standard: [
@@ -661,11 +728,56 @@ export const StandardCardWithSlideshow: Story = {
 				},
 				{
 					...slideshowCard,
+					boostLevel: 'boost',
+					headline: 'Boosted card with an audio slideshow',
+					mainMedia: {
+						type: 'Audio',
+						duration: '46:12',
+						podcastImage: {
+							src: 'https://uploads.guim.co.uk/2021/01/22/AudioLongReadJan2021.jpg',
+							altText: 'The Audio Long Read',
+						},
+					},
+					articleMedia: {
+						type: 'Audio',
+						duration: '46:12',
+					},
+					format: {
+						design: ArticleDesign.Audio,
+						display: ArticleDisplay.Standard,
+						theme: Pillar.Sport,
+					},
+				},
+				{
+					...slideshowCard,
 					boostLevel: 'megaboost',
 					headline: 'MegaBoosted card with a slideshow',
+				},
+				{
+					...slideshowCard,
+					boostLevel: 'megaboost',
+					headline: 'MegaBoosted card with an audio slideshow',
+					mainMedia: {
+						type: 'Audio',
+						duration: '46:12',
+						podcastImage: {
+							src: 'https://uploads.guim.co.uk/2021/01/22/AudioLongReadJan2021.jpg',
+							altText: 'The Audio Long Read',
+						},
+					},
+					articleMedia: {
+						type: 'Audio',
+						duration: '46:12',
+					},
+					format: {
+						design: ArticleDesign.Audio,
+						display: ArticleDisplay.Standard,
+						theme: Pillar.Sport,
+					},
 				},
 			],
 		},
 		collectionId: 1,
+		containerLevel: 'Primary',
 	},
 };


### PR DESCRIPTION
## What does this change?

Adds space between the carousel buttons and the podcast waveform.

## Why?

Improve UI. Carousel buttons are obscured.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/2094888c-b7ba-4119-bd1d-a0d75d8c3ea4
[after]: https://github.com/user-attachments/assets/cda11fa4-c9b4-4aef-80a8-05a4a81365c6

