### PR TITLE
Fix NewsletterPreviewButton spacing issue and refactor

### DIFF
--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -152,7 +152,6 @@ export const EmailSignUpWrapper = ({
 					exampleUrl={exampleUrl}
 					renderingTarget={renderingTarget}
 					isSignedIn={isSignedIn}
-					isAlreadySubscribed={isSubscribed}
 				>
 					{(previewAction) => (
 						<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -152,6 +152,7 @@ export const EmailSignUpWrapper = ({
 					exampleUrl={exampleUrl}
 					renderingTarget={renderingTarget}
 					isSignedIn={isSignedIn}
+					isAlreadySubscribed={isSubscribed}
 				>
 					{(previewAction) => (
 						<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/components/NewsletterPreviewButton.tsx
+++ b/dotcom-rendering/src/components/NewsletterPreviewButton.tsx
@@ -1,0 +1,62 @@
+import type { Size, ThemeButton } from '@guardian/source/react-components';
+import { Button, LinkButton, SvgEye } from '@guardian/source/react-components';
+import { palette } from '../palette';
+
+export type NewsletterPreviewAction =
+	| {
+			behaviour: 'modal';
+			onClick: () => void;
+	  }
+	| {
+			behaviour: 'link';
+			href: string;
+			onClick: () => void;
+	  };
+
+/**
+ * Colour overrides for newsletter tertiary buttons so that they are visible
+ * in both light and dark mode, independent of the article theme.
+ *
+ * Used by the preview button and the "Browse more newsletters" link.
+ */
+export const newsletterTertiaryButtonTheme: Partial<ThemeButton> = {
+	textTertiary: palette('--newsletter-preview-button-text'),
+	borderTertiary: palette('--newsletter-preview-button-border'),
+	backgroundTertiaryHover: palette('--newsletter-preview-button-hover'),
+};
+
+export const NewsletterPreviewButton = ({
+	previewAction,
+	size = 'default',
+}: {
+	previewAction: NewsletterPreviewAction;
+	size?: Size;
+}) =>
+	previewAction.behaviour === 'link' ? (
+		<LinkButton
+			data-ignore="global-link-styling"
+			priority="tertiary"
+			icon={<SvgEye />}
+			iconSide="left"
+			href={previewAction.href}
+			target="_blank"
+			rel="noreferrer"
+			onClick={previewAction.onClick}
+			size={size}
+			theme={newsletterTertiaryButtonTheme}
+		>
+			Preview latest
+		</LinkButton>
+	) : (
+		<Button
+			priority="tertiary"
+			icon={<SvgEye />}
+			iconSide="left"
+			onClick={previewAction.onClick}
+			type="button"
+			size={size}
+			theme={newsletterTertiaryButtonTheme}
+		>
+			Preview latest
+		</Button>
+	);

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -8,6 +8,8 @@ import {
 } from '@guardian/source/foundations';
 import { SvgNewsletterFilled } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
+import type { NewsletterPreviewAction } from './NewsletterPreviewButton';
+import { NewsletterPreviewButton } from './NewsletterPreviewButton';
 
 export type NewsletterSignupCardProps = {
 	name: string;
@@ -15,6 +17,8 @@ export type NewsletterSignupCardProps = {
 	description: string;
 	illustrationSquare?: string;
 	children?: React.ReactNode;
+	previewAction?: NewsletterPreviewAction;
+	isSignedIn?: boolean | 'Pending';
 };
 
 const containerStyles = css`
@@ -87,12 +91,13 @@ const illustrationStyles = css`
 	}
 `;
 
-const NewsletterSignupHeader = (props: {
-	frequency: string;
-	name: string;
-	description: string;
-	illustrationSquare?: string;
-}) => (
+const previewButtonWrapperStyles = css`
+	margin-bottom: ${space[4]}px;
+`;
+
+const NewsletterSignupHeader = (
+	props: Omit<NewsletterSignupCardProps, 'children'>,
+) => (
 	<div css={headerStyles}>
 		<div css={titleAndMetaStyles}>
 			<div css={frequencyTagStyles}>
@@ -103,6 +108,14 @@ const NewsletterSignupHeader = (props: {
 				Sign up to <span>{props.name}</span>
 			</p>
 			<p css={descriptionStyles}>{props.description}</p>
+			{props.previewAction !== undefined && props.isSignedIn !== true && (
+				<div css={previewButtonWrapperStyles}>
+					<NewsletterPreviewButton
+						previewAction={props.previewAction}
+						size="small"
+					/>
+				</div>
+			)}
 		</div>
 		{!!props.illustrationSquare && (
 			<img
@@ -122,6 +135,8 @@ export const NewsletterSignupCard = ({
 	description,
 	illustrationSquare,
 	children,
+	previewAction,
+	isSignedIn,
 }: NewsletterSignupCardProps) => (
 	<>
 		<hr css={dividerStyles} />
@@ -131,6 +146,8 @@ export const NewsletterSignupCard = ({
 				name={name}
 				description={description}
 				illustrationSquare={illustrationSquare}
+				previewAction={previewAction}
+				isSignedIn={isSignedIn}
 			/>
 			{children}
 		</aside>

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -21,7 +21,11 @@ const defaultProps = {
 
 const renderContainer = (props = {}) =>
 	render(
-		<NewsletterSignupCardContainer {...defaultProps} {...props}>
+		<NewsletterSignupCardContainer
+			{...defaultProps}
+			isSignedIn={true}
+			{...props}
+		>
 			{(previewAction) => (
 				<button
 					type="button"
@@ -142,6 +146,7 @@ describe('NewsletterSignupCardContainer', () => {
 				name="Morning Briefing"
 				frequency="Every weekday"
 				description="Start your day with top stories."
+				isSignedIn={true}
 			>
 				{(previewAction) =>
 					previewAction?.behaviour === 'link' ? (

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -45,7 +45,6 @@ type Props = Pick<
 	renderingTarget: RenderingTarget;
 	theme: string;
 	isSignedIn?: boolean | 'Pending';
-	isAlreadySubscribed?: boolean;
 	children?: (
 		previewAction: NewsletterPreviewAction | undefined,
 	) => React.ReactNode;
@@ -69,7 +68,6 @@ export const NewsletterSignupCardContainer = ({
 	illustrationSquare,
 	children,
 	isSignedIn,
-	isAlreadySubscribed,
 }: Props) => {
 	const showPrivacyMessageOutside = isSignedIn === true;
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
@@ -136,12 +134,6 @@ export const NewsletterSignupCardContainer = ({
 			  }
 		: undefined;
 
-	// Suppress the preview action when the user is already subscribed — the
-	// card header and children both receive the same value so they stay in sync.
-	const effectivePreviewAction = isAlreadySubscribed
-		? undefined
-		: previewAction;
-
 	return (
 		<div css={themeColorStyles(theme)}>
 			{isPreviewOpen && hasPreviewUrl && (
@@ -161,10 +153,10 @@ export const NewsletterSignupCardContainer = ({
 					frequency={frequency}
 					description={description}
 					illustrationSquare={illustrationSquare}
-					previewAction={effectivePreviewAction}
+					previewAction={previewAction}
 					isSignedIn={isSignedIn}
 				>
-					{children?.(effectivePreviewAction)}
+					{children?.(previewAction)}
 				</NewsletterSignupCard>
 				{showPrivacyMessageOutside && (
 					<NewsletterPrivacyMessage

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -7,21 +7,11 @@ import {
 	sendNewsletterSignupEvent,
 } from '../lib/newsletterSignupTracking';
 import type { RenderingTarget } from '../types/renderingTarget';
+import type { NewsletterPreviewAction } from './NewsletterPreviewButton';
 import { NewsletterPreviewModal } from './NewsletterPreviewModal';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
 import type { NewsletterSignupCardProps } from './NewsletterSignupCard';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
-
-export type NewsletterPreviewAction =
-	| {
-			behaviour: 'modal';
-			onClick: () => void;
-	  }
-	| {
-			behaviour: 'link';
-			href: string;
-			onClick: () => void;
-	  };
 
 type PreviewEventDescription = 'preview-open' | 'preview-close';
 
@@ -45,17 +35,17 @@ const sendPreviewTracking = ({
 	});
 };
 
-type Props = Omit<NewsletterSignupCardProps, 'children'> & {
+type Props = Pick<
+	NewsletterSignupCardProps,
+	'name' | 'frequency' | 'description' | 'illustrationSquare'
+> & {
 	identityName: string;
 	category?: string;
 	exampleUrl?: string;
 	renderingTarget: RenderingTarget;
 	theme: string;
-	/**
-	 * Pass the signed-in status so the container can render the privacy message
-	 * below the card (rather than inside the form) when the user is signed in.
-	 */
 	isSignedIn?: boolean | 'Pending';
+	isAlreadySubscribed?: boolean;
 	children?: (
 		previewAction: NewsletterPreviewAction | undefined,
 	) => React.ReactNode;
@@ -79,6 +69,7 @@ export const NewsletterSignupCardContainer = ({
 	illustrationSquare,
 	children,
 	isSignedIn,
+	isAlreadySubscribed,
 }: Props) => {
 	const showPrivacyMessageOutside = isSignedIn === true;
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
@@ -145,6 +136,12 @@ export const NewsletterSignupCardContainer = ({
 			  }
 		: undefined;
 
+	// Suppress the preview action when the user is already subscribed — the
+	// card header and children both receive the same value so they stay in sync.
+	const effectivePreviewAction = isAlreadySubscribed
+		? undefined
+		: previewAction;
+
 	return (
 		<div css={themeColorStyles(theme)}>
 			{isPreviewOpen && hasPreviewUrl && (
@@ -164,8 +161,10 @@ export const NewsletterSignupCardContainer = ({
 					frequency={frequency}
 					description={description}
 					illustrationSquare={illustrationSquare}
+					previewAction={effectivePreviewAction}
+					isSignedIn={isSignedIn}
 				>
-					{children?.(previewAction)}
+					{children?.(effectivePreviewAction)}
 				</NewsletterSignupCard>
 				{showPrivacyMessageOutside && (
 					<NewsletterPrivacyMessage

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -4,6 +4,7 @@ import { fn, mocked } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import type { NewsletterSignupFormState } from '../lib/useNewsletterSignupForm';
+import type { NewsletterPreviewAction } from './NewsletterPreviewButton';
 import { NewsletterSignupCard } from './NewsletterSignupCard';
 import { NewsletterSignupForm } from './NewsletterSignupForm.island';
 import { Section } from './Section';
@@ -12,7 +13,16 @@ const meta = preview.meta({
 	title: 'Components/Newsletter Signup Form',
 	component: NewsletterSignupForm,
 	decorators: [
-		(Story) => (
+		(
+			Story,
+			{
+				args,
+				parameters,
+			}: {
+				args: { previewAction?: NewsletterPreviewAction };
+				parameters: { isSignedIn?: boolean };
+			},
+		) => (
 			<Section
 				title="NewsletterSignupForm"
 				showTopBorder={true}
@@ -24,6 +34,8 @@ const meta = preview.meta({
 					frequency="Weekly"
 					description="An exclusive roundup of the week's best Guardian journalism from the editor-in-chief, Katharine Viner, free to your inbox every Saturday."
 					illustrationSquare="https://i.guim.co.uk/img/uploads/2023/11/01/SaturdayEdition_-_5-3.jpg?width=220&dpr=2&s=none&crop=5%3A3"
+					previewAction={args.previewAction}
+					isSignedIn={parameters.isSignedIn === true}
 				>
 					<Story />
 				</NewsletterSignupCard>
@@ -95,22 +107,8 @@ export const SignedOut = meta.story({
 
 /**
  * After the user focuses the email field — marketing toggle and privacy
- * message are revealed.
+ * message are revealed, email typed in, ready to submit.
  */
-export const SignedOutFocused = meta.story({
-	args: defaultArgs,
-	beforeEach() {
-		mocked(useNewsletterSignupForm).mockReturnValue(
-			mockForm({
-				isInteracted: true,
-				showMarketingToggle: true,
-				marketingOptIn: true,
-			}),
-		);
-	},
-});
-
-/** Signed-out user with an email typed in, ready to submit. */
 export const SignedOutWithEmail = meta.story({
 	args: defaultArgs,
 	beforeEach() {
@@ -131,6 +129,7 @@ export const SignedOutWithEmail = meta.story({
  */
 export const SignedIn = meta.story({
 	args: defaultArgs,
+	parameters: { isSignedIn: true },
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({
@@ -201,26 +200,13 @@ export const InvalidEmail = meta.story({
 	},
 });
 
-/** reCAPTCHA widget failed to load — form replaced by bordered error box. */
-export const CaptchaLoadError = meta.story({
+/** reCAPTCHA failed — form replaced by bordered error box. */
+export const CaptchaError = meta.story({
 	args: defaultArgs,
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({
 				errorMessage: 'Sorry, the reCAPTCHA failed to load.',
-				isValidationError: false,
-			}),
-		);
-	},
-});
-
-/** reCAPTCHA check expired or was dismissed — form replaced by bordered error box. */
-export const CaptchaNotPassed = meta.story({
-	args: defaultArgs,
-	beforeEach() {
-		mocked(useNewsletterSignupForm).mockReturnValue(
-			mockForm({
-				errorMessage: 'The reCAPTCHA check did not complete.',
 				isValidationError: false,
 			}),
 		);

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -154,7 +154,7 @@ export const Loading = meta.story({
 
 /** Subscription confirmed. */
 export const Success = meta.story({
-	args: defaultArgs,
+	args: { ...defaultArgs, previewAction: undefined },
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({ responseOk: true }),
@@ -164,7 +164,7 @@ export const Success = meta.story({
 
 /** Server returned a non-2xx response — error message and "Try again" button. */
 export const SubmissionFailed = meta.story({
-	args: defaultArgs,
+	args: { ...defaultArgs, previewAction: undefined },
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({ responseOk: false }),
@@ -232,5 +232,14 @@ export const HidePrivacyMessage = meta.story({
 				marketingOptIn: true,
 			}),
 		);
+	},
+});
+
+/** User is already subscribed — success message shown immediately. */
+export const AlreadySubscribed = meta.story({
+	args: { ...defaultArgs, isAlreadySubscribed: true },
+	parameters: { isSignedIn: true },
+	beforeEach() {
+		mocked(useNewsletterSignupForm).mockReturnValue(mockForm({}));
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -1,14 +1,13 @@
 import { css } from '@emotion/react';
 import type { AbTest } from '@guardian/ophan-tracker-js';
 import { from, space, textSans15, until } from '@guardian/source/foundations';
-import type { Size, ThemeButton } from '@guardian/source/react-components';
+import type { ThemeButton } from '@guardian/source/react-components';
 import {
 	Button,
 	InlineError,
 	InlineSuccess,
 	Link,
 	LinkButton,
-	SvgEye,
 	SvgReload,
 	TextInput,
 } from '@guardian/source/react-components';
@@ -21,8 +20,12 @@ import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
+import {
+	NewsletterPreviewButton,
+	newsletterTertiaryButtonTheme,
+} from './NewsletterPreviewButton';
+import type { NewsletterPreviewAction } from './NewsletterPreviewButton';
 import { NewsletterPrivacyMessage } from './NewsletterPrivacyMessage';
-import type { NewsletterPreviewAction } from './NewsletterSignupCardContainer';
 
 type Props = {
 	newsletterId: string;
@@ -92,10 +95,6 @@ const submitButtonStyles = css`
 	${from.tablet} {
 		max-width: 220px;
 	}
-`;
-
-const previewButtonContainerStyles = css`
-	margin-bottom: ${space[2]}px;
 `;
 
 const toggleContainerStyles = css`
@@ -170,52 +169,6 @@ const primaryButtonTheme: Partial<ThemeButton> = {
 	textPrimary: palette('--newsletter-signup-submit-text'),
 };
 
-/**
- * Colour overrides for tertiary buttons so that they are visible
- * in both light and dark mode, independent of the article theme.
- */
-const tertiaryButtonTheme: Partial<ThemeButton> = {
-	textTertiary: palette('--newsletter-preview-button-text'),
-	borderTertiary: palette('--newsletter-preview-button-border'),
-	backgroundTertiaryHover: palette('--newsletter-preview-button-hover'),
-};
-
-const PreviewButton = ({
-	previewAction,
-	size = 'default',
-}: {
-	previewAction: NewsletterPreviewAction;
-	size?: Size;
-}) =>
-	previewAction.behaviour === 'link' ? (
-		<LinkButton
-			data-ignore="global-link-styling"
-			priority="tertiary"
-			icon={<SvgEye />}
-			iconSide="left"
-			href={previewAction.href}
-			target="_blank"
-			rel="noreferrer"
-			onClick={previewAction.onClick}
-			size={size}
-			theme={tertiaryButtonTheme}
-		>
-			Preview latest
-		</LinkButton>
-	) : (
-		<Button
-			priority="tertiary"
-			icon={<SvgEye />}
-			iconSide="left"
-			onClick={previewAction.onClick}
-			type="button"
-			size={size}
-			theme={tertiaryButtonTheme}
-		>
-			Preview latest
-		</Button>
-	);
-
 const ErrorMessageWithAdvice = ({ text }: { text?: string }) => (
 	<InlineError>
 		<span>
@@ -253,7 +206,7 @@ const SuccessMessage = ({
 			<LinkButton
 				href="/email-newsletters"
 				priority="tertiary"
-				theme={tertiaryButtonTheme}
+				theme={newsletterTertiaryButtonTheme}
 				cssOverrides={tryAgainButtonStyles}
 				data-ignore="global-link-styling"
 			>
@@ -360,11 +313,6 @@ const NewsletterSignupFormActive = ({
 
 	return (
 		<>
-			{showForm && previewAction && !isSignedIn && (
-				<div css={previewButtonContainerStyles}>
-					<PreviewButton previewAction={previewAction} size="small" />
-				</div>
-			)}
 			<form
 				onSubmit={handleSubmit}
 				id={`newsletter-signup-${newsletterId}`}
@@ -419,7 +367,9 @@ const NewsletterSignupFormActive = ({
 				)}
 				<div css={submitButtonContainerStyles}>
 					{isSignedIn && previewAction && (
-						<PreviewButton previewAction={previewAction} />
+						<NewsletterPreviewButton
+							previewAction={previewAction}
+						/>
 					)}
 					<Button
 						cssOverrides={submitButtonStyles}


### PR DESCRIPTION
## What does this change?

Moves the "Preview latest" button for signed-out users from inside `NewsletterSignupForm.island.tsx` into the `NewsletterSignupCard` header (rendered in `NewsletterSignupCard.tsx`), so it sits directly below the description text with controlled spacing via CSS margins.

As part of this, the `PreviewButton` component and `NewsletterPreviewAction` type are extracted into a new shared `NewsletterPreviewButton.tsx` file, removing duplication between the form and the card.

The layout for signed-in users is unchanged — the preview button continues to appear alongside the submit button inside the form.

## Why?

There was too much space between the "Preview latest" button and the description text above it in the signed-out view. Because the button was previously rendered inside the form island, its spacing was determined by the form's internal layout rather than the card's. Moving it into the card header makes the spacing straightforward to control with explicit margins.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3d82a538-7a58-4541-8671-c000cecbb2f1
[after]: https://github.com/user-attachments/assets/da50f1d1-42dd-4152-8edd-ae3411e7a75f
