### PR TITLE
Send auxia banner tracking events

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -43,7 +43,7 @@
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",
-		"@guardian/support-dotcom-components": "8.5.0",
+		"@guardian/support-dotcom-components": "9.0.1",
 		"@guardian/tsconfig": "0.2.0",
 		"@playwright/test": "1.58.0",
 		"@sentry/browser": "10.39.0",

--- a/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx
@@ -299,6 +299,7 @@ export const canShowRRBanner: CanShowFunctionType<
 		fetchEmail,
 		submitComponentEvent: (componentEvent: ComponentEvent) =>
 			submitComponentEvent(componentEvent, renderingTarget),
+		contributionsServiceUrl,
 	};
 
 	return {

--- a/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/common/BannerWrapper.tsx
@@ -3,6 +3,7 @@
  * This file was migrated from:
  * https://github.com/guardian/support-dotcom-components/blob/0a2439b701586a7a2cc60dce10b4d96cf7a828db/packages/modules/src/modules/banners/common/BannerWrapper.tsx
  */
+import { getCookie } from '@guardian/libs';
 import {
 	bannerSchema,
 	containsNonArticleCountPlaceholder,
@@ -11,6 +12,7 @@ import {
 	SecondaryCtaType,
 } from '@guardian/support-dotcom-components';
 import type {
+	AuxiaTracking,
 	BannerContent,
 	BannerProps,
 	Cta,
@@ -68,6 +70,38 @@ export const getParagraphsOrMessageText = (
 	return bodyCopy;
 };
 
+type AuxiaInteractionType = 'VIEWED' | 'CLICKED' | 'SNOOZED' | 'DISMISSED';
+
+const sendAuxiaInteractionEvent = (
+	contributionsServiceUrl: string,
+	auxiaTracking: AuxiaTracking,
+	interactionType: AuxiaInteractionType,
+) => {
+	const browserId = getCookie({ name: 'bwid', shouldMemoize: true });
+	if (browserId) {
+		const params = {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				browserId,
+				interactionType,
+				treatmentTrackingId: auxiaTracking.treatmentTrackingId,
+				treatmentId: auxiaTracking.treatmentId,
+			}),
+		};
+		fetch(`${contributionsServiceUrl}/banner/interaction`, params).catch(
+			(error) => {
+				window.guardian.modules.sentry.reportError(
+					new Error(
+						`Error sending banner interaction: ${String(error)}`,
+					),
+					'rr-banner',
+				);
+			},
+		);
+	}
+};
+
 const withBannerData =
 	(
 		Banner: ReactComponent<BannerRenderProps>,
@@ -94,6 +128,7 @@ const withBannerData =
 			abandonedBasket,
 			promoCodes,
 			isCollapsible,
+			contributionsServiceUrl,
 		} = bannerProps;
 
 		const [hasBeenSeen, setNode] = useIsInView({
@@ -109,8 +144,21 @@ const withBannerData =
 						tracking.campaignCode,
 					),
 				);
+
+				if (tracking.auxia && contributionsServiceUrl) {
+					sendAuxiaInteractionEvent(
+						contributionsServiceUrl,
+						tracking.auxia,
+						'VIEWED',
+					);
+				}
 			}
