### PR TITLE
feat: Expand Google One Tap to EU27 countries

### DIFF
--- a/dotcom-rendering/src/components/GoogleOneTap.island.tsx
+++ b/dotcom-rendering/src/components/GoogleOneTap.island.tsx
@@ -121,7 +121,38 @@ const getProviders = (stage: StageType): IdentityProviderConfig[] => {
 	}
 };
 
-const ENABLED_COUNTRIES: CountryCode[] = ['IE', 'NZ', 'AU'];
+const ENABLED_COUNTRIES: CountryCode[] = [
+	'NZ', // New Zealand
+	'AU', // Australia
+	// EU27 Countries
+	'AT', // Austria
+	'BE', // Belgium
+	'BG', // Bulgaria
+	'CY', // Cyprus
+	'CZ', // Czechia
+	'DE', // Germany
+	'DK', // Denmark
+	'EE', // Estonia
+	'ES', // Spain
+	'FI', // Finland
+	'FR', // France
+	'GR', // Greece
+	'HR', // Croatia
+	'HU', // Hungary
+	'IE', // Ireland
+	'IT', // Italy
+	'LT', // Lithuania
+	'LU', // Luxembourg
+	'LV', // Latvia
+	'MT', // Malta
+	'NL', // Netherlands
+	'PL', // Poland
+	'PT', // Portugal
+	'RO', // Romania
+	'SE', // Sweden
+	'SI', // Slovenia
+	'SK', // Slovakia
+];
 
 export const initializeFedCM = async ({
 	isSignedIn,


### PR DESCRIPTION
## What does this change?

Rollout Google One Tap to all [EU27 countries](https://www.gov.uk/eu-eea)

## Why?

We'd like to expand our test to more users as we've seen positive results in Ireland, Australia, and New Zealand.

## Screenshots

<img width="1017" height="300" alt="image" src="https://github.com/user-attachments/assets/196d66b1-806b-4d10-a218-1d99c98ee829" />

