### PR TITLE
Newsletter Signup Form - signed in and out

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -29,6 +29,8 @@ sb.mock(import('../src/lib/useNewsletterSubscription.ts'), { spy: true });
 sb.mock(import('../src/lib/useAuthStatus.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -1,4 +1,5 @@
 import type { Breakpoint } from '@guardian/source/foundations';
+import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
 import { useConfig } from './ConfigContext';
 import type { EmailSignUpProps } from './EmailSignup';
@@ -7,6 +8,7 @@ import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { Island } from './Island';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import { NewsletterSignupCardContainer } from './NewsletterSignupCardContainer';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
 import { Placeholder } from './Placeholder';
 import { SecureSignup } from './SecureSignup.island';
 
@@ -65,14 +67,12 @@ export const EmailSignUpWrapper = ({
 	showNewNewsletterSignupCard = false,
 }: EmailSignUpWrapperProps) => {
 	const { renderingTarget } = useConfig();
-	const shouldCheckSubscription =
-		hideNewsletterSignupComponentForSubscribers &&
-		!showNewNewsletterSignupCard;
 	const isSubscribed = useNewsletterSubscription(
 		listId,
 		idApiUrl,
-		shouldCheckSubscription,
+		hideNewsletterSignupComponentForSubscribers,
 	);
+	const isSignedIn = useIsSignedIn();
 
 	// When the new card design is enabled, always show it regardless of subscription status
 	if (showNewNewsletterSignupCard) {
@@ -91,14 +91,20 @@ export const EmailSignUpWrapper = ({
 					category={category}
 					exampleUrl={exampleUrl}
 					renderingTarget={renderingTarget}
+					isSignedIn={isSignedIn}
 				>
-					<Island priority="feature" defer={{ until: 'visible' }}>
-						<SecureSignup
-							newsletterId={identityName}
-							successDescription={successDescription}
-						/>
-					</Island>
-					{!hidePrivacyMessage && <NewsletterPrivacyMessage />}
+					{(openPreview) => (
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<NewsletterSignupForm
+								newsletterId={identityName}
+								newsletterName={name}
+								frequency={frequency}
+								hidePrivacyMessage={isSignedIn === true}
+								onPreviewClick={openPreview}
+								isAlreadySubscribed={isSubscribed === true}
+							/>
+						</Island>
+					)}
 				</NewsletterSignupCardContainer>
 			</InlineSkipToWrapper>
 		);

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryObj } from '@storybook/react-webpack5';
-import { mocked } from 'storybook/test';
+import { mocked, within } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { useIsSignedIn } from '../lib/useAuthStatus';
@@ -24,6 +24,15 @@ const defaultArgs = {
 	successDescription: "We'll send you The Recap every week",
 	theme: 'sport',
 	idApiUrl: 'https://idapi.theguardian.com',
+	exampleUrl: 'https://www.theguardian.com/email/the-recap',
+} satisfies Story['args'];
+
+const newCardArgs = {
+	...defaultArgs,
+	showNewNewsletterSignupCard: true,
+	hideNewsletterSignupComponentForSubscribers: true,
+	illustrationSquare:
+		'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
 } satisfies Story['args'];
 
 // Loading state - shows placeholder while auth status is being determined
@@ -33,7 +42,7 @@ export const Placeholder = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(undefined);
 	},
 });
@@ -44,7 +53,7 @@ export const DefaultStory = meta.story({
 		hidePrivacyMessage: true,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -58,7 +67,7 @@ export const DefaultStoryWithPrivacy = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -73,7 +82,7 @@ export const SignedInNotSubscribed = meta.story({
 		hidePrivacyMessage: false,
 		...defaultArgs,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -91,7 +100,7 @@ export const SignedInAlreadySubscribed = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: true,
 	},
-	async beforeEach() {
+	beforeEach() {
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 	},
 });
@@ -104,7 +113,7 @@ export const FeatureFlagDisabled = meta.story({
 		...defaultArgs,
 		hideNewsletterSignupComponentForSubscribers: false,
 	},
-	async beforeEach() {
+	beforeEach() {
 		// Even though we mock this to return true (subscribed),
 		// the feature flag being disabled means it won't be checked
 		mocked(useNewsletterSubscription).mockReturnValue(false);
@@ -119,5 +128,65 @@ export const FeatureFlagDisabled = meta.story({
 				story: 'When the hideNewsletterSignupComponentForSubscribers feature flag is disabled, the signup form is always shown regardless of subscription status.',
 			},
 		},
+	},
+});
+
+export const NewsletterSignupCardSignedInNotSubscribed = meta.story({
+	args: newCardArgs,
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(true);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve('test@example.com'),
+		);
+	},
+});
+
+export const NewsletterSignupCardSignedOutNotSubscribed = meta.story({
+	args: newCardArgs,
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+	},
+});
+
+export const NewsletterSignupCardSignedInAlreadySubscribed = meta.story({
+	args: newCardArgs,
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+		mocked(useIsSignedIn).mockReturnValue(true);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve('test@example.com'),
+		);
+	},
+});
+
+export const NewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
+	args: newCardArgs,
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(true);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+	},
+});
+
+export const NewsletterSignupCardFocused = meta.story({
+	args: newCardArgs,
+	beforeEach() {
+		mocked(useNewsletterSubscription).mockReturnValue(false);
+		mocked(useIsSignedIn).mockReturnValue(false);
+		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+	},
+	async play({ canvasElement }) {
+		const canvas = within(canvasElement);
+		const emailInput = await canvas.findByLabelText('Enter your email');
+		emailInput.focus();
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterPrivacyMessage.tsx
+++ b/dotcom-rendering/src/components/NewsletterPrivacyMessage.tsx
@@ -1,8 +1,5 @@
 import { css } from '@emotion/react';
-import {
-	palette as sourcePalette,
-	textSans12,
-} from '@guardian/source/foundations';
+import { textSans12 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
 
@@ -65,7 +62,7 @@ const textStyles = (textColor: 'supporting' | 'regular') => {
 			`;
 		case 'regular':
 			return css`
-				color: ${sourcePalette.neutral[20]};
+				color: ${themePalette('--privacy-text-regular')};
 				a,
 				strong {
 					color: ${themePalette('--privacy-text-regular')};

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	headlineMedium20,
 	space,
 	textSans14,
@@ -17,9 +18,9 @@ export type NewsletterSignupCardProps = {
 };
 
 const containerStyles = css`
+	clear: left;
 	background-color: ${themePalette('--newsletter-card-background')};
-	margin-bottom: ${space[6]}px;
-	padding: ${space[2]}px ${space[2]}px ${space[4]}px ${space[2]}px;
+	padding: ${space[3]}px ${space[3]}px ${space[4]}px ${space[3]}px;
 `;
 
 const dividerStyles = css`
@@ -45,7 +46,7 @@ const titleAndMetaStyles = css`
 
 const titleStyles = css`
 	${headlineMedium20};
-	margin-bottom: ${space[2]}px;
+	margin-bottom: ${space[1]}px;
 	color: ${themePalette('--newsletter-card-title')};
 `;
 
@@ -68,17 +69,22 @@ const frequencyTagStyles = css`
 const descriptionStyles = css`
 	${textSans14};
 	line-height: 1.15;
-	margin-bottom: ${space[1]}px;
+	margin-bottom: ${space[2]}px;
 	clear: both;
 	color: ${themePalette('--newsletter-card-description')};
 `;
 
 const illustrationStyles = css`
 	flex-shrink: 0;
-	width: 100px;
-	height: 100px;
+	width: 90px;
+	height: 90px;
 	border-radius: 50%;
 	object-fit: cover;
+
+	${from.tablet} {
+		width: 100px;
+		height: 100px;
+	}
 `;
 
 const NewsletterSignupHeader = (props: {

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -18,7 +18,13 @@ describe('NewsletterSignupCardContainer', () => {
 				name="Morning Briefing"
 				frequency="Every weekday"
 				description="Start your day with top stories."
-			/>,
+			>
+				{(openPreview) => (
+					<button type="button" onClick={openPreview}>
+						Preview latest
+					</button>
+				)}
+			</NewsletterSignupCardContainer>,
 		);
 
 		fireEvent.click(screen.getByRole('button', { name: 'Preview latest' }));

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -1,19 +1,13 @@
 import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source/foundations';
-import { Button, SvgEye } from '@guardian/source/react-components';
 import { useCallback, useState } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import { buildNewsletterPreviewUrl } from '../lib/newsletterPreviewUrl';
-import { palette } from '../palette';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { NewsletterPreviewModal } from './NewsletterPreviewModal';
+import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import type { NewsletterSignupCardProps } from './NewsletterSignupCard';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
-
-const previewButtonStyles = css`
-	margin-top: ${space[1]}px;
-	margin-bottom: ${space[4]}px;
-`;
 
 type PreviewEventDescription = 'preview-open' | 'preview-close';
 
@@ -50,13 +44,18 @@ const sendPreviewTracking = ({
 	);
 };
 
-type Props = NewsletterSignupCardProps & {
+type Props = Omit<NewsletterSignupCardProps, 'children'> & {
 	identityName: string;
 	category?: string;
 	exampleUrl?: string;
 	renderingTarget: RenderingTarget;
 	theme: string;
-	children?: React.ReactNode;
+	/**
+	 * Pass the signed-in status so the container can render the privacy message
+	 * below the card (rather than inside the form) when the user is signed in.
+	 */
+	isSignedIn?: boolean | 'Pending';
+	children?: (openPreview: (() => void) | undefined) => React.ReactNode;
 };
 
 const themeColorStyles = (theme: string) => css`
@@ -76,7 +75,9 @@ export const NewsletterSignupCardContainer = ({
 	description,
 	illustrationSquare,
 	children,
+	isSignedIn,
 }: Props) => {
+	const showPrivacyMessageOutside = isSignedIn === true;
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
 	const renderUrl = buildNewsletterPreviewUrl({
@@ -126,37 +127,26 @@ export const NewsletterSignupCardContainer = ({
 					onClose={closePreview}
 				/>
 			)}
-			<NewsletterSignupCard
-				name={name}
-				frequency={frequency}
-				description={description}
-				illustrationSquare={illustrationSquare}
+			<div
+				css={css`
+					display: flex;
+					flex-direction: column;
+					gap: ${space[2]}px;
+					margin-bottom: ${space[6]}px;
+				`}
 			>
-				{hasPreviewUrl && (
-					<Button
-						size="small"
-						priority="tertiary"
-						icon={<SvgEye size="small" />}
-						iconSide="left"
-						onClick={openPreview}
-						cssOverrides={previewButtonStyles}
-						theme={{
-							textTertiary: palette(
-								'--newsletter-preview-button-text',
-							),
-							borderTertiary: palette(
-								'--newsletter-preview-button-border',
-							),
-							backgroundTertiaryHover: palette(
-								'--newsletter-preview-button-hover',
-							),
-						}}
-					>
-						Preview latest
-					</Button>
+				<NewsletterSignupCard
+					name={name}
+					frequency={frequency}
+					description={description}
+					illustrationSquare={illustrationSquare}
+				>
+					{children?.(hasPreviewUrl ? openPreview : undefined)}
+				</NewsletterSignupCard>
+				{showPrivacyMessageOutside && (
+					<NewsletterPrivacyMessage textColor="regular" />
 				)}
-				{children}
-			</NewsletterSignupCard>
+			</div>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -1,0 +1,219 @@
+import { createRef } from 'react';
+import type ReactGoogleRecaptcha from 'react-google-recaptcha';
+import { fn, mocked } from 'storybook/test';
+import preview from '../../.storybook/preview';
+import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
+import type { NewsletterSignupFormState } from '../lib/useNewsletterSignupForm';
+import { NewsletterSignupCard } from './NewsletterSignupCard';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
+import { Section } from './Section';
+
+const meta = preview.meta({
+	title: 'Components/Newsletter Signup Form',
+	component: NewsletterSignupForm,
+	decorators: [
+		(Story) => (
+			<Section
+				title="NewsletterSignupForm"
+				showTopBorder={true}
+				padContent={false}
+				centralBorder="partial"
+			>
+				<NewsletterSignupCard
+					name="Saturday Edition"
+					frequency="Weekly"
+					description="An exclusive roundup of the week's best Guardian journalism from the editor-in-chief, Katharine Viner, free to your inbox every Saturday."
+					illustrationSquare="https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3"
+				>
+					<Story />
+				</NewsletterSignupCard>
+			</Section>
+		),
+	],
+});
+
+const defaultArgs = {
+	newsletterId: 'saturday-edition',
+	newsletterName: 'Saturday Edition',
+	frequency: 'every Saturday',
+	onPreviewClick: fn(),
+};
+
+/** Shared no-op handlers — stories that focus on visual state don't need real callbacks. */
+const noopHandlers: Pick<
+	NewsletterSignupFormState,
+	| 'handleEmailChange'
+	| 'handleEmailFocus'
+	| 'handleEmailInvalid'
+	| 'handleMarketingToggle'
+	| 'handleSubmit'
+	| 'handleSubmitButtonClick'
+	| 'handleReset'
+	| 'handleCaptchaComplete'
+	| 'handleCaptchaLoadError'
+> = {
+	handleEmailChange: fn(),
+	handleEmailFocus: fn(),
+	handleEmailInvalid: fn(),
+	handleMarketingToggle: fn(),
+	handleSubmit: fn(),
+	handleSubmitButtonClick: fn(),
+	handleReset: fn(),
+	handleCaptchaComplete: fn(),
+	handleCaptchaLoadError: fn(),
+};
+
+const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
+	userEmail: undefined,
+	isSignedIn: false,
+	isInteracted: false,
+	showMarketingToggle: false,
+	marketingOptIn: undefined,
+	isWaitingForResponse: false,
+	responseOk: undefined,
+	errorMessage: undefined,
+	recaptchaRef: createRef<ReactGoogleRecaptcha>(),
+	captchaSiteKey: undefined,
+	...noopHandlers,
+	...state,
+});
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Signed-out idle state. Preview button appears above the form. */
+export const SignedOut = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ showMarketingToggle: false }),
+		);
+	},
+});
+
+/**
+ * After the user focuses the email field — marketing toggle and privacy
+ * message are revealed.
+ */
+export const SignedOutFocused = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});
+
+/** Signed-out user with an email typed in, ready to submit. */
+export const SignedOutWithEmail = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'reader@example.com',
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});
+
+/**
+ * Signed-in user — email pre-filled from Identity, email input hidden,
+ * marketing toggle hidden, preview button moves into the submit row.
+ */
+export const SignedIn = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'reader@example.com',
+				isSignedIn: true,
+				isInteracted: true,
+				showMarketingToggle: false,
+			}),
+		);
+	},
+});
+
+/** Spinner shown while the POST request is in-flight; form is hidden. */
+export const Loading = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ isWaitingForResponse: true }),
+		);
+	},
+});
+
+/** Subscription confirmed. */
+export const Success = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ responseOk: true }),
+		);
+	},
+});
+
+/** Server returned a non-2xx response — error message and "Try again" button. */
+export const SubmissionFailed = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ responseOk: false }),
+		);
+	},
+});
+
+/** User submitted without entering an email — inline validation error on the input. */
+export const ValidationError = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({ errorMessage: 'Please enter your email address.' }),
+		);
+	},
+});
+
+/** User submitted with a malformed email — browser fires `invalid`, shown inline on the input. */
+export const InvalidEmail = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'not-an-email',
+				isInteracted: true,
+				errorMessage: 'Incorrect email format. Please check.',
+			}),
+		);
+	},
+});
+
+/** Form without a preview button (no `onPreviewClick` prop). */
+export const WithoutPreview = meta.story({
+	args: { ...defaultArgs, onPreviewClick: undefined },
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(mockForm({}));
+	},
+});
+
+/** `hidePrivacyMessage` — focused state without the privacy notice. */
+export const HidePrivacyMessage = meta.story({
+	args: { ...defaultArgs, hidePrivacyMessage: true },
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				isInteracted: true,
+				showMarketingToggle: true,
+				marketingOptIn: true,
+			}),
+		);
+	},
+});

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -72,6 +72,7 @@ const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
 	isWaitingForResponse: false,
 	responseOk: undefined,
 	errorMessage: undefined,
