### PR TITLE
Fullscreen controls on mobile

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -354,6 +354,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
+	const [showNativeControls, setShowNativeControls] = useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -640,10 +641,44 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
+	useEffect(() => {
+		const video = vidRef.current;
+		if (!video) return;
+
+		const onFullscreenChange = () => {
+			const isFullscreen = !!document.fullscreenElement;
+			setShowNativeControls(isFullscreen);
+		};
+
+		const onWebkitBeginFullscreen = () => setShowNativeControls(true);
+		const onWebkitEndFullscreen = () => setShowNativeControls(false);
+
+		document.addEventListener('fullscreenchange', onFullscreenChange);
+		video.addEventListener(
+			'webkitbeginfullscreen',
+			onWebkitBeginFullscreen,
+		);
+		video.addEventListener('webkitendfullscreen', onWebkitEndFullscreen);
+
+		return () => {
+			document.removeEventListener(
+				'fullscreenchange',
+				onFullscreenChange,
+			);
+			video.removeEventListener(
+				'webkitbeginfullscreen',
+				onWebkitBeginFullscreen,
+			);
+			video.removeEventListener(
+				'webkitendfullscreen',
+				onWebkitEndFullscreen,
+			);
+		};
+	}, [vidRef]);
+
 	if (adapted) {
 		return FallbackImageComponent;
 	}
-
 	const handleLoadedMetadata = () => {
 		const video = vidRef.current;
 		if (!video) return;
@@ -978,6 +1013,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
+						showNativeControls={showNativeControls}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -142,6 +142,7 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	showNativeControls: boolean;
 };
 
 /**
@@ -195,6 +196,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
+			showNativeControls,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -220,6 +222,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						isInteractive && interactiveStyles,
 						showSubtitles && subtitleStyles(subtitleSize),
 					]}
+					controls={showNativeControls}
 					crossOrigin="anonymous"
 					ref={ref}
 					tabIndex={0}


### PR DESCRIPTION
## What does this change?
Add fullscreen listeners to the self hosted video player to toggle native controls on and off when the user enters and exits fullscreen.

## Why?
This is required because Firefox mobile doesn't show controls unless they are explicitly set on the video element

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b5743d97-a688-4cb8-8d3e-bfaebd2b8634
[after]: https://github.com/user-attachments/assets/fc911476-a089-41cb-a09a-cdb59853307a


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
