### PR TITLE
Track webkit fullscreen state to hide custom subtitles in native fullscreen

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -771,6 +771,13 @@ export const SelfHostedVideo = ({
 	}
 
 	const positionCues = (video: HTMLVideoElement) => {
+		if (
+			!videoStyleSettings.canShowSubtitles ||
+			!videoStyleSettings.supportsAudio
+		) {
+			return;
+		}
+
 		const track = video.textTracks[0];
 		if (!track?.cues) {
 			return;

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -711,7 +711,10 @@ export const SelfHostedVideo = ({
 		const video = vidRef.current;
 		if (!video) return;
 
-		const handleEndFullscreen = () => setIsWebKitFullscreen(false);
+		const handleEndFullscreen = () => {
+			setIsWebKitFullscreen(false);
+			positionCues(video);
+		};
 
 		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -577,6 +577,35 @@ export const SelfHostedVideo = ({
 		/>
 	);
 
+	const positionCues = useCallback(
+		(video: HTMLVideoElement) => {
+			if (
+				!videoStyleSettings.canShowSubtitles ||
+				!videoStyleSettings.supportsAudio
+			) {
+				return;
+			}
+
+			const track = video.textTracks[0];
+			if (!track?.cues) {
+				return;
+			}
+
+			const pxFromBottom = space[3];
+			const videoHeight = video.getBoundingClientRect().height;
+			const percentFromTop =
+				((videoHeight - pxFromBottom) / videoHeight) * 100;
+
+			for (const cue of Array.from(track.cues)) {
+				if (cue instanceof VTTCue) {
+					cue.snapToLines = false;
+					cue.line = percentFromTop;
+				}
+			}
+		},
+		[videoStyleSettings.canShowSubtitles, videoStyleSettings.supportsAudio],
+	);
+
 	/**
 	 * Setup.
 	 *
@@ -723,7 +752,7 @@ export const SelfHostedVideo = ({
 				'webkitendfullscreen',
 				handleEndFullscreen,
 			);
-	}, []);
+	}, [positionCues]);
 
 	/**
 	 * Track the first time the video comes into view.
@@ -769,32 +798,6 @@ export const SelfHostedVideo = ({
 	if (adapted) {
 		return FallbackImageComponent;
 	}
-
-	const positionCues = (video: HTMLVideoElement) => {
-		if (
-			!videoStyleSettings.canShowSubtitles ||
-			!videoStyleSettings.supportsAudio
-		) {
-			return;
-		}
-
-		const track = video.textTracks[0];
-		if (!track?.cues) {
-			return;
-		}
-
-		const pxFromBottom = space[3];
-		const videoHeight = video.getBoundingClientRect().height;
-		const percentFromTop =
-			((videoHeight - pxFromBottom) / videoHeight) * 100;
-
-		for (const cue of Array.from(track.cues)) {
-			if (cue instanceof VTTCue) {
-				cue.snapToLines = false;
-				cue.line = percentFromTop;
-			}
-		}
-	};
 
 	const handleLoadedMetadata = () => {
 		const video = vidRef.current;

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -387,6 +387,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
+	const [isNativeFullscreen, setIsNativeFullscreen] = useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -746,16 +747,24 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
+	useEffect(() => {
+		const video = vidRef.current;
+		if (!video) return;
+
+		const handleEndFullscreen = () => setIsNativeFullscreen(false);
+		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
+		return () =>
+			video.removeEventListener(
+				'webkitendfullscreen',
+				handleEndFullscreen,
+			);
+	}, []);
+
 	if (adapted) {
 		return FallbackImageComponent;
 	}
 
-	const handleLoadedMetadata = () => {
-		const video = vidRef.current;
-		if (!video) {
-			return;
-		}
-
+	const positionCues = (video: HTMLVideoElement) => {
 		const track = video.textTracks[0];
 		if (!track?.cues) {
 			return;
@@ -772,6 +781,15 @@ export const SelfHostedVideo = ({
 				cue.line = percentFromTop;
 			}
 		}
+	};
+
+	const handleLoadedMetadata = () => {
+		const video = vidRef.current;
+		if (!video) {
+			return;
+		}
+
+		positionCues(video);
 	};
 
 	const handleLoadedData = () => {
@@ -853,8 +871,10 @@ export const SelfHostedVideo = ({
 			};
 
 			if (webkitVideo.webkitDisplayingFullscreen) {
+				setIsNativeFullscreen(false);
 				return webkitVideo.webkitExitFullscreen();
 			} else {
+				setIsNativeFullscreen(true);
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}
@@ -1071,6 +1091,7 @@ export const SelfHostedVideo = ({
 							videoStyleSettings.showFullscreenIcon
 						}
 						isInteractive={videoStyleSettings.isInteractive}
+						isNativeFullscreen={isNativeFullscreen}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -387,7 +387,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
-	const [isNativeFullscreen, setIsNativeFullscreen] = useState(false);
+	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -751,7 +751,7 @@ export const SelfHostedVideo = ({
 		const video = vidRef.current;
 		if (!video) return;
 
-		const handleEndFullscreen = () => setIsNativeFullscreen(false);
+		const handleEndFullscreen = () => setIsWebKitFullscreen(false);
 		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
 		return () =>
 			video.removeEventListener(
@@ -871,10 +871,10 @@ export const SelfHostedVideo = ({
 			};
 
 			if (webkitVideo.webkitDisplayingFullscreen) {
-				setIsNativeFullscreen(false);
+				setIsWebKitFullscreen(false);
 				return webkitVideo.webkitExitFullscreen();
 			} else {
-				setIsNativeFullscreen(true);
+				setIsWebKitFullscreen(true);
 				return webkitVideo.webkitEnterFullscreen();
 			}
 		}
@@ -1091,7 +1091,7 @@ export const SelfHostedVideo = ({
 							videoStyleSettings.showFullscreenIcon
 						}
 						isInteractive={videoStyleSettings.isInteractive}
-						isNativeFullscreen={isNativeFullscreen}
+						isWebKitFullscreen={isWebKitFullscreen}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -706,6 +706,22 @@ export const SelfHostedVideo = ({
 		ophanVideoStyle,
 	]);
 
+	/* Creates video-specific event listeners to handle fullscreen behaviour */
+	useEffect(() => {
+		const video = vidRef.current;
+		if (!video) return;
+
+		const handleEndFullscreen = () => setIsWebKitFullscreen(false);
+
+		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
+
+		return () =>
+			video.removeEventListener(
+				'webkitendfullscreen',
+				handleEndFullscreen,
+			);
+	}, []);
+
 	/**
 	 * Track the first time the video comes into view.
 	 */
@@ -746,19 +762,6 @@ export const SelfHostedVideo = ({
 			setShowPosterImage(true);
 		}
 	}, [shouldAutoplay, isInView, playerState]);
-
-	useEffect(() => {
-		const video = vidRef.current;
-		if (!video) return;
-
-		const handleEndFullscreen = () => setIsWebKitFullscreen(false);
-		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
-		return () =>
-			video.removeEventListener(
-				'webkitendfullscreen',
-				handleEndFullscreen,
-			);
-	}, []);
 
 	if (adapted) {
 		return FallbackImageComponent;

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -82,7 +82,7 @@ const subtitleFontStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	}
 `;
 
-const hideNativeSubtitles = css`
+const hideNativeSubtitlesStyles = css`
 	::cue {
 		/* Hide the cue as we prefer custom overlay */
 		visibility: hidden;
@@ -246,7 +246,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
 						showSubtitles && subtitleFontStyles(subtitleSize),
-						showCustomSubtitles && hideNativeSubtitles,
+						showCustomSubtitles && hideNativeSubtitlesStyles,
 					]}
 					crossOrigin="anonymous"
 					ref={ref}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -283,7 +283,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 					))}
 					{showSubtitles && (
 						<track
-							/** Only use default native subtitles when we are not displaying custom subtitles */
+							/**
+							 * On iOS/WebKit, `default` forces native subtitle rendering.
+							 * Disable it when custom subtitles are enabled.
+							 */
 							default={!showCustomSubtitles}
 							kind="subtitles"
 							src={subtitleSource}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -166,7 +166,7 @@ export type Props = {
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
 	playerContainerRef: React.RefObject<HTMLDivElement>;
-	isNativeFullscreen: boolean;
+	isWebKitFullscreen: boolean;
 };
 
 /**
@@ -220,7 +220,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			iconsPosition,
 			subtitlesPosition,
 			playerContainerRef,
-			isNativeFullscreen,
+			isWebKitFullscreen,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -229,7 +229,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const currentRefExists = ref && 'current' in ref && !!ref.current;
 
 		const showSubtitles = canShowSubtitles && !!subtitleSource;
-		const showCustomSubtitles = showSubtitles && !isNativeFullscreen;
+		const showCustomSubtitles = showSubtitles && !isWebKitFullscreen;
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -73,14 +73,19 @@ const interactiveStyles = css`
 	cursor: pointer;
 `;
 
-const subtitleStyles = (subtitleSize: SubtitleSize | undefined) => css`
+const subtitleFontStyles = (subtitleSize: SubtitleSize | undefined) => css`
 	::cue {
-		/* Hide the cue by default as we prefer custom overlay */
-		visibility: hidden;
 		color: ${palette('--video-subtitle-text')};
 		${subtitleSize === 'small' && textSans15};
 		${subtitleSize === 'medium' && textSans17};
 		${subtitleSize === 'large' && textSans20};
+	}
+`;
+
+const hideNativeSubtitles = css`
+	::cue {
+		/* Hide the cue as we prefer custom overlay */
+		visibility: hidden;
 	}
 `;
 
@@ -161,6 +166,7 @@ export type Props = {
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
 	playerContainerRef: React.RefObject<HTMLDivElement>;
+	isNativeFullscreen: boolean;
 };
 
 /**
@@ -214,6 +220,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			iconsPosition,
 			subtitlesPosition,
 			playerContainerRef,
+			isNativeFullscreen,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -222,6 +229,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const currentRefExists = ref && 'current' in ref && !!ref.current;
 
 		const showSubtitles = canShowSubtitles && !!subtitleSource;
+		const showCustomSubtitles = showSubtitles && !isNativeFullscreen;
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
@@ -237,7 +245,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 					css={[
 						videoStyles(aspectRatio),
 						isInteractive && interactiveStyles,
-						showSubtitles && subtitleStyles(subtitleSize),
+						showSubtitles && subtitleFontStyles(subtitleSize),
+						showCustomSubtitles && hideNativeSubtitles,
 					]}
 					crossOrigin="anonymous"
 					ref={ref}
@@ -274,8 +283,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 					))}
 					{showSubtitles && (
 						<track
-							// Don't use default - it forces native rendering on iOS
-							default={false}
+							/** Only use default native subtitles when we are not displaying custom subtitles */
+							default={!showCustomSubtitles}
 							kind="subtitles"
 							src={subtitleSource}
 							srcLang="en"
@@ -283,7 +292,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					)}
 					{FallbackImageComponent}
 				</video>
-				{showSubtitles && !!activeCue?.text && (
+				{showCustomSubtitles && !!activeCue?.text && (
 					<SubtitleOverlay
 						text={activeCue.text}
 						size={subtitleSize}

--- a/dotcom-rendering/src/lib/useSubtitles.ts
+++ b/dotcom-rendering/src/lib/useSubtitles.ts
@@ -34,13 +34,6 @@ export const useSubtitles = ({
 			/* We currently only support one text track per video, so we are OK to access [0] here. */
 			if (!track) return;
 
-			/* Keep track in 'showing' mode for iOS reliability.
-			 * We'll hide the native subtitles with CSS instead
-			 */
-			if (track.mode !== 'showing') {
-				track.mode = 'showing';
-			}
-
 			setActiveTrack(track);
 		};
 
@@ -69,13 +62,6 @@ export const useSubtitles = ({
 			return;
 		}
 
-		/* Keep track in 'showing' mode.
-		 * this makes iOS more reliable with cuechange events and activeCues
-		 */
-		if (track.mode !== 'showing') {
-			track.mode = 'showing';
-		}
-
 		/* listen to cuechange and set the active cue */
 		const onCueChange = () => {
 			const list = track.activeCues;
@@ -98,8 +84,6 @@ export const useSubtitles = ({
 
 		return () => {
 			track.removeEventListener('cuechange', onCueChange);
-			/* Keep it showing even on cleanup for consistency */
-			track.mode = 'showing';
 		};
 	}, [activeTrack, shouldShow, currentTime]);
 


### PR DESCRIPTION
## What does this change?
Track when the video enters/exits webkit fullscreen via a new `isNativeFullscreen` state in SelfHostedVideo, toggled by `handleFullscreenClick` and a `webkitendfullscreen` listener. This is used to apply the `hideNativeSubtitles` style (i.e. only render our custom overlay) when we are NOT in native fullscreen. This lets the browser show its native subtitles in iOS fullscreen while we continue to render our custom overlay everywhere else.

## Why?
When a self-hosted video enters native (webkit) fullscreen on iOS Safari, the browser renders its own native subtitle UI on top of the video. Our custom subtitle overlay is rendered outside the `<video>` element and is not visible in native fullscreen, so we previously had to hide the native track to avoid duplicate subtitles, leaving users in iOS fullscreen with no subtitles at all.

## Testing
Deploy to code and check on a simulator or iPhone.

## Screenshots

https://github.com/user-attachments/assets/25e357d4-7a6a-4f8c-a967-6a0468106e86

<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
