### PR TITLE
Match notification bridge

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -115,6 +115,12 @@ export const getNativeABTestingClient: BridgetApi<
 		new Map(Object.entries({ 'test-id': 'variant' })),
 });
 
+export const getMatchNotificationsClient: BridgetApi<
+	'getMatchNotificationsClient'
+> = () => ({
+	isAvailable: async () => ({ isAvailable: true }),
+});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -134,6 +140,7 @@ export const ensure_all_exports_are_present = {
 	getListenToArticleClient,
 	getAudioClient,
 	getNativeABTestingClient,
+	getMatchNotificationsClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -33,6 +33,8 @@ sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
 sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/useAB.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/bridgetApi.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -30,7 +30,7 @@
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "22.2.0",
-		"@guardian/bridget": "8.9.0",
+		"@guardian/bridget": "8.9.1-2026-04-28",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "62.6.1",
 		"@guardian/commercial-core": "32.0.0",

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -1,6 +1,8 @@
 import { gridContainerDecorator } from '../../../.storybook/decorators/gridDecorators';
 import preview from '../../../.storybook/preview';
 import { palette } from '../../palette';
+import { fn, mocked } from 'storybook/test';
+import { getMatchNotificationsClient } from '../../lib/bridgetApi';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';
@@ -17,6 +19,11 @@ export const Fixture = meta.story({
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 	},
 	decorators: [gridContainerDecorator],
+	beforeEach() {
+		mocked(getMatchNotificationsClient).mockReturnValue({
+			isAvailable: fn(() => Promise.resolve({ isAvailable: true })),
+		} as ReturnType<typeof getMatchNotificationsClient>);
+	},
 	parameters: {
 		colourSchemeBackground: {
 			light: palette(background('Fixture')),
@@ -67,5 +74,23 @@ export const Result = Live.extend({
 			...Live.input.args.match,
 			kind: 'Result',
 		},
+	},
+});
+
+/**
+ * When the user already has team notifications for one of the teams, the app
+ * returns `isAvailable: false` so we show a message instead of the toggle.
+ */
+export const Unavailable = Fixture.extend({
+	beforeEach() {
+		mocked(getMatchNotificationsClient).mockReturnValue({
+			isAvailable: fn(() =>
+				Promise.resolve({
+					isAvailable: false,
+					unavailableReason:
+						'You have already signed up for Arsenal notifications',
+				}),
+			),
+		} as ReturnType<typeof getMatchNotificationsClient>);
 	},
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -22,7 +22,7 @@ export const Fixture = meta.story({
 	beforeEach() {
 		mocked(getMatchNotificationsClient).mockReturnValue({
 			isAvailable: fn(() => Promise.resolve({ isAvailable: true })),
-		} as ReturnType<typeof getMatchNotificationsClient>);
+		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
 	},
 	parameters: {
 		colourSchemeBackground: {
@@ -91,6 +91,6 @@ export const Unavailable = Fixture.extend({
 						'You have already signed up for Arsenal notifications',
 				}),
 			),
-		} as ReturnType<typeof getMatchNotificationsClient>);
+		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
 	},
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -1,9 +1,15 @@
 import { css } from '@emotion/react';
-import { space, textSans14Object } from '@guardian/source/foundations';
-import { useMemo } from 'react';
+import { log } from '@guardian/libs';
+import {
+	space,
+	textSans14,
+	textSans14Object,
+} from '@guardian/source/foundations';
+import { useEffect, useMemo, useState } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import type { NotificationsClient } from '../../lib/bridgetApi';
+import { getMatchNotificationsClient } from '../../lib/bridgetApi';
 import {
 	type EditionId,
 	getLocaleFromEdition,
@@ -23,11 +29,44 @@ type Props = {
 
 export const Notifications = (props: Props) => {
 	const { renderingTarget } = useConfig();
+	const [isAvailable, setIsAvailable] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [unavailableReason, setUnavailableReason] = useState<
+		string | undefined
+	>(undefined);
+
 	// useMemo to limit constructions of `Intl.DateTimeFormat`
 	const displayName = useMemo(
 		() => notificationDisplayName(props.edition),
 		[props.edition],
 	);
+
+	useEffect(() => {
+		if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
+			return;
+		}
+
+		void getMatchNotificationsClient()
+			.isAvailable()
+			.then((availability) => {
+				setIsAvailable(availability.isAvailable);
+				setUnavailableReason(availability.unavailableReason);
+			})
+			.catch((error: unknown) => {
+				window.guardian.modules.sentry.reportError(
+					error instanceof Error ? error : new Error(String(error)),
+					'bridget-getMatchNotificationsClient-isAvailable-error',
+				);
+				log(
+					'dotcom',
+					'Bridget getMatchNotificationsClient.isAvailable Error:',
+					error,
+				);
+				// Treat errors as available to avoid silently hiding the button
+				setIsAvailable(true);
+			});
+	}, [renderingTarget, props.match.kind]);
 
 	if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
 		return null;
@@ -36,37 +75,62 @@ export const Notifications = (props: Props) => {
 	return (
 		<>
 			<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
-			<p
-				css={{
-					...textSans14Object,
-					'&': css(grid.column.centre),
-					paddingTop: space[2],
-					paddingBottom: space[3],
-					paddingLeft: 6,
-					paddingRight: 6,
-				}}
-				style={{
-					color: palette(primaryText(props.match.kind)),
-				}}
-			>
-				Be notified about the lineup, kick-off time, goals, half-time
-				and full time scores
-			</p>
-			<NotificationsToggle
-				displayName={displayName(props.match)}
-				id={props.match.paId}
-				notificationType="football-match"
-				notificationsClient={props.notificationsClient}
-				colour={primaryText(props.match.kind)}
-				backgroundColour={background(props.match.kind)}
-				iconColour={primaryText(props.match.kind)}
-				css={{
-					'&': css(grid.column.centre),
-					paddingLeft: 6,
-					paddingRight: 6,
-					paddingBottom: space[4],
-				}}
-			/>
+			{isAvailable === false ? (
+				<p
+					css={[
+						textSans14,
+						css({
+							'&': css(grid.column.centre),
+							paddingTop: space[2],
+							paddingBottom: space[3],
+							paddingLeft: 6,
+							paddingRight: 6,
+						}),
+					]}
+					style={{
+						color: palette(primaryText(props.match.kind)),
+					}}
+				>
+					{unavailableReason ??
+						'You have already signed up for team notifications'}
+				</p>
+			) : (
+				<>
+					<p
+						css={{
+							...textSans14Object,
+							'&': css(grid.column.centre),
+							paddingTop: space[2],
+							paddingBottom: space[3],
+							paddingLeft: 6,
+							paddingRight: 6,
+						}}
+						style={{
+							color: palette(primaryText(props.match.kind)),
+						}}
+					>
+						Be notified about the lineup, kick-off time, goals,
+						half-time and full time scores
+					</p>
+					{isAvailable === true && (
+						<NotificationsToggle
+							displayName={displayName(props.match)}
+							id={props.match.paId}
+							notificationType="football-match"
+							notificationsClient={props.notificationsClient}
+							colour={primaryText(props.match.kind)}
+							backgroundColour={background(props.match.kind)}
+							iconColour={primaryText(props.match.kind)}
+							css={{
+								'&': css(grid.column.centre),
+								paddingLeft: 6,
+								paddingRight: 6,
+								paddingBottom: space[4],
+							}}
+						/>
+					)}
+				</>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/NotificationsToggleWrapper.island.tsx
+++ b/dotcom-rendering/src/components/NotificationsToggleWrapper.island.tsx
@@ -1,5 +1,11 @@
+import { log } from '@guardian/libs';
+import { textSans14 } from '@guardian/source/foundations';
 import type { ComponentProps } from 'react';
-import { getNotificationsClient } from '../lib/bridgetApi';
+import { useEffect, useState } from 'react';
+import {
+	getMatchNotificationsClient,
+	getNotificationsClient,
+} from '../lib/bridgetApi';
 import { NotificationsToggle } from './NotificationsToggle';
 
 type Props = Omit<
@@ -7,9 +13,53 @@ type Props = Omit<
 	'notificationsClient'
 >;
 
-export const NotificationsToggleWrapper = (props: Props) => (
-	<NotificationsToggle
-		notificationsClient={getNotificationsClient()}
-		{...props}
-	/>
-);
+export const NotificationsToggleWrapper = (props: Props) => {
+	const [isAvailable, setIsAvailable] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [unavailableReason, setUnavailableReason] = useState<
+		string | undefined
+	>(undefined);
+
+	useEffect(() => {
+		void getMatchNotificationsClient()
+			.isAvailable()
+			.then((availability) => {
+				setIsAvailable(availability.isAvailable);
+				setUnavailableReason(availability.unavailableReason);
+			})
+			.catch((error: unknown) => {
+				window.guardian.modules.sentry.reportError(
+					error instanceof Error ? error : new Error(String(error)),
+					'bridget-getMatchNotificationsClient-isAvailable-error',
+				);
+				log(
+					'dotcom',
+					'Bridget getMatchNotificationsClient.isAvailable Error:',
+					error,
+				);
+				// Treat errors as available to avoid silently hiding the button
+				setIsAvailable(true);
+			});
+	}, []);
+
+	if (isAvailable === undefined) {
+		return null;
+	}
+
+	if (!isAvailable) {
+		return (
+			<p css={textSans14}>
+				{unavailableReason ??
+					'You have already signed up for team notifications'}
+			</p>
+		);
+	}
+
+	return (
+		<NotificationsToggle
+			notificationsClient={getNotificationsClient()}
+			{...props}
+		/>
+	);
+};

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -10,6 +10,7 @@ import * as Gallery from '@guardian/bridget/Gallery';
 import * as Interaction from '@guardian/bridget/Interaction';
 import * as Interactives from '@guardian/bridget/Interactives';
 import * as ListenToArticle from '@guardian/bridget/ListenToArticle';
+import * as MatchNotifications from '@guardian/bridget/MatchNotifications';
 import * as Metrics from '@guardian/bridget/Metrics';
 import * as Navigation from '@guardian/bridget/Navigation';
 import * as Newsletters from '@guardian/bridget/Newsletters';
@@ -241,3 +242,15 @@ export const getNativeABTestingClient = (): AbTesting.Client<void> => {
 	}
 	return nativeAbTestingClient;
 };
+
+let matchNotificationsClient: MatchNotifications.Client<void> | undefined =
+	undefined;
+export const getMatchNotificationsClient =
+	(): MatchNotifications.Client<void> => {
+		if (!matchNotificationsClient) {
+			matchNotificationsClient = createAppClient<
+				MatchNotifications.Client<void>
+			>(MatchNotifications.Client, 'buffered', 'compact');
+		}
+		return matchNotificationsClient;
+	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,8 +255,8 @@ importers:
         specifier: 22.2.0
         version: 22.2.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.0(@guardian/ophan-tracker-js@2.8.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.9.1-2026-04-28
+        version: 8.9.1-2026-04-28
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2356,8 +2356,8 @@ packages:
       '@guardian/source': ^9.0.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.9.0':
-    resolution: {integrity: sha512-OAo45mzxGJeCVhfsle9r0J0tqOWcDL6EyL63324ovAwREC2Joj7zOnuhPPtFLx7pjvUl6qMQzuyIiWppZkFbiA==}
+  '@guardian/bridget@8.9.1-2026-04-28':
+    resolution: {integrity: sha512-cBugAJi7uW00M5KuFnjQ/xqxG+6YydPQA6o2fHGosiRlmLADKLvMVesY7PovEOYqIU0J6bPpcvi6HsS4VNJvhg==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -11587,7 +11587,7 @@ snapshots:
       '@guardian/source': 11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.9.0': {}
+  '@guardian/bridget@8.9.1-2026-04-28': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
