### PR TITLE
upgrade react-crossword to 17.1.0, reintroduces display of formatted clues

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -40,7 +40,7 @@
 		"@guardian/identity-auth-frontend": "8.1.0",
 		"@guardian/libs": "31.0.1",
 		"@guardian/ophan-tracker-js": "3.0.0",
-		"@guardian/react-crossword": "11.1.0",
+		"@guardian/react-crossword": "17.1.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "11.3.0",
 		"@guardian/source-development-kitchen": "18.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,8 +285,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@guardian/react-crossword':
-        specifier: 11.1.0
-        version: 11.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.1(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+        specifier: 17.1.0
+        version: 17.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.1(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@guardian/shimport':
         specifier: 1.0.2
         version: 1.0.2
@@ -2448,15 +2448,15 @@ packages:
       prettier: ^3.0.0
       tslib: ^2.5.3
 
-  '@guardian/react-crossword@11.1.0':
-    resolution: {integrity: sha512-GfkyqCHCajiyuMdK8s/s8TH+LhADTcJeIXFEqbesCYp0wQO/DdTR27tRtaFhKqVRCgzRIKFyxd68HcAy+Z7eBQ==}
+  '@guardian/react-crossword@17.1.0':
+    resolution: {integrity: sha512-OF0/iAU2bwyHkMwhfC3/3mBexVk70G4OoScXBPjehCwsFa0widb7w8UZoZ/55b3B6EU7Fb05Q7Vl+KExYg15aA==}
     peerDependencies:
       '@emotion/react': ^11.11.4
-      '@guardian/libs': ^26.0.0
-      '@guardian/source': ^11.0.0
+      '@guardian/libs': ^31.0.0
+      '@guardian/source': ^12.0.0
       '@types/react': ^18.2.79
       react: ^18.2.0
-      typescript: ~5.5.2
+      typescript: ~5.9.3
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -11708,13 +11708,13 @@ snapshots:
       prettier: 3.0.3
       tslib: 2.6.2
 
-  '@guardian/react-crossword@11.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.1(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@guardian/react-crossword@17.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@31.0.1(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.1)(react@18.3.1)
       '@guardian/libs': 31.0.1(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3)
       '@guardian/source': 11.3.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
-      tslib: 2.6.2
+      tslib: 2.8.1
       use-local-storage-state: 19.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.1


### PR DESCRIPTION
## What does this change?

It was pointed out to me that crosswords on web have at some point stopped displaying clues with any of the (restricted) formatting that can be applied to them (bold, italic, subscript and superscript tags).

react-crossword 17.1.0 reintroduces that formatting, so upgrade to that version.

This bump includes several major version steps; most of these are dependency upgrades that I believe are already incorporated into the dependency tree, the only other change included is [this one](https://github.com/guardian/csnx/pull/2236) which allows the mini crossword grid to grow a bit and take a little more screen space.

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="222" height="107" alt="image" src="https://github.com/user-attachments/assets/3189aeb9-76da-448d-bf68-52a7294746ce" /> | <img width="172" height="89" alt="image" src="https://github.com/user-attachments/assets/51b4e3e6-c021-44e8-b46b-0a21a93a517e" /> |
| <img width="228" height="57" alt="image" src="https://github.com/user-attachments/assets/c0e87185-4263-44e0-adb1-c7f4f4282f1d" /> | <img width="217" height="54" alt="image" src="https://github.com/user-attachments/assets/30483e67-83a3-4c98-ae43-c9d9bf81b5dc" /> |
| <img width="230" height="468" alt="image" src="https://github.com/user-attachments/assets/1ec0c4d2-105e-4ed8-a680-eeceea03d2eb" /> | <img width="237" height="475" alt="image" src="https://github.com/user-attachments/assets/9ffd364d-b901-4132-9eb6-c56334424f54" /> |
| <img width="1423" height="751" alt="image" src="https://github.com/user-attachments/assets/ed9c9b2b-c2b4-407c-a847-7b85645deaa5" /> | <img width="1508" height="778" alt="image" src="https://github.com/user-attachments/assets/9771c61e-8912-457c-96d8-4d604b2c1b37" /> |








<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
