### PR TITLE
newsletter-signup-form

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -29,6 +29,8 @@ sb.mock(import('../src/lib/useNewsletterSubscription.ts'), { spy: true });
 sb.mock(import('../src/lib/useAuthStatus.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -102,7 +102,7 @@ export const EmailSignUpWrapper = ({
 				id={`EmailSignup-skip-link-${index}`}
 				blockDescription="newsletter promotion"
 			>
-				<NewsletterSignupCard {...emailSignUpProps}>
+				<NewsletterSignupCardContainer {...emailSignUpProps}>
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<NewsletterSignupForm
 							newsletterId={emailSignUpProps.identityName}
@@ -111,7 +111,7 @@ export const EmailSignUpWrapper = ({
 							onPreviewClick={onPreviewClick}
 						/>
 					</Island>
-				</NewsletterSignupCard>
+				</NewsletterSignupCardContainer>
 				{isSignedIn === true && (
 					<NewsletterPrivacyMessage textColor="regular" />
 				)}

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -94,6 +94,7 @@ export const EmailSignUpWrapper = ({
 					category={category}
 					exampleUrl={exampleUrl}
 					renderingTarget={renderingTarget}
+					isSignedIn={isSignedIn}
 				>
 					{(openPreview) => (
 						<Island priority="feature" defer={{ until: 'visible' }}>
@@ -107,9 +108,6 @@ export const EmailSignUpWrapper = ({
 						</Island>
 					)}
 				</NewsletterSignupCardContainer>
-				{isSignedIn === true && (
-					<NewsletterPrivacyMessage textColor="regular" />
-				)}
 			</InlineSkipToWrapper>
 		);
 	}

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -37,7 +37,6 @@ interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	hideNewsletterSignupComponentForSubscribers?: boolean;
 	/** Feature flag to show the new NewsletterSignupCard design instead of EmailSignup */
 	showNewNewsletterSignupCard?: boolean;
-	onPreviewClick?: () => void;
 }
 
 /**
@@ -66,7 +65,6 @@ export const EmailSignUpWrapper = ({
 	hidePrivacyMessage,
 	hideNewsletterSignupComponentForSubscribers = false,
 	showNewNewsletterSignupCard = false,
-	onPreviewClick,
 }: EmailSignUpWrapperProps) => {
 	const { renderingTarget } = useConfig();
 	const shouldCheckSubscription =
@@ -97,15 +95,17 @@ export const EmailSignUpWrapper = ({
 					exampleUrl={exampleUrl}
 					renderingTarget={renderingTarget}
 				>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<NewsletterSignupForm
-							newsletterId={identityName}
-							newsletterName={name}
-							frequency={frequency}
-							hidePrivacyMessage={isSignedIn === true}
-							onPreviewClick={onPreviewClick}
-						/>
-					</Island>
+					{(openPreview) => (
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<NewsletterSignupForm
+								newsletterId={identityName}
+								newsletterName={name}
+								frequency={frequency}
+								hidePrivacyMessage={isSignedIn === true}
+								onPreviewClick={openPreview}
+							/>
+						</Island>
+					)}
 				</NewsletterSignupCardContainer>
 				{isSignedIn === true && (
 					<NewsletterPrivacyMessage textColor="regular" />

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -6,6 +6,7 @@ import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { Island } from './Island';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import { NewsletterSignupCardContainer } from './NewsletterSignupCardContainer';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
 import { Placeholder } from './Placeholder';
 import { SecureSignup } from './SecureSignup.island';
 
@@ -91,7 +92,7 @@ export const EmailSignUpWrapper = ({
 	}
 
 	// When the new card design is enabled, always show it regardless of subscription status
-	if (showNewNewsletterSignupCard) {
+	if (true) {
 		return (
 			<InlineSkipToWrapper
 				id={`EmailSignup-skip-link-${index}`}
@@ -99,7 +100,7 @@ export const EmailSignUpWrapper = ({
 			>
 				<NewsletterSignupCard {...emailSignUpProps}>
 					<Island priority="feature" defer={{ until: 'visible' }}>
-						<SecureSignup
+						<NewsletterSignupForm
 							newsletterId={emailSignUpProps.identityName}
 							successDescription={emailSignUpProps.description}
 						/>

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -1,4 +1,5 @@
 import type { Breakpoint } from '@guardian/source/foundations';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
 import type { EmailSignUpProps } from './EmailSignup';
 import { EmailSignup } from './EmailSignup';
@@ -61,6 +62,7 @@ export const EmailSignUpWrapper = ({
 		idApiUrl,
 		shouldCheckSubscription,
 	);
+	const isSignedIn = useIsSignedIn();
 
 	// When the new card design is enabled, always show it regardless of subscription status
 	if (showNewNewsletterSignupCard) {
@@ -103,9 +105,13 @@ export const EmailSignUpWrapper = ({
 						<NewsletterSignupForm
 							newsletterId={emailSignUpProps.identityName}
 							successDescription={emailSignUpProps.description}
+							hidePrivacyMessage={isSignedIn === true}
 						/>
 					</Island>
 				</NewsletterSignupCard>
+				{isSignedIn === true && (
+					<NewsletterPrivacyMessage textColor="regular" />
+				)}
 			</InlineSkipToWrapper>
 		);
 	}

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -22,7 +22,6 @@ interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	index: number;
 	listId: number;
 	identityName: string;
-	successDescription: string;
 	/** Illustration image URL (square crop) for the NewsletterSignupCard variant */
 	illustrationSquare?: string;
 	idApiUrl: string;
@@ -32,6 +31,7 @@ interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	hideNewsletterSignupComponentForSubscribers?: boolean;
 	/** Feature flag to show the new NewsletterSignupCard design instead of EmailSignup */
 	showNewNewsletterSignupCard?: boolean;
+	successDescription: string;
 }
 
 /**
@@ -86,6 +86,28 @@ export const EmailSignUpWrapper = ({
 						<NewsletterPrivacyMessage />
 					)}
 				</NewsletterSignupCardContainer>
+			</InlineSkipToWrapper>
+		);
+	}
+
+	// When the new card design is enabled, always show it regardless of subscription status
+	if (showNewNewsletterSignupCard) {
+		return (
+			<InlineSkipToWrapper
+				id={`EmailSignup-skip-link-${index}`}
+				blockDescription="newsletter promotion"
+			>
+				<NewsletterSignupCard {...emailSignUpProps}>
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<SecureSignup
+							newsletterId={emailSignUpProps.identityName}
+							successDescription={emailSignUpProps.description}
+						/>
+					</Island>
+					{!emailSignUpProps.hidePrivacyMessage && (
+						<NewsletterPrivacyMessage />
+					)}
+				</NewsletterSignupCard>
 			</InlineSkipToWrapper>
 		);
 	}

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -92,7 +92,7 @@ export const EmailSignUpWrapper = ({
 	}
 
 	// When the new card design is enabled, always show it regardless of subscription status
-	if (true) {
+	if (showNewNewsletterSignupCard) {
 		return (
 			<InlineSkipToWrapper
 				id={`EmailSignup-skip-link-${index}`}
@@ -105,9 +105,6 @@ export const EmailSignUpWrapper = ({
 							successDescription={emailSignUpProps.description}
 						/>
 					</Island>
-					{!emailSignUpProps.hidePrivacyMessage && (
-						<NewsletterPrivacyMessage />
-					)}
 				</NewsletterSignupCard>
 			</InlineSkipToWrapper>
 		);

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -73,40 +73,12 @@ export const EmailSignUpWrapper = ({
 				id={`EmailSignup-skip-link-${index}`}
 				blockDescription="newsletter promotion"
 			>
-				<NewsletterSignupCardContainer
-					name={emailSignUpProps.name}
-					frequency={emailSignUpProps.frequency}
-					description={emailSignUpProps.description}
-					illustrationSquare={emailSignUpProps.illustrationSquare}
-				>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<SecureSignup
-							newsletterId={emailSignUpProps.identityName}
-							successDescription={
-								emailSignUpProps.successDescription
-							}
-						/>
-					</Island>
-					{!emailSignUpProps.hidePrivacyMessage && (
-						<NewsletterPrivacyMessage />
-					)}
-				</NewsletterSignupCardContainer>
-			</InlineSkipToWrapper>
-		);
-	}
-
-	// When the new card design is enabled, always show it regardless of subscription status
-	if (showNewNewsletterSignupCard) {
-		return (
-			<InlineSkipToWrapper
-				id={`EmailSignup-skip-link-${index}`}
-				blockDescription="newsletter promotion"
-			>
 				<NewsletterSignupCardContainer {...emailSignUpProps}>
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<NewsletterSignupForm
 							newsletterId={emailSignUpProps.identityName}
-							successDescription={emailSignUpProps.description}
+							newsletterName={emailSignUpProps.name}
+							frequency={emailSignUpProps.frequency}
 							hidePrivacyMessage={isSignedIn === true}
 							onPreviewClick={onPreviewClick}
 						/>

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -67,13 +67,10 @@ export const EmailSignUpWrapper = ({
 	showNewNewsletterSignupCard = false,
 }: EmailSignUpWrapperProps) => {
 	const { renderingTarget } = useConfig();
-	const shouldCheckSubscription =
-		hideNewsletterSignupComponentForSubscribers &&
-		!showNewNewsletterSignupCard;
 	const isSubscribed = useNewsletterSubscription(
 		listId,
 		idApiUrl,
-		shouldCheckSubscription,
+		hideNewsletterSignupComponentForSubscribers,
 	);
 	const isSignedIn = useIsSignedIn();
 
@@ -104,6 +101,7 @@ export const EmailSignUpWrapper = ({
 								frequency={frequency}
 								hidePrivacyMessage={isSignedIn === true}
 								onPreviewClick={openPreview}
+								isAlreadySubscribed={isSubscribed === true}
 							/>
 						</Island>
 					)}

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -34,6 +34,7 @@ interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	/** Feature flag to show the new NewsletterSignupCard design instead of EmailSignup */
 	showNewNewsletterSignupCard?: boolean;
 	successDescription: string;
+	onPreviewClick?: () => void;
 }
 
 /**
@@ -52,6 +53,7 @@ export const EmailSignUpWrapper = ({
 	idApiUrl,
 	hideNewsletterSignupComponentForSubscribers = false,
 	showNewNewsletterSignupCard = false,
+	onPreviewClick,
 	...emailSignUpProps
 }: EmailSignUpWrapperProps) => {
 	const shouldCheckSubscription =
@@ -106,6 +108,7 @@ export const EmailSignUpWrapper = ({
 							newsletterId={emailSignUpProps.identityName}
 							successDescription={emailSignUpProps.description}
 							hidePrivacyMessage={isSignedIn === true}
+							onPreviewClick={onPreviewClick}
 						/>
 					</Island>
 				</NewsletterSignupCard>

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -24,6 +24,7 @@ const defaultArgs = {
 	successDescription: "We'll send you The Recap every week",
 	theme: 'sport',
 	idApiUrl: 'https://idapi.theguardian.com',
+	exampleUrl: 'https://www.theguardian.com/email/the-recap',
 } satisfies Story['args'];
 
 // Loading state - shows placeholder while auth status is being determined

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -24,7 +24,6 @@ const defaultArgs = {
 	successDescription: "We'll send you The Recap every week",
 	theme: 'sport',
 	idApiUrl: 'https://idapi.theguardian.com',
-	onPreviewClick: () => alert('Preview latest clicked'),
 } satisfies Story['args'];
 
 // Loading state - shows placeholder while auth status is being determined

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -33,7 +33,7 @@ export const Placeholder = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(undefined);
 	},
 });
@@ -44,7 +44,7 @@ export const DefaultStory = meta.story({
 		hidePrivacyMessage: true,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -58,7 +58,7 @@ export const DefaultStoryWithPrivacy = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -73,7 +73,7 @@ export const SignedInNotSubscribed = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -91,7 +91,7 @@ export const SignedInAlreadySubscribed = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: true,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 	},
 });
@@ -104,7 +104,7 @@ export const FeatureFlagDisabled = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: false,
 	},
-	async beforeEach() {
+	beforeEach() {
 		// Even though we mock this to return true (subscribed),
 		// the feature flag being disabled means it won't be checked
 		mocked(useNewsletterSubscription).mockReturnValue(false);
@@ -119,5 +119,34 @@ export const FeatureFlagDisabled = meta.story({
 				story: 'When the hideNewsletterSignupComponentForSubscribers feature flag is disabled, the signup form is always shown regardless of subscription status.',
 			},
 		},
+	},
+});
+
+export const NewNewsletterSignupCard = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		// The new card should still show even if the user is subscribed
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+	},
+});
+
+export const NewNewsletterSignupCardSignedOut = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
 	},
 });

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -27,6 +27,14 @@ const defaultArgs = {
 	exampleUrl: 'https://www.theguardian.com/email/the-recap',
 } satisfies Story['args'];
 
+const newCardArgs = {
+	...defaultArgs,
+	showNewNewsletterSignupCard: true,
+	hideNewsletterSignupComponentForSubscribers: true,
+	illustrationSquare:
+		'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+} satisfies Story['args'];
+
 // Loading state - shows placeholder while auth status is being determined
 // This prevents layout shift when subscription status is resolved
 export const Placeholder = meta.story({
@@ -123,14 +131,8 @@ export const FeatureFlagDisabled = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCardSignedInNotSubscribed = meta.story({
-	args: {
-		...defaultArgs,
-		showNewNewsletterSignupCard: true,
-		hideNewsletterSignupComponentForSubscribers: true,
-		illustrationSquare:
-			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
-	},
+export const NewsletterSignupCardSignedInNotSubscribed = meta.story({
+	args: newCardArgs,
 	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
@@ -140,14 +142,8 @@ export const NewNewsletterSignupCardSignedInNotSubscribed = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCardSignedOutNotSubscribed = meta.story({
-	args: {
-		...defaultArgs,
-		showNewNewsletterSignupCard: true,
-		hideNewsletterSignupComponentForSubscribers: true,
-		illustrationSquare:
-			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
-	},
+export const NewsletterSignupCardSignedOutNotSubscribed = meta.story({
+	args: newCardArgs,
 	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
@@ -157,14 +153,8 @@ export const NewNewsletterSignupCardSignedOutNotSubscribed = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCardSignedInAlreadySubscribed = meta.story({
-	args: {
-		...defaultArgs,
-		showNewNewsletterSignupCard: true,
-		hideNewsletterSignupComponentForSubscribers: true,
-		illustrationSquare:
-			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
-	},
+export const NewsletterSignupCardSignedInAlreadySubscribed = meta.story({
+	args: newCardArgs,
 	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 		mocked(useIsSignedIn).mockReturnValue(true);
@@ -174,14 +164,8 @@ export const NewNewsletterSignupCardSignedInAlreadySubscribed = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
-	args: {
-		...defaultArgs,
-		showNewNewsletterSignupCard: true,
-		hideNewsletterSignupComponentForSubscribers: true,
-		illustrationSquare:
-			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
-	},
+export const NewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
+	args: newCardArgs,
 	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 		mocked(useIsSignedIn).mockReturnValue(false);
@@ -191,14 +175,8 @@ export const NewNewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCardFocused = meta.story({
-	args: {
-		...defaultArgs,
-		showNewNewsletterSignupCard: true,
-		hideNewsletterSignupComponentForSubscribers: true,
-		illustrationSquare:
-			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
-	},
+export const NewsletterSignupCardFocused = meta.story({
+	args: newCardArgs,
 	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryObj } from '@storybook/react-webpack5';
-import { mocked } from 'storybook/test';
+import { mocked, within } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { useIsSignedIn } from '../lib/useAuthStatus';
@@ -122,23 +122,28 @@ export const FeatureFlagDisabled = meta.story({
 	},
 });
 
-export const NewNewsletterSignupCard = meta.story({
+export const NewNewsletterSignupCardSignedInNotSubscribed = meta.story({
 	args: {
 		...defaultArgs,
 		showNewNewsletterSignupCard: true,
+		hideNewsletterSignupComponentForSubscribers: true,
 		illustrationSquare:
 			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
 	},
 	beforeEach() {
-		// The new card should still show even if the user is subscribed
-		mocked(useNewsletterSubscription).mockReturnValue(true);
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(true);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve('test@example.com'),
+		);
 	},
 });
 
-export const NewNewsletterSignupCardSignedOut = meta.story({
+export const NewNewsletterSignupCardSignedOutNotSubscribed = meta.story({
 	args: {
 		...defaultArgs,
 		showNewNewsletterSignupCard: true,
+		hideNewsletterSignupComponentForSubscribers: true,
 		illustrationSquare:
 			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
 	},
@@ -148,5 +153,61 @@ export const NewNewsletterSignupCardSignedOut = meta.story({
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
 			Promise.resolve(null),
 		);
+	},
+});
+
+export const NewNewsletterSignupCardSignedInAlreadySubscribed = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		hideNewsletterSignupComponentForSubscribers: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+		mocked(useIsSignedIn).mockReturnValue(true);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve('test@example.com'),
+		);
+	},
+});
+
+export const NewNewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		hideNewsletterSignupComponentForSubscribers: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+	},
+});
+
+export const NewNewsletterSignupCardFocused = meta.story({
+	args: {
+		...defaultArgs,
+		showNewNewsletterSignupCard: true,
+		hideNewsletterSignupComponentForSubscribers: true,
+		illustrationSquare:
+			'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
+	},
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+	},
+	async play({ canvasElement }) {
+		const canvas = within(canvasElement);
+		const emailInput = await canvas.findByLabelText('Enter your email');
+		emailInput.focus();
 	},
 });

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -24,6 +24,7 @@ const defaultArgs = {
 	successDescription: "We'll send you The Recap every week",
 	theme: 'sport',
 	idApiUrl: 'https://idapi.theguardian.com',
+	onPreviewClick: () => alert('Preview latest clicked'),
 } satisfies Story['args'];
 
 // Loading state - shows placeholder while auth status is being determined

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -15,7 +15,6 @@ export type NewsletterSignupCardProps = {
 	description: string;
 	illustrationSquare?: string;
 	children?: React.ReactNode;
-	/** Override bottom margin of the card container (default: space[6] = 24px) */
 	marginBottom?: number;
 };
 
@@ -23,7 +22,7 @@ const containerStyles = (marginBottom: number) => css`
 	clear: left;
 	background-color: ${themePalette('--newsletter-card-background')};
 	margin-bottom: ${marginBottom}px;
-	padding: ${space[2]}px ${space[2]}px ${space[4]}px ${space[2]}px;
+	padding: ${space[3]}px ${space[3]}px ${space[4]}px ${space[3]}px;
 `;
 
 const dividerStyles = css`
@@ -49,7 +48,7 @@ const titleAndMetaStyles = css`
 
 const titleStyles = css`
 	${headlineMedium20};
-	margin-bottom: ${space[2]}px;
+	margin-bottom: ${space[1]}px;
 	color: ${themePalette('--newsletter-card-title')};
 `;
 
@@ -72,7 +71,7 @@ const frequencyTagStyles = css`
 const descriptionStyles = css`
 	${textSans14};
 	line-height: 1.15;
-	margin-bottom: ${space[1]}px;
+	margin-bottom: ${space[2]}px;
 	clear: both;
 	color: ${themePalette('--newsletter-card-description')};
 `;

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -15,13 +15,11 @@ export type NewsletterSignupCardProps = {
 	description: string;
 	illustrationSquare?: string;
 	children?: React.ReactNode;
-	marginBottom?: number;
 };
 
-const containerStyles = (marginBottom: number) => css`
+const containerStyles = css`
 	clear: left;
 	background-color: ${themePalette('--newsletter-card-background')};
-	margin-bottom: ${marginBottom}px;
 	padding: ${space[3]}px ${space[3]}px ${space[4]}px ${space[3]}px;
 `;
 
@@ -124,14 +122,10 @@ export const NewsletterSignupCard = ({
 	description,
 	illustrationSquare,
 	children,
-	marginBottom = space[6],
 }: NewsletterSignupCardProps) => (
 	<>
 		<hr css={dividerStyles} />
-		<aside
-			css={containerStyles(marginBottom)}
-			aria-label="newsletter promotion"
-		>
+		<aside css={containerStyles} aria-label="newsletter promotion">
 			<NewsletterSignupHeader
 				frequency={frequency}
 				name={name}

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	headlineMedium20,
 	space,
 	textSans14,
@@ -78,10 +79,15 @@ const descriptionStyles = css`
 
 const illustrationStyles = css`
 	flex-shrink: 0;
-	width: 100px;
-	height: 100px;
+	width: 90px;
+	height: 90px;
 	border-radius: 50%;
 	object-fit: cover;
+
+	${from.tablet} {
+		width: 100px;
+		height: 100px;
+	}
 `;
 
 const NewsletterSignupHeader = (props: {

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -17,6 +17,7 @@ export type NewsletterSignupCardProps = {
 };
 
 const containerStyles = css`
+	clear: left;
 	background-color: ${themePalette('--newsletter-card-background')};
 	margin-bottom: ${space[6]}px;
 	padding: ${space[2]}px ${space[2]}px ${space[4]}px ${space[2]}px;

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -14,12 +14,14 @@ export type NewsletterSignupCardProps = {
 	description: string;
 	illustrationSquare?: string;
 	children?: React.ReactNode;
+	/** Override bottom margin of the card container (default: space[6] = 24px) */
+	marginBottom?: number;
 };
 
-const containerStyles = css`
+const containerStyles = (marginBottom: number) => css`
 	clear: left;
 	background-color: ${themePalette('--newsletter-card-background')};
-	margin-bottom: ${space[6]}px;
+	margin-bottom: ${marginBottom}px;
 	padding: ${space[2]}px ${space[2]}px ${space[4]}px ${space[2]}px;
 `;
 
@@ -117,10 +119,14 @@ export const NewsletterSignupCard = ({
 	description,
 	illustrationSquare,
 	children,
+	marginBottom = space[6],
 }: NewsletterSignupCardProps) => (
 	<>
 		<hr css={dividerStyles} />
-		<aside css={containerStyles} aria-label="newsletter promotion">
+		<aside
+			css={containerStyles(marginBottom)}
+			aria-label="newsletter promotion"
+		>
 			<NewsletterSignupHeader
 				frequency={frequency}
 				name={name}

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -18,7 +18,13 @@ describe('NewsletterSignupCardContainer', () => {
 				name="Morning Briefing"
 				frequency="Every weekday"
 				description="Start your day with top stories."
-			/>,
+			>
+				{(openPreview) => (
+					<button type="button" onClick={openPreview}>
+						Preview latest
+					</button>
+				)}
+			</NewsletterSignupCardContainer>,
 		);
 
 		fireEvent.click(screen.getByRole('button', { name: 'Preview latest' }));

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -1,19 +1,12 @@
 import { css } from '@emotion/react';
-import { palette as sourcePalette, space } from '@guardian/source/foundations';
-import { Button, SvgEye } from '@guardian/source/react-components';
+import { palette as sourcePalette } from '@guardian/source/foundations';
 import { useCallback, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { buildNewsletterPreviewUrl } from '../lib/newsletterPreviewUrl';
-import { palette } from '../palette';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { NewsletterPreviewModal } from './NewsletterPreviewModal';
 import type { NewsletterSignupCardProps } from './NewsletterSignupCard';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
-
-const previewButtonStyles = css`
-	margin-top: ${space[1]}px;
-	margin-bottom: ${space[4]}px;
-`;
 
 type PreviewEventDescription = 'preview-open' | 'preview-close';
 
@@ -50,13 +43,13 @@ const sendPreviewTracking = ({
 	);
 };
 
-type Props = NewsletterSignupCardProps & {
+type Props = Omit<NewsletterSignupCardProps, 'children'> & {
 	identityName: string;
 	category?: string;
 	exampleUrl?: string;
 	renderingTarget: RenderingTarget;
 	theme: string;
-	children?: React.ReactNode;
+	children?: (openPreview: (() => void) | undefined) => React.ReactNode;
 };
 
 const themeColorStyles = (theme: string) => css`
@@ -132,30 +125,7 @@ export const NewsletterSignupCardContainer = ({
 				description={description}
 				illustrationSquare={illustrationSquare}
 			>
-				{hasPreviewUrl && (
-					<Button
-						size="small"
-						priority="tertiary"
-						icon={<SvgEye size="small" />}
-						iconSide="left"
-						onClick={openPreview}
-						cssOverrides={previewButtonStyles}
-						theme={{
-							textTertiary: palette(
-								'--newsletter-preview-button-text',
-							),
-							borderTertiary: palette(
-								'--newsletter-preview-button-border',
-							),
-							backgroundTertiaryHover: palette(
-								'--newsletter-preview-button-hover',
-							),
-						}}
-					>
-						Preview latest
-					</Button>
-				)}
-				{children}
+				{children?.(hasPreviewUrl ? openPreview : undefined)}
 			</NewsletterSignupCard>
 		</div>
 	);

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react';
-import { palette as sourcePalette } from '@guardian/source/foundations';
+import { palette as sourcePalette, space } from '@guardian/source/foundations';
 import { useCallback, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { buildNewsletterPreviewUrl } from '../lib/newsletterPreviewUrl';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { NewsletterPreviewModal } from './NewsletterPreviewModal';
+import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import type { NewsletterSignupCardProps } from './NewsletterSignupCard';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
 
@@ -43,12 +44,17 @@ const sendPreviewTracking = ({
 	);
 };
 
-type Props = Omit<NewsletterSignupCardProps, 'children'> & {
+type Props = Omit<NewsletterSignupCardProps, 'children' | 'marginBottom'> & {
 	identityName: string;
 	category?: string;
 	exampleUrl?: string;
 	renderingTarget: RenderingTarget;
 	theme: string;
+	/**
+	 * Pass the signed-in status so the container can render the privacy message
+	 * below the card (rather than inside the form) when the user is signed in.
+	 */
+	isSignedIn?: boolean | 'Pending';
 	children?: (openPreview: (() => void) | undefined) => React.ReactNode;
 };
 
@@ -69,7 +75,9 @@ export const NewsletterSignupCardContainer = ({
 	description,
 	illustrationSquare,
 	children,
+	isSignedIn,
 }: Props) => {
+	const showPrivacyMessageOutside = isSignedIn === true;
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
 	const renderUrl = buildNewsletterPreviewUrl({
@@ -124,9 +132,19 @@ export const NewsletterSignupCardContainer = ({
 				frequency={frequency}
 				description={description}
 				illustrationSquare={illustrationSquare}
+				marginBottom={showPrivacyMessageOutside ? space[2] : undefined}
 			>
 				{children?.(hasPreviewUrl ? openPreview : undefined)}
 			</NewsletterSignupCard>
+			{showPrivacyMessageOutside && (
+				<div
+					css={css`
+						margin-bottom: ${space[6]}px;
+					`}
+				>
+					<NewsletterPrivacyMessage textColor="regular" />
+				</div>
+			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -44,7 +44,7 @@ const sendPreviewTracking = ({
 	);
 };
 
-type Props = Omit<NewsletterSignupCardProps, 'children' | 'marginBottom'> & {
+type Props = Omit<NewsletterSignupCardProps, 'children'> & {
 	identityName: string;
 	category?: string;
 	exampleUrl?: string;
@@ -127,24 +127,26 @@ export const NewsletterSignupCardContainer = ({
 					onClose={closePreview}
 				/>
 			)}
-			<NewsletterSignupCard
-				name={name}
-				frequency={frequency}
-				description={description}
-				illustrationSquare={illustrationSquare}
-				marginBottom={showPrivacyMessageOutside ? space[2] : undefined}
+			<div
+				css={css`
+					display: flex;
+					flex-direction: column;
+					gap: ${space[2]}px;
+					margin-bottom: ${space[6]}px;
+				`}
 			>
-				{children?.(hasPreviewUrl ? openPreview : undefined)}
-			</NewsletterSignupCard>
-			{showPrivacyMessageOutside && (
-				<div
-					css={css`
-						margin-bottom: ${space[6]}px;
-					`}
+				<NewsletterSignupCard
+					name={name}
+					frequency={frequency}
+					description={description}
+					illustrationSquare={illustrationSquare}
 				>
+					{children?.(hasPreviewUrl ? openPreview : undefined)}
+				</NewsletterSignupCard>
+				{showPrivacyMessageOutside && (
 					<NewsletterPrivacyMessage textColor="regular" />
-				</div>
-			)}
+				)}
+			</div>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -32,7 +32,8 @@ const meta = preview.meta({
 
 const defaultArgs = {
 	newsletterId: 'saturday-edition',
-	successDescription: "We'll send you Saturday Edition every week.",
+	newsletterName: 'Saturday Edition',
+	frequency: 'every Saturday',
 	onPreviewClick: fn(),
 };
 

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -57,7 +57,7 @@ const noopHandlers: Pick<
 
 const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
 	userEmail: undefined,
-	hideEmailInput: false,
+	isSignedIn: false,
 	isInteracted: false,
 	showMarketingToggle: false,
 	marketingOptIn: undefined,
@@ -124,7 +124,7 @@ export const SignedIn = meta.story({
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({
 				userEmail: 'reader@example.com',
-				hideEmailInput: true,
+				isSignedIn: true,
 				isInteracted: true,
 				showMarketingToggle: false,
 			}),

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -1,0 +1,194 @@
+import { fn, mocked } from 'storybook/test';
+import preview from '../../.storybook/preview';
+import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
+import type { NewsletterSignupFormState } from '../lib/useNewsletterSignupForm';
+import { NewsletterSignupCard } from './NewsletterSignupCard';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
+import { Section } from './Section';
+
+const meta = preview.meta({
+	title: 'Components/Newsletter Signup Form',
+	component: NewsletterSignupForm,
+	decorators: [
+		(Story) => (
+			<Section
+				title="NewsletterSignupForm"
+				showTopBorder={true}
+				padContent={false}
+				centralBorder="partial"
+			>
+				<NewsletterSignupCard
+					name="Saturday Edition"
+					frequency="Weekly"
+					description="An exclusive roundup of the week's best Guardian journalism from the editor-in-chief, Katharine Viner, free to your inbox every Saturday."
+					illustrationSquare="https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3"
+				>
+					<Story />
+				</NewsletterSignupCard>
+			</Section>
+		),
+	],
+});
+
+const defaultArgs = {
+	newsletterId: 'saturday-edition',
+	successDescription: "We'll send you Saturday Edition every week.",
+	onPreviewClick: fn(),
+};
+
+/** Shared no-op handlers — stories that focus on visual state don't need real callbacks. */
+const noopHandlers: Pick<
+	NewsletterSignupFormState,
+	| 'handleEmailChange'
+	| 'handleEmailFocus'
+	| 'handleMarketingToggle'
+	| 'handleSubmit'
+	| 'handleSubmitButtonClick'
+	| 'handleReset'
+> = {
+	handleEmailChange: fn(),
+	handleEmailFocus: fn(),
+	handleMarketingToggle: fn(),
+	handleSubmit: fn(),
+	handleSubmitButtonClick: fn(),
+	handleReset: fn(),
+};
+
+const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
+	userEmail: undefined,
+	hideEmailInput: false,
+	isInteracted: false,
+	showMarketingToggle: false,
+	marketingOptIn: undefined,
+	isWaitingForResponse: false,
+	responseOk: undefined,
+	errorMessage: undefined,
+	...noopHandlers,
+	...state,
+});
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Signed-out idle state. Preview button appears above the form. */
+export const SignedOut = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ showMarketingToggle: false }),
+		);
+	},
+});
+
+/**
+ * After the user focuses the email field — marketing toggle and privacy
+ * message are revealed.
+ */
+export const SignedOutFocused = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});
+
+/** Signed-out user with an email typed in, ready to submit. */
+export const SignedOutWithEmail = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'reader@example.com',
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});
+
+/**
+ * Signed-in user — email pre-filled from Identity, email input hidden,
+ * marketing toggle hidden, preview button moves into the submit row.
+ */
+export const SignedIn = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'reader@example.com',
+				hideEmailInput: true,
+				isInteracted: true,
+				showMarketingToggle: false,
+			}),
+		);
+	},
+});
+
+/** Spinner shown while the POST request is in-flight; form is hidden. */
+export const Loading = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ isWaitingForResponse: true }),
+		);
+	},
+});
+
+/** Subscription confirmed. */
+export const Success = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ responseOk: true }),
+		);
+	},
+});
+
+/** Server returned a non-2xx response — error message and "Try again" button. */
+export const SubmissionFailed = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ responseOk: false }),
+		);
+	},
+});
+
+/** User submitted without entering an email — inline validation error. */
+export const ValidationError = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ errorMessage: 'Please enter a valid email address.' }),
+		);
+	},
+});
+
+/** Form without a preview button (no `onPreviewClick` prop). */
+export const WithoutPreview = meta.story({
+	args: { ...defaultArgs, onPreviewClick: undefined },
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(mockForm({}));
+	},
+});
+
+/** `hidePrivacyMessage` — focused state without the privacy notice. */
+export const HidePrivacyMessage = meta.story({
+	args: { ...defaultArgs, hidePrivacyMessage: true },
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -44,6 +44,7 @@ const noopHandlers: Pick<
 	NewsletterSignupFormState,
 	| 'handleEmailChange'
 	| 'handleEmailFocus'
+	| 'handleEmailInvalid'
 	| 'handleMarketingToggle'
 	| 'handleSubmit'
 	| 'handleSubmitButtonClick'
@@ -53,6 +54,7 @@ const noopHandlers: Pick<
 > = {
 	handleEmailChange: fn(),
 	handleEmailFocus: fn(),
+	handleEmailInvalid: fn(),
 	handleMarketingToggle: fn(),
 	handleSubmit: fn(),
 	handleSubmitButtonClick: fn(),
@@ -170,12 +172,26 @@ export const SubmissionFailed = meta.story({
 	},
 });
 
-/** User submitted without entering an email — inline validation error. */
+/** User submitted without entering an email — inline validation error on the input. */
 export const ValidationError = meta.story({
 	args: defaultArgs,
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
-			mockForm({ errorMessage: 'Please enter a valid email address.' }),
+			mockForm({ errorMessage: 'Please enter your email address.' }),
+		);
+	},
+});
+
+/** User submitted with a malformed email — browser fires `invalid`, shown inline on the input. */
+export const InvalidEmail = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'not-an-email',
+				isInteracted: true,
+				errorMessage: 'Incorrect email format. Please check.',
+			}),
 		);
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -1,3 +1,5 @@
+import { createRef } from 'react';
+import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { fn, mocked } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
@@ -46,6 +48,8 @@ const noopHandlers: Pick<
 	| 'handleSubmit'
 	| 'handleSubmitButtonClick'
 	| 'handleReset'
