### PR TITLE
Support MatchNotifications Bridget API to prevent duplicate notifications

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -114,6 +114,12 @@ export const getNativeABTestingClient: BridgetApi<
 		new Map(Object.entries({ 'test-id': 'variant' })),
 });
 
+export const getMatchNotificationsClient: BridgetApi<
+	'getMatchNotificationsClient'
+> = () => ({
+	isAvailable: async () => ({ isAvailable: true }),
+});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -133,6 +139,7 @@ export const ensure_all_exports_are_present = {
 	getListenToArticleClient,
 	getAudioClient,
 	getNativeABTestingClient,
+	getMatchNotificationsClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -30,8 +30,6 @@ sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
 sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/useAB.ts'), { spy: true });
-// @ts-ignore -- Storybook wants the file extension, TS does not.
-sb.mock(import('../src/lib/bridgetApi.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -30,6 +30,8 @@ sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
 sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/useAB.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/bridgetApi.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
@@ -11,9 +11,9 @@ import type { MatchNotificationsClient } from '../../lib/bridgetApi';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { FootballMatchHeader as FootballMatchHeaderComponent } from './FootballMatchHeader';
 
-const mockMatchNotificationsClient = {
+const mockMatchNotificationsClient: MatchNotificationsClient = {
 	isAvailable: () => Promise.resolve({ isAvailable: true }),
-} as unknown as MatchNotificationsClient;
+};
 
 const meta = preview.meta({
 	component: FootballMatchHeaderComponent,

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
@@ -7,8 +7,13 @@ import {
 	matchResult,
 } from '../../../fixtures/manual/footballMatches';
 import type { FEFootballMatchHeader } from '../../frontend/feFootballMatchHeader';
+import type { MatchNotificationsClient } from '../../lib/bridgetApi';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { FootballMatchHeader as FootballMatchHeaderComponent } from './FootballMatchHeader';
+
+const mockMatchNotificationsClient = {
+	isAvailable: () => Promise.resolve({ isAvailable: true }),
+} as unknown as MatchNotificationsClient;
 
 const meta = preview.meta({
 	component: FootballMatchHeaderComponent,
@@ -69,6 +74,7 @@ export const FixtureWeb = meta.story({
 			'https://api.nextgen.guardianapps.co.uk/football/api/match-header/2026/02/08/26247/48490.json',
 		renderingTarget: 'Web',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
+		matchNotificationsClient: mockMatchNotificationsClient,
 	},
 	play: async ({ canvas, canvasElement, step }) => {
 		const nav = canvas.getByRole('navigation');
@@ -118,6 +124,7 @@ export const LiveApps = meta.story({
 			}),
 		renderingTarget: 'Apps',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
+		matchNotificationsClient: mockMatchNotificationsClient,
 	},
 	play: async ({ canvas, canvasElement, step }) => {
 		await step(
@@ -170,6 +177,7 @@ export const ResultWeb = meta.story({
 			}),
 		renderingTarget: 'Web',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
+		matchNotificationsClient: mockMatchNotificationsClient,
 	},
 
 	play: async ({ canvas, canvasElement, step }) => {
@@ -216,6 +224,7 @@ export const ResultApps = meta.story({
 			}),
 		renderingTarget: 'Apps',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
+		matchNotificationsClient: mockMatchNotificationsClient,
 	},
 
 	play: async ({ canvas, canvasElement, step }) => {

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -19,7 +19,10 @@ import useSWR from 'swr';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
-import type { NotificationsClient } from '../../lib/bridgetApi';
+import type {
+	MatchNotificationsClient,
+	NotificationsClient,
+} from '../../lib/bridgetApi';
 import {
 	type EditionId,
 	getLocaleFromEdition,
@@ -54,6 +57,7 @@ type Props = FootballMatchHeaderProps & {
 	getHeaderData: (url: string) => Promise<unknown>;
 	refreshInterval: number;
 	notificationsClient: NotificationsClient;
+	matchNotificationsClient: MatchNotificationsClient;
 };
 
 export const FootballMatchHeader = (props: Props) => {
@@ -129,6 +133,7 @@ export const FootballMatchHeader = (props: Props) => {
 					edition={props.edition}
 					match={match}
 					notificationsClient={props.notificationsClient}
+					matchNotificationsClient={props.matchNotificationsClient}
 				/>
 				<Hr borderStyle="solid" borderColour={border(match.kind)} />
 				<Tabs {...tabs} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -1,14 +1,15 @@
-import { fn, mocked, sb } from 'storybook/test';
 import { gridContainerDecorator } from '../../../.storybook/decorators/gridDecorators';
 import preview from '../../../.storybook/preview';
-import { getMatchNotificationsClient } from '../../lib/bridgetApi';
-// @ts-ignore -- Storybook wants the file extension, TS does not.
-sb.mock(import('../../lib/bridgetApi.ts'), { spy: true });
+import type { MatchNotificationsClient } from '../../lib/bridgetApi';
 import { palette } from '../../palette';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';
 import { Notifications } from './Notifications';
+
+const mockMatchNotificationsClient = {
+	isAvailable: () => Promise.resolve({ isAvailable: true }),
+} as unknown as MatchNotificationsClient;
 
 const meta = preview.meta({
 	component: Notifications,
@@ -19,13 +20,9 @@ export const Fixture = meta.story({
 		match: FixtureWeb.input.args.initialData.match,
 		edition: 'UK',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
+		matchNotificationsClient: mockMatchNotificationsClient,
 	},
 	decorators: [gridContainerDecorator],
-	beforeEach() {
-		mocked(getMatchNotificationsClient).mockReturnValue({
-			isAvailable: fn(() => Promise.resolve({ isAvailable: true })),
-		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
-	},
 	parameters: {
 		colourSchemeBackground: {
 			light: palette(background('Fixture')),
@@ -84,15 +81,14 @@ export const Result = Live.extend({
  * returns `isAvailable: false` so we show a message instead of the toggle.
  */
 export const Unavailable = Fixture.extend({
-	beforeEach() {
-		mocked(getMatchNotificationsClient).mockReturnValue({
-			isAvailable: fn(() =>
+	args: {
+		matchNotificationsClient: {
+			isAvailable: () =>
 				Promise.resolve({
 					isAvailable: false,
 					unavailableReason:
 						'Notifications for this match are on because you follow Arsenal. Turn off anytime in Settings > Notifications',
 				}),
-			),
-		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
+		} as unknown as MatchNotificationsClient,
 	},
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -1,7 +1,9 @@
-import { fn, mocked } from 'storybook/test';
+import { fn, mocked, sb } from 'storybook/test';
 import { gridContainerDecorator } from '../../../.storybook/decorators/gridDecorators';
 import preview from '../../../.storybook/preview';
 import { getMatchNotificationsClient } from '../../lib/bridgetApi';
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../../lib/bridgetApi.ts'), { spy: true });
 import { palette } from '../../palette';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { background } from './colours';

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -1,8 +1,8 @@
+import { fn, mocked } from 'storybook/test';
 import { gridContainerDecorator } from '../../../.storybook/decorators/gridDecorators';
 import preview from '../../../.storybook/preview';
-import { palette } from '../../palette';
-import { fn, mocked } from 'storybook/test';
 import { getMatchNotificationsClient } from '../../lib/bridgetApi';
+import { palette } from '../../palette';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -7,9 +7,9 @@ import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';
 import { Notifications } from './Notifications';
 
-const mockMatchNotificationsClient = {
+const mockMatchNotificationsClient: MatchNotificationsClient = {
 	isAvailable: () => Promise.resolve({ isAvailable: true }),
-} as unknown as MatchNotificationsClient;
+};
 
 const meta = preview.meta({
 	component: Notifications,
@@ -89,6 +89,6 @@ export const Unavailable = Fixture.extend({
 					unavailableReason:
 						'Notifications for this match are on because you follow Arsenal. Turn off anytime in Settings > Notifications',
 				}),
-		} as unknown as MatchNotificationsClient,
+		} satisfies MatchNotificationsClient,
 	},
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -1,6 +1,8 @@
 import { gridContainerDecorator } from '../../../.storybook/decorators/gridDecorators';
 import preview from '../../../.storybook/preview';
 import { palette } from '../../palette';
+import { fn, mocked } from 'storybook/test';
+import { getMatchNotificationsClient } from '../../lib/bridgetApi';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';
@@ -17,6 +19,11 @@ export const Fixture = meta.story({
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 	},
 	decorators: [gridContainerDecorator],
+	beforeEach() {
+		mocked(getMatchNotificationsClient).mockReturnValue({
+			isAvailable: fn(() => Promise.resolve({ isAvailable: true })),
+		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
+	},
 	parameters: {
 		colourSchemeBackground: {
 			light: palette(background('Fixture')),
@@ -67,5 +74,23 @@ export const Result = Live.extend({
 			...Live.input.args.match,
 			kind: 'Result',
 		},
+	},
+});
+
+/**
+ * When the user already has team notifications for one of the teams, the app
+ * returns `isAvailable: false` so we show a message instead of the toggle.
+ */
+export const Unavailable = Fixture.extend({
+	beforeEach() {
+		mocked(getMatchNotificationsClient).mockReturnValue({
+			isAvailable: fn(() =>
+				Promise.resolve({
+					isAvailable: false,
+					unavailableReason:
+						'Notifications for this match are on because you follow Arsenal. Turn off anytime in Settings > Notifications',
+				}),
+			),
+		} as unknown as ReturnType<typeof getMatchNotificationsClient>);
 	},
 });

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -50,11 +50,11 @@ export const Notifications = (props: Props) => {
 		void getMatchNotificationsClient()
 			.isAvailable({
 				homeTeam: {
-					id: props.match.homeTeam.paID,
+					paId: props.match.homeTeam.paID,
 					name: props.match.homeTeam.name,
 				},
 				awayTeam: {
-					id: props.match.awayTeam.paID,
+					paId: props.match.awayTeam.paID,
 					name: props.match.awayTeam.name,
 				},
 			})

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -79,7 +79,9 @@ export const Notifications = (props: Props) => {
 		renderingTarget,
 		props.match.kind,
 		props.match.homeTeam.paID,
+		props.match.homeTeam.name,
 		props.match.awayTeam.paID,
+		props.match.awayTeam.name,
 	]);
 
 	if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -1,10 +1,6 @@
 import { css } from '@emotion/react';
 import { log } from '@guardian/libs';
-import {
-	space,
-	textSans14,
-	textSans14Object,
-} from '@guardian/source/foundations';
+import { space, textSans14Object } from '@guardian/source/foundations';
 import { useEffect, useMemo, useState } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
@@ -75,8 +71,9 @@ export const Notifications = (props: Props) => {
 					'Bridget getMatchNotificationsClient.isAvailable Error:',
 					error,
 				);
-				// Treat errors as available to avoid silently hiding the button
-				setIsAvailable(true);
+				// Hide the button on error as we can't confirm notifications
+				// are available and the button may not work
+				setIsAvailable(false);
 			});
 	}, [
 		renderingTarget,
@@ -92,67 +89,78 @@ export const Notifications = (props: Props) => {
 		return null;
 	}
 
-	return (
-		<>
-			<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
-			{isAvailable === false ? (
-				<p
-					css={[
-						textSans14,
-						css({
-							'&': css(grid.column.centre),
-							paddingTop: space[2],
-							paddingBottom: space[3],
-							paddingLeft: 6,
-							paddingRight: 6,
-						}),
-					]}
-					style={{
-						color: palette(primaryText(props.match.kind)),
-					}}
-				>
-					{unavailableReason ??
-						'Notifications for this match are on because you are following a team. Turn off anytime in Settings > Notifications'}
-				</p>
-			) : (
+	const Description = ({ children }: { children: string | undefined }) =>
+		children === undefined ? null : (
+			<p
+				css={{
+					...textSans14Object,
+					'&': css(grid.column.centre),
+					paddingTop: space[2],
+					paddingBottom: space[3],
+					paddingLeft: 6,
+					paddingRight: 6,
+				}}
+				style={{
+					color: palette(primaryText(props.match.kind)),
+				}}
+			>
+				{children}
+			</p>
+		);
+
+	switch (isAvailable) {
+		case false:
+			return (
 				<>
-					<p
-						css={{
-							...textSans14Object,
-							'&': css(grid.column.centre),
-							paddingTop: space[2],
-							paddingBottom: space[3],
-							paddingLeft: 6,
-							paddingRight: 6,
-						}}
-						style={{
-							color: palette(primaryText(props.match.kind)),
-						}}
-					>
+					<Hr
+						borderStyle="solid"
+						borderColour={border(props.match.kind)}
+					/>
+					<Description>{unavailableReason}</Description>
+				</>
+			);
+		case true:
+			return (
+				<>
+					<Hr
+						borderStyle="solid"
+						borderColour={border(props.match.kind)}
+					/>
+					<Description>
 						Be notified about the lineup, kick-off time, goals,
 						half-time and full time scores
-					</p>
-					{isAvailable === true && (
-						<NotificationsToggle
-							displayName={displayName(props.match)}
-							id={props.match.paId}
-							notificationType="football-match"
-							notificationsClient={props.notificationsClient}
-							colour={primaryText(props.match.kind)}
-							backgroundColour={background(props.match.kind)}
-							iconColour={primaryText(props.match.kind)}
-							css={{
-								'&': css(grid.column.centre),
-								paddingLeft: 6,
-								paddingRight: 6,
-								paddingBottom: space[4],
-							}}
-						/>
-					)}
+					</Description>
+					<NotificationsToggle
+						displayName={displayName(props.match)}
+						id={props.match.paId}
+						notificationType="football-match"
+						notificationsClient={props.notificationsClient}
+						colour={primaryText(props.match.kind)}
+						backgroundColour={background(props.match.kind)}
+						iconColour={primaryText(props.match.kind)}
+						css={{
+							'&': css(grid.column.centre),
+							paddingLeft: 6,
+							paddingRight: 6,
+							paddingBottom: space[4],
+						}}
+					/>
 				</>
-			)}
-		</>
-	);
+			);
+		case undefined:
+			return (
+				<>
+					<Hr
+						borderStyle="solid"
+						borderColour={border(props.match.kind)}
+					/>
+					<Description>
+						Be notified about the lineup, kick-off time, goals,
+						half-time and full time scores
+					</Description>
+				</>
+			);
+	}
 };
 
 /**

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -49,8 +49,14 @@ export const Notifications = (props: Props) => {
 
 		void getMatchNotificationsClient()
 			.isAvailable({
-				homeTeam: { id: props.match.homeTeam.paID },
-				awayTeam: { id: props.match.awayTeam.paID },
+				homeTeam: {
+					id: props.match.homeTeam.paID,
+					name: props.match.homeTeam.name,
+				},
+				awayTeam: {
+					id: props.match.awayTeam.paID,
+					name: props.match.awayTeam.name,
+				},
 			})
 			.then((availability) => {
 				setIsAvailable(availability.isAvailable);

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -1,9 +1,15 @@
 import { css } from '@emotion/react';
-import { space, textSans14Object } from '@guardian/source/foundations';
-import { useMemo } from 'react';
+import { log } from '@guardian/libs';
+import {
+	space,
+	textSans14,
+	textSans14Object,
+} from '@guardian/source/foundations';
+import { useEffect, useMemo, useState } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import type { NotificationsClient } from '../../lib/bridgetApi';
+import { getMatchNotificationsClient } from '../../lib/bridgetApi';
 import {
 	type EditionId,
 	getLocaleFromEdition,
@@ -23,11 +29,52 @@ type Props = {
 
 export const Notifications = (props: Props) => {
 	const { renderingTarget } = useConfig();
+	const [isAvailable, setIsAvailable] = useState<boolean | undefined>(
+		undefined,
+	);
+	const [unavailableReason, setUnavailableReason] = useState<
+		string | undefined
+	>(undefined);
+
 	// useMemo to limit constructions of `Intl.DateTimeFormat`
 	const displayName = useMemo(
 		() => notificationDisplayName(props.edition),
 		[props.edition],
 	);
+
+	useEffect(() => {
+		if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
+			return;
+		}
+
+		void getMatchNotificationsClient()
+			.isAvailable({
+				homeTeam: { id: props.match.homeTeam.paID },
+				awayTeam: { id: props.match.awayTeam.paID },
+			})
+			.then((availability) => {
+				setIsAvailable(availability.isAvailable);
+				setUnavailableReason(availability.unavailableReason);
+			})
+			.catch((error: unknown) => {
+				window.guardian.modules.sentry.reportError(
+					error instanceof Error ? error : new Error(String(error)),
+					'bridget-getMatchNotificationsClient-isAvailable-error',
+				);
+				log(
+					'dotcom',
+					'Bridget getMatchNotificationsClient.isAvailable Error:',
+					error,
+				);
+				// Treat errors as available to avoid silently hiding the button
+				setIsAvailable(true);
+			});
+	}, [
+		renderingTarget,
+		props.match.kind,
+		props.match.homeTeam.paID,
+		props.match.awayTeam.paID,
+	]);
 
 	if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
 		return null;
@@ -36,37 +83,62 @@ export const Notifications = (props: Props) => {
 	return (
 		<>
 			<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
-			<p
-				css={{
-					...textSans14Object,
-					'&': css(grid.column.centre),
-					paddingTop: space[2],
-					paddingBottom: space[3],
-					paddingLeft: 6,
-					paddingRight: 6,
-				}}
-				style={{
-					color: palette(primaryText(props.match.kind)),
-				}}
-			>
-				Be notified about the lineup, kick-off time, goals, half-time
-				and full time scores
-			</p>
-			<NotificationsToggle
-				displayName={displayName(props.match)}
-				id={props.match.paId}
-				notificationType="football-match"
-				notificationsClient={props.notificationsClient}
-				colour={primaryText(props.match.kind)}
-				backgroundColour={background(props.match.kind)}
-				iconColour={primaryText(props.match.kind)}
-				css={{
-					'&': css(grid.column.centre),
-					paddingLeft: 6,
-					paddingRight: 6,
-					paddingBottom: space[4],
-				}}
-			/>
+			{isAvailable === false ? (
+				<p
+					css={[
+						textSans14,
+						css({
+							'&': css(grid.column.centre),
+							paddingTop: space[2],
+							paddingBottom: space[3],
+							paddingLeft: 6,
+							paddingRight: 6,
+						}),
+					]}
+					style={{
+						color: palette(primaryText(props.match.kind)),
+					}}
+				>
+					{unavailableReason ??
+						'Notifications for this match are on because you are following a team. Turn off anytime in Settings > Notifications'}
+				</p>
+			) : (
+				<>
+					<p
+						css={{
+							...textSans14Object,
+							'&': css(grid.column.centre),
+							paddingTop: space[2],
+							paddingBottom: space[3],
+							paddingLeft: 6,
+							paddingRight: 6,
+						}}
+						style={{
+							color: palette(primaryText(props.match.kind)),
+						}}
+					>
+						Be notified about the lineup, kick-off time, goals,
+						half-time and full time scores
+					</p>
+					{isAvailable === true && (
+						<NotificationsToggle
+							displayName={displayName(props.match)}
+							id={props.match.paId}
+							notificationType="football-match"
+							notificationsClient={props.notificationsClient}
+							colour={primaryText(props.match.kind)}
+							backgroundColour={background(props.match.kind)}
+							iconColour={primaryText(props.match.kind)}
+							css={{
+								'&': css(grid.column.centre),
+								paddingLeft: 6,
+								paddingRight: 6,
+								paddingBottom: space[4],
+							}}
+						/>
+					)}
+				</>
+			)}
 		</>
 	);
 };

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -8,8 +8,10 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
-import type { NotificationsClient } from '../../lib/bridgetApi';
-import { getMatchNotificationsClient } from '../../lib/bridgetApi';
+import type {
+	MatchNotificationsClient,
+	NotificationsClient,
+} from '../../lib/bridgetApi';
 import {
 	type EditionId,
 	getLocaleFromEdition,
@@ -25,6 +27,7 @@ type Props = {
 	match: FootballMatch;
 	edition: EditionId;
 	notificationsClient: NotificationsClient;
+	matchNotificationsClient: MatchNotificationsClient;
 };
 
 export const Notifications = (props: Props) => {
@@ -47,7 +50,7 @@ export const Notifications = (props: Props) => {
 			return;
 		}
 
-		void getMatchNotificationsClient()
+		void props.matchNotificationsClient
 			.isAvailable({
 				homeTeam: {
 					paId: props.match.homeTeam.paID,
@@ -82,6 +85,7 @@ export const Notifications = (props: Props) => {
 		props.match.homeTeam.name,
 		props.match.awayTeam.paID,
 		props.match.awayTeam.name,
+		props.matchNotificationsClient,
 	]);
 
 	if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {

--- a/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
@@ -1,4 +1,7 @@
-import { getNotificationsClient } from '../lib/bridgetApi';
+import {
+	getMatchNotificationsClient,
+	getNotificationsClient,
+} from '../lib/bridgetApi';
 import type { FootballMatchHeaderProps } from './FootballMatchHeader/FootballMatchHeader';
 import { FootballMatchHeader } from './FootballMatchHeader/FootballMatchHeader';
 import type { HeaderData } from './FootballMatchHeader/headerData';
@@ -29,6 +32,7 @@ export const FootballMatchHeaderWrapper = (props: Props) => (
 		refreshInterval={16_000}
 		renderingTarget={props.renderingTarget}
 		notificationsClient={getNotificationsClient()}
+		matchNotificationsClient={getMatchNotificationsClient()}
 	/>
 );
 

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -10,6 +10,7 @@ import * as Gallery from '@guardian/bridget/Gallery';
 import * as Interaction from '@guardian/bridget/Interaction';
 import * as Interactives from '@guardian/bridget/Interactives';
 import * as ListenToArticle from '@guardian/bridget/ListenToArticle';
+import * as MatchNotifications from '@guardian/bridget/MatchNotifications';
 import * as Metrics from '@guardian/bridget/Metrics';
 import * as Navigation from '@guardian/bridget/Navigation';
 import * as Newsletters from '@guardian/bridget/Newsletters';
@@ -241,3 +242,15 @@ export const getNativeABTestingClient = (): AbTesting.Client<void> => {
 	}
 	return nativeAbTestingClient;
 };
+
+let matchNotificationsClient: MatchNotifications.Client<void> | undefined =
+	undefined;
+export const getMatchNotificationsClient =
+	(): MatchNotifications.Client<void> => {
+		if (!matchNotificationsClient) {
+			matchNotificationsClient = createAppClient<
+				MatchNotifications.Client<void>
+			>(MatchNotifications.Client, 'buffered', 'compact');
+		}
+		return matchNotificationsClient;
+	};

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -243,14 +243,14 @@ export const getNativeABTestingClient = (): AbTesting.Client<void> => {
 	return nativeAbTestingClient;
 };
 
-let matchNotificationsClient: MatchNotifications.Client<void> | undefined =
-	undefined;
-export const getMatchNotificationsClient =
-	(): MatchNotifications.Client<void> => {
-		if (!matchNotificationsClient) {
-			matchNotificationsClient = createAppClient<
-				MatchNotifications.Client<void>
-			>(MatchNotifications.Client, 'buffered', 'compact');
-		}
-		return matchNotificationsClient;
-	};
+export type MatchNotificationsClient = BridgetClient<MatchNotifications.Client>;
+
+let matchNotificationsClient: MatchNotificationsClient | undefined = undefined;
+export const getMatchNotificationsClient = (): MatchNotificationsClient => {
+	if (!matchNotificationsClient) {
+		matchNotificationsClient = createAppClient<
+			MatchNotifications.Client<void>
+		>(MatchNotifications.Client, 'buffered', 'compact');
+	}
+	return matchNotificationsClient;
+};


### PR DESCRIPTION
## What does this change?
Bumps @guardian/bridget to consume the newly added [MatchNotifications service](https://github.com/guardian/bridget/pull/245) and adds getMatchNotificationsClient to Bridget API wrappers. Updates the Notifications component within FootballMatchHeader to query the app for match notification availability (isAvailable) on mount. If the app returns isAvailable: false, the notification toggle is hidden and replaced with the unavailableReason message provided by the app (or a fallback message). If the Bridget call fails, it gracefully handles the error by logging to Sentry and defaulting to isAvailable: true so the button doesn't silently disappear. Also adds mock Bridget clients and an Unavailable state to Storybook to test the UI changes.

## Why?
On match info and liveblog pages, we offer the ability to sign up for notifications about that match. However, the native apps also allow users to sign up for notifications about a particular team, which automatically includes the matches they're playing in. Therefore, we don't want to offer the option to sign up for these matches separately to those users, as it would result in duplicate notifications.

Currently, the apps solve this problem natively by removing the button and instead displaying a message explaining that the user has already signed up for team notifications. This PR implements the webview side of this interaction, utilising the new Bridget API to check the user's team subscription status with the app and adjusting the webview UI to match the native experience.

Part of https://github.com/guardian/dotcom-rendering/issues/15591

Bridget PR https://github.com/guardian/bridget/pull/245
