### PR TITLE
Remove border radius from default player progress bar

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -24,17 +24,6 @@ import { VideoProgressBarInteractive } from './VideoProgressBarInteractive';
 export type SubtitleSize = 'small' | 'medium' | 'large';
 export type ControlsPosition = 'top' | 'bottom';
 
-const videoStyles = (aspectRatio: number) => css`
-	position: relative;
-	display: block;
-	height: auto;
-	width: 100%;
-	-webkit-tap-highlight-color: transparent;
-
-	/* Prevents CLS by letting the browser know the space the video will take up. */
-	aspect-ratio: ${aspectRatio};
-`;
-
 const playerContainerStyles = css`
 	&:fullscreen {
 		display: flex;
@@ -55,6 +44,17 @@ const playerContainerStyles = css`
 			object-fit: contain;
 		}
 	}
+`;
+
+const videoStyles = (aspectRatio: number) => css`
+	position: relative;
+	display: block;
+	height: auto;
+	width: 100%;
+	-webkit-tap-highlight-color: transparent;
+
+	/* Prevents CLS by letting the browser know the space the video will take up. */
+	aspect-ratio: ${aspectRatio};
 `;
 
 const videoControlsStyles = css`
@@ -93,7 +93,7 @@ const iconsContainerStyles = css`
 `;
 
 const iconsBottomPositionStyles = (useLongFormProgressBar: boolean) => css`
-	bottom: ${useLongFormProgressBar ? space[12] : space[3]}px;
+	bottom: ${useLongFormProgressBar ? '46px' : `${space[3]}px`};
 `;
 
 const iconsTopPositionStyles = css`

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -32,7 +32,6 @@ const trackStyles = css`
 	-webkit-appearance: none;
 	appearance: none;
 	height: 5px;
-	border-radius: 5px;
 `;
 
 const thumbStyles = css`
@@ -51,7 +50,7 @@ const progressBarStyles = (roundedProgressPercentage: number) => css`
 	width: 100%;
 	cursor: pointer;
 	height: 5px;
-	border-radius: 5px;
+	margin: 0;
 	-webkit-appearance: none; /* Hides the slider so that custom slider can be made */
 	appearance: none;
 	/* The colour to the left of the thumb is different to the right to indicate progress */
@@ -182,7 +181,6 @@ export const VideoProgressBarInteractive = ({
 const timeStyles = css`
 	${textSans12};
 	color: ${sourcePalette.neutral[100]};
-	margin-left: 1px; /* To make it _feel_ more aligned with the progress bar, which has a border radius. */
 `;
 
 const Time = ({ current, duration }: { current: number; duration: number }) => {


### PR DESCRIPTION
## What does this change?

- Removes the border radius from the progress bar used for default-style video
- Reduces the height above the bottom of the controls from 48px to 46px.
- Remove inherent margin from input element

## Why?

To match designs

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/a21f4266-3b67-4cfc-bcee-550f43a3cacc
[after]: https://github.com/user-attachments/assets/e58bcda1-97b9-4c66-b1cd-276dc8ac69bb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