+	| 'handleCaptchaComplete'
+	| 'handleCaptchaLoadError'
 > = {
 	handleEmailChange: fn(),
 	handleEmailFocus: fn(),
@@ -53,6 +57,8 @@ const noopHandlers: Pick<
 	handleSubmit: fn(),
 	handleSubmitButtonClick: fn(),
 	handleReset: fn(),
+	handleCaptchaComplete: fn(),
+	handleCaptchaLoadError: fn(),
 };
 
 const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
@@ -64,6 +70,8 @@ const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
 	isWaitingForResponse: false,
 	responseOk: undefined,
 	errorMessage: undefined,
+	recaptchaRef: createRef<ReactGoogleRecaptcha>(),
+	captchaSiteKey: undefined,
 	...noopHandlers,
 	...state,
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -70,11 +70,11 @@ const getTrackedEventDescription = (call: unknown[]): string => {
 	return value.eventDescription;
 };
 
-const getDecodedRequestBody = (callIndex = 0): string => {
+const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
 	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
 		callIndex
 	] as [string, RequestInit];
-	return decodeURIComponent(requestInit.body?.toString() ?? '');
+	return new URLSearchParams(requestInit.body?.toString() ?? '');
 };
 
 const expectTrackedEventDescriptions = (expected: string[]): void => {
@@ -147,12 +147,12 @@ describe('NewsletterSignupForm', () => {
 			}),
 		);
 
-		const decodedBody = getDecodedRequestBody();
+		const params = getRequestBodyParams();
 
