### PR TITLE
Show native subtitles when the video is fullscreen

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -434,6 +434,24 @@ export const SelfHostedVideo = ({
 		}
 	}, []);
 
+	/**
+	 * On Safari mobile, webkit fullscreen is a native layer separate from the DOM.
+	 * The custom SubtitleOverlay div won't appear there, but native VTT cue rendering
+	 * will work if cues have their default (snap-to-lines) positioning.
+	 * positionCues() uses getBoundingClientRect() which returns 0 in the native layer,
+	 * so we must reset cues to defaults before entering webkit fullscreen.
+	 */
+	const resetCuesToDefault = useCallback((video: HTMLVideoElement) => {
+		const track = video.textTracks[0];
+		if (!track?.cues) return;
+		for (const cue of Array.from(track.cues)) {
+			if (cue instanceof VTTCue) {
+				cue.snapToLines = true;
+				cue.line = -1;
+			}
+		}
+	}, []);
+
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
 		if (!video) return;
@@ -679,7 +697,9 @@ export const SelfHostedVideo = ({
 			setIsFullscreen(!!document.fullscreenElement);
 			if (video) positionCues(video);
 		};
-		const handleWebkitEnter = () => setIsFullscreen(true);
+		const handleWebkitEnter = () => {
+			setIsFullscreen(true);
+		};
 		const handleWebkitExit = () => {
 			setIsFullscreen(false);
 			if (video) positionCues(video);
@@ -806,6 +826,14 @@ export const SelfHostedVideo = ({
 			if (webkitVideo.webkitDisplayingFullscreen) {
 				return webkitVideo.webkitExitFullscreen();
 			} else {
+				/**
+				 * Reset cue positioning BEFORE entering webkit fullscreen.
+				 * The native iOS fullscreen player captures VTT cue data (snapToLines, line)
+				 * when webkitEnterFullscreen() is called. If we wait for the webkitbeginfullscreen
+				 * event it is too late — the native layer has already read the cue properties
+				 * modified by positionCues(), which can place subtitles off-screen.
+				 */
+				resetCuesToDefault(video);
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}
@@ -1028,7 +1056,7 @@ export const SelfHostedVideo = ({
 						showIcons={showIcons}
 						controlsPosition={controlsPosition}
 						subtitlesPosition={subtitlesPosition}
-						activeCue={activeCue}
+						activeCue={isFullscreen ? null : activeCue}
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -813,18 +813,12 @@ export const SelfHostedVideo = ({
 
 	const handleFullscreenClick = (event: React.SyntheticEvent) => {
 		void submitClickComponentEvent(event.currentTarget, renderingTarget);
-		event.stopPropagation(); // Don't pause the video
+		event.stopPropagation();
 
 		const video = vidRef.current;
 		if (!video) return;
 
 		if (shouldUseWebkitFullscreen(video)) {
-			/***
-			 * webkit fullscreen methods are not part of the standard HTMLVideoElement
-			 * type definition as they are iOS only.
-			 * We need to extend the type expect these handlers when we're on iOS to keep TS happy.
-			 * @see https://developer.apple.com/documentation/webkitjs/htmlvideoelement/1633500-webkitenterfullscreen
-			 */
 			const webkitVideo = video as HTMLVideoElement & {
 				webkitDisplayingFullscreen: boolean;
 				webkitEnterFullscreen: () => void;
@@ -834,17 +828,8 @@ export const SelfHostedVideo = ({
 			if (webkitVideo.webkitDisplayingFullscreen) {
 				return webkitVideo.webkitExitFullscreen();
 			} else {
-				/**
-				 * Reset cue positioning BEFORE entering webkit fullscreen so the native iOS
-				 * player doesn't render cues at the custom overlay positions (which can be off-screen).
-				 *
-				 * Also add the ios-fullscreen-subtitles class BEFORE calling webkitEnterFullscreen().
-				 * The CSS pseudo-classes :fullscreen and :-webkit-full-screen are NOT triggered by
-				 * webkitEnterFullscreen() on iOS — they only apply to the standard requestFullscreen
-				 * API. Without this class, ::cue { visibility: hidden } stays active in the native
-				 * fullscreen player and subtitles are never shown.
-				 */
 				resetCuesToDefault(video);
+				video.classList.add('ios-fullscreen-subtitles'); // ← ADD THIS
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}
@@ -854,7 +839,6 @@ export const SelfHostedVideo = ({
 		}
 		void video.requestFullscreen();
 	};
-
 	/**
 	 * If the video was paused and we know that it wasn't paused by the user
 	 * or the intersection observer, we can deduce that it was paused by the

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -647,10 +647,7 @@ export const SelfHostedVideo = ({
 		return FallbackImageComponent;
 	}
 
-	const handleLoadedMetadata = () => {
-		const video = vidRef.current;
-		if (!video) return;
-
+	const positionCues = (video: HTMLVideoElement) => {
 		const track = video.textTracks[0];
 		if (!track?.cues) return;
 
@@ -665,6 +662,12 @@ export const SelfHostedVideo = ({
 				cue.line = percentFromTop;
 			}
 		}
+	};
+
+	const handleLoadedMetadata = () => {
+		const video = vidRef.current;
+		if (!video) return;
+		positionCues(video);
 	};
 
 	const handleLoadedData = () => {
@@ -753,6 +756,21 @@ export const SelfHostedVideo = ({
 			void document.exitFullscreen();
 		}
 		void video.requestFullscreen();
+
+		/* Reposition cues after fullscreen transition settles */
+		video.addEventListener('fullscreenchange', () => positionCues(video), {
+			once: true,
+		});
+		video.addEventListener(
+			'webkitbeginfullscreen',
+			() => positionCues(video),
+			{ once: true },
+		);
+		video.addEventListener(
+			'webkitendfullscreen',
+			() => positionCues(video),
+			{ once: true },
+		);
 	};
 
 	/**

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined, log, storage } from '@guardian/libs';
-import { from, space, until } from '@guardian/source/foundations';
+import { from, until } from '@guardian/source/foundations';
 import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -406,51 +406,20 @@ export const SelfHostedVideo = ({
 		currentTime,
 	});
 
-	const positionCues = useCallback((video: HTMLVideoElement) => {
-		const track = video.textTracks[0];
-		if (!track?.cues) return;
-
-		const isFullScreen =
-			document.fullscreenElement === video ||
-			('webkitDisplayingFullscreen' in video &&
-				video.webkitDisplayingFullscreen);
-
-		/**
-		 * In fullscreen, push cues above the native controls.
-		 * In normal view, use SubtitleOverlay instead (cues hidden via CSS).
-		 */
-		const pxFromBottom = isFullScreen ? space[18] : space[3];
-		const videoHeight = video.getBoundingClientRect().height;
-		if (videoHeight === 0) return;
-
-		const percentFromTop =
-			((videoHeight - pxFromBottom) / videoHeight) * 100;
-
-		for (const cue of Array.from(track.cues)) {
-			if (cue instanceof VTTCue) {
-				cue.snapToLines = false;
-				cue.line = percentFromTop;
-			}
-		}
-	}, []);
-
 	/**
-	 * On Safari mobile, webkit fullscreen is a native layer separate from the DOM.
-	 * The custom SubtitleOverlay div won't appear there, but native VTT cue rendering
-	 * will work if cues have their default (snap-to-lines) positioning.
-	 * positionCues() uses getBoundingClientRect() which returns 0 in the native layer,
-	 * so we must reset cues to defaults before entering webkit fullscreen.
+	 * Switch the native text track mode based on fullscreen state.
+	 * - 'showing' in fullscreen: native browser rendering handles captions inside the
+	 *   native fullscreen layer (required for iOS webkit fullscreen where the DOM is inaccessible).
+	 * - 'hidden' outside fullscreen: cuechange events still fire so useSubtitles can
+	 *   populate activeCue, but native rendering is suppressed in favour of SubtitleOverlay.
 	 */
-	const resetCuesToDefault = useCallback((video: HTMLVideoElement) => {
+	useEffect(() => {
+		const video = vidRef.current;
+		if (!video) return;
 		const track = video.textTracks[0];
-		if (!track?.cues) return;
-		for (const cue of Array.from(track.cues)) {
-			if (cue instanceof VTTCue) {
-				cue.snapToLines = true;
-				cue.line = -1;
-			}
-		}
-	}, []);
+		if (!track) return;
+		track.mode = isFullscreen ? 'showing' : 'hidden';
+	}, [isFullscreen]);
 
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
@@ -695,22 +664,12 @@ export const SelfHostedVideo = ({
 
 		const handleFullscreenChange = () => {
 			setIsFullscreen(!!document.fullscreenElement);
-			if (video) positionCues(video);
 		};
 		const handleWebkitEnter = () => {
-			/**
-			 * Add the class here (alongside setIsFullscreen) so that native cues become
-			 * visible at the exact same render cycle that hides the custom SubtitleOverlay.
-			 * Adding the class earlier (in handleFullscreenClick) causes a brief window where
-			 * both native cues and the custom overlay are visible simultaneously.
-			 */
-			video?.classList.add('ios-fullscreen-subtitles');
 			setIsFullscreen(true);
 		};
 		const handleWebkitExit = () => {
 			setIsFullscreen(false);
-			video?.classList.remove('ios-fullscreen-subtitles');
-			if (video) positionCues(video);
 		};
 
 		document.addEventListener('fullscreenchange', handleFullscreenChange);
@@ -744,16 +703,14 @@ export const SelfHostedVideo = ({
 			);
 			video?.removeEventListener('webkitendfullscreen', handleWebkitExit);
 		};
-	}, [positionCues]);
+	}, []);
 
 	if (adapted) {
 		return FallbackImageComponent;
 	}
 
 	const handleLoadedMetadata = () => {
-		const video = vidRef.current;
-		if (!video) return;
-		positionCues(video);
+		// metadata loaded; no action needed for subtitle positioning
 	};
 
 	const handleLoadedData = () => {
@@ -828,8 +785,6 @@ export const SelfHostedVideo = ({
 			if (webkitVideo.webkitDisplayingFullscreen) {
 				return webkitVideo.webkitExitFullscreen();
 			} else {
-				resetCuesToDefault(video);
-				video.classList.add('ios-fullscreen-subtitles'); // ← ADD THIS
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -702,6 +702,7 @@ export const SelfHostedVideo = ({
 		};
 		const handleWebkitExit = () => {
 			setIsFullscreen(false);
+			video?.classList.remove('ios-fullscreen-subtitles');
 			if (video) positionCues(video);
 		};
 
@@ -827,13 +828,17 @@ export const SelfHostedVideo = ({
 				return webkitVideo.webkitExitFullscreen();
 			} else {
 				/**
-				 * Reset cue positioning BEFORE entering webkit fullscreen.
-				 * The native iOS fullscreen player captures VTT cue data (snapToLines, line)
-				 * when webkitEnterFullscreen() is called. If we wait for the webkitbeginfullscreen
-				 * event it is too late — the native layer has already read the cue properties
-				 * modified by positionCues(), which can place subtitles off-screen.
+				 * Reset cue positioning BEFORE entering webkit fullscreen so the native iOS
+				 * player doesn't render cues at the custom overlay positions (which can be off-screen).
+				 *
+				 * Also add the ios-fullscreen-subtitles class BEFORE calling webkitEnterFullscreen().
+				 * The CSS pseudo-classes :fullscreen and :-webkit-full-screen are NOT triggered by
+				 * webkitEnterFullscreen() on iOS — they only apply to the standard requestFullscreen
+				 * API. Without this class, ::cue { visibility: hidden } stays active in the native
+				 * fullscreen player and subtitles are never shown.
 				 */
 				resetCuesToDefault(video);
+				video.classList.add('ios-fullscreen-subtitles');
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -360,6 +360,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
+	const [isFullscreen, setIsFullscreen] = useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -404,6 +405,34 @@ export const SelfHostedVideo = ({
 		playerState,
 		currentTime,
 	});
+
+	const positionCues = useCallback((video: HTMLVideoElement) => {
+		const track = video.textTracks[0];
+		if (!track?.cues) return;
+
+		const isFullScreen =
+			document.fullscreenElement === video ||
+			('webkitDisplayingFullscreen' in video &&
+				video.webkitDisplayingFullscreen);
+
+		/**
+		 * In fullscreen, push cues above the native controls.
+		 * In normal view, use SubtitleOverlay instead (cues hidden via CSS).
+		 */
+		const pxFromBottom = isFullScreen ? space[18] : space[3];
+		const videoHeight = video.getBoundingClientRect().height;
+		if (videoHeight === 0) return;
+
+		const percentFromTop =
+			((videoHeight - pxFromBottom) / videoHeight) * 100;
+
+		for (const cue of Array.from(track.cues)) {
+			if (cue instanceof VTTCue) {
+				cue.snapToLines = false;
+				cue.line = percentFromTop;
+			}
+		}
+	}, []);
 
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
@@ -643,26 +672,55 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
+	useEffect(() => {
+		const video = vidRef.current;
+
+		const handleFullscreenChange = () => {
+			setIsFullscreen(!!document.fullscreenElement);
+			if (video) positionCues(video);
+		};
+		const handleWebkitEnter = () => setIsFullscreen(true);
+		const handleWebkitExit = () => {
+			setIsFullscreen(false);
+			if (video) positionCues(video);
+		};
+
+		document.addEventListener('fullscreenchange', handleFullscreenChange);
+		document.addEventListener(
+			'webkitfullscreenchange',
+			handleFullscreenChange,
+		);
+		document.addEventListener(
+			'mozfullscreenchange',
+			handleFullscreenChange,
+		);
+		video?.addEventListener('webkitbeginfullscreen', handleWebkitEnter);
+		video?.addEventListener('webkitendfullscreen', handleWebkitExit);
+
+		return () => {
+			document.removeEventListener(
+				'fullscreenchange',
+				handleFullscreenChange,
+			);
+			document.removeEventListener(
+				'webkitfullscreenchange',
+				handleFullscreenChange,
+			);
+			document.removeEventListener(
+				'mozfullscreenchange',
+				handleFullscreenChange,
+			);
+			video?.removeEventListener(
+				'webkitbeginfullscreen',
+				handleWebkitEnter,
+			);
+			video?.removeEventListener('webkitendfullscreen', handleWebkitExit);
+		};
+	}, [positionCues]);
+
 	if (adapted) {
 		return FallbackImageComponent;
 	}
-
-	const positionCues = (video: HTMLVideoElement) => {
-		const track = video.textTracks[0];
-		if (!track?.cues) return;
-
-		const pxFromBottom = space[3];
-		const videoHeight = video.getBoundingClientRect().height;
-		const percentFromTop =
-			((videoHeight - pxFromBottom) / videoHeight) * 100;
-
-		for (const cue of Array.from(track.cues)) {
-			if (cue instanceof VTTCue) {
-				cue.snapToLines = false;
-				cue.line = percentFromTop;
-			}
-		}
-	};
 
 	const handleLoadedMetadata = () => {
 		const video = vidRef.current;
@@ -756,21 +814,6 @@ export const SelfHostedVideo = ({
 			void document.exitFullscreen();
 		}
 		void video.requestFullscreen();
-
-		/* Reposition cues after fullscreen transition settles */
-		video.addEventListener('fullscreenchange', () => positionCues(video), {
-			once: true,
-		});
-		video.addEventListener(
-			'webkitbeginfullscreen',
-			() => positionCues(video),
-			{ once: true },
-		);
-		video.addEventListener(
-			'webkitendfullscreen',
-			() => positionCues(video),
-			{ once: true },
-		);
 	};
 
 	/**
@@ -989,6 +1032,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
+						isFullscreen={isFullscreen}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -698,6 +698,13 @@ export const SelfHostedVideo = ({
 			if (video) positionCues(video);
 		};
 		const handleWebkitEnter = () => {
+			/**
+			 * Add the class here (alongside setIsFullscreen) so that native cues become
+			 * visible at the exact same render cycle that hides the custom SubtitleOverlay.
+			 * Adding the class earlier (in handleFullscreenClick) causes a brief window where
+			 * both native cues and the custom overlay are visible simultaneously.
+			 */
+			video?.classList.add('ios-fullscreen-subtitles');
 			setIsFullscreen(true);
 		};
 		const handleWebkitExit = () => {
@@ -838,7 +845,6 @@ export const SelfHostedVideo = ({
 				 * fullscreen player and subtitles are never shown.
 				 */
 				resetCuesToDefault(video);
-				video.classList.add('ios-fullscreen-subtitles');
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -143,6 +143,7 @@ export type Props = {
 	isInteractive: boolean;
 	controlsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	isFullscreen: boolean;
 };
 
 /**
@@ -196,6 +197,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			controlsPosition,
 			subtitlesPosition,
+			isFullscreen,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -211,6 +213,9 @@ export const SelfHostedVideoPlayer = forwardRef(
 			showPlayIcon ? 'play' : 'pause'
 		}-${atomId}`;
 
+		/* TODO:: remove after testing */
+		console.log(showFullscreenIcon);
+
 		return (
 			<>
 				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Not all videos require captions. */}
@@ -221,6 +226,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						isInteractive && interactiveStyles,
 						showSubtitles && nativeSubtitleStyles,
 					]}
+					controls={isFullscreen}
 					crossOrigin="anonymous"
 					ref={ref}
 					tabIndex={0}
@@ -308,7 +314,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 								smallIconsPositionStyles(controlsPosition),
 						]}
 					>
-						{showFullscreenIcon && (
+						{true && (
 							<FullscreenIcon
 								handleClick={handleFullscreenClick}
 								atomId={atomId}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -5,7 +5,6 @@ import type { ReactElement, SyntheticEvent } from 'react';
 import { forwardRef } from 'react';
 import type { ActiveCue } from '../lib/useSubtitles';
 import type { Source } from '../lib/video';
-import { palette } from '../palette';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { narrowPlayIconDiameter, PlayIcon } from './Card/components/PlayIcon';
 import {
@@ -33,34 +32,6 @@ const videoStyles = (aspectRatio: number) => css`
 
 const interactiveStyles = css`
 	cursor: pointer;
-`;
-
-const nativeSubtitleStyles = css`
-	::cue {
-		/* Hide the cue by default as we prefer the custom SubtitleOverlay */
-		visibility: hidden;
-		color: ${palette('--video-subtitle-text')};
-	}
-
-	/**
-	 * When entering iOS webkit fullscreen (webkitEnterFullscreen), the CSS
-	 * pseudo-classes :fullscreen and :-webkit-full-screen are NOT triggered —
-	 * they only apply to the standard requestFullscreen / webkitRequestFullscreen APIs.
-	 * Instead we add this class via JS immediately before calling webkitEnterFullscreen()
-	 * so that native cues are visible in the iOS native fullscreen player.
-	 */
-	&.ios-fullscreen-subtitles::cue {
-		visibility: visible;
-	}
-
-	/* Standard fullscreen API (desktop browsers) */
-	&:fullscreen::cue {
-		visibility: visible;
-	}
-
-	&:-webkit-full-screen::cue {
-		visibility: visible;
-	}
 `;
 
 const playIconStyles = css`
@@ -218,13 +189,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showSubtitles = canShowSubtitles && !!subtitleSource;
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
-
+		console.log(showFullscreenIcon);
 		const dataLinkName = `gu-video-${videoStyle.toLowerCase()}-${
 			showPlayIcon ? 'play' : 'pause'
 		}-${atomId}`;
-
-		/* TODO:: remove after testing */
-		console.log(showFullscreenIcon);
 
 		return (
 			<>
@@ -234,7 +202,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 					css={[
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
-						showSubtitles && nativeSubtitleStyles,
 					]}
 					controls={isFullscreen}
 					crossOrigin="anonymous"
@@ -269,10 +236,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 							type={mimeType}
 						/>
 					))}
-					{showSubtitles && (
+					{!!subtitleSource && (
 						<track
-							// Don't use default - it forces native rendering on iOS
-							default={false}
 							kind="subtitles"
 							src={subtitleSource}
 							srcLang="en"

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	space,
-	textSans15,
-	textSans17,
-	textSans20,
-} from '@guardian/source/foundations';
+import { space } from '@guardian/source/foundations';
 import type { IconProps } from '@guardian/source/react-components';
 import type { ReactElement, SyntheticEvent } from 'react';
 import { forwardRef } from 'react';
@@ -40,15 +35,21 @@ const interactiveStyles = css`
 	cursor: pointer;
 `;
 
-const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
+const nativeSubtitleStyles = css`
 	::cue {
 		/* Hide the cue by default as we prefer custom overlay */
 		visibility: hidden;
-
 		color: ${palette('--video-subtitle-text')};
-		${subtitleSize === 'small' && textSans15};
-		${subtitleSize === 'medium' && textSans17};
-		${subtitleSize === 'large' && textSans20};
+	}
+
+	/* Display the native cues when in fullscreen */
+
+	&:fullscreen::cue {
+		visibility: visible;
+	}
+
+	&:-webkit-full-screen::cue {
+		visibility: visible;
 	}
 `;
 
@@ -218,7 +219,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					css={[
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
-						showSubtitles && subtitleStyles(subtitleSize),
+						showSubtitles && nativeSubtitleStyles,
 					]}
 					crossOrigin="anonymous"
 					ref={ref}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -37,13 +37,23 @@ const interactiveStyles = css`
 
 const nativeSubtitleStyles = css`
 	::cue {
-		/* Hide the cue by default as we prefer custom overlay */
+		/* Hide the cue by default as we prefer the custom SubtitleOverlay */
 		visibility: hidden;
 		color: ${palette('--video-subtitle-text')};
 	}
 
-	/* Display the native cues when in fullscreen */
+	/**
+	 * When entering iOS webkit fullscreen (webkitEnterFullscreen), the CSS
+	 * pseudo-classes :fullscreen and :-webkit-full-screen are NOT triggered —
+	 * they only apply to the standard requestFullscreen / webkitRequestFullscreen APIs.
+	 * Instead we add this class via JS immediately before calling webkitEnterFullscreen()
+	 * so that native cues are visible in the iOS native fullscreen player.
+	 */
+	&.ios-fullscreen-subtitles::cue {
+		visibility: visible;
+	}
 
+	/* Standard fullscreen API (desktop browsers) */
 	&:fullscreen::cue {
 		visibility: visible;
 	}

--- a/dotcom-rendering/src/lib/useSubtitles.ts
+++ b/dotcom-rendering/src/lib/useSubtitles.ts
@@ -34,11 +34,12 @@ export const useSubtitles = ({
 			/* We currently only support one text track per video, so we are OK to access [0] here. */
 			if (!track) return;
 
-			/* Keep track in 'showing' mode for iOS reliability.
-			 * We'll hide the native subtitles with CSS instead
+			/* Use 'hidden' mode so cuechange events fire and activeCues are populated,
+			 * but native rendering is suppressed. The track mode is switched to
+			 * 'showing' only during fullscreen (managed in SelfHostedVideoPlayer).
 			 */
-			if (track.mode !== 'showing') {
-				track.mode = 'showing';
+			if (track.mode === 'disabled') {
+				track.mode = 'hidden';
 			}
 
 			setActiveTrack(track);
@@ -69,14 +70,6 @@ export const useSubtitles = ({
 			return;
 		}
 
-		/* Keep track in 'showing' mode.
-		 * this makes iOS more reliable with cuechange events and activeCues
-		 */
-		if (track.mode !== 'showing') {
-			track.mode = 'showing';
-		}
-
-		/* listen to cuechange and set the active cue */
 		const onCueChange = () => {
 			const list = track.activeCues;
 			if (!list || list.length === 0) {
@@ -98,8 +91,6 @@ export const useSubtitles = ({
 
 		return () => {
 			track.removeEventListener('cuechange', onCueChange);
-			/* Keep it showing even on cleanup for consistency */
-			track.mode = 'showing';
 		};
 	}, [activeTrack, shouldShow, currentTime]);
 


### PR DESCRIPTION
## What does this change?
Adds css rules to control the visibility of native subtitles when a video is fullscreen.

NB the positioning of cues in handleLoadedMetadata is currently causing cues to crash into progress bar in fullscreen. This will be addressed in a future PR. 
## Why?
When a video is played inline, DCR prefers custom subtitle overlay and so hides the native subtitles with CSS. 

With the introduction of default (or long form) self hosted videos, there is a requirement to support the video player in fullscreen. Up until now, no self hosted video types support fullscreen. In order to fulfill this requirement, we will be serving the native browser fullscreen implementation as a first pass, rather than a custom overlay.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/8ec97f02-7db1-4a3d-910d-3605bc81e123
[after]: https://github.com/user-attachments/assets/63bfd824-05df-46c9-b7cd-9de7ffde8d32

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