+	isValidationError: false,
 	recaptchaRef: createRef<ReactGoogleRecaptcha>(),
 	captchaSiteKey: undefined,
 	...noopHandlers,
@@ -177,7 +178,10 @@ export const ValidationError = meta.story({
 	args: defaultArgs,
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
-			mockForm({ errorMessage: 'Please enter your email address.' }),
+			mockForm({
+				errorMessage: 'Please enter your email address.',
+				isValidationError: true,
+			}),
 		);
 	},
 });
@@ -191,6 +195,33 @@ export const InvalidEmail = meta.story({
 				userEmail: 'not-an-email',
 				isInteracted: true,
 				errorMessage: 'Incorrect email format. Please check.',
+				isValidationError: true,
+			}),
+		);
+	},
+});
+
+/** reCAPTCHA widget failed to load — form replaced by bordered error box. */
+export const CaptchaLoadError = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				errorMessage: 'Sorry, the reCAPTCHA failed to load.',
+				isValidationError: false,
+			}),
+		);
+	},
+});
+
+/** reCAPTCHA check expired or was dismissed — form replaced by bordered error box. */
+export const CaptchaNotPassed = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				errorMessage: 'The reCAPTCHA check did not complete.',
+				isValidationError: false,
 			}),
 		);
 	},

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -1,0 +1,353 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { forwardRef, useImperativeHandle } from 'react';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
+import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
+import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useBrowserId } from '../lib/useBrowserId';
+import { ConfigProvider } from './ConfigContext';
+import { NewsletterSignupForm } from './NewsletterSignupForm.island';
+
+jest.mock('../client/ophan/ophan', () => ({
+	submitComponentEvent: jest.fn(),
+}));
+
+jest.mock('../lib/fetchEmail', () => ({
+	lazyFetchEmailWithTimeout: jest.fn(),
+}));
+
+jest.mock('../lib/newsletterSubscriptionCache', () => ({
+	clearSubscriptionCache: jest.fn(),
+}));
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useAuthStatus: jest.fn(),
+	useIsSignedIn: jest.fn(),
+}));
+
+jest.mock('../lib/useBrowserId', () => ({
+	useBrowserId: jest.fn(),
+}));
+
+// Mock reCAPTCHA: immediately call onChange with a fake token when execute() is called.
+jest.mock('react-google-recaptcha', () => ({
+	__esModule: true,
+	default: forwardRef<
+		{ execute: () => void; reset: () => void },
+		{ onChange?: (token: string) => void }
+	>(function MockRecaptcha({ onChange }, ref) {
+		useImperativeHandle(ref, () => ({
+			execute: () => onChange?.('test-recaptcha-token'),
+			reset: () => undefined,
+		}));
+		return null;
+	}),
+}));
+
+const renderForm = (hidePrivacyMessage = false) =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<NewsletterSignupForm
+				newsletterId="morning-briefing"
+				newsletterName="Morning Briefing"
+				frequency="every day"
+				hidePrivacyMessage={hidePrivacyMessage}
+			/>
+		</ConfigProvider>,
+	);
+
+const getTrackedEventDescription = (call: unknown[]): string => {
+	const payload = call[0] as { value: string };
+	const value = JSON.parse(payload.value) as { eventDescription: string };
+	return value.eventDescription;
+};
+
+const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
+	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
+		callIndex
+	] as [string, RequestInit];
+	return new URLSearchParams(requestInit.body?.toString() ?? '');
+};
+
+const expectTrackedEventDescriptions = (expected: string[]): void => {
+	const eventDescriptions = (
+		submitComponentEvent as jest.Mock
+	).mock.calls.map(getTrackedEventDescription);
+	expect(eventDescriptions).toEqual(expected);
+};
+
+const typeEmailAddress = async (
+	testUser: ReturnType<typeof user.setup>,
+	email = 'reader@example.com',
+): Promise<void> => {
+	await testUser.type(screen.getByLabelText('Enter your email'), email);
+};
+
+describe('NewsletterSignupForm', () => {
+	const pageConfig = window.guardian.config
+		.page as typeof window.guardian.config.page & {
+		ajaxUrl?: string;
+		idApiUrl?: string;
+		googleRecaptchaSiteKey?: string;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(useIsSignedIn as jest.Mock).mockReturnValue(false);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
+		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
+		(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
+			Promise.resolve(null),
+		);
+		(submitComponentEvent as jest.Mock).mockResolvedValue(undefined);
+
+		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
+		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
+		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
+		if (window.guardian.ophan) {
+			window.guardian.ophan.pageViewId = 'test-page-view-id';
+		}
+		global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+	});
+
+	it('submits for a signed-out user and includes marketing/browser fields', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
+			).toBeInTheDocument();
+		});
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://api.nextgen.guardianapps.co.uk/email',
+			expect.objectContaining({
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			}),
+		);
+
+		const params = getRequestBodyParams();
+
+		expect(params.get('email')).toBe('reader@example.com');
+		expect(params.get('listName')).toBe('morning-briefing');
+		expect(params.get('marketing')).toBe('true');
+		expect(params.get('browserId')).toBe('test-browser-id');
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'open-captcha',
+			'captcha-passed',
+			'form-submission',
+			'submission-confirmed',
+		]);
+	});
+
+	it('supports tab order from email input to marketing toggle to sign up', async () => {
+		const testUser = user.setup();
+
+		renderForm(true);
+
+		await testUser.tab();
+		expect(screen.getByLabelText('Enter your email')).toHaveFocus();
+
+		await testUser.tab();
+		expect(screen.getByRole('switch')).toHaveFocus();
+
+		await testUser.tab();
+		const signUpButton = screen.getByRole('button', { name: 'Sign up' });
+		expect(signUpButton).toHaveFocus();
+	});
+
+	it('allows signed-out users to opt out of marketing before submit', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		const marketingSwitch = screen.getByRole('switch');
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'true');
+
+		await testUser.click(marketingSwitch);
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'false');
+
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalled();
+		});
+
+		const params = getRequestBodyParams();
+		expect(params.get('marketing')).toBe('false');
+	});
+
+	it('supports keyboard interaction for marketing toggle and submit button', async () => {
+		const testUser = user.setup();
+
+		renderForm(true);
+
+		await testUser.tab();
+		const emailInput = screen.getByLabelText('Enter your email');
+		expect(emailInput).toHaveFocus();
+		await testUser.type(emailInput, 'reader@example.com');
+
+		await testUser.tab();
+		const marketingSwitch = screen.getByRole('switch');
+		expect(marketingSwitch).toHaveFocus();
+
+		await testUser.keyboard('{Enter}');
+		expect(marketingSwitch).toHaveAttribute('aria-checked', 'false');
+
+		await testUser.tab();
+		const signUpButton = screen.getByRole('button', { name: 'Sign up' });
+		expect(signUpButton).toHaveFocus();
+		await testUser.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
+			).toBeInTheDocument();
+		});
+
+		const params = getRequestBodyParams();
+		expect(params.get('marketing')).toBe('false');
+	});
+
+	it('uses prefilled email for signed-in users and clears cached subscriptions on success', async () => {
+		const testUser = user.setup();
+		(useIsSignedIn as jest.Mock).mockReturnValue(true);
+		(useAuthStatus as jest.Mock).mockReturnValue({
+			kind: 'SignedIn',
+			accessToken: { accessToken: 'token' },
+			idToken: { claims: { email: 'signed.in@example.com' } },
+		});
+		(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
+			Promise.resolve('signed.in@example.com'),
+		);
+
+		renderForm();
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', { name: 'Sign up' }),
+			).toBeInTheDocument();
+		});
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You will receive Morning Briefing every day.',
+				),
+			).toBeInTheDocument();
+		});
+
+		expect(clearSubscriptionCache).toHaveBeenCalledTimes(1);
+
+		const params = getRequestBodyParams();
+		expect(params.get('email')).toBe('signed.in@example.com');
+	});
+
+	it('shows an inline validation error when submitting with an empty email', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Please enter your email address.'),
+		).toBeInTheDocument();
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('shows an inline validation error when submitting with an invalid email format', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser, 'not-an-email');
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Incorrect email format. Please check.'),
+		).toBeInTheDocument();
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('clears the validation error as the user corrects their email', async () => {
+		const testUser = user.setup();
+
+		renderForm();
+
+		await typeEmailAddress(testUser, 'not-an-email');
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		expect(
+			screen.getByText('Incorrect email format. Please check.'),
+		).toBeInTheDocument();
+
+		// Typing clears the error immediately
+		await testUser.type(
+			screen.getByLabelText('Enter your email', { exact: false }),
+			'{Backspace}',
+		);
+
+		expect(
+			screen.queryByText('Incorrect email format. Please check.'),
+		).not.toBeInTheDocument();
+	});
+
+	it('shows failure UI with retry and supports hiding the privacy message', async () => {
+		const testUser = user.setup();
+		global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+
+		renderForm(true);
+
+		expect(screen.queryByText('Privacy Notice:')).not.toBeInTheDocument();
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(screen.getByText(/Sign up failed\./)).toBeInTheDocument();
+		});
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'open-captcha',
+			'captcha-passed',
+			'form-submission',
+			'submission-failed',
+		]);
+
+		await testUser.click(screen.getByRole('button', { name: 'Try again' }));
+
+		expect(
+			screen.getByRole('button', { name: 'Sign up' }),
+		).toBeInTheDocument();
+	});
+});

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -30,19 +30,42 @@ jest.mock('../lib/useBrowserId', () => ({
 	useBrowserId: jest.fn(),
 }));
 
