### PR TITLE
Allow 3 / 4 as the minimum aspect ratio for non-feature front cards 

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -976,7 +976,7 @@ export const Card = ({
 										media.mainMedia.subtitleSource
 									}
 									subtitleSize={subtitleSize}
-									minAspectRatio={4 / 5}
+									minAspectRatio={3 / 4}
 									containerAspectRatioDesktop={5 / 4}
 								/>
 							</Island>


### PR DESCRIPTION
## What does this change?
Allow 3/4 as the minimum aspect ratio for all non-feature cards.

This PR does not allow 3/4 in feature cards because doing so would create a scenario where two cards alongside each other could have varying aspect ratios.

## Why?
Editorial would like to support 3/4 aspect ratio videos on site as this will cut off less vertically than a 4:5 would 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/6c13bedc-7aa6-44b9-9279-7e0cb445d7ed
[after]: https://github.com/user-attachments/assets/4a60db77-65eb-4180-a218-bc6b7444c3a0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
