### PR TITLE
Set 'storybook.thegulocal.com' as an allowed host in storybook

### DIFF
--- a/dotcom-rendering/.storybook/main.ts
+++ b/dotcom-rendering/.storybook/main.ts
@@ -84,6 +84,9 @@ export default defineMain({
 		// See: https://storybook.js.org/docs/react/configure/environment-variables
 		CI: 'true',
 	}),
+	core: {
+		allowedHosts: ['storybook.thegulocal.com'],
+	},
 
 	framework: {
 		name: '@storybook/react-webpack5',

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -66,7 +66,13 @@ storybook-dev: clear clean-dist install
 	$(call log, "starting Storybook DEV server")
 	@pnpm storybook
 
+storybook-dev-proxy: clear clean-dist install
+	$(call log, "starting Storybook DEV reverse proxy server")
+	@pnpm storybook-proxy
+
 storybook: storybook-dev
+
+storybook-proxy: storybook-dev-proxy
 
 # tests #####################################
 

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -16,6 +16,7 @@
 		"playwright:run": "playwright test",
 		"unused-exports": "pnpm ts-unused-exports ./tsconfig.json --ignoreFiles='(/(fixtures|__mocks__)/|.+\\.(stories|mocks))' --exitWithCount",
 		"storybook": "storybook dev -p 4002",
+		"storybook-proxy": "storybook dev -p 4002 --host storybook.thegulocal.com",
 		"build-storybook": "storybook build"
 	},
 	"dependencies": {


### PR DESCRIPTION
## What does this change?
Adds `storybook.thegulocal.com` as an allowed host in storybook `core.allowedHosts` config. 

It also extends the list of make commands to include `storybook-proxy`. Running this will open storybook on the storybook.thegulocal.com domain by default, reducing some friction whilst devloping of having to remember the domain. This has been added as a separate command rather than extending the current `storybook` command so that users are not forced to use nginx mappings. 

## Why?
Storybook's dev server validates the `Host` header on incoming requests and rejects any host not explicitly allowed, returning a 403. When accessing Storybook via the local reverse proxy at storybook.thegulocal.com (rather than localhost:4002 directly), requests were being rejected with an invalid host error.

Adding the proxy domain to allowedHosts allows Storybook to be accessed through the nginx reverse proxy, which is necessary for developing components, such as videos with subtitles, that require a specific origin to satisfy cross-origin policies.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/810258d2-2689-4800-a264-acdf35777a39
[after]: https://github.com/user-attachments/assets/3d84089f-f3ad-40f5-ba77-4ad8d16f2980

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
