### PR TITLE
Fix sizing and positioning issues in the hosted CTA atom

### DIFF
--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -69,20 +69,11 @@ const buttonWrapperStyles = css`
 	position: absolute;
 	flex-direction: column;
 	justify-content: end;
-	align-items: center;
+	align-items: start;
 	padding: 0 ${space[2]}px ${space[6]}px;
 	bottom: 0;
 	left: 0;
 	right: 0;
-
-	/* We want the CTA LinkButton to take full width on smaller screens and it uses an anchor element instead of a button */
-	a {
-		width: 100%;
-
-		${from.tablet} {
-			width: auto;
-		}
-	}
 
 	${from.tablet} {
 		flex-direction: row;
@@ -104,12 +95,9 @@ const textStyles = css`
 
 	${from.tablet} {
 		${textSansBold28}
+		width: auto;
 		margin: 0;
 		margin-right: ${space[5]}px;
-	}
-
-	${from.desktop} {
-		width: auto;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

This amends the size of the CTA button, and the size and positioning of the accompanying text, at mobile and tablet breakpoints.

## Why?

This was requested as part of the design review.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="446" height="215" alt="Screenshot 2026-05-13 at 12 29 55" src="https://github.com/user-attachments/assets/9cfc66e0-b842-4632-ba5e-ac374afc3056" /> | <img width="460" height="330" alt="Screenshot 2026-05-13 at 12 26 14" src="https://github.com/user-attachments/assets/80638bda-e39f-4a9f-8fb8-c9783294ec5d" /> |
| <img width="785" height="265" alt="Screenshot 2026-05-13 at 12 29 46" src="https://github.com/user-attachments/assets/1ff7657c-e8d1-45c1-9b8d-18d80d472c0b" /> | <img width="796" height="304" alt="Screenshot 2026-05-13 at 12 26 45" src="https://github.com/user-attachments/assets/785835fc-d907-4160-ac21-88b3fae46853" /> |

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214550476197448