-// Mock reCAPTCHA: immediately call onChange with a fake token when execute() is called.
+type RecaptchaProps = {
+	onChange?: (token: string | null) => void;
+	onError?: () => void;
+};
+
+type RecaptchaHandle = { execute: () => void; reset: () => void };
+
+// The default mock resolves the captcha immediately with a valid token.
+// Individual tests can override this via mockRecaptcha().
+let recaptchaBehaviour: (
+	handle: RecaptchaHandle,
+	props: RecaptchaProps,
+) => void = (_handle, props) => props.onChange?.('test-recaptcha-token');
+
+/** Override what happens when reCAPTCHA's execute() is called in a single test. */
+const mockRecaptcha = (
+	behaviour: (handle: RecaptchaHandle, props: RecaptchaProps) => void,
+) => {
+	recaptchaBehaviour = behaviour;
+};
+
 jest.mock('react-google-recaptcha', () => ({
 	__esModule: true,
-	default: forwardRef<
-		{ execute: () => void; reset: () => void },
-		{ onChange?: (token: string) => void }
-	>(function MockRecaptcha({ onChange }, ref) {
-		useImperativeHandle(ref, () => ({
-			execute: () => onChange?.('test-recaptcha-token'),
-			reset: () => undefined,
-		}));
-		return null;
-	}),
+	default: forwardRef<RecaptchaHandle, RecaptchaProps>(
+		function MockRecaptcha(props, ref) {
+			useImperativeHandle(ref, () => ({
+				execute: () =>
+					recaptchaBehaviour(
+						{ execute: () => undefined, reset: () => undefined },
+						props,
+					),
+				reset: () => undefined,
+			}));
+			return null;
+		},
+	),
 }));
 
 const renderForm = (hidePrivacyMessage = false) =>
