### PR TITLE
Disable default video in feature cards

### DIFF
--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -265,26 +265,30 @@ const getMedia = ({
 	mainMedia?: MainMedia;
 	showVideo?: boolean;
 }) => {
-	if (mainMedia?.type === 'SelfHostedVideo' && showVideo) {
-		let type: CardMediaType;
+	if (
+		showVideo &&
+		mainMedia?.type === 'SelfHostedVideo' &&
+		(mainMedia.videoStyle === 'Loop' ||
+			mainMedia.videoStyle === 'Cinemagraph')
+	) {
+		let style: CardMediaType;
 		switch (mainMedia.videoStyle) {
 			case 'Loop':
-				type = 'loop-video';
+				style = 'loop-video';
 				break;
 			case 'Cinemagraph':
-				type = 'cinemagraph';
+				style = 'cinemagraph';
 				break;
-			default:
-				type = 'default-video';
 		}
 
 		return {
-			type,
+			type: 'self-hosted-video',
+			style,
 			mainMedia,
 		} as const;
 	}
 
-	if (mainMedia?.type === 'YoutubeVideo' && showVideo) {
+	if (showVideo && mainMedia?.type === 'YoutubeVideo') {
 		return {
 			type: 'youtube-video',
 			mainMedia,
@@ -455,13 +459,9 @@ export const FeatureCard = ({
 
 	const isYoutubeVideo = media.type === 'youtube-video';
 
-	const isSelfHostedVideo =
-		media.type === 'loop-video' ||
-		media.type === 'default-video' ||
-		media.type === 'cinemagraph';
+	const isSelfHostedVideo = media.type === 'self-hosted-video';
 
-	const isSelfHostedVideoWithControls =
-		media.type === 'loop-video' || media.type === 'default-video';
+	const isSelfHostedVideoWithControls = media.style === 'loop-video';
 
 	const labsDataAttributes = branding
 		? getOphanComponents({
@@ -476,7 +476,7 @@ export const FeatureCard = ({
 
 	/* The whole card is clickable on cinemagraphs and pictures */
 	const allowLinkThroughOverlay =
-		media.type === 'cinemagraph' || media.type === 'picture';
+		media.style === 'cinemagraph' || media.type === 'picture';
 
 	return (
 		<FormatBoundary format={format}>


### PR DESCRIPTION
## What does this change?

Disables Default video in feature cards. Loops and Cinemagraphs are still permitted.

## Why?

Default video is not supported in feature cards.

## Screenshots

Feature card in Feature Two container with replacement default (non-youtube) video

| Before - Replacement video is the card media   | After - An image is the card media    |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e9bb243a-b226-4651-84e6-f27c982af550
[after]: https://github.com/user-attachments/assets/bf3bf4e1-c479-480e-9243-048d0ee2fe87

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
