### PR TITLE
Pnpm security updates

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ allowBuilds:
 minimumReleaseAge: 2880 # 2 day minimum package version age
 minimumReleaseAgeExclude:
   - '@guardian/*'
+blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ allowBuilds:
   '@swc/core': true
   esbuild: true
   nice-napi: true
+minimumReleaseAge: 2880 # 2 day minimum package version age

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ allowBuilds:
   esbuild: true
   nice-napi: true
 minimumReleaseAge: 2880 # 2 day minimum package version age
+minimumReleaseAgeExclude:
+  - '@guardian/*'


### PR DESCRIPTION
## What does this change?

Update pnpm security settings as per recommendations from DevX.

- Sets a [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) within `pnpm-workspace.yaml` of two days (2880 minutes)
- Allows `@guardian` packages to bypass this rule via [`minimumReleaseAgeExclude`](https://pnpm.io/settings#minimumreleaseageexclude)
- Enables [`blockExoticSubdeps`](https://pnpm.io/settings#blockexoticsubdeps) to prevent packages being installed from non trustworthy sources

h/t @cemms1 for implementing this first in: https://github.com/guardian/commercial-templates/pull/608

