### PR TITLE
Prevent banner vertical scrollbar by removing height constraint and adding proper margin

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -888,16 +888,23 @@ const styles = {
 	bannerVisualContainer: css`
 		grid-area: main-image;
 
-		margin-left: ${space[2]}px;
-		margin-right: ${space[2]}px;
+		margin: 0;
+		padding: 0;
+
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
 
 		${from.phablet} {
 			max-width: ${phabletContentMaxWidth};
 			justify-self: center;
 		}
+		${from.tablet} {
+			height: 100%;
+			width: 100%;
+		}
 		${from.desktop} {
-			margin-top: ${space[6]}px;
-			padding-left: ${space[2]}px;
 			justify-self: end;
 		}
 		${between.desktop.and.wide} {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/DesignableBanner.tsx
@@ -901,10 +901,10 @@ const styles = {
 			justify-self: center;
 		}
 		${from.tablet} {
-			height: 100%;
 			width: 100%;
 		}
 		${from.desktop} {
+			margin: ${space[6]}px 0;
 			justify-self: end;
 		}
 		${between.desktop.and.wide} {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/Banner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/Banner.tsx
@@ -178,16 +178,23 @@ const styles = {
 	bannerVisualContainer: css`
 		grid-area: main-image;
 
-		margin-left: ${space[2]}px;
-		margin-right: ${space[2]}px;
+		margin: 0;
+		padding: 0;
+
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
 
 		${from.phablet} {
 			max-width: ${phabletContentMaxWidth};
 			justify-self: center;
 		}
+		${from.tablet} {
+			height: 100%;
+			width: 100%;
+		}
 		${from.desktop} {
-			margin-top: ${space[6]}px;
-			padding-left: ${space[2]}px;
 			justify-self: end;
 		}
 		${between.desktop.and.wide} {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/Banner.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/Banner.tsx
@@ -191,10 +191,10 @@ const styles = {
 			justify-self: center;
 		}
 		${from.tablet} {
-			height: 100%;
 			width: 100%;
 		}
 		${from.desktop} {
+			margin: ${space[6]}px 0;
 			justify-self: end;
 		}
 		${between.desktop.and.wide} {

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerVisual.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerVisual.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { between, from, space } from '@guardian/source/foundations';
+import { between, from } from '@guardian/source/foundations';
 import type { Image } from '@guardian/support-dotcom-components/dist/shared/types';
 import type { ImageAttrs } from '../../../../shared/ResponsiveImage';
 import { ResponsiveImage } from '../../../../shared/ResponsiveImage';
@@ -45,16 +45,23 @@ const getStyles = (isHeaderImage = false) => {
 		container: css`
 			grid-area: main-image;
 
-			margin-left: ${space[2]}px;
-			margin-right: ${space[2]}px;
+			margin: 0;
+			padding: 0;
+
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
 
 			${from.phablet} {
 				max-width: 492px;
 				justify-self: center;
 			}
+			${from.tablet} {
+				height: 100%;
+				width: 100%;
+			}
 			${from.desktop} {
-				margin-top: ${space[6]}px;
-				padding-left: ${space[2]}px;
 				justify-self: end;
 			}
 			${between.desktop.and.wide} {
@@ -78,12 +85,6 @@ const getStyles = (isHeaderImage = false) => {
 					max-height: none;
 					padding-bottom: 0;
 				}
-			}
-
-			${from.tablet} {
-				height: 100%;
-				width: 100%;
-				align-items: center;
 			}
 		`,
 	};

--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerVisual.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/v2/components/BannerVisual.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { between, from } from '@guardian/source/foundations';
+import { between, from, space } from '@guardian/source/foundations';
 import type { Image } from '@guardian/support-dotcom-components/dist/shared/types';
 import type { ImageAttrs } from '../../../../shared/ResponsiveImage';
 import { ResponsiveImage } from '../../../../shared/ResponsiveImage';
@@ -58,10 +58,10 @@ const getStyles = (isHeaderImage = false) => {
 				justify-self: center;
 			}
 			${from.tablet} {
-				height: 100%;
 				width: 100%;
 			}
 			${from.desktop} {
+				margin: ${space[6]}px 0;
 				justify-self: end;
 			}
 			${between.desktop.and.wide} {


### PR DESCRIPTION
This commit fixes a vertical scrollbar issue in banner components caused by large images exceeding the container height.

**Problem solved:**
- Large banner images were causing vertical scrollbars to appear
- The `height: 100%` constraint at tablet breakpoint was forcing content to overflow

**Changes made:**
- Removed `height: 100%` constraint from tablet breakpoint to allow natural content height
- Added `margin: ${space[6]}px 0` at desktop breakpoint for proper vertical spacing
- Applied changes consistently across all banner components:
  - `DesignableBanner` component
  - `v2/Banner` component  
  - `v2/BannerVisual` component

This ensures banner visuals display properly without causing unwanted vertical scrollbars when images are larger than the container.