### PR TITLE
Fix side borders on hosted article and hosted video pages

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -159,6 +159,8 @@ const ctaStyles = css`
 
 const sideBorders = css`
 	${from.desktop} {
+		/* box-sizing property needed to prevent the width of the grid taking into account the border width */
+		box-sizing: content-box;
 		border-left: 1px solid ${themePalette('--article-border')};
 		border-right: 1px solid ${themePalette('--article-border')};
 	}

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -156,6 +156,8 @@ const ctaStyles = css`
 
 const sideBorders = css`
 	${from.desktop} {
+		/* box-sizing property needed to prevent the width of the grid taking into account the border width */
+		box-sizing: content-box;
 		border-left: 1px solid ${themePalette('--article-border')};
 		border-right: 1px solid ${themePalette('--article-border')};
 	}


### PR DESCRIPTION
## What does this change?

Fixes side borders on hosted video and hosted article pages

## Why?

There's some bugs at the moment where the borders appear in the wrong place and/or on top of the full width image 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c933ce20-50f8-4bd7-8604-0e4386c2133b
[after]: https://github.com/user-attachments/assets/1ea7477b-fe36-44b2-9101-ee136656a9d3
