### PR TITLE
Upgrade chromatic cli to 16.7.0

### DIFF
--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Chromatic - DCR
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: chromaui/action@v13.3.0
+        uses: chromaui/action@v16.7.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

Upgrades Chromatic action v16.7.0

https://github.com/chromaui/chromatic-cli/releases

## Why?

We are currently seeing this warning in Chromatic builds:

<img width="878" height="50" alt="Screenshot 2026-05-05 at 13 57 40" src="https://github.com/user-attachments/assets/e1ff5b8f-e822-421d-9219-537a7d58136c" />

