### PR TITLE
Sends Ophan media events when fullscreen mode is entered and exited

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -720,17 +720,24 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
+	/**
+	 * Capture fullscreen tracking events across browsers and devices
+	 * We need to support events across:
+	 * 	- Browsers with fullscreen API support
+	 * 	- OSX Safari
+	 * 	- iOS Safari
+	 */
 	useEffect(() => {
 		const video = vidRef.current;
+		const playerContainer = playerContainerRef.current;
 
-		if (!video) {
-			return;
-		}
+		if (!playerContainer && !video) return;
 
 		const reportFullscreenEvent = () => {
 			const event =
 				document.fullscreenElement ||
-				('webkitDisplayingFullscreen' in video &&
+				(video &&
+					'webkitDisplayingFullscreen' in video &&
 					video.webkitDisplayingFullscreen)
 					? 'enter_fullscreen'
 					: 'exit_fullscreen';
@@ -739,12 +746,27 @@ export const SelfHostedVideo = ({
 		};
 
 		for (const event of fullscreenChangeEvents) {
-			video.addEventListener(event, reportFullscreenEvent);
+			if (video) {
+				video.addEventListener(event, reportFullscreenEvent);
+			}
+
+			if (playerContainer) {
+				playerContainer.addEventListener(event, reportFullscreenEvent);
+			}
 		}
 
 		return () => {
 			for (const event of fullscreenChangeEvents) {
-				video.removeEventListener(event, reportFullscreenEvent);
+				if (video) {
+					video.removeEventListener(event, reportFullscreenEvent);
+				}
+
+				if (playerContainer) {
+					playerContainer.removeEventListener(
+						event,
+						reportFullscreenEvent,
+					);
+				}
 			}
 		};
 	}, [sendOphanTrackingEvent]);

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -710,6 +710,38 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
+	useEffect(() => {
+		const video = vidRef.current;
+
+		if (!video) {
+			return;
+		}
+
+		const reportFullscreenEvent = () => {
+			sendOphanTrackingEvent(
+				document.fullscreenElement
+					? 'enter_fullscreen'
+					: 'exit_fullscreen',
+			);
+		};
+
+		video.addEventListener('fullscreenchange', reportFullscreenEvent);
+
+		video.addEventListener('webkitfullscreenchange', reportFullscreenEvent);
+
+		return () => {
+			video.removeEventListener(
+				'fullscreenchange',
+				reportFullscreenEvent,
+			);
+
+			video.removeEventListener(
+				'webkitfullscreenchange',
+				reportFullscreenEvent,
+			);
+		};
+	}, [sendOphanTrackingEvent]);
+
 	if (adapted) {
 		return FallbackImageComponent;
 	}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -241,6 +241,16 @@ const shouldUseWebkitFullscreen = (video: HTMLVideoElement): boolean => {
 };
 
 /**
+ * 	The events we need to respond to for fullscreen tracking
+ * */
+const fullscreenChangeEvents = [
+	'fullscreenchange',
+	'webkitfullscreenchange',
+	'webkitbeginfullscreen',
+	'webkitendfullscreen',
+];
+
+/**
  * Ensures the aspect ratio falls between the minimum and maximum allowed aspect ratios, if specified.
  * For example, we may not want to render a square video inside a 4:5 feature card. In this case, the
  * minimum & maximum aspect ratio would be 4:5, so that the video fits the fixed-aspect ratio feature card
@@ -718,27 +728,24 @@ export const SelfHostedVideo = ({
 		}
 
 		const reportFullscreenEvent = () => {
-			sendOphanTrackingEvent(
-				document.fullscreenElement
+			const event =
+				document.fullscreenElement ||
+				('webkitDisplayingFullscreen' in video &&
+					video.webkitDisplayingFullscreen)
 					? 'enter_fullscreen'
-					: 'exit_fullscreen',
-			);
+					: 'exit_fullscreen';
+
+			sendOphanTrackingEvent(event);
 		};
 
-		video.addEventListener('fullscreenchange', reportFullscreenEvent);
-
-		video.addEventListener('webkitfullscreenchange', reportFullscreenEvent);
+		for (const event of fullscreenChangeEvents) {
+			video.addEventListener(event, reportFullscreenEvent);
+		}
 
 		return () => {
-			video.removeEventListener(
-				'fullscreenchange',
-				reportFullscreenEvent,
-			);
-
-			video.removeEventListener(
-				'webkitfullscreenchange',
-				reportFullscreenEvent,
-			);
+			for (const event of fullscreenChangeEvents) {
+				video.removeEventListener(event, reportFullscreenEvent);
+			}
 		};
 	}, [sendOphanTrackingEvent]);
 

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -329,7 +329,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 							{showFullscreenIcon && (
 								<FullscreenIcon
 									handleClick={handleFullscreenClick}
-									atomId={atomId}
 								/>
 							)}
 							{hasAudio && (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -53,19 +53,16 @@ export const AudioIcon = ({ isMuted, handleClick }: AudioIconProps) => {
 };
 
 type FullscreenIconProps = {
-	atomId: SelfHostedVideoPlayerProps['atomId'];
 	handleClick: SelfHostedVideoPlayerProps['handleFullscreenClick'];
 };
 
 export const FullscreenIcon = ({
-	atomId,
 	handleClick,
 }: FullscreenIconProps) => (
 	<button
 		type="button"
 		onClick={handleClick}
 		css={[buttonStyles, iconContainerStyles]}
-		data-link-name={`gu-video-loop-fullscreen-${atomId}`}
 		data-testid="fullscreen-icon"
 	>
 		<SvgArrowExpand

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -56,9 +56,7 @@ type FullscreenIconProps = {
 	handleClick: SelfHostedVideoPlayerProps['handleFullscreenClick'];
 };
 
-export const FullscreenIcon = ({
-	handleClick,
-}: FullscreenIconProps) => (
+export const FullscreenIcon = ({ handleClick }: FullscreenIconProps) => (
 	<button
 		type="button"
 		onClick={handleClick}


### PR DESCRIPTION
## What does this change?

This change submis tracking events when self-hosted video enters or exits fullscreen mode. 

> [!NOTE]
>  I'm currently asking whether we also need to include the inpage click events or the media events will be suffcient.

## Why?

This will allow us to gather data about user interactions with the self hosted media player, following on from #15804. 

## Testing

I have tested this change across Chrome, Firefox and Safari. 


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
