### PR TITLE
Refactor `ControlsPosition` in self-hosted video 

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -31,6 +31,7 @@ import { Caption } from './Caption';
 import { CardPicture, type Props as CardPictureProps } from './CardPicture';
 import { useConfig } from './ConfigContext';
 import type {
+	ControlsPosition,
 	PLAYER_STATES,
 	PlayerStates,
 	SubtitleSize,
@@ -297,7 +298,7 @@ type Props = {
 	/**
 	 * The position of subtitles and the audio icon.
 	 */
-	controlsPosition?: 'top' | 'bottom';
+	controlsPosition?: ControlsPosition;
 	/**
 	 * The minimum/maximum aspect ratio the video will have. The video will be cropped if this
 	 * value is defined and the video aspect ratio is less/greater than this value.
@@ -965,7 +966,7 @@ export const SelfHostedVideo = ({
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}
 						showIcons={showIcons}
-						controlsPosition={controlsPosition}
+						iconsPosition={controlsPosition}
 						subtitlesPosition={subtitlesPosition}
 						activeCue={activeCue}
 						shouldLoop={shouldLoop}

--- a/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
@@ -73,7 +73,7 @@ export const Default: Story = {
 export const WithoutProgressBar: Story = {
 	args: {
 		...Loop.args,
-		hideProgressBar: false,
+		hideProgressBar: true,
 	},
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -140,7 +140,7 @@ export type Props = {
 	activeCue?: ActiveCue | null;
 	shouldLoop: boolean;
 	isInteractive: boolean;
-	controlsPosition: ControlsPosition;
+	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
 };
 
@@ -193,7 +193,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			activeCue,
 			shouldLoop,
 			isInteractive,
-			controlsPosition,
+			iconsPosition,
 			subtitlesPosition,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
@@ -302,9 +302,9 @@ export const SelfHostedVideoPlayer = forwardRef(
 						css={[
 							iconsContainerStyles,
 							iconSize === 'large' &&
-								largeIconsPositionStyles(controlsPosition),
+								largeIconsPositionStyles(iconsPosition),
 							iconSize === 'small' &&
-								smallIconsPositionStyles(controlsPosition),
+								smallIconsPositionStyles(iconsPosition),
 						]}
 					>
 						{showFullscreenIcon && (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -4,9 +4,6 @@ import { SvgArrowExpand } from '@guardian/source/react-components';
 import { palette } from '../palette';
 import type { Props as SelfHostedVideoPlayerProps } from './SelfHostedVideoPlayer';
 
-export type SubtitleSize = 'small' | 'medium' | 'large';
-export type ControlsPosition = 'top' | 'bottom';
-
 const buttonStyles = css`
 	border: none;
 	background: none;


### PR DESCRIPTION
## What does this change?

No-op change (except one story).

Renamed `controlsPosition` to `iconsPosition` in `<SelfHostedVideoPlayer />`. Since this prop refers only to the position of the icons, the renaming makes it clearer that the position of the progress bar is unaffected. The progress bar would not have been thought of as a control, but now might be following https://github.com/guardian/dotcom-rendering/pull/15726.

Removes duplicated exports in `SelfHostedVideoPlayerIcons`. These were unintentionally included during [a refactor here](https://github.com/guardian/dotcom-rendering/pull/15718).

Inverts a bool for a story.

## Why?

Consumers of `<SelfHostedVideo />` still only need to specify the condition of the controls. The player component `<SelfHostedVideoPlayer />` receives both `iconsPosition` and `subtitlesPosition` as these can differ.
