### PR TITLE
Refactor card content spacing

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -338,7 +338,11 @@ export const WithANewsletter = () => {
 	return (
 		<CardGroup>
 			<CardWrapper>
-				<Card {...basicCardProps} isNewsletter={true} />
+				<Card
+					{...basicCardProps}
+					isNewsletter={true}
+					contentSpacing="large"
+				/>
 			</CardWrapper>
 		</CardGroup>
 	);
@@ -360,6 +364,7 @@ export const WithMediaType = () => {
 						articleMedia={youtubeMetaData}
 						headlineText="Video"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 				<CardWrapper>
@@ -377,6 +382,7 @@ export const WithMediaType = () => {
 						}}
 						headlineText="Video without duration"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 				<CardWrapper>
@@ -399,6 +405,7 @@ export const WithMediaType = () => {
 						}}
 						headlineText="Live video"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 			</CardGroup>
@@ -415,6 +422,7 @@ export const WithMediaType = () => {
 						articleMedia={{ ...youtubeMetaData }}
 						headlineText="Self hosted video with Youtube article media"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 				<CardWrapper>
@@ -429,6 +437,7 @@ export const WithMediaType = () => {
 						articleMedia={{ ...selfHostedMetaData }}
 						headlineText="Self hosted video"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 			</CardGroup>
@@ -445,6 +454,7 @@ export const WithMediaType = () => {
 						articleMedia={audioMetaData}
 						headlineText="Audio"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 				<CardWrapper>
@@ -459,6 +469,7 @@ export const WithMediaType = () => {
 						articleMedia={audioMetaData}
 						headlineText="Audio with self-hosted video main media"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 			</CardGroup>
@@ -475,6 +486,7 @@ export const WithMediaType = () => {
 						articleMedia={galleryMetaData}
 						headlineText="Gallery"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 				<CardWrapper>
@@ -489,6 +501,7 @@ export const WithMediaType = () => {
 						articleMedia={galleryMetaData}
 						headlineText="Gallery with self-hosted video main media"
 						mediaPositionOnMobile="top"
+						contentSpacing="large"
 					/>
 				</CardWrapper>
 			</CardGroup>
@@ -512,6 +525,7 @@ export const WithMediaTypeAndSublinks = () => {
 					headlineText="Video"
 					supportingContent={twoSublinks}
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -527,6 +541,7 @@ export const WithMediaTypeAndSublinks = () => {
 					headlineText="Video without duration"
 					supportingContent={twoSublinks}
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -542,6 +557,7 @@ export const WithMediaTypeAndSublinks = () => {
 					headlineText="Audio"
 					supportingContent={twoSublinks}
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -557,6 +573,7 @@ export const WithMediaTypeAndSublinks = () => {
 					headlineText="Gallery"
 					supportingContent={twoSublinks}
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 		</CardGroup>
@@ -578,6 +595,7 @@ export const WithMediaTypeSpecialReportAlt = () => {
 					articleMedia={{ ...youtubeMetaData, duration: 30 }}
 					headlineText="Video"
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -592,6 +610,7 @@ export const WithMediaTypeSpecialReportAlt = () => {
 					articleMedia={mainAudio}
 					headlineText="Audio"
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 			<CardWrapper>
@@ -606,6 +625,7 @@ export const WithMediaTypeSpecialReportAlt = () => {
 					articleMedia={mainGallery}
 					headlineText="Gallery"
 					mediaPositionOnMobile="top"
+					contentSpacing="large"
 				/>
 			</CardWrapper>
 		</CardGroup>
@@ -1234,6 +1254,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mediaPositionOnMobile="top"
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
+						contentSpacing="large"
 					/>
 				</LI>
 			</UL>
@@ -1251,6 +1272,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mediaPositionOnMobile="top"
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
+						contentSpacing="large"
 					/>
 				</LI>
 				<LI percentage={'25%'} padSides={true} showDivider={true}>
@@ -1265,6 +1287,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
 						canPlayInline={false}
+						contentSpacing="large"
 					/>
 				</LI>
 			</UL>
@@ -1282,6 +1305,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mediaPositionOnMobile="bottom"
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
+						contentSpacing="large"
 					/>
 				</LI>
 				<LI percentage="50%">
@@ -1298,6 +1322,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 								mainMedia={mainYoutubeVideo}
 								articleMedia={youtubeMetaData}
 								canPlayInline={false}
+								contentSpacing="large"
 							/>
 						</LI>
 						<LI padSides={true}>
@@ -1312,6 +1337,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 								mainMedia={mainYoutubeVideo}
 								articleMedia={youtubeMetaData}
 								canPlayInline={false}
+								contentSpacing="large"
 							/>
 						</LI>
 
@@ -1327,6 +1353,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 								mainMedia={mainYoutubeVideo}
 								articleMedia={youtubeMetaData}
 								canPlayInline={false}
+								contentSpacing="large"
 							/>
 						</LI>
 					</UL>
@@ -1347,6 +1374,7 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mediaPositionOnMobile="top"
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
+						contentSpacing="large"
 					/>
 				</LI>
 				<LI percentage={'33.333%'} padSides={true} showDivider={true}>
@@ -1362,12 +1390,14 @@ export const WhenYoutubeVideoWithPlayButton = () => {
 						mediaSize="medium"
 						mainMedia={mainYoutubeVideo}
 						articleMedia={youtubeMetaData}
+						contentSpacing="large"
 					/>
 				</LI>
 			</UL>
 		</Section>
 	);
 };
+
 export const WithLetterDesign = () => {
 	return (
 		<CardWrapper>
@@ -1384,8 +1414,6 @@ export const WithLetterDesign = () => {
 		</CardWrapper>
 	);
 };
-
-WithLetterDesign.storyName = 'WithLetterDesign';
 
 export const WithLetterDesignAndShowQuotedHeadline = () => {
 	return (
@@ -1404,9 +1432,6 @@ export const WithLetterDesignAndShowQuotedHeadline = () => {
 		</CardWrapper>
 	);
 };
-
-WithLetterDesignAndShowQuotedHeadline.storyName =
-	'WithLetterDesignAndShowQuotedHeadline';
 
 const containerPalettes = [
 	'InvestigationPalette',
@@ -1492,6 +1517,7 @@ export const WithBranding = () => {
 							articleMedia={mainGallery}
 							containerPalette={containerPalette}
 							branding={branding}
+							contentSpacing="large"
 						/>
 					</LI>
 					<LI percentage={'33.333%'} padSides={true}>
@@ -1575,10 +1601,12 @@ export const WithSpecialPaletteVariations = () => {
 					articleMedia={mainAudio}
 					containerPalette={containerPalette}
 					branding={branding}
+					contentSpacing="large"
 				/>
 			</LI>
 		</UL>
 	);
+
 	return (
 		<>
 			{containerPalettes.map((containerPalette) => (

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -162,6 +162,7 @@ export type Props = {
 	/** Determines if the headline should be positioned within the content or outside the content */
 	headlinePosition?: 'inner' | 'outer';
 	starRatingSize?: RatingSizeType;
+	contentSpacing?: 'small' | 'large';
 };
 
 const waveformWrapper = (
@@ -347,27 +348,6 @@ const decideSublinkPosition = (
 	return alignment === 'vertical' ? 'inner' : 'outer';
 };
 
-const determinePadContent = (
-	isMediaCardOrNewsletter: boolean,
-	isFrontContainer: boolean,
-	isOnwardContent: boolean,
-	isInGalleryContext: boolean,
-): 'large' | 'small' | undefined => {
-	if (isInGalleryContext) {
-		return undefined;
-	}
-
-	if (isMediaCardOrNewsletter) {
-		return isFrontContainer ? 'large' : 'small';
-	}
-
-	if (isOnwardContent) {
-		return 'small';
-	}
-
-	return undefined;
-};
-
 export const Card = ({
 	linkTo,
 	format,
@@ -428,6 +408,7 @@ export const Card = ({
 	subtitleSize = 'small',
 	starRatingSize = 'small',
 	articleMedia,
+	contentSpacing,
 }: Props) => {
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -449,6 +430,8 @@ export const Card = ({
 	 * It is treated as a media card in the design system.
 	 */
 	const isVideoArticle = format.design === ArticleDesign.Video;
+
+	const isOnwardsContent = onwardsSource !== undefined;
 
 	const isLabs = format.theme === ArticleSpecial.Labs;
 
@@ -627,23 +610,12 @@ export const Card = ({
 			}
 
 			return {
-				row: 'none',
-				column: 'none',
+				row: 'tiny',
+				column: 'tiny',
 			};
 		}
 
 		if (!isFrontContainer) {
-			/**
-			 * Media cards have 4px padding around the content so we have a
-			 * tiny (4px) gap to account for this and make it 8px total
-			 */
-			if (isMediaCardOrNewsletter) {
-				return {
-					row: 'tiny',
-					column: 'tiny',
-				};
-			}
-
 			return { row: 'small', column: 'small' };
 		}
 
@@ -895,11 +867,7 @@ export const Card = ({
 						articleMedia={articleMedia}
 						mediaPositionOnDesktop={mediaPositionOnDesktop}
 						mediaPositionOnMobile={mediaPositionOnMobile}
-						padMedia={
-							isMediaCardOrNewsletter &&
-							isFrontContainer &&
-							!isGallerySecondaryOnward
-						}
+						padMedia={isMediaCardOrNewsletter && !isOnwardsContent}
 						isSmallCard={isSmallCard}
 					>
 						{media.type === 'slideshow' && (
@@ -1108,19 +1076,13 @@ export const Card = ({
 				<ContentWrapper
 					mediaSize={mediaSize}
 					isAvatar={media?.type === 'avatar'}
-					isFrontContainer={isFrontContainer}
 					mediaPositionOnDesktop={
 						media ? mediaPositionOnDesktop : 'none'
 					}
 					mediaPositionOnMobile={
 						media ? mediaPositionOnMobile : 'none'
 					}
-					padContent={determinePadContent(
-						isMediaCardOrNewsletter,
-						isFrontContainer,
-						isOnwardContent,
-						isInGalleryContext,
-					)}
+					padContent={contentSpacing}
 				>
 					{/* the div is needed to keep the headline and trail text justified at the start */}
 					<div

--- a/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
+++ b/dotcom-rendering/src/components/Card/components/ContentWrapper.tsx
@@ -109,7 +109,6 @@ type Props = {
 	children: React.ReactNode;
 	mediaSize: MediaSizeType;
 	isAvatar: boolean;
-	isFrontContainer: boolean;
 	mediaPositionOnDesktop: MediaPositionType;
 	mediaPositionOnMobile: MediaPositionType;
 	padContent?: 'small' | 'large';
@@ -119,7 +118,6 @@ export const ContentWrapper = ({
 	children,
 	mediaSize,
 	isAvatar,
-	isFrontContainer,
 	mediaPositionOnDesktop,
 	mediaPositionOnMobile,
 	padContent,
@@ -137,12 +135,6 @@ export const ContentWrapper = ({
 						isAvatar,
 					}),
 				padContent &&
-					!isFrontContainer &&
-					css`
-						padding: ${space[paddingSpace]}px;
-					`,
-				padContent &&
-					isFrontContainer &&
 					paddingStyles(
 						mediaPositionOnMobile,
 						mediaPositionOnDesktop,

--- a/dotcom-rendering/src/components/Carousel.island.tsx
+++ b/dotcom-rendering/src/components/Carousel.island.tsx
@@ -533,6 +533,7 @@ const CarouselCard = ({
 				showTopBarDesktop={!isOnwardContent}
 				showTopBarMobile={!isOnwardContent}
 				aspectRatio="5:4"
+				contentSpacing="small"
 			/>
 		</LI>
 	);

--- a/dotcom-rendering/src/components/FrontCard.tsx
+++ b/dotcom-rendering/src/components/FrontCard.tsx
@@ -1,4 +1,5 @@
 import { ArticleDesign } from '../lib/articleFormat';
+import { isMediaCard } from '../lib/cardHelpers';
 import type { DCRFrontCard } from '../types/front';
 import type { Props as CardProps } from './Card/Card';
 import { Card } from './Card/Card';
@@ -25,34 +26,39 @@ type Props = {
  */
 export const FrontCard = (props: Props) => {
 	const { trail, ...cardProps } = props;
+
+	const contentSpacing =
+		isMediaCard(trail.format) || trail.isNewsletter ? 'large' : undefined;
+
 	const defaultProps: Omit<CardProps, 'imageLoading' | 'serverTime'> = {
-		linkTo: trail.url,
-		format: trail.format,
-		headlineText: trail.headline,
+		articleMedia: trail.articleMedia,
+		avatarUrl: trail.avatarUrl,
+		branding: trail.branding,
 		byline: trail.byline,
-		showByline: trail.showByline,
-		showQuotedHeadline: trail.showQuotedHeadline,
-		webPublicationDate: trail.webPublicationDate,
-		kickerText: trail.kickerText,
-		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,
-		showClock: false,
-		image: trail.image,
-		isCrossword: trail.isCrossword,
-		isNewsletter: trail.isNewsletter,
-		starRating: trail.starRating,
+		contentSpacing,
 		dataLinkName: trail.dataLinkName,
-		snapData: trail.snapData,
 		discussionApiUrl: trail.discussionApiUrl,
 		discussionId: trail.discussionId,
-		avatarUrl: trail.avatarUrl,
-		mainMedia: trail.mainMedia,
+		format: trail.format,
+		headlineText: trail.headline,
+		image: trail.image,
+		isCrossword: trail.isCrossword,
 		isExternalLink: trail.isExternalLink,
-		branding: trail.branding,
-		slideshowImages: trail.slideshowImages,
+		isNewsletter: trail.isNewsletter,
+		kickerText: trail.kickerText,
+		linkTo: trail.url,
+		mainMedia: trail.mainMedia,
+		showByline: trail.showByline,
+		showClock: false,
 		showLivePlayable: trail.showLivePlayable,
+		showPulsingDot: trail.format.design === ArticleDesign.LiveBlog,
+		showQuotedHeadline: trail.showQuotedHeadline,
 		showVideo: trail.showVideo,
+		slideshowImages: trail.slideshowImages,
+		snapData: trail.snapData,
+		starRating: trail.starRating,
 		uniqueId: trail.uniqueId,
-		articleMedia: trail.articleMedia,
+		webPublicationDate: trail.webPublicationDate,
 	};
 
 	return Card({ ...defaultProps, ...cardProps });


### PR DESCRIPTION
## What does this change?

The amount of spacing that is required around the content of a card is now passed in via a prop.

For Onwards Content, the padding is removed from the side of the content next to the image. A gap is added to the card to replace this spacing. There is no visual difference to the user.

Updates Card stories with certain media (video|audio|gallery|newsletter) to represent modern usage: i.e. the media has padding around it.

Tag pages now display these media cards correctly. 

## Why?

Previously, the Card component used information about it's parent (e.g. is it in onwards content? a front card? etc) to calculate the amount of spacing required around the content. Now, the amount of spacing is passed in by the parent, so this logic can be removed. The component should know as little about its parent as possible, to make it more maintainable

Since the front redesign, we have padding around the card content except for the side of the content in which the media is. For example, for a card where the content sits above the image, there will be no padding on the bottom of the content. This is because a gap is provided at card level to separate the content from the media. This PR refactors Onwards Content to follow this new model, allowing us to remove the `isFrontContainer` prop from ContentWrapper.

ContentWrapper's props should describe its behaviour. It shouldn't care about whether the Card is within a front container or not.

To bring presentation of cards in tag pages closer to how we display cards on fronts.

## Screenshots

| <img width=60/> | Before | After |
| - | - | - |
| Tag pages | ![mobile-before] | ![mobile-after] |

[mobile-before]: https://github.com/user-attachments/assets/35bdc189-f6f2-4ad1-a7f0-0f13a5189b02
[mobile-after]: https://github.com/user-attachments/assets/7decfbc8-c0fb-4ada-af63-de86ec5e8684

| <img width=200/> | Before | After |
| - | - | - |
| Onwards content (no visual change) | ![desktop-before] | ![desktop-after] |

[desktop-before]: https://github.com/user-attachments/assets/953e0e2d-bc20-43d0-88c2-0d385cc5ebb7
[desktop-after]: https://github.com/user-attachments/assets/0aa9c68e-9303-41a6-b570-1a9fd7ac394a
