### PR TITLE
Use a new interactive progress bar for long-form (default) video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -811,9 +811,7 @@ export const SelfHostedVideo = ({
 		}
 	};
 
-	const handleKeyDownVideo = (
-		event: React.KeyboardEvent<HTMLVideoElement>,
-	): void => {
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
 		if (isCinemagraph) return;
 
 		switch (event.key) {
@@ -833,24 +831,6 @@ export const SelfHostedVideo = ({
 				break;
 			case 'm':
 				setIsMuted(!isMuted);
-				break;
-		}
-	};
-
-	const handleKeyDownProgressBar = (
-		event: React.KeyboardEvent<HTMLInputElement>,
-	): void => {
-		switch (event.key) {
-			case 'Enter':
-			case ' ':
-				event.preventDefault();
-				playPauseVideo();
-				break;
-			case 'ArrowRight':
-				seekForward();
-				break;
-			case 'ArrowLeft':
-				seekBackward();
 				break;
 		}
 	};
@@ -962,9 +942,8 @@ export const SelfHostedVideo = ({
 						handlePlayPauseClick={handlePlayPauseClick}
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
-						handleKeyDownVideo={handleKeyDownVideo}
+						handleKeyDown={handleKeyDown}
 						useLongFormProgressBar={isDefault}
-						handleKeyDownProgressBar={handleKeyDownProgressBar}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
 						updateCurrentTime={updateCurrentTime}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -786,7 +786,7 @@ export const SelfHostedVideo = ({
 		const video = vidRef.current;
 		if (!video) return;
 
-		const increment = 1;
+		const increment = isDefault ? 10 : 1;
 		const newTime = Math.min(video.currentTime + increment, video.duration);
 
 		updateCurrentTime(newTime);
@@ -796,7 +796,7 @@ export const SelfHostedVideo = ({
 		const video = vidRef.current;
 		if (!video) return;
 
-		const increment = 1;
+		const increment = isDefault ? 10 : 1;
 		const newTime = Math.max(video.currentTime - increment, 0);
 
 		updateCurrentTime(newTime);
@@ -811,7 +811,7 @@ export const SelfHostedVideo = ({
 		}
 	};
 
-	const handleKeyDown = (
+	const handleKeyDownVideo = (
 		event: React.KeyboardEvent<HTMLVideoElement>,
 	): void => {
 		if (isCinemagraph) return;
@@ -833,6 +833,24 @@ export const SelfHostedVideo = ({
 				break;
 			case 'm':
 				setIsMuted(!isMuted);
+				break;
+		}
+	};
+
+	const handleKeyDownProgressBar = (
+		event: React.KeyboardEvent<HTMLInputElement>,
+	): void => {
+		switch (event.key) {
+			case 'Enter':
+			case ' ':
+				event.preventDefault();
+				playPauseVideo();
+				break;
+			case 'ArrowRight':
+				seekForward();
+				break;
+			case 'ArrowLeft':
+				seekBackward();
 				break;
 		}
 	};
@@ -944,9 +962,12 @@ export const SelfHostedVideo = ({
 						handlePlayPauseClick={handlePlayPauseClick}
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
-						handleKeyDown={handleKeyDown}
+						handleKeyDownVideo={handleKeyDownVideo}
+						useLongFormProgressBar={isDefault}
+						handleKeyDownProgressBar={handleKeyDownProgressBar}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
+						updateCurrentTime={updateCurrentTime}
 						onError={onError}
 						AudioIcon={hasAudio ? AudioIcon : null}
 						preloadPartialData={!!shouldAutoplay}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -36,6 +36,7 @@ import type {
 	SubtitleSize,
 } from './SelfHostedVideoPlayer';
 import { SelfHostedVideoPlayer } from './SelfHostedVideoPlayer';
+import type { SubtitlesPosition } from './SubtitleOverlay';
 import type { OphanVideoStyle } from './YoutubeAtom/eventEmitters';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 
@@ -383,6 +384,13 @@ export const SelfHostedVideo = ({
 	const showIcons = !isCinemagraph && playerState !== 'NOT_STARTED';
 
 	const iconSize = isDefault ? 'large' : 'small';
+
+	const useLongFormProgressBar = isDefault;
+
+	const subtitlesPosition: SubtitlesPosition =
+		useLongFormProgressBar && controlsPosition === 'bottom'
+			? 'bottom-elevated'
+			: controlsPosition;
 
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 
@@ -943,7 +951,7 @@ export const SelfHostedVideo = ({
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
 						handleKeyDown={handleKeyDown}
-						useLongFormProgressBar={isDefault}
+						useLongFormProgressBar={useLongFormProgressBar}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
 						updateCurrentTime={updateCurrentTime}
@@ -958,6 +966,7 @@ export const SelfHostedVideo = ({
 						subtitleSize={subtitleSize}
 						showIcons={showIcons}
 						controlsPosition={controlsPosition}
+						subtitlesPosition={subtitlesPosition}
 						activeCue={activeCue}
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -117,11 +117,8 @@ export type Props = {
 	handlePlaying: (event: SyntheticEvent) => void;
 	handlePlayPauseClick: (event: SyntheticEvent) => void;
 	handleAudioClick: (event: SyntheticEvent) => void;
-	handleKeyDownVideo: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
+	handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
-	handleKeyDownProgressBar: (
-		event: React.KeyboardEvent<HTMLInputElement>,
-	) => void;
 	useLongFormProgressBar: boolean;
 	handlePause: (event: SyntheticEvent) => void;
 	handleFullscreenClick?: (event: SyntheticEvent) => void;
@@ -174,9 +171,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handlePlaying,
 			handlePlayPauseClick,
 			handleAudioClick,
-			handleKeyDownVideo,
+			handleKeyDown,
 			handleTimeUpdate,
-			handleKeyDownProgressBar,
 			useLongFormProgressBar,
 			handlePause,
 			handleFullscreenClick,
@@ -242,7 +238,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onTimeUpdate={handleTimeUpdate}
 					onPause={handlePause}
 					onClick={handlePlayPauseClick}
-					onKeyDown={handleKeyDownVideo}
+					onKeyDown={handleKeyDown}
 					onError={onError}
 				>
 					{sources.map(({ src, mimeType }) => (
@@ -293,7 +289,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 							currentTime={currentTime}
 							updateCurrentTime={updateCurrentTime}
 							duration={ref.current!.duration}
-							handleKeyDown={handleKeyDownProgressBar}
+							handleKeyDown={handleKeyDown}
 						/>
 					) : (
 						<VideoProgressBar

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -19,6 +19,7 @@ import {
 } from './SelfHostedVideoPlayerIcons';
 import { SubtitleOverlay } from './SubtitleOverlay';
 import { VideoProgressBar } from './VideoProgressBar';
+import { VideoProgressBarInteractive } from './VideoProgressBarInteractive';
 
 export type SubtitleSize = 'small' | 'medium' | 'large';
 export type ControlsPosition = 'top' | 'bottom';
@@ -69,9 +70,13 @@ const iconsContainerStyles = css`
 	right: ${space[2]}px;
 `;
 
-const iconsPositionStyles = (position: ControlsPosition) => css`
-	/* Take into account the progress bar height */
+const smallIconsPositionStyles = (position: ControlsPosition) => css`
 	${position === 'bottom' && `bottom: ${space[3]}px;`}
+	${position === 'top' && `top: ${space[2]}px;`}
+`;
+
+const largeIconsPositionStyles = (position: ControlsPosition) => css`
+	${position === 'bottom' && `bottom: ${space[12]}px;`}
 	${position === 'top' && `top: ${space[2]}px;`}
 `;
 
@@ -112,10 +117,15 @@ export type Props = {
 	handlePlaying: (event: SyntheticEvent) => void;
 	handlePlayPauseClick: (event: SyntheticEvent) => void;
 	handleAudioClick: (event: SyntheticEvent) => void;
-	handleKeyDown: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
+	handleKeyDownVideo: (event: React.KeyboardEvent<HTMLVideoElement>) => void;
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
+	handleKeyDownProgressBar: (
+		event: React.KeyboardEvent<HTMLInputElement>,
+	) => void;
+	useLongFormProgressBar: boolean;
 	handlePause: (event: SyntheticEvent) => void;
 	handleFullscreenClick?: (event: SyntheticEvent) => void;
+	updateCurrentTime: (time: number) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	AudioIcon: ((iconProps: IconProps) => JSX.Element) | null;
 	iconSize: 'small' | 'large';
@@ -164,10 +174,13 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handlePlaying,
 			handlePlayPauseClick,
 			handleAudioClick,
-			handleKeyDown,
+			handleKeyDownVideo,
 			handleTimeUpdate,
+			handleKeyDownProgressBar,
+			useLongFormProgressBar,
 			handlePause,
 			handleFullscreenClick,
+			updateCurrentTime,
 			onError,
 			AudioIcon,
 			iconSize,
@@ -229,7 +242,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onTimeUpdate={handleTimeUpdate}
 					onPause={handlePause}
 					onClick={handlePlayPauseClick}
-					onKeyDown={handleKeyDown}
+					onKeyDown={handleKeyDownVideo}
 					onError={onError}
 				>
 					{sources.map(({ src, mimeType }) => (
@@ -255,7 +268,11 @@ export const SelfHostedVideoPlayer = forwardRef(
 					<SubtitleOverlay
 						text={activeCue.text}
 						size={subtitleSize}
-						position={controlsPosition}
+						position={
+							useLongFormProgressBar
+								? 'raised-bottom'
+								: controlsPosition
+						}
 					/>
 				)}
 				{showPlayIcon && (
@@ -269,18 +286,30 @@ export const SelfHostedVideoPlayer = forwardRef(
 						<PlayIcon iconWidth="narrow" />
 					</button>
 				)}
-				{showProgressBar && (
-					<VideoProgressBar
-						videoId={videoId}
-						currentTime={currentTime}
-						duration={ref.current!.duration}
-					/>
-				)}
+				{showProgressBar &&
+					(useLongFormProgressBar ? (
+						<VideoProgressBarInteractive
+							videoId={videoId}
+							currentTime={currentTime}
+							updateCurrentTime={updateCurrentTime}
+							duration={ref.current!.duration}
+							handleKeyDown={handleKeyDownProgressBar}
+						/>
+					) : (
+						<VideoProgressBar
+							videoId={videoId}
+							currentTime={currentTime}
+							duration={ref.current!.duration}
+						/>
+					))}
 				{showIcons && (
 					<div
 						css={[
 							iconsContainerStyles,
-							iconsPositionStyles(controlsPosition),
+							iconSize === 'large' &&
+								largeIconsPositionStyles(controlsPosition),
+							iconSize === 'small' &&
+								smallIconsPositionStyles(controlsPosition),
 						]}
 					>
 						{showFullscreenIcon && (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -17,6 +17,7 @@ import {
 	AudioIcon as AudioIconComponent,
 	FullscreenIcon,
 } from './SelfHostedVideoPlayerIcons';
+import type { SubtitlesPosition } from './SubtitleOverlay';
 import { SubtitleOverlay } from './SubtitleOverlay';
 import { VideoProgressBar } from './VideoProgressBar';
 import { VideoProgressBarInteractive } from './VideoProgressBarInteractive';
@@ -140,6 +141,7 @@ export type Props = {
 	shouldLoop: boolean;
 	isInteractive: boolean;
 	controlsPosition: ControlsPosition;
+	subtitlesPosition: SubtitlesPosition;
 };
 
 /**
@@ -192,6 +194,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			shouldLoop,
 			isInteractive,
 			controlsPosition,
+			subtitlesPosition,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -264,11 +267,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					<SubtitleOverlay
 						text={activeCue.text}
 						size={subtitleSize}
-						position={
-							useLongFormProgressBar
-								? 'raised-bottom'
-								: controlsPosition
-						}
+						position={subtitlesPosition}
 					/>
 				)}
 				{showPlayIcon && (

--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -14,7 +14,7 @@ export type SubtitlesPosition =
 	/**
 	 * Subtitles are anchored to the bottom, but leave enough room for a tall progress bar
 	 */
-	| 'raised-bottom';
+	| 'bottom-elevated';
 
 const subtitleOverlayStyles = css`
 	width: 100%;
@@ -27,7 +27,7 @@ const subtitleOverlayStyles = css`
 const subtitlePositionStyles = (position: SubtitlesPosition) => css`
 	${position === 'top' && `top: ${space[4]}px;`};
 	${position === 'bottom' && `bottom: ${space[4]}px;`};
-	${position === 'raised-bottom' && `bottom: ${space[12]}px;`};
+	${position === 'bottom-elevated' && `bottom: ${space[12]}px;`};
 `;
 
 const cueBoxStyles = css`

--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -6,17 +6,28 @@ import {
 	textSans20,
 } from '@guardian/source/foundations';
 import { palette } from '../palette';
-import type { ControlsPosition, SubtitleSize } from './SelfHostedVideoPlayer';
+import type { SubtitleSize } from './SelfHostedVideoPlayer';
 
-const subtitleOverlayStyles = (position: ControlsPosition) => css`
+export type SubtitlesPosition =
+	| 'top'
+	| 'bottom'
+	/**
+	 * Subtitles are anchored to the bottom, but leave enough room for a tall progress bar
+	 */
+	| 'raised-bottom';
+
+const subtitleOverlayStyles = css`
 	width: 100%;
 	display: flex;
 	justify-content: center;
 	pointer-events: none;
 	position: absolute;
+`;
 
+const subtitlePositionStyles = (position: SubtitlesPosition) => css`
 	${position === 'top' && `top: ${space[4]}px;`};
 	${position === 'bottom' && `bottom: ${space[4]}px;`};
+	${position === 'raised-bottom' && `bottom: ${space[12]}px;`};
 `;
 
 const cueBoxStyles = css`
@@ -62,10 +73,10 @@ export const SubtitleOverlay = ({
 }: {
 	text: string;
 	size: SubtitleSize;
-	position: 'top' | 'bottom';
+	position: SubtitlesPosition;
 }) => {
 	return (
-		<div css={subtitleOverlayStyles(position)}>
+		<div css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}>
 			<div css={cueBoxStyles}>
 				<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
 			</div>

--- a/dotcom-rendering/src/components/VideoProgressBar.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBar.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { getZIndex } from '../lib/getZIndex';
+import { convertCurrentTimeToProgressPercentage } from '../lib/video';
 import { palette } from '../palette';
 
 const styles = css`
@@ -49,11 +50,11 @@ export const VideoProgressBar = ({ videoId, currentTime, duration }: Props) => {
 	 */
 	const adjustedDuration = duration > 1 ? duration - 0.25 : duration;
 
-	const progressPercentage = Math.min(
-		(currentTime * 100) / adjustedDuration,
-		100,
+	const progressPercentage = convertCurrentTimeToProgressPercentage(
+		currentTime,
+		adjustedDuration,
 	);
-	if (Number.isNaN(progressPercentage)) {
+	if (progressPercentage === null) {
 		return null;
 	}
 

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -1,0 +1,213 @@
+import { css } from '@emotion/react';
+import {
+	focusHalo,
+	palette as sourcePalette,
+	textSans12,
+} from '@guardian/source/foundations';
+import { getZIndex } from '../lib/getZIndex';
+import {
+	convertCurrentTimeToProgressPercentage,
+	convertProgressPercentageToCurrentTime,
+} from '../lib/video';
+import { palette } from '../palette';
+
+const containerStyles = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	height: 44px;
+	width: 100%;
+	z-index: ${getZIndex('video-progress-bar-background')};
+	cursor: pointer;
+	padding: 0 12px;
+	background: linear-gradient(
+		to top,
+		${sourcePalette.neutral[0]} 0%,
+		transparent 100%
+	);
+`;
+
+const trackStyles = css`
+	-webkit-appearance: none;
+	appearance: none;
+	height: 5px;
+	border-radius: 5px;
+`;
+
+const thumbStyles = css`
+	-webkit-appearance: none;
+	appearance: none;
+	width: 14px;
+	height: 14px;
+	border: none;
+	border-radius: 50%;
+	background-color: ${palette('--video-progress-bar-interactive-value')};
+	z-index: ${getZIndex('video-progress-bar-foreground')};
+	cursor: pointer;
+`;
+
+const progressBarStyles = (roundedProgressPercentage: number) => css`
+	width: 100%;
+	cursor: pointer;
+	height: 5px;
+	border-radius: 5px;
+	-webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+	appearance: none;
+	/* The colour to the left of the thumb is different to the right to indicate progress */
+	background: ${`linear-gradient(
+		to right,
+		${palette('--video-progress-bar-interactive-value')} 0%,
+		${palette(
+			'--video-progress-bar-interactive-value',
+		)} ${roundedProgressPercentage}%,
+		${palette(
+			'--video-progress-bar-interactive-background',
+		)} ${roundedProgressPercentage}%,
+		${palette('--video-progress-bar-interactive-background')} 100%
+	)`};
+
+	/* We don't use the default focus ring as it includes the thumb, which looks odd. */
+	:focus-visible {
+		${focusHalo}
+	}
+
+	/** Extend the clickable area of the progress bar (only works on Chrome) */
+	::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		height: 36px;
+	}
+
+	::-webkit-slider-runnable-track {
+		${trackStyles}
+	}
+	::-moz-range-track {
+		${trackStyles}
+	}
+	::-ms-track {
+		${trackStyles}
+		width: 100%;
+	}
+
+	::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		margin-top: -5px;
+		${thumbStyles}
+	}
+	::-moz-range-thumb {
+		${thumbStyles}
+	}
+	::-ms-thumb {
+		${thumbStyles}
+	}
+`;
+
+const handleChange = (
+	value: string,
+	duration: Props['duration'],
+	updateCurrentTime: Props['updateCurrentTime'],
+) => {
+	const percentage = Number(value);
+	const time = convertProgressPercentageToCurrentTime(percentage, duration);
+
+	if (time === null) return;
+
+	updateCurrentTime(time);
+};
+
+type Props = {
+	videoId: string;
+	currentTime: number;
+	updateCurrentTime: (time: number) => void;
+	handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+	duration: number;
+};
+
+/**
+ * A progress bar for the self-hosted video component.
+ *
+ * Q. Why don't we use the <progress /> element?
+ * A. It was not possible to properly style the native progress element in Safari.
+ */
+export const VideoProgressBarInteractive = ({
+	videoId,
+	currentTime,
+	updateCurrentTime,
+	handleKeyDown,
+	duration,
+}: Props) => {
+	if (duration <= 0) return null;
+
+	const progressPercentage = convertCurrentTimeToProgressPercentage(
+		currentTime,
+		duration,
+	);
+	if (progressPercentage === null) {
+		return null;
+	}
+
+	const roundedProgressPercentage = Number(progressPercentage.toFixed(2));
+
+	return (
+		<div css={containerStyles}>
+			<Time current={currentTime} duration={duration} />
+			<input
+				type="range"
+				value={roundedProgressPercentage}
+				css={progressBarStyles(roundedProgressPercentage)}
+				className={`progress-bar-${videoId}`}
+				role="progressbar"
+				aria-labelledby={videoId}
+				min={0}
+				max={100}
+				step={0.01}
+				tabIndex={0}
+				onChange={(event) =>
+					handleChange(
+						event.target.value,
+						duration,
+						updateCurrentTime,
+					)
+				}
+				onKeyDown={handleKeyDown}
+			/>
+		</div>
+	);
+};
+
+const timeStyles = css`
+	${textSans12};
+	color: ${sourcePalette.neutral[100]};
+	margin-left: 1px; /* To make it _feel_ more aligned with the progress bar, which has a border radius. */
+`;
+
+const formatTime = (timeInSeconds: number) => {
+	const clampedTimeInSeconds = Math.max(0, timeInSeconds);
+
+	const minutes = Math.floor(clampedTimeInSeconds / 60);
+	const seconds = Math.floor(clampedTimeInSeconds % 60);
+
+	if (isNaN(minutes) || isNaN(seconds)) {
+		return null;
+	}
+
+	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+const Time = ({ current, duration }: { current: number; duration: number }) => {
+	const right = formatTime(duration);
+	const left = formatTime(Math.min(current, duration));
+
+	if (right === null || left === null) {
+		return null;
+	}
+
+	return (
+		<time css={timeStyles}>
+			{left} / {right}
+		</time>
+	);
+};

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -8,6 +8,7 @@ import { getZIndex } from '../lib/getZIndex';
 import {
 	convertCurrentTimeToProgressPercentage,
 	convertProgressPercentageToCurrentTime,
+	formatTimeForDisplay,
 } from '../lib/video';
 import { palette } from '../palette';
 
@@ -184,26 +185,9 @@ const timeStyles = css`
 	margin-left: 1px; /* To make it _feel_ more aligned with the progress bar, which has a border radius. */
 `;
 
-const formatTime = (timeInSeconds: number) => {
-	const clampedTimeInSeconds = Math.max(0, timeInSeconds);
-
-	const minutes = Math.floor(clampedTimeInSeconds / 60);
-	const seconds = Math.floor(clampedTimeInSeconds % 60);
-
-	if (isNaN(minutes) || isNaN(seconds)) {
-		return null;
-	}
-
-	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-};
-
 const Time = ({ current, duration }: { current: number; duration: number }) => {
-	const right = formatTime(duration);
-	const left = formatTime(Math.min(current, duration));
-
-	if (right === null || left === null) {
-		return null;
-	}
+	const right = formatTimeForDisplay(duration);
+	const left = formatTimeForDisplay(Math.min(current, duration));
 
 	return (
 		<time css={timeStyles}>

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -316,7 +316,7 @@ describe('video', () => {
 
 	describe('formatTimeForDisplay', () => {
 		it.each([
-			{ timeInSeconds: -10, expectedFormattedTime: '0:00' },
+			{ timeInSeconds: -1.24, expectedFormattedTime: '0:00' },
 			{ timeInSeconds: 0, expectedFormattedTime: '0:00' },
 			{ timeInSeconds: 59, expectedFormattedTime: '0:59' },
 			{ timeInSeconds: 60, expectedFormattedTime: '1:00' },

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -6,6 +6,7 @@ import {
 	convertProgressPercentageToCurrentTime,
 	extractValidSourcesFromAssets,
 	findOptimisedSourcePerMimeType,
+	formatTimeForDisplay,
 	getAspectRatioFromSources,
 } from './video';
 import type { Source } from './video';
@@ -293,6 +294,8 @@ describe('video', () => {
 			{ progressPercentage: 75, duration: 32, expectedCurrentTime: 24 },
 			{ progressPercentage: 100, duration: 56, expectedCurrentTime: 56 },
 			{ progressPercentage: 103, duration: 11, expectedCurrentTime: 11 },
+			{ progressPercentage: 10, duration: 0, expectedCurrentTime: null },
+			{ progressPercentage: 8, duration: -10, expectedCurrentTime: null },
 			{
 				progressPercentage: -0.1244235,
 				duration: 10,
@@ -307,6 +310,26 @@ describe('video', () => {
 						duration,
 					),
 				).toEqual(expectedCurrentTime);
+			},
+		);
+	});
+
+	describe('formatTimeForDisplay', () => {
+		it.each([
+			{ timeInSeconds: -10, expectedFormattedTime: '0:00' },
+			{ timeInSeconds: 0, expectedFormattedTime: '0:00' },
+			{ timeInSeconds: 59, expectedFormattedTime: '0:59' },
+			{ timeInSeconds: 60, expectedFormattedTime: '1:00' },
+			{ timeInSeconds: 61, expectedFormattedTime: '1:01' },
+			{ timeInSeconds: 92.5, expectedFormattedTime: '1:32' },
+			{ timeInSeconds: 1000, expectedFormattedTime: '16:40' },
+			{ timeInSeconds: 10000, expectedFormattedTime: '166:40' },
+		])(
+			'should return the correct formatted time based on the time in seconds',
+			({ timeInSeconds, expectedFormattedTime }) => {
+				expect(formatTimeForDisplay(timeInSeconds)).toEqual(
+					expectedFormattedTime,
+				);
 			},
 		);
 	});

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -1,7 +1,9 @@
 import type { FEMediaAsset } from '../frontend/feFront';
 import type { VideoAssets } from '../types/content';
 import {
+	convertCurrentTimeToProgressPercentage,
 	convertFEMediaAssetsToVideoAssets,
+	convertProgressPercentageToCurrentTime,
 	extractValidSourcesFromAssets,
 	findOptimisedSourcePerMimeType,
 	getAspectRatioFromSources,
@@ -262,5 +264,50 @@ describe('video', () => {
 
 			expect(sources).toEqual([mp4Src720h, m3u8Src720h]);
 		});
+	});
+
+	describe('convertCurrentTimeToProgressPercentage', () => {
+		it.each([
+			{ currentTime: 0, duration: 23, expectedPercentage: 0 },
+			{ currentTime: 24, duration: 32, expectedPercentage: 75 },
+			{ currentTime: 56, duration: 56, expectedPercentage: 100 },
+			{ currentTime: 12, duration: 11, expectedPercentage: 100 },
+			{ currentTime: -5, duration: 10, expectedPercentage: null },
+			{ currentTime: 5, duration: -10, expectedPercentage: null },
+		])(
+			'should return the correct progress percentage based on the current time and duration',
+			({ currentTime, duration, expectedPercentage }) => {
+				expect(
+					convertCurrentTimeToProgressPercentage(
+						currentTime,
+						duration,
+					),
+				).toEqual(expectedPercentage);
+			},
+		);
+	});
+
+	describe('convertProgressPercentageToCurrentTime', () => {
+		it.each([
+			{ progressPercentage: 0, duration: 23, expectedCurrentTime: 0 },
+			{ progressPercentage: 75, duration: 32, expectedCurrentTime: 24 },
+			{ progressPercentage: 100, duration: 56, expectedCurrentTime: 56 },
+			{ progressPercentage: 103, duration: 11, expectedCurrentTime: 11 },
+			{
+				progressPercentage: -0.1244235,
+				duration: 10,
+				expectedCurrentTime: 0,
+			},
+		])(
+			'should return the correct current time based on the progress percentage and duration',
+			({ progressPercentage, duration, expectedCurrentTime }) => {
+				expect(
+					convertProgressPercentageToCurrentTime(
+						progressPercentage,
+						duration,
+					),
+				).toEqual(expectedCurrentTime);
+			},
+		);
 	});
 });

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -161,3 +161,12 @@ export const convertProgressPercentageToCurrentTime = (
 
 	return (clampedPercentage / 100) * duration;
 };
+
+export const formatTimeForDisplay = (timeInSeconds: number) => {
+	const clampedTimeInSeconds = Math.max(0, timeInSeconds);
+
+	const minutes = Math.floor(clampedTimeInSeconds / 60);
+	const seconds = Math.floor(clampedTimeInSeconds % 60);
+
+	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -141,3 +141,23 @@ export const findOptimisedSourcePerMimeType = (
 		return acc;
 	}, []);
 };
+
+export const convertCurrentTimeToProgressPercentage = (
+	currentTime: number,
+	duration: number,
+): number | null => {
+	if (currentTime < 0 || duration <= 0) return null;
+
+	return Math.min((currentTime * 100) / duration, 100);
+};
+
+export const convertProgressPercentageToCurrentTime = (
+	progressPercentage: number,
+	duration: number,
+): number | null => {
+	if (duration <= 0) return null;
+
+	const clampedPercentage = Math.max(0, Math.min(progressPercentage, 100));
+
+	return (clampedPercentage / 100) * duration;
+};

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -162,7 +162,7 @@ export const convertProgressPercentageToCurrentTime = (
 	return (clampedPercentage / 100) * duration;
 };
 
-export const formatTimeForDisplay = (timeInSeconds: number) => {
+export const formatTimeForDisplay = (timeInSeconds: number): string => {
 	const clampedTimeInSeconds = Math.max(0, timeInSeconds);
 
 	const minutes = Math.floor(clampedTimeInSeconds / 60);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -8429,6 +8429,14 @@ const paletteColours = {
 		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
 		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
 	},
+	'--video-progress-bar-interactive-background': {
+		light: () => transparentColour(sourcePalette.neutral[100], 0.5),
+		dark: () => transparentColour(sourcePalette.neutral[100], 0.5),
+	},
+	'--video-progress-bar-interactive-value': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[100],
+	},
 	'--video-progress-bar-value': {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[86],


### PR DESCRIPTION
## What does this change?

Implements an alternative progress bar for Default (non-Youtube) video. This progress bar:
- is taller
- is interactive: clicks take the user to a specific point in the video
- is scrubbable
- has a linear background gradient
- has the current time and duration

<img width="614" height="48" alt="image" src="https://github.com/user-attachments/assets/88f4391d-bd01-4bc4-808f-78cfa28a7489" />

Tested on Chrome, Firefox, Safari & Edge; on mobile (using browserstack) and desktop browsers.

I have an alternative implementation of this progress bar which uses `div`'s with CSS/JS instead of `<input type="range" ... />`. In this approach, the smooth transition of progress is maintained and it is easier to style and control with CSS/JS. However, scrubbing comes "for free" with the `input` approach, which would be tricky to implement well otherwise, and also has better accessibility by default.

Styling sources:
- https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/
- https://blog.logrocket.com/creating-custom-css-range-slider-javascript-upgrades/
- https://css-tricks.com/sliding-nightmare-understanding-range-input/

## What does this PR not do?

- Implement a smooth transition. I couldn't find a way to do this with this implementation that uses `<input type="range" ... />`. This is a nice-to-have. Other popular video players on the web have a mixture of smooth and stuttered transitions.
- If you scrub to the end of the video and then back, the player will be paused. Let's consider this edge case later.
- The thumb is not perfectly centered within the progress bar. It is maybe half a pixel too high. This is the default implementation across all tested browsers.
- Hide the progress bar if it is playing and not hovered/interacted with, to match designs. This will be looked at in a future PR.
- Captures progress bar clicks/scrubs from around the bar itself on desktop browsers other than Chrome. I think this will be useful as the bar is only 5px high. This will require JS to make work and has been left to a future PR.

## Why?

To match designs. Long-form video would benefit more from extra video features.

## How to test?

- [Run storybook locally](https://github.com/guardian/dotcom-rendering/blob/80315a4610b50a4f925f78cdad09e7d6afb008b7/dotcom-rendering/docs/testing.md?plain=1#L55). Locate the Default story in SelfHostedVideo.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/600ba158-6718-456c-a804-bf7069a2c9b7
[after]: https://github.com/user-attachments/assets/5dd03ba6-9e51-4e79-a5ec-962e266ba9b1


https://github.com/user-attachments/assets/ca94146a-ed24-40f6-b0d0-905c92682b27

