### PR TITLE
Improve resolution of Hosted Content main media images

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -178,33 +178,33 @@ const decideImageWidths = ({
 			return [
 				{
 					breakpoint: breakpoints.mobile,
-					width: 660,
+					width: breakpoints.mobileLandscape,
 					aspectRatio: '5:4',
 				},
 				{
 					breakpoint: breakpoints.mobileLandscape,
-					width: 660,
+					width: breakpoints.phablet,
 					aspectRatio: '5:3',
 				},
 				{
 					breakpoint: breakpoints.phablet,
-					width: 740,
+					width: breakpoints.tablet,
 					aspectRatio: '5:3',
 				},
 				{
 					breakpoint: breakpoints.tablet,
-					width: 980,
+					width: breakpoints.desktop,
 					aspectRatio: '5:3',
 				},
 				{
 					breakpoint: breakpoints.desktop,
-					width: 1140,
+					width: breakpoints.leftCol,
 				},
 				{
 					breakpoint: breakpoints.leftCol,
-					width: 1300,
+					width: breakpoints.wide,
 				},
-				{ breakpoint: breakpoints.wide, width: 1300 },
+				{ breakpoint: breakpoints.wide, width: breakpoints.wide },
 			];
 		}
 		switch (format.display) {


### PR DESCRIPTION
## What does this change?

Updates the `Picture` component for `mainMedia` to allow wide variations of main media image for hosted pages (`HostedArticle`, `HostedVideo`, `HostedGallery`)

## Why?

When rendering the pages as is, the images are very blurry on wide screens as the width requested from the Fastly image optimiser is just 620px. This PR allows the requested width to be up to 1300px on wide screen sizes. The image is never larger than that due to the designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/5a0086f8-b334-4aab-ad93-0703d950efb7
[after]: https://github.com/user-attachments/assets/adeab1ed-e532-4256-9454-3609411ad1e2

[before2]: https://github.com/user-attachments/assets/693587b8-6321-4dfa-b698-ab8e778186bc
[after2]: https://github.com/user-attachments/assets/7e2f27ec-e61c-48f5-91f5-1d6291681562

