### PR TITLE
Prevent showing branding on front containers without branding type label

### DIFF
--- a/dotcom-rendering/src/components/FrontSectionTitle.tsx
+++ b/dotcom-rendering/src/components/FrontSectionTitle.tsx
@@ -149,20 +149,9 @@ export const FrontSectionTitle = ({
 			}
 
 			return (
-				<>
-					<Hide until="leftCol">
-						<BrandingLabel branding={collectionBranding.branding} />
-					</Hide>
-					<div id={`${sectionId}-title`} css={titleStyle}>
-						<Hide from="leftCol">
-							<BrandingLabel
-								branding={collectionBranding.branding}
-								dataTestId="front-branding-logo"
-							/>
-						</Hide>
-						{title}
-					</div>
-				</>
+				<div id={`${sectionId}-title`} css={titleStyle}>
+					{title}
+				</div>
 			);
 		}
 		case 'sponsored': {


### PR DESCRIPTION
## What does this change?

Omits the brand logo from containers which contain branded content from the same brand but do not have the Labs styling applied (ie. do not have the `Branded` tag)

## Why?

We don't want to display branding without any other visual information to explain why the branding is there. This is usually indicated by the branding label e.g "Paid for by"

This scenario usually doesn't happen in practice because branded containers usually have the `Branded` label applied to them which results in Labs branding

## Screenshots

_The following screenshots are of a container where all cards represent paid content from the same brand. Usually the `Branded` tag would be applied in the fronts tool to convert it into a Labs-styled container, but in case this is omitted, this is what the result would look like:_

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/231bf334-2d01-492a-83df-202a884f9a63
[after]: https://github.com/user-attachments/assets/4eaea3c6-7656-419c-918e-31f858f88f91
