### PR TITLE
Set `pickMessageResult` in `SlotBodyEnd` regardless of the result message type

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd.island.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.island.tsx
@@ -205,9 +205,7 @@ export const SlotBodyEnd = ({
 		};
 		pickMessage(epicConfig, renderingTarget)
 			.then((result) => {
-				if (result.type === 'MessageSelected') {
-					setPickMessageResult(result);
-				}
+				setPickMessageResult(result);
 			})
 			.catch((e) =>
 				console.error(`SlotBodyEnd pickMessage - error: ${String(e)}`),


### PR DESCRIPTION
## What does this change?

Fixes a bug where we weren't setting the value of the picked message in all scenarios and only setting it for the success scenario

## Why?

We have been missing `article-end` ad slots in the US for about a month, with https://github.com/guardian/dotcom-rendering/pull/15484 likely being the culprit

## Screenshots

_Before this fix, the SlotBodyEnd island has no children when no Epic is due to show. After, we have an ad slot container as the child regardless of whether the ad is filled or not_
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/8cc6bdd1-5739-4ba3-8d2b-84cbcd194858
[after]: https://github.com/user-attachments/assets/37e568d6-781f-46c3-98ec-170799225840