### PR TITLE
Update hosted video layout + wire up CTA component

### DIFF
--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -23,6 +23,8 @@ import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideMainMediaCaption } from '../lib/decide-caption';
 import { palette as themePalette } from '../palette';
 import type { Article } from '../types/article';
+import type { Block } from '../types/blocks';
+import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
@@ -40,21 +42,11 @@ interface AppProps extends Props {
 	renderingTarget: 'Apps';
 }
 
-const headerStyles = css`
-	${grid.container}
-	${grid.column.all}
-	grid-row: 1;
-`;
-
-const contentStyles = css`
-	${grid.container}
-	${grid.column.all}
-	grid-row: 2;
-`;
-
 const mainMediaStyles = css`
 	${grid.column.all}
-	grid-row: 1;
+	grid-row-start: 1;
+
+	z-index: 1;
 	overflow: hidden;
 	max-height: 400px;
 
@@ -66,7 +58,7 @@ const mainMediaStyles = css`
 
 const captionStyles = css`
 	${grid.column.centre}
-	grid-row: 2;
+	grid-row-start: 2;
 
 	${from.desktop} {
 		${grid.span(12, 2)}
@@ -77,35 +69,48 @@ const captionStyles = css`
 `;
 
 const headlineStyles = css`
-	margin-top: ${space[4]}px;
 	${grid.column.centre}
+	grid-row-start: 4;
+
+	margin-top: ${space[4]}px;
+
 	${from.desktop} {
 		${grid.span(4, 8)}
-		grid-row: 2;
+		grid-row-start: 2;
 	}
+
 	${from.leftCol} {
 		${grid.column.centre}
 	}
 `;
+
 const metaStyles = css`
-	margin-top: ${space[4]}px;
-	padding: ${space[1]}px;
 	${grid.column.centre}
-	grid-row: 3;
+	grid-row-start: 3;
+
 	${from.desktop} {
-		grid-row: 2;
+		grid-row-start: 2;
 	}
+
 	${from.leftCol} {
 		${grid.column.left}
 	}
 `;
 
+const shareButtonStyles = css`
+	margin-top: ${space[4]}px;
+	padding: ${space[1]}px;
+`;
+
 const standfirstStyles = css`
 	${grid.column.centre}
-	grid-row: 1;
+	grid-row-start: 5;
+
 	${from.desktop} {
 		${grid.between(4, 'right-column-end')}
+		grid-row-start: 3;
 	}
+
 	${from.leftCol} {
 		${grid.column.centre}
 	}
@@ -113,39 +118,39 @@ const standfirstStyles = css`
 
 const articleBodyStyles = css`
 	${grid.column.centre}
-	grid-row:auto;
+
+	padding-bottom: ${space[6]}px;
+
 	${from.desktop} {
 		${grid.between(4, 'right-column-end')}
-		grid-row: 2;
 	}
+
 	${from.leftCol} {
 		${grid.column.centre}
-		grid-row: 2;
 	}
-	padding-bottom: 24px;
 `;
 
 const onwardContentStyles = css`
+	${grid.column.centre}
+
 	height: 20px;
 	background-color: lightgrey;
-
-	${grid.column.centre}
-	grid-row:auto;
+	margin-bottom: ${space[6]}px;
 
 	${from.desktop} {
 		${grid.span(4, 8)}
-		grid-row: 3;
 	}
+
 	${from.leftCol} {
 		${grid.column.right}
-		grid-row: 1
+		grid-row-start: 3;
 	}
-	margin-bottom: 24px;
 `;
 
 const ctaStyles = css`
+	z-index: 1;
 	${grid.column.all}
