### PR TITLE
Fetch onward content for Hosted pages within an island

### DIFF
--- a/dotcom-rendering/fixtures/manual/hostedArticle.ts
+++ b/dotcom-rendering/fixtures/manual/hostedArticle.ts
@@ -720,7 +720,7 @@ export const hostedArticle: FEArticle = {
 		contentType: 'Article',
 		isDev: true,
 		isPaidContent: true,
-		ajaxUrl: 'http://localhost:9000',
+		ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
 		keywords: '',
 		revisionNumber: '92184802ad2f64c03a3b23978c48d6fcec1e42ae',
 		mmaUrl: 'https://manage.theguardian.com',

--- a/dotcom-rendering/fixtures/manual/hostedVideo.ts
+++ b/dotcom-rendering/fixtures/manual/hostedVideo.ts
@@ -362,7 +362,7 @@ export const hostedVideo: FEArticle = {
 		contentType: 'Article',
 		isDev: true,
 		isPaidContent: true,
-		ajaxUrl: 'http://localhost:9000',
+		ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
 		keywords: '',
 		revisionNumber: 'a0f26041f01f9df1cc879cd484aff1837f998895',
 		mmaUrl: 'https://manage.theguardian.com',

--- a/dotcom-rendering/fixtures/manual/onwardsTrails.ts
+++ b/dotcom-rendering/fixtures/manual/onwardsTrails.ts
@@ -195,3 +195,39 @@ export const galleryOnwardsTrails: TrailType[] = [
 		articleMedia: { type: 'Gallery', count: '6' },
 	},
 ];
+
+export const hostedOnwardsTrails: TrailType[] = [
+	{
+		url: 'https://www.theguardian.com/money/gallery/2026/mar/27/loft-style-apartments-for-sale-in-england-in-pictures',
+		headline: 'Loft-style apartments for sale in England – in pictures',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@1',
+		image: {
+			src: 'https://media.guim.co.uk/276ed08e0380a9a3045a779ea1ca8c93f7c1b51e/500_0_5000_4000/2000.jpg',
+			altText:
+				'Loft-style apartment interior in Clapton, east London with industrial design elements',
+		},
+	},
+	{
+		url: 'https://www.theguardian.com/books/2026/apr/01/under-water-by-tara-menon-review-love-loss-and-a-longing-for-the-ocean',
+		headline:
+			'Under Water by Tara Menon review – love, loss and a longing for the ocean',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@2',
+		image: {
+			src: 'https://media.guim.co.uk/95d6b3df9e3471344dc19a32d94bb3d5ff6f5016/205_5_2978_2382/2000.jpg',
+			altText: 'Tropical fish',
+		},
+	},
+	{
+		url: 'https://www.theguardian.com/money/gallery/2026/feb/27/homes-a-short-walk-from-the-sea-in-england-and-scotland-in-pictures',
+		headline:
+			'Homes a short walk from the sea in England and Scotland – in pictures',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@3',
+		image: {
+			src: 'https://media.guim.co.uk/9879e5d3275b5dae8c8bfd8e1ac700332e2de8c4/237_0_3750_3000/2000.jpg',
+			altText: 'Craster, Northumberland',
+		},
+	},
+];

--- a/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
+++ b/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
@@ -9,30 +9,19 @@ type Props = {
 };
 
 type OnwardsResponse = {
-	result: {
-		owner: string;
-		trails: Array<TrailType>;
-		// trails: Array<{
-		// 	/** URL of the article, used for the anchor tag */
-		// 	url: string;
-		// 	/** Headline of the article represented by trail */
-		// 	headline: string;
-		// 	/** Image thumbnail details for the article */
-		// 	image: {
-		// 		/** Trail image URL */
-		// 		src: string;
-		// 		/** Alt text for the trail image */
-		// 		alt: string;
-		// 	};
-		// 	format: FEFormat;
-		// }>;
-	};
+	trails: Array<TrailType>;
 };
 
 export const FetchHostedOnwards = ({ branding, url }: Props) => {
-	const { data } = useApi<OnwardsResponse>(url);
+	const { data, error } = useApi<OnwardsResponse>(url);
 
-	const { result: { trails = [] } = {} } = data ?? {};
+	if (error) {
+		// Send the error to Sentry and then prevent the element from rendering
+		window.guardian.modules.sentry.reportError(error, 'hosted-onwards');
+		return null;
+	}
+
+	const { trails = [] } = data ?? {};
 
 	if (!trails.length) {
 		return null;

--- a/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
+++ b/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
@@ -1,0 +1,48 @@
+import { useApi } from '../lib/useApi';
+import type { Branding } from '../types/branding';
+import type { TrailType } from '../types/trails';
+import { HostedContentOnwards } from './HostedContentOnwards';
+
+type Props = {
+	url: string;
+	branding?: Branding;
+};
+
+type OnwardsResponse = {
+	result: {
+		owner: string;
+		trails: Array<TrailType>;
+		// trails: Array<{
+		// 	/** URL of the article, used for the anchor tag */
+		// 	url: string;
+		// 	/** Headline of the article represented by trail */
+		// 	headline: string;
+		// 	/** Image thumbnail details for the article */
+		// 	image: {
+		// 		/** Trail image URL */
+		// 		src: string;
+		// 		/** Alt text for the trail image */
+		// 		alt: string;
+		// 	};
+		// 	format: FEFormat;
+		// }>;
+	};
+};
+
+export const FetchHostedOnwards = ({ branding, url }: Props) => {
+	const { data } = useApi<OnwardsResponse>(url);
+
+	const { result: { trails = [] } = {} } = data ?? {};
+
+	if (!trails.length) {
+		return null;
+	}
+
+	return (
+		<HostedContentOnwards
+			trails={trails}
+			brandName={branding?.sponsorName ?? ''}
+			accentColor={branding?.hostedCampaignColour}
+		/>
+	);
+};

--- a/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
@@ -1,5 +1,41 @@
-import { trails } from '../layouts/HostedArticleLayout';
+import type { TrailType } from '../types/trails';
 import { HostedContentOnwards } from './HostedContentOnwards';
+
+const trails: TrailType[] = [
+	{
+		url: 'https://www.theguardian.com/money/gallery/2026/mar/27/loft-style-apartments-for-sale-in-england-in-pictures',
+		headline: 'Loft-style apartments for sale in England – in pictures',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@1',
+		image: {
+			src: 'https://media.guim.co.uk/276ed08e0380a9a3045a779ea1ca8c93f7c1b51e/500_0_5000_4000/2000.jpg',
+			altText:
+				'Loft-style apartment interior in Clapton, east London with industrial design elements',
+		},
+	},
+	{
+		url: 'https://www.theguardian.com/books/2026/apr/01/under-water-by-tara-menon-review-love-loss-and-a-longing-for-the-ocean',
+		headline:
+			'Under Water by Tara Menon review – love, loss and a longing for the ocean',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@2',
+		image: {
+			src: 'https://media.guim.co.uk/95d6b3df9e3471344dc19a32d94bb3d5ff6f5016/205_5_2978_2382/2000.jpg',
+			altText: 'Tropical fish',
+		},
+	},
+	{
+		url: 'https://www.theguardian.com/money/gallery/2026/feb/27/homes-a-short-walk-from-the-sea-in-england-and-scotland-in-pictures',
+		headline:
+			'Homes a short walk from the sea in England and Scotland – in pictures',
+		format: { design: 27, display: 1, theme: 6 },
+		dataLinkName: 'media | group-0 | card-@3',
+		image: {
+			src: 'https://media.guim.co.uk/9879e5d3275b5dae8c8bfd8e1ac700332e2de8c4/237_0_3750_3000/2000.jpg',
+			altText: 'Craster, Northumberland',
+		},
+	},
+];
 
 export default {
 	component: HostedContentOnwards,

--- a/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
@@ -1,41 +1,5 @@
-import type { TrailType } from '../types/trails';
+import { hostedOnwardsTrails } from '../../fixtures/manual/onwardsTrails';
 import { HostedContentOnwards } from './HostedContentOnwards';
-
-const trails: TrailType[] = [
-	{
-		url: 'https://www.theguardian.com/money/gallery/2026/mar/27/loft-style-apartments-for-sale-in-england-in-pictures',
-		headline: 'Loft-style apartments for sale in England – in pictures',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@1',
-		image: {
-			src: 'https://media.guim.co.uk/276ed08e0380a9a3045a779ea1ca8c93f7c1b51e/500_0_5000_4000/2000.jpg',
-			altText:
-				'Loft-style apartment interior in Clapton, east London with industrial design elements',
-		},
-	},
-	{
-		url: 'https://www.theguardian.com/books/2026/apr/01/under-water-by-tara-menon-review-love-loss-and-a-longing-for-the-ocean',
-		headline:
-			'Under Water by Tara Menon review – love, loss and a longing for the ocean',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@2',
-		image: {
-			src: 'https://media.guim.co.uk/95d6b3df9e3471344dc19a32d94bb3d5ff6f5016/205_5_2978_2382/2000.jpg',
-			altText: 'Tropical fish',
-		},
-	},
-	{
-		url: 'https://www.theguardian.com/money/gallery/2026/feb/27/homes-a-short-walk-from-the-sea-in-england-and-scotland-in-pictures',
-		headline:
-			'Homes a short walk from the sea in England and Scotland – in pictures',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@3',
-		image: {
-			src: 'https://media.guim.co.uk/9879e5d3275b5dae8c8bfd8e1ac700332e2de8c4/237_0_3750_3000/2000.jpg',
-			altText: 'Craster, Northumberland',
-		},
-	},
-];
 
 export default {
 	component: HostedContentOnwards,
@@ -43,7 +7,12 @@ export default {
 };
 
 export const Default = () => {
-	return <HostedContentOnwards trails={trails} brandName="TrendAI" />;
+	return (
+		<HostedContentOnwards
+			trails={hostedOnwardsTrails}
+			brandName="TrendAI"
+		/>
+	);
 };
 
 Default.storyName = 'default';
@@ -51,7 +20,7 @@ Default.storyName = 'default';
 export const WithAccentColour = () => {
 	return (
 		<HostedContentOnwards
-			trails={trails}
+			trails={hostedOnwardsTrails}
 			brandName="TrendAI"
 			accentColor="#FF0000"
 		/>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.stories.tsx
@@ -1,14 +1,25 @@
 import { allModes } from '../../.storybook/modes';
 import preview from '../../.storybook/preview';
 import { hostedArticle } from '../../fixtures/manual/hostedArticle';
+import { hostedOnwardsTrails } from '../../fixtures/manual/onwardsTrails';
 import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleSpecial,
 } from '../lib/articleFormat';
+import { customMockFetch } from '../lib/mockRESTCalls';
 import { enhanceArticleType } from '../types/article';
 import type { Branding } from '../types/branding';
 import { HostedArticleLayout } from './HostedArticleLayout';
+
+const mockOnwardsContentFetch = customMockFetch([
+	{
+		mockedMethod: 'GET',
+		mockedUrl: `${hostedArticle.config.ajaxUrl}/${hostedArticle.config.pageId}/onward.json`,
+		mockedStatus: 200,
+		mockedBody: { trails: hostedOnwardsTrails },
+	},
+]);
 
 const meta = preview.meta({
 	title: 'Layouts/HostedArticle',
@@ -19,6 +30,10 @@ const meta = preview.meta({
 				'light leftCol': allModes['light leftCol'],
 			},
 		},
+	},
+	render: (args) => {
+		global.fetch = mockOnwardsContentFetch;
+		return <HostedArticleLayout {...args} />;
 	},
 });
 

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -329,9 +329,7 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 					<div css={onwardContentStyles}>
 						<Island priority="feature" defer={{ until: 'idle' }}>
 							<FetchHostedOnwards
-								url={
-									'http://localhost:9000/advertiser-content/we-are-still-in/faces-of-we-are-still-in/onward.json'
-								}
+								url={`${frontendData.config.ajaxUrl}/${frontendData.config.pageId}/onward.json`}
 								branding={branding}
 							/>
 						</Island>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -10,9 +10,9 @@ import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { CallToActionAtom } from '../components/CallToActionAtom';
 import { Caption } from '../components/Caption';
+import { FetchHostedOnwards } from '../components/FetchHostedOnwards.island';
 import { HostedContentDisclaimer } from '../components/HostedContentDisclaimer';
 import { HostedContentHeader } from '../components/HostedContentHeader';
-import { HostedContentOnwards } from '../components/HostedContentOnwards';
 import { Island } from '../components/Island';
 import { MainMedia } from '../components/MainMedia';
 import { Section } from '../components/Section';
@@ -26,7 +26,6 @@ import { palette as themePalette } from '../palette';
 import type { Article } from '../types/article';
 import type { Block } from '../types/blocks';
 import type { RenderingTarget } from '../types/renderingTarget';
-import type { TrailType } from '../types/trails';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -168,42 +167,6 @@ const sideBorders = css`
 		border-right: 1px solid ${themePalette('--article-border')};
 	}
 `;
-// This is dummy data until we have the actual trails for hosted content onwards.
-export const trails: TrailType[] = [
-	{
-		url: 'https://www.theguardian.com/money/gallery/2026/mar/27/loft-style-apartments-for-sale-in-england-in-pictures',
-		headline: 'Loft-style apartments for sale in England – in pictures',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@1',
-		image: {
-			src: 'https://media.guim.co.uk/276ed08e0380a9a3045a779ea1ca8c93f7c1b51e/500_0_5000_4000/2000.jpg',
-			altText:
-				'Loft-style apartment interior in Clapton, east London with industrial design elements',
-		},
-	},
-	{
-		url: 'https://www.theguardian.com/books/2026/apr/01/under-water-by-tara-menon-review-love-loss-and-a-longing-for-the-ocean',
-		headline:
-			'Under Water by Tara Menon review – love, loss and a longing for the ocean',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@2',
-		image: {
-			src: 'https://media.guim.co.uk/95d6b3df9e3471344dc19a32d94bb3d5ff6f5016/205_5_2978_2382/2000.jpg',
-			altText: 'Tropical fish',
-		},
-	},
-	{
-		url: 'https://www.theguardian.com/money/gallery/2026/feb/27/homes-a-short-walk-from-the-sea-in-england-and-scotland-in-pictures',
-		headline:
-			'Homes a short walk from the sea in England and Scotland – in pictures',
-		format: { design: 27, display: 1, theme: 6 },
-		dataLinkName: 'media | group-0 | card-@3',
-		image: {
-			src: 'https://media.guim.co.uk/9879e5d3275b5dae8c8bfd8e1ac700332e2de8c4/237_0_3750_3000/2000.jpg',
-			altText: 'Craster, Northumberland',
-		},
-	},
-];
 
 export const HostedArticleLayout = (props: WebProps | AppProps) => {
 	const {
@@ -364,11 +327,14 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 					</div>
 
 					<div css={onwardContentStyles}>
-						<HostedContentOnwards
-							trails={trails}
-							brandName="TrendAI"
-							accentColor={branding?.hostedCampaignColour}
-						/>
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<FetchHostedOnwards
+								url={
+									'http://localhost:9000/advertiser-content/we-are-still-in/faces-of-we-are-still-in/onward.json'
+								}
+								branding={branding}
+							/>
+						</Island>
 					</div>
 
 					{cta && (

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.stories.tsx
@@ -1,13 +1,24 @@
 import { allModes } from '../../.storybook/modes';
 import preview from '../../.storybook/preview';
 import { hostedVideo } from '../../fixtures/manual/hostedVideo';
+import { hostedOnwardsTrails } from '../../fixtures/manual/onwardsTrails';
 import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleSpecial,
 } from '../lib/articleFormat';
+import { customMockFetch } from '../lib/mockRESTCalls';
 import { enhanceArticleType } from '../types/article';
 import { HostedVideoLayout } from './HostedVideoLayout';
+
+const mockOnwardsContentFetch = customMockFetch([
+	{
+		mockedMethod: 'GET',
+		mockedUrl: `${hostedVideo.config.ajaxUrl}/${hostedVideo.config.pageId}/onward.json`,
+		mockedStatus: 200,
+		mockedBody: { trails: hostedOnwardsTrails },
+	},
+]);
 
 const meta = preview.meta({
 	title: 'Layouts/HostedVideo',
@@ -18,6 +29,10 @@ const meta = preview.meta({
 				'light leftCol': allModes['light leftCol'],
 			},
 		},
+	},
+	render: (args) => {
+		global.fetch = mockOnwardsContentFetch;
+		return <HostedVideoLayout {...args} />;
 	},
 });
 

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -323,7 +323,10 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 
 					<div css={onwardContentStyles}>
 						<Island priority="feature" defer={{ until: 'idle' }}>
-							<FetchHostedOnwards branding={branding} />
+							<FetchHostedOnwards
+								url={`${frontendData.config.ajaxUrl}/${frontendData.config.pageId}/onward.json`}
+								branding={branding}
+							/>
 						</Island>
 					</div>
 

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -11,9 +11,9 @@ import { ArticleContainer } from '../components/ArticleContainer';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { CallToActionAtom } from '../components/CallToActionAtom';
 import { Caption } from '../components/Caption';
+import { FetchHostedOnwards } from '../components/FetchHostedOnwards.island';
 import { HostedContentDisclaimer } from '../components/HostedContentDisclaimer';
 import { HostedContentHeader } from '../components/HostedContentHeader';
-import { HostedContentOnwards } from '../components/HostedContentOnwards';
 import { Island } from '../components/Island';
 import { MainMedia } from '../components/MainMedia';
 import { Section } from '../components/Section';
@@ -28,7 +28,6 @@ import type { Article } from '../types/article';
 import type { Block } from '../types/blocks';
 import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
-import { trails } from './HostedArticleLayout';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -323,11 +322,9 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 					</div>
 
 					<div css={onwardContentStyles}>
-						<HostedContentOnwards
-							trails={trails} //Temporary trails dummy data which is exported from HostedArticleLayout
-							brandName="TrendAI"
-							accentColor={branding?.hostedCampaignColour}
-						/>
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<FetchHostedOnwards branding={branding} />
+						</Island>
 					</div>
 
 					{cta && (


### PR DESCRIPTION
## What does this change?

Implements `FetchHostedOnwards` as a client-side rendered component that fetches the onward data from the API endpoint and renders it using the `HostedContentOnwards` component

## Why?

As part of the migration of Hosted Content pages from frontend-rendered to using DCR

This ties the two pieces of logic together: the frontend work (https://github.com/guardian/dotcom-rendering/pull/15648) and the backend work (https://github.com/guardian/frontend/pull/28718)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/95449c03-a04b-4c4e-b9f8-3c3224e14496
[after]: https://github.com/user-attachments/assets/2b908b41-7cff-4bc2-8f20-487f025acc70

