### PR TITLE
Disable picture in picture for self hosted videos

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -244,6 +244,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onClick={handlePlayPauseClick}
 					onKeyDown={handleKeyDown}
 					onError={onError}
+					disablePictureInPicture={true}
 				>
 					{sources.map(({ src, mimeType }) => (
 						<source


### PR DESCRIPTION


## What does this change?
Explicitly set `disablePictureInPicture` to true for all self hosted videos.

## Why?
This fix is required to prevent Firefox from (sometimes) displaying a native picture-in-picture (PiP) control on top of the video on hover. Firefox decides when to show the PiP control depending on if the video meets its own criteria. This criteria is
```
- Is the video less than 45 seconds?
- Is either the width or the height of the video less than 160px?
- Is the video silent?
```
This makes the support for PiP not only inconsistent across browser, but also across videos within Firefox. More detail on this can be found at https://firefox-source-docs.mozilla.org/toolkit/components/pictureinpicture/pictureinpicture/index.html

At time of writing, we do not support PiP for self hosted videos, and when we do, it will need to be consistent across browsers and video types. 

## Screenshots

Before     
https://github.com/user-attachments/assets/fcabd6ec-628b-41bb-b911-ea7188113ec8
After 
https://github.com/user-attachments/assets/9282d911-00f2-47cd-97c0-53fdd0e01b06

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214712591220834