### PR TITLE
NewsletterSignupCard — static presentational shell

### DIFF
--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -5,6 +5,7 @@ import { EmailSignup } from './EmailSignup';
 import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { Island } from './Island';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
+import { NewsletterSignupCard } from './NewsletterSignupCard';
 import { Placeholder } from './Placeholder';
 import { SecureSignup } from './SecureSignup.island';
 
@@ -21,12 +22,16 @@ interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	index: number;
 	listId: number;
 	identityName: string;
-	successDescription: string;
+	/** Illustration image URL 1x1 for the NewsletterSignupCard variant */
+	illustrationSquare?: string;
 	idApiUrl: string;
 	/** You should only set this to true if the privacy message will be shown elsewhere on the page */
 	hidePrivacyMessage?: boolean;
 	/** Feature flag to enable hiding newsletter signup for already subscribed users */
 	hideNewsletterSignupComponentForSubscribers?: boolean;
+	/** Feature flag to show the new NewsletterSignupCard design instead of EmailSignup */
+	showNewNewsletterSignupCard?: boolean;
+	successDescription: string;
 }
 
 /**
@@ -44,6 +49,7 @@ export const EmailSignUpWrapper = ({
 	listId,
 	idApiUrl,
 	hideNewsletterSignupComponentForSubscribers = false,
+	showNewNewsletterSignupCard = false,
 	...emailSignUpProps
 }: EmailSignUpWrapperProps) => {
 	const isSubscribed = useNewsletterSubscription(
@@ -51,6 +57,28 @@ export const EmailSignUpWrapper = ({
 		idApiUrl,
 		hideNewsletterSignupComponentForSubscribers,
 	);
+
+	// When the new card design is enabled, always show it regardless of subscription status
+	if (showNewNewsletterSignupCard) {
+		return (
+			<InlineSkipToWrapper
+				id={`EmailSignup-skip-link-${index}`}
+				blockDescription="newsletter promotion"
+			>
+				<NewsletterSignupCard {...emailSignUpProps}>
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<SecureSignup
+							newsletterId={emailSignUpProps.identityName}
+							successDescription={emailSignUpProps.description}
+						/>
+					</Island>
+					{!emailSignUpProps.hidePrivacyMessage && (
+						<NewsletterPrivacyMessage />
+					)}
+				</NewsletterSignupCard>
+			</InlineSkipToWrapper>
+		);
+	}
 
 	// Show placeholder while subscription status is being determined
 	// This prevents layout shift in both subscribed and non-subscribed cases

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -33,7 +33,7 @@ export const Placeholder = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(undefined);
 	},
 });
@@ -44,7 +44,7 @@ export const DefaultStory = meta.story({
 		hidePrivacyMessage: true,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -58,7 +58,7 @@ export const DefaultStoryWithPrivacy = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -73,7 +73,7 @@ export const SignedInNotSubscribed = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -91,7 +91,7 @@ export const SignedInAlreadySubscribed = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: true,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 	},
 });
@@ -104,7 +104,7 @@ export const FeatureFlagDisabled = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: false,
 	},
-	async beforeEach() {
+	beforeEach() {
 		// Even though we mock this to return true (subscribed),
 		// the feature flag being disabled means it won't be checked
 		mocked(useNewsletterSubscription).mockReturnValue(false);
@@ -119,5 +119,34 @@ export const FeatureFlagDisabled = meta.story({
 				story: 'When the hideNewsletterSignupComponentForSubscribers feature flag is disabled, the signup form is always shown regardless of subscription status.',
 			},
 		},
+	},
+});
+
+export const NewNewsletterSignupCard = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		// The new card should still show even if the user is subscribed
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+	},
+});
+
+export const NewNewsletterSignupCardSignedOut = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterSignupCard.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.stories.tsx
@@ -1,0 +1,41 @@
+import { allModes } from '../../.storybook/modes';
+import preview from '../../.storybook/preview';
+import { NewsletterSignupCard } from './NewsletterSignupCard';
+import { Section } from './Section';
+
+const meta = preview.meta({
+	component: NewsletterSignupCard,
+	title: 'Components/Newsletter Signup Card',
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobile': allModes['vertical mobile'],
+				'vertical tablet': allModes['vertical tablet'],
+			},
+		},
+	},
+	decorators: [
+		(Story) => (
+			<Section
+				title="NewsletterSignupCard"
+				showTopBorder={true}
+				padContent={false}
+				centralBorder="partial"
+			>
+				<Story />
+			</Section>
+		),
+	],
+});
+
+export const Default = meta.story({
+	args: {
+		name: 'Saturday Edition',
+		description:
+			"An exclusive roundup of the week's best Guardian journalism from the editor-in-chief, Katharine Viner, free to your inbox every Saturday.",
+		frequency: 'Weekly',
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+		children: <></>,
+	},
+});

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -1,0 +1,119 @@
+import { css } from '@emotion/react';
+import {
+	headlineMedium20,
+	space,
+	textSans14,
+	textSans15,
+} from '@guardian/source/foundations';
+import { SvgNewsletterFilled } from '@guardian/source/react-components';
+import { palette as themePalette } from '../palette';
+
+export type NewsletterSignupCardProps = {
+	name: string;
+	frequency: string;
+	description: string;
+	illustrationSquare?: string;
+	children?: React.ReactNode;
+};
+
+const containerStyles = css`
+	clear: left;
+	background-color: ${themePalette('--newsletter-card-background')};
+	margin-bottom: ${space[3]}px;
+	padding: ${space[2]}px ${space[2]}px ${space[4]}px ${space[2]}px;
+`;
+
+const headerStyles = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: ${space[2]}px;
+	margin-bottom: ${space[2]}px;
+`;
+
+const titleAndMetaStyles = css`
+	display: flex;
+	flex-direction: column;
+`;
+
+const titleStyles = css`
+	${headlineMedium20};
+	margin-bottom: ${space[2]}px;
+`;
+
+const frequencyTagStyles = css`
+	display: flex;
+	align-items: center;
+	color: ${themePalette('--newsletter-frequency-tag')};
+	${textSans15};
+	margin-left: -1px;
+	margin-top: -1px;
+	margin-bottom: ${space[1]}px;
+
+	svg {
+		fill: currentColor;
+		height: 20px;
+		width: 20px;
+	}
+`;
+
+const descriptionStyles = css`
+	${textSans14};
+	line-height: 1.15;
+	margin-bottom: ${space[2]}px;
+	clear: both;
+`;
+
+const illustrationStyles = css`
+	flex-shrink: 0;
+	width: 100px;
+	height: 100px;
+	border-radius: 50%;
+	object-fit: cover;
+`;
+
+const NewsletterSignupHeader = (props: {
+	frequency: string;
+	name: string;
+	description: string;
+	illustrationSquare?: string;
+}) => (
+	<div css={headerStyles}>
+		<div css={titleAndMetaStyles}>
+			<div css={frequencyTagStyles}>
+				<SvgNewsletterFilled />
+				Newsletter | {props.frequency}
+			</div>
+			<p css={titleStyles}>
+				Sign up to <span>{props.name}</span>
+			</p>
+			<p css={descriptionStyles}>{props.description}</p>
+		</div>
+		{!!props.illustrationSquare && (
+			<img
+				css={illustrationStyles}
+				src={props.illustrationSquare}
+				alt=""
+			/>
+		)}
+	</div>
+);
+
+export const NewsletterSignupCard = ({
+	name,
+	frequency,
+	description,
+	illustrationSquare,
+	children,
+}: NewsletterSignupCardProps) => (
+	<aside css={containerStyles} aria-label="newsletter promotion">
+		<NewsletterSignupHeader
+			frequency={frequency}
+			name={name}
+			description={description}
+			illustrationSquare={illustrationSquare}
+		/>
+		{children}
+	</aside>
+);

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -421,6 +421,9 @@
                 },
                 "illustrationCard": {
                     "type": "string"
+                },
+                "illustrationSquare": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -3066,6 +3069,9 @@
                             "type": "string"
                         },
                         "illustrationCard": {
+                            "type": "string"
+                        },
+                        "illustrationSquare": {
                             "type": "string"
                         }
                     },

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -584,6 +584,9 @@ export const renderElement = ({
 				idApiUrl: idApiUrl ?? '',
 				hideNewsletterSignupComponentForSubscribers:
 					!!switches.hideNewsletterSignupComponentForSubscribers,
+				showNewNewsletterSignupCard:
+					!!switches.showNewNewsletterSignupCard,
+				illustrationSquare: element.newsletter.illustrationSquare ?? '',
 			};
 			if (isListElement || isTimeline) return null;
 			return (

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -2549,6 +2549,9 @@
                         },
                         "illustrationCard": {
                             "type": "string"
+                        },
+                        "illustrationSquare": {
+                            "type": "string"
                         }
                     },
                     "required": [

--- a/dotcom-rendering/src/model/newsletter-page-schema.json
+++ b/dotcom-rendering/src/model/newsletter-page-schema.json
@@ -38,6 +38,9 @@
                     },
                     "illustrationCard": {
                         "type": "string"
+                    },
+                    "illustrationSquare": {
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7593,6 +7593,14 @@ const paletteColours = {
 		light: navSearchBarText,
 		dark: navSearchBarText,
 	},
+	'--newsletter-card-background': {
+		light: () => '#F3F7FF',
+		dark: () => '#F3F7FF',
+	},
+	'--newsletter-frequency-tag': {
+		light: () => sourcePalette.neutral[38],
+		dark: () => sourcePalette.neutral[38],
+	},
 	'--numbered-list-heading': {
 		light: numberedListHeadingLight,
 		dark: numberedListHeadingDark,

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -1203,6 +1203,7 @@ export type Newsletter = {
 	group: string;
 	regionFocus?: string;
 	illustrationCard?: string;
+	illustrationSquare?: string;
 };
 
 export type NewsletterLayout = {


### PR DESCRIPTION
## What does this change?

Create a new presentational component NewsletterSignupCard.tsx to support development of the new in-article newsletter sign-up component.

## Why?

To support development of the new article-based newsletter sign-up card

## Screenshots

<img width="605" height="138" alt="image" src="https://github.com/user-attachments/assets/56584cc7-303d-480f-833d-153be4c0c231" />

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
