### PR TITLE
Hide controls without hover on non-touch devices

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -131,6 +131,16 @@ const figureStyles = (
 	`}
 `;
 
+const showControlsStyles = css`
+	:hover .controls-container {
+		visibility: visible;
+		opacity: 1;
+		transition:
+			visibility 0.2s,
+			opacity 0.2s ease-in-out;
+	}
+`;
+
 /**
  * Dispatches a custom play audio event so that other videos listening
  * for this event will be muted.
@@ -378,6 +388,9 @@ export const SelfHostedVideo = ({
 		!hideProgressBar && !isCinemagraph && playerState !== 'NOT_STARTED';
 
 	const showIcons = !isCinemagraph && playerState !== 'NOT_STARTED';
+
+	// Controls are temporarily hidden so the full video can be displayed to the user without distractions.
+	const hideControls = isDefault && playerState === 'PLAYING';
 
 	const iconSize = isDefault ? 'large' : 'small';
 
@@ -874,6 +887,15 @@ export const SelfHostedVideo = ({
 			playerState === 'PAUSED_BY_BROWSER' ||
 			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
 
+	const showPauseIcon = hideControls;
+
+	let showPlayPauseIcon: 'play' | 'pause' | null = null;
+	if (showPlayIcon) {
+		showPlayPauseIcon = 'play';
+	} else if (showPauseIcon) {
+		showPlayPauseIcon = 'pause';
+	}
+
 	/** The aspect ratio of the video will be clamped within the specified range */
 	const aspectRatioOfVisibleVideo = getAspectRatioOfVisibleVideo(
 		aspectRatio,
@@ -917,15 +939,18 @@ export const SelfHostedVideo = ({
 				]}
 			>
 				<div
-					css={figureStyles(
-						aspectRatio,
-						aspectRatioOfVisibleVideo,
-						isGreyBarsAtSidesOnDesktop,
-						isGreyBarsAtTopAndBottomOnDesktop,
-						isVideoCroppedAtTopBottom,
-						isVideoCroppedAtLeftRight,
-						containerAspectRatioDesktop,
-					)}
+					css={[
+						figureStyles(
+							aspectRatio,
+							aspectRatioOfVisibleVideo,
+							isGreyBarsAtSidesOnDesktop,
+							isGreyBarsAtTopAndBottomOnDesktop,
+							isVideoCroppedAtTopBottom,
+							isVideoCroppedAtLeftRight,
+							containerAspectRatioDesktop,
+						),
+						hideControls && showControlsStyles,
+					]}
 				>
 					<SelfHostedVideoPlayer
 						sources={optimisedSources}
@@ -956,7 +981,7 @@ export const SelfHostedVideo = ({
 						AudioIcon={supportsAudio ? AudioIcon : null}
 						preloadPartialData={!!shouldAutoplay}
 						iconSize={iconSize}
-						showPlayIcon={showPlayIcon}
+						showPlayPauseIcon={showPlayPauseIcon}
 						showProgressBar={showProgressBar}
 						showSubtitles={!isCinemagraph}
 						subtitleSource={subtitleSource}
@@ -968,6 +993,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
+						hideControls={hideControls}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -132,12 +132,29 @@ const figureStyles = (
 `;
 
 const showControlsStyles = css`
-	:hover .controls-container {
+	.controls-container {
 		visibility: visible;
 		opacity: 1;
 		transition:
 			visibility 0.2s,
 			opacity 0.2s ease-in-out;
+	}
+`;
+
+const hideControlsStyles = css`
+	.controls-container {
+		visibility: hidden;
+		opacity: 0;
+		transition:
+			visibility 0.3s,
+			opacity 0.3s ease-in-out;
+		transition-delay: 2.7s;
+	}
+
+	@media (hover: hover) {
+		:hover {
+			${showControlsStyles}
+		}
 	}
 `;
 
@@ -389,8 +406,11 @@ export const SelfHostedVideo = ({
 
 	const showIcons = !isCinemagraph && playerState !== 'NOT_STARTED';
 
-	// Controls are temporarily hidden so the full video can be displayed to the user without distractions.
-	const hideControls = isDefault && playerState === 'PLAYING';
+	/**
+	 * Functionality to hide controls when the video is not interacted with
+	 * so the full unobscured video can be displayed to the user without distractions.
+	 */
+	const isHideControlsEnabled = isDefault;
 
 	const iconSize = isDefault ? 'large' : 'small';
 
@@ -887,8 +907,7 @@ export const SelfHostedVideo = ({
 			playerState === 'PAUSED_BY_BROWSER' ||
 			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
 
-	const showPauseIcon = hideControls;
-
+	const showPauseIcon = isHideControlsEnabled && playerState === 'PLAYING';
 	let showPlayPauseIcon: 'play' | 'pause' | null = null;
 	if (showPlayIcon) {
 		showPlayPauseIcon = 'play';
@@ -949,7 +968,10 @@ export const SelfHostedVideo = ({
 							isVideoCroppedAtLeftRight,
 							containerAspectRatioDesktop,
 						),
-						hideControls && showControlsStyles,
+						isHideControlsEnabled &&
+							(playerState === 'PLAYING'
+								? hideControlsStyles
+								: showControlsStyles),
 					]}
 				>
 					<SelfHostedVideoPlayer
@@ -993,7 +1015,6 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
-						hideControls={hideControls}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.stories.tsx
@@ -48,6 +48,7 @@ export const Loop: Story = {
 		sources: loop54Card.mainMedia.sources,
 		aspectRatio: loop54Card.mainMedia.aspectRatio,
 		uniqueId: 'test-video-1',
+		atomId: 'test-atom-1',
 		videoStyle: 'Loop',
 		posterImage:
 			'https://media.guim.co.uk/9bdb802e6da5d3fd249b5060f367b3a817965f0c/0_0_1800_1080/master/1800.jpg',

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -12,10 +12,10 @@ import type { ActiveCue } from '../lib/useSubtitles';
 import type { Source } from '../lib/video';
 import { palette } from '../palette';
 import type { VideoPlayerFormat } from '../types/mainMedia';
-import { narrowPlayIconDiameter, PlayIcon } from './Card/components/PlayIcon';
 import {
 	AudioIcon as AudioIconComponent,
 	FullscreenIcon,
+	PlayPauseIcon,
 } from './SelfHostedVideoPlayerIcons';
 import type { SubtitlesPosition } from './SubtitleOverlay';
 import { SubtitleOverlay } from './SubtitleOverlay';
@@ -36,6 +36,27 @@ const videoStyles = (aspectRatio: number) => css`
 	aspect-ratio: ${aspectRatio};
 `;
 
+const videoControlsStyles = css`
+	height: 100%;
+	width: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	pointer-events: none;
+	& > * {
+		pointer-events: auto;
+	}
+`;
+
+const hideControlsStyles = css`
+	visibility: hidden;
+	opacity: 0;
+	transition:
+		visibility 0.3s,
+		opacity 0.3s ease-in-out;
+	transition-delay: 1s;
+`;
+
 const interactiveStyles = css`
 	cursor: pointer;
 `;
@@ -50,17 +71,6 @@ const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
 		${subtitleSize === 'medium' && textSans17};
 		${subtitleSize === 'large' && textSans20};
 	}
-`;
-
-const playIconStyles = css`
-	position: absolute;
-	/* Center the icon */
-	top: calc(50% - ${narrowPlayIconDiameter / 2}px);
-	left: calc(50% - ${narrowPlayIconDiameter / 2}px);
-	cursor: pointer;
-	border: none;
-	background: none;
-	padding: 0;
 `;
 
 const iconsContainerStyles = css`
@@ -130,7 +140,7 @@ export type Props = {
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showProgressBar: boolean;
-	showPlayIcon: boolean;
+	showPlayPauseIcon: 'play' | 'pause' | null;
 	showIcons: boolean;
 	showFullscreenIcon: boolean;
 	showSubtitles: boolean;
@@ -142,6 +152,7 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	hideControls: boolean;
 };
 
 /**
@@ -184,7 +195,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			iconSize,
 			preloadPartialData,
 			showProgressBar: canShowProgressBar,
-			showPlayIcon,
+			showPlayPauseIcon,
 			showIcons: canShowIcons,
 			showFullscreenIcon,
 			showSubtitles: canShowSubtitles,
@@ -195,6 +206,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
+			hideControls,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -207,7 +219,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showIcons = canShowIcons && currentRefExists;
 
 		const dataLinkName = `gu-video-${videoStyle.toLowerCase()}-${
-			showPlayIcon ? 'play' : 'pause'
+			showPlayPauseIcon === 'play' ? 'play' : 'pause'
 		}-${atomId}`;
 
 		return (
@@ -270,61 +282,65 @@ export const SelfHostedVideoPlayer = forwardRef(
 						position={subtitlesPosition}
 					/>
 				)}
-				{showPlayIcon && (
-					<button
-						type="button"
-						onClick={handlePlayPauseClick}
-						css={playIconStyles}
-						data-link-name={`gu-video-loop-play-${atomId}`}
-						data-testid="play-icon"
-					>
-						<PlayIcon iconWidth="narrow" />
-					</button>
-				)}
-				{showProgressBar &&
-					(useLongFormProgressBar ? (
-						<VideoProgressBarInteractive
-							videoId={videoId}
-							currentTime={currentTime}
-							updateCurrentTime={updateCurrentTime}
-							duration={ref.current!.duration}
-							handleKeyDown={handleKeyDown}
+				<div
+					className="controls-container"
+					css={[
+						videoControlsStyles,
+						hideControls && hideControlsStyles,
+					]}
+				>
+					{showPlayPauseIcon !== null && (
+						<PlayPauseIcon
+							type={showPlayPauseIcon}
+							atomId={atomId}
+							handleClick={handlePlayPauseClick}
 						/>
-					) : (
-						<VideoProgressBar
-							videoId={videoId}
-							currentTime={currentTime}
-							duration={ref.current!.duration}
-						/>
-					))}
-				{showIcons && (
-					<div
-						css={[
-							iconsContainerStyles,
-							iconSize === 'large' &&
-								largeIconsPositionStyles(iconsPosition),
-							iconSize === 'small' &&
-								smallIconsPositionStyles(iconsPosition),
-						]}
-					>
-						{showFullscreenIcon && (
-							<FullscreenIcon
-								handleClick={handleFullscreenClick}
-								atomId={atomId}
-								size={iconSize}
+					)}
+					{showProgressBar &&
+						(useLongFormProgressBar ? (
+							<VideoProgressBarInteractive
+								videoId={videoId}
+								currentTime={currentTime}
+								updateCurrentTime={updateCurrentTime}
+								duration={ref.current!.duration}
+								handleKeyDown={handleKeyDown}
 							/>
-						)}
-						{AudioIcon && (
-							<AudioIconComponent
-								Icon={AudioIcon}
-								handleClick={handleAudioClick}
-								isMuted={isMuted}
-								atomId={atomId}
-								size={iconSize}
+						) : (
+							<VideoProgressBar
+								videoId={videoId}
+								currentTime={currentTime}
+								duration={ref.current!.duration}
 							/>
-						)}
-					</div>
-				)}
+						))}
+					{showIcons && (
+						<div
+							css={[
+								iconsContainerStyles,
+								iconSize === 'large' &&
+									largeIconsPositionStyles(iconsPosition),
+								iconSize === 'small' &&
+									smallIconsPositionStyles(iconsPosition),
+							]}
+						>
+							{showFullscreenIcon && (
+								<FullscreenIcon
+									handleClick={handleFullscreenClick}
+									atomId={atomId}
+									size={iconSize}
+								/>
+							)}
+							{AudioIcon && (
+								<AudioIconComponent
+									Icon={AudioIcon}
+									handleClick={handleAudioClick}
+									isMuted={isMuted}
+									atomId={atomId}
+									size={iconSize}
+								/>
+							)}
+						</div>
+					)}
+				</div>
 			</>
 		);
 	},

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -48,15 +48,6 @@ const videoControlsStyles = css`
 	}
 `;
 
-const hideControlsStyles = css`
-	visibility: hidden;
-	opacity: 0;
-	transition:
-		visibility 0.3s,
-		opacity 0.3s ease-in-out;
-	transition-delay: 1s;
-`;
-
 const interactiveStyles = css`
 	cursor: pointer;
 `;
@@ -152,7 +143,6 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
-	hideControls: boolean;
 };
 
 /**
@@ -206,7 +196,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
-			hideControls,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -282,13 +271,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						position={subtitlesPosition}
 					/>
 				)}
-				<div
-					className="controls-container"
-					css={[
-						videoControlsStyles,
-						hideControls && hideControlsStyles,
-					]}
-				>
+				<div className="controls-container" css={videoControlsStyles}>
 					{showPlayPauseIcon !== null && (
 						<PlayPauseIcon
 							type={showPlayPauseIcon}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -1,7 +1,11 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
-import { SvgArrowExpand } from '@guardian/source/react-components';
+import { palette as sourcePalette, space } from '@guardian/source/foundations';
+import {
+	SvgArrowExpand,
+	SvgMediaControlsPause,
+} from '@guardian/source/react-components';
 import { palette } from '../palette';
+import { narrowPlayIconDiameter, PlayIcon } from './Card/components/PlayIcon';
 import type { Props as SelfHostedVideoPlayerProps } from './SelfHostedVideoPlayer';
 
 const buttonStyles = css`
@@ -104,6 +108,56 @@ export const FullscreenIcon = ({
 					fill: palette('--video-icon'),
 				}}
 			/>
+		</div>
+	</button>
+);
+
+const playPauseButtonStyles = css`
+	position: absolute;
+	/* Center the icon */
+	top: calc(50% - ${narrowPlayIconDiameter / 2}px);
+	left: calc(50% - ${narrowPlayIconDiameter / 2}px);
+	cursor: pointer;
+	border: none;
+	background: none;
+	padding: 0;
+`;
+
+const playPauseIconStyles = css`
+	width: 56px;
+	height: 56px;
+	background-color: ${palette('--narrow-play-icon-background')};
+	border-radius: 50%;
+	border: 1px solid ${palette('--narrow-play-icon-border')};
+	fill: ${palette('--narrow-play-icon-fill')};
+`;
+
+type PlayPauseIconProps = {
+	type: 'play' | 'pause';
+	atomId: SelfHostedVideoPlayerProps['atomId'];
+	handleClick: SelfHostedVideoPlayerProps['handlePlayPauseClick'];
+};
+
+export const PlayPauseIcon = ({
+	type,
+	atomId,
+	handleClick,
+}: PlayPauseIconProps) => (
+	<button
+		type="button"
+		onClick={handleClick}
+		css={playPauseButtonStyles}
+		data-link-name={`gu-video-loop-pause-${atomId}`}
+		data-testid={`${type}-icon`}
+	>
+		<div css={[iconContainerStyles, playPauseIconStyles]}>
+			{type === 'play' ? (
+				<PlayIcon iconWidth="narrow" />
+			) : (
+				<SvgMediaControlsPause
+					theme={{ fill: sourcePalette.neutral[100] }}
+				/>
+			)}
 		</div>
 	</button>
 );


### PR DESCRIPTION
## What does this change?

- Displays a pause icon when the video is playing.
- Hides controls when the video is playing and not hovered or interacted with. There is a transition when hiding controls.

## What does this not change?
 
- `PlayIcon.tsx` can be refactored now that the icon is in source. Within the `PlayPauseIcon` component, we use `PlayIcon` for the play button and we get the pause button direct from source. This will be tidied up when `PlayIcon.tsx` receives a much due refactor.

## Why?

- To match designs

## Screenshots

| <img width=60/> | Before | After |
| - | - | - |
| Hover | ![mobile-before] | ![mobile-after] |
| No hover | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/c5da4836-4f39-4591-8fd8-0d1bc33ad07b
[desktop-before]: https://github.com/user-attachments/assets/c5da4836-4f39-4591-8fd8-0d1bc33ad07b
[mobile-after]: https://github.com/user-attachments/assets/da447904-571d-442c-b3c6-0a0dd8cd8f1d
[desktop-after]: https://github.com/user-attachments/assets/90219398-5e1d-40aa-a900-bdaa140f8aab

https://github.com/user-attachments/assets/96ba60f6-c43c-4833-ae1a-dd9b7c0877c5

https://github.com/user-attachments/assets/637721a8-4a85-4538-b605-9dcce32868cb

