### PR TITLE
Send browserId in the payload to the epic API

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd/ReaderRevenueEpic.tsx
@@ -31,6 +31,7 @@ import type { CanShowResult } from '../../lib/messagePicker';
 import { getEpic } from '../../lib/sdcRequests';
 import type { RenderingTarget } from '../../types/renderingTarget';
 import type { TagType } from '../../types/tag';
+import { hasRequiredConsents } from '../SignInGate/displayRules';
 
 const wrapperMargins = css`
 	margin: 18px 0;
@@ -54,6 +55,7 @@ export type CanShowData = {
 	pageId?: string;
 	inHoldbackGroup?: boolean;
 	isSensitive: boolean;
+	browserId?: string;
 };
 
 const buildPayload = async (
@@ -77,6 +79,7 @@ const buildPayload = async (
 		pageId: data.pageId,
 		inHoldbackGroup: data.inHoldbackGroup,
 		isSensitive: data.isSensitive,
+		browserId: data.browserId,
 	},
 });
 
@@ -108,8 +111,17 @@ export const canShowReaderRevenueEpic = async (
 		'contributions-epic-data',
 	);
 
+	//Send user consent status to the epic API
+	const userConsent = await hasRequiredConsents();
+
+	const getBrowserId = (): string | undefined => {
+		if (!userConsent) return undefined;
+		return getCookie({ name: 'bwid', shouldMemoize: true }) ?? undefined;
+	};
+
 	const contributionsPayload = await buildPayload({
 		...data,
+		browserId: getBrowserId(),
 		hideSupportMessagingForUser,
 	});
 


### PR DESCRIPTION
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214348418702844)
## What does this change?
This change adds browserId to the payload of epic API POST request only for users that are consented.
## Why?
We have the ability to look for users profiles in mParticle by browserId even even for users, who are not signed it. This allows application of targeted messages to some browser users, who consented and are not signed in.
## Screenshots
<img width="623" height="462" alt="Screenshot 2026-05-06 at 15 27 06" src="https://github.com/user-attachments/assets/d6bce662-4a72-4669-8f96-8b9eddc2951b" />
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
