### PR TITLE
Cricket match header result

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -129,7 +129,7 @@ export const Result = {
 				winner: {
 					type: 'runs',
 					team: 'Australia',
-					margin: '47',
+					margin: 47,
 				},
 			},
 		},
@@ -162,11 +162,10 @@ export const ResultWinByWickets = {
 			],
 			result: {
 				type: 'home-win',
-				description: 'Australia win by 2 wickets',
 				winner: {
 					type: 'wickets',
 					team: 'Australia',
-					margin: '2',
+					margin: 2,
 				},
 			},
 		},

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -123,6 +123,15 @@ export const Result = {
 					fallOfWicket: 10,
 				},
 			],
+			result: {
+				type: 'home-win',
+				description: 'Australia win by an innings and 47 runs',
+				winner: {
+					type: 'runs',
+					team: 'Australia',
+					margin: '47',
+				},
+			},
 		},
 	},
 } satisfies Story;
@@ -151,6 +160,15 @@ export const ResultWinByWickets = {
 					fallOfWicket: 8,
 				},
 			],
+			result: {
+				type: 'home-win',
+				description: 'Australia win by 2 wickets',
+				winner: {
+					type: 'wickets',
+					team: 'Australia',
+					margin: '2',
+				},
+			},
 		},
 	},
 } satisfies Story;
@@ -196,6 +214,9 @@ export const ResultDrawn = {
 					fallOfWicket: 7,
 				},
 			],
+			result: {
+				type: 'draw',
+			},
 		},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -49,9 +49,9 @@ type WinnerResult = {
 	type: 'home-win' | 'away-win';
 	description?: string;
 	winner: {
-		type: 'runs' | 'wickets' | 'innings' | 'forefeit' | 'run-rate';
+		type: 'runs' | 'wickets' | 'innings' | 'forfeit' | 'run-rate';
 		team: string;
-		margin?: string;
+		margin?: number;
 	};
 };
 
@@ -558,20 +558,31 @@ const resultDescription = (result: Result): string => {
 	switch (result.type) {
 		case 'home-win':
 		case 'away-win':
-			return `${result.winner.team} won by ${
-				result.winner.margin ?? result.winner.type
-			}`;
+			if (result.winner.type === 'forfeit') {
+				return `${result.winner.team} win by forfeit`;
+			}
+			if (
+				['runs', 'wickets', 'innings'].includes(result.winner.type) &&
+				typeof result.winner.margin === 'number'
+			) {
+				return `${result.winner.team} win by ${result.winner.margin} ${result.winner.type}`;
+			}
+			if (result.winner.type === 'run-rate') {
+				// Run-rate is an old method of deciding a winner in rain-affected matches before DLS
+				return `${result.winner.team} win by run rate`;
+			}
+			return `${result.winner.team} win`;
 		// none is usually accompanied by a description, but if it's not, "No result" seems like a reasonable default
 		case 'none':
 		case 'no-result':
-			return 'No Result';
+			return 'No result';
 		case 'draw':
 		case 'level-scores-draw':
-			return 'Match Drawn';
+			return 'Match drawn';
 		case 'abandoned':
-			return 'Match Abandoned';
+			return 'Match abandoned';
 		case 'tied':
-			return 'Match Tied';
+			return 'Match tied';
 	}
 };
 

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -10,6 +10,7 @@ import {
 	textSansBold14Object,
 	textSansBold17Object,
 	until,
+	type Breakpoint,
 } from '@guardian/source/foundations';
 import { Fragment, type ReactNode, useMemo } from 'react';
 import { grid } from '../../grid';
@@ -110,10 +111,19 @@ export const CricketMatchHeader = (props: Props) => {
 				}}
 			>
 				<StatusLine match={match} edition={props.edition} />
-				<Hr borderStyle="dotted" borderColour={border(match.kind)} />
+				<Hr
+					borderStyle="dotted"
+					borderColour={border(match.kind)}
+					hide={from.leftCol}
+				/>
 				<Teams match={match} />
 				<Hr borderStyle="solid" borderColour={border(match.kind)} />
 			</div>
+			<Hr
+				borderStyle="solid"
+				borderColour={border(match.kind)}
+				hide={from.leftCol}
+			/>
 		</section>
 	);
 };
