### PR TITLE
Add tabs to cricket header component

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -94,6 +94,7 @@ export const LiveYetToBat = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Live',
 			liveURL: new URL(
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
@@ -182,6 +183,7 @@ export const ResultWinByWickets = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Result',
 			liveURL: new URL(
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -30,6 +30,7 @@ export const Fixture = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Fixture',
 		},
 	},
@@ -63,6 +64,7 @@ export const Live = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Live',
 			liveURL: new URL(
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
@@ -144,6 +146,7 @@ export const Result = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Result',
 			liveURL: new URL(
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
@@ -231,6 +234,7 @@ export const ResultDrawn = {
 		},
 		tabs: {
 			selected: 'info',
+			sportKind: 'cricket',
 			matchKind: 'Result',
 			liveURL: new URL(
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -28,6 +28,10 @@ export const Fixture = {
 			},
 			innings: [],
 		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Fixture',
+		},
 	},
 } satisfies Story;
 
@@ -57,6 +61,13 @@ export const Live = {
 				},
 			],
 		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Live',
+			liveURL: new URL(
+				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+			),
+		},
 	},
 } satisfies Story;
 
@@ -78,6 +89,13 @@ export const LiveYetToBat = {
 					fallOfWicket: 10,
 				},
 			],
+		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Live',
+			liveURL: new URL(
+				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+			),
 		},
 	},
 } satisfies Story;
@@ -124,6 +142,13 @@ export const Result = {
 				},
 			],
 		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Result',
+			liveURL: new URL(
+				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+			),
+		},
 	},
 } satisfies Story;
 
@@ -151,6 +176,13 @@ export const ResultWinByWickets = {
 					fallOfWicket: 8,
 				},
 			],
+		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Result',
+			liveURL: new URL(
+				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+			),
 		},
 	},
 } satisfies Story;
@@ -196,6 +228,13 @@ export const ResultDrawn = {
 					fallOfWicket: 7,
 				},
 			],
+		},
+		tabs: {
+			selected: 'info',
+			matchKind: 'Result',
+			liveURL: new URL(
+				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+			),
 		},
 	},
 } satisfies Story;

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -11,7 +11,8 @@ import {
 	textSansBold17Object,
 	until,
 } from '@guardian/source/foundations';
-import { ComponentProps, Fragment, type ReactNode, useMemo } from 'react';
+import type { ComponentProps } from 'react';
+import { Fragment, type ReactNode, useMemo } from 'react';
 import { grid } from '../../grid';
 import {
 	type EditionId,

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -11,7 +11,7 @@ import {
 	textSansBold17Object,
 	until,
 } from '@guardian/source/foundations';
-import { Fragment, type ReactNode, useMemo } from 'react';
+import { ComponentProps, Fragment, type ReactNode, useMemo } from 'react';
 import { grid } from '../../grid';
 import {
 	type EditionId,
@@ -28,6 +28,7 @@ import {
 	primaryText,
 	secondaryText,
 } from '../FootballMatchHeader/colours';
+import { Tabs } from '../FootballMatchHeader/Tabs';
 
 type CricketTeam = {
 	name: string;
@@ -58,6 +59,7 @@ type CricketMatch = {
 type Props = {
 	edition: EditionId;
 	match: CricketMatch;
+	tabs: ComponentProps<typeof Tabs>;
 };
 
 export const CricketMatchHeader = (props: Props) => {
@@ -87,6 +89,7 @@ export const CricketMatchHeader = (props: Props) => {
 				<Hr borderStyle="dotted" borderColour={border(match.kind)} />
 				<Teams match={match} />
 				<Hr borderStyle="solid" borderColour={border(match.kind)} />
+				<Tabs {...props.tabs} />
 			</div>
 		</section>
 	);

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -15,7 +15,8 @@ import { border, primaryText, selected } from './colours';
 
 type Props = {
 	matchKind: FootballMatch['kind'];
-	sport?: 'football' | 'cricket';
+	// eslint-disable-next-line react/no-unused-prop-types -- false positive, this is passed into the tab components
+	sportKind?: 'football' | 'cricket';
 } & (
 	| {
 			selected: 'info';
@@ -90,7 +91,7 @@ const LiveFeed = (props: Props) => {
 };
 
 const MatchInfo = (props: Props) => {
-	const tabText = props.sport === 'cricket' ? 'Scorecard' : 'Match info';
+	const tabText = props.sportKind === 'cricket' ? 'Scorecard' : 'Match info';
 	if (props.selected === 'info') {
 		return <Tab matchKind={props.matchKind}>{tabText}</Tab>;
 	}

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -15,6 +15,7 @@ import { border, primaryText, selected } from './colours';
 
 type Props = {
 	matchKind: FootballMatch['kind'];
+	sport?: 'football' | 'cricket';
 } & (
 	| {
 			selected: 'info';
@@ -89,13 +90,14 @@ const LiveFeed = (props: Props) => {
 };
 
 const MatchInfo = (props: Props) => {
+	const tabText = props.sport === 'cricket' ? 'Scorecard' : 'Match info';
 	if (props.selected === 'info') {
-		return <Tab matchKind={props.matchKind}>Match info</Tab>;
+		return <Tab matchKind={props.matchKind}>{tabText}</Tab>;
 	}
 
 	return (
 		<Tab matchKind={props.matchKind} href={props.infoURL}>
-			Match info
+			{tabText}
 		</Tab>
 	);
 };


### PR DESCRIPTION
## What does this change?
Add tabs to the cricket header component, this is pretty much a drop in of the football one, "Match Info" just needed to be changed to "Scorecard" for cricket.

Imported from the football components for now, I think once both of these have settled they'll be combined/tidied.

## Screenshots
<img width="378" height="266" alt="Screenshot 2026-05-12 at 17 50 37" src="https://github.com/user-attachments/assets/ba23f345-18d2-4919-b22a-09e880e5ee75" />

<img width="372" height="202" alt="Screenshot 2026-05-12 at 17 50 05" src="https://github.com/user-attachments/assets/6abc0a80-ac39-4df7-93b1-78682637cba4" />

<img width="1142" height="239" alt="Screenshot 2026-05-12 at 17 50 27" src="https://github.com/user-attachments/assets/8ed18d10-d53d-4426-80de-47b4fd46e396" />

<img width="1138" height="169" alt="Screenshot 2026-05-12 at 17 50 15" src="https://github.com/user-attachments/assets/97bca1b8-71b5-470a-8aba-ed65419907a4" />
