### PR TITLE
Use large icons for default video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -379,6 +379,8 @@ export const SelfHostedVideo = ({
 
 	const showProgressBar = !hideProgressBar && !isCinemagraph;
 
+	const iconSize = isDefault ? 'large' : 'small';
+
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 
 	const [isInView, setNode] = useIsInView({
@@ -935,6 +937,7 @@ export const SelfHostedVideo = ({
 						onError={onError}
 						AudioIcon={hasAudio ? AudioIcon : null}
 						preloadPartialData={!!shouldAutoplay}
+						iconSize={iconSize}
 						showPlayIcon={showPlayIcon}
 						showProgressBar={showProgressBar}
 						showSubtitles={!isCinemagraph}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -6,7 +6,6 @@ import {
 	textSans20,
 } from '@guardian/source/foundations';
 import type { IconProps } from '@guardian/source/react-components';
-import { SvgArrowExpand } from '@guardian/source/react-components';
 import type {
 	Dispatch,
 	ReactElement,
@@ -19,6 +18,10 @@ import type { Source } from '../lib/video';
 import { palette } from '../palette';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { narrowPlayIconDiameter, PlayIcon } from './Card/components/PlayIcon';
+import {
+	AudioIcon as AudioIconComponent,
+	FullscreenIcon,
+} from './SelfHostedVideoPlayerIcons';
 import { SubtitleOverlay } from './SubtitleOverlay';
 import { VideoProgressBar } from './VideoProgressBar';
 
@@ -63,7 +66,7 @@ const playIconStyles = css`
 	padding: 0;
 `;
 
-const controlContainerStyles = (position: ControlsPosition) => css`
+const iconsContainerStyles = (position: ControlsPosition) => css`
 	position: absolute;
 	display: flex;
 	flex-direction: column;
@@ -72,24 +75,6 @@ const controlContainerStyles = (position: ControlsPosition) => css`
 	/* Take into account the progress bar height */
 	${position === 'bottom' && `bottom: ${space[3]}px;`}
 	${position === 'top' && `top: ${space[2]}px;`}
-`;
-
-const buttonStyles = css`
-	border: none;
-	background: none;
-	padding: 0;
-	cursor: pointer;
-`;
-
-const iconContainerStyles = css`
-	width: ${space[8]}px;
-	height: ${space[8]}px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	background-color: ${palette('--video-icon-background')};
-	border-radius: 50%;
-	border: 1px solid ${palette('--video-icon-border')};
 `;
 
 export const PLAYER_STATES = [
@@ -112,7 +97,7 @@ export const PLAYER_STATES = [
 
 export type PlayerStates = (typeof PLAYER_STATES)[number];
 
-type Props = {
+export type Props = {
 	sources: Source[];
 	atomId: string;
 	uniqueId: string;
@@ -137,6 +122,7 @@ type Props = {
 	handleFullscreenClick?: (event: SyntheticEvent) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: ((iconProps: IconProps) => JSX.Element) | null;
+	iconSize: 'small' | 'large';
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showProgressBar: boolean;
@@ -190,6 +176,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handleFullscreenClick,
 			onError,
 			AudioIcon,
+			iconSize,
 			preloadPartialData,
 			showProgressBar: canShowProgressBar,
 			showPlayIcon,
@@ -300,50 +287,22 @@ export const SelfHostedVideoPlayer = forwardRef(
 					/>
 				)}
 				{showIcons && (
-					<div css={controlContainerStyles(controlsPosition)}>
-						{AudioIcon && (
-							<button
-								type="button"
-								onClick={handleAudioClick}
-								css={buttonStyles}
-								data-link-name={`gu-video-loop-${
-									isMuted ? 'unmute' : 'mute'
-								}-${atomId}`}
-							>
-								<div
-									css={iconContainerStyles}
-									data-testid={`${
-										isMuted ? 'unmute' : 'mute'
-									}-icon`}
-								>
-									<AudioIcon
-										size="xsmall"
-										theme={{
-											fill: palette('--video-icon'),
-										}}
-									/>
-								</div>
-							</button>
-						)}
+					<div css={iconsContainerStyles(controlsPosition)}>
 						{showFullscreenIcon && (
-							<button
-								type="button"
-								onClick={handleFullscreenClick}
-								css={buttonStyles}
-								data-link-name={`gu-video-loop-fullscreen-${atomId}`}
-							>
-								<div
-									css={iconContainerStyles}
-									data-testid="fullscreen-icon"
-								>
-									<SvgArrowExpand
-										size="xsmall"
-										theme={{
-											fill: palette('--video-icon'),
-										}}
-									/>
-								</div>
-							</button>
+							<FullscreenIcon
+								handleClick={handleFullscreenClick}
+								atomId={atomId}
+								size={iconSize}
+							/>
+						)}
+						{AudioIcon && (
+							<AudioIconComponent
+								Icon={AudioIcon}
+								handleClick={handleAudioClick}
+								isMuted={isMuted}
+								atomId={atomId}
+								size={iconSize}
+							/>
 						)}
 					</div>
 				)}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -1,0 +1,112 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import { SvgArrowExpand } from '@guardian/source/react-components';
+import { palette } from '../palette';
+import type { Props as SelfHostedVideoPlayerProps } from './SelfHostedVideoPlayer';
+
+export type SubtitleSize = 'small' | 'medium' | 'large';
+export type ControlsPosition = 'top' | 'bottom';
+
+const buttonStyles = css`
+	border: none;
+	background: none;
+	padding: 0;
+	cursor: pointer;
+`;
+
+const iconContainerStyles = css`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+const smallIconContainerStyles = css`
+	width: ${space[8]}px;
+	height: ${space[8]}px;
+	background-color: ${palette('--video-icon-small-background')};
+	border-radius: 50%;
+	border: 1px solid ${palette('--video-icon-border')};
+`;
+
+const largeIconContainerStyles = css`
+	width: 44px;
+	height: 44px;
+	background-color: ${palette('--video-icon-large-background')};
+	border-radius: ${space[5]}px;
+`;
+
+type AudioIconProps = {
+	Icon: Exclude<SelfHostedVideoPlayerProps['AudioIcon'], null>;
+	atomId: SelfHostedVideoPlayerProps['atomId'];
+	size: 'small' | 'large';
+	isMuted: SelfHostedVideoPlayerProps['isMuted'];
+	handleClick: SelfHostedVideoPlayerProps['handleAudioClick'];
+};
+
+export const AudioIcon = ({
+	Icon,
+	atomId,
+	size,
+	isMuted,
+	handleClick,
+}: AudioIconProps) => (
+	<button
+		type="button"
+		onClick={handleClick}
+		css={buttonStyles}
+		data-link-name={`gu-video-loop-${
+			isMuted ? 'unmute' : 'mute'
+		}-${atomId}`}
+	>
+		<div
+			css={[
+				iconContainerStyles,
+				size === 'small' && smallIconContainerStyles,
+				size === 'large' && largeIconContainerStyles,
+			]}
+			data-testid={`${isMuted ? 'unmute' : 'mute'}-icon`}
+		>
+			<Icon
+				size="xsmall"
+				theme={{
+					fill: palette('--video-icon'),
+				}}
+			/>
+		</div>
+	</button>
+);
+
+type FullscreenIconProps = {
+	atomId: SelfHostedVideoPlayerProps['atomId'];
+	size: 'small' | 'large';
+	handleClick: SelfHostedVideoPlayerProps['handleFullscreenClick'];
+};
+
+export const FullscreenIcon = ({
+	atomId,
+	size,
+	handleClick,
+}: FullscreenIconProps) => (
+	<button
+		type="button"
+		onClick={handleClick}
+		css={buttonStyles}
+		data-link-name={`gu-video-loop-fullscreen-${atomId}`}
+	>
+		<div
+			css={[
+				iconContainerStyles,
+				size === 'small' && smallIconContainerStyles,
+				size === 'large' && largeIconContainerStyles,
+			]}
+			data-testid="fullscreen-icon"
+		>
+			<SvgArrowExpand
+				size="xsmall"
+				theme={{
+					fill: palette('--video-icon'),
+				}}
+			/>
+		</div>
+	</button>
+);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -8381,13 +8381,17 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[100],
 	},
-	'--video-icon-background': {
-		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
-		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
-	},
 	'--video-icon-border': {
 		light: () => sourcePalette.neutral[60],
 		dark: () => sourcePalette.neutral[60],
+	},
+	'--video-icon-large-background': {
+		light: () => transparentColour(sourcePalette.neutral[7], 0.6),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.6),
+	},
+	'--video-icon-small-background': {
+		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
 	},
 	'--video-progress-bar-background': {
 		light: () => transparentColour(sourcePalette.neutral[7], 0.7),


### PR DESCRIPTION
## What does this change?

Use large icons for default video.

For better readability, creates a new file for icons components & reusable icon styles/logic. A share button will be coming soon, which is an extra reason to separate icons out. 

## Why?

To match designs.

## Screenshots

Note: The designs have the icons higher up. This will be implemented when the new, taller, progress bar arrives.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/0da88f56-42a6-4588-97b6-c81a0ed08f17
[after]: https://github.com/user-attachments/assets/164a1cce-48a1-4292-82ba-f752ac7a192a
[before2]: https://github.com/user-attachments/assets/9080ebf4-2a3e-4f92-8dc8-af594f1bc6f0
[after2]: https://github.com/user-attachments/assets/1669b0a0-ad71-4c3d-bb9e-0f39c048f062

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