-		}, [hasBeenSeen, submitComponentEvent, tracking]);
+		}, [
+			hasBeenSeen,
+			submitComponentEvent,
+			tracking,
+			contributionsServiceUrl,
+		]);
 
 		useEffect(() => {
 			if (hasBeenSeen) {
@@ -267,7 +315,11 @@ const withBannerData =
 			};
 		};
 
-		const clickHandlerFor = (componentId: string, close: boolean) => {
+		const clickHandlerFor = (
+			componentId: string,
+			close: boolean,
+			auxiaInteractionType?: AuxiaInteractionType,
+		) => {
 			return (): void => {
 				const componentClickEvent = createClickEventFromTracking(
 					tracking,
@@ -276,13 +328,24 @@ const withBannerData =
 				if (submitComponentEvent) {
 					void submitComponentEvent(componentClickEvent);
 				}
+				if (
+					auxiaInteractionType &&
+					tracking.auxia &&
+					contributionsServiceUrl
+				) {
+					sendAuxiaInteractionEvent(
+						contributionsServiceUrl,
+						tracking.auxia,
+						auxiaInteractionType,
+					);
+				}
 				if (close) {
 					onClose();
 				}
 			};
 		};
 
-		const onCtaClick = clickHandlerFor(componentIds.cta, true);
+		const onCtaClick = clickHandlerFor(componentIds.cta, true, 'CLICKED');
 		const onSecondaryCtaClick = clickHandlerFor(
 			componentIds.secondaryCta,
 			true,
@@ -299,10 +362,18 @@ const withBannerData =
 			componentIds.reminderClose,
 			false,
 		);
-		const onCloseClick = clickHandlerFor(componentIds.close, true);
+		const onCloseClick = clickHandlerFor(
+			componentIds.close,
+			true,
+			'DISMISSED',
+		);
 		const onNotNowClick = clickHandlerFor(componentIds.notNow, true);
 		const onSignInClick = clickHandlerFor(componentIds.signIn, false);
-		const onCollapseClick = clickHandlerFor(componentIds.collapse, false);
+		const onCollapseClick = clickHandlerFor(
+			componentIds.collapse,
+			false,
+			'SNOOZED',
+		);
 		const onExpandClick = clickHandlerFor(componentIds.expand, false);
 
 		try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: 18.1.1
         version: 18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/support-dotcom-components':
-        specifier: 8.5.0
-        version: 8.5.0(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)
+        specifier: 9.0.1
+        version: 9.0.1(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)
       '@guardian/tsconfig':
         specifier: 0.2.0
         version: 0.2.0
@@ -2555,8 +2555,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/support-dotcom-components@8.5.0':
-    resolution: {integrity: sha512-T2uo7LlQXBaveHzitz0Tcibc5K7JYKSLv04BrYFtxsEpi5rTOQol+/ACpDISBe/RANp5x2rsNmlCnL0jgo6zig==}
+  '@guardian/support-dotcom-components@9.0.1':
+    resolution: {integrity: sha512-NUTOr8Mv7f6efjUGHHPl6np+LM3FRstiY71R2AU2xZi0601Jd2yldXtTRf71c0gy1KfR7HdWoNTD42vaBasBFQ==}
     peerDependencies:
       '@guardian/libs': ^22.0.0
       '@guardian/ophan-tracker-js': 2.8.0
@@ -5175,9 +5175,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -11812,7 +11811,7 @@ snapshots:
       react: 18.3.1
       typescript: 5.5.3
 
-  '@guardian/support-dotcom-components@8.5.0(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)':
+  '@guardian/support-dotcom-components@9.0.1(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/ophan-tracker-js@2.8.0)(zod@4.1.12)':
     dependencies:
       '@aws-sdk/client-cloudwatch': 3.995.0
       '@aws-sdk/client-dynamodb': 3.996.0
@@ -11825,7 +11824,7 @@ snapshots:
       '@okta/jwt-verifier': 4.0.2
       compression: 1.8.1
       cors: 2.8.5
-      date-fns: 2.30.0
+      date-fns: 4.1.0
       express: 4.22.1
       jsonschema: 1.4.1
       lodash.debounce: 4.0.8
@@ -14957,9 +14956,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.28.4
+  date-fns@4.1.0: {}
 
   date-format@4.0.14: {}
 


### PR DESCRIPTION
This is part of the work to use Auxia for controlling the banner. The first dotcom-rendering change was to send the browserId to SDC: https://github.com/guardian/dotcom-rendering/pull/15562

We recently added an endpoint for proxying tracking events to Auxia: https://github.com/guardian/support-dotcom-components/pull/1626
We need to use this endpoint to track views/clicks for any banners which have been served by an Auxia treatment.

If the tracking data from the server includes an `auxia` field then we make a request to the new endpoint for each view/click event.

## Testing
Tested locally by observing the network requests for a browser_id that has been setup as a QA user in Auxia.
A banner is returned by SDC with auxia tracking data:
<img width="613" height="221" alt="Screenshot 2026-04-22 at 09 37 01" src="https://github.com/user-attachments/assets/fe59199e-2cba-4b3c-bc3a-9cd40b526b76" />

The view event is sent to the new endpoint:
<img width="480" height="128" alt="Screenshot 2026-04-22 at 09 36 34" src="https://github.com/user-attachments/assets/ca7de9b2-8915-406d-9bef-d1ec3d8f9feb" />

And a click event is also sent:
<img width="485" height="92" alt="Screenshot 2026-04-22 at 09 37 15" src="https://github.com/user-attachments/assets/8f015885-f821-4b59-81f3-889f4fb82065" />
