### PR TITLE
newsletter preview app fallback

### DIFF
--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -93,14 +93,14 @@ export const EmailSignUpWrapper = ({
 					renderingTarget={renderingTarget}
 					isSignedIn={isSignedIn}
 				>
-					{(openPreview) => (
+					{(previewAction) => (
 						<Island priority="feature" defer={{ until: 'visible' }}>
 							<NewsletterSignupForm
 								newsletterId={identityName}
 								newsletterName={name}
 								frequency={frequency}
 								hidePrivacyMessage={isSignedIn === true}
-								onPreviewClick={openPreview}
+								previewAction={previewAction}
 								isAlreadySubscribed={isSubscribed === true}
 							/>
 						</Island>

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { submitComponentEvent } from '../client/ophan/ophan';
 import { NewsletterSignupCardContainer } from './NewsletterSignupCardContainer';
 
 jest.mock('../client/ophan/ophan', () => ({
@@ -19,8 +20,15 @@ describe('NewsletterSignupCardContainer', () => {
 				frequency="Every weekday"
 				description="Start your day with top stories."
 			>
-				{(openPreview) => (
-					<button type="button" onClick={openPreview}>
+				{(previewAction) => (
+					<button
+						type="button"
+						onClick={
+							previewAction?.behaviour === 'modal'
+								? previewAction.onClick
+								: undefined
+						}
+					>
 						Preview latest
 					</button>
 				)}
@@ -37,5 +45,53 @@ describe('NewsletterSignupCardContainer', () => {
 		await waitFor(() => {
 			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 		});
+	});
+
+	it('renders a preview link for apps and tracks the open event', () => {
+		render(
+			<NewsletterSignupCardContainer
+				identityName="morning-briefing"
+				category="fronts-based"
+				exampleUrl="/world/newsletters/morning-mail"
+				renderingTarget="Apps"
+				theme="news"
+				name="Morning Briefing"
+				frequency="Every weekday"
+				description="Start your day with top stories."
+			>
+				{(previewAction) =>
+					previewAction?.behaviour === 'link' ? (
+						<a
+							href={previewAction.href}
+							onClick={previewAction.onClick}
+						>
+							Preview latest
+						</a>
+					) : null
+				}
+			</NewsletterSignupCardContainer>,
+		);
+
+		const previewLink = screen.getByRole('link', {
+			name: 'Preview latest',
+		});
+
+		expect(previewLink).toHaveAttribute(
+			'href',
+			'https://email-rendering.guardianapis.com/fronts/world/newsletters/morning-mail?variant=persephone&readonly=true&embed=true',
+		);
+
+		fireEvent.click(previewLink);
+
+		expect(submitComponentEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: 'EXPAND',
+				component: expect.objectContaining({
+					id: 'DCR NewsletterPreview morning-briefing',
+				}),
+			}),
+			'Apps',
+		);
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -171,7 +171,9 @@ describe('NewsletterSignupCardContainer', () => {
 			expect.objectContaining({
 				action: 'EXPAND',
 				component: expect.objectContaining({
-					id: 'DCR NewsletterPreview morning-briefing',
+					id: NEWSLETTER_SIGNUP_COMPONENT_ID.variant(
+						defaultProps.identityName,
+					),
 				}),
 			}),
 			'Apps',

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -9,6 +9,17 @@ import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import type { NewsletterSignupCardProps } from './NewsletterSignupCard';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
 
+export type NewsletterPreviewAction =
+	| {
+			behaviour: 'modal';
+			onClick: () => void;
+	  }
+	| {
+			behaviour: 'link';
+			href: string;
+			onClick: () => void;
+	  };
+
 type PreviewEventDescription = 'preview-open' | 'preview-close';
 
 const sendPreviewTracking = ({
@@ -55,7 +66,9 @@ type Props = Omit<NewsletterSignupCardProps, 'children'> & {
 	 * below the card (rather than inside the form) when the user is signed in.
 	 */
 	isSignedIn?: boolean | 'Pending';
-	children?: (openPreview: (() => void) | undefined) => React.ReactNode;
+	children?: (
+		previewAction: NewsletterPreviewAction | undefined,
+	) => React.ReactNode;
 };
 
 const themeColorStyles = (theme: string) => css`
@@ -103,6 +116,17 @@ export const NewsletterSignupCardContainer = ({
 		});
 	}, [identityName, renderingTarget, renderUrl]);
 
+	const trackPreviewLinkOpen = useCallback(() => {
+		if (!renderUrl) return;
+
+		sendPreviewTracking({
+			identityName,
+			eventDescription: 'preview-open',
+			renderingTarget,
+			renderUrl,
+		});
+	}, [identityName, renderingTarget, renderUrl]);
+
 	const closePreview = useCallback(() => {
 		setIsPreviewOpen((isOpen) => {
 			if (isOpen && renderUrl) {
@@ -117,6 +141,19 @@ export const NewsletterSignupCardContainer = ({
 			return false;
 		});
 	}, [identityName, renderingTarget, renderUrl]);
+
+	const previewAction = hasPreviewUrl
+		? renderingTarget === 'Apps'
+			? {
+					behaviour: 'link' as const,
+					href: renderUrl ?? '',
+					onClick: trackPreviewLinkOpen,
+			  }
+			: {
+					behaviour: 'modal' as const,
+					onClick: openPreview,
+			  }
+		: undefined;
 
 	return (
 		<div css={themeColorStyles(theme)}>
@@ -141,7 +178,7 @@ export const NewsletterSignupCardContainer = ({
 					description={description}
 					illustrationSquare={illustrationSquare}
 				>
-					{children?.(hasPreviewUrl ? openPreview : undefined)}
+					{children?.(previewAction)}
 				</NewsletterSignupCard>
 				{showPrivacyMessageOutside && (
 					<NewsletterPrivacyMessage textColor="regular" />

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -36,7 +36,7 @@ const defaultArgs = {
 	newsletterId: 'saturday-edition',
 	newsletterName: 'Saturday Edition',
 	frequency: 'every Saturday',
-	onPreviewClick: fn(),
+	previewAction: { behaviour: 'modal' as const, onClick: fn() },
 };
 
 /** Shared no-op handlers — stories that focus on visual state don't need real callbacks. */
@@ -227,9 +227,9 @@ export const CaptchaNotPassed = meta.story({
 	},
 });
 
-/** Form without a preview button (no `onPreviewClick` prop). */
+/** Form without a preview button (no `previewAction` prop). */
 export const WithoutPreview = meta.story({
-	args: { ...defaultArgs, onPreviewClick: undefined },
+	args: { ...defaultArgs, previewAction: undefined },
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(mockForm({}));
 	},

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -15,18 +15,20 @@ import { ToggleSwitch } from '@guardian/source-development-kitchen/react-compone
 // Note - the package also exports a component as a named export "ReCAPTCHA",
 // that version will compile and render but is non-functional.
 // Use the default export instead.
+import type { ChangeEvent } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
+import type { NewsletterPreviewAction } from './NewsletterSignupCardContainer';
 
 type Props = {
 	newsletterId: string;
 	newsletterName: string;
 	frequency: string;
 	hidePrivacyMessage?: boolean;
-	onPreviewClick?: () => void;
+	previewAction?: NewsletterPreviewAction;
 	/** When `true`, the success message is shown immediately (user is already subscribed). */
 	isAlreadySubscribed?: boolean;
 };
@@ -176,24 +178,39 @@ const tertiaryButtonTheme: Partial<ThemeButton> = {
 };
 
 const PreviewButton = ({
-	onClick,
+	previewAction,
 	size = 'default',
 }: {
-	onClick: () => void;
+	previewAction: NewsletterPreviewAction;
 	size?: Size;
-}) => (
-	<Button
-		priority="tertiary"
-		icon={<SvgEye />}
-		iconSide="left"
-		onClick={onClick}
-		type="button"
-		size={size}
-		theme={tertiaryButtonTheme}
-	>
-		Preview latest
-	</Button>
-);
+}) =>
+	previewAction.behaviour === 'link' ? (
+		<LinkButton
+			priority="tertiary"
+			icon={<SvgEye />}
+			iconSide="left"
+			href={previewAction.href}
+			target="_blank"
+			rel="noreferrer"
+			onClick={previewAction.onClick}
+			size={size}
+			theme={tertiaryButtonTheme}
+		>
+			Preview latest
+		</LinkButton>
+	) : (
+		<Button
+			priority="tertiary"
+			icon={<SvgEye />}
+			iconSide="left"
+			onClick={previewAction.onClick}
+			type="button"
+			size={size}
+			theme={tertiaryButtonTheme}
+		>
+			Preview latest
+		</Button>
+	);
 
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 	<InlineError>
@@ -294,7 +311,7 @@ const NewsletterSignupFormActive = ({
 	newsletterName,
 	frequency,
 	hidePrivacyMessage = false,
-	onPreviewClick,
+	previewAction,
 }: Omit<Props, 'isAlreadySubscribed'>) => {
 	const { renderingTarget } = useConfig();
 
@@ -337,9 +354,9 @@ const NewsletterSignupFormActive = ({
 
 	return (
 		<>
-			{showForm && onPreviewClick && !isSignedIn && (
+			{showForm && previewAction && !isSignedIn && (
 				<div css={previewButtonContainerStyles}>
-					<PreviewButton onClick={onPreviewClick} size="small" />
+					<PreviewButton previewAction={previewAction} size="small" />
 				</div>
 			)}
 			<form
@@ -364,7 +381,9 @@ const NewsletterSignupFormActive = ({
 							value={userEmail ?? ''}
 							error={isValidationError ? errorMessage : undefined}
 							onFocus={handleEmailFocus}
-							onChange={(e) => handleEmailChange(e.target.value)}
+							onChange={(e: ChangeEvent<HTMLInputElement>) =>
+								handleEmailChange(e.target.value)
+							}
 							onInvalid={handleEmailInvalid}
 						/>
 					</div>
@@ -393,8 +412,8 @@ const NewsletterSignupFormActive = ({
 					</>
 				)}
 				<div css={submitButtonContainerStyles}>
-					{isSignedIn && onPreviewClick && (
-						<PreviewButton onClick={onPreviewClick} />
+					{isSignedIn && previewAction && (
+						<PreviewButton previewAction={previewAction} />
 					)}
 					<Button
 						cssOverrides={submitButtonStyles}

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -177,6 +177,17 @@ const tertiaryButtonTheme: Partial<ThemeButton> = {
 	backgroundTertiaryHover: palette('--newsletter-preview-button-hover'),
 };
 
+const previewLinkButtonStyles = css`
+	&&,
+	&&:hover,
+	&&:focus,
+	&&:visited {
+		color: ${palette('--newsletter-preview-button-text')};
+		text-decoration: none;
+		border-color: ${palette('--newsletter-preview-button-border')};
+	}
+`;
+
 const PreviewButton = ({
 	previewAction,
 	size = 'default',
@@ -195,6 +206,7 @@ const PreviewButton = ({
 			onClick={previewAction.onClick}
 			size={size}
 			theme={tertiaryButtonTheme}
+			cssOverrides={previewLinkButtonStyles}
 		>
 			Preview latest
 		</LinkButton>

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -180,17 +180,6 @@ const tertiaryButtonTheme: Partial<ThemeButton> = {
 	backgroundTertiaryHover: palette('--newsletter-preview-button-hover'),
 };
 
-const previewLinkButtonStyles = css`
-	&&,
-	&&:hover,
-	&&:focus,
-	&&:visited {
-		color: ${palette('--newsletter-preview-button-text')};
-		text-decoration: none;
-		border-color: ${palette('--newsletter-preview-button-border')};
-	}
-`;
-
 const PreviewButton = ({
 	previewAction,
 	size = 'default',
@@ -200,6 +189,7 @@ const PreviewButton = ({
 }) =>
 	previewAction.behaviour === 'link' ? (
 		<LinkButton
+			data-ignore="global-link-styling"
 			priority="tertiary"
 			icon={<SvgEye />}
 			iconSide="left"
@@ -209,7 +199,6 @@ const PreviewButton = ({
 			onClick={previewAction.onClick}
 			size={size}
 			theme={tertiaryButtonTheme}
-			cssOverrides={previewLinkButtonStyles}
 		>
 			Preview latest
 		</LinkButton>


### PR DESCRIPTION
## What does this change?

Adds a fallback newsletter preview functionality when rendered within the native app.
Preview will open in a new browser tab.

## Why?

To avoid modal rendering issues in the native app.