### PR TITLE
Fix Storybook for Newsletter Signup Card

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -31,6 +31,8 @@ sb.mock(import('../src/lib/useAuthStatus.ts'), { spy: true });
 sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/useAB.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();
@@ -81,6 +83,7 @@ style.appendChild(document.createTextNode(css));
 		},
 		tests: {},
 		switches: {},
+		serverSideABTests: {},
 	},
 	ophan: {
 		record: ({}) => {},

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.stories.tsx
@@ -2,9 +2,21 @@ import type { StoryObj } from '@storybook/react-webpack5';
 import { mocked, within } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
+import { useBetaAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
 import { EmailSignUpWrapper } from './EmailSignUpWrapper.island';
+
+/** Resolves `useBetaAB` as if the AB framework has hydrated, placing the user in control or variant. */
+const mockBetaAB = (isInVariant: boolean) => {
+	mocked(useBetaAB).mockReturnValue({
+		isUserInTestGroup: (_testName: string, group: string) =>
+			group === 'variant' ? isInVariant : !isInVariant,
+		isUserInTest: () => true,
+		getParticipations: () => ({}),
+		trackABTests: () => ({}),
+	});
+};
 
 const meta = preview.meta({
 	title: 'Components/EmailSignUpWrapper',
@@ -35,25 +47,18 @@ const newCardArgs = {
 		'https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3',
 } satisfies Story['args'];
 
-// Loading state - shows placeholder while auth status is being determined
-// This prevents layout shift when subscription status is resolved
 export const Placeholder = meta.story({
-	args: {
-		hidePrivacyMessage: false,
-		...defaultArgs,
-	},
+	args: { hidePrivacyMessage: false, ...defaultArgs },
 	beforeEach() {
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(undefined);
 	},
 });
 
-// Default story - signed out user sees the signup form with email input
 export const DefaultStory = meta.story({
-	args: {
-		hidePrivacyMessage: true,
-		...defaultArgs,
-	},
+	args: { hidePrivacyMessage: true, ...defaultArgs },
 	beforeEach() {
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -63,11 +68,9 @@ export const DefaultStory = meta.story({
 });
 
 export const DefaultStoryWithPrivacy = meta.story({
-	args: {
-		hidePrivacyMessage: false,
-		...defaultArgs,
-	},
+	args: { hidePrivacyMessage: false, ...defaultArgs },
 	beforeEach() {
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -76,13 +79,10 @@ export const DefaultStoryWithPrivacy = meta.story({
 	},
 });
 
-// User is signed in but NOT subscribed - email field is hidden, only signup button shows
 export const SignedInNotSubscribed = meta.story({
-	args: {
-		hidePrivacyMessage: false,
-		...defaultArgs,
-	},
+	args: { hidePrivacyMessage: false, ...defaultArgs },
 	beforeEach() {
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -91,9 +91,6 @@ export const SignedInNotSubscribed = meta.story({
 	},
 });
 
-// User is signed in and IS subscribed - component returns null (hidden)
-// Note: This story will render nothing as the component returns null when subscribed
-// Requires hideNewsletterSignupComponentForSubscribers: true to enable the subscription check
 export const SignedInAlreadySubscribed = meta.story({
 	args: {
 		hidePrivacyMessage: false,
@@ -101,12 +98,11 @@ export const SignedInAlreadySubscribed = meta.story({
 		hideNewsletterSignupComponentForSubscribers: true,
 	},
 	beforeEach() {
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 	},
 });
 
-// Feature flag disabled - always shows signup form regardless of subscription status
-// When hideNewsletterSignupComponentForSubscribers is false, the subscription check is skipped
 export const FeatureFlagDisabled = meta.story({
 	args: {
 		hidePrivacyMessage: false,
@@ -114,8 +110,7 @@ export const FeatureFlagDisabled = meta.story({
 		hideNewsletterSignupComponentForSubscribers: false,
 	},
 	beforeEach() {
-		// Even though we mock this to return true (subscribed),
-		// the feature flag being disabled means it won't be checked
+		mockBetaAB(false);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -134,6 +129,7 @@ export const FeatureFlagDisabled = meta.story({
 export const NewsletterSignupCardSignedInNotSubscribed = meta.story({
 	args: newCardArgs,
 	beforeEach() {
+		mockBetaAB(true);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -145,6 +141,7 @@ export const NewsletterSignupCardSignedInNotSubscribed = meta.story({
 export const NewsletterSignupCardSignedOutNotSubscribed = meta.story({
 	args: newCardArgs,
 	beforeEach() {
+		mockBetaAB(true);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -156,6 +153,7 @@ export const NewsletterSignupCardSignedOutNotSubscribed = meta.story({
 export const NewsletterSignupCardSignedInAlreadySubscribed = meta.story({
 	args: newCardArgs,
 	beforeEach() {
+		mockBetaAB(true);
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 		mocked(useIsSignedIn).mockReturnValue(true);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -167,6 +165,7 @@ export const NewsletterSignupCardSignedInAlreadySubscribed = meta.story({
 export const NewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
 	args: newCardArgs,
 	beforeEach() {
+		mockBetaAB(true);
 		mocked(useNewsletterSubscription).mockReturnValue(true);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>
@@ -178,6 +177,7 @@ export const NewsletterSignupCardSignedOutAlreadySubscribed = meta.story({
 export const NewsletterSignupCardFocused = meta.story({
 	args: newCardArgs,
 	beforeEach() {
+		mockBetaAB(true);
 		mocked(useNewsletterSubscription).mockReturnValue(false);
 		mocked(useIsSignedIn).mockReturnValue(false);
 		mocked(lazyFetchEmailWithTimeout).mockReturnValue(() =>


### PR DESCRIPTION
## Fix: Newsletter signup stories stuck on loading state in Storybook

### Problem

All `EmailSignUpWrapper` stories using `showNewNewsletterSignupCard: true` were permanently showing the placeholder/loading state in Storybook.

The component waits for `useBetaAB()` to resolve before rendering (when `abTestEnabled` is true). In production this is satisfied by `SetABTests`, but in Storybook `useBetaAB` was never mocked — so it returned `undefined` forever, and the placeholder never gave way to the actual component.

### Changes

**`.storybook/preview.ts`**

Added `useBetaAB` to the global `sb.mock` list alongside the other hooks already mocked there, so it can be controlled per-story.

**`EmailSignUpWrapper.stories.tsx`**

Added a `mockBetaAB(isInVariant)` helper that resolves `useBetaAB` with a stub implementation, and calls it in every story's `beforeEach`:

- `mockBetaAB(false)` — control group, for the standard signup form stories
- `mockBetaAB(true)` — variant group, for the new card stories
