### PR TITLE
Support default video style

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -747,7 +747,6 @@ export const selfHostedLoopVideo53Card = {
 				height: 720,
 			},
 		],
-
 		aspectRatio: 5 / 3,
 	},
 } satisfies DCRFrontCard;

--- a/dotcom-rendering/src/components/FeatureCard.stories.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.stories.tsx
@@ -2,6 +2,10 @@ import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import {
+	selfHostedLoopVideo45Card,
+	selfHostedLoopVideo53Card,
+} from '../../fixtures/manual/trails';
+import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleSpecial,
@@ -422,21 +426,7 @@ export const WithSelfHostedLoopVideo = {
 	args: {
 		...cardProps,
 		showVideo: true,
-		mainMedia: {
-			type: 'SelfHostedVideo',
-			videoStyle: 'Loop',
-			atomId: 'atom-id-123',
-			sources: [
-				{
-					src: 'https://uploads.guim.co.uk/2026/01/09/Front_loop__Iran_TiF_Latest--64220ebf-d63d-48dd-9317-16b3b150a4ac-1.1.m3u8',
-					mimeType: 'application/vnd.apple.mpegurl',
-					width: 576,
-					height: 720,
-				},
-			],
-			aspectRatio: 4 / 5,
-			duration: 18,
-		},
+		mainMedia: selfHostedLoopVideo45Card.mainMedia,
 	},
 } satisfies Story;
 
@@ -469,18 +459,7 @@ export const WithSelfHostedImmersiveLoopVideo = {
 	args: {
 		...WithSelfHostedLoopVideo.args,
 		...Immersive.args,
-		mainMedia: {
-			...WithSelfHostedLoopVideo.args.mainMedia,
-			sources: [
-				{
-					src: 'https://uploads.guim.co.uk/2025/11/27/5_3_Test--26763e61-c16b-4c10-8c16-3f11882da154-1.0.mp4',
-					mimeType: 'video/mp4',
-					width: 1200,
-					height: 720,
-				},
-			],
-			aspectRatio: 5 / 3,
-		},
+		mainMedia: selfHostedLoopVideo53Card.mainMedia,
 	},
 } satisfies Story;
 
@@ -512,19 +491,7 @@ export const WithReplacementMediaOnGalleryCard = {
 		...Gallery.args,
 		showVideo: true,
 		mainMedia: {
-			type: 'SelfHostedVideo',
-			videoStyle: 'Loop',
-			atomId: 'atom-id-123',
-			sources: [
-				{
-					src: 'https://uploads.guim.co.uk/2026/01/09/Front_loop__Iran_TiF_Latest--64220ebf-d63d-48dd-9317-16b3b150a4ac-1.1.m3u8',
-					mimeType: 'application/vnd.apple.mpegurl',
-					width: 576,
-					height: 720,
-				},
-			],
-			aspectRatio: 4 / 5,
-			duration: 18,
+			...WithSelfHostedLoopVideo.args.mainMedia,
 		},
 	},
 } satisfies Story;
@@ -534,19 +501,7 @@ export const WithReplacementMediaOnVideoCard = {
 		...YoutubeVideo.args,
 		showVideo: true,
 		mainMedia: {
-			type: 'SelfHostedVideo',
-			videoStyle: 'Loop',
-			atomId: 'atom-id-123',
-			sources: [
-				{
-					src: 'https://uploads.guim.co.uk/2026/01/09/Front_loop__Iran_TiF_Latest--64220ebf-d63d-48dd-9317-16b3b150a4ac-1.1.m3u8',
-					mimeType: 'application/vnd.apple.mpegurl',
-					width: 576,
-					height: 720,
-				},
-			],
-			aspectRatio: 4 / 5,
-			duration: 18,
+			...WithSelfHostedLoopVideo.args.mainMedia,
 		},
 	},
 } satisfies Story;