-		expect(decodedBody).toContain('email=reader@example.com');
-		expect(decodedBody).toContain('listName=morning-briefing');
-		expect(decodedBody).toContain('marketing=true');
-		expect(decodedBody).toContain('browserId=test-browser-id');
+		expect(params.get('email')).toBe('reader@example.com');
+		expect(params.get('listName')).toBe('morning-briefing');
+		expect(params.get('marketing')).toBe('true');
+		expect(params.get('browserId')).toBe('test-browser-id');
 
 		expectTrackedEventDescriptions([
 			'click-button',
@@ -191,17 +191,14 @@ describe('NewsletterSignupForm', () => {
 		await testUser.click(marketingSwitch);
 		expect(marketingSwitch).toHaveAttribute('aria-checked', 'false');
 
-		const signUpButton = screen.queryByRole('button', { name: 'Sign up' });
-		if (signUpButton) {
-			await testUser.click(signUpButton);
-		}
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
 
 		await waitFor(() => {
 			expect(global.fetch).toHaveBeenCalled();
 		});
 
-		const decodedBody = getDecodedRequestBody();
-		expect(decodedBody).toContain('marketing=false');
+		const params = getRequestBodyParams();
+		expect(params.get('marketing')).toBe('false');
 	});
 
 	it('supports keyboard interaction for marketing toggle and submit button', async () => {
@@ -235,8 +232,8 @@ describe('NewsletterSignupForm', () => {
 			).toBeInTheDocument();
 		});
 
-		const decodedBody = getDecodedRequestBody();
-		expect(decodedBody).toContain('marketing=false');
+		const params = getRequestBodyParams();
+		expect(params.get('marketing')).toBe('false');
 	});
 
 	it('uses prefilled email for signed-in users and clears cached subscriptions on success', async () => {
@@ -271,8 +268,8 @@ describe('NewsletterSignupForm', () => {
 
 		expect(clearSubscriptionCache).toHaveBeenCalledTimes(1);
 
-		const decodedBody = getDecodedRequestBody();
-		expect(decodedBody).toContain('email=signed.in@example.com');
+		const params = getRequestBodyParams();
+		expect(params.get('email')).toBe('signed.in@example.com');
 	});
 
 	it('shows an inline validation error when submitting with an empty email', async () => {
@@ -316,7 +313,7 @@ describe('NewsletterSignupForm', () => {
 
 		// Typing clears the error immediately
 		await testUser.type(
-			screen.getByLabelText('Enter your email'),
+			screen.getByLabelText('Enter your email', { exact: false }),
 			'{Backspace}',
 		);
 

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
+import { forwardRef, useImperativeHandle } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
@@ -27,6 +28,21 @@ jest.mock('../lib/useAuthStatus', () => ({
 
 jest.mock('../lib/useBrowserId', () => ({
 	useBrowserId: jest.fn(),
+}));
+
+// Mock reCAPTCHA: immediately call onChange with a fake token when execute() is called.
+jest.mock('react-google-recaptcha', () => ({
+	__esModule: true,
+	default: forwardRef<
+		{ execute: () => void; reset: () => void },
+		{ onChange?: (token: string) => void }
+	>(function MockRecaptcha({ onChange }, ref) {
+		useImperativeHandle(ref, () => ({
+			execute: () => onChange?.('test-recaptcha-token'),
+			reset: () => undefined,
+		}));
+		return null;
+	}),
 }));
 
 const renderForm = (hidePrivacyMessage = false) =>
@@ -80,6 +96,7 @@ describe('NewsletterSignupForm', () => {
 		.page as typeof window.guardian.config.page & {
 		ajaxUrl?: string;
 		idApiUrl?: string;
+		googleRecaptchaSiteKey?: string;
 	};
 
 	beforeEach(() => {
@@ -95,6 +112,7 @@ describe('NewsletterSignupForm', () => {
 
 		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
+		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
 		if (window.guardian.ophan) {
 			window.guardian.ophan.pageViewId = 'test-page-view-id';
 		}
@@ -138,6 +156,8 @@ describe('NewsletterSignupForm', () => {
 
 		expectTrackedEventDescriptions([
 			'click-button',
+			'open-captcha',
+			'captcha-passed',
 			'form-submission',
 			'submission-confirmed',
 		]);
@@ -271,6 +291,8 @@ describe('NewsletterSignupForm', () => {
 
 		expectTrackedEventDescriptions([
 			'click-button',
+			'open-captcha',
+			'captcha-passed',
 			'form-submission',
 			'submission-failed',
 		]);

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -275,6 +275,56 @@ describe('NewsletterSignupForm', () => {
 		expect(decodedBody).toContain('email=signed.in@example.com');
 	});
 
+	it('shows an inline validation error when submitting with an empty email', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Please enter your email address.'),
+		).toBeInTheDocument();
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('shows an inline validation error when submitting with an invalid email format', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser, 'not-an-email');
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Incorrect email format. Please check.'),
+		).toBeInTheDocument();
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('clears the validation error as the user corrects their email', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser, 'not-an-email');
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Incorrect email format. Please check.'),
+		).toBeInTheDocument();
+
+		// Typing clears the error immediately
+		await testUser.type(
+			screen.getByLabelText('Enter your email'),
+			'{Backspace}',
+		);
+
+		expect(
+			screen.queryByText('Incorrect email format. Please check.'),
+		).not.toBeInTheDocument();
+	});
+
 	it('shows failure UI with retry and supports hiding the privacy message', async () => {
 		const testUser = user.setup();
 		global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -41,7 +41,8 @@ const renderForm = (hidePrivacyMessage = false) =>
 		>
 			<NewsletterSignupForm
 				newsletterId="morning-briefing"
-				successDescription="Thanks for subscribing"
+				newsletterName="Morning Briefing"
+				frequency="every day"
 				hidePrivacyMessage={hidePrivacyMessage}
 			/>
 		</ConfigProvider>,
@@ -109,8 +110,11 @@ describe('NewsletterSignupForm', () => {
 		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
 
 		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
 			expect(
-				screen.getByText('Subscription Confirmed.'),
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
 			).toBeInTheDocument();
 		});
 
@@ -203,8 +207,11 @@ describe('NewsletterSignupForm', () => {
 		await testUser.keyboard('{Enter}');
 
 		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
 			expect(
-				screen.getByText('Subscription Confirmed.'),
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
 			).toBeInTheDocument();
 		});
 
@@ -234,8 +241,11 @@ describe('NewsletterSignupForm', () => {
 		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
 
 		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
 			expect(
-				screen.getByText('Subscription Confirmed.'),
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
 			).toBeInTheDocument();
 		});
 

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -1,0 +1,274 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
+import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
+import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useBrowserId } from '../lib/useBrowserId';
+import { ConfigProvider } from './ConfigContext';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
+
+jest.mock('../client/ophan/ophan', () => ({
+	submitComponentEvent: jest.fn(),
+}));
+
+jest.mock('../lib/fetchEmail', () => ({
+	lazyFetchEmailWithTimeout: jest.fn(),
+}));
+
+jest.mock('../lib/newsletterSubscriptionCache', () => ({
+	clearSubscriptionCache: jest.fn(),
+}));
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useAuthStatus: jest.fn(),
+	useIsSignedIn: jest.fn(),
+}));
+
+jest.mock('../lib/useBrowserId', () => ({
+	useBrowserId: jest.fn(),
+}));
+
+const renderForm = (hidePrivacyMessage = false) =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<NewsletterSignupForm
+				newsletterId="morning-briefing"
+				successDescription="Thanks for subscribing"
+				hidePrivacyMessage={hidePrivacyMessage}
+			/>
+		</ConfigProvider>,
+	);
+
+const getTrackedEventDescription = (call: unknown[]): string => {
+	const payload = call[0] as { value: string };
+	const value = JSON.parse(payload.value) as { eventDescription: string };
+	return value.eventDescription;
+};
+
+const getDecodedRequestBody = (callIndex = 0): string => {
+	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
+		callIndex
+	] as [string, RequestInit];
+	return decodeURIComponent(requestInit.body?.toString() ?? '');
+};
+
+const expectTrackedEventDescriptions = (expected: string[]): void => {
+	const eventDescriptions = (
+		submitComponentEvent as jest.Mock
+	).mock.calls.map(getTrackedEventDescription);
+	expect(eventDescriptions).toEqual(expected);
+};
+
+const typeEmailAddress = async (
+	testUser: ReturnType<typeof user.setup>,
+	email = 'reader@example.com',
+): Promise<void> => {
+	await testUser.type(screen.getByLabelText('Enter your email'), email);
+};
+
+describe('NewsletterSignupForm', () => {
+	const pageConfig = window.guardian.config
+		.page as typeof window.guardian.config.page & {
+		ajaxUrl?: string;
+		idApiUrl?: string;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(useIsSignedIn as jest.Mock).mockReturnValue(false);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
+		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
+		(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+		(submitComponentEvent as jest.Mock).mockResolvedValue(undefined);
+
+		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
+		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
+		if (window.guardian.ophan) {
+			window.guardian.ophan.pageViewId = 'test-page-view-id';
+		}
+		global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+	});
+
+	it('submits for a signed-out user and includes marketing/browser fields', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Subscription Confirmed.'),
+			).toBeInTheDocument();
+		});
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://api.nextgen.guardianapps.co.uk/email',
+			expect.objectContaining({
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			}),
+		);
+
+		const decodedBody = getDecodedRequestBody();
+
+		expect(decodedBody).toContain('email=reader@example.com');
+		expect(decodedBody).toContain('listName=morning-briefing');
+		expect(decodedBody).toContain('marketing=true');
+		expect(decodedBody).toContain('browserId=test-browser-id');
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'form-submission',
+			'submission-confirmed',
+		]);
+	});
+
+	it('supports tab order from email input to marketing toggle to sign up', async () => {
+		const testUser = user.setup();
+
+		renderForm(true);
+
+		await testUser.tab();
+		expect(screen.getByLabelText('Enter your email')).toHaveFocus();
+
+		await testUser.tab();
+		expect(screen.getByRole('switch')).toHaveFocus();
+
+		await testUser.tab();
+		const signUpButton = screen.getByRole('button', { name: 'Sign up' });
+		expect(signUpButton).toHaveFocus();
+	});
+
+	it('allows signed-out users to opt out of marketing before submit', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		const marketingSwitch = screen.getByRole('switch');
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'true');
+
+		await testUser.click(marketingSwitch);
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'false');
+
+		const signUpButton = screen.queryByRole('button', { name: 'Sign up' });
+		if (signUpButton) {
+			await testUser.click(signUpButton);
+		}
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalled();
+		});
+
+		const decodedBody = getDecodedRequestBody();
+		expect(decodedBody).toContain('marketing=false');
+	});
+
+	it('supports keyboard interaction for marketing toggle and submit button', async () => {
+		const testUser = user.setup();
+
+		renderForm(true);
+
+		await testUser.tab();
+		const emailInput = screen.getByLabelText('Enter your email');
+		expect(emailInput).toHaveFocus();
+		await testUser.type(emailInput, 'reader@example.com');
+
+		await testUser.tab();
+		const marketingSwitch = screen.getByRole('switch');
+		expect(marketingSwitch).toHaveFocus();
+
+		await testUser.keyboard('{Enter}');
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'false');
+
+		await testUser.tab();
+		const signUpButton = screen.getByRole('button', { name: 'Sign up' });
+		expect(signUpButton).toHaveFocus();
+		await testUser.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Subscription Confirmed.'),
+			).toBeInTheDocument();
+		});
+
+		const decodedBody = getDecodedRequestBody();
+		expect(decodedBody).toContain('marketing=false');
+	});
+
+	it('uses prefilled email for signed-in users and clears cached subscriptions on success', async () => {
+		const testUser = user.setup();
+		(useIsSignedIn as jest.Mock).mockReturnValue(true);
+		(useAuthStatus as jest.Mock).mockReturnValue({
+			kind: 'SignedIn',
+			accessToken: { accessToken: 'token' },
+			idToken: { claims: { email: 'signed.in@example.com' } },
+		});
+		(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
+			Promise.resolve('signed.in@example.com'),
+		);
+
+		renderForm();
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', { name: 'Sign up' }),
+			).toBeInTheDocument();
+		});
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Subscription Confirmed.'),
+			).toBeInTheDocument();
+		});
+
+		expect(clearSubscriptionCache).toHaveBeenCalledTimes(1);
+
+		const decodedBody = getDecodedRequestBody();
+		expect(decodedBody).toContain('email=signed.in@example.com');
+	});
+
+	it('shows failure UI with retry and supports hiding the privacy message', async () => {
+		const testUser = user.setup();
+		global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+
+		renderForm(true);
+
+		expect(screen.queryByText('Privacy Notice:')).not.toBeInTheDocument();
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/Sign up failed\./)).toBeInTheDocument();
+		});
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'form-submission',
+			'submission-failed',
+		]);
+
+		await testUser.click(screen.getByRole('button', { name: 'Try again' }));
+
+		expect(
+			screen.getByRole('button', { name: 'Sign up' }),
+		).toBeInTheDocument();
+	});
+});

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -83,17 +83,7 @@ const submitButtonContainerStyles = css`
 	gap: ${space[2]}px;
 `;
 
