### PR TITLE
extend expiry date for intentIQ AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -152,7 +152,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module.",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-05-14",
+		expirationDate: "2026-05-21",
 		type: "client",
 		status: "ON",
 		audienceSize: 0 / 100,


### PR DESCRIPTION
## What does this change?
Extends the expiry date for IntentIQ AB test in the test config.
## Why?
We would like to gather more data for intentIQ as we continue to test.
