### PR TITLE
Enable custom overlays for default self hosted videos

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -957,7 +957,8 @@ export const Card = ({
 									atomId={media.mainMedia.atomId}
 									uniqueId={uniqueId}
 									aspectRatio={media.mainMedia.aspectRatio}
-									videoStyle={media.mainMedia.videoStyle}
+									videoStyle={'Default'}
+									// videoStyle={media.mainMedia.videoStyle}
 									posterImage={
 										media.mainMedia.image.src ?? ''
 									}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -342,6 +342,7 @@ export const SelfHostedVideo = ({
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
 	const vidRef = useRef<HTMLVideoElement>(null);
+	const playerContainerRef = useRef<HTMLDivElement>(null);
 	const [isPlayable, setIsPlayable] = useState(false);
 	const [isMuted, setIsMuted] = useState(true);
 	const [showPosterImage, setShowPosterImage] = useState<boolean>(false);
@@ -356,7 +357,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
-
+	const [isNativeFullscreen, setIsNativeFullscreen] = useState(false);
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 
@@ -399,7 +400,7 @@ export const SelfHostedVideo = ({
 	});
 
 	const activeCue = useSubtitles({
-		video: isDefault ? null : vidRef.current,
+		video: vidRef.current,
 		playerState,
 		currentTime,
 	});
@@ -603,6 +604,19 @@ export const SelfHostedVideo = ({
 		};
 	}, [uniqueId, atomId, sources, renderingTarget, ophanVideoStyle]);
 
+	useEffect(() => {
+		const video = vidRef.current;
+		if (!video) return;
+
+		const handleEndFullscreen = () => setIsNativeFullscreen(false);
+		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
+		return () =>
+			video.removeEventListener(
+				'webkitendfullscreen',
+				handleEndFullscreen,
+			);
+	}, []);
+
 	/**
 	 * Track the first time the video comes into view.
 	 */
@@ -664,10 +678,6 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleLoadedMetadata = () => {
-		/* Default videos don't use custom subtitles,
-		so they don't need to be positioned.*/
-		if (!isDefault) return;
-
 		/* Cinemagraphs do not have subtitles*/
 		if (!isCinemagraph) return;
 
@@ -751,16 +761,19 @@ export const SelfHostedVideo = ({
 			};
 
 			if (webkitVideo.webkitDisplayingFullscreen) {
+				setIsNativeFullscreen(false);
 				return webkitVideo.webkitExitFullscreen();
 			} else {
+				setIsNativeFullscreen(true);
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}
 
 		if (document.fullscreenElement) {
 			void document.exitFullscreen();
+		} else if (playerContainerRef.current) {
+			void playerContainerRef.current.requestFullscreen();
 		}
-		void video.requestFullscreen();
 	};
 
 	/**
@@ -950,6 +963,7 @@ export const SelfHostedVideo = ({
 						FallbackImageComponent={FallbackImageComponent}
 						currentTime={currentTime}
 						ref={vidRef}
+						playerContainerRef={playerContainerRef}
 						isMuted={isMuted}
 						handleLoadedMetadata={handleLoadedMetadata}
 						handleLoadedData={handleLoadedData}
@@ -979,7 +993,8 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
-						showCustomSubtitles={!isDefault && !isCinemagraph}
+						showCustomSubtitles={!isCinemagraph}
+						isNativeFullscreen={isNativeFullscreen}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -399,7 +399,7 @@ export const SelfHostedVideo = ({
 	});
 
 	const activeCue = useSubtitles({
-		video: vidRef.current,
+		video: isDefault ? null : vidRef.current,
 		playerState,
 		currentTime,
 	});
@@ -664,6 +664,13 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleLoadedMetadata = () => {
+		/* Default videos don't use custom subtitles,
+		so they don't need to be positioned.*/
+		if (!isDefault) return;
+
+		/* Cinemagraphs do not have subtitles*/
+		if (!isCinemagraph) return;
+
 		const video = vidRef.current;
 		if (!video) return;
 
@@ -972,7 +979,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
-						showCustomSubtitles={!isDefault}
+						showCustomSubtitles={!isDefault && !isCinemagraph}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -646,10 +646,7 @@ export const SelfHostedVideo = ({
 		return FallbackImageComponent;
 	}
 
-	const handleLoadedMetadata = () => {
-		const video = vidRef.current;
-		if (!video) return;
-
+	const positionCues = (video: HTMLVideoElement) => {
 		const track = video.textTracks[0];
 		if (!track?.cues) return;
 
@@ -664,6 +661,13 @@ export const SelfHostedVideo = ({
 				cue.line = percentFromTop;
 			}
 		}
+	};
+
+	const handleLoadedMetadata = () => {
+		const video = vidRef.current;
+		if (!video) return;
+
+		positionCues(video);
 	};
 
 	const handleLoadedData = () => {

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -968,6 +968,7 @@ export const SelfHostedVideo = ({
 						shouldLoop={shouldLoop}
 						showFullscreenIcon={isDefault}
 						isInteractive={!isCinemagraph}
+						showCustomSubtitles={!isDefault}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -43,6 +43,7 @@ const interactiveStyles = css`
 const subtitleFontStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	::cue {
 		color: ${palette('--video-subtitle-text')};
+		background-color: rgba(0, 0, 0, 0.7);
 		${subtitleSize === 'small' && textSans15};
 		${subtitleSize === 'medium' && textSans17};
 		${subtitleSize === 'large' && textSans20};
@@ -147,6 +148,8 @@ export type Props = {
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
 	showCustomSubtitles: boolean;
+	isNativeFullscreen: boolean;
+	playerContainerRef: React.RefObject<HTMLDivElement>;
 };
 
 /**
@@ -201,6 +204,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 			iconsPosition,
 			subtitlesPosition,
 			showCustomSubtitles: canShowCustomSubtitles,
+			isNativeFullscreen,
+			playerContainerRef,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -209,7 +214,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const currentRefExists = ref && 'current' in ref && !!ref.current;
 
 		const showSubtitles = canShowSubtitles && !!subtitleSource;
-		const showCustomSubtitles = showSubtitles && canShowCustomSubtitles;
+		const showCustomSubtitles =
+			showSubtitles && canShowCustomSubtitles && !isNativeFullscreen;
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
@@ -218,7 +224,15 @@ export const SelfHostedVideoPlayer = forwardRef(
 		}-${atomId}`;
 
 		return (
-			<>
+			<div
+				ref={playerContainerRef}
+				css={css`
+					position: relative;
+					width: 100%;
+					height: 100%;
+					background-color: black;
+				`}
+			>
 				{/* eslint-disable-next-line jsx-a11y/media-has-caption -- Not all videos require captions. */}
 				<video
 					id={videoId}
@@ -333,7 +347,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						)}
 					</div>
 				)}
-			</>
+			</div>
 		);
 	},
 );

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -40,15 +40,19 @@ const interactiveStyles = css`
 	cursor: pointer;
 `;
 
-const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
+const subtitleFontStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	::cue {
-		/* Hide the cue by default as we prefer custom overlay */
-		visibility: hidden;
-
 		color: ${palette('--video-subtitle-text')};
 		${subtitleSize === 'small' && textSans15};
 		${subtitleSize === 'medium' && textSans17};
 		${subtitleSize === 'large' && textSans20};
+	}
+`;
+
+const hideNativeSubtitles = css`
+	::cue {
+		/* Hide the cue by default as we prefer custom overlay */
+		visibility: hidden;
 	}
 `;
 
@@ -142,6 +146,7 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	showCustomSubtitles: boolean;
 };
 
 /**
@@ -195,6 +200,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
+			showCustomSubtitles: canShowCustomSubtitles,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -203,6 +209,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const currentRefExists = ref && 'current' in ref && !!ref.current;
 
 		const showSubtitles = canShowSubtitles && !!subtitleSource;
+		const showCustomSubtitles = showSubtitles && canShowCustomSubtitles;
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
@@ -218,7 +225,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 					css={[
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
-						showSubtitles && subtitleStyles(subtitleSize),
+						showSubtitles && subtitleFontStyles(subtitleSize),
+						showCustomSubtitles && hideNativeSubtitles,
 					]}
 					crossOrigin="anonymous"
 					ref={ref}
@@ -263,7 +271,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					)}
 					{FallbackImageComponent}
 				</video>
-				{showSubtitles && !!activeCue?.text && (
+				{showCustomSubtitles && !!activeCue?.text && (
 					<SubtitleOverlay
 						text={activeCue.text}
 						size={subtitleSize}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -262,8 +262,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 					))}
 					{showSubtitles && (
 						<track
-							// Don't use default - it forces native rendering on iOS
-							default={false}
+							/** Only use default native subtitles when we are not displaying custom subtitles */
+							default={!showCustomSubtitles}
 							kind="subtitles"
 							src={subtitleSource}
 							srcLang="en"


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