@@ -101,6 +124,11 @@ describe('NewsletterSignupForm', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+
+		// Reset reCAPTCHA to the default happy-path behaviour.
+		mockRecaptcha(
+			(_handle, props) => props.onChange?.('test-recaptcha-token'),
+		);
 
 		(useIsSignedIn as jest.Mock).mockReturnValue(false);
 		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
@@ -342,6 +370,69 @@ describe('NewsletterSignupForm', () => {
 			'captcha-passed',
 			'form-submission',
 			'submission-failed',
+		]);
+
+		await testUser.click(screen.getByRole('button', { name: 'Try again' }));
+
+		expect(
+			screen.getByRole('button', { name: 'Sign up' }),
+		).toBeInTheDocument();
+	});
+
+	it('shows failure UI when reCAPTCHA returns a null token (expired/dismissed)', async () => {
+		const testUser = user.setup();
+		mockRecaptcha((_handle, props) => props.onChange?.(null));
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/The reCAPTCHA check did not complete\./),
+			).toBeInTheDocument();
+		});
+
+		// Form is replaced by the failure box — the email input is not visible.
+		expect(screen.queryByLabelText('Enter your email')).not.toBeVisible();
+		expect(global.fetch).not.toHaveBeenCalled();
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'open-captcha',
+			'captcha-not-passed',
+		]);
+
+		// "Try again" resets back to the form.
+		await testUser.click(screen.getByRole('button', { name: 'Try again' }));
+		expect(
+			screen.getByRole('button', { name: 'Sign up' }),
+		).toBeInTheDocument();
+	});
+
+	it('shows failure UI when reCAPTCHA fires its onError callback', async () => {
+		const testUser = user.setup();
+		mockRecaptcha((_handle, props) => props.onError?.());
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/the reCAPTCHA failed to load\./),
+			).toBeInTheDocument();
+		});
+
+		expect(screen.queryByLabelText('Enter your email')).not.toBeVisible();
+		expect(global.fetch).not.toHaveBeenCalled();
+
+		expectTrackedEventDescriptions([
+			'click-button',
+			'open-captcha',
+			'captcha-load-error',
 		]);
 
 		await testUser.click(screen.getByRole('button', { name: 'Try again' }));

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,0 +1,406 @@
+import { css } from '@emotion/react';
+import { from, space, textSans15, until } from '@guardian/source/foundations';
+import type { Size } from '@guardian/source/react-components';
+import {
+	Button,
+	InlineError,
+	InlineSuccess,
+	Link,
+	LinkButton,
+	SvgEye,
+	SvgReload,
+	TextInput,
+	themeButton,
+} from '@guardian/source/react-components';
+import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
+// Note - the package also exports a component as a named export "ReCAPTCHA",
+// that version will compile and render but is non-functional.
+// Use the default export instead.
+import ReactGoogleRecaptcha from 'react-google-recaptcha';
+import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
+import { palette } from '../palette';
+import { useConfig } from './ConfigContext';
+import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
+
+type Props = {
+	newsletterId: string;
+	newsletterName: string;
+	frequency: string;
+	hidePrivacyMessage?: boolean;
+	onPreviewClick?: () => void;
+	/** When `true`, the success message is shown immediately (user is already subscribed). */
+	isAlreadySubscribed?: boolean;
+};
+
+const formStyles = css`
+	display: grid;
+	column-gap: ${space[3]}px;
+	row-gap: ${space[2]}px;
+	align-items: end;
+
+	${until.tablet} {
+		row-gap: ${space[3]}px;
+	}
+`;
+
+const signedOutLayoutStyles = css`
+	grid-template-columns: minmax(0, 1fr) 160px;
+	grid-template-areas: 'email submit';
+
+	${until.tablet} {
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'email'
+			'submit';
+	}
+`;
+
+const signedInLayoutStyles = css`
+	grid-template-columns: minmax(0, 1fr);
+	grid-template-areas: 'submit';
+	padding-bottom: ${space[2]}px;
+`;
+
+const emailFieldStyles = css`
+	grid-area: email;
+	min-width: 0;
+
+	label div {
+		color: ${palette('--article-text')};
+	}
+
+	input {
+		color: ${palette('--article-text')};
+		background-color: ${palette('--article-background')};
+	}
+`;
+
+const submitButtonContainerStyles = css`
+	grid-area: submit;
+	width: 100%;
+	display: flex;
+	gap: ${space[2]}px;
+`;
+
+const submitButtonStyles = css`
+	flex: 1;
+	button {
+		width: 100%;
+	}
+	${from.tablet} {
+		max-width: 220px;
+	}
+`;
+
+const previewButtonContainerStyles = css`
+	margin-bottom: ${space[2]}px;
+`;
+
+const toggleContainerStyles = css`
+	grid-column: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: ${space[3]}px;
+	min-width: 0;
+`;
+
+const privacyContainerStyles = css`
+	grid-column: 1 / -1;
+`;
+
+const successTextStyles = css`
+	color: ${palette('--newsletter-card-description')};
+	${textSans15};
+	strong {
+		font-weight: bold;
+	}
+`;
+
+const marketingToggleBoxStyles = css`
+	width: 100%;
+	padding: ${space[2]}px;
+	border: 1px solid ${palette('--card-border-supporting')};
+	border-radius: 4px;
+`;
+
+const responseBoxStyles = css`
+	width: 100%;
+	padding: ${space[2]}px;
+	border: 1px solid ${palette('--card-border-supporting')};
+	border-radius: 4px;
+	margin-top: ${space[2]}px;
+`;
+
+const errorContainerStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[2]}px;
+`;
+
+const tryAgainButtonStyles = css`
+	width: 100%;
+	margin-top: ${space[2]}px;
+`;
+
+const recaptchaContainerStyles = css`
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+`;
+
+const browseMoreLinksStyles = css`
+	${tryAgainButtonStyles};
+	${from.tablet} {
+		max-width: 350px;
+	}
+`;
+
+const PreviewButton = ({
+	onClick,
+	size = 'default',
+}: {
+	onClick: () => void;
+	size?: Size;
+}) => (
+	<Button
+		priority="tertiary"
+		icon={<SvgEye />}
+		iconSide="left"
+		onClick={onClick}
+		type="button"
+		size={size}
+	>
+		Preview latest
+	</Button>
+);
+
+const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
+	<InlineError>
+		<span>
+			{text} Please try again or contact{' '}
+			<Link
+				href="mailto:customer.help@theguardian.com"
+				target="_blank"
+				rel="noreferrer"
+			>
+				customer.help@theguardian.com
+			</Link>
+		</span>
+	</InlineError>
+);
+
+const SuccessMessage = ({
+	newsletterName,
+	frequency,
+}: {
+	newsletterName: string;
+	frequency: string;
+}) => {
+	return (
+		<div css={responseBoxStyles}>
+			<InlineSuccess size="medium">
+				<span css={successTextStyles}>
+					<strong>You're signed up!</strong>
+					&nbsp;
+					<span>
+						You will receive {newsletterName}{' '}
+						{frequency.toLowerCase()}.
+					</span>
+				</span>
+			</InlineSuccess>
+			<LinkButton
+				href="/email-newsletters"
+				priority="tertiary"
+				theme={themeButton}
+				cssOverrides={browseMoreLinksStyles}
+			>
+				Browse more newsletters
+			</LinkButton>
+		</div>
+	);
+};
+
+const FailureMessage = ({
+	onRetry,
+}: {
+	onRetry: React.MouseEventHandler<HTMLButtonElement>;
+}) => (
+	<div css={[responseBoxStyles, errorContainerStyles]}>
+		<ErrorMessageWithAdvice text="Sign up failed." />
+		<Button
+			size="small"
+			priority="primary"
+			icon={<SvgReload />}
+			iconSide="right"
+			onClick={onRetry}
+			cssOverrides={tryAgainButtonStyles}
+		>
+			Try again
+		</Button>
+	</div>
+);
+
+/**
+ * # Newsletter Signup Form
+ *
+ * A simplified version of SecureSignup without reCAPTCHA or A/B testing.
+ * All logic lives in {@link useNewsletterSignupForm}.
+ *
+ * When the user is already subscribed, the success message is shown immediately
+ * without invoking the form hook (no Identity fetch, reCAPTCHA, etc.).
+ */
+export const NewsletterSignupForm = ({
+	isAlreadySubscribed,
+	...rest
+}: Props) => {
+	if (isAlreadySubscribed) {
+		return (
+			<SuccessMessage
+				newsletterName={rest.newsletterName}
+				frequency={rest.frequency}
+			/>
+		);
+	}
+	return <NewsletterSignupFormActive {...rest} />;
+};
+
+const NewsletterSignupFormActive = ({
+	newsletterId,
+	newsletterName,
+	frequency,
+	hidePrivacyMessage = false,
+	onPreviewClick,
+}: Omit<Props, 'isAlreadySubscribed'>) => {
+	const { renderingTarget } = useConfig();
+
+	const {
+		userEmail,
+		isSignedIn,
+		isInteracted,
+		showMarketingToggle,
+		marketingOptIn,
+		isWaitingForResponse,
+		responseOk,
+		errorMessage,
+		recaptchaRef,
+		captchaSiteKey,
+		handleCaptchaComplete,
+		handleCaptchaLoadError,
+		handleEmailChange,
+		handleEmailFocus,
+		handleEmailInvalid,
+		handleMarketingToggle,
+		handleSubmit,
+		handleSubmitButtonClick,
+		handleReset,
+	} = useNewsletterSignupForm(newsletterId, renderingTarget);
+
+	const hasResponse = typeof responseOk === 'boolean';
+	const showForm = !hasResponse;
+	const showSuccess = hasResponse && !!responseOk;
+	const showFailure = hasResponse && !responseOk;
+	const showAdditionalFields = isInteracted || !!userEmail;
+	// Validation errors (before submission) are shown inline on the input.
+	// Network/server errors (after a failed submission) use the standalone message.
+	const isValidationError = !!errorMessage && !hasResponse;
+
+	return (
+		<>
+			{showForm && onPreviewClick && !isSignedIn && (
+				<div css={previewButtonContainerStyles}>
+					<PreviewButton onClick={onPreviewClick} size="small" />
+				</div>
+			)}
+			<form
+				onSubmit={handleSubmit}
+				id={`newsletter-signup-${newsletterId}`}
+				style={{
+					display: !showForm ? 'none' : undefined,
+				}}
+				css={[
+					formStyles,
+					isSignedIn ? signedInLayoutStyles : signedOutLayoutStyles,
+				]}
+			>
+				{isSignedIn ? (
+					<input type="hidden" name="email" value={userEmail ?? ''} />
+				) : (
+					<div css={emailFieldStyles}>
+						<TextInput
+							name="email"
+							label="Enter your email"
+							type="email"
+							value={userEmail ?? ''}
+							error={isValidationError ? errorMessage : undefined}
+							onFocus={handleEmailFocus}
+							onChange={(e) => handleEmailChange(e.target.value)}
+							onInvalid={handleEmailInvalid}
+						/>
+					</div>
+				)}
+				{showAdditionalFields && (
+					<>
+						{showMarketingToggle && (
+							<div css={toggleContainerStyles}>
+								<div css={marketingToggleBoxStyles}>
+									<ToggleSwitch
+										id={`marketing-opt-in-${newsletterId}`}
+										checked={marketingOptIn ?? false}
+										onClick={handleMarketingToggle}
+										label="Get updates about our journalism and ways to support and enjoy
+								our work. Toggle to opt out."
+										labelPosition="left"
+									/>
+								</div>
+							</div>
+						)}
+						{!hidePrivacyMessage && (
+							<div css={privacyContainerStyles}>
+								<NewsletterPrivacyMessage />
+							</div>
+						)}
+					</>
+				)}
+				<div css={submitButtonContainerStyles}>
+					{isSignedIn && onPreviewClick && (
+						<PreviewButton onClick={onPreviewClick} />
+					)}
+					<Button
+						cssOverrides={submitButtonStyles}
+						onClick={handleSubmitButtonClick}
+						type="submit"
+						isLoading={isWaitingForResponse}
+						loadingAnnouncement="Signing you up…"
+						disabled={isWaitingForResponse}
+					>
+						Sign up
+					</Button>
+				</div>
+			</form>
+
+			{!!errorMessage && !isValidationError && (
+				<ErrorMessageWithAdvice text={errorMessage} />
+			)}
+
+			{showSuccess && (
+				<SuccessMessage
+					newsletterName={newsletterName}
+					frequency={frequency}
+				/>
+			)}
+			{showFailure && <FailureMessage onRetry={handleReset} />}
+			{!!captchaSiteKey && (
+				<div css={recaptchaContainerStyles}>
+					<ReactGoogleRecaptcha
+						sitekey={captchaSiteKey}
+						ref={recaptchaRef}
+						onChange={handleCaptchaComplete}
+						onError={handleCaptchaLoadError}
+						size="invisible"
+					/>
+				</div>
+			)}
+		</>
+	);
+};

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { from, space, textSans15, until } from '@guardian/source/foundations';
-import type { Size } from '@guardian/source/react-components';
+import type { Size, ThemeButton } from '@guardian/source/react-components';
 import {
 	Button,
 	InlineError,
@@ -10,7 +10,6 @@ import {
 	SvgEye,
 	SvgReload,
 	TextInput,
-	themeButton,
 } from '@guardian/source/react-components';
 import { ToggleSwitch } from '@guardian/source-development-kitchen/react-components';
 // Note - the package also exports a component as a named export "ReCAPTCHA",
@@ -66,12 +65,12 @@ const emailFieldStyles = css`
 	min-width: 0;
 
 	label div {
-		color: ${palette('--article-text')};
+		color: ${palette('--newsletter-signup-input-text')};
 	}
 
 	input {
-		color: ${palette('--article-text')};
-		background-color: ${palette('--article-background')};
+		color: ${palette('--newsletter-signup-input-text')};
+		background-color: ${palette('--newsletter-signup-input-background')};
 	}
 `;
 
@@ -84,9 +83,7 @@ const submitButtonContainerStyles = css`
 
 const submitButtonStyles = css`
 	flex: 1;
-	button {
-		width: 100%;
-	}
+	width: 100%;
 	${from.tablet} {
 		max-width: 220px;
 	}
@@ -122,6 +119,9 @@ const marketingToggleBoxStyles = css`
 	padding: ${space[2]}px;
 	border: 1px solid ${palette('--card-border-supporting')};
 	border-radius: 4px;
