### PR TITLE
Hot fix poster aspect ratio

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -187,7 +187,10 @@ const dispatchOphanAttentionEvent = (
 	document.dispatchEvent(event);
 };
 
-const getOptimisedPosterImage = (mainImage: string): string => {
+const getOptimisedPosterImage = (
+	mainImage: string,
+	aspectRatio: string,
+): string => {
 	// This only runs on the client
 	const resolution = window.devicePixelRatio >= 2 ? 'high' : 'low';
 
@@ -195,7 +198,7 @@ const getOptimisedPosterImage = (mainImage: string): string => {
 		mainImage,
 		imageWidth: 940, // The widest a video can be: flexible special container, giga-boosted slot
 		resolution,
-		aspectRatio: '5:4',
+		aspectRatio,
 	});
 };
 
@@ -890,7 +893,7 @@ export const SelfHostedVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage)
+		? getOptimisedPosterImage(posterImage, '5:4')
 		: undefined;
 
 	return (

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -892,8 +892,20 @@ export const SelfHostedVideo = ({
 
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
+	const isVertical =
+		fallbackImageSize === 'feature' ||
+		fallbackImageSize === 'feature-large' ||
+		isGreyBarsAtSidesOnDesktop;
+
+	/* This is a hot fix for cards where the video is a different aspect ratio and will be replaced by https://github.com/guardian/dotcom-rendering/pull/15746 */
+	const posterImageAspectRatio = isVertical
+		? '4:5'
+		: isGreyBarsAtTopAndBottomOnDesktop
+		? '16:9'
+		: '5:4';
+
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage, '5:4')
+		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
 		: undefined;
 
 	return (


### PR DESCRIPTION
## What does this change?
Adds a fix for poster aspect ratios. This addresses a bug where poster images always appear in 5:4, even if the card or video is a different aspect ratio. This is a particular issue for feature cards which are 4:5

## Why hot fix?
This is usually not visible as videos autoplay but it is visible if the user is on low power mode.

There is a more robust solution in development that will read the poster image aspect ratio direct from CAPI. Once this is ready for prod, this hotfix will be replaced. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |


[before]: https://github.com/user-attachments/assets/b86c8a1f-e25a-4ee6-b0e6-423c28dc74cd
[after]: https://github.com/user-attachments/assets/d1bef649-1ded-41a7-a774-304c009317d2

[before1]:https://github.com/user-attachments/assets/a634ea19-3598-4e36-8b57-98a8ea7eedb3
[after1]: https://github.com/user-attachments/assets/87586883-51a4-4226-80be-b5a8116f8a26

[before2]: https://github.com/user-attachments/assets/08f27510-0f37-42ba-ac35-a54b5a5f6cf5
[after2]: https://github.com/user-attachments/assets/fe046391-7af0-4fea-a832-9c107e4be1dd

[before3]: https://github.com/user-attachments/assets/5db8ddd4-c9bb-4996-85a3-ffc8358cfa30
[after3]: https://github.com/user-attachments/assets/5db8ddd4-c9bb-4996-85a3-ffc8358cfa30

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
