### PR TITLE
Consistently sets self hosted video tracking ID

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -206,7 +206,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
-		const dataLinkName = `gu-video-${videoStyle}-${
+		const dataLinkName = `gu-video-${videoStyle.toLowerCase()}-${
 			showPlayIcon ? 'play' : 'pause'
 		}-${atomId}`;
 


### PR DESCRIPTION
## What does this change?

This change sets the `dataLinkName` setting the  `videoStyle ` to lower case. This is consistent with how media events are sent: 
https://github.com/guardian/dotcom-rendering/blob/9ae227ccd344f6789ab5287867e0fa8586cd3c59/dotcom-rendering/src/components/SelfHostedVideo.island.tsx#L395

## Why?

Event IDs are currently capitalised inconsistently:

Click events:
```JSON
["gu-video-Loop-play-11ca062f-a073-4ada-8d15-1cba8bc87ae6","container-3 | flexible-general","Front | /dominik"]
```

Media: 
```JSON
{"id":"gu-video-loop-11ca062f-a073-4ada-8d15-1cba8bc87ae6","eventType":"video:content:play"}
```

It's questionable whether we need these click events, but they shouldn't cause any harm. Having a consistent ID will make life easier downstream.