### PR TITLE
extend price floor AB test config

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -139,7 +139,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Measure the impact on bid response rate of enforcing a minimum $0.10 bid floor on all Prebid ad slots.",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-05-07",
+		expirationDate: "2026-05-15",
 		type: "client",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?
Extends the `commercial-prebid-price-floor` AB test expiry date to 15th May
## Why?
We would like continue to collect data for price floors in order to kee
We are extending the expiring Prebid Pricefloor AB test by 2 weeks to gather more data
