### PR TITLE
Refactor video style settings

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -414,6 +414,50 @@ export const SelfHostedVideo = ({
 			? 'bottom-elevated'
 			: controlsPosition;
 
+	/**
+	 * Show the play icon when the video is not playing, except for when it is scrolled out of view,
+	 * i.e. paused by intersection observer. In this case, the intersection observer will resume playback
+	 * and having a play icon would falsely indicate a user action is required to resume playback.
+	 */
+	const showPlayIcon =
+		videoStyleSettings.canShowPlayIcon &&
+		(playerState === 'PAUSED_BY_USER' ||
+			playerState === 'PAUSED_BY_BROWSER' ||
+			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
+
+	const showPauseIcon =
+		videoStyleSettings.hideControlsWhenNotInteractedWith &&
+		playerState === 'PLAYING';
+
+	let showPlayPauseIcon: 'play' | 'pause' | null = null;
+	if (showPlayIcon) {
+		showPlayPauseIcon = 'play';
+	} else if (showPauseIcon) {
+		showPlayPauseIcon = 'pause';
+	}
+
+	/** The aspect ratio of the video will be clamped within the specified range */
+	const aspectRatioOfVisibleVideo = getAspectRatioOfVisibleVideo(
+		aspectRatio,
+		minAspectRatio,
+		maxAspectRatio,
+	);
+
+	const isVideoCroppedAtTopBottom = aspectRatio < aspectRatioOfVisibleVideo;
+	const isVideoCroppedAtLeftRight = aspectRatio > aspectRatioOfVisibleVideo;
+
+	const isGreyBarsAtSidesOnDesktop =
+		containerAspectRatioDesktop !== undefined &&
+		containerAspectRatioDesktop > aspectRatioOfVisibleVideo;
+
+	const isGreyBarsAtTopAndBottomOnDesktop =
+		containerAspectRatioDesktop !== undefined &&
+		containerAspectRatioDesktop < aspectRatioOfVisibleVideo;
+
+	const optimisedPosterImage = showPosterImage
+		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
+		: undefined;
+
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 
 	const sendOphanTrackingEvent = useCallback(
@@ -940,50 +984,6 @@ export const SelfHostedVideo = ({
 			void pauseVideo('PAUSED_BY_INTERSECTION_OBSERVER');
 		}
 	}
-
-	/**
-	 * Show the play icon when the video is not playing, except for when it is scrolled out of view,
-	 * i.e. paused by intersection observer. In this case, the intersection observer will resume playback
-	 * and having a play icon would falsely indicate a user action is required to resume playback.
-	 */
-	const showPlayIcon =
-		videoStyleSettings.canShowPlayIcon &&
-		(playerState === 'PAUSED_BY_USER' ||
-			playerState === 'PAUSED_BY_BROWSER' ||
-			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
-
-	const showPauseIcon =
-		videoStyleSettings.hideControlsWhenNotInteractedWith &&
-		playerState === 'PLAYING';
-
-	let showPlayPauseIcon: 'play' | 'pause' | null = null;
-	if (showPlayIcon) {
-		showPlayPauseIcon = 'play';
-	} else if (showPauseIcon) {
-		showPlayPauseIcon = 'pause';
-	}
-
-	/** The aspect ratio of the video will be clamped within the specified range */
-	const aspectRatioOfVisibleVideo = getAspectRatioOfVisibleVideo(
-		aspectRatio,
-		minAspectRatio,
-		maxAspectRatio,
-	);
-
-	const isVideoCroppedAtTopBottom = aspectRatio < aspectRatioOfVisibleVideo;
-	const isVideoCroppedAtLeftRight = aspectRatio > aspectRatioOfVisibleVideo;
-
-	const isGreyBarsAtSidesOnDesktop =
-		containerAspectRatioDesktop !== undefined &&
-		containerAspectRatioDesktop > aspectRatioOfVisibleVideo;
-
-	const isGreyBarsAtTopAndBottomOnDesktop =
-		containerAspectRatioDesktop !== undefined &&
-		containerAspectRatioDesktop < aspectRatioOfVisibleVideo;
-
-	const optimisedPosterImage = showPosterImage
-		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
-		: undefined;
 
 	return (
 		<figure

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -22,6 +22,8 @@ import {
 	customYoutubePlayEventName,
 	findOptimisedSourcePerMimeType,
 } from '../lib/video';
+import type { VideoStyleSettings } from '../lib/videoStyleSettings';
+import { videoSettingsMap } from '../lib/videoStyleSettings';
 import { palette } from '../palette';
 import type { RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
@@ -44,7 +46,7 @@ import type { VideoEventKey } from './YoutubeAtom/YoutubeAtom';
 const VISIBILITY_THRESHOLD = 0.5;
 
 const videoContainerStyles = (
-	isCinemagraph: boolean,
+	isInteractive: boolean,
 	aspectRatioOfVisibleVideo: number,
 	containerAspectRatioMobile?: number,
 	containerAspectRatioDesktop?: number,
@@ -54,7 +56,7 @@ const videoContainerStyles = (
 	background-color: ${palette('--video-background')};
 	align-items: center;
 	justify-content: space-around;
-	${!isCinemagraph && `z-index: ${getZIndex('video-container')}`};
+	${isInteractive && `z-index: ${getZIndex('video-container')}`};
 
 	/**
 	 * Use the aspect ratio of the video, unless the aspect-ratio of the container is fixed
@@ -389,42 +391,30 @@ export const SelfHostedVideo = ({
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 
-	/**
-	 * In a cinemagraph, all controls are hidden: the video looks like a GIF.
-	 * This includes but may not be limited to: audio icon, play/pause icon, subtitles, progress bar.
-	 */
-	const isCinemagraph = videoStyle === 'Cinemagraph';
-	const isLoop = videoStyle === 'Loop';
-	const isDefault = videoStyle === 'Default';
+	const videoStyleSettings: VideoStyleSettings = videoSettingsMap[videoStyle];
 
-	const canAutoplay = isLoop || isCinemagraph;
-
-	const shouldAutoplay = canAutoplay && isAutoplayAllowed;
-
-	const shouldLoop = isLoop || isCinemagraph;
+	const shouldAutoplay = videoStyleSettings.autoplay && isAutoplayAllowed;
 
 	const showProgressBar =
-		!hideProgressBar && !isCinemagraph && playerState !== 'NOT_STARTED';
+		!hideProgressBar &&
+		videoStyleSettings.showProgressBar &&
+		playerState !== 'NOT_STARTED';
 
-	const showIcons = !isCinemagraph && playerState !== 'NOT_STARTED';
+	const hasAudio =
+		videoStyleSettings.supportsAudio &&
+		sources.some((source) => source.hasAudio);
 
-	/**
-	 * Functionality to hide controls when the video is not interacted with
-	 * so the full unobscured video can be displayed to the user without distractions.
-	 */
-	const isHideControlsEnabled = isDefault;
-
-	const useLongFormProgressBar = isDefault;
+	const showIcons =
+		(hasAudio || videoStyleSettings.showFullscreenIcon) &&
+		playerState !== 'NOT_STARTED';
 
 	const subtitlesPosition: SubtitlesPosition =
-		useLongFormProgressBar && controlsPosition === 'bottom'
+		videoStyleSettings.useInteractiveProgressBar &&
+		controlsPosition === 'bottom'
 			? 'bottom-elevated'
 			: controlsPosition;
 
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
-
-	const supportsAudio =
-		sources.some((source) => source.hasAudio) && !isCinemagraph;
 
 	const sendOphanTrackingEvent = useCallback(
 		(event: VideoEventKey) => {
@@ -768,7 +758,7 @@ export const SelfHostedVideo = ({
 	};
 
 	const handlePlayPauseClick = (event: React.SyntheticEvent) => {
-		if (isCinemagraph) {
+		if (!videoStyleSettings.isInteractive) {
 			return;
 		}
 
@@ -777,7 +767,7 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleAudioClick = (event: React.SyntheticEvent) => {
-		if (isCinemagraph) {
+		if (!videoStyleSettings.isInteractive) {
 			return;
 		}
 
@@ -836,7 +826,7 @@ export const SelfHostedVideo = ({
 	 * browser. Therefore we need to apply the pause state to the video.
 	 */
 	const handlePause = () => {
-		if (isCinemagraph) {
+		if (!videoStyleSettings.isInteractive) {
 			return;
 		}
 
@@ -873,7 +863,7 @@ export const SelfHostedVideo = ({
 			return;
 		}
 
-		const increment = isDefault ? 10 : 1;
+		const increment = videoStyleSettings.seekIncrement ?? 0;
 		const newTime = Math.min(video.currentTime + increment, video.duration);
 
 		updateCurrentTime(newTime);
@@ -885,7 +875,7 @@ export const SelfHostedVideo = ({
 			return;
 		}
 
-		const increment = isDefault ? 10 : 1;
+		const increment = videoStyleSettings.seekIncrement ?? 0;
 		const newTime = Math.max(video.currentTime - increment, 0);
 
 		updateCurrentTime(newTime);
@@ -903,7 +893,7 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
-		if (isCinemagraph) {
+		if (!videoStyleSettings.isInteractive) {
 			return;
 		}
 
@@ -957,12 +947,15 @@ export const SelfHostedVideo = ({
 	 * and having a play icon would falsely indicate a user action is required to resume playback.
 	 */
 	const showPlayIcon =
-		!isCinemagraph &&
+		videoStyleSettings.canShowPlayIcon &&
 		(playerState === 'PAUSED_BY_USER' ||
 			playerState === 'PAUSED_BY_BROWSER' ||
 			(playerState === 'NOT_STARTED' && shouldAutoplay === false));
 
-	const showPauseIcon = isHideControlsEnabled && playerState === 'PLAYING';
+	const showPauseIcon =
+		videoStyleSettings.hideControlsWhenNotInteractedWith &&
+		playerState === 'PLAYING';
+
 	let showPlayPauseIcon: 'play' | 'pause' | null = null;
 	if (showPlayIcon) {
 		showPlayPauseIcon = 'play';
@@ -1003,7 +996,7 @@ export const SelfHostedVideo = ({
 				ref={setNode}
 				css={[
 					videoContainerStyles(
-						isCinemagraph,
+						videoStyleSettings.isInteractive,
 						aspectRatioOfVisibleVideo,
 						containerAspectRatioMobile,
 						containerAspectRatioDesktop,
@@ -1021,7 +1014,7 @@ export const SelfHostedVideo = ({
 							isVideoCroppedAtLeftRight,
 							containerAspectRatioDesktop,
 						),
-						isHideControlsEnabled &&
+						videoStyleSettings.hideControlsWhenNotInteractedWith &&
 							(playerState === 'PLAYING'
 								? hideControlsStyles
 								: showControlsStyles),
@@ -1040,7 +1033,7 @@ export const SelfHostedVideo = ({
 						currentTime={currentTime}
 						ref={vidRef}
 						playerContainerRef={playerContainerRef}
-						hasAudio={supportsAudio}
+						hasAudio={hasAudio}
 						isMuted={isMuted}
 						handleLoadedMetadata={handleLoadedMetadata}
 						handleLoadedData={handleLoadedData}
@@ -1050,7 +1043,9 @@ export const SelfHostedVideo = ({
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
 						handleKeyDown={handleKeyDown}
-						useLongFormProgressBar={useLongFormProgressBar}
+						useLongFormProgressBar={
+							!!videoStyleSettings.useInteractiveProgressBar
+						}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
 						updateCurrentTime={updateCurrentTime}
@@ -1058,16 +1053,18 @@ export const SelfHostedVideo = ({
 						preloadPartialData={!!shouldAutoplay}
 						showPlayPauseIcon={showPlayPauseIcon}
 						showProgressBar={showProgressBar}
-						showSubtitles={!isCinemagraph}
+						showSubtitles={videoStyleSettings.canShowSubtitles}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}
 						showIcons={showIcons}
 						iconsPosition={controlsPosition}
 						subtitlesPosition={subtitlesPosition}
 						activeCue={activeCue}
-						shouldLoop={shouldLoop}
-						showFullscreenIcon={isDefault}
-						isInteractive={!isCinemagraph}
+						shouldLoop={videoStyleSettings.loop}
+						showFullscreenIcon={
+							videoStyleSettings.showFullscreenIcon
+						}
+						isInteractive={videoStyleSettings.isInteractive}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -314,7 +314,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 								duration={ref.current!.duration}
 							/>
 						))}
-					{showIcons && (
+					{showIcons && (showFullscreenIcon || hasAudio) && (
 						<div
 							css={[
 								iconsContainerStyles,

--- a/dotcom-rendering/src/lib/videoStyleSettings.ts
+++ b/dotcom-rendering/src/lib/videoStyleSettings.ts
@@ -1,21 +1,29 @@
 import type { VideoPlayerFormat } from '../types/mainMedia';
 
+type ProgessBarStyles =
+	| {
+			showProgressBar: boolean;
+			/**
+			 * A progress bar that includes seeking. Taller than the default progress bar
+			 */
+			useInteractiveProgressBar: boolean | null;
+	  }
+	| {
+			showProgressBar: false;
+			useInteractiveProgressBar?: never;
+	  };
+
 /**
  * Self-hosted video style (Cinemagraph, Loop, Default) settings.
  *
  * Defines the settings for each video style which are used to determine how the
  * video player should behave and which controls should be shown for each style.
  */
-export type VideoStyleSettings = {
+export type VideoStyleSettings = ProgessBarStyles & {
 	autoplay: boolean;
 	loop: boolean;
 	supportsAudio: boolean;
 	showFullscreenIcon: boolean;
-	showProgressBar: boolean;
-	/**
-	 * A progress bar that includes seeking. Taller than the default progress bar
-	 */
-	useInteractiveProgressBar: boolean | null;
 	/**
 	 * A play icon can be shown when the video is not playing
 	 */
@@ -52,14 +60,17 @@ const loopSettings: VideoStyleSettings = {
  * This includes but may not be limited to: audio icon, play/pause icon, subtitles, progress bar.
  */
 const cinemagraphSettings: VideoStyleSettings = {
-	...loopSettings,
+	autoplay: true,
+	loop: true,
 	supportsAudio: false,
 	showFullscreenIcon: false,
 	showProgressBar: false,
+	useInteractiveProgressBar: false,
 	canShowPlayIcon: false,
 	canShowSubtitles: false,
 	seekIncrement: null,
 	isInteractive: false,
+	hideControlsWhenNotInteractedWith: false,
 };
 
 /**
@@ -67,11 +78,16 @@ const cinemagraphSettings: VideoStyleSettings = {
  * This style is used for videos that are typically longer in length and should not loop.
  */
 const defaultSettings: VideoStyleSettings = {
-	...loopSettings,
 	autoplay: false,
 	loop: false,
+	supportsAudio: true,
+	showFullscreenIcon: true,
+	showProgressBar: true,
 	useInteractiveProgressBar: true,
+	canShowPlayIcon: true,
+	canShowSubtitles: true,
 	seekIncrement: 10,
+	isInteractive: true,
 	hideControlsWhenNotInteractedWith: true,
 };
 

--- a/dotcom-rendering/src/lib/videoStyleSettings.ts
+++ b/dotcom-rendering/src/lib/videoStyleSettings.ts
@@ -1,0 +1,82 @@
+import type { VideoPlayerFormat } from '../types/mainMedia';
+
+/**
+ * Self-hosted video style (Cinemagraph, Loop, Default) settings.
+ *
+ * Defines the settings for each video style which are used to determine how the
+ * video player should behave and which controls should be shown for each style.
+ */
+export type VideoStyleSettings = {
+	autoplay: boolean;
+	loop: boolean;
+	supportsAudio: boolean;
+	showFullscreenIcon: boolean;
+	showProgressBar: boolean;
+	/**
+	 * A progress bar that includes seeking. Taller than the default progress bar
+	 */
+	useInteractiveProgressBar: boolean | null;
+	/**
+	 * A play icon can be shown when the video is not playing
+	 */
+	canShowPlayIcon: boolean;
+	canShowSubtitles: boolean;
+	seekIncrement: number | null;
+	/**
+	 * Does the video respond to user input
+	 */
+	isInteractive: boolean;
+	/**
+	 * Functionality to hide controls when the video is not interacted with
+	 * so the full, unobscured video can be displayed to the user without distractions.
+	 */
+	hideControlsWhenNotInteractedWith: boolean;
+};
+
+const loopSettings: VideoStyleSettings = {
+	autoplay: true,
+	loop: true,
+	supportsAudio: true,
+	showFullscreenIcon: true,
+	showProgressBar: true,
+	useInteractiveProgressBar: false,
+	canShowPlayIcon: true,
+	canShowSubtitles: true,
+	seekIncrement: 1,
+	isInteractive: true,
+	hideControlsWhenNotInteractedWith: false,
+};
+
+/**
+ * In a cinemagraph, all controls are hidden: the video looks like a GIF.
+ * This includes but may not be limited to: audio icon, play/pause icon, subtitles, progress bar.
+ */
+const cinemagraphSettings: VideoStyleSettings = {
+	...loopSettings,
+	supportsAudio: false,
+	showFullscreenIcon: false,
+	showProgressBar: false,
+	canShowPlayIcon: false,
+	canShowSubtitles: false,
+	seekIncrement: null,
+	isInteractive: false,
+};
+
+/**
+ * In the tools, this style is known as "non-Youtube".
+ * This style is used for videos that are typically longer in length and should not loop.
+ */
+const defaultSettings: VideoStyleSettings = {
+	...loopSettings,
+	autoplay: false,
+	loop: false,
+	useInteractiveProgressBar: true,
+	seekIncrement: 10,
+	hideControlsWhenNotInteractedWith: true,
+};
+
+export const videoSettingsMap: Record<VideoPlayerFormat, VideoStyleSettings> = {
+	Default: defaultSettings,
+	Loop: loopSettings,
+	Cinemagraph: cinemagraphSettings,
+};


### PR DESCRIPTION
no-op change

## What does this change?

Moves all the settings that are controlled by the style of the video into one place. This list of settings has grown recently with the introduction of the long-form (default) style.

## Why?

To make it easier to update video style settings in the future.
To make it easier to add/remove video styles in the future.