### PR TITLE
Poster image aspect ratio

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -710,6 +710,7 @@ export const selfHostedLoopVideo54Card = {
 		aspectRatio: 5 / 4,
 		duration: 30,
 		image: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+		imageAspectRatio: '5:4',
 	},
 	image: {
 		src: 'https://media.guim.co.uk/966bf085fb982b1103aaba42a812b09726cc0a3c/1417_104_1378_1104/master/1378.jpg',
@@ -733,6 +734,7 @@ export const selfHostedLoopVideo45Card = {
 			},
 		],
 		aspectRatio: 4 / 5,
+		imageAspectRatio: '4:5',
 	},
 } satisfies DCRFrontCard;
 
@@ -751,6 +753,7 @@ export const selfHostedLoopVideo53Card = {
 			},
 		],
 		aspectRatio: 5 / 3,
+		imageAspectRatio: '5:3',
 	},
 } satisfies DCRFrontCard;
 
@@ -769,6 +772,7 @@ export const selfHostedLoopVideo916Card = {
 			},
 		],
 		aspectRatio: 9 / 16,
+		imageAspectRatio: '9:16',
 	},
 } satisfies DCRFrontCard;
 
@@ -787,6 +791,7 @@ export const selfHostedLoopVideo169Card = {
 			},
 		],
 		aspectRatio: 16 / 9,
+		imageAspectRatio: '16:9',
 	},
 } satisfies DCRFrontCard;
 

--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -709,8 +709,10 @@ export const selfHostedLoopVideo54Card = {
 		],
 		aspectRatio: 5 / 4,
 		duration: 30,
-		image: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
-		imageAspectRatio: '5:4',
+		image: {
+			src: 'https://media.guim.co.uk/6537e163c9164d25ec6102641f6a04fa5ba76560/0_210_5472_3283/master/5472.jpg',
+			aspectRatio: '5:4',
+		},
 	},
 	image: {
 		src: 'https://media.guim.co.uk/966bf085fb982b1103aaba42a812b09726cc0a3c/1417_104_1378_1104/master/1378.jpg',
@@ -734,7 +736,10 @@ export const selfHostedLoopVideo45Card = {
 			},
 		],
 		aspectRatio: 4 / 5,
-		imageAspectRatio: '4:5',
+		image: {
+			...selfHostedLoopVideo54Card.mainMedia.image,
+			aspectRatio: '4:5',
+		},
 	},
 } satisfies DCRFrontCard;
 
@@ -753,7 +758,10 @@ export const selfHostedLoopVideo53Card = {
 			},
 		],
 		aspectRatio: 5 / 3,
-		imageAspectRatio: '5:3',
+		image: {
+			...selfHostedLoopVideo54Card.mainMedia.image,
+			aspectRatio: '5:3',
+		},
 	},
 } satisfies DCRFrontCard;
 
@@ -772,7 +780,10 @@ export const selfHostedLoopVideo916Card = {
 			},
 		],
 		aspectRatio: 9 / 16,
-		imageAspectRatio: '9:16',
+		image: {
+			...selfHostedLoopVideo54Card.mainMedia.image,
+			aspectRatio: '9:16',
+		},
 	},
 } satisfies DCRFrontCard;
 
@@ -791,7 +802,10 @@ export const selfHostedLoopVideo169Card = {
 			},
 		],
 		aspectRatio: 16 / 9,
-		imageAspectRatio: '16:9',
+		image: {
+			...selfHostedLoopVideo54Card.mainMedia.image,
+			aspectRatio: '16:9',
+		},
 	},
 } satisfies DCRFrontCard;
 

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -86,9 +86,11 @@ const mainSelfHostedVideo: MainMedia = {
 		},
 	],
 	aspectRatio: 16 / 9,
-	image: `https://i.guim.co.uk/img/media/2eb01d138eb8fba6e59ce7589a60e3ff984f6a7a/0_0_1920_1080/1920.jpg?width=1200&quality=45&dpr=2&s=none`,
+	image: {
+		src: 'https://i.guim.co.uk/img/media/2eb01d138eb8fba6e59ce7589a60e3ff984f6a7a/0_0_1920_1080/1920.jpg?width=1200&quality=45&dpr=2&s=none',
+		aspectRatio: '16:9',
+	},
 	duration: 100,
