### PR TITLE
Replace PA football team names

### DIFF
--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -118,6 +118,9 @@ describe('footballMatches', () => {
 			Holland: 'The Netherlands',
 			'Ivory Coast': 'Côte d’Ivoire',
 			'Union Saint Gilloise': 'Union Saint-Gilloise',
+			'Bosnia-Herzegovina': 'Bosnia and Herzegovina',
+			'Congo DR': 'DR Congo',
+			Curacao: 'Curaçao',
 		};
 
 		for (const [uncleanName, cleanName] of Object.entries(

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -98,5 +98,8 @@ export const cleanTeamName = (teamName: string): string => {
 		.replace('Holland', 'The Netherlands')
 		.replace('Ivory Coast', 'Côte d’Ivoire')
 		.replace('Bialystock', 'Białystok')
-		.replace('Union Saint Gilloise', 'Union Saint-Gilloise');
+		.replace('Union Saint Gilloise', 'Union Saint-Gilloise')
+		.replace('Bosnia-Herzegovina', 'Bosnia and Herzegovina')
+		.replace('Congo DR', 'DR Congo')
+		.replace('Curacao', 'Curaçao');
 };


### PR DESCRIPTION
## What does this change?
Replace PA football team names Bosnia-Herzegovina to be Bosnia and Herzegovina, Curacao to Curaçao, Congo DR to  DR Congo.
## Why?
To match guardian style guide.
Resolves https://github.com/guardian/dotcom-rendering/issues/15775
## Screenshots
<img width="764" height="38" alt="image" src="https://github.com/user-attachments/assets/a2443831-f3f1-422b-ad24-8464caee885d" />
<img width="764" height="38" alt="image" src="https://github.com/user-attachments/assets/a0847188-6fea-4aee-98c5-e6a620f0f6dd" />
<img width="764" height="38" alt="image" src="https://github.com/user-attachments/assets/1e137272-151a-44eb-ab5e-aa4d915ae895" />

