### PR TITLE
Reduce gap between Newsletter Signup Card and line

### DIFF
--- a/dotcom-rendering/src/components/NewsletterPrivacyMessage.tsx
+++ b/dotcom-rendering/src/components/NewsletterPrivacyMessage.tsx
@@ -5,6 +5,7 @@ import { palette as themePalette } from '../palette';
 
 interface Props {
 	textColor?: 'supporting' | 'regular';
+	cssOverrides?: ReturnType<typeof css>;
 }
 
 const GUARDIAN_HOMEPAGE = 'https://www.theguardian.com';
@@ -76,8 +77,9 @@ const textStyles = (textColor: 'supporting' | 'regular') => {
 
 export const NewsletterPrivacyMessage = ({
 	textColor = 'supporting',
+	cssOverrides,
 }: Props) => (
-	<span css={[termsStyle, textStyles(textColor)]}>
+	<span css={[termsStyle, textStyles(textColor), cssOverrides]}>
 		<strong>Privacy Notice: </strong>
 		Newsletters may contain information about charities, online ads, and
 		content funded by outside parties. If you do not have an account, we

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -156,9 +156,6 @@ export const NewsletterSignupCardContainer = ({
 			)}
 			<div
 				css={css`
-					display: flex;
-					flex-direction: column;
-					gap: ${space[2]}px;
 					margin-bottom: ${space[6]}px;
 				`}
 			>
@@ -171,7 +168,13 @@ export const NewsletterSignupCardContainer = ({
 					{children?.(previewAction)}
 				</NewsletterSignupCard>
 				{showPrivacyMessageOutside && (
-					<NewsletterPrivacyMessage textColor="regular" />
+					<NewsletterPrivacyMessage
+						textColor="regular"
+						cssOverrides={css`
+							display: block;
+							margin-top: ${space[2]}px;
+						`}
+					/>
 				)}
 			</div>
 		</div>


### PR DESCRIPTION
## What does this change?

Reduce gap between Newsletter Signup Card and line

## Why?

Requested from Dani to match design

## Screenshots

Before: <img width="1000" alt="Image" src="https://github.com/user-attachments/assets/5d548387-8f3b-4235-a304-3956210b2154" />

After <img width="1287" height="153" alt="image" src="https://github.com/user-attachments/assets/9a48a61b-40aa-492e-9a1d-40303a73aefd" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
