### PR TITLE
Use devalue for Island prop serialisation

### DIFF
--- a/dotcom-rendering/jest.config.js
+++ b/dotcom-rendering/jest.config.js
@@ -2,6 +2,7 @@ const swcConfig = require('./webpack/.swcrc.json');
 
 const esModules = [
 	'@guardian/',
+	'devalue',
 	'screenfull',
 	'node-fetch',
 	'data-uri-to-buffer',

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -101,6 +101,7 @@
 		"constructs": "10.6.0",
 		"cpy": "11.0.0",
 		"css-loader": "7.1.2",
+		"devalue": "5.7.0",
 		"dompurify": "3.2.4",
 		"dynamic-import-polyfill": "0.1.1",
 		"eslint": "8.57.1",

--- a/dotcom-rendering/src/client/islands/getProps.ts
+++ b/dotcom-rendering/src/client/islands/getProps.ts
@@ -1,3 +1,5 @@
+import { parse } from 'devalue';
+
 /**
  * getProps takes the given html element and returns its props attibute
  *
@@ -10,7 +12,7 @@ export const getProps = (marker: HTMLElement): { [key: string]: unknown } => {
 	const serialised = marker.getAttribute('props');
 	let props: { [key: string]: unknown };
 	try {
-		props = serialised && JSON.parse(serialised);
+		props = serialised && parse(serialised);
 	} catch (error: unknown) {
 		console.error(
 			`🚨 Error parsing props. Is this data serialisable? ${String(

--- a/dotcom-rendering/src/components/Island.tsx
+++ b/dotcom-rendering/src/components/Island.tsx
@@ -1,3 +1,4 @@
+import { stringify } from 'devalue';
 import { useContext } from 'react';
 import type { ScheduleOptions, SchedulePriority } from '../lib/scheduler';
 import { IslandContext, IslandProvider } from './IslandContext';
@@ -72,7 +73,7 @@ export const Island = ({ priority, defer, children, role }: IslandProps) => {
 					name={name}
 					priority={priority}
 					deferUntil={defer?.until}
-					props={JSON.stringify(children.props)}
+					props={stringify(children.props)}
 					rootMargin={rootMargin}
 					data-spacefinder-role={role}
 				>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(webpack@5.104.1)
+      devalue:
+        specifier: 5.7.0
+        version: 5.7.0
       dompurify:
         specifier: 3.2.4
         version: 3.2.4
@@ -5153,6 +5156,9 @@ packages:
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
+  devalue@5.7.0:
+    resolution: {integrity: sha512-qCvc8m7cImp1QDCsiY+C2EdSBWSj7Ucfoq87scSdYboDiIKdvMtFbH1U2VReBls6WMhMaUOoK3ZJEDNG/7zm3w==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -5967,7 +5973,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -14738,6 +14744,8 @@ snapshots:
   detect-node@2.1.0: {}
 
   devalue@5.6.3: {}
+
+  devalue@5.7.0: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## What does this change?
Updates the core Island serialisation and hydration infrastructure to use the devalue library instead of JSON.stringify/parse. This fixes the issues where rich JavaScript types (like Date, Set, Map) were being lost during server-to-client prop transfer, causing runtime errors.
## Why?
This change ensures that developers can safely use real Date, Set, Map, and other complex types in Island props. It eliminates a class of hydration bugs and makes the Islands architecture more robust.



