### PR TITLE
Remove limit from standard cards in a flexible general

### DIFF
--- a/dotcom-rendering/src/components/FlexibleGeneral.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.tsx
@@ -633,12 +633,10 @@ export const FlexibleGeneral = ({
 		uniqueId: `collection-${collectionId}-splash-0`,
 	}));
 
-	const cards = [...groupedTrails.standard]
-		.slice(0, 19)
-		.map((standard, i) => ({
-			...standard,
-			uniqueId: `collection-${collectionId}-standard-${i}`,
-		}));
+	const cards = [...groupedTrails.standard].map((standard, i) => ({
+		...standard,
+		uniqueId: `collection-${collectionId}-standard-${i}`,
+	}));
 
 	const groupedCards = decideCardPositions(cards);
 


### PR DESCRIPTION
## What does this change?
Remove limit from standard cards in a flexible general. This limit was added before max card limits for this container were controlled by the fronts tool.

## Why?
This limit is handled upstream in the config. Removing this DCR imposed rendering limit ensures one source of truth (the fronts config tool). Having both limits has resulted in a bug where flexible/general was pressed as a 20 card standard group  but was only displaying 19 cards on web. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/9a5d5f61-e6ff-4de5-8e9f-0f1ca9cd2cb2
[after]: https://github.com/user-attachments/assets/a378ccdb-f00b-48a3-88d6-2139a7034698

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
