### PR TITLE
Ab/subtitles for default

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -957,7 +957,9 @@ export const Card = ({
 									atomId={media.mainMedia.atomId}
 									uniqueId={uniqueId}
 									aspectRatio={media.mainMedia.aspectRatio}
-									videoStyle={media.mainMedia.videoStyle}
+									// TODO:: undo before merging. this is required for testing only
+									videoStyle={'Default'}
+									// videoStyle={media.mainMedia.videoStyle}
 									posterImage={media.mainMedia.image ?? ''}
 									fallbackImage={media.mainMedia.image ?? ''}
 									fallbackImageSize={mediaSize}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -645,6 +645,9 @@ export const SelfHostedVideo = ({
 	}
 
 	const handleLoadedMetadata = () => {
+		/* default selfhosted videos use browser subtitles */
+		if (isDefault) return;
+
 		const video = vidRef.current;
 		if (!video) return;
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -397,7 +397,7 @@ export const SelfHostedVideo = ({
 	});
 
 	const activeCue = useSubtitles({
-		video: vidRef.current,
+		video: isDefault ? null : vidRef.current,
 		playerState,
 		currentTime,
 	});

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -978,6 +978,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
+						showCustomSubtitles={!isDefault}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -42,13 +42,17 @@ const interactiveStyles = css`
 
 const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	::cue {
-		/* Hide the cue by default as we prefer custom overlay */
-		visibility: hidden;
-
 		color: ${palette('--video-subtitle-text')};
 		${subtitleSize === 'small' && textSans15};
 		${subtitleSize === 'medium' && textSans17};
 		${subtitleSize === 'large' && textSans20};
+	}
+`;
+
+const customSubtitleStyles = css`
+	::cue {
+		/* Hide the cue by default as we prefer custom overlay */
+		visibility: hidden;
 	}
 `;
 
@@ -142,6 +146,7 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	showCustomSubtitles: boolean;
 };
 
 /**
@@ -195,6 +200,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
+			showCustomSubtitles,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -210,6 +216,13 @@ export const SelfHostedVideoPlayer = forwardRef(
 			showPlayIcon ? 'play' : 'pause'
 		}-${atomId}`;
 
+		console.log(
+			{
+				subtitleSource,
+			},
+			sources,
+		);
+
 		return (
 			<>
 				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Not all videos require captions. */}
@@ -219,6 +232,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
 						showSubtitles && subtitleStyles(subtitleSize),
+						showCustomSubtitles && customSubtitleStyles,
 					]}
 					crossOrigin="anonymous"
 					ref={ref}
@@ -263,7 +277,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					)}
 					{FallbackImageComponent}
 				</video>
-				{showSubtitles && !!activeCue?.text && (
+				{showCustomSubtitles && !!activeCue?.text && (
 					<SubtitleOverlay
 						text={activeCue.text}
 						size={subtitleSize}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -52,7 +52,7 @@ const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
 const customSubtitleStyles = css`
 	::cue {
 		/* Hide the cue by default as we prefer custom overlay */
-		opacity: 0;
+		visibility: hidden;
 	}
 `;
 
@@ -204,6 +204,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
+		console.log('showFullScreen', showFullscreenIcon);
 		const videoId = `video-${uniqueId}`;
 
 		const currentRefExists = ref && 'current' in ref && !!ref.current;
@@ -321,7 +322,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 								smallIconsPositionStyles(iconsPosition),
 						]}
 					>
-						{showFullscreenIcon && (
+						{true && (
 							<FullscreenIcon
 								handleClick={handleFullscreenClick}
 								atomId={atomId}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -52,7 +52,7 @@ const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
 const customSubtitleStyles = css`
 	::cue {
 		/* Hide the cue by default as we prefer custom overlay */
-		visibility: hidden;
+		opacity: 0;
 	}
 `;
 

--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -76,10 +76,32 @@ export const SubtitleOverlay = ({
 	position: SubtitlesPosition;
 }) => {
 	return (
-		<div css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}>
-			<div css={cueBoxStyles}>
-				<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
+		<>
+			{/* Visual subtitles (no ARIA here) */}
+			<div
+				css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}
+			>
+				<div css={cueBoxStyles}>
+					<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
+				</div>
 			</div>
-		</div>
+
+			{/* Accessibility layer (screen reader only) */}
+			<div
+				role="status"
+				aria-live="polite"
+				aria-atomic="true"
+				style={{
+					position: 'absolute',
+					width: '1px',
+					height: '1px',
+					overflow: 'hidden',
+					clip: 'rect(0 0 0 0)',
+					whiteSpace: 'nowrap',
+				}}
+			>
+				{text}
+			</div>
+		</>
 	);
 };

--- a/dotcom-rendering/src/components/SubtitleOverlay.tsx
+++ b/dotcom-rendering/src/components/SubtitleOverlay.tsx
@@ -76,32 +76,15 @@ export const SubtitleOverlay = ({
 	position: SubtitlesPosition;
 }) => {
 	return (
-		<>
-			{/* Visual subtitles (no ARIA here) */}
-			<div
-				css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}
-			>
-				<div css={cueBoxStyles}>
-					<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
-				</div>
+		<div
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			css={[subtitleOverlayStyles, subtitlePositionStyles(position)]}
+		>
+			<div css={cueBoxStyles}>
+				<div css={[cueStyles, cueTextStyles(size)]}>{text}</div>
 			</div>
-
-			{/* Accessibility layer (screen reader only) */}
-			<div
-				role="status"
-				aria-live="polite"
-				aria-atomic="true"
-				style={{
-					position: 'absolute',
-					width: '1px',
-					height: '1px',
-					overflow: 'hidden',
-					clip: 'rect(0 0 0 0)',
-					whiteSpace: 'nowrap',
-				}}
-			>
-				{text}
-			</div>
-		</>
+		</div>
 	);
 };


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
