### PR TITLE
Fix ESLint hoisting in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 save-prefix=''
 public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
 confirmModulesPurge=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-prefix=''
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 save-prefix=''
 public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*
+confirmModulesPurge=false

--- a/ab-testing/eslint.config.mjs
+++ b/ab-testing/eslint.config.mjs
@@ -1,4 +1,4 @@
-import guardian from "@guardian/eslint-config/index.js";
+import guardian from "@guardian/eslint-config";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([

--- a/ab-testing/eslint.config.mjs
+++ b/ab-testing/eslint.config.mjs
@@ -1,4 +1,4 @@
-import guardian from "@guardian/eslint-config";
+import guardian from "@guardian/eslint-config/index.js";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([


### PR DESCRIPTION
## What does this change?
Adds `public-hoist-pattern[]=*eslint*` to `.npmrc` to restore hoisting of ESLint packages to the root node_modules following [upgrade of pnpm](https://github.com/guardian/dotcom-rendering/pull/15711). [See workflows for a-b testing failing since merge](https://github.com/guardian/dotcom-rendering/actions?query=workflow%3A%22%F0%9F%A7%AA%20AB%20testing%22) 
Also adds `confirmModulesPurge=false` to `.npmrc` to allow pnpm to automatically purge and recreate node_modules in CI and pre-push hooks.

See relevant issue https://github.com/pnpm/pnpm/issues/8378
