### PR TITLE
Product image load lazily.

### DIFF
--- a/dotcom-rendering/src/components/ProductCardImage.tsx
+++ b/dotcom-rendering/src/components/ProductCardImage.tsx
@@ -30,7 +30,7 @@ export const ProductCardImage = ({
 			alt={image.alt}
 			height={image.height}
 			width={image.width}
-			loading={'eager'}
+			loading="lazy"
 		/>
 	);
 


### PR DESCRIPTION
## What does this change?
Load the product card images lazily rather than eagerly.

## Why?
To improve initial page load time. These images do not appear above the fold on initial page load and therefore do not need to be loaded eagerly.

Still need to check the experience when using anchor links to the content.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213967866998033