### PR TITLE
Extend expiry date of the AB test `commercial-loading-userids-async`

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -151,7 +151,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Testing whether the asynchronous loading of userIds will alleviate any potential blocking of downstream functions",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-03-27",
+		expirationDate: "2026-04-02",
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?

Extends the expiry date of the commercial AB test for loading user IDs asynchronously

## Why?

We want to gather a little bit more data before analysing the results