### PR TITLE
Track mute and unmute media events for the self hosted video player

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -439,6 +439,16 @@ export const SelfHostedVideo = ({
 		[isWeb, isApps, atomId, ophanVideoStyle],
 	);
 
+	const mutePlayer = useCallback(
+		(value: boolean, track: boolean = true) => {
+			setIsMuted(value);
+			if (track && playerState === 'PLAYING' && isMuted !== value) {
+				sendOphanTrackingEvent(value ? 'mute' : 'unmute');
+			}
+		},
+		[playerState, isMuted, sendOphanTrackingEvent],
+	);
+
 	const [isInView, setNode] = useIsInView({
 		repeat: true,
 		threshold: VISIBILITY_THRESHOLD,
@@ -488,7 +498,7 @@ export const SelfHostedVideo = ({
 		if (!video) return;
 
 		if (pauseReason === 'PAUSED_BY_INTERSECTION_OBSERVER') {
-			setIsMuted(true);
+			mutePlayer(true, false);
 		}
 
 		setPlayerState(pauseReason);
@@ -573,7 +583,7 @@ export const SelfHostedVideo = ({
 				const thisVideoId = uniqueId;
 
 				if (playedVideoId !== thisVideoId) {
-					setIsMuted(true);
+					mutePlayer(true);
 				}
 			}
 		};
@@ -583,7 +593,7 @@ export const SelfHostedVideo = ({
 		 * Triggered by the CustomEvent in YoutubeAtomPlayer.
 		 */
 		const handleCustomPlayYoutubeEvent = () => {
-			setIsMuted(true);
+			mutePlayer(true);
 		};
 
 		/**
@@ -647,7 +657,14 @@ export const SelfHostedVideo = ({
 				handlePageBecomesVisible();
 			});
 		};
-	}, [uniqueId, atomId, sources, renderingTarget, ophanVideoStyle]);
+	}, [
+		mutePlayer,
+		uniqueId,
+		atomId,
+		sources,
+		renderingTarget,
+		ophanVideoStyle,
+	]);
 
 	/**
 	 * Track the first time the video comes into view.
@@ -754,9 +771,9 @@ export const SelfHostedVideo = ({
 		if (isMuted) {
 			// Emit video play audio event so other components are aware when a video is played with sound
 			dispatchCustomPlayAudioEvent(uniqueId);
-			setIsMuted(false);
+			mutePlayer(false);
 		} else {
-			setIsMuted(true);
+			mutePlayer(true);
 		}
 	};
 
@@ -876,7 +893,7 @@ export const SelfHostedVideo = ({
 				seekBackward();
 				break;
 			case 'm':
-				setIsMuted(!isMuted);
+				mutePlayer(!isMuted);
 				break;
 		}
 	};

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -439,7 +439,7 @@ export const SelfHostedVideo = ({
 		[isWeb, isApps, atomId, ophanVideoStyle],
 	);
 
-	const mutePlayer = useCallback(
+	const setMutedState = useCallback(
 		(value: boolean, track: boolean = true) => {
 			setIsMuted(value);
 			if (track && playerState === 'PLAYING' && isMuted !== value) {
@@ -498,7 +498,7 @@ export const SelfHostedVideo = ({
 		if (!video) return;
 
 		if (pauseReason === 'PAUSED_BY_INTERSECTION_OBSERVER') {
-			mutePlayer(true, false);
+			setMutedState(true, false);
 		}
 
 		setPlayerState(pauseReason);
@@ -583,7 +583,7 @@ export const SelfHostedVideo = ({
 				const thisVideoId = uniqueId;
 
 				if (playedVideoId !== thisVideoId) {
-					mutePlayer(true);
+					setMutedState(true);
 				}
 			}
 		};
@@ -593,7 +593,7 @@ export const SelfHostedVideo = ({
 		 * Triggered by the CustomEvent in YoutubeAtomPlayer.
 		 */
 		const handleCustomPlayYoutubeEvent = () => {
-			mutePlayer(true);
+			setMutedState(true);
 		};
 
 		/**
@@ -658,7 +658,7 @@ export const SelfHostedVideo = ({
 			});
 		};
 	}, [
-		mutePlayer,
+		setMutedState,
 		uniqueId,
 		atomId,
 		sources,
@@ -771,9 +771,9 @@ export const SelfHostedVideo = ({
 		if (isMuted) {
 			// Emit video play audio event so other components are aware when a video is played with sound
 			dispatchCustomPlayAudioEvent(uniqueId);
-			mutePlayer(false);
+			setMutedState(false);
 		} else {
-			mutePlayer(true);
+			setMutedState(true);
 		}
 	};
 
@@ -893,7 +893,7 @@ export const SelfHostedVideo = ({
 				seekBackward();
 				break;
 			case 'm':
-				mutePlayer(!isMuted);
+				setMutedState(!isMuted);
 				break;
 		}
 	};

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -440,7 +440,7 @@ export const SelfHostedVideo = ({
 	);
 
 	const setMutedState = useCallback(
-		(value: boolean, track: boolean = true) => {
+		({ value, track = true }: { value: boolean; track?: boolean }) => {
 			setIsMuted(value);
 			if (track && playerState === 'PLAYING' && isMuted !== value) {
 				sendOphanTrackingEvent(value ? 'mute' : 'unmute');
@@ -498,7 +498,7 @@ export const SelfHostedVideo = ({
 		if (!video) return;
 
 		if (pauseReason === 'PAUSED_BY_INTERSECTION_OBSERVER') {
-			setMutedState(true, false);
+			setMutedState({ value: true, track: false });
 		}
 
 		setPlayerState(pauseReason);
@@ -583,7 +583,7 @@ export const SelfHostedVideo = ({
 				const thisVideoId = uniqueId;
 
 				if (playedVideoId !== thisVideoId) {
-					setMutedState(true);
+					setMutedState({ value: true });
 				}
 			}
 		};
@@ -593,7 +593,7 @@ export const SelfHostedVideo = ({
 		 * Triggered by the CustomEvent in YoutubeAtomPlayer.
 		 */
 		const handleCustomPlayYoutubeEvent = () => {
-			setMutedState(true);
+			setMutedState({ value: true });
 		};
 
 		/**
@@ -771,9 +771,9 @@ export const SelfHostedVideo = ({
 		if (isMuted) {
 			// Emit video play audio event so other components are aware when a video is played with sound
 			dispatchCustomPlayAudioEvent(uniqueId);
-			setMutedState(false);
+			setMutedState({ value: false });
 		} else {
-			setMutedState(true);
+			setMutedState({ value: true });
 		}
 	};
 
@@ -893,7 +893,7 @@ export const SelfHostedVideo = ({
 				seekBackward();
 				break;
 			case 'm':
-				setMutedState(!isMuted);
+				setMutedState({ value: !isMuted });
 				break;
 		}
 	};

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -442,11 +442,11 @@ export const SelfHostedVideo = ({
 	const setMutedState = useCallback(
 		({ value, track = true }: { value: boolean; track?: boolean }) => {
 			setIsMuted(value);
-			if (track && playerState === 'PLAYING' && isMuted !== value) {
+			if (track && isMuted !== value) {
 				sendOphanTrackingEvent(value ? 'mute' : 'unmute');
 			}
 		},
-		[playerState, isMuted, sendOphanTrackingEvent],
+		[isMuted, sendOphanTrackingEvent],
 	);
 
 	const [isInView, setNode] = useIsInView({

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -317,7 +317,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 									Icon={AudioIcon}
 									handleClick={handleAudioClick}
 									isMuted={isMuted}
-									atomId={atomId}
 									size={iconSize}
 								/>
 							)}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -38,7 +38,6 @@ const largeIconContainerStyles = css`
 
 type AudioIconProps = {
 	Icon: Exclude<SelfHostedVideoPlayerProps['AudioIcon'], null>;
-	atomId: SelfHostedVideoPlayerProps['atomId'];
 	size: 'small' | 'large';
 	isMuted: SelfHostedVideoPlayerProps['isMuted'];
 	handleClick: SelfHostedVideoPlayerProps['handleAudioClick'];
@@ -46,19 +45,11 @@ type AudioIconProps = {
 
 export const AudioIcon = ({
 	Icon,
-	atomId,
 	size,
 	isMuted,
 	handleClick,
 }: AudioIconProps) => (
-	<button
-		type="button"
-		onClick={handleClick}
-		css={buttonStyles}
-		data-link-name={`gu-video-loop-${
-			isMuted ? 'unmute' : 'mute'
-		}-${atomId}`}
-	>
+	<button type="button" onClick={handleClick} css={buttonStyles}>
 		<div
 			css={[
 				iconContainerStyles,


### PR DESCRIPTION
## What does this change?

This change submits tracking events when self-hosted video mutes or unmuted via user interaction. 

> [!NOTE]
>  This does not include when a video is muted by a non explicit user action e.g. scrolling the video out of view.

## Why?

This will allow us to gather data about user interactions with the self hosted media player, following on from #15804. 

## Testing

I have tested this change across Chrome, Firefox and Safari. 