### PR TITLE
Update self-hosted video icons

### DIFF
--- a/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
+++ b/dotcom-rendering/src/components/Card/components/PlayIcon.tsx
@@ -32,10 +32,9 @@ const narrowStyles = css`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: ${palette('--narrow-play-icon-background')};
+	background-color: ${palette('--video-icon-background')};
+	fill: ${palette('--video-icon')};
 	border-radius: 50%;
-	border: 1px solid ${palette('--narrow-play-icon-border')};
-	fill: ${palette('--narrow-play-icon-fill')};
 `;
 
 const theme = {

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined, log, storage } from '@guardian/libs';
 import { from, space, until } from '@guardian/source/foundations';
-import { SvgAudio, SvgAudioMute } from '@guardian/source/react-components';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	getOphan,
@@ -160,8 +159,7 @@ const hideControlsStyles = css`
 `;
 
 /**
- * Dispatches a custom play audio event so that other videos listening
- * for this event will be muted.
+ * Dispatches a custom play audio event so that other videos listening for this event will be muted.
  */
 export const dispatchCustomPlayAudioEvent = (uniqueId: string) => {
 	document.dispatchEvent(
@@ -413,8 +411,6 @@ export const SelfHostedVideo = ({
 	 * so the full unobscured video can be displayed to the user without distractions.
 	 */
 	const isHideControlsEnabled = isDefault;
-
-	const iconSize = isDefault ? 'large' : 'small';
 
 	const useLongFormProgressBar = isDefault;
 
@@ -962,8 +958,6 @@ export const SelfHostedVideo = ({
 		containerAspectRatioDesktop !== undefined &&
 		containerAspectRatioDesktop < aspectRatioOfVisibleVideo;
 
-	const AudioIcon = isMuted ? SvgAudioMute : SvgAudio;
-
 	const optimisedPosterImage = showPosterImage
 		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
 		: undefined;
@@ -1016,6 +1010,7 @@ export const SelfHostedVideo = ({
 						currentTime={currentTime}
 						ref={vidRef}
 						playerContainerRef={playerContainerRef}
+						hasAudio={supportsAudio}
 						isMuted={isMuted}
 						handleLoadedMetadata={handleLoadedMetadata}
 						handleLoadedData={handleLoadedData}
@@ -1030,9 +1025,7 @@ export const SelfHostedVideo = ({
 						handleFullscreenClick={handleFullscreenClick}
 						updateCurrentTime={updateCurrentTime}
 						onError={onError}
-						AudioIcon={supportsAudio ? AudioIcon : null}
 						preloadPartialData={!!shouldAutoplay}
-						iconSize={iconSize}
 						showPlayPauseIcon={showPlayPauseIcon}
 						showProgressBar={showProgressBar}
 						showSubtitles={!isCinemagraph}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -5,7 +5,6 @@ import {
 	textSans17,
 	textSans20,
 } from '@guardian/source/foundations';
-import type { IconProps } from '@guardian/source/react-components';
 import type { ReactElement, SyntheticEvent } from 'react';
 import { forwardRef } from 'react';
 import type { ActiveCue } from '../lib/useSubtitles';
@@ -78,7 +77,6 @@ const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	::cue {
 		/* Hide the cue by default as we prefer custom overlay */
 		visibility: hidden;
-
 		color: ${palette('--video-subtitle-text')};
 		${subtitleSize === 'small' && textSans15};
 		${subtitleSize === 'medium' && textSans17};
@@ -94,14 +92,12 @@ const iconsContainerStyles = css`
 	right: ${space[2]}px;
 `;
 
-const smallIconsPositionStyles = (position: ControlsPosition) => css`
-	${position === 'bottom' && `bottom: ${space[3]}px;`}
-	${position === 'top' && `top: ${space[2]}px;`}
+const iconsBottomPositionStyles = (useLongFormProgressBar: boolean) => css`
+	bottom: ${useLongFormProgressBar ? space[12] : space[3]}px;
 `;
 
-const largeIconsPositionStyles = (position: ControlsPosition) => css`
-	${position === 'bottom' && `bottom: ${space[12]}px;`}
-	${position === 'top' && `top: ${space[2]}px;`}
+const iconsTopPositionStyles = css`
+	top: ${space[2]}px;
 `;
 
 export const PLAYER_STATES = [
@@ -134,6 +130,7 @@ export type Props = {
 	videoStyle: VideoPlayerFormat;
 	FallbackImageComponent: ReactElement;
 	currentTime: number;
+	hasAudio: boolean;
 	isMuted: boolean;
 	handleLoadedMetadata: (event: SyntheticEvent) => void;
 	handleLoadedData: (event: SyntheticEvent) => void;
@@ -148,8 +145,6 @@ export type Props = {
 	handleFullscreenClick?: (event: SyntheticEvent) => void;
 	updateCurrentTime: (time: number) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
-	AudioIcon: ((iconProps: IconProps) => JSX.Element) | null;
-	iconSize: 'small' | 'large';
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showProgressBar: boolean;
@@ -190,6 +185,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			FallbackImageComponent,
 			posterImage,
 			currentTime,
+			hasAudio,
 			isMuted,
 			handleLoadedMetadata,
 			handleLoadedData,
@@ -204,8 +200,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handleFullscreenClick,
 			updateCurrentTime,
 			onError,
-			AudioIcon,
-			iconSize,
 			preloadPartialData,
 			showProgressBar: canShowProgressBar,
 			showPlayPauseIcon,
@@ -324,25 +318,24 @@ export const SelfHostedVideoPlayer = forwardRef(
 						<div
 							css={[
 								iconsContainerStyles,
-								iconSize === 'large' &&
-									largeIconsPositionStyles(iconsPosition),
-								iconSize === 'small' &&
-									smallIconsPositionStyles(iconsPosition),
+								iconsPosition === 'bottom' &&
+									iconsBottomPositionStyles(
+										useLongFormProgressBar,
+									),
+								iconsPosition === 'top' &&
+									iconsTopPositionStyles,
 							]}
 						>
 							{showFullscreenIcon && (
 								<FullscreenIcon
 									handleClick={handleFullscreenClick}
 									atomId={atomId}
-									size={iconSize}
 								/>
 							)}
-							{AudioIcon && (
+							{hasAudio && (
 								<AudioIconComponent
-									Icon={AudioIcon}
 									handleClick={handleAudioClick}
 									isMuted={isMuted}
-									size={iconSize}
 								/>
 							)}
 						</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -2,10 +2,12 @@ import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source/foundations';
 import {
 	SvgArrowExpand,
+	SvgAudio,
+	SvgAudioMute,
 	SvgMediaControlsPause,
+	SvgMediaControlsPlay,
 } from '@guardian/source/react-components';
 import { palette } from '../palette';
-import { narrowPlayIconDiameter, PlayIcon } from './Card/components/PlayIcon';
 import type { Props as SelfHostedVideoPlayerProps } from './SelfHostedVideoPlayer';
 
 const buttonStyles = css`
@@ -19,108 +21,73 @@ const iconContainerStyles = css`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-`;
-
-const smallIconContainerStyles = css`
 	width: ${space[8]}px;
 	height: ${space[8]}px;
-	background-color: ${palette('--video-icon-small-background')};
+	background-color: ${palette('--video-icon-background')};
 	border-radius: 50%;
-	border: 1px solid ${palette('--video-icon-border')};
-`;
-
-const largeIconContainerStyles = css`
-	width: 44px;
-	height: 44px;
-	background-color: ${palette('--video-icon-large-background')};
-	border-radius: ${space[5]}px;
 `;
 
 type AudioIconProps = {
-	Icon: Exclude<SelfHostedVideoPlayerProps['AudioIcon'], null>;
-	size: 'small' | 'large';
 	isMuted: SelfHostedVideoPlayerProps['isMuted'];
 	handleClick: SelfHostedVideoPlayerProps['handleAudioClick'];
 };
 
-export const AudioIcon = ({
-	Icon,
-	size,
-	isMuted,
-	handleClick,
-}: AudioIconProps) => (
-	<button type="button" onClick={handleClick} css={buttonStyles}>
-		<div
-			css={[
-				iconContainerStyles,
-				size === 'small' && smallIconContainerStyles,
-				size === 'large' && largeIconContainerStyles,
-			]}
+export const AudioIcon = ({ isMuted, handleClick }: AudioIconProps) => {
+	const IconComponent = isMuted ? SvgAudioMute : SvgAudio;
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			css={[buttonStyles, iconContainerStyles]}
 			data-testid={`${isMuted ? 'unmute' : 'mute'}-icon`}
 		>
-			<Icon
+			<IconComponent
 				size="xsmall"
 				theme={{
 					fill: palette('--video-icon'),
 				}}
 			/>
-		</div>
-	</button>
-);
+		</button>
+	);
+};
 
 type FullscreenIconProps = {
 	atomId: SelfHostedVideoPlayerProps['atomId'];
-	size: 'small' | 'large';
 	handleClick: SelfHostedVideoPlayerProps['handleFullscreenClick'];
 };
 
 export const FullscreenIcon = ({
 	atomId,
-	size,
 	handleClick,
 }: FullscreenIconProps) => (
 	<button
 		type="button"
 		onClick={handleClick}
-		css={buttonStyles}
+		css={[buttonStyles, iconContainerStyles]}
 		data-link-name={`gu-video-loop-fullscreen-${atomId}`}
+		data-testid="fullscreen-icon"
 	>
-		<div
-			css={[
-				iconContainerStyles,
-				size === 'small' && smallIconContainerStyles,
-				size === 'large' && largeIconContainerStyles,
-			]}
-			data-testid="fullscreen-icon"
-		>
-			<SvgArrowExpand
-				size="xsmall"
-				theme={{
-					fill: palette('--video-icon'),
-				}}
-			/>
-		</div>
+		<SvgArrowExpand
+			size="xsmall"
+			theme={{
+				fill: palette('--video-icon'),
+			}}
+		/>
 	</button>
 );
 
+const buttonSize = 56;
 const playPauseButtonStyles = css`
 	position: absolute;
 	/* Center the icon */
-	top: calc(50% - ${narrowPlayIconDiameter / 2}px);
-	left: calc(50% - ${narrowPlayIconDiameter / 2}px);
-	cursor: pointer;
-	border: none;
-	background: none;
-	padding: 0;
-`;
-
-const playPauseIconStyles = css`
-	width: 56px;
-	height: 56px;
-	background-color: ${palette('--narrow-play-icon-background')};
+	top: calc(50% - ${buttonSize / 2}px);
+	left: calc(50% - ${buttonSize / 2}px);
+	width: ${buttonSize}px;
+	height: ${buttonSize}px;
+	background-color: ${palette('--video-icon-background')};
 	border-radius: 50%;
-	border: 1px solid ${palette('--narrow-play-icon-border')};
-	fill: ${palette('--narrow-play-icon-fill')};
+	fill: ${palette('--video-icon')};
 `;
 
 type PlayPauseIconProps = {
@@ -133,22 +100,19 @@ export const PlayPauseIcon = ({
 	type,
 	atomId,
 	handleClick,
-}: PlayPauseIconProps) => (
-	<button
-		type="button"
-		onClick={handleClick}
-		css={playPauseButtonStyles}
-		data-link-name={`gu-video-loop-pause-${atomId}`}
-		data-testid={`${type}-icon`}
-	>
-		<div css={[iconContainerStyles, playPauseIconStyles]}>
-			{type === 'play' ? (
-				<PlayIcon iconWidth="narrow" />
-			) : (
-				<SvgMediaControlsPause
-					theme={{ fill: sourcePalette.neutral[100] }}
-				/>
-			)}
-		</div>
-	</button>
-);
+}: PlayPauseIconProps) => {
+	const IconComponent =
+		type === 'play' ? SvgMediaControlsPlay : SvgMediaControlsPause;
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			css={[buttonStyles, playPauseButtonStyles]}
+			data-link-name={`gu-video-loop-${type}-${atomId}`}
+			data-testid={`${type}-icon`}
+		>
+			<IconComponent theme={{ fill: sourcePalette.neutral[100] }} />
+		</button>
+	);
+};

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7571,18 +7571,6 @@ const paletteColours = {
 		light: multiBylineNonLinkedTextLight,
 		dark: multiBylineNonLinkedTextDark,
 	},
-	'--narrow-play-icon-background': {
-		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
-		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
-	},
-	'--narrow-play-icon-border': {
-		light: () => sourcePalette.neutral[60],
-		dark: () => sourcePalette.neutral[60],
-	},
-	'--narrow-play-icon-fill': {
-		light: () => sourcePalette.neutral[100],
-		dark: () => sourcePalette.neutral[100],
-	},
 	'--nav-reader-revenue-link-text': {
 		light: navReaderRevenueLinkText,
 		dark: navReaderRevenueLinkText,
@@ -8415,17 +8403,13 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[100],
 	},
+	'--video-icon-background': {
+		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
+		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
+	},
 	'--video-icon-border': {
 		light: () => sourcePalette.neutral[60],
 		dark: () => sourcePalette.neutral[60],
-	},
-	'--video-icon-large-background': {
-		light: () => transparentColour(sourcePalette.neutral[7], 0.6),
-		dark: () => transparentColour(sourcePalette.neutral[7], 0.6),
-	},
-	'--video-icon-small-background': {
-		light: () => transparentColour(sourcePalette.neutral[7], 0.7),
-		dark: () => transparentColour(sourcePalette.neutral[7], 0.7),
 	},
 	'--video-progress-bar-background': {
 		light: () => transparentColour(sourcePalette.neutral[7], 0.7),


### PR DESCRIPTION
## What does this change?

- Update icons in the long-form video player  
- Updates icons for loops, to bring consistency across self-hosted video styles
- Removes `div`'s surrounding `button`'s. These are no longer needed.
- Refactors audio: instead of importing the SVG in the island and passing it down via props, we pass down the boolean instead and import the SVG where it is used.

## Why?

To match designs.

## Screenshots

| <img width=80/> | Before | After |
| - | - | - |
| Loop | ![mobile-before] | ![mobile-after] |
| Default | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/ded510a3-a2f9-4a5f-940f-7c41453f9c85
[desktop-before]: https://github.com/user-attachments/assets/134695d4-a57e-42f5-9866-860837c223d7
[mobile-after]: https://github.com/user-attachments/assets/52aba56e-3740-4bc1-bfa0-123cab59f33c
[desktop-after]: https://github.com/user-attachments/assets/9096c291-2aee-40d4-b0b6-44e3b1b43827

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