-	imageAspectRatio: '16:9',
 };
 
 const mainAudio: MainMedia = {

--- a/dotcom-rendering/src/components/Card/Card.stories.tsx
+++ b/dotcom-rendering/src/components/Card/Card.stories.tsx
@@ -88,6 +88,7 @@ const mainSelfHostedVideo: MainMedia = {
 	aspectRatio: 16 / 9,
 	image: `https://i.guim.co.uk/img/media/2eb01d138eb8fba6e59ce7589a60e3ff984f6a7a/0_0_1920_1080/1920.jpg?width=1200&quality=45&dpr=2&s=none`,
 	duration: 100,
+	imageAspectRatio: '16:9',
 };
 
 const mainAudio: MainMedia = {

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -971,6 +971,9 @@ export const Card = ({
 									subtitleSize={subtitleSize}
 									minAspectRatio={4 / 5}
 									containerAspectRatioDesktop={5 / 4}
+									posterImageAspectRatio={
+										media.mainMedia.imageAspectRatio
+									}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -958,11 +958,15 @@ export const Card = ({
 									uniqueId={uniqueId}
 									aspectRatio={media.mainMedia.aspectRatio}
 									videoStyle={media.mainMedia.videoStyle}
-									posterImage={media.mainMedia.image ?? ''}
-									posterImageAspectRatio={
-										media.mainMedia.imageAspectRatio
+									posterImage={
+										media.mainMedia.image.src ?? ''
 									}
-									fallbackImage={media.mainMedia.image ?? ''}
+									posterImageAspectRatio={
+										media.mainMedia.image.aspectRatio
+									}
+									fallbackImage={
+										media.mainMedia.image.src ?? ''
+									}
 									fallbackImageSize={mediaSize}
 									fallbackImageLoading={imageLoading}
 									fallbackImageAlt={media.imageAltText}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -959,6 +959,9 @@ export const Card = ({
 									aspectRatio={media.mainMedia.aspectRatio}
 									videoStyle={media.mainMedia.videoStyle}
 									posterImage={media.mainMedia.image ?? ''}
+									posterImageAspectRatio={
+										media.mainMedia.imageAspectRatio
+									}
 									fallbackImage={media.mainMedia.image ?? ''}
 									fallbackImageSize={mediaSize}
 									fallbackImageLoading={imageLoading}
@@ -971,9 +974,6 @@ export const Card = ({
 									subtitleSize={subtitleSize}
 									minAspectRatio={4 / 5}
 									containerAspectRatioDesktop={5 / 4}
-									posterImageAspectRatio={
-										media.mainMedia.imageAspectRatio
-									}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -577,6 +577,9 @@ export const FeatureCard = ({
 											posterImage={
 												media.mainMedia.image ?? ''
 											}
+											posterImageAspectRatio={
+												media.mainMedia.imageAspectRatio
+											}
 											fallbackImage={
 												media.mainMedia.image ?? ''
 											}

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -575,13 +575,14 @@ export const FeatureCard = ({
 												media.mainMedia.videoStyle
 											}
 											posterImage={
-												media.mainMedia.image ?? ''
+												media.mainMedia.image.src ?? ''
 											}
 											posterImageAspectRatio={
-												media.mainMedia.imageAspectRatio
+												media.mainMedia.image
+													.aspectRatio
 											}
 											fallbackImage={
-												media.mainMedia.image ?? ''
+												media.mainMedia.image.src ?? ''
 											}
 											fallbackImageSize={imageSize}
 											fallbackImageLoading={imageLoading}

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -136,6 +136,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo45Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '4:5',
 							},
 						},
 					]}
@@ -150,6 +151,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo916Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '9:16',
 							},
 						},
 					]}
@@ -164,6 +166,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo53Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '5:3',
 							},
 						},
 					]}

--- a/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableFeature.stories.tsx
@@ -136,7 +136,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo45Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '4:5',
+								image: {
+									...selfHostedLoopVideo45Card.mainMedia
+										.image,
+									aspectRatio: '4:5',
+								},
 							},
 						},
 					]}
