### PR TITLE
Convert spacefinder on interactive 0% test to holdback test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -36,7 +36,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Holdback proportion of the audience without new spacefinder logic on interactive pages",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-04-09",
+		expirationDate: "2026-04-30",
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?
Update the spacefinder ads in interactives test to be a "holdback" test.

## Why?
It's been live behind a 0% test for some time for some of us to keep an eye on how ads behave in interactives. We will keep 5% of the audience without the new feature to potentially look at revenue and user metrics.

Commercial PR https://github.com/guardian/commercial/pull/2490