@@ -232,6 +242,7 @@ const MatchDateFormatterForEdition = (
 const Hr = (props: {
 	borderStyle: 'dotted' | 'solid';
 	borderColour: ColourName;
+	hide?: Breakpoint;
 }) => (
 	<hr
 		css={{
@@ -240,7 +251,7 @@ const Hr = (props: {
 			width: '100%',
 			borderWidth: 0,
 			borderBottomWidth: 1,
-			[from.leftCol]: {
+			[props.hide]: {
 				display: 'none',
 			},
 		}}

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -275,14 +275,6 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 		(inning) => inning.battingTeam === props.team.name,
 	);
 
-	/**
-	 * TODO: Determine if there is a match winner and the nature of the victory
-	 * (eg. won by x runs or x wickets). A match may have no overall winner due
-	 * to a draw or the match being abandoned.
-	 */
-	const isWinner = false;
-	const marginOfVictory = '';
-
 	return (
 		<div
 			css={{
@@ -356,19 +348,6 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 						Yet to bat
 					</span>
 				))}
-			{isWinner && (
-				<div
-					css={{
-						...textSans14Object,
-						paddingTop: space[2],
-					}}
-				>
-					Won by{' '}
-					<span css={{ ...textSansBold14Object }}>
-						{marginOfVictory}
-					</span>
-				</div>
-			)}
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -43,6 +43,31 @@ type Inning = {
 	fallOfWicket: number;
 };
 
+type WinnerResult = {
+	type: 'home-win' | 'away-win';
+	description?: string;
+	winner: {
+		type: 'runs' | 'wickets' | 'innings' | 'forefeit' | 'run-rate';
+		team: {
+			name: string;
+		};
+		margin?: string;
+	};
+};
+
+type OtherResult = {
+	type:
+		| 'no-result'
+		| 'draw'
+		| 'abandoned'
+		| 'tied'
+		| 'level-scores-draw'
+		| 'none';
+	description?: string;
+};
+
+type Result = WinnerResult | OtherResult;
+
 type CricketMatch = {
 	kind: 'Fixture' | 'Live' | 'Result';
 	series: string;
@@ -53,6 +78,7 @@ type CricketMatch = {
 	homeTeam: CricketTeam;
 	awayTeam: CricketTeam;
 	innings: Inning[];
+	result?: Result;
 };
 
 type Props = {

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -9,6 +9,8 @@ import {
 	textSans15Object,
 	textSansBold14Object,
 	textSansBold17Object,
+	textSansItalic14Object,
+	textSansItalic15Object,
 	until,
 } from '@guardian/source/foundations';
 import { Fragment, type ReactNode, useMemo } from 'react';
@@ -108,28 +110,12 @@ export const CricketMatchHeader = (props: Props) => {
 				}}
 			>
 				<StatusLine match={match} edition={props.edition} />
-				<Hr
-					borderStyle="dotted"
-					borderColour={border(match.kind)}
-					hide={from.leftCol}
-				/>
+				<Hr borderStyle="dotted" borderColour={border(match.kind)} />
 				<Teams match={match} />
 
-				{match.result && (
-					<>
-						<Hr
-							borderStyle="dotted"
-							borderColour={border(match.kind)}
-						/>
-						<ResultLine result={match.result} />
-					</>
-				)}
+				{match.result && <ResultLine result={match.result} />}
 			</div>
-			<Hr
-				borderStyle="solid"
-				borderColour={border(match.kind)}
-				hide={from.leftCol}
-			/>
+			<Hr borderStyle="solid" borderColour={border(match.kind)} />
 		</section>
 	);
 };
@@ -248,7 +234,6 @@ const MatchDateFormatterForEdition = (
 const Hr = (props: {
 	borderStyle: 'dotted' | 'solid';
 	borderColour: ColourName;
-	hide?: string;
 }) => (
 	<hr
 		css={{
@@ -257,13 +242,9 @@ const Hr = (props: {
 			width: '100%',
 			borderWidth: 0,
 			borderBottomWidth: 1,
-			...(props.hide
-				? {
-						[props.hide]: {
-							display: 'none',
-						},
-				  }
-				: {}),
+			[from.leftCol]: {
+				display: 'none',
+			},
 		}}
 		style={{
 			borderBottomColor: palette(props.borderColour),
@@ -278,11 +259,11 @@ const Teams = (props: { match: CricketMatch }) => (
 			'&': css(grid.column.centre),
 			display: 'flex',
 			paddingTop: space[2],
-			paddingBottom: props.match.result ? space[2] : space[3],
+			paddingBottom: space[3],
 			[from.leftCol]: {
 				'&': css(grid.column.centre),
 				paddingTop: 0,
-				paddingBottom: props.match.result ? space[2] : space[5],
+				paddingBottom: space[5],
 			},
 		}}
 	>
@@ -598,21 +579,24 @@ const resultDescription = (result: Result): string => {
 const ResultLine = (props: { result: Result }) => {
 	const description = resultDescription(props.result);
 	return (
-		<p
+		<div
 			css={{
-				...textSans14Object,
-				'&': css(grid.column.all),
-				paddingTop: space[2],
-				paddingBottom: space[2],
-				paddingLeft: grid.columnGap,
-				paddingRight: grid.columnGap,
-				textAlign: 'center',
-				[from.desktop]: {
-					textAlign: 'left',
+				'&': css(grid.column.centre),
+				paddingBottom: space[3],
+				[from.leftCol]: {
+					paddingLeft: 10,
+					paddingBottom: space[5],
 				},
 			}}
 		>
-			{description}
-		</p>
+			<p
+				css={{
+					...textSansItalic14Object,
+					[from.leftCol]: textSansItalic15Object,
+				}}
+			>
+				{description}
+			</p>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -49,9 +49,7 @@ type WinnerResult = {
 	description?: string;
 	winner: {
 		type: 'runs' | 'wickets' | 'innings' | 'forefeit' | 'run-rate';
-		team: {
-			name: string;
-		};
+		team: string;
 		margin?: string;
 	};
 };
@@ -117,7 +115,19 @@ export const CricketMatchHeader = (props: Props) => {
 					hide={from.leftCol}
 				/>
 				<Teams match={match} />
-				<Hr borderStyle="solid" borderColour={border(match.kind)} />
+
+				{match.result && (
+					<>
+						<Hr
+							borderStyle="dotted"
+							borderColour={border(match.kind)}
+						/>
+						<ResultLine
+							result={match.result}
+							matchKind={match.kind}
+						/>
+					</>
+				)}
 			</div>
 			<Hr
 				borderStyle="solid"
@@ -268,11 +278,11 @@ const Teams = (props: { match: CricketMatch }) => (
 			'&': css(grid.column.centre),
 			display: 'flex',
 			paddingTop: space[2],
-			paddingBottom: space[3],
+			paddingBottom: props.match.result ? space[2] : space[3],
 			[from.leftCol]: {
 				'&': css(grid.column.centre),
 				paddingTop: 0,
-				paddingBottom: space[5],
+				paddingBottom: props.match.result ? space[2] : space[5],
 			},
 		}}
 	>
@@ -553,4 +563,59 @@ const crestUrl = (teamId: string): URL | undefined => {
 	} catch (e) {
 		return undefined;
 	}
+};
+
+/**
+ * In most cases, the result will come with a description that we can use directly.
+ * But in some cases, we just get the data about the result and need to generate
+ * a description from that.
+ */
+const resultDescription = (result: Result): string => {
+	if (result.description) {
+		return result.description;
+	}
+
+	switch (result.type) {
+		case 'home-win':
+		case 'away-win':
+			return `${result.winner.team} won by ${
+				result.winner.margin || result.winner.type
+			}`;
+		// none is usually accompanied by a description, but if it's not, "No result" seems like a reasonable default
+		case 'none':
+		case 'no-result':
+			return 'No Result';
+		case 'draw':
+		case 'level-scores-draw':
+			return 'Match Drawn';
+		case 'abandoned':
+			return 'Match Abandoned';
+		case 'tied':
+			return 'Match Tied';
+	}
+};
+
+const ResultLine = (props: {
+	result: Result;
+	matchKind: CricketMatch['kind'];
+}) => {
+	const description = resultDescription(props.result);
+	return (
+		<p
+			css={{
+				...textSans14Object,
+				'&': css(grid.column.all),
+				paddingTop: space[2],
+				paddingBottom: space[2],
+				paddingLeft: grid.columnGap,
+				paddingRight: grid.columnGap,
+				textAlign: 'center',
+				[from.desktop]: {
+					textAlign: 'left',
+				},
+			}}
+		>
+			{description}
+		</p>
+	);
 };

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -112,10 +112,9 @@ export const CricketMatchHeader = (props: Props) => {
 				<StatusLine match={match} edition={props.edition} />
 				<Hr borderStyle="dotted" borderColour={border(match.kind)} />
 				<Teams match={match} />
-
 				{match.result && <ResultLine result={match.result} />}
+				<Hr borderStyle="solid" borderColour={border(match.kind)} />
 			</div>
-			<Hr borderStyle="solid" borderColour={border(match.kind)} />
 		</section>
 	);
 };

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -10,7 +10,6 @@ import {
 	textSansBold14Object,
 	textSansBold17Object,
 	until,
-	type Breakpoint,
 } from '@guardian/source/foundations';
 import { Fragment, type ReactNode, useMemo } from 'react';
 import { grid } from '../../grid';
@@ -122,10 +121,7 @@ export const CricketMatchHeader = (props: Props) => {
 							borderStyle="dotted"
 							borderColour={border(match.kind)}
 						/>
-						<ResultLine
-							result={match.result}
-							matchKind={match.kind}
-						/>
+						<ResultLine result={match.result} />
 					</>
 				)}
 			</div>
@@ -252,7 +248,7 @@ const MatchDateFormatterForEdition = (
 const Hr = (props: {
 	borderStyle: 'dotted' | 'solid';
 	borderColour: ColourName;
-	hide?: Breakpoint;
+	hide?: string;
 }) => (
 	<hr
 		css={{
@@ -261,9 +257,13 @@ const Hr = (props: {
 			width: '100%',
 			borderWidth: 0,
 			borderBottomWidth: 1,
-			[props.hide]: {
-				display: 'none',
-			},
+			...(props.hide
+				? {
+						[props.hide]: {
+							display: 'none',
+						},
+				  }
+				: {}),
 		}}
 		style={{
 			borderBottomColor: palette(props.borderColour),
@@ -579,7 +579,7 @@ const resultDescription = (result: Result): string => {
 		case 'home-win':
 		case 'away-win':
 			return `${result.winner.team} won by ${
-				result.winner.margin || result.winner.type
+				result.winner.margin ?? result.winner.type
 			}`;
 		// none is usually accompanied by a description, but if it's not, "No result" seems like a reasonable default
 		case 'none':
@@ -595,10 +595,7 @@ const resultDescription = (result: Result): string => {
 	}
 };
 
-const ResultLine = (props: {
-	result: Result;
-	matchKind: CricketMatch['kind'];
-}) => {
+const ResultLine = (props: { result: Result }) => {
 	const description = resultDescription(props.result);
 	return (
 		<p


### PR DESCRIPTION
closes #15684
## What does this change?
Add types and UI for the cricket match result based on the data from PA, most of the time there is a nice description like "Australia win by an innings and 47 runs" which we can use, but sometimes there isn't so we can fallback to one constructed from the data available.

I've used the same style as the "comment" from the football header which is used for football results:

<img width="831" height="198" alt="Screenshot 2026-05-07 at 17 17 11" src="https://github.com/user-attachments/assets/505cac0f-a708-41c0-b0e4-b1cb51b54270" />

This is different from the original idea of the winning score at the bottom of the team column as cricket results can be [varied and complex](https://en.wikipedia.org/wiki/Result_(cricket)):

<img width="285" height="203" alt="Image" src="https://github.com/user-attachments/assets/a083463a-2b98-4937-84da-598a05741dba" /> 

Examples I've come across already
- "Match Tied (South Africa win the second Super Over)"
- "New Zealand win by 6 wickets (DLS Method)"
- "Match abandoned without a ball bowled"

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/cfcacb81-3585-49f0-8609-f1fd7cfc4981
[after]: https://github.com/user-attachments/assets/23f85280-4d9a-4af4-9771-397f034d6a22
[before2]: https://github.com/user-attachments/assets/fd1fd6ce-c08a-4e8c-ac4e-c312f85da2b3
[after2]: https://github.com/user-attachments/assets/7d3fe274-09ce-4ca0-b6b3-844c557b3da3
<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