@@ -151,7 +155,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo916Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '9:16',
+								image: {
+									...selfHostedLoopVideo916Card.mainMedia
+										.image,
+									aspectRatio: '9:16',
+								},
 							},
 						},
 					]}
@@ -166,7 +174,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo53Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '5:3',
+								image: {
+									...selfHostedLoopVideo53Card.mainMedia
+										.image,
+									aspectRatio: '5:3',
+								},
 							},
 						},
 					]}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -892,20 +892,8 @@ export const SelfHostedVideo = ({
 
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
-	const isVertical =
-		fallbackImageSize === 'feature' ||
-		fallbackImageSize === 'feature-large' ||
-		isGreyBarsAtSidesOnDesktop;
-
-	/* This is a hot fix for cards where the video is a different aspect ratio and will be replaced by https://github.com/guardian/dotcom-rendering/pull/15746 */
-	const posterImageAspectRatio = isVertical
-		? '4:5'
-		: isGreyBarsAtTopAndBottomOnDesktop
-		? '16:9'
-		: '5:4';
-
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
+		? getOptimisedPosterImage(posterImage, '5:4')
 		: undefined;
 
 	return (

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -309,6 +309,7 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
+	posterImageAspectRatio?: string;
 };
 
 export const SelfHostedVideo = ({
@@ -336,6 +337,7 @@ export const SelfHostedVideo = ({
 	format,
 	isMainMedia,
 	role,
+	posterImageAspectRatio,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -893,7 +895,7 @@ export const SelfHostedVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage, '5:4')
+		? getOptimisedPosterImage(posterImage, posterImageAspectRatio ?? '5:4')
 		: undefined;
 
 	return (

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -280,6 +280,7 @@ type Props = {
 	videoStyle: VideoPlayerFormat;
 	aspectRatio: number;
 	posterImage: string;
+	posterImageAspectRatio: string;
 	fallbackImage: CardPictureProps['mainImage'];
 	fallbackImageSize: CardPictureProps['imageSize'];
 	fallbackImageLoading: CardPictureProps['loading'];
@@ -309,7 +310,6 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
-	posterImageAspectRatio?: string;
 };
 
 export const SelfHostedVideo = ({
@@ -895,10 +895,7 @@ export const SelfHostedVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(
-				posterImage,
-				posterImageAspectRatio ?? fallbackImageAspectRatio ?? '5:4',
-		  )
+		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
 		: undefined;
 
 	return (

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -895,7 +895,10 @@ export const SelfHostedVideo = ({
 	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
 
 	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage, posterImageAspectRatio ?? '5:4')
+		? getOptimisedPosterImage(
+				posterImage,
+				posterImageAspectRatio ?? fallbackImageAspectRatio ?? '5:4',
+		  )
 		: undefined;
 
 	return (

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -50,6 +50,7 @@ export const SelfHostedVideoInArticle = ({
 				aspectRatio={aspectRatio}
 				linkTo="Article-embed-MediaAtomBlockElement"
 				posterImage={posterImageUrl}
+				posterImageAspectRatio={firstVideoSource?.aspectRatio ?? '5:4'}
 				sources={sources}
 				subtitleSize="medium"
 				subtitleSource={getSubtitleAsset(element.assets)}

--- a/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
@@ -112,6 +112,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo45Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '4:5',
 							},
 						},
 					]}
@@ -126,6 +127,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo916Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '9:16',
 							},
 						},
 					]}
@@ -140,6 +142,7 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo53Card.mainMedia,
 								videoStyle: 'Cinemagraph',
+								imageAspectRatio: '5:3',
 							},
 						},
 					]}

--- a/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
+++ b/dotcom-rendering/src/components/StaticFeatureTwo.stories.tsx
@@ -112,7 +112,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo45Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '4:5',
+								image: {
+									...selfHostedLoopVideo45Card.mainMedia
+										.image,
+									aspectRatio: '4:5',
+								},
 							},
 						},
 					]}
@@ -127,7 +131,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo916Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '9:16',
+								image: {
+									...selfHostedLoopVideo916Card.mainMedia
+										.image,
+									aspectRatio: '9:16',
+								},
 							},
 						},
 					]}