-const signedOutSubmitButtonStyles = css`
-	flex: 1;
-	button {
-		width: 100%;
-	}
-	${from.tablet} {
-		max-width: 220px;
-	}
-`;
-
-const signedInSubmitButtonStyles = css`
+const submitButtonStyles = css`
 	flex: 1;
 	button {
 		width: 100%;
@@ -232,20 +222,57 @@ const SuccessMessage = ({
 	);
 };
 
+const FailureMessage = ({
+	onRetry,
+}: {
+	onRetry: React.MouseEventHandler<HTMLButtonElement>;
+}) => (
+	<div css={[responseBoxStyles, errorContainerStyles]}>
+		<ErrorMessageWithAdvice text="Sign up failed." />
+		<Button
+			size="small"
+			priority="primary"
+			icon={<SvgReload />}
+			iconSide="right"
+			onClick={onRetry}
+			cssOverrides={tryAgainButtonStyles}
+		>
+			Try again
+		</Button>
+	</div>
+);
+
 /**
  * # Newsletter Signup Form
  *
  * A simplified version of SecureSignup without reCAPTCHA or A/B testing.
  * All logic lives in {@link useNewsletterSignupForm}.
+ *
+ * When the user is already subscribed, the success message is shown immediately
+ * without invoking the form hook (no Identity fetch, reCAPTCHA, etc.).
  */
 export const NewsletterSignupForm = ({
+	isAlreadySubscribed,
+	...rest
+}: Props) => {
+	if (isAlreadySubscribed) {
+		return (
+			<SuccessMessage
+				newsletterName={rest.newsletterName}
+				frequency={rest.frequency}
+			/>
+		);
+	}
+	return <NewsletterSignupFormActive {...rest} />;
+};
+
+const NewsletterSignupFormActive = ({
 	newsletterId,
 	newsletterName,
 	frequency,
 	hidePrivacyMessage = false,
 	onPreviewClick,
-	isAlreadySubscribed = false,
-}: Props) => {
+}: Omit<Props, 'isAlreadySubscribed'>) => {
 	const { renderingTarget } = useConfig();
 
 	const {
@@ -271,8 +298,9 @@ export const NewsletterSignupForm = ({
 	} = useNewsletterSignupForm(newsletterId, renderingTarget);
 
 	const hasResponse = typeof responseOk === 'boolean';
-	const showForm =
-		!isAlreadySubscribed && !hasResponse && !isWaitingForResponse;
+	const showForm = !hasResponse && !isWaitingForResponse;
+	const showSuccess = hasResponse && !!responseOk;
+	const showFailure = hasResponse && !responseOk;
 	const showAdditionalFields = isInteracted || !!userEmail;
 	// Validation errors (before submission) are shown inline on the input.
 	// Network/server errors (after a failed submission) use the standalone message.
@@ -280,15 +308,11 @@ export const NewsletterSignupForm = ({
 
 	return (
 		<>
-			{!isAlreadySubscribed &&
-				!hasResponse &&
-				!isWaitingForResponse &&
-				onPreviewClick &&
-				!isSignedIn && (
-					<div css={previewButtonContainerStyles}>
-						<PreviewButton onClick={onPreviewClick} size="small" />
-					</div>
-				)}
+			{showForm && onPreviewClick && !isSignedIn && (
+				<div css={previewButtonContainerStyles}>
+					<PreviewButton onClick={onPreviewClick} size="small" />
+				</div>
+			)}
 			<form
 				onSubmit={handleSubmit}
 				id={`newsletter-signup-${newsletterId}`}
@@ -344,11 +368,7 @@ export const NewsletterSignupForm = ({
 						<PreviewButton onClick={onPreviewClick} />
 					)}
 					<Button
-						cssOverrides={
-							isSignedIn
-								? signedInSubmitButtonStyles
-								: signedOutSubmitButtonStyles
-						}
+						cssOverrides={submitButtonStyles}
 						onClick={handleSubmitButtonClick}
 						type="submit"
 					>
@@ -366,34 +386,13 @@ export const NewsletterSignupForm = ({
 				<ErrorMessageWithAdvice text={errorMessage} />
 			)}
 
-			{isAlreadySubscribed && (
+			{showSuccess && (
 				<SuccessMessage
 					newsletterName={newsletterName}
 					frequency={frequency}
 				/>
 			)}
-			{!isAlreadySubscribed &&
-				hasResponse &&
-				(responseOk ? (
-					<SuccessMessage
-						newsletterName={newsletterName}
-						frequency={frequency}
-					/>
-				) : (
-					<div css={[responseBoxStyles, errorContainerStyles]}>
-						<ErrorMessageWithAdvice text="Sign up failed." />
-						<Button
-							size="small"
-							priority="primary"
-							icon={<SvgReload />}
-							iconSide="right"
-							onClick={handleReset}
-							cssOverrides={tryAgainButtonStyles}
-						>
-							Try again
-						</Button>
-					</div>
-				))}
+			{showFailure && <FailureMessage onRetry={handleReset} />}
 			{!!captchaSiteKey && (
 				<div css={recaptchaContainerStyles}>
 					<ReactGoogleRecaptcha

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -11,7 +11,7 @@ import {
 	TextInput,
 } from '@guardian/source/react-components';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
-import type { CSSProperties, FormEvent, ReactEventHandler } from 'react';
+import type { FormEvent, ReactEventHandler } from 'react';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
@@ -31,70 +31,66 @@ type Props = {
 
 const formStyles = css`
 	display: grid;
-	grid-template-columns: auto 160px;
-	grid-template-rows: 24px 48px;
-	gap: 0 ${space[3]}px;
+	column-gap: ${space[3]}px;
+	row-gap: ${space[3]}px;
+	align-items: end;
+`;
 
+const signedOutLayoutStyles = css`
+	grid-template-columns: minmax(0, 1fr) 160px;
 	grid-template-areas:
-		'label label'
-		'input button'
+		'email submit'
 		'marketing .'
 		'privacy privacy';
 
-	label {
-		grid-area: label;
-		div {
-			color: ${palette('--article-text')};
-		}
-	}
-	input {
-		grid-area: input;
-		margin-top: 0;
-		color: ${palette('--article-text')};
-		background-color: ${palette('--article-background')};
-	}
-	button {
-		grid-area: button;
-	}
-
 	${until.tablet} {
 		grid-template-columns: 1fr;
-		grid-template-rows: auto auto auto auto;
 		grid-template-areas:
-			'label'
-			'input'
-			'button'
-			'marketing';
+			'email'
+			'submit'
+			'marketing'
 			'privacy';
-		gap: ${space[3]}px 0;
-
-		button {
-			width: 100%;
-		}
 	}
 `;
 
-const formStylesWhenSignedIn = {
-	gridTemplateColumns: 'auto 1fr',
-	gridTemplateAreas: [
-		// this is easier to parse over multiple lines
-		'"label  label"',
-		'"button input"',
-	].join(' '),
-} satisfies CSSProperties;
+const signedInLayoutStyles = css`
+	grid-template-columns: minmax(0, 1fr);
+	grid-template-areas:
+		'submit'
+		'marketing'
+		'privacy';
+`;
+
+const emailFieldStyles = css`
+	grid-area: email;
+	min-width: 0;
+
+	label div {
+		color: ${palette('--article-text')};
+	}
+
+	input {
+		color: ${palette('--article-text')};
+		background-color: ${palette('--article-background')};
+	}
+`;
+
+const submitButtonContainerStyles = css`
+	grid-area: submit;
+	width: 100%;
+
+	button {
+		width: 100%;
+	}
+`;
 
 const errorContainerStyles = css`
 	display: flex;
 	align-items: flex-start;
+	gap: ${space[2]}px;
+
 	${until.tablet} {
 		flex-wrap: wrap;
-	}
-	button {
-		margin-left: ${space[1]}px;
-		background-color: ${palette('--recaptcha-button')};
-		:hover {
-			background-color: ${palette('--recaptcha-button-hover')};
-		}
 	}
 `;
 
@@ -104,12 +100,11 @@ const toggleContainerStyles = css`
 	flex-direction: column;
 	align-items: flex-start;
 	gap: ${space[3]}px;
-	margin-top: ${space[3]}px;
+	min-width: 0;
 `;
 
 const privacyContainerStyles = css`
 	grid-area: privacy;
-	margin-top: ${space[3]}px;
 `;
 
 const marketingBoxStyles = css`
@@ -265,7 +260,7 @@ export const NewsletterSignupForm = ({
 	hidePrivacyMessage = false,
 }: Props) => {
 	const [userEmail, setUserEmail] = useState<string>();
-	const [hideEmailInput, setHideEmailInput] = useState<boolean>();
+	const [hideEmailInput, setHideEmailInput] = useState<boolean>(false);
 	const [isWaitingForResponse, setIsWaitingForResponse] =
 		useState<boolean>(false);
 	const [responseOk, setResponseOk] = useState<boolean | undefined>(
@@ -301,11 +296,7 @@ export const NewsletterSignupForm = ({
 
 	const hasResponse = typeof responseOk === 'boolean';
 
-	const submitForm = async (): Promise<void> => {
-		const input: HTMLInputElement | null =
-			document.querySelector('input[type="email"]') ?? null;
-		const emailAddress: string = input?.value ?? '';
-
+	const submitForm = async (emailAddress: string): Promise<void> => {
 		sendTracking(newsletterId, 'form-submission', renderingTarget);
 
 		const formData = buildFormData(
@@ -348,9 +339,16 @@ export const NewsletterSignupForm = ({
 		if (isWaitingForResponse) {
 			return;
 		}
+
+		const emailAddress = userEmail?.trim() ?? '';
+		if (!emailAddress) {
+			setErrorMessage('Please enter a valid email address.');
+			return;
+		}
+
 		setErrorMessage(undefined);
 		setIsWaitingForResponse(true);
-		submitForm().catch((error) => {
+		submitForm(emailAddress).catch((error) => {
 			// eslint-disable-next-line no-console -- unexpected error
 			console.error(error);
 			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
@@ -371,23 +369,31 @@ export const NewsletterSignupForm = ({
 						hasResponse || isWaitingForResponse
 							? 'none'
 							: undefined,
-					...(hideEmailInput ? formStylesWhenSignedIn : undefined),
 				}}
-				css={formStyles}
+				css={[
+					formStyles,
+					hideEmailInput
+						? signedInLayoutStyles
+						: signedOutLayoutStyles,
+				]}
 			>
-				<TextInput
-					hidden={hideEmailInput}
-					hideLabel={hideEmailInput}
-					name="email"
-					label="Enter your email"
-					type="email"
-					value={userEmail ?? ''}
-					onFocus={() => setIsInteracted(true)}
-					onChange={(e) => {
-						setUserEmail(e.target.value);
-						setIsInteracted(true);
-					}}
-				/>
+				{hideEmailInput ? (
+					<input type="hidden" name="email" value={userEmail ?? ''} />
+				) : (
+					<div css={emailFieldStyles}>
+						<TextInput
+							name="email"
+							label="Enter your email"
+							type="email"
+							value={userEmail ?? ''}
+							onFocus={() => setIsInteracted(true)}
+							onChange={(e) => {
+								setUserEmail(e.target.value);
+								setIsInteracted(true);
+							}}
+						/>
+					</div>
+				)}
 				{showAdditionalFields && (
 					<>
 						{isSignedIn === false && (
@@ -396,9 +402,11 @@ export const NewsletterSignupForm = ({
 									<ToggleSwitch
 										id={`marketing-opt-in-${newsletterId}`}
 										checked={marketingOptIn ?? false}
-										onClick={() =>
-											setMarketingOptIn(!marketingOptIn)
-										}
+										onClick={(event) => {
+											// ToggleSwitch renders a button; prevent accidental form submit.
+											event.preventDefault();
+											setMarketingOptIn(!marketingOptIn);
+										}}
 										label="Get updates about our journalism and ways to support and enjoy
 								our work. Toggle to opt out."
 										labelPosition="left"
@@ -413,9 +421,11 @@ export const NewsletterSignupForm = ({
 						)}
 					</>
 				)}
-				<Button onClick={handleClick} type="submit">
-					Sign up
-				</Button>
+				<div css={submitButtonContainerStyles}>
+					<Button onClick={handleClick} type="submit">
+						Sign up
+					</Button>
+				</div>
 			</form>
 			{isWaitingForResponse && (
 				<div role="status" aria-label="loading">
@@ -435,6 +445,7 @@ export const NewsletterSignupForm = ({
 						<ErrorMessageWithAdvice text={`Sign up failed.`} />
 						<Button
 							size="small"
+							priority="primary"
 							icon={<SvgReload />}
 							iconSide={'right'}
 							onClick={resetForm}

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -140,6 +140,12 @@ const feedbackButtonStyles = css`
 	margin-top: ${space[1]}px;
 `;
 
+const recaptchaContainerStyles = css`
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+`;
+
 const browseMoreLinksStyles = feedbackButtonStyles;
 
 const PreviewButton = ({
@@ -354,13 +360,15 @@ export const NewsletterSignupForm = ({
 					</div>
 				))}
 			{!!captchaSiteKey && (
-				<ReactGoogleRecaptcha
-					sitekey={captchaSiteKey}
-					ref={recaptchaRef}
-					onChange={handleCaptchaComplete}
-					onError={handleCaptchaLoadError}
-					size="invisible"
-				/>
+				<div css={recaptchaContainerStyles}>
+					<ReactGoogleRecaptcha
+						sitekey={captchaSiteKey}
+						ref={recaptchaRef}
+						onChange={handleCaptchaComplete}
+						onError={handleCaptchaLoadError}
+						size="invisible"
+					/>
+				</div>
 			)}
 		</>
 	);

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -120,6 +120,7 @@ const privacyContainerStyles = css`
 
 const successTextStyles = css`
 	color: ${palette('--newsletter-card-description')};
+	font-size: 15px;
 	strong {
 		font-weight: bold;
 	}
@@ -130,6 +131,12 @@ const marketingSuccessBoxStyles = css`
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
+`;
+
+const browseMoreLinksStyles = css`
+	width: 350px;
+	max-width: 100%;
+	margin-top: ${space[1]}px;
 `;
 
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
@@ -156,7 +163,7 @@ const SuccessMessage = ({
 }) => {
 	return (
 		<div css={marketingSuccessBoxStyles}>
-			<InlineSuccess>
+			<InlineSuccess size="medium">
 				<span css={successTextStyles}>
 					<strong>You're signed up!</strong>
 					&nbsp;
@@ -165,7 +172,11 @@ const SuccessMessage = ({
 					</span>
 				</span>
 			</InlineSuccess>
-			<LinkButton href="/email-newsletters" priority="tertiary">
+			<LinkButton
+				href="/email-newsletters"
+				priority="tertiary"
+				cssOverrides={browseMoreLinksStyles}
+			>
 				Browse more newsletters
 			</LinkButton>
 		</div>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { space, until } from '@guardian/source/foundations';
+import type { Size } from '@guardian/source/react-components';
 import {
 	Button,
 	InlineError,
@@ -137,13 +138,20 @@ const feedbackButtonStyles = css`
 
 const browseMoreLinksStyles = feedbackButtonStyles;
 
-const PreviewButton = ({ onClick }: { onClick: () => void }) => (
+const PreviewButton = ({
+	onClick,
+	size = 'default',
+}: {
+	onClick: () => void;
+	size?: Size;
+}) => (
 	<Button
 		priority="tertiary"
 		icon={<SvgEye />}
 		iconSide="left"
 		onClick={onClick}
 		type="button"
+		size={size}
 	>
 		Preview latest
 	</Button>
@@ -210,7 +218,7 @@ export const NewsletterSignupForm = ({
 
 	const {
 		userEmail,
-		hideEmailInput,
+		isSignedIn,
 		isInteracted,
 		showMarketingToggle,
 		marketingOptIn,
@@ -233,9 +241,9 @@ export const NewsletterSignupForm = ({
 			{!hasResponse &&
 				!isWaitingForResponse &&
 				onPreviewClick &&
-				!hideEmailInput && (
+				!isSignedIn && (
 					<div css={previewButtonContainerStyles}>
-						<PreviewButton onClick={onPreviewClick} />
+						<PreviewButton onClick={onPreviewClick} size="small" />
 					</div>
 				)}
 			<form
@@ -249,12 +257,10 @@ export const NewsletterSignupForm = ({
 				}}
 				css={[
 					formStyles,
-					hideEmailInput
-						? signedInLayoutStyles
-						: signedOutLayoutStyles,
+					isSignedIn ? signedInLayoutStyles : signedOutLayoutStyles,
 				]}
 			>
-				{hideEmailInput ? (
+				{isSignedIn ? (
 					<input type="hidden" name="email" value={userEmail ?? ''} />
 				) : (
 					<div css={emailFieldStyles}>
@@ -292,12 +298,12 @@ export const NewsletterSignupForm = ({
 					</>
 				)}
 				<div css={submitButtonContainerStyles}>
-					{hideEmailInput && onPreviewClick && (
+					{isSignedIn && onPreviewClick && (
 						<PreviewButton onClick={onPreviewClick} />
 					)}
 					<Button
 						cssOverrides={
-							hideEmailInput
+							isSignedIn
 								? signedInSubmitButtonStyles
 								: signedOutSubmitButtonStyles
 						}

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -13,6 +13,10 @@ import {
 	TextInput,
 } from '@guardian/source/react-components';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
+// Note - the package also exports a component as a named export "ReCAPTCHA",
+// that version will compile and render but is non-functional.
+// Use the default export instead.
+import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
@@ -225,6 +229,10 @@ export const NewsletterSignupForm = ({
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,
+		recaptchaRef,
+		captchaSiteKey,
+		handleCaptchaComplete,
+		handleCaptchaLoadError,
 		handleEmailChange,
 		handleEmailFocus,
 		handleMarketingToggle,
@@ -345,6 +353,15 @@ export const NewsletterSignupForm = ({
 						</Button>
 					</div>
 				))}
+			{!!captchaSiteKey && (
+				<ReactGoogleRecaptcha
+					sitekey={captchaSiteKey}
+					ref={recaptchaRef}
+					onChange={handleCaptchaComplete}
+					onError={handleCaptchaLoadError}
+					size="invisible"
+				/>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -7,6 +7,7 @@ import {
 	InlineSuccess,
 	Link,
 	Spinner,
+	SvgEye,
 	SvgReload,
 	TextInput,
 } from '@guardian/source/react-components';
@@ -27,12 +28,13 @@ type Props = {
 	newsletterId: string;
 	successDescription: string;
 	hidePrivacyMessage?: boolean;
+	onPreviewClick?: () => void;
 };
 
 const formStyles = css`
 	display: grid;
 	column-gap: ${space[3]}px;
-	row-gap: ${space[3]}px;
+	row-gap: ${space[2]}px;
 	align-items: end;
 `;
 
@@ -78,10 +80,24 @@ const emailFieldStyles = css`
 const submitButtonContainerStyles = css`
 	grid-area: submit;
 	width: 100%;
+	display: flex;
+	gap: ${space[2]}px;
+`;
 
+const signedOutSubmitButtonStyles = css`
+	flex: 1;
 	button {
 		width: 100%;
 	}
+`;
+
+const signedInSubmitButtonStyles = css`
+	width: 100%;
+	max-width: 220px;
+`;
+
+const previewButtonContainerStyles = css`
+	margin-bottom: ${space[3]}px;
 `;
 
 const errorContainerStyles = css`
@@ -258,6 +274,7 @@ export const NewsletterSignupForm = ({
 	newsletterId,
 	successDescription,
 	hidePrivacyMessage = false,
+	onPreviewClick,
 }: Props) => {
 	const [userEmail, setUserEmail] = useState<string>();
 	const [hideEmailInput, setHideEmailInput] = useState<boolean>(false);
@@ -361,6 +378,22 @@ export const NewsletterSignupForm = ({
 
 	return (
 		<>
+			{!hasResponse &&
+				!isWaitingForResponse &&
+				onPreviewClick &&
+				!hideEmailInput && (
+					<div css={previewButtonContainerStyles}>
+						<Button
+							priority="tertiary"
+							icon={<SvgEye />}
+							iconSide="left"
+							onClick={onPreviewClick}
+							type="button"
+						>
+							Preview latest
+						</Button>
+					</div>
+				)}
 			<form
 				onSubmit={handleSubmit}
 				id={`newsletter-signup-${newsletterId}`}
@@ -422,7 +455,26 @@ export const NewsletterSignupForm = ({
 					</>
 				)}
 				<div css={submitButtonContainerStyles}>
-					<Button onClick={handleClick} type="submit">
+					{hideEmailInput && onPreviewClick && (
+						<Button
+							priority="tertiary"
+							icon={<SvgEye />}
+							iconSide="left"
+							onClick={onPreviewClick}
+							type="button"
+						>
+							Preview latest
+						</Button>
+					)}
+					<Button
+						cssOverrides={
+							hideEmailInput
+								? signedInSubmitButtonStyles
+								: signedOutSubmitButtonStyles
+						}
+						onClick={handleClick}
+						type="submit"
+					>
 						Sign up
 					</Button>
 				</div>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, textSans15, until } from '@guardian/source/foundations';
+import { from, space, textSans15, until } from '@guardian/source/foundations';
 import type { Size } from '@guardian/source/react-components';
 import {
 	Button,
@@ -88,12 +88,18 @@ const signedOutSubmitButtonStyles = css`
 	button {
 		width: 100%;
 	}
+	${from.tablet} {
+		max-width: 220px;
+	}
 `;
 
 const signedInSubmitButtonStyles = css`
 	flex: 1;
 	button {
 		width: 100%;
+	}
+	${from.tablet} {
+		max-width: 220px;
 	}
 `;
 
@@ -143,7 +149,7 @@ const errorContainerStyles = css`
 	gap: ${space[2]}px;
 `;
 
-const feedbackButtonStyles = css`
+const tryAgainButtonStyles = css`
 	width: 100%;
 	margin-top: ${space[2]}px;
 `;
@@ -154,7 +160,12 @@ const recaptchaContainerStyles = css`
 	}
 `;
 
-const browseMoreLinksStyles = feedbackButtonStyles;
+const browseMoreLinksStyles = css`
+	${tryAgainButtonStyles};
+	${from.tablet} {
+		max-width: 350px;
+	}
+`;
 
 const PreviewButton = ({
 	onClick,
@@ -377,7 +388,7 @@ export const NewsletterSignupForm = ({
 							icon={<SvgReload />}
 							iconSide="right"
 							onClick={handleReset}
-							cssOverrides={feedbackButtonStyles}
+							cssOverrides={tryAgainButtonStyles}
 						>
 							Try again
 						</Button>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, until } from '@guardian/source/foundations';
+import { space, textSans15, until } from '@guardian/source/foundations';
 import type { Size } from '@guardian/source/react-components';
 import {
 	Button,
@@ -37,6 +37,10 @@ const formStyles = css`
 	column-gap: ${space[3]}px;
 	row-gap: ${space[2]}px;
 	align-items: end;
+
+	${until.tablet} {
+		row-gap: ${space[3]}px;
+	}
 `;
 
 const signedOutLayoutStyles = css`
@@ -86,12 +90,14 @@ const signedOutSubmitButtonStyles = css`
 `;
 
 const signedInSubmitButtonStyles = css`
-	width: 100%;
-	max-width: 220px;
+	flex: 1;
+	button {
+		width: 100%;
+	}
 `;
 
 const previewButtonContainerStyles = css`
-	margin-bottom: ${space[3]}px;
+	margin-bottom: ${space[2]}px;
 `;
 
 const toggleContainerStyles = css`
@@ -109,7 +115,7 @@ const privacyContainerStyles = css`
 
 const successTextStyles = css`
 	color: ${palette('--newsletter-card-description')};
-	font-size: 15px;
+	${textSans15};
 	strong {
 		font-weight: bold;
 	}
@@ -127,7 +133,7 @@ const responseBoxStyles = css`
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
-	margin-top: ${space[4]}px;
+	margin-top: ${space[2]}px;
 `;
 
 const errorContainerStyles = css`
@@ -137,9 +143,8 @@ const errorContainerStyles = css`
 `;
 
 const feedbackButtonStyles = css`
-	width: 350px;
-	max-width: 100%;
-	margin-top: ${space[1]}px;
+	width: 100%;
+	margin-top: ${space[2]}px;
 `;
 
 const recaptchaContainerStyles = css`

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -95,14 +95,10 @@ const previewButtonContainerStyles = css`
 `;
 
 const errorContainerStyles = css`
-	margin-top: ${space[6]}px;
+	margin-top: ${space[2]}px;
 	display: flex;
-	align-items: flex-start;
+	flex-direction: column;
 	gap: ${space[2]}px;
-
-	${until.tablet} {
-		flex-wrap: wrap;
-	}
 `;
 
 const toggleContainerStyles = css`
@@ -133,11 +129,13 @@ const marketingSuccessBoxStyles = css`
 	border-radius: 4px;
 `;
 
-const browseMoreLinksStyles = css`
+const feedbackButtonStyles = css`
 	width: 350px;
 	max-width: 100%;
 	margin-top: ${space[1]}px;
 `;
+
+const browseMoreLinksStyles = feedbackButtonStyles;
 
 const PreviewButton = ({ onClick }: { onClick: () => void }) => (
 	<Button
@@ -325,7 +323,9 @@ export const NewsletterSignupForm = ({
 						frequency={frequency}
 					/>
 				) : (
-					<div css={errorContainerStyles}>
+					<div
+						css={[marketingSuccessBoxStyles, errorContainerStyles]}
+					>
 						<ErrorMessageWithAdvice text="Sign up failed." />
 						<Button
 							size="small"
@@ -333,6 +333,7 @@ export const NewsletterSignupForm = ({
 							icon={<SvgReload />}
 							iconSide="right"
 							onClick={handleReset}
+							cssOverrides={feedbackButtonStyles}
 						>
 							Try again
 						</Button>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -241,6 +241,7 @@ export const NewsletterSignupForm = ({
 		handleCaptchaLoadError,
 		handleEmailChange,
 		handleEmailFocus,
+		handleEmailInvalid,
 		handleMarketingToggle,
 		handleSubmit,
 		handleSubmitButtonClick,
@@ -249,6 +250,9 @@ export const NewsletterSignupForm = ({
 
 	const hasResponse = typeof responseOk === 'boolean';
 	const showAdditionalFields = isInteracted || !!userEmail;
+	// Validation errors (before submission) are shown inline on the input.
+	// Network/server errors (after a failed submission) use the standalone message.
+	const isValidationError = !!errorMessage && !hasResponse;
 
 	return (
 		<>
@@ -283,8 +287,10 @@ export const NewsletterSignupForm = ({
 							label="Enter your email"
 							type="email"
 							value={userEmail ?? ''}
+							error={isValidationError ? errorMessage : undefined}
 							onFocus={handleEmailFocus}
 							onChange={(e) => handleEmailChange(e.target.value)}
+							onInvalid={handleEmailInvalid}
 						/>
 					</div>
 				)}
@@ -334,7 +340,9 @@ export const NewsletterSignupForm = ({
 				</div>
 			)}
 
-			{!!errorMessage && <ErrorMessageWithAdvice text={errorMessage} />}
+			{!!errorMessage && !isValidationError && (
+				<ErrorMessageWithAdvice text={errorMessage} />
+			)}
 
 			{hasResponse &&
 				(responseOk ? (

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -11,6 +11,7 @@ import {
 	SvgEye,
 	SvgReload,
 	TextInput,
+	themeButton,
 } from '@guardian/source/react-components';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
 // Note - the package also exports a component as a named export "ReCAPTCHA",
@@ -211,6 +212,7 @@ const SuccessMessage = ({
 			<LinkButton
 				href="/email-newsletters"
 				priority="tertiary"
+				theme={themeButton}
 				cssOverrides={browseMoreLinksStyles}
 			>
 				Browse more newsletters

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -26,6 +26,7 @@ import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 type Props = {
 	newsletterId: string;
 	successDescription: string;
+	hidePrivacyMessage?: boolean;
 };
 
 const formStyles = css`
@@ -37,7 +38,8 @@ const formStyles = css`
 	grid-template-areas:
 		'label label'
 		'input button'
-		'marketing marketing';
+		'marketing .'
+		'privacy privacy';
 
 	label {
 		grid-area: label;
@@ -63,6 +65,7 @@ const formStyles = css`
 			'input'
 			'button'
 			'marketing';
+			'privacy';
 		gap: ${space[3]}px 0;
 
 		button {
@@ -101,6 +104,11 @@ const toggleContainerStyles = css`
 	flex-direction: column;
 	align-items: flex-start;
 	gap: ${space[3]}px;
+	margin-top: ${space[3]}px;
+`;
+
+const privacyContainerStyles = css`
+	grid-area: privacy;
 	margin-top: ${space[3]}px;
 `;
 
@@ -180,7 +188,7 @@ const postFormData = async (
 	for (const [key, value] of formData.entries()) {
 		requestBodyStrings.push(
 			`${encodeURIComponent(key)}=${encodeURIComponent(
-				// eslint-disable-next-line @typescript-eslint/no-base-to-string
+				// eslint-disable-next-line @typescript-eslint/no-base-to-string -- value.toString() is safe here as we are dealing with FormData entries
 				value.toString(),
 			)}`,
 		);
@@ -254,6 +262,7 @@ const sendTracking = (
 export const NewsletterSignupForm = ({
 	newsletterId,
 	successDescription,
+	hidePrivacyMessage = false,
 }: Props) => {
 	const [userEmail, setUserEmail] = useState<string>();
 	const [hideEmailInput, setHideEmailInput] = useState<boolean>();
@@ -380,23 +389,29 @@ export const NewsletterSignupForm = ({
 					}}
 				/>
 				{showAdditionalFields && (
-					<div css={toggleContainerStyles}>
+					<>
 						{isSignedIn === false && (
-							<div css={marketingBoxStyles}>
-								<ToggleSwitch
-									id={`marketing-opt-in-${newsletterId}`}
-									checked={marketingOptIn ?? false}
-									onClick={() =>
-										setMarketingOptIn(!marketingOptIn)
-									}
-									label="Get updates about our journalism and ways to support and enjoy
+							<div css={toggleContainerStyles}>
+								<div css={marketingBoxStyles}>
+									<ToggleSwitch
+										id={`marketing-opt-in-${newsletterId}`}
+										checked={marketingOptIn ?? false}
+										onClick={() =>
+											setMarketingOptIn(!marketingOptIn)
+										}
+										label="Get updates about our journalism and ways to support and enjoy
 								our work. Toggle to opt out."
-									labelPosition="left"
-								/>
+										labelPosition="left"
+									/>
+								</div>
 							</div>
 						)}
-						<NewsletterPrivacyMessage />
-					</div>
+						{!hidePrivacyMessage && (
+							<div css={privacyContainerStyles}>
+								<NewsletterPrivacyMessage />
+							</div>
+						)}
+					</>
 				)}
 				<Button onClick={handleClick} type="submit">
 					Sign up

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -21,6 +21,7 @@ import { useBrowserId } from '../lib/useBrowserId';
 import { palette } from '../palette';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
+import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 
 type Props = {
 	newsletterId: string;
@@ -36,7 +37,7 @@ const formStyles = css`
 	grid-template-areas:
 		'label label'
 		'input button'
-		'marketing .';
+		'marketing marketing';
 
 	label {
 		grid-area: label;
@@ -97,15 +98,17 @@ const errorContainerStyles = css`
 const toggleContainerStyles = css`
 	grid-area: marketing;
 	display: flex;
+	flex-direction: column;
 	align-items: flex-start;
-	label {
-		align-items: flex-start;
-	}
-	justify-content: space-between;
+	gap: ${space[3]}px;
+	margin-top: ${space[3]}px;
+`;
+
+const marketingBoxStyles = css`
+	width: 100%;
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
-	margin-top: ${space[3]}px;
 `;
 
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
@@ -265,6 +268,7 @@ export const NewsletterSignupForm = ({
 	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
 		undefined,
 	);
+	const [isInteracted, setIsInteracted] = useState<boolean>(false);
 	const isSignedIn = useIsSignedIn();
 	const authStatus = useAuthStatus();
 
@@ -278,6 +282,9 @@ export const NewsletterSignupForm = ({
 		void resolveEmailIfSignedIn().then((email) => {
 			setUserEmail(email);
 			setHideEmailInput(isString(email));
+			if (isString(email)) {
+				setIsInteracted(true);
+			}
 		});
 	}, []);
 	const { renderingTarget } = useConfig();
@@ -343,6 +350,8 @@ export const NewsletterSignupForm = ({
 		});
 	};
 
+	const showAdditionalFields = isInteracted || !!userEmail;
+
 	return (
 		<>
 			<form
@@ -364,18 +373,29 @@ export const NewsletterSignupForm = ({
 					label="Enter your email"
 					type="email"
 					value={userEmail ?? ''}
-					onChange={(e) => setUserEmail(e.target.value)}
+					onFocus={() => setIsInteracted(true)}
+					onChange={(e) => {
+						setUserEmail(e.target.value);
+						setIsInteracted(true);
+					}}
 				/>
-				{isSignedIn === false && (
+				{showAdditionalFields && (
 					<div css={toggleContainerStyles}>
-						<ToggleSwitch
-							id={`marketing-opt-in-${newsletterId}`}
-							checked={marketingOptIn ?? false}
-							onClick={() => setMarketingOptIn(!marketingOptIn)}
-							label="Get updates about our journalism and ways to support and enjoy
-							our work. Toggle to opt out."
-							labelPosition="left"
-						/>
+						{isSignedIn === false && (
+							<div css={marketingBoxStyles}>
+								<ToggleSwitch
+									id={`marketing-opt-in-${newsletterId}`}
+									checked={marketingOptIn ?? false}
+									onClick={() =>
+										setMarketingOptIn(!marketingOptIn)
+									}
+									label="Get updates about our journalism and ways to support and enjoy
+								our work. Toggle to opt out."
+									labelPosition="left"
+								/>
+							</div>
+						)}
+						<NewsletterPrivacyMessage />
 					</div>
 				)}
 				<Button onClick={handleClick} type="submit">

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -205,7 +205,8 @@ const SuccessMessage = ({
 					<strong>You're signed up!</strong>
 					&nbsp;
 					<span>
-						You will receive {newsletterName} {frequency}.
+						You will receive {newsletterName}{' '}
+						{frequency.toLowerCase()}.
 					</span>
 				</span>
 			</InlineSuccess>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,0 +1,412 @@
+import { css } from '@emotion/react';
+import { isString } from '@guardian/libs';
+import { space, until } from '@guardian/source/foundations';
+import {
+	Button,
+	InlineError,
+	InlineSuccess,
+	Link,
+	Spinner,
+	SvgReload,
+	TextInput,
+} from '@guardian/source/react-components';
+import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
+import type { CSSProperties, FormEvent, ReactEventHandler } from 'react';
+import { useEffect, useState } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
+import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
+import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useBrowserId } from '../lib/useBrowserId';
+import { palette } from '../palette';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { useConfig } from './ConfigContext';
+
+type Props = {
+	newsletterId: string;
+	successDescription: string;
+};
+
+const formStyles = css`
+	display: grid;
+	align-items: center;
+	grid-template-columns: auto 160px;
+	grid-template-rows: 24px 48px;
+	gap: 0 ${space[3]}px;
+
+	grid-template-areas:
+		'label label'
+		'input button'
+		'marketing .';
+
+	label {
+		grid-area: label;
+		div {
+			color: ${palette('--article-text')};
+		}
+	}
+	input {
+		grid-area: input;
+		margin-top: 0;
+		color: ${palette('--article-text')};
+		background-color: ${palette('--article-background')};
+	}
+	button {
+		grid-area: button;
+	}
+
+	${until.tablet} {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto auto auto auto;
+		grid-template-areas:
+			'label'
+			'input'
+			'button'
+			'marketing';
+		gap: ${space[3]}px 0;
+
+		button {
+			width: 100%;
+		}
+	}
+`;
+
+const formStylesWhenSignedIn = {
+	gridTemplateColumns: 'auto 1fr',
+	gridTemplateAreas: [
+		// this is easier to parse over multiple lines
+		'"label  label"',
+		'"button input"',
+	].join(' '),
+} satisfies CSSProperties;
+
+const errorContainerStyles = css`
+	display: flex;
+	align-items: flex-start;
+	${until.tablet} {
+		flex-wrap: wrap;
+	}
+	button {
+		margin-left: ${space[1]}px;
+		background-color: ${palette('--recaptcha-button')};
+		:hover {
+			background-color: ${palette('--recaptcha-button-hover')};
+		}
+	}
+`;
+
+const toggleContainerStyles = css`
+	grid-area: marketing;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+
+	padding: ${space[1]}px;
+	border: 1px solid ${palette('--article-border')};
+	border-radius: 4px;
+	margin-top: ${space[3]}px;
+`;
+
+const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
+	<InlineError>
+		<span>
+			{text} Please try again or contact{' '}
+			<Link
+				href="mailto:customer.help@theguardian.com"
+				target="_blank"
+				rel="noreferrer"
+			>
+				customer.help@theguardian.com
+			</Link>
+		</span>
+	</InlineError>
+);
+
+const SuccessMessage = ({ text }: { text?: string }) => (
+	<InlineSuccess>
+		<span>
+			<b>Subscription Confirmed.&nbsp;</b>
+			<span>{text}</span>
+		</span>
+	</InlineSuccess>
+);
+
+const buildFormData = (
+	emailAddress: string,
+	newsletterId: string,
+	marketingOptIn?: boolean,
+	browserId?: string,
+): FormData => {
+	const pageRef = window.location.origin + window.location.pathname;
+	const refViewId = window.guardian.ophan?.pageViewId ?? '';
+
+	const formData = new FormData();
+	formData.append('email', emailAddress);
+	formData.append('csrfToken', '');
+	formData.append('listName', newsletterId);
+	formData.append('ref', pageRef);
+	formData.append('refViewId', refViewId);
+	formData.append('name', '');
+
+	if (marketingOptIn !== undefined) {
+		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (browserId !== undefined) {
+		formData.append('browserId', browserId);
+	}
+
+	return formData;
+};
+
+const resolveEmailIfSignedIn = async (): Promise<string | undefined> => {
+	const { idApiUrl } = window.guardian.config.page;
+	if (!idApiUrl) return;
+	const fetchedEmail = await lazyFetchEmailWithTimeout()();
+	if (!fetchedEmail) return;
+	return fetchedEmail;
+};
+
+const postFormData = async (
+	endpoint: string,
+	formData: FormData,
+): Promise<Response> => {
+	const requestBodyStrings: string[] = [];
+
+	for (const [key, value] of formData.entries()) {
+		requestBodyStrings.push(
+			`${encodeURIComponent(key)}=${encodeURIComponent(
+				// eslint-disable-next-line @typescript-eslint/no-base-to-string
+				value.toString(),
+			)}`,
+		);
+	}
+
+	return fetch(endpoint, {
+		method: 'POST',
+		body: requestBodyStrings.join('&'),
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+	});
+};
+
+type EventDescription =
+	| 'click-button'
+	| 'form-submission'
+	| 'submission-confirmed'
+	| 'submission-failed'
+	| 'form-submit-error';
+
+const sendTracking = (
+	newsletterId: string,
+	eventDescription: EventDescription,
+	renderingTarget: RenderingTarget,
+): void => {
+	let action: 'CLICK' | 'ANSWER' | 'SUBSCRIBE' | 'CLOSE';
+
+	switch (eventDescription) {
+		case 'form-submission':
+			action = 'ANSWER';
+			break;
+		case 'submission-confirmed':
+			action = 'SUBSCRIBE';
+			break;
+		case 'form-submit-error':
+		case 'submission-failed':
+			action = 'CLOSE';
+			break;
+		case 'click-button':
+		default:
+			action = 'CLICK';
+			break;
+	}
+
+	const value = JSON.stringify({
+		eventDescription,
+		newsletterId,
+		timestamp: Date.now(),
+	});
+
+	void submitComponentEvent(
+		{
+			action,
+			value,
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: `AR NewsletterSignupForm ${newsletterId}`,
+			},
+		},
+		renderingTarget,
+	);
+};
+
+/**
+ * # Newsletter Signup Form
+ *
+ * A simplified version of SecureSignup without reCAPTCHA or A/B testing.
+ */
+export const NewsletterSignupForm = ({
+	newsletterId,
+	successDescription,
+}: Props) => {
+	const [userEmail, setUserEmail] = useState<string>();
+	const [hideEmailInput, setHideEmailInput] = useState<boolean>();
+	const [isWaitingForResponse, setIsWaitingForResponse] =
+		useState<boolean>(false);
+	const [responseOk, setResponseOk] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [errorMessage, setErrorMessage] = useState<string | undefined>(
+		undefined,
+	);
+	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
+		undefined,
+	);
+	const isSignedIn = useIsSignedIn();
+	const authStatus = useAuthStatus();
+
+	useEffect(() => {
+		if (isSignedIn !== 'Pending' && !isSignedIn) {
+			setMarketingOptIn(true);
+		}
+	}, [isSignedIn]);
+
+	useEffect(() => {
+		void resolveEmailIfSignedIn().then((email) => {
+			setUserEmail(email);
+			setHideEmailInput(isString(email));
+		});
+	}, []);
+	const { renderingTarget } = useConfig();
+	const browserId = useBrowserId();
+
+	const hasResponse = typeof responseOk === 'boolean';
+
+	const submitForm = async (): Promise<void> => {
+		const input: HTMLInputElement | null =
+			document.querySelector('input[type="email"]') ?? null;
+		const emailAddress: string = input?.value ?? '';
+
+		sendTracking(newsletterId, 'form-submission', renderingTarget);
+
+		const formData = buildFormData(
+			emailAddress,
+			newsletterId,
+			marketingOptIn,
+			browserId,
+		);
+
+		const response = await postFormData(
+			window.guardian.config.page.ajaxUrl + '/email',
+			formData,
+		);
+
+		setIsWaitingForResponse(false);
+		setResponseOk(response.ok);
+
+		if (response.ok && authStatus.kind === 'SignedIn') {
+			clearSubscriptionCache();
+		}
+
+		sendTracking(
+			newsletterId,
+			response.ok ? 'submission-confirmed' : 'submission-failed',
+			renderingTarget,
+		);
+	};
+
+	const resetForm: ReactEventHandler<HTMLButtonElement> = () => {
+		setErrorMessage(undefined);
+		setResponseOk(undefined);
+	};
+
+	const handleClick = (): void => {
+		sendTracking(newsletterId, 'click-button', renderingTarget);
+	};
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+		event.preventDefault();
+		if (isWaitingForResponse) {
+			return;
+		}
+		setErrorMessage(undefined);
+		setIsWaitingForResponse(true);
+		submitForm().catch((error) => {
+			// eslint-disable-next-line no-console -- unexpected error
+			console.error(error);
+			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
+			setErrorMessage(`Sorry, there was an error signing you up.`);
+			setIsWaitingForResponse(false);
+		});
+	};
+
+	return (
+		<>
+			<form
+				onSubmit={handleSubmit}
+				id={`newsletter-signup-${newsletterId}`}
+				style={{
+					display:
+						hasResponse || isWaitingForResponse
+							? 'none'
+							: undefined,
+					...(hideEmailInput ? formStylesWhenSignedIn : undefined),
+				}}
+				css={formStyles}
+			>
+				<TextInput
+					hidden={hideEmailInput}
+					hideLabel={hideEmailInput}
+					name="email"
+					label="Enter your email"
+					type="email"
+					value={userEmail ?? ''}
+					onChange={(e) => setUserEmail(e.target.value)}
+				/>
+				{isSignedIn === false && (
+					<div css={toggleContainerStyles}>
+						<ToggleSwitch
+							id={`marketing-opt-in-${newsletterId}`}
+							checked={marketingOptIn ?? false}
+							onClick={() => setMarketingOptIn(!marketingOptIn)}
+							label="Get updates about our journalism and ways to support and enjoy
+							our work. Toggle to opt out."
+							labelPosition="left"
+						/>
+					</div>
+				)}
+				<Button onClick={handleClick} type="submit">
+					Sign up
+				</Button>
+			</form>
+			{isWaitingForResponse && (
+				<div role="status" aria-label="loading">
+					<Spinner size="small" />
+				</div>
+			)}
+
+			{!!errorMessage && <ErrorMessageWithAdvice text={errorMessage} />}
+
+			{hasResponse &&
+				(responseOk ? (
+					<div>
+						<SuccessMessage text={successDescription} />
+					</div>
+				) : (
+					<div css={errorContainerStyles}>
+						<ErrorMessageWithAdvice text={`Sign up failed.`} />
+						<Button
+							size="small"
+							icon={<SvgReload />}
+							iconSide={'right'}
+							onClick={resetForm}
+						>
+							Try again
+						</Button>
+					</div>
+				))}
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { isString } from '@guardian/libs';
 import { space, until } from '@guardian/source/foundations';
 import {
 	Button,
@@ -12,15 +11,8 @@ import {
 	TextInput,
 } from '@guardian/source/react-components';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
-import type { FormEvent, ReactEventHandler } from 'react';
-import { useEffect, useState } from 'react';
-import { submitComponentEvent } from '../client/ophan/ophan';
-import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
-import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
-import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
-import { useBrowserId } from '../lib/useBrowserId';
+import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import { palette } from '../palette';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 
@@ -155,121 +147,11 @@ const SuccessMessage = ({ text }: { text?: string }) => (
 	</InlineSuccess>
 );
 
-const buildFormData = (
-	emailAddress: string,
-	newsletterId: string,
-	marketingOptIn?: boolean,
-	browserId?: string,
-): FormData => {
-	const pageRef = window.location.origin + window.location.pathname;
-	const refViewId = window.guardian.ophan?.pageViewId ?? '';
-
-	const formData = new FormData();
-	formData.append('email', emailAddress);
-	formData.append('csrfToken', '');
-	formData.append('listName', newsletterId);
-	formData.append('ref', pageRef);
-	formData.append('refViewId', refViewId);
-	formData.append('name', '');
-
-	if (marketingOptIn !== undefined) {
-		formData.append('marketing', marketingOptIn ? 'true' : 'false');
-	}
-
-	if (browserId !== undefined) {
-		formData.append('browserId', browserId);
-	}
-
-	return formData;
-};
-
-const resolveEmailIfSignedIn = async (): Promise<string | undefined> => {
-	const { idApiUrl } = window.guardian.config.page;
-	if (!idApiUrl) return;
-	const fetchedEmail = await lazyFetchEmailWithTimeout()();
-	if (!fetchedEmail) return;
-	return fetchedEmail;
-};
-
-const postFormData = async (
-	endpoint: string,
-	formData: FormData,
-): Promise<Response> => {
-	const requestBodyStrings: string[] = [];
-
-	for (const [key, value] of formData.entries()) {
-		requestBodyStrings.push(
-			`${encodeURIComponent(key)}=${encodeURIComponent(
-				// eslint-disable-next-line @typescript-eslint/no-base-to-string -- value.toString() is safe here as we are dealing with FormData entries
-				value.toString(),
-			)}`,
-		);
-	}
-
-	return fetch(endpoint, {
-		method: 'POST',
-		body: requestBodyStrings.join('&'),
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/x-www-form-urlencoded',
-		},
-	});
-};
-
-type EventDescription =
-	| 'click-button'
-	| 'form-submission'
-	| 'submission-confirmed'
-	| 'submission-failed'
-	| 'form-submit-error';
-
-const sendTracking = (
-	newsletterId: string,
-	eventDescription: EventDescription,
-	renderingTarget: RenderingTarget,
-): void => {
-	let action: 'CLICK' | 'ANSWER' | 'SUBSCRIBE' | 'CLOSE';
-
-	switch (eventDescription) {
-		case 'form-submission':
-			action = 'ANSWER';
-			break;
-		case 'submission-confirmed':
-			action = 'SUBSCRIBE';
-			break;
-		case 'form-submit-error':
-		case 'submission-failed':
-			action = 'CLOSE';
-			break;
-		case 'click-button':
-		default:
-			action = 'CLICK';
-			break;
-	}
-
-	const value = JSON.stringify({
-		eventDescription,
-		newsletterId,
-		timestamp: Date.now(),
-	});
-
-	void submitComponentEvent(
-		{
-			action,
-			value,
-			component: {
-				componentType: 'NEWSLETTER_SUBSCRIPTION',
-				id: `AR NewsletterSignupForm ${newsletterId}`,
-			},
-		},
-		renderingTarget,
-	);
-};
-
 /**
  * # Newsletter Signup Form
  *
  * A simplified version of SecureSignup without reCAPTCHA or A/B testing.
+ * All logic lives in {@link useNewsletterSignupForm}.
  */
 export const NewsletterSignupForm = ({
 	newsletterId,
@@ -277,104 +159,26 @@ export const NewsletterSignupForm = ({
 	hidePrivacyMessage = false,
 	onPreviewClick,
 }: Props) => {
-	const [userEmail, setUserEmail] = useState<string>();
-	const [hideEmailInput, setHideEmailInput] = useState<boolean>(false);
-	const [isWaitingForResponse, setIsWaitingForResponse] =
-		useState<boolean>(false);
-	const [responseOk, setResponseOk] = useState<boolean | undefined>(
-		undefined,
-	);
-	const [errorMessage, setErrorMessage] = useState<string | undefined>(
-		undefined,
-	);
-	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
-		undefined,
-	);
-	const [isInteracted, setIsInteracted] = useState<boolean>(false);
-	const isSignedIn = useIsSignedIn();
-	const authStatus = useAuthStatus();
-
-	useEffect(() => {
-		if (isSignedIn !== 'Pending' && !isSignedIn) {
-			setMarketingOptIn(true);
-		}
-	}, [isSignedIn]);
-
-	useEffect(() => {
-		void resolveEmailIfSignedIn().then((email) => {
-			setUserEmail(email);
-			setHideEmailInput(isString(email));
-			if (isString(email)) {
-				setIsInteracted(true);
-			}
-		});
-	}, []);
 	const { renderingTarget } = useConfig();
-	const browserId = useBrowserId();
+
+	const {
+		userEmail,
+		hideEmailInput,
+		isInteracted,
+		showMarketingToggle,
+		marketingOptIn,
+		isWaitingForResponse,
+		responseOk,
+		errorMessage,
+		handleEmailChange,
+		handleEmailFocus,
+		handleMarketingToggle,
+		handleSubmit,
+		handleSubmitButtonClick,
+		handleReset,
+	} = useNewsletterSignupForm(newsletterId, renderingTarget);
 
 	const hasResponse = typeof responseOk === 'boolean';
-
-	const submitForm = async (emailAddress: string): Promise<void> => {
-		sendTracking(newsletterId, 'form-submission', renderingTarget);
-
-		const formData = buildFormData(
-			emailAddress,
-			newsletterId,
-			marketingOptIn,
-			browserId,
-		);
-
-		const response = await postFormData(
-			window.guardian.config.page.ajaxUrl + '/email',
-			formData,
-		);
-
-		setIsWaitingForResponse(false);
-		setResponseOk(response.ok);
-
-		if (response.ok && authStatus.kind === 'SignedIn') {
-			clearSubscriptionCache();
-		}
-
-		sendTracking(
-			newsletterId,
-			response.ok ? 'submission-confirmed' : 'submission-failed',
-			renderingTarget,
-		);
-	};
-
-	const resetForm: ReactEventHandler<HTMLButtonElement> = () => {
-		setErrorMessage(undefined);
-		setResponseOk(undefined);
-	};
-
-	const handleClick = (): void => {
-		sendTracking(newsletterId, 'click-button', renderingTarget);
-	};
-
-	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-		event.preventDefault();
-		if (isWaitingForResponse) {
-			return;
-		}
-
-		const emailAddress = userEmail?.trim() ?? '';
-		if (!emailAddress) {
-			setErrorMessage('Please enter a valid email address.');
-			return;
-		}
-
-		setErrorMessage(undefined);
-		setIsWaitingForResponse(true);
-		submitForm(emailAddress).catch((error) => {
-			// eslint-disable-next-line no-console -- unexpected error
-			console.error(error);
-			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
-			setErrorMessage(`Sorry, there was an error signing you up.`);
-			setIsWaitingForResponse(false);
-		});
-	};
-
 	const showAdditionalFields = isInteracted || !!userEmail;
 
 	return (
@@ -420,27 +224,20 @@ export const NewsletterSignupForm = ({
 							label="Enter your email"
 							type="email"
 							value={userEmail ?? ''}
-							onFocus={() => setIsInteracted(true)}
-							onChange={(e) => {
-								setUserEmail(e.target.value);
-								setIsInteracted(true);
-							}}
+							onFocus={handleEmailFocus}
+							onChange={(e) => handleEmailChange(e.target.value)}
 						/>
 					</div>
 				)}
 				{showAdditionalFields && (
 					<>
-						{isSignedIn === false && (
+						{showMarketingToggle && (
 							<div css={toggleContainerStyles}>
 								<div css={marketingBoxStyles}>
 									<ToggleSwitch
 										id={`marketing-opt-in-${newsletterId}`}
 										checked={marketingOptIn ?? false}
-										onClick={(event) => {
-											// ToggleSwitch renders a button; prevent accidental form submit.
-											event.preventDefault();
-											setMarketingOptIn(!marketingOptIn);
-										}}
+										onClick={handleMarketingToggle}
 										label="Get updates about our journalism and ways to support and enjoy
 								our work. Toggle to opt out."
 										labelPosition="left"
@@ -473,7 +270,7 @@ export const NewsletterSignupForm = ({
 								? signedInSubmitButtonStyles
 								: signedOutSubmitButtonStyles
 						}
-						onClick={handleClick}
+						onClick={handleSubmitButtonClick}
 						type="submit"
 					>
 						Sign up
@@ -495,13 +292,13 @@ export const NewsletterSignupForm = ({
 					</div>
 				) : (
 					<div css={errorContainerStyles}>
-						<ErrorMessageWithAdvice text={`Sign up failed.`} />
+						<ErrorMessageWithAdvice text="Sign up failed." />
 						<Button
 							size="small"
 							priority="primary"
 							icon={<SvgReload />}
-							iconSide={'right'}
-							onClick={resetForm}
+							iconSide="right"
+							onClick={handleReset}
 						>
 							Try again
 						</Button>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -28,6 +28,8 @@ type Props = {
 	frequency: string;
 	hidePrivacyMessage?: boolean;
 	onPreviewClick?: () => void;
+	/** When `true`, the success message is shown immediately (user is already subscribed). */
+	isAlreadySubscribed?: boolean;
 };
 
 const formStyles = css`
@@ -99,13 +101,6 @@ const previewButtonContainerStyles = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-const errorContainerStyles = css`
-	margin-top: ${space[2]}px;
-	display: flex;
-	flex-direction: column;
-	gap: ${space[2]}px;
-`;
-
 const toggleContainerStyles = css`
 	grid-area: marketing;
 	display: flex;
@@ -127,11 +122,25 @@ const successTextStyles = css`
 	}
 `;
 
-const marketingSuccessBoxStyles = css`
+const marketingToggleBoxStyles = css`
 	width: 100%;
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
+`;
+
+const responseBoxStyles = css`
+	width: 100%;
+	padding: ${space[2]}px;
+	border: 1px solid ${palette('--card-border-supporting')};
+	border-radius: 4px;
+	margin-top: ${space[4]}px;
+`;
+
+const errorContainerStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[2]}px;
 `;
 
 const feedbackButtonStyles = css`
@@ -190,7 +199,7 @@ const SuccessMessage = ({
 	frequency: string;
 }) => {
 	return (
-		<div css={marketingSuccessBoxStyles}>
+		<div css={responseBoxStyles}>
 			<InlineSuccess size="medium">
 				<span css={successTextStyles}>
 					<strong>You're signed up!</strong>
@@ -223,6 +232,7 @@ export const NewsletterSignupForm = ({
 	frequency,
 	hidePrivacyMessage = false,
 	onPreviewClick,
+	isAlreadySubscribed = false,
 }: Props) => {
 	const { renderingTarget } = useConfig();
 
@@ -249,6 +259,8 @@ export const NewsletterSignupForm = ({
 	} = useNewsletterSignupForm(newsletterId, renderingTarget);
 
 	const hasResponse = typeof responseOk === 'boolean';
+	const showForm =
+		!isAlreadySubscribed && !hasResponse && !isWaitingForResponse;
 	const showAdditionalFields = isInteracted || !!userEmail;
 	// Validation errors (before submission) are shown inline on the input.
 	// Network/server errors (after a failed submission) use the standalone message.
@@ -256,7 +268,8 @@ export const NewsletterSignupForm = ({
 
 	return (
 		<>
-			{!hasResponse &&
+			{!isAlreadySubscribed &&
+				!hasResponse &&
 				!isWaitingForResponse &&
 				onPreviewClick &&
 				!isSignedIn && (
@@ -268,10 +281,7 @@ export const NewsletterSignupForm = ({
 				onSubmit={handleSubmit}
 				id={`newsletter-signup-${newsletterId}`}
 				style={{
-					display:
-						hasResponse || isWaitingForResponse
-							? 'none'
-							: undefined,
+					display: !showForm ? 'none' : undefined,
 				}}
 				css={[
 					formStyles,
@@ -298,7 +308,7 @@ export const NewsletterSignupForm = ({
 					<>
 						{showMarketingToggle && (
 							<div css={toggleContainerStyles}>
-								<div css={marketingSuccessBoxStyles}>
+								<div css={marketingToggleBoxStyles}>
 									<ToggleSwitch
 										id={`marketing-opt-in-${newsletterId}`}
 										checked={marketingOptIn ?? false}
@@ -344,16 +354,21 @@ export const NewsletterSignupForm = ({
 				<ErrorMessageWithAdvice text={errorMessage} />
 			)}
 
-			{hasResponse &&
+			{isAlreadySubscribed && (
+				<SuccessMessage
+					newsletterName={newsletterName}
+					frequency={frequency}
+				/>
+			)}
+			{!isAlreadySubscribed &&
+				hasResponse &&
 				(responseOk ? (
 					<SuccessMessage
 						newsletterName={newsletterName}
 						frequency={frequency}
 					/>
 				) : (
-					<div
-						css={[marketingSuccessBoxStyles, errorContainerStyles]}
-					>
+					<div css={[responseBoxStyles, errorContainerStyles]}>
 						<ErrorMessageWithAdvice text="Sign up failed." />
 						<Button
 							size="small"

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -139,6 +139,18 @@ const browseMoreLinksStyles = css`
 	margin-top: ${space[1]}px;
 `;
 
+const PreviewButton = ({ onClick }: { onClick: () => void }) => (
+	<Button
+		priority="tertiary"
+		icon={<SvgEye />}
+		iconSide="left"
+		onClick={onClick}
+		type="button"
+	>
+		Preview latest
+	</Button>
+);
+
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 	<InlineError>
 		<span>
@@ -225,15 +237,7 @@ export const NewsletterSignupForm = ({
 				onPreviewClick &&
 				!hideEmailInput && (
 					<div css={previewButtonContainerStyles}>
-						<Button
-							priority="tertiary"
-							icon={<SvgEye />}
-							iconSide="left"
-							onClick={onPreviewClick}
-							type="button"
-						>
-							Preview latest
-						</Button>
+						<PreviewButton onClick={onPreviewClick} />
 					</div>
 				)}
 			<form
@@ -291,15 +295,7 @@ export const NewsletterSignupForm = ({
 				)}
 				<div css={submitButtonContainerStyles}>
 					{hideEmailInput && onPreviewClick && (
-						<Button
-							priority="tertiary"
-							icon={<SvgEye />}
-							iconSide="left"
-							onClick={onPreviewClick}
-							type="button"
-						>
-							Preview latest
-						</Button>
+						<PreviewButton onClick={onPreviewClick} />
 					)}
 					<Button
 						cssOverrides={

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -5,6 +5,7 @@ import {
 	InlineError,
 	InlineSuccess,
 	Link,
+	LinkButton,
 	Spinner,
 	SvgEye,
 	SvgReload,
@@ -18,7 +19,8 @@ import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 
 type Props = {
 	newsletterId: string;
-	successDescription: string;
+	newsletterName: string;
+	frequency: string;
 	hidePrivacyMessage?: boolean;
 	onPreviewClick?: () => void;
 };
@@ -116,7 +118,14 @@ const privacyContainerStyles = css`
 	grid-area: privacy;
 `;
 
-const marketingBoxStyles = css`
+const successTextStyles = css`
+	color: ${palette('--newsletter-card-description')};
+	strong {
+		font-weight: bold;
+	}
+`;
+
+const marketingSuccessBoxStyles = css`
 	width: 100%;
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
@@ -138,14 +147,30 @@ const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 	</InlineError>
 );
 
-const SuccessMessage = ({ text }: { text?: string }) => (
-	<InlineSuccess>
-		<span>
-			<b>Subscription Confirmed.&nbsp;</b>
-			<span>{text}</span>
-		</span>
-	</InlineSuccess>
-);
+const SuccessMessage = ({
+	newsletterName,
+	frequency,
+}: {
+	newsletterName: string;
+	frequency: string;
+}) => {
+	return (
+		<div css={marketingSuccessBoxStyles}>
+			<InlineSuccess>
+				<span css={successTextStyles}>
+					<strong>You're signed up!</strong>
+					&nbsp;
+					<span>
+						You will receive {newsletterName} {frequency}.
+					</span>
+				</span>
+			</InlineSuccess>
+			<LinkButton href="/email-newsletters" priority="tertiary">
+				Browse more newsletters
+			</LinkButton>
+		</div>
+	);
+};
 
 /**
  * # Newsletter Signup Form
@@ -155,7 +180,8 @@ const SuccessMessage = ({ text }: { text?: string }) => (
  */
 export const NewsletterSignupForm = ({
 	newsletterId,
-	successDescription,
+	newsletterName,
+	frequency,
 	hidePrivacyMessage = false,
 	onPreviewClick,
 }: Props) => {
@@ -233,7 +259,7 @@ export const NewsletterSignupForm = ({
 					<>
 						{showMarketingToggle && (
 							<div css={toggleContainerStyles}>
-								<div css={marketingBoxStyles}>
+								<div css={marketingSuccessBoxStyles}>
 									<ToggleSwitch
 										id={`marketing-opt-in-${newsletterId}`}
 										checked={marketingOptIn ?? false}
@@ -287,9 +313,10 @@ export const NewsletterSignupForm = ({
 
 			{hasResponse &&
 				(responseOk ? (
-					<div>
-						<SuccessMessage text={successDescription} />
-					</div>
+					<SuccessMessage
+						newsletterName={newsletterName}
+						frequency={frequency}
+					/>
 				) : (
 					<div css={errorContainerStyles}>
 						<ErrorMessageWithAdvice text="Sign up failed." />

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -29,7 +29,6 @@ type Props = {
 
 const formStyles = css`
 	display: grid;
-	align-items: center;
 	grid-template-columns: auto 160px;
 	grid-template-rows: 24px 48px;
 	gap: 0 ${space[3]}px;
@@ -99,10 +98,12 @@ const toggleContainerStyles = css`
 	grid-area: marketing;
 	display: flex;
 	align-items: flex-start;
+	label {
+		align-items: flex-start;
+	}
 	justify-content: space-between;
-
-	padding: ${space[1]}px;
-	border: 1px solid ${palette('--article-border')};
+	padding: ${space[2]}px;
+	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
 	margin-top: ${space[3]}px;
 `;

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -41,27 +41,20 @@ const formStyles = css`
 
 const signedOutLayoutStyles = css`
 	grid-template-columns: minmax(0, 1fr) 160px;
-	grid-template-areas:
-		'email submit'
-		'marketing .'
-		'privacy privacy';
+	grid-template-areas: 'email submit';
 
 	${until.tablet} {
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			'email'
-			'submit'
-			'marketing'
-			'privacy';
+			'submit';
 	}
 `;
 
 const signedInLayoutStyles = css`
 	grid-template-columns: minmax(0, 1fr);
-	grid-template-areas:
-		'submit'
-		'marketing'
-		'privacy';
+	grid-template-areas: 'submit';
+	padding-bottom: ${space[2]}px;
 `;
 
 const emailFieldStyles = css`
@@ -102,7 +95,7 @@ const previewButtonContainerStyles = css`
 `;
 
 const toggleContainerStyles = css`
-	grid-area: marketing;
+	grid-column: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -111,7 +104,7 @@ const toggleContainerStyles = css`
 `;
 
 const privacyContainerStyles = css`
-	grid-area: privacy;
+	grid-column: 1 / -1;
 `;
 
 const successTextStyles = css`

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -101,6 +101,7 @@ const previewButtonContainerStyles = css`
 `;
 
 const errorContainerStyles = css`
+	margin-top: ${space[6]}px;
 	display: flex;
 	align-items: flex-start;
 	gap: ${space[2]}px;

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -588,7 +588,8 @@ export const renderElement = ({
 				idApiUrl: idApiUrl ?? '',
 				hideNewsletterSignupComponentForSubscribers:
 					!!switches.hideNewsletterSignupComponentForSubscribers,
-				showNewsletterSignupCard: !!switches.showNewsletterSignupCard,
+				showNewNewsletterSignupCard:
+					!!switches.showNewNewsletterSignupCard,
 			};
 			if (isListElement || isTimeline) return null;
 			return (

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -267,7 +267,7 @@ export const useNewsletterSignupForm = (
 	useEffect(() => {
 		if (marketingDefaultAppliedRef.current) return;
 		if (isSignedIn === 'Pending') return;
-		if (isSignedIn === false) {
+		if (!isSignedIn) {
 			setMarketingOptIn(true);
 		}
 		marketingDefaultAppliedRef.current = true;

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -1,4 +1,5 @@
 import { isString } from '@guardian/libs';
+import type { TAction } from '@guardian/ophan-tracker-js';
 import type { FormEvent, ReactEventHandler } from 'react';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -93,7 +94,7 @@ const sendTracking = (
 	eventDescription: EventDescription,
 	renderingTarget: RenderingTarget,
 ): void => {
-	let action: 'CLICK' | 'ANSWER' | 'SUBSCRIBE' | 'CLOSE';
+	let action: TAction = 'CLICK';
 
 	switch (eventDescription) {
 		case 'form-submission':
@@ -110,7 +111,7 @@ const sendTracking = (
 			action = 'CLOSE';
 			break;
 		case 'open-captcha':
-			action = 'EXPAND' as typeof action;
+			action = 'EXPAND';
 			break;
 		case 'click-button':
 		default:

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -183,6 +183,7 @@ export type NewsletterSignupFormState = {
 	// Event handlers
 	handleEmailChange: (value: string) => void;
 	handleEmailFocus: () => void;
+	handleEmailInvalid: React.FormEventHandler<HTMLInputElement>;
 	handleMarketingToggle: ReactEventHandler<HTMLButtonElement>;
 	handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
 	handleSubmitButtonClick: () => void;
@@ -303,7 +304,7 @@ export const useNewsletterSignupForm = (
 
 		const emailAddress = userEmail?.trim() ?? '';
 		if (!emailAddress) {
-			setErrorMessage('Please enter a valid email address.');
+			setErrorMessage('Please enter your email address.');
 			return;
 		}
 
@@ -329,8 +330,13 @@ export const useNewsletterSignupForm = (
 		handleEmailChange: (value) => {
 			setUserEmail(value);
 			setIsInteracted(true);
+			setErrorMessage(undefined);
 		},
 		handleEmailFocus: () => setIsInteracted(true),
+		handleEmailInvalid: (event) => {
+			event.preventDefault();
+			setErrorMessage('Incorrect email format. Please check.');
+		},
 		handleMarketingToggle: (event) => {
 			event.preventDefault();
 			setMarketingOptIn((prev) => !prev);

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -134,7 +134,7 @@ export type NewsletterSignupFormState = {
 	 * When `true` the email `<input>` should be hidden (signed-in user whose
 	 * address was fetched automatically).
 	 */
-	hideEmailInput: boolean;
+	isSignedIn: boolean;
 	/**
 	 * `true` once the user has focused or typed in the email field, or when
 	 * the user's email was pre-filled. Reveals the marketing toggle and
@@ -265,7 +265,7 @@ export const useNewsletterSignupForm = (
 
 	return {
 		userEmail,
-		hideEmailInput,
+		isSignedIn: hideEmailInput,
 		isInteracted,
 		showMarketingToggle: isSignedIn === false,
 		marketingOptIn,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -1,0 +1,292 @@
+import { isString } from '@guardian/libs';
+import type { FormEvent, ReactEventHandler } from 'react';
+import { useEffect, useState } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { lazyFetchEmailWithTimeout } from './fetchEmail';
+import { clearSubscriptionCache } from './newsletterSubscriptionCache';
+import { useAuthStatus, useIsSignedIn } from './useAuthStatus';
+import { useBrowserId } from './useBrowserId';
+
+// ---------------------------------------------------------------------------
+// Helpers (kept local — not part of the public API)
+// ---------------------------------------------------------------------------
+
+const buildFormData = (
+	emailAddress: string,
+	newsletterId: string,
+	marketingOptIn?: boolean,
+	browserId?: string,
+): FormData => {
+	const pageRef = window.location.origin + window.location.pathname;
+	const refViewId = window.guardian.ophan?.pageViewId ?? '';
+
+	const formData = new FormData();
+	formData.append('email', emailAddress);
+	formData.append('csrfToken', '');
+	formData.append('listName', newsletterId);
+	formData.append('ref', pageRef);
+	formData.append('refViewId', refViewId);
+	formData.append('name', '');
+
+	if (marketingOptIn !== undefined) {
+		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (browserId !== undefined) {
+		formData.append('browserId', browserId);
+	}
+
+	return formData;
+};
+
+const resolveEmailIfSignedIn = async (): Promise<string | undefined> => {
+	const { idApiUrl } = window.guardian.config.page;
+	if (!idApiUrl) return;
+	const fetchedEmail = await lazyFetchEmailWithTimeout()();
+	if (!fetchedEmail) return;
+	return fetchedEmail;
+};
+
+const postFormData = async (
+	endpoint: string,
+	formData: FormData,
+): Promise<Response> => {
+	const requestBodyStrings: string[] = [];
+
+	for (const [key, value] of formData.entries()) {
+		requestBodyStrings.push(
+			`${encodeURIComponent(key)}=${encodeURIComponent(
+				// eslint-disable-next-line @typescript-eslint/no-base-to-string -- value.toString() is safe here as we are dealing with FormData entries
+				value.toString(),
+			)}`,
+		);
+	}
+
+	return fetch(endpoint, {
+		method: 'POST',
+		body: requestBodyStrings.join('&'),
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+	});
+};
+
+type EventDescription =
+	| 'click-button'
+	| 'form-submission'
+	| 'submission-confirmed'
+	| 'submission-failed'
+	| 'form-submit-error';
+
+const sendTracking = (
+	newsletterId: string,
+	eventDescription: EventDescription,
+	renderingTarget: RenderingTarget,
+): void => {
+	let action: 'CLICK' | 'ANSWER' | 'SUBSCRIBE' | 'CLOSE';
+
+	switch (eventDescription) {
+		case 'form-submission':
+			action = 'ANSWER';
+			break;
+		case 'submission-confirmed':
+			action = 'SUBSCRIBE';
+			break;
+		case 'form-submit-error':
+		case 'submission-failed':
+			action = 'CLOSE';
+			break;
+		case 'click-button':
+		default:
+			action = 'CLICK';
+			break;
+	}
+
+	const value = JSON.stringify({
+		eventDescription,
+		newsletterId,
+		timestamp: Date.now(),
+	});
+
+	void submitComponentEvent(
+		{
+			action,
+			value,
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: `AR NewsletterSignupForm ${newsletterId}`,
+			},
+		},
+		renderingTarget,
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type NewsletterSignupFormState = {
+	/** The email address currently in the field (or resolved from Identity). */
+	userEmail: string | undefined;
+	/**
+	 * When `true` the email `<input>` should be hidden (signed-in user whose
+	 * address was fetched automatically).
+	 */
+	hideEmailInput: boolean;
+	/**
+	 * `true` once the user has focused or typed in the email field, or when
+	 * the user's email was pre-filled. Reveals the marketing toggle and
+	 * privacy message.
+	 */
+	isInteracted: boolean;
+	/** `true` for signed-out users — shows the marketing opt-in toggle. */
+	showMarketingToggle: boolean;
+	marketingOptIn: boolean | undefined;
+
+	/** `true` while the POST request is in-flight. */
+	isWaitingForResponse: boolean;
+	/**
+	 * `true`  → subscription confirmed
+	 * `false` → server returned a non-2xx response
+	 * `undefined` → no response yet
+	 */
+	responseOk: boolean | undefined;
+	/** Inline validation / network error copy. */
+	errorMessage: string | undefined;
+
+	// Event handlers
+	handleEmailChange: (value: string) => void;
+	handleEmailFocus: () => void;
+	handleMarketingToggle: ReactEventHandler<HTMLButtonElement>;
+	handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+	handleSubmitButtonClick: () => void;
+	handleReset: ReactEventHandler<HTMLButtonElement>;
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Encapsulates all state and side-effects for the newsletter signup form.
+ * The component itself only needs to call this hook and render the returned
+ * state — making every visual state trivially reproducible in Storybook by
+ * mocking this hook.
+ */
+export const useNewsletterSignupForm = (
+	newsletterId: string,
+	renderingTarget: RenderingTarget,
+): NewsletterSignupFormState => {
+	const [userEmail, setUserEmail] = useState<string>();
+	const [hideEmailInput, setHideEmailInput] = useState(false);
+	const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+	const [responseOk, setResponseOk] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [errorMessage, setErrorMessage] = useState<string | undefined>(
+		undefined,
+	);
+	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [isInteracted, setIsInteracted] = useState(false);
+
+	const isSignedIn = useIsSignedIn();
+	const authStatus = useAuthStatus();
+	const browserId = useBrowserId();
+
+	useEffect(() => {
+		if (isSignedIn !== 'Pending' && !isSignedIn) {
+			setMarketingOptIn(true);
+		}
+	}, [isSignedIn]);
+
+	useEffect(() => {
+		void resolveEmailIfSignedIn().then((email) => {
+			setUserEmail(email);
+			setHideEmailInput(isString(email));
+			if (isString(email)) {
+				setIsInteracted(true);
+			}
+		});
+	}, []);
+
+	const submitForm = async (emailAddress: string): Promise<void> => {
+		sendTracking(newsletterId, 'form-submission', renderingTarget);
+
+		const formData = buildFormData(
+			emailAddress,
+			newsletterId,
+			marketingOptIn,
+			browserId,
+		);
+
+		const response = await postFormData(
+			window.guardian.config.page.ajaxUrl + '/email',
+			formData,
+		);
+
+		setIsWaitingForResponse(false);
+		setResponseOk(response.ok);
+
+		if (response.ok && authStatus.kind === 'SignedIn') {
+			clearSubscriptionCache();
+		}
+
+		sendTracking(
+			newsletterId,
+			response.ok ? 'submission-confirmed' : 'submission-failed',
+			renderingTarget,
+		);
+	};
+
+	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+		event.preventDefault();
+		if (isWaitingForResponse) return;
+
+		const emailAddress = userEmail?.trim() ?? '';
+		if (!emailAddress) {
+			setErrorMessage('Please enter a valid email address.');
+			return;
+		}
+
+		setErrorMessage(undefined);
+		setIsWaitingForResponse(true);
+		submitForm(emailAddress).catch((error) => {
+			// eslint-disable-next-line no-console -- unexpected error
+			console.error(error);
+			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
+			setErrorMessage('Sorry, there was an error signing you up.');
+			setIsWaitingForResponse(false);
+		});
+	};
+
+	return {
+		userEmail,
+		hideEmailInput,
+		isInteracted,
+		showMarketingToggle: isSignedIn === false,
+		marketingOptIn,
+		isWaitingForResponse,
+		responseOk,
+		errorMessage,
+		handleEmailChange: (value) => {
+			setUserEmail(value);
+			setIsInteracted(true);
+		},
+		handleEmailFocus: () => setIsInteracted(true),
+		handleMarketingToggle: (event) => {
+			event.preventDefault();
+			setMarketingOptIn((prev) => !prev);
+		},
+		handleSubmit,
+		handleSubmitButtonClick: () =>
+			sendTracking(newsletterId, 'click-button', renderingTarget),
+		handleReset: () => {
+			setErrorMessage(undefined);
+			setResponseOk(undefined);
+		},
+	};
+};

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -1,6 +1,8 @@
 import { isString } from '@guardian/libs';
 import type { FormEvent, ReactEventHandler } from 'react';
-import { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { lazyFetchEmailWithTimeout } from './fetchEmail';
@@ -15,6 +17,7 @@ import { useBrowserId } from './useBrowserId';
 const buildFormData = (
 	emailAddress: string,
 	newsletterId: string,
+	token: string,
 	marketingOptIn?: boolean,
 	browserId?: string,
 ): FormData => {
@@ -28,7 +31,7 @@ const buildFormData = (
 	formData.append('ref', pageRef);
 	formData.append('refViewId', refViewId);
 	formData.append('name', '');
-	formData.append('g-recaptcha-response', '');
+	formData.append('g-recaptcha-response', token);
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
@@ -79,7 +82,11 @@ type EventDescription =
 	| 'form-submission'
 	| 'submission-confirmed'
 	| 'submission-failed'
-	| 'form-submit-error';
+	| 'open-captcha'
+	| 'captcha-load-error'
+	| 'form-submit-error'
+	| 'captcha-not-passed'
+	| 'captcha-passed';
 
 const sendTracking = (
 	newsletterId: string,
@@ -90,14 +97,20 @@ const sendTracking = (
 
 	switch (eventDescription) {
 		case 'form-submission':
+		case 'captcha-not-passed':
+		case 'captcha-passed':
 			action = 'ANSWER';
 			break;
 		case 'submission-confirmed':
 			action = 'SUBSCRIBE';
 			break;
+		case 'captcha-load-error':
 		case 'form-submit-error':
 		case 'submission-failed':
 			action = 'CLOSE';
+			break;
+		case 'open-captcha':
+			action = 'EXPAND' as typeof action;
 			break;
 		case 'click-button':
 		default:
@@ -157,6 +170,15 @@ export type NewsletterSignupFormState = {
 	/** Inline validation / network error copy. */
 	errorMessage: string | undefined;
 
+	/** Ref to pass to the `<ReactGoogleRecaptcha>` widget. */
+	recaptchaRef: React.RefObject<ReactGoogleRecaptcha>;
+	/** Site key for the reCAPTCHA widget — `undefined` until resolved. */
+	captchaSiteKey: string | undefined;
+	/** Pass to `ReactGoogleRecaptcha`'s `onChange` prop. */
+	handleCaptchaComplete: (token: string | null) => void;
+	/** Pass to `ReactGoogleRecaptcha`'s `onError` prop. */
+	handleCaptchaLoadError: () => void;
+
 	// Event handlers
 	handleEmailChange: (value: string) => void;
 	handleEmailFocus: () => void;
@@ -180,6 +202,8 @@ export const useNewsletterSignupForm = (
 	newsletterId: string,
 	renderingTarget: RenderingTarget,
 ): NewsletterSignupFormState => {
+	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
+	const [captchaSiteKey, setCaptchaSiteKey] = useState<string>();
 	const [userEmail, setUserEmail] = useState<string>();
 	const [hideEmailInput, setHideEmailInput] = useState(false);
 	const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
@@ -205,6 +229,7 @@ export const useNewsletterSignupForm = (
 	}, [isSignedIn]);
 
 	useEffect(() => {
+		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
 		void resolveEmailIfSignedIn().then((email) => {
 			setUserEmail(email);
 			setHideEmailInput(isString(email));
@@ -214,12 +239,16 @@ export const useNewsletterSignupForm = (
 		});
 	}, []);
 
-	const submitForm = async (emailAddress: string): Promise<void> => {
+	const submitForm = async (
+		emailAddress: string,
+		token: string,
+	): Promise<void> => {
 		sendTracking(newsletterId, 'form-submission', renderingTarget);
 
 		const formData = buildFormData(
 			emailAddress,
 			newsletterId,
+			token,
 			marketingOptIn,
 			browserId,
 		);
@@ -243,6 +272,30 @@ export const useNewsletterSignupForm = (
 		);
 	};
 
+	const handleCaptchaComplete = (token: string | null): void => {
+		if (!token) {
+			sendTracking(newsletterId, 'captcha-not-passed', renderingTarget);
+			setIsWaitingForResponse(false);
+			return;
+		}
+		sendTracking(newsletterId, 'captcha-passed', renderingTarget);
+		const emailAddress = userEmail?.trim() ?? '';
+		submitForm(emailAddress, token).catch((error) => {
+			// eslint-disable-next-line no-console -- unexpected error
+			console.error(error);
+			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
+			setErrorMessage('Sorry, there was an error signing you up.');
+			setIsWaitingForResponse(false);
+			recaptchaRef.current?.reset();
+		});
+	};
+
+	const handleCaptchaLoadError = (): void => {
+		sendTracking(newsletterId, 'captcha-load-error', renderingTarget);
+		setErrorMessage('Sorry, the reCAPTCHA failed to load.');
+		recaptchaRef.current?.reset();
+	};
+
 	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
 		event.preventDefault();
 		if (isWaitingForResponse) return;
@@ -255,13 +308,8 @@ export const useNewsletterSignupForm = (
 
 		setErrorMessage(undefined);
 		setIsWaitingForResponse(true);
-		submitForm(emailAddress).catch((error) => {
-			// eslint-disable-next-line no-console -- unexpected error
-			console.error(error);
-			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
-			setErrorMessage('Sorry, there was an error signing you up.');
-			setIsWaitingForResponse(false);
-		});
+		sendTracking(newsletterId, 'open-captcha', renderingTarget);
+		recaptchaRef.current?.execute();
 	};
 
 	return {
@@ -273,6 +321,10 @@ export const useNewsletterSignupForm = (
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,
+		recaptchaRef,
+		captchaSiteKey,
+		handleCaptchaComplete,
+		handleCaptchaLoadError,
 		handleEmailChange: (value) => {
 			setUserEmail(value);
 			setIsInteracted(true);

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -1,8 +1,8 @@
 import { isString } from '@guardian/libs';
 import type { TAction } from '@guardian/ophan-tracker-js';
-import type { FormEvent, ReactEventHandler } from 'react';
+import type { FormEvent, ReactEventHandler, RefObject } from 'react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -45,12 +45,21 @@ const buildFormData = (
 	return formData;
 };
 
-const resolveEmailIfSignedIn = async (): Promise<string | undefined> => {
+/**
+ * Fetch the user's email from Identity if they are signed in.
+ *
+ * Previously named `resolveEmailIfSignedIn`, but only checked that `idApiUrl`
+ * was configured — it would fire for every visitor. Now it takes the real
+ * sign-in state and bails out for signed-out / pending users.
+ */
+const resolveUserEmail = async (
+	isSignedIn: boolean | 'Pending',
+): Promise<string | undefined> => {
+	if (isSignedIn !== true) return;
 	const { idApiUrl } = window.guardian.config.page;
 	if (!idApiUrl) return;
 	const fetchedEmail = await lazyFetchEmailWithTimeout()();
-	if (!fetchedEmail) return;
-	return fetchedEmail;
+	return fetchedEmail ?? undefined;
 };
 
 const postFormData = async (
@@ -89,36 +98,32 @@ type EventDescription =
 	| 'captcha-not-passed'
 	| 'captcha-passed';
 
+const actionForEventDescription = (
+	eventDescription: EventDescription,
+): TAction => {
+	switch (eventDescription) {
+		case 'form-submission':
+		case 'captcha-not-passed':
+		case 'captcha-passed':
+			return 'ANSWER';
+		case 'submission-confirmed':
+			return 'SUBSCRIBE';
+		case 'captcha-load-error':
+		case 'form-submit-error':
+		case 'submission-failed':
+			return 'CLOSE';
+		case 'open-captcha':
+			return 'EXPAND';
+		case 'click-button':
+			return 'CLICK';
+	}
+};
+
 const sendTracking = (
 	newsletterId: string,
 	eventDescription: EventDescription,
 	renderingTarget: RenderingTarget,
 ): void => {
-	let action: TAction = 'CLICK';
-
-	switch (eventDescription) {
-		case 'form-submission':
-		case 'captcha-not-passed':
-		case 'captcha-passed':
-			action = 'ANSWER';
-			break;
-		case 'submission-confirmed':
-			action = 'SUBSCRIBE';
-			break;
-		case 'captcha-load-error':
-		case 'form-submit-error':
-		case 'submission-failed':
-			action = 'CLOSE';
-			break;
-		case 'open-captcha':
-			action = 'EXPAND';
-			break;
-		case 'click-button':
-		default:
-			action = 'CLICK';
-			break;
-	}
-
 	const value = JSON.stringify({
 		eventDescription,
 		newsletterId,
@@ -127,7 +132,7 @@ const sendTracking = (
 
 	void submitComponentEvent(
 		{
-			action,
+			action: actionForEventDescription(eventDescription),
 			value,
 			component: {
 				componentType: 'NEWSLETTER_SUBSCRIPTION',
@@ -146,8 +151,12 @@ export type NewsletterSignupFormState = {
 	/** The email address currently in the field (or resolved from Identity). */
 	userEmail: string | undefined;
 	/**
-	 * When `true` the email `<input>` should be hidden (signed-in user whose
-	 * address was fetched automatically).
+	 * `true` once we've successfully pre-filled the email from Identity, which
+	 * means the email `<input>` should be hidden.
+	 *
+	 * NOTE: this is NOT the same as "the user is signed in" — the Identity
+	 * fetch can fail or time out even for signed-in users. Consumers that
+	 * need the real sign-in state should call `useIsSignedIn` directly.
 	 */
 	isSignedIn: boolean;
 	/**
@@ -172,7 +181,7 @@ export type NewsletterSignupFormState = {
 	errorMessage: string | undefined;
 
 	/** Ref to pass to the `<ReactGoogleRecaptcha>` widget. */
-	recaptchaRef: React.RefObject<ReactGoogleRecaptcha>;
+	recaptchaRef: RefObject<ReactGoogleRecaptcha>;
 	/** Site key for the reCAPTCHA widget — `undefined` until resolved. */
 	captchaSiteKey: string | undefined;
 	/** Pass to `ReactGoogleRecaptcha`'s `onChange` prop. */
@@ -207,7 +216,7 @@ export const useNewsletterSignupForm = (
 	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
 	const [captchaSiteKey, setCaptchaSiteKey] = useState<string>();
 	const [userEmail, setUserEmail] = useState<string>();
-	const [hideEmailInput, setHideEmailInput] = useState(false);
+	const [hasPrefilledEmail, setHasPrefilledEmail] = useState(false);
 	const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
 	const [responseOk, setResponseOk] = useState<boolean | undefined>(
 		undefined,
@@ -224,129 +233,253 @@ export const useNewsletterSignupForm = (
 	const authStatus = useAuthStatus();
 	const browserId = useBrowserId();
 
+	// Refs that mirror state — read inside submit handlers so we always see the
+	// latest value rather than whatever was captured when the handler was
+	// created. This avoids the stale-closure bug where a user could toggle
+	// marketing opt-in between pressing Sign Up and the captcha resolving.
+	const marketingOptInRef = useRef(marketingOptIn);
+	const browserIdRef = useRef(browserId);
+	const authStatusRef = useRef(authStatus);
 	useEffect(() => {
-		if (isSignedIn !== 'Pending' && !isSignedIn) {
+		marketingOptInRef.current = marketingOptIn;
+	}, [marketingOptIn]);
+	useEffect(() => {
+		browserIdRef.current = browserId;
+	}, [browserId]);
+	useEffect(() => {
+		authStatusRef.current = authStatus;
+	}, [authStatus]);
+
+	// The email address that was validated at submit-time. We stash it in a
+	// ref and read it back when the captcha resolves, so it can't change out
+	// from under us between validation and POST.
+	const pendingEmailRef = useRef<string | undefined>(undefined);
+
+	// Track whether the user has attempted to submit, so we only show inline
+	// validation errors from the `invalid` event after a submit attempt —
+	// not on focus/blur or other browser-triggered validity checks.
+	const hasAttemptedSubmitRef = useRef(false);
+
+	// Default marketing opt-in to `true` for signed-out users, but only once —
+	// guard with a ref so flipping `isSignedIn` later (e.g. token expiry)
+	// doesn't overwrite the user's choice.
+	const marketingDefaultAppliedRef = useRef(false);
+	useEffect(() => {
+		if (marketingDefaultAppliedRef.current) return;
+		if (isSignedIn === 'Pending') return;
+		if (isSignedIn === false) {
 			setMarketingOptIn(true);
 		}
+		marketingDefaultAppliedRef.current = true;
 	}, [isSignedIn]);
 
+	// Pre-fill the email from Identity once sign-in status is known.
+	// Guarded with a ref so we don't re-fetch if the hook re-mounts or
+	// `isSignedIn` briefly flips.
+	const emailFetchStartedRef = useRef(false);
 	useEffect(() => {
 		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
-		void resolveEmailIfSignedIn().then((email) => {
-			setUserEmail(email);
-			setHideEmailInput(isString(email));
-			if (isString(email)) {
-				setIsInteracted(true);
-			}
-		});
 	}, []);
+	useEffect(() => {
+		if (emailFetchStartedRef.current) return;
+		if (isSignedIn === 'Pending') return;
+		emailFetchStartedRef.current = true;
 
-	const submitForm = async (
-		emailAddress: string,
-		token: string,
-	): Promise<void> => {
-		sendTracking(newsletterId, 'form-submission', renderingTarget);
-
-		const formData = buildFormData(
-			emailAddress,
-			newsletterId,
-			token,
-			marketingOptIn,
-			browserId,
-		);
-
-		const response = await postFormData(
-			window.guardian.config.page.ajaxUrl + '/email',
-			formData,
-		);
-
-		setIsWaitingForResponse(false);
-		setResponseOk(response.ok);
-
-		if (response.ok && authStatus.kind === 'SignedIn') {
-			clearSubscriptionCache();
-		}
-
-		sendTracking(
-			newsletterId,
-			response.ok ? 'submission-confirmed' : 'submission-failed',
-			renderingTarget,
-		);
-	};
-
-	const handleCaptchaComplete = (token: string | null): void => {
-		if (!token) {
-			sendTracking(newsletterId, 'captcha-not-passed', renderingTarget);
-			setIsWaitingForResponse(false);
-			return;
-		}
-		sendTracking(newsletterId, 'captcha-passed', renderingTarget);
-		const emailAddress = userEmail?.trim() ?? '';
-		submitForm(emailAddress, token).catch((error) => {
-			// eslint-disable-next-line no-console -- unexpected error
-			console.error(error);
-			sendTracking(newsletterId, 'form-submit-error', renderingTarget);
-			setErrorMessage('Sorry, there was an error signing you up.');
-			setIsWaitingForResponse(false);
-			recaptchaRef.current?.reset();
+		void resolveUserEmail(isSignedIn).then((email) => {
+			if (!isString(email)) return;
+			setUserEmail(email);
+			setHasPrefilledEmail(true);
+			setIsInteracted(true);
 		});
-	};
+	}, [isSignedIn]);
 
-	const handleCaptchaLoadError = (): void => {
+	const submitForm = useCallback(
+		async (emailAddress: string, token: string): Promise<void> => {
+			sendTracking(newsletterId, 'form-submission', renderingTarget);
+
+			const formData = buildFormData(
+				emailAddress,
+				newsletterId,
+				token,
+				marketingOptInRef.current,
+				browserIdRef.current,
+			);
+
+			const response = await postFormData(
+				window.guardian.config.page.ajaxUrl + '/email',
+				formData,
+			);
+
+			try {
+				if (response.ok && authStatusRef.current.kind === 'SignedIn') {
+					clearSubscriptionCache();
+				}
+			} catch (error) {
+				// Don't let a cache-clear failure block the UI state update below.
+				// eslint-disable-next-line no-console -- unexpected error
+				console.error(error);
+			}
+
+			setResponseOk(response.ok);
+
+			sendTracking(
+				newsletterId,
+				response.ok ? 'submission-confirmed' : 'submission-failed',
+				renderingTarget,
+			);
+		},
+		[newsletterId, renderingTarget],
+	);
+
+	const handleCaptchaComplete = useCallback(
+		(token: string | null): void => {
+			if (!token) {
+				sendTracking(
+					newsletterId,
+					'captcha-not-passed',
+					renderingTarget,
+				);
+				setIsWaitingForResponse(false);
+				return;
+			}
+			sendTracking(newsletterId, 'captcha-passed', renderingTarget);
+			// Read the email that was validated at submit-time — not the
+			// current value, which may have been edited since.
+			const emailAddress = pendingEmailRef.current ?? '';
+			submitForm(emailAddress, token)
+				.catch((error) => {
+					// eslint-disable-next-line no-console -- unexpected error
+					console.error(error);
+					sendTracking(
+						newsletterId,
+						'form-submit-error',
+						renderingTarget,
+					);
+					setErrorMessage(
+						'Sorry, there was an error signing you up.',
+					);
+					recaptchaRef.current?.reset();
+				})
+				.finally(() => {
+					setIsWaitingForResponse(false);
+				});
+		},
+		[newsletterId, renderingTarget, submitForm],
+	);
+
+	const handleCaptchaLoadError = useCallback((): void => {
 		sendTracking(newsletterId, 'captcha-load-error', renderingTarget);
 		setErrorMessage('Sorry, the reCAPTCHA failed to load.');
 		recaptchaRef.current?.reset();
-	};
+	}, [newsletterId, renderingTarget]);
 
-	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-		event.preventDefault();
-		if (isWaitingForResponse) return;
+	const handleSubmit = useCallback(
+		(event: FormEvent<HTMLFormElement>): void => {
+			event.preventDefault();
+			if (isWaitingForResponse) return;
 
-		const emailAddress = userEmail?.trim() ?? '';
-		if (!emailAddress) {
-			setErrorMessage('Please enter your email address.');
-			return;
-		}
+			const emailAddress = userEmail?.trim() ?? '';
+			if (!emailAddress) {
+				setErrorMessage('Please enter your email address.');
+				return;
+			}
 
+			pendingEmailRef.current = emailAddress;
+			setErrorMessage(undefined);
+			setIsWaitingForResponse(true);
+			sendTracking(newsletterId, 'open-captcha', renderingTarget);
+			recaptchaRef.current?.execute();
+		},
+		[isWaitingForResponse, newsletterId, renderingTarget, userEmail],
+	);
+
+	const handleEmailChange = useCallback((value: string): void => {
+		setUserEmail(value);
+		setIsInteracted(true);
 		setErrorMessage(undefined);
-		setIsWaitingForResponse(true);
-		sendTracking(newsletterId, 'open-captcha', renderingTarget);
-		recaptchaRef.current?.execute();
-	};
+	}, []);
 
-	return {
-		userEmail,
-		isSignedIn: hideEmailInput,
-		isInteracted,
-		showMarketingToggle: isSignedIn === false,
-		marketingOptIn,
-		isWaitingForResponse,
-		responseOk,
-		errorMessage,
-		recaptchaRef,
-		captchaSiteKey,
-		handleCaptchaComplete,
-		handleCaptchaLoadError,
-		handleEmailChange: (value) => {
-			setUserEmail(value);
-			setIsInteracted(true);
-			setErrorMessage(undefined);
-		},
-		handleEmailFocus: () => setIsInteracted(true),
-		handleEmailInvalid: (event) => {
-			event.preventDefault();
-			setErrorMessage('Incorrect email format. Please check.');
-		},
-		handleMarketingToggle: (event) => {
-			event.preventDefault();
-			setMarketingOptIn((prev) => !prev);
-		},
-		handleSubmit,
-		handleSubmitButtonClick: () =>
-			sendTracking(newsletterId, 'click-button', renderingTarget),
-		handleReset: () => {
-			setErrorMessage(undefined);
-			setResponseOk(undefined);
-		},
-	};
+	const handleEmailFocus = useCallback((): void => {
+		setIsInteracted(true);
+	}, []);
+
+	const handleEmailInvalid = useCallback<
+		React.FormEventHandler<HTMLInputElement>
+	>((event) => {
+		event.preventDefault();
+		if (!hasAttemptedSubmitRef.current) return;
+		const { validity } = event.currentTarget;
+		setErrorMessage(
+			validity.valueMissing
+				? 'Please enter your email address.'
+				: 'Incorrect email format. Please check.',
+		);
+	}, []);
+
+	const handleMarketingToggle = useCallback<
+		ReactEventHandler<HTMLButtonElement>
+	>((event) => {
+		event.preventDefault();
+		setMarketingOptIn((prev) => !prev);
+	}, []);
+
+	const handleSubmitButtonClick = useCallback((): void => {
+		hasAttemptedSubmitRef.current = true;
+		sendTracking(newsletterId, 'click-button', renderingTarget);
+	}, [newsletterId, renderingTarget]);
+
+	const handleReset = useCallback<
+		ReactEventHandler<HTMLButtonElement>
+	>(() => {
+		setErrorMessage(undefined);
+		setResponseOk(undefined);
+		hasAttemptedSubmitRef.current = false;
+	}, []);
+
+	// Memoise the returned object so referential equality holds across renders
+	// when none of the fields have changed — important for any memoised
+	// children the consumer renders.
+	return useMemo<NewsletterSignupFormState>(
+		() => ({
+			userEmail,
+			isSignedIn: hasPrefilledEmail,
+			isInteracted,
+			showMarketingToggle: isSignedIn === false,
+			marketingOptIn,
+			isWaitingForResponse,
+			responseOk,
+			errorMessage,
+			recaptchaRef,
+			captchaSiteKey,
+			handleCaptchaComplete,
+			handleCaptchaLoadError,
+			handleEmailChange,
+			handleEmailFocus,
+			handleEmailInvalid,
+			handleMarketingToggle,
+			handleSubmit,
+			handleSubmitButtonClick,
+			handleReset,
+		}),
+		[
+			userEmail,
+			hasPrefilledEmail,
+			isInteracted,
+			isSignedIn,
+			marketingOptIn,
+			isWaitingForResponse,
+			responseOk,
+			errorMessage,
+			captchaSiteKey,
+			handleCaptchaComplete,
+			handleCaptchaLoadError,
+			handleEmailChange,
+			handleEmailFocus,
+			handleEmailInvalid,
+			handleMarketingToggle,
+			handleSubmit,
+			handleSubmitButtonClick,
+			handleReset,
+		],
+	);
 };

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -28,6 +28,7 @@ const buildFormData = (
 	formData.append('ref', pageRef);
 	formData.append('refViewId', refViewId);
 	formData.append('name', '');
+	formData.append('g-recaptcha-response', '');
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
