### PR TITLE
15743 implement skeleton loading for newsletter preview iframe

### DIFF
--- a/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { NewsletterPreviewModal } from './NewsletterPreviewModal';
 
 const baseProps = {
@@ -154,6 +154,62 @@ describe('NewsletterPreviewModal', () => {
 			}
 			document.documentElement.style.overflow = previousRootOverflow;
 			document.body.style.overflow = previousBodyOverflow;
+		}
+	});
+
+	it('shows a skeleton while loading and hides it once iframe is loaded', () => {
+		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+
+		expect(
+			screen.getByLabelText('Loading newsletter preview'),
+		).toBeInTheDocument();
+
+		const iframe = screen.getByTitle('Morning Briefing preview');
+		fireEvent.load(iframe);
+
+		expect(
+			screen.queryByLabelText('Loading newsletter preview'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('Preview failed to load'),
+		).not.toBeInTheDocument();
+	});
+
+	it('shows a timeout fallback and allows retrying the preview load', () => {
+		jest.useFakeTimers();
+
+		try {
+			render(
+				<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />,
+			);
+
+			act(() => {
+				jest.advanceTimersByTime(10_000);
+			});
+
+			expect(
+				screen.getByText('Preview failed to load'),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole('button', { name: 'Retry preview' }),
+			).toBeInTheDocument();
+
+			fireEvent.click(
+				screen.getByRole('button', { name: 'Retry preview' }),
+			);
+
+			expect(
+				screen.getByLabelText('Loading newsletter preview'),
+			).toBeInTheDocument();
+
+			const iframe = screen.getByTitle('Morning Briefing preview');
+			fireEvent.load(iframe);
+
+			expect(
+				screen.queryByText('Preview failed to load'),
+			).not.toBeInTheDocument();
+		} finally {
+			jest.useRealTimers();
 		}
 	});
 });

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
@@ -5,10 +5,14 @@ import { NewsletterPreviewModal } from './NewsletterPreviewModal';
 const baseProps = {
 	newsletterName: 'Morning Briefing',
 	renderUrl:
-		'https://email-rendering.guardianapis.com/fronts/email/europe/daily?variant=persephone&readonly=true',
+		'https://email-rendering.guardianapis.com/fronts/email/europe/daily?variant=persephone&readonly=true&embed=true',
 };
 
 describe('NewsletterPreviewModal', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('renders a labelled dialog and focuses it on mount', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
 
@@ -191,6 +195,11 @@ describe('NewsletterPreviewModal', () => {
 				screen.getByText('Preview failed to load'),
 			).toBeInTheDocument();
 			expect(
+				screen.getByText(
+					'The preview is taking longer than expected. You can retry loading it.',
+				),
+			).toBeInTheDocument();
+			expect(
 				screen.getByRole('button', { name: 'Retry preview' }),
 			).toBeInTheDocument();
 
@@ -211,5 +220,73 @@ describe('NewsletterPreviewModal', () => {
 		} finally {
 			jest.useRealTimers();
 		}
+	});
+
+	it('shows failure state when iframe posts embed-status with ok=false', () => {
+		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					origin: 'https://email-rendering.guardianapis.com',
+					data: { type: 'embed-status', ok: false, code: 500 },
+				}),
+			);
+		});
+
+		expect(screen.getByText('Preview failed to load')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'This preview is currently unavailable. Please try again shortly.',
+			),
+		).toBeInTheDocument();
+	});
+
+	it('keeps failure state when embed-status reports failure before iframe load event', () => {
+		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+
+		const iframe = screen.getByTitle('Morning Briefing preview');
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					origin: 'https://email-rendering.guardianapis.com',
+					data: { type: 'embed-status', ok: false },
+				}),
+			);
+		});
+
+		fireEvent.load(iframe);
+
+		expect(screen.getByText('Preview failed to load')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'This preview is currently unavailable. Please try again shortly.',
+			),
+		).toBeInTheDocument();
+	});
+
+	it('hides skeleton when iframe posts embed-status with ok=true', () => {
+		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+
+		expect(
+			screen.getByLabelText('Loading newsletter preview'),
+		).toBeInTheDocument();
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					origin: 'https://email-rendering.guardianapis.com',
+					data: { type: 'embed-status', ok: true },
+				}),
+			);
+		});
+
+		expect(
+			screen.queryByLabelText('Loading newsletter preview'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('Preview failed to load'),
+		).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
@@ -224,11 +224,19 @@ describe('NewsletterPreviewModal', () => {
 
 	it('shows failure state when iframe posts embed-status with ok=false', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+		const iframe = screen.getByTitle(
+			'Morning Briefing preview',
+		) as HTMLIFrameElement;
+		const iframeSource = iframe.contentWindow;
+		if (!iframeSource) {
+			throw new Error('Expected iframe contentWindow to be available');
+		}
 
 		act(() => {
 			window.dispatchEvent(
 				new MessageEvent('message', {
 					origin: 'https://email-rendering.guardianapis.com',
+					source: iframeSource,
 					data: { type: 'embed-status', ok: false, code: 500 },
 				}),
 			);
@@ -245,12 +253,19 @@ describe('NewsletterPreviewModal', () => {
 	it('keeps failure state when embed-status reports failure before iframe load event', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
 
-		const iframe = screen.getByTitle('Morning Briefing preview');
+		const iframe = screen.getByTitle(
+			'Morning Briefing preview',
+		) as HTMLIFrameElement;
+		const iframeSource = iframe.contentWindow;
+		if (!iframeSource) {
+			throw new Error('Expected iframe contentWindow to be available');
+		}
 
 		act(() => {
 			window.dispatchEvent(
 				new MessageEvent('message', {
 					origin: 'https://email-rendering.guardianapis.com',
+					source: iframeSource,
 					data: { type: 'embed-status', ok: false },
 				}),
 			);
@@ -268,6 +283,13 @@ describe('NewsletterPreviewModal', () => {
 
 	it('hides skeleton when iframe posts embed-status with ok=true', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+		const iframe = screen.getByTitle(
+			'Morning Briefing preview',
+		) as HTMLIFrameElement;
+		const iframeSource = iframe.contentWindow;
+		if (!iframeSource) {
+			throw new Error('Expected iframe contentWindow to be available');
+		}
 
 		expect(
 			screen.getByLabelText('Loading newsletter preview'),
@@ -277,6 +299,7 @@ describe('NewsletterPreviewModal', () => {
 			window.dispatchEvent(
 				new MessageEvent('message', {
 					origin: 'https://email-rendering.guardianapis.com',
+					source: iframeSource,
 					data: { type: 'embed-status', ok: true },
 				}),
 			);
@@ -285,6 +308,26 @@ describe('NewsletterPreviewModal', () => {
 		expect(
 			screen.queryByLabelText('Loading newsletter preview'),
 		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('Preview failed to load'),
+		).not.toBeInTheDocument();
+	});
+
+	it('ignores embed-status messages without a matching iframe source', () => {
+		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent('message', {
+					origin: 'https://email-rendering.guardianapis.com',
+					data: { type: 'embed-status', ok: false },
+				}),
+			);
+		});
+
+		expect(
+			screen.getByLabelText('Loading newsletter preview'),
+		).toBeInTheDocument();
 		expect(
 			screen.queryByText('Preview failed to load'),
 		).not.toBeInTheDocument();

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.test.tsx
@@ -224,9 +224,10 @@ describe('NewsletterPreviewModal', () => {
 
 	it('shows failure state when iframe posts embed-status with ok=false', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
-		const iframe = screen.getByTitle(
-			'Morning Briefing preview',
-		) as HTMLIFrameElement;
+		const iframe = screen.getByTitle('Morning Briefing preview');
+		if (!(iframe instanceof HTMLIFrameElement)) {
+			throw new Error('Expected preview element to be an iframe');
+		}
 		const iframeSource = iframe.contentWindow;
 		if (!iframeSource) {
 			throw new Error('Expected iframe contentWindow to be available');
@@ -253,9 +254,10 @@ describe('NewsletterPreviewModal', () => {
 	it('keeps failure state when embed-status reports failure before iframe load event', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
 
-		const iframe = screen.getByTitle(
-			'Morning Briefing preview',
-		) as HTMLIFrameElement;
+		const iframe = screen.getByTitle('Morning Briefing preview');
+		if (!(iframe instanceof HTMLIFrameElement)) {
+			throw new Error('Expected preview element to be an iframe');
+		}
 		const iframeSource = iframe.contentWindow;
 		if (!iframeSource) {
 			throw new Error('Expected iframe contentWindow to be available');
@@ -283,9 +285,10 @@ describe('NewsletterPreviewModal', () => {
 
 	it('hides skeleton when iframe posts embed-status with ok=true', () => {
 		render(<NewsletterPreviewModal {...baseProps} onClose={jest.fn()} />);
-		const iframe = screen.getByTitle(
-			'Morning Briefing preview',
-		) as HTMLIFrameElement;
+		const iframe = screen.getByTitle('Morning Briefing preview');
+		if (!(iframe instanceof HTMLIFrameElement)) {
+			throw new Error('Expected preview element to be an iframe');
+		}
 		const iframeSource = iframe.contentWindow;
 		if (!iframeSource) {
 			throw new Error('Expected iframe contentWindow to be available');

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -13,6 +13,65 @@ import { createPortal } from 'react-dom';
 import { getZIndex } from '../lib/getZIndex';
 
 const PREVIEW_LOAD_TIMEOUT_MS = 10_000;
+const TIMEOUT_FAILURE_MESSAGE =
+	'The preview is taking longer than expected. You can retry loading it.';
+const UNAVAILABLE_FAILURE_MESSAGE =
+	'This preview is currently unavailable. Please try again shortly.';
+
+type EmbedStatusMessage = {
+	type: 'embed-status';
+	ok: boolean;
+};
+
+const parseEmbedStatusMessage = (
+	data: unknown,
+): EmbedStatusMessage | undefined => {
+	let payload: unknown = data;
+
+	if (typeof payload === 'string') {
+		try {
+			payload = JSON.parse(payload);
+		} catch {
+			return undefined;
+		}
+	}
+
+	if (!payload || typeof payload !== 'object') return undefined;
+
+	const { type, ok } = payload as {
+		type?: unknown;
+		ok?: unknown;
+	};
+
+	if (type !== 'embed-status' || typeof ok !== 'boolean') return undefined;
+
+	return {
+		type: 'embed-status',
+		ok,
+	};
+};
+
+const isTrustedIframeMessage = ({
+	event,
+	trustedOrigin,
+	iframeWindow,
+}: {
+	event: MessageEvent;
+	trustedOrigin: string;
+	iframeWindow: Window | null;
+}): boolean => {
+	const isTrustedOrigin = event.origin === trustedOrigin;
+	const isUnexpectedSource =
+		iframeWindow !== null &&
+		event.source !== null &&
+		event.source !== iframeWindow;
+
+	if (!isTrustedOrigin || isUnexpectedSource) {
+		return false;
+	}
+
+	return true;
+};
 
 const FOCUSABLE_SELECTOR =
 	'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
@@ -249,10 +308,28 @@ export const NewsletterPreviewModal = ({
 	onClose,
 }: Props) => {
 	const dialogRef = useRef<HTMLDivElement>(null);
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const hasEmbedStatusFailureRef = useRef(false);
 	const titleId = useId();
 	const [isLoading, setIsLoading] = useState(true);
 	const [hasLoadFailed, setHasLoadFailed] = useState(false);
+	const [failureMessage, setFailureMessage] = useState(
+		UNAVAILABLE_FAILURE_MESSAGE,
+	);
 	const [iframeKey, setIframeKey] = useState(0);
+
+	const trustedIframeOrigin = new URL(renderUrl).origin;
+
+	const applyEmbedStatus = (ok: boolean) => {
+		hasEmbedStatusFailureRef.current = !ok;
+
+		if (!ok) {
+			setFailureMessage(UNAVAILABLE_FAILURE_MESSAGE);
+		}
+
+		setIsLoading(false);
+		setHasLoadFailed(!ok);
+	};
 
 	const getVisibleFocusableElements = (dialog: HTMLElement): HTMLElement[] =>
 		Array.from(
@@ -368,14 +445,17 @@ export const NewsletterPreviewModal = ({
 	}, [onClose]);
 
 	useEffect(() => {
+		hasEmbedStatusFailureRef.current = false;
 		setIsLoading(true);
 		setHasLoadFailed(false);
+		setFailureMessage(UNAVAILABLE_FAILURE_MESSAGE);
 	}, [renderUrl, iframeKey]);
 
 	useEffect(() => {
 		if (!isLoading) return;
 
 		const timeoutId = window.setTimeout(() => {
+			setFailureMessage(TIMEOUT_FAILURE_MESSAGE);
 			setHasLoadFailed(true);
 			setIsLoading(false);
 		}, PREVIEW_LOAD_TIMEOUT_MS);
@@ -385,12 +465,42 @@ export const NewsletterPreviewModal = ({
 		};
 	}, [isLoading]);
 
+	useEffect(() => {
+		const handleMessage = (event: MessageEvent) => {
+			if (!iframeRef.current) return;
+
+			const iframeWindow = iframeRef.current.contentWindow;
+			if (
+				!isTrustedIframeMessage({
+					event,
+					trustedOrigin: trustedIframeOrigin,
+					iframeWindow,
+				})
+			) {
+				return;
+			}
+
+			const embedStatusMessage = parseEmbedStatusMessage(event.data);
+			if (!embedStatusMessage) return;
+
+			applyEmbedStatus(embedStatusMessage.ok);
+		};
+
+		window.addEventListener('message', handleMessage);
+
+		return () => {
+			window.removeEventListener('message', handleMessage);
+		};
+	}, [trustedIframeOrigin]);
+
 	const handleIframeLoad = () => {
+		if (hasEmbedStatusFailureRef.current) return;
 		setIsLoading(false);
 		setHasLoadFailed(false);
 	};
 
 	const handleIframeError = () => {
+		setFailureMessage(UNAVAILABLE_FAILURE_MESSAGE);
 		setHasLoadFailed(true);
 		setIsLoading(false);
 	};
@@ -451,8 +561,7 @@ export const NewsletterPreviewModal = ({
 									Preview failed to load
 								</h3>
 								<p css={previewStatusBodyStyles}>
-									The preview is taking longer than expected.
-									You can retry loading it.
+									{failureMessage}
 								</p>
 								<Button
 									size="small"
@@ -465,6 +574,7 @@ export const NewsletterPreviewModal = ({
 						</div>
 					)}
 					<iframe
+						ref={iframeRef}
 						key={iframeKey}
 						title={`${newsletterName} preview`}
 						src={renderUrl}

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -11,6 +11,7 @@ import { Button, SvgCross } from '@guardian/source/react-components';
 import { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getZIndex } from '../lib/getZIndex';
+import { EMAIL_PREVIEW_ORIGIN } from '../lib/newsletterPreviewUrl';
 
 const PREVIEW_LOAD_TIMEOUT_MS = 10_000;
 const TIMEOUT_FAILURE_MESSAGE =
@@ -51,6 +52,15 @@ const parseEmbedStatusMessage = (
 	};
 };
 
+const getTrustedIframeOrigin = (url: string): string | undefined => {
+	try {
+		const origin = new URL(url).origin;
+		return origin === EMAIL_PREVIEW_ORIGIN ? origin : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
 const isTrustedIframeMessage = ({
 	event,
 	trustedOrigin,
@@ -61,12 +71,10 @@ const isTrustedIframeMessage = ({
 	iframeWindow: Window | null;
 }): boolean => {
 	const isTrustedOrigin = event.origin === trustedOrigin;
-	const isUnexpectedSource =
-		iframeWindow !== null &&
-		event.source !== null &&
-		event.source !== iframeWindow;
+	const isExpectedSource =
+		iframeWindow !== null && event.source === iframeWindow;
 
-	if (!isTrustedOrigin || isUnexpectedSource) {
+	if (!isTrustedOrigin || !isExpectedSource) {
 		return false;
 	}
 
@@ -318,7 +326,7 @@ export const NewsletterPreviewModal = ({
 	);
 	const [iframeKey, setIframeKey] = useState(0);
 
-	const trustedIframeOrigin = new URL(renderUrl).origin;
+	const trustedIframeOrigin = getTrustedIframeOrigin(renderUrl);
 
 	const applyEmbedStatus = (ok: boolean) => {
 		hasEmbedStatusFailureRef.current = !ok;
@@ -466,6 +474,8 @@ export const NewsletterPreviewModal = ({
 	}, [isLoading]);
 
 	useEffect(() => {
+		if (!trustedIframeOrigin) return;
+
 		const handleMessage = (event: MessageEvent) => {
 			if (!iframeRef.current) return;
 

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -80,11 +80,6 @@ const previewFrameStyles = css`
 	border: 0;
 	background: ${palette.neutral[100]};
 	padding: 0;
-	min-width: 0;
-
-	${from.tablet} {
-		padding: 0;
-	}
 `;
 
 const previewFrameContainerStyles = css`
@@ -111,10 +106,10 @@ const previewLoadingOverlayStyles = css`
 	justify-content: flex-start;
 	padding: 0 ${space[3]}px ${space[4]}px;
 	background: ${palette.neutral[100]};
-	overflow-y: auto;
+	overflow-y: hidden;
 
 	${from.tablet} {
-		padding: 0 ${space[6]}px ${space[6]}px;
+		padding: 0 ${space[9]}px ${space[9]}px;
 	}
 `;
 
@@ -140,7 +135,7 @@ const previewSkeletonBlockStyles = css`
 	}
 `;
 
-const previewSkeletonLongStyles = css`
+const previewSkeletonBannerStyles = css`
 	${previewSkeletonBlockStyles};
 	height: 96px;
 `;
@@ -148,24 +143,12 @@ const previewSkeletonLongStyles = css`
 const previewSkeletonLargeStyles = css`
 	${previewSkeletonBlockStyles};
 	height: 332px;
-	margin-top: 16px;
+	margin: 16px 0;
 `;
 
-const previewSkeletonThirdStyles = css`
+const previewSkeletonSmallStyles = css`
 	${previewSkeletonBlockStyles};
 	height: 52px;
-	margin-top: 32px;
-`;
-
-const previewSkeletonFourthStyles = css`
-	${previewSkeletonBlockStyles};
-	height: 52px;
-	margin-top: 16px;
-`;
-
-const previewSkeletonFinalStyles = css`
-	${previewSkeletonBlockStyles};
-	height: 272px;
 	margin-top: 16px;
 `;
 
@@ -444,17 +427,17 @@ export const NewsletterPreviewModal = ({
 					</Button>
 				</div>
 				<div css={previewFrameContainerStyles}>
-					{true && (
+					{isLoading && (
 						<div
 							css={previewLoadingOverlayStyles}
 							aria-live="polite"
 							aria-label="Loading newsletter preview"
 						>
-							<div css={previewSkeletonLongStyles} />
+							<div css={previewSkeletonBannerStyles} />
 							<div css={previewSkeletonLargeStyles} />
-							<div css={previewSkeletonThirdStyles} />
-							<div css={previewSkeletonFourthStyles} />
-							<div css={previewSkeletonFinalStyles} />
+							<div css={previewSkeletonSmallStyles} />
+							<div css={previewSkeletonSmallStyles} />
+							<div css={previewSkeletonLargeStyles} />
 						</div>
 					)}
 					{hasLoadFailed && (

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -109,12 +109,12 @@ const previewLoadingOverlayStyles = css`
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
-	padding: ${space[4]}px ${space[3]}px;
+	padding: 0 ${space[3]}px ${space[4]}px;
 	background: ${palette.neutral[100]};
 	overflow-y: auto;
 
 	${from.tablet} {
-		padding: ${space[6]}px;
+		padding: 0 ${space[6]}px ${space[6]}px;
 	}
 `;
 
@@ -123,9 +123,9 @@ const previewSkeletonBlockStyles = css`
 	flex-shrink: 0;
 	background: linear-gradient(
 		90deg,
-		${palette.neutral[93]} 25%,
+		${palette.neutral[86]} 25%,
 		${palette.neutral[97]} 50%,
-		${palette.neutral[93]} 75%
+		${palette.neutral[86]} 75%
 	);
 	background-size: 200% 100%;
 	animation: preview-skeleton-shimmer 1.2s linear infinite;
@@ -167,14 +167,6 @@ const previewSkeletonFinalStyles = css`
 	${previewSkeletonBlockStyles};
 	height: 272px;
 	margin-top: 16px;
-	background: linear-gradient(
-		90deg,
-		${palette.neutral[93]} 25%,
-		${palette.neutral[97]} 50%,
-		${palette.neutral[93]} 75%
-	);
-	background-size: 200% 100%;
-	animation: preview-skeleton-shimmer 1.2s linear infinite;
 `;
 
 const previewStatusStyles = css`

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -108,8 +108,10 @@ const previewLoadingOverlayStyles = css`
 	inset: 0;
 	display: flex;
 	flex-direction: column;
+	justify-content: flex-start;
 	padding: ${space[4]}px ${space[3]}px;
 	background: ${palette.neutral[100]};
+	overflow-y: auto;
 
 	${from.tablet} {
 		padding: ${space[6]}px;
@@ -117,7 +119,8 @@ const previewLoadingOverlayStyles = css`
 `;
 
 const previewSkeletonBlockStyles = css`
-	height: 14px;
+	width: 100%;
+	flex-shrink: 0;
 	background: linear-gradient(
 		90deg,
 		${palette.neutral[93]} 25%,
@@ -139,36 +142,31 @@ const previewSkeletonBlockStyles = css`
 
 const previewSkeletonLongStyles = css`
 	${previewSkeletonBlockStyles};
-	width: 100%;
-	height: 64px;
+	height: 96px;
 `;
 
 const previewSkeletonLargeStyles = css`
 	${previewSkeletonBlockStyles};
-	width: 100%;
-	height: 272px;
-	margin-top: 12px;
+	height: 332px;
+	margin-top: 16px;
 `;
 
 const previewSkeletonThirdStyles = css`
 	${previewSkeletonBlockStyles};
-	width: 100%;
-	height: 36px;
-	margin-top: 30px;
+	height: 52px;
+	margin-top: 32px;
 `;
 
 const previewSkeletonFourthStyles = css`
 	${previewSkeletonBlockStyles};
-	width: 100%;
-	height: 36px;
-	margin-top: 12px;
+	height: 52px;
+	margin-top: 16px;
 `;
 
 const previewSkeletonFinalStyles = css`
 	${previewSkeletonBlockStyles};
-	width: 100%;
 	height: 272px;
-	margin-top: 12px;
+	margin-top: 16px;
 	background: linear-gradient(
 		90deg,
 		${palette.neutral[93]} 25%,
@@ -454,7 +452,7 @@ export const NewsletterPreviewModal = ({
 					</Button>
 				</div>
 				<div css={previewFrameContainerStyles}>
-					{isLoading && (
+					{true && (
 						<div
 							css={previewLoadingOverlayStyles}
 							aria-live="polite"

--- a/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewModal.tsx
@@ -5,11 +5,14 @@ import {
 	headlineMedium24,
 	palette,
 	space,
+	textSans15,
 } from '@guardian/source/foundations';
 import { Button, SvgCross } from '@guardian/source/react-components';
-import { useEffect, useId, useRef } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getZIndex } from '../lib/getZIndex';
+
+const PREVIEW_LOAD_TIMEOUT_MS = 10_000;
 
 const FOCUSABLE_SELECTOR =
 	'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
@@ -70,11 +73,141 @@ const previewTitleStyles = css`
 
 const previewFrameStyles = css`
 	flex: 1;
+	min-height: 0;
+	height: 100%;
 	width: 100%;
+	display: block;
+	border: 0;
+	background: ${palette.neutral[100]};
+	padding: 0;
+	min-width: 0;
+
+	${from.tablet} {
+		padding: 0;
+	}
+`;
+
+const previewFrameContainerStyles = css`
+	position: relative;
+	display: flex;
+	min-height: 0;
+	flex: 1;
+	background: ${palette.neutral[100]};
 
 	${from.tablet} {
 		padding: 0 ${space[6]}px;
 	}
+`;
+
+const previewIframeHiddenStyles = css`
+	visibility: hidden;
+`;
+
+const previewLoadingOverlayStyles = css`
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	padding: ${space[4]}px ${space[3]}px;
+	background: ${palette.neutral[100]};
+
+	${from.tablet} {
+		padding: ${space[6]}px;
+	}
+`;
+
+const previewSkeletonBlockStyles = css`
+	height: 14px;
+	background: linear-gradient(
+		90deg,
+		${palette.neutral[93]} 25%,
+		${palette.neutral[97]} 50%,
+		${palette.neutral[93]} 75%
+	);
+	background-size: 200% 100%;
+	animation: preview-skeleton-shimmer 1.2s linear infinite;
+
+	@keyframes preview-skeleton-shimmer {
+		from {
+			background-position: 200% 0;
+		}
+		to {
+			background-position: -200% 0;
+		}
+	}
+`;
+
+const previewSkeletonLongStyles = css`
+	${previewSkeletonBlockStyles};
+	width: 100%;
+	height: 64px;
+`;
+
+const previewSkeletonLargeStyles = css`
+	${previewSkeletonBlockStyles};
+	width: 100%;
+	height: 272px;
+	margin-top: 12px;
+`;
+
+const previewSkeletonThirdStyles = css`
+	${previewSkeletonBlockStyles};
+	width: 100%;
+	height: 36px;
+	margin-top: 30px;
+`;
+
+const previewSkeletonFourthStyles = css`
+	${previewSkeletonBlockStyles};
+	width: 100%;
+	height: 36px;
+	margin-top: 12px;
+`;
+
+const previewSkeletonFinalStyles = css`
+	${previewSkeletonBlockStyles};
+	width: 100%;
+	height: 272px;
+	margin-top: 12px;
+	background: linear-gradient(
+		90deg,
+		${palette.neutral[93]} 25%,
+		${palette.neutral[97]} 50%,
+		${palette.neutral[93]} 75%
+	);
+	background-size: 200% 100%;
+	animation: preview-skeleton-shimmer 1.2s linear infinite;
+`;
+
+const previewStatusStyles = css`
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: ${space[4]}px ${space[3]}px;
+	background: ${palette.neutral[100]};
+	text-align: center;
+
+	${from.tablet} {
+		padding: ${space[6]}px;
+	}
+`;
+
+const previewStatusInnerStyles = css`
+	max-width: 520px;
+`;
+
+const previewStatusTitleStyles = css`
+	${headlineMedium20};
+	margin: 0 0 ${space[2]}px;
+	color: ${palette.neutral[7]};
+`;
+
+const previewStatusBodyStyles = css`
+	${textSans15};
+	margin: 0 0 ${space[4]}px;
+	color: ${palette.neutral[20]};
 `;
 
 const desktopCloseButtonStyles = css`
@@ -144,6 +277,9 @@ export const NewsletterPreviewModal = ({
 }: Props) => {
 	const dialogRef = useRef<HTMLDivElement>(null);
 	const titleId = useId();
+	const [isLoading, setIsLoading] = useState(true);
+	const [hasLoadFailed, setHasLoadFailed] = useState(false);
+	const [iframeKey, setIframeKey] = useState(0);
 
 	const getVisibleFocusableElements = (dialog: HTMLElement): HTMLElement[] =>
 		Array.from(
@@ -258,6 +394,38 @@ export const NewsletterPreviewModal = ({
 		};
 	}, [onClose]);
 
+	useEffect(() => {
+		setIsLoading(true);
+		setHasLoadFailed(false);
+	}, [renderUrl, iframeKey]);
+
+	useEffect(() => {
+		if (!isLoading) return;
+
+		const timeoutId = window.setTimeout(() => {
+			setHasLoadFailed(true);
+			setIsLoading(false);
+		}, PREVIEW_LOAD_TIMEOUT_MS);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [isLoading]);
+
+	const handleIframeLoad = () => {
+		setIsLoading(false);
+		setHasLoadFailed(false);
+	};
+
+	const handleIframeError = () => {
+		setHasLoadFailed(true);
+		setIsLoading(false);
+	};
+
+	const retryLoad = () => {
+		setIframeKey((currentKey) => currentKey + 1);
+	};
+
 	if (typeof document === 'undefined') return null;
 
 	return createPortal(
@@ -285,11 +453,57 @@ export const NewsletterPreviewModal = ({
 						Close preview
 					</Button>
 				</div>
-				<iframe
-					title={`${newsletterName} preview`}
-					src={renderUrl}
-					css={previewFrameStyles}
-				/>
+				<div css={previewFrameContainerStyles}>
+					{isLoading && (
+						<div
+							css={previewLoadingOverlayStyles}
+							aria-live="polite"
+							aria-label="Loading newsletter preview"
+						>
+							<div css={previewSkeletonLongStyles} />
+							<div css={previewSkeletonLargeStyles} />
+							<div css={previewSkeletonThirdStyles} />
+							<div css={previewSkeletonFourthStyles} />
+							<div css={previewSkeletonFinalStyles} />
+						</div>
+					)}
+					{hasLoadFailed && (
+						<div
+							css={previewStatusStyles}
+							role="status"
+							aria-live="polite"
+						>
+							<div css={previewStatusInnerStyles}>
+								<h3 css={previewStatusTitleStyles}>
+									Preview failed to load
+								</h3>
+								<p css={previewStatusBodyStyles}>
+									The preview is taking longer than expected.
+									You can retry loading it.
+								</p>
+								<Button
+									size="small"
+									priority="primary"
+									onClick={retryLoad}
+								>
+									Retry preview
+								</Button>
+							</div>
+						</div>
+					)}
+					<iframe
+						key={iframeKey}
+						title={`${newsletterName} preview`}
+						src={renderUrl}
+						onLoad={handleIframeLoad}
+						onError={handleIframeError}
+						css={[
+							previewFrameStyles,
+							(isLoading || hasLoadFailed) &&
+								previewIframeHiddenStyles,
+						]}
+					/>
+				</div>
 				<div css={mobileCloseBarStyles}>
 					<Button
 						priority="tertiary"

--- a/dotcom-rendering/src/lib/newsletterPreviewUrl.test.ts
+++ b/dotcom-rendering/src/lib/newsletterPreviewUrl.test.ts
@@ -25,7 +25,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'fronts-based',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/fronts/uk/newsletters/morning-mail?variant=persephone&readonly=true',
+			'https://email-rendering.guardianapis.com/fronts/uk/newsletters/morning-mail?variant=persephone&readonly=true&embed=true',
 		);
 	});
 
@@ -37,7 +37,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'fronts-based',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/fronts/world/newsletters/morning-mail?variant=persephone&readonly=true',
+			'https://email-rendering.guardianapis.com/fronts/world/newsletters/morning-mail?variant=persephone&readonly=true&embed=true',
 		);
 	});
 
@@ -48,7 +48,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'article-based',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/article/world/series/first-edition?variant=kronos&readonly=true',
+			'https://email-rendering.guardianapis.com/article/world/series/first-edition?variant=kronos&readonly=true&embed=true',
 		);
 	});
 
@@ -59,7 +59,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'article-based-legacy',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/article/world/series/first-edition?variant=kronos&readonly=true',
+			'https://email-rendering.guardianapis.com/article/world/series/first-edition?variant=kronos&readonly=true&embed=true',
 		);
 	});
 
@@ -70,7 +70,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'article-based',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/fronts/email/global-dispatch?variant=persephone&readonly=true',
+			'https://email-rendering.guardianapis.com/fronts/email/global-dispatch?variant=persephone&readonly=true&embed=true',
 		);
 	});
 
@@ -82,7 +82,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'other',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/article/sport/series/tokyo-2020-daily-briefing/latest?variant=kronos&readonly=true',
+			'https://email-rendering.guardianapis.com/article/sport/series/tokyo-2020-daily-briefing/latest?variant=kronos&readonly=true&embed=true',
 		);
 	});
 
@@ -93,7 +93,7 @@ describe('buildNewsletterPreviewUrl', () => {
 				category: 'fronts-based',
 			}),
 		).toBe(
-			'https://email-rendering.guardianapis.com/fronts/world/newsletters/briefing%20with%20spaces?variant=persephone&readonly=true',
+			'https://email-rendering.guardianapis.com/fronts/world/newsletters/briefing%20with%20spaces?variant=persephone&readonly=true&embed=true',
 		);
 	});
 });

--- a/dotcom-rendering/src/lib/newsletterPreviewUrl.ts
+++ b/dotcom-rendering/src/lib/newsletterPreviewUrl.ts
@@ -5,6 +5,8 @@ const FRONTS_EMAIL_PREVIEW_VARIANT = 'persephone';
 const ARTICLE_EMAIL_PREVIEW_VARIANT = 'kronos';
 const READ_ONLY_PARAM_KEY = 'readonly';
 const READ_ONLY_PARAM_VALUE = 'true';
+const EMBED_PARAM_KEY = 'embed';
+const EMBED_PARAM_VALUE = 'true';
 
 const getPathname = (urlOrPath: string): string => {
 	try {
@@ -56,6 +58,7 @@ const buildPreviewUrl = ({
 	previewUrl.search = new URLSearchParams({
 		variant,
 		[READ_ONLY_PARAM_KEY]: READ_ONLY_PARAM_VALUE,
+		[EMBED_PARAM_KEY]: EMBED_PARAM_VALUE,
 	}).toString();
 
 	return previewUrl.toString();

--- a/dotcom-rendering/src/lib/newsletterPreviewUrl.ts
+++ b/dotcom-rendering/src/lib/newsletterPreviewUrl.ts
@@ -1,4 +1,6 @@
-const EMAIL_PREVIEW_BASE_URL = 'https://email-rendering.guardianapis.com';
+export const EMAIL_PREVIEW_BASE_URL =
+	'https://email-rendering.guardianapis.com';
+export const EMAIL_PREVIEW_ORIGIN = new URL(EMAIL_PREVIEW_BASE_URL).origin;
 const FRONTS_EMAIL_PREVIEW_PATH = 'fronts';
 const ARTICLE_EMAIL_PREVIEW_PATH = 'article';
 const FRONTS_EMAIL_PREVIEW_VARIANT = 'persephone';


### PR DESCRIPTION
## What does this change?

This adds loading skeleton for email newsletter preview modal

## Why?

To improve user experience and keep users informed.

## Screenshots

<img width="820" height="907" alt="Screenshot 2026-04-24 at 12 50 41" src="https://github.com/user-attachments/assets/35cf6d26-7fab-402b-b2b1-fddf9885b224" />
<img width="796" height="891" alt="Screenshot 2026-04-24 at 15 14 43" src="https://github.com/user-attachments/assets/7c76b1e6-6bf5-4103-9479-3ec00b53c124" />
<img width="373" height="894" alt="Screenshot 2026-04-24 at 12 50 57" src="https://github.com/user-attachments/assets/94dedec3-93f0-43af-9a8c-dc156c2f7910" />
<img width="395" height="924" alt="Screenshot 2026-04-24 at 15 15 10" src="https://github.com/user-attachments/assets/397fb1c5-52dd-4fc0-8879-f17ea4473182" />

https://github.com/user-attachments/assets/4c88bde2-c749-4aa1-988e-7959af706adc