@@ -142,7 +150,11 @@ export const SelfHostedVideo = {
 							mainMedia: {
 								...selfHostedLoopVideo53Card.mainMedia,
 								videoStyle: 'Cinemagraph',
-								imageAspectRatio: '5:3',
+								image: {
+									...selfHostedLoopVideo53Card.mainMedia
+										.image,
+									aspectRatio: '5:3',
+								},
 							},
 						},
 					]}

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5742,17 +5742,25 @@
                             "type": "string"
                         },
                         "image": {
-                            "type": "string"
-                        },
-                        "imageAspectRatio": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "src": {
+                                    "type": "string"
+                                },
+                                "aspectRatio": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "aspectRatio"
+                            ]
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
-                        "imageAspectRatio",
+                        "image",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5743,12 +5743,16 @@
                         },
                         "image": {
                             "type": "string"
+                        },
+                        "imageAspectRatio": {
+                            "type": "string"
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
+                        "imageAspectRatio",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3995,12 +3995,16 @@
                         },
                         "image": {
                             "type": "string"
+                        },
+                        "imageAspectRatio": {
+                            "type": "string"
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
+                        "imageAspectRatio",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3994,17 +3994,25 @@
                             "type": "string"
                         },
                         "image": {
-                            "type": "string"
-                        },
-                        "imageAspectRatio": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "src": {
+                                    "type": "string"
+                                },
+                                "aspectRatio": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "aspectRatio"
+                            ]
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
-                        "imageAspectRatio",
+                        "image",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -2295,12 +2295,16 @@
                         },
                         "image": {
                             "type": "string"
+                        },
+                        "imageAspectRatio": {
+                            "type": "string"
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
+                        "imageAspectRatio",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -2294,17 +2294,25 @@
                             "type": "string"
                         },
                         "image": {
-                            "type": "string"
-                        },
-                        "imageAspectRatio": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "src": {
+                                    "type": "string"
+                                },
+                                "aspectRatio": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "aspectRatio"
+                            ]
                         }
                     },
                     "required": [
                         "aspectRatio",
                         "atomId",
                         "duration",
-                        "imageAspectRatio",
+                        "image",
                         "sources",
                         "type",
                         "videoStyle"

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -15,6 +15,17 @@ export const getLargest = (images: Image[]): Image | undefined => {
 /**
  * Finds the largest image by width in an array of images
  */
+export const getLargestImage = (images?: Image[]): Image | undefined => {
+	if (!images || images.length === 0) return undefined;
+
+	return [...images]
+		.sort((a, b) => Number(a.fields.width) - Number(b.fields.width))
+		.pop();
+};
+
+/**
+ * Finds the largest image by width in an array of images
+ */
 export const getLargestImageSize = (
 	images: {
 		url: string;

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -6,6 +6,8 @@ export type CustomPlayEventDetail = { uniqueId: string };
 /** We expect all videos to include dimensions since the field was added to FEMediaAsset */
 export const DEFAULT_ASPECT_RATIO = 5 / 4;
 
+export const DEFAULT_IMAGE_ASPECT_RATIO = '5:4';
+
 export const customSelfHostedVideoPlayAudioEventName =
 	'self-hosted-video:play-with-audio';
 export const customYoutubePlayEventName = 'youtube-video:play';

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -189,6 +189,7 @@ describe('Enhance Cards', () => {
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
 				subtitleSource: undefined,
+				imageAspectRatio: '5:4',
 				sources: [
 					{
 						mimeType: 'video/mp4',
@@ -240,6 +241,7 @@ describe('Enhance Cards', () => {
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
 				subtitleSource: 'https://guim-example.co.uk/atomID-1.vtt',
+				imageAspectRatio: '5:4',
 				sources: [
 					{
 						mimeType: 'video/mp4',

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -92,7 +92,10 @@ describe('Enhance Cards', () => {
 				atomId: 'atomID',
 				duration: 15,
 				aspectRatio: 5 / 4,
-				image: '',
+				image: {
+					src: '',
+					aspectRatio: '5:4',
+				},
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
 				subtitleSource: undefined,
@@ -105,7 +108,6 @@ describe('Enhance Cards', () => {
 						hasAudio: true,
 					},
 				],
-				imageAspectRatio: '5:4',
 			});
 		});
 
@@ -185,11 +187,13 @@ describe('Enhance Cards', () => {
 				atomId: 'atomID',
 				duration: 15,
 				aspectRatio: 5 / 4,
-				image: '',
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
 				subtitleSource: undefined,
-				imageAspectRatio: '5:4',
+				image: {
+					src: '',
+					aspectRatio: '5:4',
+				},
 				sources: [
 					{
 						mimeType: 'video/mp4',
@@ -237,11 +241,13 @@ describe('Enhance Cards', () => {
 				atomId: 'atomID',
 				duration: 15,
 				aspectRatio: 5 / 4,
-				image: '',
+				image: {
+					src: '',
+					aspectRatio: '5:4',
+				},
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
 				subtitleSource: 'https://guim-example.co.uk/atomID-1.vtt',
-				imageAspectRatio: '5:4',
 				sources: [
 					{
 						mimeType: 'video/mp4',
@@ -292,7 +298,10 @@ describe('Enhance Cards', () => {
 				sources: [],
 				aspectRatio: 5 / 4,
 				duration: 151,
-				imageAspectRatio: '5:4',
+				image: {
+					src: '',
+					aspectRatio: '5:4',
+				},
 			};
 
 			expect(getMediaMetadata(testSelfHostedMainMedia)).toEqual({
@@ -441,7 +450,10 @@ describe('Enhance Cards', () => {
 				atomId: 'atomID',
 				duration: 15,
 				aspectRatio: 5 / 4,
-				image: 'https://guim-example.co.uk/video-image',
+				image: {
+					src: 'https://guim-example.co.uk/video-image',
+					aspectRatio: '5:4',
+				},
 				sources: [
 					{
 						mimeType: 'video/mp4',
@@ -452,7 +464,6 @@ describe('Enhance Cards', () => {
 					},
 				],
 				videoStyle: 'Loop',
-				imageAspectRatio: '5:4',
 			});
 		});
 	});
@@ -494,7 +505,10 @@ describe('Enhance Cards', () => {
 				],
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
-				imageAspectRatio: '5:4',
+				image: {
+					src: undefined,
+					aspectRatio: '5:4',
+				},
 			});
 		});
 
@@ -510,7 +524,10 @@ describe('Enhance Cards', () => {
 				atomId: 'atomID',
 				duration: 15,
 				aspectRatio: 5 / 4,
-				image: undefined,
+				image: {
+					src: undefined,
+					aspectRatio: '5:4',
+				},
 				sources: [
 					{
 						mimeType: 'video/mp4',
@@ -522,7 +539,6 @@ describe('Enhance Cards', () => {
 				],
 				subtitleSource: undefined,
 				videoStyle: 'Loop',
-				imageAspectRatio: '5:4',
 			});
 		});
 	});

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -105,6 +105,7 @@ describe('Enhance Cards', () => {
 						hasAudio: true,
 					},
 				],
+				imageAspectRatio: '5:4',
 			});
 		});
 
@@ -449,6 +450,7 @@ describe('Enhance Cards', () => {
 					},
 				],
 				videoStyle: 'Loop',
+				imageAspectRatio: '5:4',
 			});
 		});
 	});
@@ -490,6 +492,7 @@ describe('Enhance Cards', () => {
 				],
 				type: 'SelfHostedVideo',
 				videoStyle: 'Loop',
+				imageAspectRatio: '5:4',
 			});
 		});
 
@@ -517,6 +520,7 @@ describe('Enhance Cards', () => {
 				],
 				subtitleSource: undefined,
 				videoStyle: 'Loop',
+				imageAspectRatio: '5:4',
 			});
 		});
 	});

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -289,6 +289,7 @@ describe('Enhance Cards', () => {
 				sources: [],
 				aspectRatio: 5 / 4,
 				duration: 151,
+				imageAspectRatio: '5:4',
 			};
 
 			expect(getMediaMetadata(testSelfHostedMainMedia)).toEqual({

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -177,13 +177,10 @@ const getLargestImageUrl = (images?: Image[]) => {
  */
 const decideMediaAtomImage = (
 	videoReplace: boolean,
-	mediaAtom: FEMediaAtom,
+	mediaAtomImages?: Image[],
 	cardTrailImage?: string,
-	isSelfHostedVideo?: boolean,
 ) => {
-	const largestMediaAtomImage = isSelfHostedVideo
-		? getLargestImageUrl(mediaAtom.posterImage?.allImages)
-		: getLargestImageUrl(mediaAtom.trailImage?.allImages);
+	const largestMediaAtomImage = getLargestImageUrl(mediaAtomImages);
 
 	if (videoReplace) {
 		return largestMediaAtomImage ?? cardTrailImage;
@@ -213,13 +210,6 @@ export const getActiveMediaAtom = (
 		)[0];
 		if (!firstVideoAsset) return undefined;
 
-		const image = decideMediaAtomImage(
-			videoReplace,
-			mediaAtom,
-			cardTrailImage,
-			firstVideoAsset.platform === 'Url',
-		);
-
 		/**
 		 * Each version of a media atom will contain assets for self-hosted OR YouTube, but not both.
 		 * Therefore, we check the platform of the first asset and assume the rest are the same.
@@ -230,6 +220,12 @@ export const getActiveMediaAtom = (
 			);
 			const subtitleAsset = assets.find(
 				({ assetType }) => assetType === 'Subtitles',
+			);
+
+			const image = decideMediaAtomImage(
+				videoReplace,
+				mediaAtom.posterImage?.allImages,
+				cardTrailImage,
 			);
 
 			const videoAssets =
@@ -254,6 +250,12 @@ export const getActiveMediaAtom = (
 		 * There should only be one asset for Youtube atoms, so we use the first one.
 		 */
 		if (firstVideoAsset.platform === 'Youtube') {
+			const image = decideMediaAtomImage(
+				videoReplace,
+				mediaAtom.trailImage?.allImages,
+				cardTrailImage,
+			);
+
 			return {
 				type: 'YoutubeVideo',
 				id: mediaAtom.id,

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -246,9 +246,11 @@ export const getActiveMediaAtom = (
 				subtitleSource: subtitleAsset?.id,
 				aspectRatio,
 				duration: mediaAtom.duration ?? 0,
-				image: image.src,
-				imageAspectRatio:
-					image.imageAspectRatio ?? DEFAULT_IMAGE_ASPECT_RATIO,
+				image: {
+					src: image.src,
+					aspectRatio:
+						image.imageAspectRatio ?? DEFAULT_IMAGE_ASPECT_RATIO,
+				},
 			};
 		}
 

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -234,6 +234,10 @@ export const getActiveMediaAtom = (
 
 			const aspectRatio = getAspectRatioFromSources(sources);
 
+			const imageAspectRatio =
+				mediaAtom.posterImage?.allImages[0]?.fields.aspectRatio ??
+				'5:4';
+
 			return {
 				type: 'SelfHostedVideo',
 				videoStyle: mediaAtom.videoPlayerFormat ?? 'Loop',
@@ -243,6 +247,7 @@ export const getActiveMediaAtom = (
 				aspectRatio,
 				duration: mediaAtom.duration ?? 0,
 				image,
+				imageAspectRatio,
 			};
 		}
 

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -13,9 +13,10 @@ import { getSoleContributor } from '../lib/byline';
 import type { EditionId } from '../lib/edition';
 import type { Group } from '../lib/getDataLinkName';
 import { getDataLinkNameCard } from '../lib/getDataLinkName';
-import { getLargestImageSize } from '../lib/image';
+import { getLargestImage } from '../lib/image';
 import {
 	convertFEMediaAssetsToVideoAssets,
+	DEFAULT_IMAGE_ASPECT_RATIO,
 	extractValidSourcesFromAssets,
 	getAspectRatioFromSources,
 } from '../lib/video';
@@ -162,31 +163,34 @@ const decideSlideshowImages = (
 	return undefined;
 };
 
-const getLargestImageUrl = (images?: Image[]) => {
-	return getLargestImageSize(
-		images?.map(({ url, fields: { width } }) => ({
-			url,
-			width: Number(width),
-		})) ?? [],
-	)?.url;
-};
-
 /**
- * If we have a replacement video, we should prioritise the largest available trail image from the media atom.
- * For all other videos, we should prioritise the card's trail image.
+ * If we have a replacement video, we prioritise the largest available trail image from the media atom.
+ * For all other videos, we prioritise the card's trail image.
  */
 const decideMediaAtomImage = (
 	videoReplace: boolean,
 	mediaAtomImages?: Image[],
 	cardTrailImage?: string,
-) => {
-	const largestMediaAtomImage = getLargestImageUrl(mediaAtomImages);
+): { src?: string; imageAspectRatio?: string } => {
+	const largestMediaAtomImage = getLargestImage(mediaAtomImages);
 
-	if (videoReplace) {
-		return largestMediaAtomImage ?? cardTrailImage;
+	if (isUndefined(largestMediaAtomImage)) {
+		return { src: cardTrailImage };
 	}
 
-	return cardTrailImage ?? largestMediaAtomImage;
+	if (isUndefined(cardTrailImage)) {
+		return {
+			src: largestMediaAtomImage.url,
+			imageAspectRatio: largestMediaAtomImage.fields.aspectRatio,
+		};
+	}
+
+	return videoReplace
+		? {
+				src: largestMediaAtomImage.url,
+				imageAspectRatio: largestMediaAtomImage.fields.aspectRatio,
+		  }
+		: { src: cardTrailImage };
 };
 
 /**
@@ -234,10 +238,6 @@ export const getActiveMediaAtom = (
 
 			const aspectRatio = getAspectRatioFromSources(sources);
 
-			const imageAspectRatio =
-				mediaAtom.posterImage?.allImages[0]?.fields.aspectRatio ??
-				'5:4';
-
 			return {
 				type: 'SelfHostedVideo',
 				videoStyle: mediaAtom.videoPlayerFormat ?? 'Loop',
@@ -246,8 +246,9 @@ export const getActiveMediaAtom = (
 				subtitleSource: subtitleAsset?.id,
 				aspectRatio,
 				duration: mediaAtom.duration ?? 0,
-				image,
-				imageAspectRatio,
+				image: image.src,
+				imageAspectRatio:
+					image.imageAspectRatio ?? DEFAULT_IMAGE_ASPECT_RATIO,
 			};
 		}
 
@@ -277,7 +278,7 @@ export const getActiveMediaAtom = (
 				 * a soft contract with Editorial who manually set the duration of videos.
 				 */
 				isLive: mediaAtom.duration === 0,
-				image,
+				image: image.src,
 			};
 		}
 	}

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -32,6 +32,7 @@ type SelfHostedVideo = Media & {
 	duration: number;
 	subtitleSource?: string;
 	image?: string;
+	imageAspectRatio: string;
 };
 
 type Audio = Media & {

--- a/dotcom-rendering/src/types/mainMedia.ts
+++ b/dotcom-rendering/src/types/mainMedia.ts
@@ -31,8 +31,10 @@ type SelfHostedVideo = Media & {
 	aspectRatio: number;
 	duration: number;
 	subtitleSource?: string;
-	image?: string;
-	imageAspectRatio: string;
+	image: {
+		src?: string;
+		aspectRatio: string;
+	};
 };
 
 type Audio = Media & {


### PR DESCRIPTION
## What does this change?
Passes through the poster image aspect ratio from frontend to the self hosted video player

## Why?
so that self hosted videos can display a poster image in a different aspect ratio to the underlying fronts card. This is required for videos that are click to play by default or due to low power mode. 

This removes [this brittle hotfix](https://github.com/guardian/dotcom-rendering/pull/15773) which derives poster aspect ratio rather than piping the frontend value through. 

## Front card Screenshots

| 5:4      | 3:4      | 9:16      |
| ----------- | ---------- | ---------- |
| ![before][] | ![after][] | ![after1][] |

[before]: https://github.com/user-attachments/assets/b3e0d678-950a-477c-baa5-be79dbb429ed
[after]: https://github.com/user-attachments/assets/6cadf448-b361-446a-b2d2-8be63389659b
[after1]: https://github.com/user-attachments/assets/bd88c358-8b03-4940-bcc4-c21a7afbcc19

##  Article screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before2][] | ![after2][] |

[before2]: https://github.com/user-attachments/assets/a5c25d8e-7300-47f1-8458-942d00219f28
[after2]: https://github.com/user-attachments/assets/421a481b-c745-4351-ba32-c01c2692dc88

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