@@ -556,19 +511,7 @@ export const WithReplacementMediaOnPodcastCard = {
 		...Podcast.args,
 		showVideo: true,
 		mainMedia: {
-			type: 'SelfHostedVideo',
-			videoStyle: 'Loop',
-			atomId: 'atom-id-123',
-			sources: [
-				{
-					src: 'https://uploads.guim.co.uk/2026/01/09/Front_loop__Iran_TiF_Latest--64220ebf-d63d-48dd-9317-16b3b150a4ac-1.1.m3u8',
-					mimeType: 'application/vnd.apple.mpegurl',
-					width: 576,
-					height: 720,
-				},
-			],
-			aspectRatio: 4 / 5,
-			duration: 18,
+			...WithSelfHostedLoopVideo.args.mainMedia,
 		},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -589,7 +589,7 @@ export const FeatureCard = ({
 												aspectRatio
 											}
 											linkTo={linkTo}
-											showProgressBar={false}
+											hideProgressBar={true}
 											subtitleSource={
 												media.mainMedia.subtitleSource
 											}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -184,6 +184,7 @@ const dispatchOphanAttentionEvent = (
 };
 
 const getOptimisedPosterImage = (mainImage: string): string => {
+	// We only run this on the client
 	const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
 
 	return generateImageURL({
@@ -218,8 +219,9 @@ const shouldUseWebkitFullscreen = (video: HTMLVideoElement): boolean => {
 };
 
 /**
- * Ensure the aspect ratio of the video is within the boundary, if specified.
- * For example, we may not want to render a square video inside a 4:5 feature card.
+ * Ensures the aspect ratio falls between the minimum and maximum allowed aspect ratios, if specified.
+ * For example, we may not want to render a square video inside a 4:5 feature card. In this case, the
+ * minimum & maximum aspect ratio would be 4:5, so that the video fits the fixed-aspect ratio feature card
  */
 const getAspectRatioOfVisibleVideo = (
 	aspectRatio: number,
@@ -234,42 +236,6 @@ const getAspectRatioOfVisibleVideo = (
 	}
 
 	return aspectRatio;
-};
-
-type Props = {
-	sources: Source[];
-	atomId: string;
-	uniqueId: string;
-	videoStyle: VideoPlayerFormat;
-	aspectRatio: number;
-	posterImage: string;
-	fallbackImage: CardPictureProps['mainImage'];
-	fallbackImageSize: CardPictureProps['imageSize'];
-	fallbackImageLoading: CardPictureProps['loading'];
-	fallbackImageAlt: CardPictureProps['alt'];
-	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
-	linkTo: string;
-	showProgressBar?: boolean;
-	subtitleSource?: string;
-	subtitleSize: SubtitleSize;
-	/** The position of subtitles and the audio icon. Usually at the bottom, with the exception of Feature Cards. */
-	controlsPosition?: 'top' | 'bottom';
-	/**
-	 * The minimum/maximum aspect ratio the video will have. The video will be cropped if this
-	 * value is defined and the video aspect ratio is less/greater than this value.
-	 */
-	minAspectRatio?: number;
-	maxAspectRatio?: number;
-	/**
-	 * Specify this value to enforce the size of the video container on mobile/desktop.
-	 * Grey bars will appear if this value is defined and differs from the video aspect ratio.
-	 */
-	containerAspectRatioMobile?: number;
-	containerAspectRatioDesktop?: number;
-	caption?: string;
-	format?: ArticleFormat;
-	isMainMedia?: boolean;
-	role?: RoleType;
 };
 
 const doesUserPermitAutoplayOnWeb = (): boolean => {
@@ -294,7 +260,6 @@ const doesUserPermitAutoplayOnWeb = (): boolean => {
 const doesUserPermitAutoplayOnApps = async (): Promise<boolean> => {
 	/* isAutoplayEnabled is available on the video client from 8.8.0 onwards */
 	const isBridgetCompatible = await hasMinimumBridgetVersion('8.8.0');
-
 	if (!isBridgetCompatible) return true;
 
 	try {
@@ -310,6 +275,44 @@ const doesUserPermitAutoplayOnApps = async (): Promise<boolean> => {
 		log('dotcom', 'Failed to set app autoplay user preference:', error);
 		return true;
 	}
+};
+
+type Props = {
+	sources: Source[];
+	atomId: string;
+	uniqueId: string;
+	videoStyle: VideoPlayerFormat;
+	aspectRatio: number;
+	posterImage: string;
+	fallbackImage: CardPictureProps['mainImage'];
+	fallbackImageSize: CardPictureProps['imageSize'];
+	fallbackImageLoading: CardPictureProps['loading'];
+	fallbackImageAlt: CardPictureProps['alt'];
+	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
+	linkTo: string;
+	showProgressBar?: boolean;
+	subtitleSource?: string;
+	subtitleSize: SubtitleSize;
+	/**
+	 * The position of subtitles and the audio icon.
+	 */
+	controlsPosition?: 'top' | 'bottom';
+	/**
+	 * The minimum/maximum aspect ratio the video will have. The video will be cropped if this
+	 * value is defined and the video aspect ratio is less/greater than this value.
+	 */
+	minAspectRatio?: number;
+	maxAspectRatio?: number;
+	/**
+	 * Specify this value to enforce the size of the video container on mobile/desktop.
+	 * Grey bars will appear if this value is defined and differs from the video aspect ratio.
+	 */
+	containerAspectRatioMobile?: number;
+	containerAspectRatioDesktop?: number;
+	caption?: string;
+	format?: ArticleFormat;
+	isMainMedia?: boolean;
+	role?: RoleType;
 };
 
 export const SelfHostedVideo = ({
@@ -361,10 +364,18 @@ export const SelfHostedVideo = ({
 	const isApps = renderingTarget === 'Apps';
 
 	/**
-	 * All controls on the video are hidden: the video looks like a GIF.
+	 * In a cinemagraph, all controls are hidden: the video looks like a GIF.
 	 * This includes but may not be limited to: audio icon, play/pause icon, subtitles, progress bar.
 	 */
 	const isCinemagraph = videoStyle === 'Cinemagraph';
+	const isLoop = videoStyle === 'Loop';
+	const isDefault = videoStyle === 'Default';
+
+	const canAutoplay = isLoop || isCinemagraph;
+
+	const shouldAutoplay = canAutoplay && isAutoplayAllowed;
+
+	const shouldLoop = isLoop || isCinemagraph;
 
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 
@@ -603,12 +614,12 @@ export const SelfHostedVideo = ({
 	 */
 	useEffect(() => {
 		if (
-			isAutoplayAllowed === false ||
+			!shouldAutoplay ||
 			(isInView === false && playerState === 'NOT_STARTED')
 		) {
 			setShowPosterImage(true);
 		}
-	}, [isAutoplayAllowed, isInView, playerState]);
+	}, [shouldAutoplay, isInView, playerState]);
 
 	if (adapted) {
 		return FallbackImageComponent;
@@ -813,9 +824,9 @@ export const SelfHostedVideo = ({
 	 *
 	 * Stops playback when the video is scrolled out of view.
 	 */
-	if (vidRef.current && isPlayable) {
+	if (isPlayable) {
 		if (
-			isAutoplayAllowed &&
+			shouldAutoplay &&
 			isInView &&
 			(playerState === 'NOT_STARTED' ||
 				playerState === 'PAUSED_BY_INTERSECTION_OBSERVER' ||
@@ -831,14 +842,15 @@ export const SelfHostedVideo = ({
 	}
 
 	/**
-	 * Show the play icon when the video is not playing, except for when it is scrolled
-	 * out of view. In this case, the intersection observer will resume playback and
-	 * having a play icon would falsely indicate a user action is required to resume playback.
+	 * Show the play icon when the video is not playing, except for when it is scrolled out of view,
+	 * i.e. paused by intersection observer. In this case, the intersection observer will resume playback
+	 * and having a play icon would falsely indicate a user action is required to resume playback.
 	 */
 	const showPlayIcon =
-		playerState === 'PAUSED_BY_USER' ||
-		playerState === 'PAUSED_BY_BROWSER' ||
-		(playerState === 'NOT_STARTED' && !isAutoplayAllowed);
+		!isCinemagraph &&
+		(playerState === 'PAUSED_BY_USER' ||
+			playerState === 'PAUSED_BY_BROWSER' ||
+			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
 
 	/** The aspect ratio of the video will be clamped within the specified range */
 	const aspectRatioOfVisibleVideo = getAspectRatioOfVisibleVideo(
@@ -863,12 +875,6 @@ export const SelfHostedVideo = ({
 	const optimisedPosterImage = showPosterImage
 		? getOptimisedPosterImage(posterImage)
 		: undefined;
-
-	/**
-	 * We almost always want to preload some of the video data. The exception
-	 * is when autoplay is off and the video is only partially in view.
-	 */
-	const preloadPartialData = !!isAutoplayAllowed || !!isInView;
 
 	return (
 		<figure
@@ -926,13 +932,18 @@ export const SelfHostedVideo = ({
 						handleFullscreenClick={handleFullscreenClick}
 						onError={onError}
 						AudioIcon={hasAudio ? AudioIcon : null}
-						preloadPartialData={preloadPartialData}
+						preloadPartialData={!!shouldAutoplay}
 						showPlayIcon={showPlayIcon}
 						showProgressBar={showProgressBar}
+						showSubtitles={!isCinemagraph}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}
+						showIcons={!isCinemagraph}
 						controlsPosition={controlsPosition}
 						activeCue={activeCue}
+						shouldLoop={shouldLoop}
+						showFullscreenIcon={isDefault}
+						isInteractive={!isCinemagraph}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -184,7 +184,7 @@ const dispatchOphanAttentionEvent = (
 };
 
 const getOptimisedPosterImage = (mainImage: string): string => {
-	// We only run this on the client
+	// This only runs on the client
 	const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
 
 	return generateImageURL({
@@ -290,7 +290,7 @@ type Props = {
 	fallbackImageAlt: CardPictureProps['alt'];
 	fallbackImageAspectRatio: CardPictureProps['aspectRatio'];
 	linkTo: string;
-	showProgressBar?: boolean;
+	hideProgressBar?: boolean;
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
 	/**
@@ -328,7 +328,7 @@ export const SelfHostedVideo = ({
 	fallbackImageAlt,
 	fallbackImageAspectRatio,
 	linkTo,
-	showProgressBar = true,
+	hideProgressBar = false,
 	subtitleSource,
 	subtitleSize,
 	controlsPosition = 'bottom',
@@ -376,6 +376,8 @@ export const SelfHostedVideo = ({
 	const shouldAutoplay = canAutoplay && isAutoplayAllowed;
 
 	const shouldLoop = isLoop || isCinemagraph;
+
+	const showProgressBar = !hideProgressBar && !isCinemagraph;
 
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -616,7 +616,7 @@ export const SelfHostedVideo = ({
 	 */
 	useEffect(() => {
 		if (
-			!shouldAutoplay ||
+			shouldAutoplay === false ||
 			(isInView === false && playerState === 'NOT_STARTED')
 		) {
 			setShowPosterImage(true);

--- a/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story = {
 export const WithoutProgressBar: Story = {
 	args: {
 		...Loop.args,
-		showProgressBar: false,
+		hideProgressBar: false,
 	},
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -30,7 +30,6 @@ const videoStyles = (aspectRatio: number) => css`
 	display: block;
 	height: auto;
 	width: 100%;
-	cursor: auto;
 	-webkit-tap-highlight-color: transparent;
 
 	/* Prevents CLS by letting the browser know the space the video will take up. */

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -30,15 +30,15 @@ const videoStyles = (aspectRatio: number) => css`
 	display: block;
 	height: auto;
 	width: 100%;
-	cursor: pointer;
+	cursor: auto;
 	-webkit-tap-highlight-color: transparent;
 
 	/* Prevents CLS by letting the browser know the space the video will take up. */
 	aspect-ratio: ${aspectRatio};
 `;
 
-const cinemagraphStyles = css`
-	cursor: auto;
+const interactiveStyles = css`
+	cursor: pointer;
 `;
 
 const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
@@ -63,6 +63,7 @@ const playIconStyles = css`
 	background: none;
 	padding: 0;
 `;
+
 const controlContainerStyles = (position: ControlsPosition) => css`
 	position: absolute;
 	display: flex;
@@ -95,6 +96,9 @@ const iconContainerStyles = css`
 export const PLAYER_STATES = [
 	'NOT_STARTED',
 	'PLAYING',
+	/**
+	 * A user action pauses the video.
+	 */
 	'PAUSED_BY_USER',
 	/**
 	 * The video is paused when the user scrolls away.
@@ -136,13 +140,18 @@ type Props = {
 	AudioIcon: ((iconProps: IconProps) => JSX.Element) | null;
 	posterImage?: string;
 	preloadPartialData: boolean;
-	showPlayIcon: boolean;
 	showProgressBar: boolean;
+	showPlayIcon: boolean;
+	showIcons: boolean;
+	showFullscreenIcon: boolean;
+	showSubtitles: boolean;
 	subtitleSource?: string;
-	subtitleSize?: SubtitleSize;
+	subtitleSize: SubtitleSize;
+	activeCue?: ActiveCue | null;
+	shouldLoop: boolean;
+	isInteractive: boolean;
 	controlsPosition: ControlsPosition;
 	/* used in custom subtitle overlays */
-	activeCue?: ActiveCue | null;
 };
 
 /**
@@ -183,28 +192,27 @@ export const SelfHostedVideoPlayer = forwardRef(
 			onError,
 			AudioIcon,
 			preloadPartialData,
+			showProgressBar: canShowProgressBar,
 			showPlayIcon,
-			showProgressBar,
+			showIcons: canShowIcons,
+			showFullscreenIcon,
+			showSubtitles: canShowSubtitles,
 			subtitleSource,
 			subtitleSize,
-			controlsPosition,
 			activeCue,
+			shouldLoop,
+			isInteractive,
+			controlsPosition,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
-		const isCinemagraph = videoStyle === 'Cinemagraph';
 		const videoId = `video-${uniqueId}`;
-		const showSubtitles =
-			!isCinemagraph && !!subtitleSource && !!subtitleSize;
 
-		const showControls =
-			!isCinemagraph &&
-			ref &&
-			'current' in ref &&
-			ref.current &&
-			isPlayable;
+		const currentRefExists = ref && 'current' in ref && !!ref.current;
 
-		const showFullscreenIcon = videoStyle === 'Default';
+		const showSubtitles = canShowSubtitles && !!subtitleSource;
+		const showProgressBar = canShowProgressBar && currentRefExists;
+		const showIcons = canShowIcons && currentRefExists && isPlayable;
 
 		const dataLinkName = `gu-video-${videoStyle}-${
 			showPlayIcon ? 'play' : 'pause'
@@ -217,7 +225,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					id={videoId}
 					css={[
 						videoStyles(aspectRatio),
-						isCinemagraph && cinemagraphStyles,
+						isInteractive && interactiveStyles,
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
 					crossOrigin="anonymous"
@@ -229,7 +237,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					data-link-name={dataLinkName}
 					data-chromatic="ignore"
 					preload={preloadPartialData ? 'metadata' : 'none'}
-					loop={true}
+					loop={shouldLoop}
 					muted={isMuted}
 					playsInline={true}
 					poster={posterImage}
@@ -239,13 +247,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onCanPlayThrough={handleCanPlay}
 					onPlaying={handlePlaying}
 					onTimeUpdate={() => {
-						if (
-							ref &&
-							'current' in ref &&
-							ref.current &&
-							playerState === 'PLAYING'
-						) {
-							setCurrentTime(ref.current.currentTime);
+						if (currentRefExists && playerState === 'PLAYING') {
+							setCurrentTime(ref.current!.currentTime);
 						}
 					}}
 					onPause={handlePause}
@@ -279,73 +282,71 @@ export const SelfHostedVideoPlayer = forwardRef(
 						position={controlsPosition}
 					/>
 				)}
-				{showControls && (
-					<>
-						{showPlayIcon && (
+				{showPlayIcon && (
+					<button
+						type="button"
+						onClick={handlePlayPauseClick}
+						css={playIconStyles}
+						data-link-name={`gu-video-loop-play-${atomId}`}
+						data-testid="play-icon"
+					>
+						<PlayIcon iconWidth="narrow" />
+					</button>
+				)}
+				{showProgressBar && (
+					<VideoProgressBar
+						videoId={videoId}
+						currentTime={currentTime}
+						duration={ref.current!.duration}
+					/>
+				)}
+				{showIcons && (
+					<div css={controlContainerStyles(controlsPosition)}>
+						{AudioIcon && (
 							<button
 								type="button"
-								onClick={handlePlayPauseClick}
-								css={playIconStyles}
-								data-link-name={`gu-video-loop-play-${atomId}`}
-								data-testid="play-icon"
+								onClick={handleAudioClick}
+								css={buttonStyles}
+								data-link-name={`gu-video-loop-${
+									isMuted ? 'unmute' : 'mute'
+								}-${atomId}`}
 							>
-								<PlayIcon iconWidth="narrow" />
+								<div
+									css={iconContainerStyles}
+									data-testid={`${
+										isMuted ? 'unmute' : 'mute'
+									}-icon`}
+								>
+									<AudioIcon
+										size="xsmall"
+										theme={{
+											fill: palette('--video-icon'),
+										}}
+									/>
+								</div>
 							</button>
 						)}
-						{showProgressBar && (
-							<VideoProgressBar
-								videoId={videoId}
-								currentTime={currentTime}
-								duration={ref.current!.duration}
-							/>
+						{showFullscreenIcon && (
+							<button
+								type="button"
+								onClick={handleFullscreenClick}
+								css={buttonStyles}
+								data-link-name={`gu-video-loop-fullscreen-${atomId}`}
+							>
+								<div
+									css={iconContainerStyles}
+									data-testid="fullscreen-icon"
+								>
+									<SvgArrowExpand
+										size="xsmall"
+										theme={{
+											fill: palette('--video-icon'),
+										}}
+									/>
+								</div>
+							</button>
 						)}
-						<div css={controlContainerStyles(controlsPosition)}>
-							{AudioIcon && (
-								<button
-									type="button"
-									onClick={handleAudioClick}
-									css={buttonStyles}
-									data-link-name={`gu-video-loop-${
-										isMuted ? 'unmute' : 'mute'
-									}-${atomId}`}
-								>
-									<div
-										css={iconContainerStyles}
-										data-testid={`${
-											isMuted ? 'unmute' : 'mute'
-										}-icon`}
-									>
-										<AudioIcon
-											size="xsmall"
-											theme={{
-												fill: palette('--video-icon'),
-											}}
-										/>
-									</div>
-								</button>
-							)}
-							{showFullscreenIcon && (
-								<button
-									type="button"
-									onClick={handleFullscreenClick}
-									css={buttonStyles}
-									data-link-name={`gu-video-loop-fullscreen-${atomId}`}
-								>
-									<div
-										css={iconContainerStyles}
-										data-testid="fullscreen-icon"
-									>
-										<SvgArrowExpand
-											size="xsmall"
-											theme={{
-												fill: palette('--video-icon'),
-											}}
-										/>
-									</div>
-								</button>
-							)}
-						</div>
-					</>
+					</div>
 				)}
 			</>
 		);

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -147,11 +147,11 @@ type Props = {
 	showSubtitles: boolean;
 	subtitleSource?: string;
 	subtitleSize: SubtitleSize;
+	/* used in custom subtitle overlays */
 	activeCue?: ActiveCue | null;
 	shouldLoop: boolean;
 	isInteractive: boolean;
 	controlsPosition: ControlsPosition;
-	/* used in custom subtitle overlays */
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Adds support for the "Default" video style of self-hosted. This style is known as "non-youtube" in the tools. 

Default video:
- Does not loop
- Does not autoplay. This is subject to change.
- Does not preload data. Setting `preload=metadata` can be costly as a portion of the video is downloaded alongside the metadata. There is no way to only download the video metadata using the `preload` attribute. If we find that default videos are usually played or the wait between clicking play and the video playing is too long, then we will revisit this. This is also tied to autoplay: if we autoplay, we will preload data.

`ShowControls` is split out: we may want to display the play icon even if the video is not currently playable (we haven't preloaded data).

Removes `videoStyle` logic from the player component. Let's keep the logic within the island component as much as we can, so that the player can be "dumb".

Updates feature card self-hosted video stories to use the videos in fixtures.

Note: Designs will be updated in a future PR.

## Why?

So that we can start using longer videos. We don't necessarily want to loop or autoplay longer videos.

## Screenshots

### Immersive feature card

shows no autoplay and icons appear on playback

https://github.com/user-attachments/assets/fcffcefa-31fc-4410-ba7b-c2caea0f1af3

### Card

Also demonstrates shows button functionality and no loop

https://github.com/user-attachments/assets/d1e1a270-f39e-484e-8a93-b8b933732b64