-	grid-row:auto;
+
 	overflow: hidden;
 	max-height: 400px;
 	${from.wide} {
@@ -177,6 +182,19 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 	const { branding } =
 		frontendData.commercialProperties[frontendData.editionId];
 
+	const isCtaElement = (element: FEElement) =>
+		element._type ===
+		'model.dotcomrendering.pageElements.CallToActionAtomBlockElement';
+
+	// The CTA atom is extracted and rendered separately at the end of the article body
+	const cta = frontendData.blocks[0]?.elements.find(isCtaElement);
+
+	// Block elements without CTA atoms
+	const blocks: Block[] = frontendData.blocks.map((block) => ({
+		...block,
+		elements: block.elements.filter((element) => !isCtaElement(element)),
+	}));
+
 	return (
 		<>
 			{branding ? (
@@ -197,36 +215,36 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 
 			<main data-layout="HostedVideoLayout">
 				<article css={[grid.paddedContainer, sideBorders]}>
-					<header css={headerStyles}>
-						<div css={mainMediaStyles}>
-							<MainMedia
-								format={format}
-								elements={frontendData.mainMediaElements}
-								host={frontendData.config.host}
-								pageId={frontendData.pageId}
-								webTitle={frontendData.webTitle}
-								ajaxUrl={frontendData.config.ajaxUrl}
-								abTests={frontendData.config.abTests}
-								switches={frontendData.config.switches}
-								isAdFreeUser={frontendData.isAdFreeUser}
-								isSensitive={frontendData.config.isSensitive}
-								editionId={frontendData.editionId}
-								hideCaption={true}
-								shouldHideAds={true}
-								contentType={frontendData.contentType}
-							/>
-						</div>
+					<div css={mainMediaStyles}>
+						<MainMedia
+							format={format}
+							elements={frontendData.mainMediaElements}
+							host={frontendData.config.host}
+							pageId={frontendData.pageId}
+							webTitle={frontendData.webTitle}
+							ajaxUrl={frontendData.config.ajaxUrl}
+							abTests={frontendData.config.abTests}
+							switches={frontendData.config.switches}
+							isAdFreeUser={frontendData.isAdFreeUser}
+							isSensitive={frontendData.config.isSensitive}
+							editionId={frontendData.editionId}
+							hideCaption={true}
+							shouldHideAds={true}
+							contentType={frontendData.contentType}
+						/>
+					</div>
 
-						<div css={captionStyles}>
-							<Caption
-								captionText={mainMediaCaptionText}
-								format={format}
-								isMainMedia={true}
-							/>
-						</div>
+					<div css={captionStyles}>
+						<Caption
+							captionText={mainMediaCaptionText}
+							format={format}
+							isMainMedia={true}
+						/>
+					</div>
 
+					<div data-print-layout="hide" css={metaStyles}>
 						{props.renderingTarget === 'Web' && (
-							<div data-print-layout="hide" css={metaStyles}>
+							<div css={shareButtonStyles}>
 								<Island
 									priority="feature"
 									defer={{ until: 'visible' }}
@@ -240,82 +258,81 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 								</Island>
 							</div>
 						)}
+					</div>
 
-						<div css={headlineStyles}>
-							<ArticleHeadline
+					<div css={headlineStyles}>
+						<ArticleHeadline
+							format={format}
+							headlineString={frontendData.headline}
+							tags={frontendData.tags}
+							byline={frontendData.byline}
+							webPublicationDateDeprecated={
+								frontendData.webPublicationDateDeprecated
+							}
+						/>
+					</div>
+
+					<div css={standfirstStyles}>
+						<Standfirst
+							format={format}
+							standfirst={frontendData.standfirst}
+						/>
+					</div>
+
+					<div css={articleBodyStyles}>
+						<ArticleContainer format={format}>
+							<ArticleBody
 								format={format}
-								headlineString={frontendData.headline}
-								tags={frontendData.tags}
-								byline={frontendData.byline}
-								webPublicationDateDeprecated={
-									frontendData.webPublicationDateDeprecated
+								blocks={blocks}
+								editionId={frontendData.editionId}
+								host={frontendData.config.host}
+								pageId={frontendData.pageId}
+								webTitle={frontendData.webTitle}
+								ajaxUrl={frontendData.config.ajaxUrl}
+								isAdFreeUser={frontendData.isAdFreeUser}
+								switches={frontendData.config.switches}
+								sectionId={frontendData.config.section}
+								shouldHideReaderRevenue={
+									frontendData.shouldHideReaderRevenue
 								}
+								tags={frontendData.tags}
+								isPaidContent={
+									!!frontendData.config.isPaidContent
+								}
+								contributionsServiceUrl={
+									contributionsServiceUrl
+								}
+								contentType={frontendData.contentType}
+								idUrl={frontendData.config.idUrl ?? ''}
+								isSensitive={frontendData.config.isSensitive}
+								isDev={!!frontendData.config.isDev}
+								keywordIds={frontendData.config.keywordIds}
+								abTests={frontendData.config.abTests}
+								shouldHideAds={frontendData.shouldHideAds}
+								lang={frontendData.lang}
+								isRightToLeftLang={
+									frontendData.isRightToLeftLang
+								}
+								accentColor={branding?.hostedCampaignColour}
 							/>
-						</div>
-					</header>
+							<HostedContentDisclaimer />
+						</ArticleContainer>
+					</div>
 
-					<div css={contentStyles}>
-						<div css={standfirstStyles}>
-							<Standfirst
-								format={format}
-								standfirst={frontendData.standfirst}
-							/>
-						</div>
+					<div css={onwardContentStyles}>
+						{'Placeholder - onward content'}
+					</div>
 
-						<div css={articleBodyStyles}>
-							<ArticleContainer format={format}>
-								<ArticleBody
-									format={format}
-									blocks={frontendData.blocks}
-									editionId={frontendData.editionId}
-									host={frontendData.config.host}
-									pageId={frontendData.pageId}
-									webTitle={frontendData.webTitle}
-									ajaxUrl={frontendData.config.ajaxUrl}
-									isAdFreeUser={frontendData.isAdFreeUser}
-									switches={frontendData.config.switches}
-									sectionId={frontendData.config.section}
-									shouldHideReaderRevenue={
-										frontendData.shouldHideReaderRevenue
-									}
-									tags={frontendData.tags}
-									isPaidContent={
-										!!frontendData.config.isPaidContent
-									}
-									contributionsServiceUrl={
-										contributionsServiceUrl
-									}
-									contentType={frontendData.contentType}
-									idUrl={frontendData.config.idUrl ?? ''}
-									isSensitive={
-										frontendData.config.isSensitive
-									}
-									isDev={!!frontendData.config.isDev}
-									keywordIds={frontendData.config.keywordIds}
-									abTests={frontendData.config.abTests}
-									shouldHideAds={frontendData.shouldHideAds}
-									lang={frontendData.lang}
-									isRightToLeftLang={
-										frontendData.isRightToLeftLang
-									}
-								/>
-								<HostedContentDisclaimer />
-							</ArticleContainer>
-						</div>
-
-						<div css={onwardContentStyles}>
-							{'Placeholder - onward content'}
-						</div>
-
+					{cta && (
 						<div css={ctaStyles}>
 							<CallToActionAtom
-								linkUrl="https://safety.epicgames.com/en-US?lang=en-US"
-								backgroundImage="https://media.guim.co.uk/7fe58f11470360bc9f1e4b6bbcbf45d7cf06cfcf/0_0_1300_375/1300.jpg"
-								text="This is a call to action text"
-								buttonText="Learn more"
+								linkUrl={cta.url}
+								backgroundImage={cta.image}
+								text={cta.label}
+								buttonText={cta.btnText}
 							/>
 						</div>
-					</div>
+					)}
 				</article>
 			</main>
 		</>


### PR DESCRIPTION
## What does this change?

Refactoring
- Updates `HostedVideoLayout` to more closely match `HostedArticleLayout` (See https://github.com/guardian/dotcom-rendering/pull/15516)

Updating page content:
- Updates the CTA atom in the hosted video layout component to use real data in the props rather than hardcoded

## Why?

Migrating Hosted Content pages from frontend to DCR


## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/13a51af6-c4c1-412f-94dc-0e96a1a7d6a2
[after]: https://github.com/user-attachments/assets/25232492-301b-4fdd-9a8c-a20fb91c5828

