### PR TITLE
Custom subtitles screen reader

### DIFF
--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -76,7 +76,10 @@ export const SubtitleOverlay = ({
 	position: SubtitlesPosition;
 }) => {
 	return (
-		<div css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}>
+		<div
+			role="status"
+			css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}
+		>
 			<div css={cueBoxStyles}>
 				<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
 			</div>


### PR DESCRIPTION
## What does this change?
Add [role="status"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role) to the custom subtitle overlay for self hosted videos. This is to make sure the subtitle overlay is read out by screen readers.

`role="status"` implicitly sets both `aria-live="polite"` and `aria-atomic="true"` per the WAI-ARIA spec. `aria-live="polite"` tells screen readers to watch the region and announce changes automatically, without interrupting what's currently being read.

## Why?
So that self hosted videos are accessible to screen readers when we have custom subtitles.

## Screenshots


https://github.com/user-attachments/assets/6f8023fe-5e29-4297-8594-09ca7c53b277


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
