### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/ab-testing/frontend/src/lib/components/GrafanaLink.svelte
+++ b/ab-testing/frontend/src/lib/components/GrafanaLink.svelte
@@ -6,9 +6,10 @@
 	const { testName }: Props = $props();
 </script>
 
-<a
-	href={`https://metrics.gutools.co.uk/d/bfd4abner943ke/page-views?folderUid=efd48ip6ch3i8f&orgId=1&from=now-7d&to=now&var-test_name=${testName}`}
-	target="_blank"
->
+	<a
+		href={`https://metrics.gutools.co.uk/d/bfd4abner943ke/page-views?folderUid=efd48ip6ch3i8f&orgId=1&from=now-7d&to=now&var-test_name=${testName}`}
+		target="_blank"
+		rel="noopener noreferrer"
+	>
 	Grafana
 </a>

--- a/ab-testing/frontend/src/lib/components/OphanLink.svelte
+++ b/ab-testing/frontend/src/lib/components/OphanLink.svelte
@@ -6,9 +6,10 @@
 	const { testName }: Props = $props();
 </script>
 
-<a
-	href={`https://dashboard.ophan.co.uk/graph/breakdown?day=today&ab=${testName}`}
-	target="_blank"
->
+	<a
+		href={`https://dashboard.ophan.co.uk/graph/breakdown?day=today&ab=${testName}`}
+		target="_blank"
+		rel="noopener noreferrer"
+	>
 	Ophan
 </a>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `ab-testing/frontend/src/lib/components/OphanLink.svelte:L10`

The OphanLink.svelte and GrafanaLink.svelte components use target="_blank" without rel="noopener noreferrer", which allows the opened page to access window.opener and potentially redirect the original page. This is a known security issue called tabnabbing.

## Solution

Add rel="noopener noreferrer" to the anchor tag: <a href="..." target="_blank" rel="noopener noreferrer">

## Changes

- `ab-testing/frontend/src/lib/components/OphanLink.svelte` (modified)
- `ab-testing/frontend/src/lib/components/GrafanaLink.svelte` (modified)