### PR TITLE
Add 0% AB test to test the refactored commercial passback process

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -159,6 +159,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: "commercial-passback-refactor",
+		description: "Test the refactored commercial passback process",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-05-14",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?

Adds an AB test for 0% of the audience initially to trial a new passback process within the commercial bundle

