### PR TITLE
add 0% ab test for prebid price floor

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -146,6 +146,19 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: "commercial-prebid-price-floor",
+		description:
+			"Measure the impact on bid response rate o f enforcing a minimum $0.10 bid floor on all Prebid ad slots.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-05-07",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
What does this change?
This PR sets up an AB test configuration, 0% of the total audience, to allow for opting in to test, for the `commercial-prebid-price-floor`

Why?
This is part of the work to pass floor prices to our Prebid partners, related PR in commercial https://github.com/guardian/commercial/pull/2530.