### PR TITLE
Explicitly specify directories for github actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,9 @@ updates:
         exclude-patterns:
           - '@storybook/*'
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - '/.github/workflows'
+      - '/.github/actions/setup-node-env'
     schedule:
       interval: 'daily'
     rebase-strategy: 'disabled'


### PR DESCRIPTION
## What does this change?
Explicitly specify directories for github actions dependabot

## Why?
Just setting to `/` means dependabot will not look at actions in the `setup-node-env` workflow, so the actions in there are pretty out of date.