+	label {
+		color: ${palette('--newsletter-signup-toggle-text')};
+	}
 `;
 
 const responseBoxStyles = css`
@@ -146,20 +146,34 @@ const tryAgainButtonStyles = css`
 	}
 `;
 
-/** Prevent article-level link styles (e.g. red for Opinion) from bleeding in */
-const browseMoreLinksStyles = css`
-	color: ${palette('--newsletter-preview-button-text')};
-	border-color: ${palette('--newsletter-preview-button-border')};
-	&:hover {
-		color: ${palette('--newsletter-preview-button-text')};
-	}
-`;
-
 const recaptchaContainerStyles = css`
 	.grecaptcha-badge {
 		visibility: hidden;
 	}
 `;
+
+/**
+ * Colour overrides for primary buttons so that article-level themes
+ * (e.g. Opinion red) don't bleed in. Uses CSS custom properties from
+ * the palette so the colours work in both light and dark mode.
+ */
+const primaryButtonTheme: Partial<ThemeButton> = {
+	backgroundPrimary: palette('--newsletter-signup-submit-background'),
+	backgroundPrimaryHover: palette(
+		'--newsletter-signup-submit-background-hover',
+	),
+	textPrimary: palette('--newsletter-signup-submit-text'),
+};
+
+/**
+ * Colour overrides for tertiary buttons so that they are visible
+ * in both light and dark mode, independent of the article theme.
+ */
+const tertiaryButtonTheme: Partial<ThemeButton> = {
+	textTertiary: palette('--newsletter-preview-button-text'),
+	borderTertiary: palette('--newsletter-preview-button-border'),
+	backgroundTertiaryHover: palette('--newsletter-preview-button-hover'),
+};
 
 const PreviewButton = ({
 	onClick,
@@ -175,6 +189,7 @@ const PreviewButton = ({
 		onClick={onClick}
 		type="button"
 		size={size}
+		theme={tertiaryButtonTheme}
 	>
 		Preview latest
 	</Button>
@@ -217,8 +232,8 @@ const SuccessMessage = ({
 			<LinkButton
 				href="/email-newsletters"
 				priority="tertiary"
-				theme={themeButton}
-				cssOverrides={[tryAgainButtonStyles, browseMoreLinksStyles]}
+				theme={tertiaryButtonTheme}
+				cssOverrides={tryAgainButtonStyles}
 			>
 				Browse more newsletters
 			</LinkButton>
@@ -239,6 +254,7 @@ const FailureMessage = ({
 			icon={<SvgReload />}
 			iconSide="right"
 			onClick={onRetry}
+			theme={primaryButtonTheme}
 			cssOverrides={tryAgainButtonStyles}
 		>
 			Try again
@@ -375,6 +391,7 @@ const NewsletterSignupFormActive = ({
 						cssOverrides={submitButtonStyles}
 						onClick={handleSubmitButtonClick}
 						type="submit"
+						theme={primaryButtonTheme}
 						isLoading={isWaitingForResponse}
 						loadingAnnouncement="Signing you up…"
 						disabled={isWaitingForResponse}

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -141,18 +141,16 @@ const errorContainerStyles = css`
 const tryAgainButtonStyles = css`
 	width: 100%;
 	margin-top: ${space[2]}px;
+	${from.tablet} {
+		max-width: 350px;
+	}
 `;
+
+const browseMoreLinksStyles = tryAgainButtonStyles;
 
 const recaptchaContainerStyles = css`
 	.grecaptcha-badge {
 		visibility: hidden;
-	}
-`;
-
-const browseMoreLinksStyles = css`
-	${tryAgainButtonStyles};
-	${from.tablet} {
-		max-width: 350px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -146,7 +146,14 @@ const tryAgainButtonStyles = css`
 	}
 `;
 
-const browseMoreLinksStyles = tryAgainButtonStyles;
+/** Prevent article-level link styles (e.g. red for Opinion) from bleeding in */
+const browseMoreLinksStyles = css`
+	color: ${palette('--newsletter-preview-button-text')};
+	border-color: ${palette('--newsletter-preview-button-border')};
+	&:hover {
+		color: ${palette('--newsletter-preview-button-text')};
+	}
+`;
 
 const recaptchaContainerStyles = css`
 	.grecaptcha-badge {
@@ -211,7 +218,7 @@ const SuccessMessage = ({
 				href="/email-newsletters"
 				priority="tertiary"
 				theme={themeButton}
-				cssOverrides={browseMoreLinksStyles}
+				cssOverrides={[tryAgainButtonStyles, browseMoreLinksStyles]}
 			>
 				Browse more newsletters
 			</LinkButton>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -243,11 +243,13 @@ const SuccessMessage = ({
 
 const FailureMessage = ({
 	onRetry,
+	text,
 }: {
 	onRetry: React.MouseEventHandler<HTMLButtonElement>;
+	text: string;
 }) => (
 	<div css={[responseBoxStyles, errorContainerStyles]}>
-		<ErrorMessageWithAdvice text="Sign up failed." />
+		<ErrorMessageWithAdvice text={text} />
 		<Button
 			size="small"
 			priority="primary"
@@ -265,7 +267,8 @@ const FailureMessage = ({
 /**
  * # Newsletter Signup Form
  *
- * A simplified version of SecureSignup without reCAPTCHA or A/B testing.
+ * Renders a newsletter signup form with email input, optional marketing opt-in
+ * toggle, privacy message, reCAPTCHA, and success/failure feedback states.
  * All logic lives in {@link useNewsletterSignupForm}.
  *
  * When the user is already subscribed, the success message is shown immediately
@@ -304,6 +307,7 @@ const NewsletterSignupFormActive = ({
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,
+		isValidationError,
 		recaptchaRef,
 		captchaSiteKey,
 		handleCaptchaComplete,
@@ -318,13 +322,18 @@ const NewsletterSignupFormActive = ({
 	} = useNewsletterSignupForm(newsletterId, renderingTarget);
 
 	const hasResponse = typeof responseOk === 'boolean';
-	const showForm = !hasResponse;
+	const hasNonValidationError = !!errorMessage && !isValidationError;
+	const showForm = !hasResponse && !hasNonValidationError;
 	const showSuccess = hasResponse && !!responseOk;
-	const showFailure = hasResponse && !responseOk;
+	// Show the failure box for server errors (responseOk === false) and for
+	// reCAPTCHA / network errors that occur before a response is received.
+	const showFailure = (hasResponse && !responseOk) || hasNonValidationError;
+	const failureMessage = hasNonValidationError
+		? errorMessage
+		: 'Sign up failed.';
 	const showAdditionalFields = isInteracted || !!userEmail;
-	// Validation errors (before submission) are shown inline on the input.
-	// Network/server errors (after a failed submission) use the standalone message.
-	const isValidationError = !!errorMessage && !hasResponse;
+	// isValidationError comes from the hook — true only for inline field
+	// errors (empty / bad format), false for reCAPTCHA / network errors.
 
 	return (
 		<>
@@ -401,17 +410,15 @@ const NewsletterSignupFormActive = ({
 				</div>
 			</form>
 
-			{!!errorMessage && !isValidationError && (
-				<ErrorMessageWithAdvice text={errorMessage} />
-			)}
-
 			{showSuccess && (
 				<SuccessMessage
 					newsletterName={newsletterName}
 					frequency={frequency}
 				/>
 			)}
-			{showFailure && <FailureMessage onRetry={handleReset} />}
+			{showFailure && (
+				<FailureMessage text={failureMessage} onRetry={handleReset} />
+			)}
 			{!!captchaSiteKey && (
 				<div css={recaptchaContainerStyles}>
 					<ReactGoogleRecaptcha

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -588,7 +588,8 @@ export const renderElement = ({
 				idApiUrl: idApiUrl ?? '',
 				hideNewsletterSignupComponentForSubscribers:
 					!!switches.hideNewsletterSignupComponentForSubscribers,
-				showNewsletterSignupCard: !!switches.showNewsletterSignupCard,
+				showNewNewsletterSignupCard:
+					!!switches.showNewNewsletterSignupCard,
 			};
 			if (isListElement || isTimeline) return null;
 			return (

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -181,6 +181,12 @@ export type NewsletterSignupFormState = {
 	responseOk: boolean | undefined;
 	/** Inline validation / network error copy. */
 	errorMessage: string | undefined;
+	/**
+	 * `true` when the error should be shown inline on the email input
+	 * (e.g. empty field, bad format).  `false` for reCAPTCHA / network
+	 * errors, which are shown as a standalone message below the form.
+	 */
+	isValidationError: boolean;
 
 	/** Ref to pass to the `<ReactGoogleRecaptcha>` widget. */
 	recaptchaRef: RefObject<ReactGoogleRecaptcha>;
@@ -226,6 +232,7 @@ export const useNewsletterSignupForm = (
 	const [errorMessage, setErrorMessage] = useState<string | undefined>(
 		undefined,
 	);
+	const [isValidationError, setIsValidationError] = useState(false);
 	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
 		undefined,
 	);
@@ -341,7 +348,10 @@ export const useNewsletterSignupForm = (
 					'captcha-not-passed',
 					renderingTarget,
 				);
+				setIsValidationError(false);
+				setErrorMessage('The reCAPTCHA check did not complete.');
 				setIsWaitingForResponse(false);
+				recaptchaRef.current?.reset();
 				return;
 			}
 			sendTracking(newsletterId, 'captcha-passed', renderingTarget);
@@ -357,6 +367,7 @@ export const useNewsletterSignupForm = (
 						'form-submit-error',
 						renderingTarget,
 					);
+					setIsValidationError(false);
 					setErrorMessage(
 						'Sorry, there was an error signing you up.',
 					);
@@ -371,7 +382,9 @@ export const useNewsletterSignupForm = (
 
 	const handleCaptchaLoadError = useCallback((): void => {
 		sendTracking(newsletterId, 'captcha-load-error', renderingTarget);
+		setIsValidationError(false);
 		setErrorMessage('Sorry, the reCAPTCHA failed to load.');
+		setIsWaitingForResponse(false);
 		recaptchaRef.current?.reset();
 	}, [newsletterId, renderingTarget]);
 
@@ -382,11 +395,13 @@ export const useNewsletterSignupForm = (
 
 			const emailAddress = userEmail?.trim() ?? '';
 			if (!emailAddress) {
+				setIsValidationError(true);
 				setErrorMessage('Please enter your email address.');
 				return;
 			}
 
 			pendingEmailRef.current = emailAddress;
+			setIsValidationError(false);
 			setErrorMessage(undefined);
 			setIsWaitingForResponse(true);
 			sendTracking(newsletterId, 'open-captcha', renderingTarget);
@@ -398,6 +413,7 @@ export const useNewsletterSignupForm = (
 	const handleEmailChange = useCallback((value: string): void => {
 		setUserEmail(value);
 		setIsInteracted(true);
+		setIsValidationError(false);
 		setErrorMessage(undefined);
 	}, []);
 
@@ -411,6 +427,7 @@ export const useNewsletterSignupForm = (
 		event.preventDefault();
 		if (!hasAttemptedSubmitRef.current) return;
 		const { validity } = event.currentTarget;
+		setIsValidationError(true);
 		setErrorMessage(
 			validity.valueMissing
 				? 'Please enter your email address.'
@@ -433,6 +450,7 @@ export const useNewsletterSignupForm = (
 	const handleReset = useCallback<
 		ReactEventHandler<HTMLButtonElement>
 	>(() => {
+		setIsValidationError(false);
 		setErrorMessage(undefined);
 		setResponseOk(undefined);
 		hasAttemptedSubmitRef.current = false;
@@ -448,6 +466,7 @@ export const useNewsletterSignupForm = (
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,
+		isValidationError,
 		recaptchaRef,
 		captchaSiteKey,
 		handleCaptchaComplete,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -1,0 +1,485 @@
+import { isString } from '@guardian/libs';
+import type { TAction } from '@guardian/ophan-tracker-js';
+import type { FormEvent, ReactEventHandler, RefObject } from 'react';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type ReactGoogleRecaptcha from 'react-google-recaptcha';
+import { submitComponentEvent } from '../client/ophan/ophan';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { lazyFetchEmailWithTimeout } from './fetchEmail';
+import { clearSubscriptionCache } from './newsletterSubscriptionCache';
+import { useAuthStatus, useIsSignedIn } from './useAuthStatus';
+import { useBrowserId } from './useBrowserId';
+
+// ---------------------------------------------------------------------------
+// Helpers (kept local — not part of the public API)
+// ---------------------------------------------------------------------------
+
+const buildFormData = (
+	emailAddress: string,
+	newsletterId: string,
+	token: string,
+	marketingOptIn?: boolean,
+	browserId?: string,
+): FormData => {
+	const pageRef = window.location.origin + window.location.pathname;
+	const refViewId = window.guardian.ophan?.pageViewId ?? '';
+
+	const formData = new FormData();
+	formData.append('email', emailAddress);
+	formData.append('csrfToken', '');
+	formData.append('listName', newsletterId);
+	formData.append('ref', pageRef);
+	formData.append('refViewId', refViewId);
+	formData.append('name', '');
+	formData.append('g-recaptcha-response', token);
+
+	if (marketingOptIn !== undefined) {
+		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (browserId !== undefined) {
+		formData.append('browserId', browserId);
+	}
+
+	return formData;
+};
+
+/**
+ * Fetch the user's email from Identity if they are signed in.
+ *
+ * Previously named `resolveEmailIfSignedIn`, but only checked that `idApiUrl`
+ * was configured — it would fire for every visitor. Now it takes the real
+ * sign-in state and bails out for signed-out / pending users.
+ */
+const resolveUserEmail = async (
+	isSignedIn: boolean | 'Pending',
+): Promise<string | undefined> => {
+	if (isSignedIn !== true) return;
+	const { idApiUrl } = window.guardian.config.page;
+	if (!idApiUrl) return;
+	const fetchedEmail = await lazyFetchEmailWithTimeout()();
+	return fetchedEmail ?? undefined;
+};
+
+const postFormData = async (
+	endpoint: string,
+	formData: FormData,
+): Promise<Response> => {
+	const requestBodyStrings: string[] = [];
+
+	for (const [key, value] of formData.entries()) {
+		requestBodyStrings.push(
+			`${encodeURIComponent(key)}=${encodeURIComponent(
+				// eslint-disable-next-line @typescript-eslint/no-base-to-string -- value.toString() is safe here as we are dealing with FormData entries
+				value.toString(),
+			)}`,
+		);
+	}
+
+	return fetch(endpoint, {
+		method: 'POST',
+		body: requestBodyStrings.join('&'),
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+	});
+};
+
+type EventDescription =
+	| 'click-button'
+	| 'form-submission'
+	| 'submission-confirmed'
+	| 'submission-failed'
+	| 'open-captcha'
+	| 'captcha-load-error'
+	| 'form-submit-error'
+	| 'captcha-not-passed'
+	| 'captcha-passed';
+
+const actionForEventDescription = (
+	eventDescription: EventDescription,
+): TAction => {
+	switch (eventDescription) {
+		case 'form-submission':
+		case 'captcha-not-passed':
+		case 'captcha-passed':
+			return 'ANSWER';
+		case 'submission-confirmed':
+			return 'SUBSCRIBE';
+		case 'captcha-load-error':
+		case 'form-submit-error':
+		case 'submission-failed':
+			return 'CLOSE';
+		case 'open-captcha':
+			return 'EXPAND';
+		case 'click-button':
+			return 'CLICK';
+	}
+};
+
+const sendTracking = (
+	newsletterId: string,
+	eventDescription: EventDescription,
+	renderingTarget: RenderingTarget,
+): void => {
+	const value = JSON.stringify({
+		eventDescription,
+		newsletterId,
+		timestamp: Date.now(),
+	});
+
+	void submitComponentEvent(
+		{
+			action: actionForEventDescription(eventDescription),
+			value,
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: `AR NewsletterSignupForm ${newsletterId}`,
+			},
+		},
+		renderingTarget,
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type NewsletterSignupFormState = {
+	/** The email address currently in the field (or resolved from Identity). */
+	userEmail: string | undefined;
+	/**
+	 * `true` once we've successfully pre-filled the email from Identity, which
+	 * means the email `<input>` should be hidden.
+	 *
+	 * NOTE: this is NOT the same as "the user is signed in" — the Identity
+	 * fetch can fail or time out even for signed-in users. Consumers that
+	 * need the real sign-in state should call `useIsSignedIn` directly.
+	 */
+	isSignedIn: boolean;
+	/**
+	 * `true` once the user has focused or typed in the email field, or when
+	 * the user's email was pre-filled. Reveals the marketing toggle and
+	 * privacy message.
+	 */
+	isInteracted: boolean;
+	/** `true` for signed-out users — shows the marketing opt-in toggle. */
+	showMarketingToggle: boolean;
+	marketingOptIn: boolean | undefined;
+
+	/** `true` while the POST request is in-flight. */
+	isWaitingForResponse: boolean;
+	/**
+	 * `true`  → subscription confirmed
+	 * `false` → server returned a non-2xx response
+	 * `undefined` → no response yet
+	 */
+	responseOk: boolean | undefined;
+	/** Inline validation / network error copy. */
+	errorMessage: string | undefined;
+
+	/** Ref to pass to the `<ReactGoogleRecaptcha>` widget. */
+	recaptchaRef: RefObject<ReactGoogleRecaptcha>;
+	/** Site key for the reCAPTCHA widget — `undefined` until resolved. */
+	captchaSiteKey: string | undefined;
+	/** Pass to `ReactGoogleRecaptcha`'s `onChange` prop. */
+	handleCaptchaComplete: (token: string | null) => void;
+	/** Pass to `ReactGoogleRecaptcha`'s `onError` prop. */
+	handleCaptchaLoadError: () => void;
+
+	// Event handlers
+	handleEmailChange: (value: string) => void;
+	handleEmailFocus: () => void;
+	handleEmailInvalid: React.FormEventHandler<HTMLInputElement>;
+	handleMarketingToggle: ReactEventHandler<HTMLButtonElement>;
+	handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+	handleSubmitButtonClick: () => void;
+	handleReset: ReactEventHandler<HTMLButtonElement>;
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Encapsulates all state and side-effects for the newsletter signup form.
+ * The component itself only needs to call this hook and render the returned
+ * state — making every visual state trivially reproducible in Storybook by
+ * mocking this hook.
+ */
+export const useNewsletterSignupForm = (
+	newsletterId: string,
+	renderingTarget: RenderingTarget,
+): NewsletterSignupFormState => {
+	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
+	const [captchaSiteKey, setCaptchaSiteKey] = useState<string>();
+	const [userEmail, setUserEmail] = useState<string>();
+	const [hasPrefilledEmail, setHasPrefilledEmail] = useState(false);
+	const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+	const [responseOk, setResponseOk] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [errorMessage, setErrorMessage] = useState<string | undefined>(
+		undefined,
+	);
+	const [marketingOptIn, setMarketingOptIn] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [isInteracted, setIsInteracted] = useState(false);
+
+	const isSignedIn = useIsSignedIn();
+	const authStatus = useAuthStatus();
+	const browserId = useBrowserId();
+
+	// Refs that mirror state — read inside submit handlers so we always see the
+	// latest value rather than whatever was captured when the handler was
+	// created. This avoids the stale-closure bug where a user could toggle
+	// marketing opt-in between pressing Sign Up and the captcha resolving.
+	const marketingOptInRef = useRef(marketingOptIn);
+	const browserIdRef = useRef(browserId);
+	const authStatusRef = useRef(authStatus);
+	useEffect(() => {
+		marketingOptInRef.current = marketingOptIn;
+	}, [marketingOptIn]);
+	useEffect(() => {
+		browserIdRef.current = browserId;
+	}, [browserId]);
+	useEffect(() => {
+		authStatusRef.current = authStatus;
+	}, [authStatus]);
+
+	// The email address that was validated at submit-time. We stash it in a
+	// ref and read it back when the captcha resolves, so it can't change out
+	// from under us between validation and POST.
+	const pendingEmailRef = useRef<string | undefined>(undefined);
+
+	// Track whether the user has attempted to submit, so we only show inline
+	// validation errors from the `invalid` event after a submit attempt —
+	// not on focus/blur or other browser-triggered validity checks.
+	const hasAttemptedSubmitRef = useRef(false);
+
+	// Default marketing opt-in to `true` for signed-out users, but only once —
+	// guard with a ref so flipping `isSignedIn` later (e.g. token expiry)
+	// doesn't overwrite the user's choice.
+	const marketingDefaultAppliedRef = useRef(false);
+	useEffect(() => {
+		if (marketingDefaultAppliedRef.current) return;
+		if (isSignedIn === 'Pending') return;
+		if (!isSignedIn) {
+			setMarketingOptIn(true);
+		}
+		marketingDefaultAppliedRef.current = true;
+	}, [isSignedIn]);
+
+	// Pre-fill the email from Identity once sign-in status is known.
+	// Guarded with a ref so we don't re-fetch if the hook re-mounts or
+	// `isSignedIn` briefly flips.
+	const emailFetchStartedRef = useRef(false);
+	useEffect(() => {
+		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
+	}, []);
+	useEffect(() => {
+		if (emailFetchStartedRef.current) return;
+		if (isSignedIn === 'Pending') return;
+		emailFetchStartedRef.current = true;
+
+		void resolveUserEmail(isSignedIn).then((email) => {
+			if (!isString(email)) return;
+			setUserEmail(email);
+			setHasPrefilledEmail(true);
+			setIsInteracted(true);
+		});
+	}, [isSignedIn]);
+
+	const submitForm = useCallback(
+		async (emailAddress: string, token: string): Promise<void> => {
+			sendTracking(newsletterId, 'form-submission', renderingTarget);
+
+			const formData = buildFormData(
+				emailAddress,
+				newsletterId,
+				token,
+				marketingOptInRef.current,
+				browserIdRef.current,
+			);
+
+			const response = await postFormData(
+				window.guardian.config.page.ajaxUrl + '/email',
+				formData,
+			);
+
+			try {
+				if (response.ok && authStatusRef.current.kind === 'SignedIn') {
+					clearSubscriptionCache();
+				}
+			} catch (error) {
+				// Don't let a cache-clear failure block the UI state update below.
+				// eslint-disable-next-line no-console -- unexpected error
+				console.error(error);
+			}
+
+			setResponseOk(response.ok);
+
+			sendTracking(
+				newsletterId,
+				response.ok ? 'submission-confirmed' : 'submission-failed',
+				renderingTarget,
+			);
+		},
+		[newsletterId, renderingTarget],
+	);
+
+	const handleCaptchaComplete = useCallback(
+		(token: string | null): void => {
+			if (!token) {
+				sendTracking(
+					newsletterId,
+					'captcha-not-passed',
+					renderingTarget,
+				);
+				setIsWaitingForResponse(false);
+				return;
+			}
+			sendTracking(newsletterId, 'captcha-passed', renderingTarget);
+			// Read the email that was validated at submit-time — not the
+			// current value, which may have been edited since.
+			const emailAddress = pendingEmailRef.current ?? '';
+			submitForm(emailAddress, token)
+				.catch((error) => {
+					// eslint-disable-next-line no-console -- unexpected error
+					console.error(error);
+					sendTracking(
+						newsletterId,
+						'form-submit-error',
+						renderingTarget,
+					);
+					setErrorMessage(
+						'Sorry, there was an error signing you up.',
+					);
+					recaptchaRef.current?.reset();
+				})
+				.finally(() => {
+					setIsWaitingForResponse(false);
+				});
+		},
+		[newsletterId, renderingTarget, submitForm],
+	);
+
+	const handleCaptchaLoadError = useCallback((): void => {
+		sendTracking(newsletterId, 'captcha-load-error', renderingTarget);
+		setErrorMessage('Sorry, the reCAPTCHA failed to load.');
+		recaptchaRef.current?.reset();
+	}, [newsletterId, renderingTarget]);
+
+	const handleSubmit = useCallback(
+		(event: FormEvent<HTMLFormElement>): void => {
+			event.preventDefault();
+			if (isWaitingForResponse) return;
+
+			const emailAddress = userEmail?.trim() ?? '';
+			if (!emailAddress) {
+				setErrorMessage('Please enter your email address.');
+				return;
+			}
+
+			pendingEmailRef.current = emailAddress;
+			setErrorMessage(undefined);
+			setIsWaitingForResponse(true);
+			sendTracking(newsletterId, 'open-captcha', renderingTarget);
+			recaptchaRef.current?.execute();
+		},
+		[isWaitingForResponse, newsletterId, renderingTarget, userEmail],
+	);
+
+	const handleEmailChange = useCallback((value: string): void => {
+		setUserEmail(value);
+		setIsInteracted(true);
+		setErrorMessage(undefined);
+	}, []);
+
+	const handleEmailFocus = useCallback((): void => {
+		setIsInteracted(true);
+	}, []);
+
+	const handleEmailInvalid = useCallback<
+		React.FormEventHandler<HTMLInputElement>
+	>((event) => {
+		event.preventDefault();
+		if (!hasAttemptedSubmitRef.current) return;
+		const { validity } = event.currentTarget;
+		setErrorMessage(
+			validity.valueMissing
+				? 'Please enter your email address.'
+				: 'Incorrect email format. Please check.',
+		);
+	}, []);
+
+	const handleMarketingToggle = useCallback<
+		ReactEventHandler<HTMLButtonElement>
+	>((event) => {
+		event.preventDefault();
+		setMarketingOptIn((prev) => !prev);
+	}, []);
+
+	const handleSubmitButtonClick = useCallback((): void => {
+		hasAttemptedSubmitRef.current = true;
+		sendTracking(newsletterId, 'click-button', renderingTarget);
+	}, [newsletterId, renderingTarget]);
+
+	const handleReset = useCallback<
+		ReactEventHandler<HTMLButtonElement>
+	>(() => {
+		setErrorMessage(undefined);
+		setResponseOk(undefined);
+		hasAttemptedSubmitRef.current = false;
+	}, []);
+
+	// Memoise the returned object so referential equality holds across renders
+	// when none of the fields have changed — important for any memoised
+	// children the consumer renders.
+	return useMemo<NewsletterSignupFormState>(
+		() => ({
+			userEmail,
+			isSignedIn: hasPrefilledEmail,
+			isInteracted,
+			showMarketingToggle: isSignedIn === false,
+			marketingOptIn,
+			isWaitingForResponse,
+			responseOk,
+			errorMessage,
+			recaptchaRef,
+			captchaSiteKey,
+			handleCaptchaComplete,
+			handleCaptchaLoadError,
+			handleEmailChange,
+			handleEmailFocus,
+			handleEmailInvalid,
+			handleMarketingToggle,
+			handleSubmit,
+			handleSubmitButtonClick,
+			handleReset,
+		}),
+		[
+			userEmail,
+			hasPrefilledEmail,
+			isInteracted,
+			isSignedIn,
+			marketingOptIn,
+			isWaitingForResponse,
+			responseOk,
+			errorMessage,
+			captchaSiteKey,
+			handleCaptchaComplete,
+			handleCaptchaLoadError,
+			handleEmailChange,
+			handleEmailFocus,
+			handleEmailInvalid,
+			handleMarketingToggle,
+			handleSubmit,
+			handleSubmitButtonClick,
+			handleReset,
+		],
+	);
+};

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -32,7 +32,9 @@ const buildFormData = (
 	formData.append('ref', pageRef);
 	formData.append('refViewId', refViewId);
 	formData.append('name', '');
-	formData.append('g-recaptcha-response', token);
+	if (window.guardian.config.switches.emailSignupRecaptcha) {
+		formData.append('g-recaptcha-response', token);
+	}
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
@@ -434,6 +436,7 @@ export const useNewsletterSignupForm = (
 		setErrorMessage(undefined);
 		setResponseOk(undefined);
 		hasAttemptedSubmitRef.current = false;
+		recaptchaRef.current?.reset();
 	}, []);
 
 	return {

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -2,7 +2,7 @@ import { isString } from '@guardian/libs';
 import type { TAction } from '@guardian/ophan-tracker-js';
 import type { FormEvent, ReactEventHandler, RefObject } from 'react';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { submitComponentEvent } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -436,50 +436,25 @@ export const useNewsletterSignupForm = (
 		hasAttemptedSubmitRef.current = false;
 	}, []);
 
-	// Memoise the returned object so referential equality holds across renders
-	// when none of the fields have changed — important for any memoised
-	// children the consumer renders.
-	return useMemo<NewsletterSignupFormState>(
-		() => ({
-			userEmail,
-			isSignedIn: hasPrefilledEmail,
-			isInteracted,
-			showMarketingToggle: isSignedIn === false,
-			marketingOptIn,
-			isWaitingForResponse,
-			responseOk,
-			errorMessage,
-			recaptchaRef,
-			captchaSiteKey,
-			handleCaptchaComplete,
-			handleCaptchaLoadError,
-			handleEmailChange,
-			handleEmailFocus,
-			handleEmailInvalid,
-			handleMarketingToggle,
-			handleSubmit,
-			handleSubmitButtonClick,
-			handleReset,
-		}),
-		[
-			userEmail,
-			hasPrefilledEmail,
-			isInteracted,
-			isSignedIn,
-			marketingOptIn,
-			isWaitingForResponse,
-			responseOk,
-			errorMessage,
-			captchaSiteKey,
-			handleCaptchaComplete,
-			handleCaptchaLoadError,
-			handleEmailChange,
-			handleEmailFocus,
-			handleEmailInvalid,
-			handleMarketingToggle,
-			handleSubmit,
-			handleSubmitButtonClick,
-			handleReset,
-		],
-	);
+	return {
+		userEmail,
+		isSignedIn: hasPrefilledEmail,
+		isInteracted,
+		showMarketingToggle: isSignedIn === false,
+		marketingOptIn,
+		isWaitingForResponse,
+		responseOk,
+		errorMessage,
+		recaptchaRef,
+		captchaSiteKey,
+		handleCaptchaComplete,
+		handleCaptchaLoadError,
+		handleEmailChange,
+		handleEmailFocus,
+		handleEmailInvalid,
+		handleMarketingToggle,
+		handleSubmit,
+		handleSubmitButtonClick,
+		handleReset,
+	};
 };

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7630,10 +7630,8 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[46],
 	},
 	'--newsletter-preview-button-hover': {
-		light: () => sourcePalette.neutral[97],
-		dark: () =>
-			themeButtonBrand.backgroundTertiaryHover ??
-			sourcePalette.brand[300],
+		light: () => sourcePalette.brand[800],
+		dark: () => sourcePalette.brand[300],
 	},
 	'--newsletter-preview-button-text': {
 		light: () => sourcePalette.brand[400],
@@ -7648,23 +7646,20 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[100],
 	},
 	'--newsletter-signup-submit-background': {
-		light: () => themeButton.backgroundPrimary,
-		dark: () => themeButtonBrand.backgroundPrimary,
+		light: () => sourcePalette.brand[400],
+		dark: () => sourcePalette.neutral[100],
 	},
 	'--newsletter-signup-submit-background-hover': {
-		light: () =>
-			themeButton.backgroundPrimaryHover ?? themeButton.backgroundPrimary,
-		dark: () =>
-			themeButtonBrand.backgroundPrimaryHover ??
-			themeButtonBrand.backgroundPrimary,
+		light: () => sourcePalette.brand[600],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--newsletter-signup-submit-text': {
-		light: () => themeButton.textPrimary,
-		dark: () => themeButtonBrand.textPrimary,
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.brand[400],
 	},
 	'--newsletter-signup-toggle-text': {
 		light: () => sourcePalette.neutral[20],
-		dark: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[73],
 	},
 	'--numbered-list-heading': {
 		light: numberedListHeadingLight,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -5164,7 +5164,7 @@ const privacyTextSupportingLight: PaletteFunction = () =>
 const privacyTextSupportingSubduedLight: PaletteFunction = () =>
 	sourcePalette.neutral[46];
 const privacyTextSupportingSubduedDark: PaletteFunction = () =>
-	sourcePalette.neutral[60];
+	sourcePalette.neutral[73];
 
 const productCarouselCardBorderLight: PaletteFunction = () =>
 	sourcePalette.neutral[86];
@@ -7631,11 +7631,40 @@ const paletteColours = {
 	},
 	'--newsletter-preview-button-hover': {
 		light: () => sourcePalette.neutral[97],
-		dark: () => sourcePalette.neutral[20],
+		dark: () =>
+			themeButtonBrand.backgroundTertiaryHover ??
+			sourcePalette.brand[300],
 	},
 	'--newsletter-preview-button-text': {
 		light: () => sourcePalette.brand[400],
 		dark: () => sourcePalette.neutral[100],
+	},
+	'--newsletter-signup-input-background': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.brand[300],
+	},
+	'--newsletter-signup-input-text': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[100],
+	},
+	'--newsletter-signup-submit-background': {
+		light: () => themeButton.backgroundPrimary,
+		dark: () => themeButtonBrand.backgroundPrimary,
+	},
+	'--newsletter-signup-submit-background-hover': {
+		light: () =>
+			themeButton.backgroundPrimaryHover ?? themeButton.backgroundPrimary,
+		dark: () =>
+			themeButtonBrand.backgroundPrimaryHover ??
+			themeButtonBrand.backgroundPrimary,
+	},
+	'--newsletter-signup-submit-text': {
+		light: () => themeButton.textPrimary,
+		dark: () => themeButtonBrand.textPrimary,
+	},
+	'--newsletter-signup-toggle-text': {
+		light: () => sourcePalette.neutral[20],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--numbered-list-heading': {
 		light: numberedListHeadingLight,


### PR DESCRIPTION
## What does this change?

Implements the signed-in and signed-out flows for the new `NewsletterSignupForm` component, closing issues #15678 and #15686.

### New components & files

- **`NewsletterSignupForm.island.tsx`** — the new auth-aware signup form, replacing `SecureSignup` as the inner content of the newsletter signup card when `showNewNewsletterSignupCard` is enabled. Supports both signed-in (email pre-filled from Identity, email input hidden) and signed-out (email input visible) states in a single component.
- **`useNewsletterSignupForm.ts`** — a custom hook that encapsulates all form state and side-effects (email resolution, reCAPTCHA, Ophan tracking, form submission). Extracted from the component so that every visual state is trivially reproducible in Storybook by mocking a single hook, and to keep the component itself as a pure rendering layer.

### Signed-in flow (closes #15678)
- Email is pre-filled from Identity; the email `<input>` is hidden
- "Sign up" button is shown; on success, displays "You're signed up!", the newsletter name & frequency, and a "Browse more newsletters" link
- Privacy message is rendered outside the card (below it), since the marketing toggle is not shown for signed-in users
- Ophan tracking reuses the same interaction lifecycle as `SecureSignup`

### Signed-out flow (closes #15686)
- Email input with "Enter your email" label and a "Sign up" button
- Marketing opt-in toggle and privacy message are revealed when the email field is focused/interacted with
- Inline validation error shown for empty or incorrectly formatted email
- Same success state as the signed-in flow after submission completes
- Ophan tracking reuses the same interaction lifecycle as `SecureSignup`

### Why a custom hook?

All form logic (email fetch, reCAPTCHA, marketing opt-in, Ophan tracking, submission, validation) lives in `useNewsletterSignupForm`. This separation means:
1. **Storybook screenshots are easy** — every visual state (idle, focused, loading, success, failure, validation error) can be covered by mocking the single hook return value, with no need to stub network requests or drive interactions.
2. **The component stays thin** — `NewsletterSignupFormActive` is purely a rendering layer, making it straightforward to review and maintain.

### Refactored from `SecureSignup`

The submission and tracking logic (`buildFormData`, `postFormData`, `sendTracking`) has been lifted from `SecureSignup.island.tsx` and consolidated into `useNewsletterSignupForm`. `SecureSignup` was previously used as an intermediate placeholder inside the new card; it is now replaced by `NewsletterSignupForm`.

### Other changes
- `NewsletterSignupCardContainer` updated to accept a render-prop `children` (so it can pass `openPreview` down), and now renders the privacy message outside the card when the user is signed in
- `EmailSignUpWrapper` wired up to pass `isSignedIn` and the new form props through to `NewsletterSignupCardContainer`
- `renderElement.tsx` prop name corrected (`showNewsletterSignupCard` → `showNewNewsletterSignupCard`)
- Minor `NewsletterSignupCard` style tweaks (illustration size, spacing)

## Why?

Part of the rollout of the new newsletter signup card design. This PR delivers the complete signup experience for both signed-in and signed-out readers.
