### PR TITLE
switch prebid pricefloor AB test switch to off

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -128,7 +128,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-05-15",
 		type: "client",
-		status: "ON",
+		status: "OFF",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],


### PR DESCRIPTION
## What does this change?
Set the AB test status switch to "OFF".

## Why?
We have gathered the required data for this test and are switching it off. We are keeping the code for the AB test config in place as we will shortly be moving to testing V2.
