### PR TITLE
Disable A/B testing logic on app rendering

### DIFF
--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
@@ -72,11 +72,11 @@ const defaultProps = {
 	idApiUrl: 'https://idapi.theguardian.com',
 };
 
-const renderWrapper = (props = {}) =>
+const renderWrapper = (props = {}, renderingTarget: 'Web' | 'Apps' = 'Web') =>
 	render(
 		<ConfigProvider
 			value={{
-				renderingTarget: 'Web',
+				renderingTarget,
 				darkModeAvailable: false,
 				assetOrigin: '/',
 				editionId: 'UK',
@@ -182,6 +182,29 @@ describe('EmailSignUpWrapper', () => {
 			expect(
 				screen.getByTestId('newsletter-signup-card-container'),
 			).toBeInTheDocument();
+		});
+	});
+
+	describe('Apps rendering target', () => {
+		it('renders the legacy EmailSignup without waiting for AB to resolve', () => {
+			// useBetaAB remains undefined (AB framework never initialises on Apps)
+			// but the component should not block on it
+			renderWrapper({ showNewNewsletterSignupCard: true }, 'Apps');
+			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
+			expect(
+				screen.queryByTestId('newsletter-signup-card-container'),
+			).not.toBeInTheDocument();
+		});
+
+		it('fires a VIEW tracking event without waiting for AB to resolve', () => {
+			renderWrapper({ showNewNewsletterSignupCard: true }, 'Apps');
+			expect(submitComponentEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: 'VIEW',
+					abTest: { name: AB_TEST_NAME, variant: 'control' },
+				}),
+				'Apps',
+			);
 		});
 	});
 

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -74,13 +74,19 @@ export const EmailSignUpWrapper = ({
 	showNewNewsletterSignupCard = false,
 }: EmailSignUpWrapperProps) => {
 	const { renderingTarget } = useConfig();
+
+	const abTestEnabled =
+		showNewNewsletterSignupCard && renderingTarget === 'Web';
+
 	const abTests = useBetaAB();
-	// `abTests` is undefined before the AB client has hydrated — treat that as
-	// "not yet resolved" rather than "in control", so we don't fire premature
-	// tracking events.
 	const abResolved = abTests !== undefined;
-	const isInVariantGroup =
-		abTests?.isUserInTestGroup(AB_TEST_NAME, 'variant') ?? false;
+
+	const isVariant =
+		abTestEnabled &&
+		(abTests?.isUserInTestGroup(AB_TEST_NAME, 'variant') ?? false);
+
+	const abVariant = isVariant ? 'variant' : 'control';
+
 	const isSubscribed = useNewsletterSubscription(
 		listId,
 		idApiUrl,
@@ -88,14 +94,10 @@ export const EmailSignUpWrapper = ({
 	);
 	const isSignedIn = useIsSignedIn();
 
-	const isVariant = showNewNewsletterSignupCard && isInVariantGroup;
-
-	const abVariant = isVariant ? 'variant' : 'control';
-
 	const viewFiredRef = useRef(false);
 
 	useEffect(() => {
-		if (!abResolved) return;
+		if (abTestEnabled && !abResolved) return;
 		// Wait for subscription status in both branches — we only want to track
 		// a view of the actual signup form, not a loading state or success message.
 		if (isSubscribed === undefined) return;
@@ -125,15 +127,11 @@ export const EmailSignUpWrapper = ({
 		identityName,
 		isSubscribed,
 		isVariant,
+		abTestEnabled,
 		renderingTarget,
 	]);
 
-	// Show placeholder while AB tests or subscription status is loading.
-	// Keeping this before the isVariant branch ensures SSR and the first client
-	// render always match (both see the placeholder), avoiding a hydration
-	// mismatch that would leave the placeholder visible behind the card.
-	// It also prevents a jump from form → success state on subscription resolve.
-	if (!abResolved || isSubscribed === undefined) {
+	if ((abTestEnabled && !abResolved) || isSubscribed === undefined) {
 		return <Placeholder heights={PLACEHOLDER_HEIGHTS} />;
 	}
 


### PR DESCRIPTION
## Fix: EmailSignUpWrapper stuck on placeholder in Apps webview

### Problem

`EmailSignUpWrapper` was unconditionally waiting for the AB testing framework to resolve before rendering. The AB framework (`SetABTests`) is only ever initialised on Web.

This meant that on Apps, `useBetaAB()` returned `undefined` forever, and the component would show a blank placeholder indefinitely instead of the newsletter signup form.


### Behaviour

| Scenario | Before | After |
|---|---|---|
| Apps (any flag state) | Stuck on placeholder forever | Renders control form immediately |
| Web, flag off | Waited for AB unnecessarily | Renders control form immediately |
| Web, flag on, AB pending | Shows placeholder | Shows placeholder (unchanged) |
| Web, flag on, AB resolved | Renders correct variant | Renders correct variant (unchanged) |

### Tests

Two new tests added to `EmailSignUpWrapper.island.test.tsx` covering the Apps rendering target:
- Renders the legacy signup form without waiting for AB to resolve
- Fires a VIEW tracking event without waiting for AB to resolve
