### PR TITLE
Add vertical rules to grid module

### DIFF
--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -1,9 +1,11 @@
 // ----- Imports ----- //
 
 import {
+	between as betweenBreakpoint,
 	breakpoints,
 	from as fromBreakpoint,
 } from '@guardian/source/foundations';
+import { palette } from './palette';
 
 // ----- Columns & Lines ----- //
 
@@ -81,6 +83,69 @@ const paddedContainer = `
     ${fromBreakpoint.wide} {
 		width: ${breakpoints.wide}px;
     }
+`;
+
+// ----- Vertical Rules ----- //
+
+type VerticalRuleOptions = {
+	centre?: boolean;
+};
+
+/**
+ * Render Guardian grid vertical rules.
+ *
+ * Left and right rules are always present.
+ * A centre rule can optionally be enabled.
+ *
+ * Usage:
+ * css([grid.container, grid.verticalRules()])
+ * css([grid.container, grid.verticalRules({ centre: true })])
+ */
+const optionalCentreRule = `/* CENTRE RULE */
+    & > *:first-child::before {
+      grid-column: centre-column-start;
+      transform: translateX(-${columnGap});
+	  ${fromBreakpoint.leftCol} {
+		transform: translateX(calc(-${columnGap} / 2));
+	  }
+    }`;
+
+const verticalRules = (options: VerticalRuleOptions = {}): string => `
+  ${fromBreakpoint.tablet} {
+    position: relative;
+
+    &::before,
+    &::after
+    ${options.centre ? ', & > *:first-child::before' : ''} {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: ${palette('--article-border')};
+      content: '';
+    }
+
+    /* LEFT OUTER RULE */
+    &::before {
+      grid-column: centre-column-start;
+      transform: translateX(-${columnGap});
+
+      ${fromBreakpoint.leftCol} {
+        grid-column: left-column-start;
+      }
+    }
+
+    /* RIGHT OUTER RULE */
+    &::after {
+      grid-column: right-column-end;
+      transform: translateX(-1px);
+
+      ${betweenBreakpoint.tablet.and.desktop} {
+        grid-column: centre-column-end;
+      }
+    }
+
+    ${options.centre ? optionalCentreRule : ''}
 `;
 
 // ----- API ----- //
@@ -182,6 +247,8 @@ const grid = {
 	 * breakpoint.
 	 */
 	mobileColumnGap,
+
+	verticalRules,
 } as const;
 
 // ----- Exports ----- //


### PR DESCRIPTION
## What does this change?

Branching off of https://github.com/guardian/dotcom-rendering/pull/15428, this adds a `verticalRules` section to the `grid` module, allowing for lines to be snapped to their appropriate place in the layout. To be set just as the containers are.

For the outer lines only:

```ts
css([grid.container, grid.verticalRules])
```

Or for the central one too:

```ts
css([grid.container, grid.verticalRules({ centre: true })])
```

After a few iterations I made this something that's pure CSS and baked into the grid module itself. `verticalRules` adds outer borders, while `verticalRules({ centre: true })` adds an additional one to the left hand side of the centre column.

In action over at https://github.com/guardian/dotcom-rendering/pull/15428, which is built on top of this change:

<img width="2087" height="1002" alt="image" src="https://github.com/user-attachments/assets/0841b7f5-4f45-48ac-a0a1-9fb5889ee9bf" />
