### PR TITLE
Update CTA image blur for Hosted Content 

### DIFF
--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -20,7 +20,10 @@ type CallToActionProps = {
 
 const blurStyles = css`
 	position: absolute;
-	inset: 0;
+	top: -${space[2]}px;
+	bottom: 0;
+	left: 0;
+	right: 0;
 	backdrop-filter: blur(12px) brightness(0.5);
 	@supports not (backdrop-filter: blur(12px)) {
 		background-color: linear-gradient(
@@ -29,11 +32,15 @@ const blurStyles = css`
 		);
 	}
 	mask-image: linear-gradient(
-		to top,
-		${transparentColour(sourcePalette.neutral[10], 0.99)},
-		${transparentColour(sourcePalette.neutral[10], 0.96)},
-		${transparentColour(sourcePalette.neutral[10], 0.89)},
-		transparent
+		transparent 0px,
+		rgba(0, 0, 0, 0.0381) 8px,
+		rgba(0, 0, 0, 0.1464) 16px,
+		rgba(0, 0, 0, 0.3087) 24px,
+		rgba(0, 0, 0, 0.5) 32px,
+		rgba(0, 0, 0, 0.6913) 40px,
+		rgba(0, 0, 0, 0.8536) 48px,
+		rgba(0, 0, 0, 0.9619) 56px,
+		rgb(0, 0, 0) 64px
 	);
 `;
 
@@ -50,7 +57,7 @@ const textAndButtonWrapperStyles = css`
 	flex-direction: column;
 	justify-content: end;
 	align-items: start;
-	padding: 0 ${space[2]}px ${space[6]}px;
+	padding: ${space[2]}px ${space[2]}px ${space[6]}px;
 	z-index: 1;
 
 	${from.tablet} {

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -20,7 +20,7 @@ type CallToActionProps = {
 
 const blurStyles = css`
 	position: absolute;
-	top: -${space[2]}px;
+	top: -${space[10]}px;
 	bottom: 0;
 	left: 0;
 	right: 0;
@@ -42,6 +42,10 @@ const blurStyles = css`
 		rgba(0, 0, 0, 0.9619) 56px,
 		rgb(0, 0, 0) 64px
 	);
+
+	${from.tablet} {
+		top: -${space[8]}px;
+	}
 `;
 
 const blurAndTextWrapperStyles = css`
@@ -57,7 +61,7 @@ const textAndButtonWrapperStyles = css`
 	flex-direction: column;
 	justify-content: end;
 	align-items: start;
-	padding: ${space[2]}px ${space[2]}px ${space[6]}px;
+	padding: ${space[3]}px ${space[2]}px ${space[6]}px;
 	z-index: 1;
 
 	${from.tablet} {

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -20,11 +20,6 @@ type CallToActionProps = {
 
 const blurStyles = css`
 	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-
 	inset: 0;
 	backdrop-filter: blur(12px) brightness(0.5);
 	@supports not (backdrop-filter: blur(12px)) {
@@ -46,13 +41,18 @@ const blurStyles = css`
 const buttonWrapperStyles = css`
 	display: flex;
 	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+`;
+
+const textAndButtonWrapperStyles = css`
+	display: flex;
 	flex-direction: column;
 	justify-content: end;
 	align-items: start;
 	padding: 0 ${space[2]}px ${space[6]}px;
-	bottom: 0;
-	left: 0;
-	right: 0;
+	z-index: 1;
 
 	${from.tablet} {
 		flex-direction: row;
@@ -113,11 +113,7 @@ export const CallToActionAtom = ({
 				`}
 			/>
 			<div css={buttonWrapperStyles}>
-				<div
-					css={css`
-						z-index: 1;
-					`}
-				>
+				<div css={textAndButtonWrapperStyles}>
 					{!!text && <h2 css={textStyles}>{text}</h2>}
 					<LinkButton
 						href={linkUrl}

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -28,17 +28,17 @@ const blurStyles = css`
 			0
 		);
 	}
-	/* This might need adjusting a little! */
 	mask-image: linear-gradient(
 		to top,
 		${transparentColour(sourcePalette.neutral[10], 0.95)},
 		${transparentColour(sourcePalette.neutral[10], 0.9)},
-		${transparentColour(sourcePalette.neutral[10], 0.85)},
+		${transparentColour(sourcePalette.neutral[10], 0.8)},
+		${transparentColour(sourcePalette.neutral[10], 0.7)},
 		transparent
 	);
 `;
 
-const buttonWrapperStyles = css`
+const blurAndTextWrapperStyles = css`
 	display: flex;
 	position: absolute;
 	bottom: 0;
@@ -112,7 +112,7 @@ export const CallToActionAtom = ({
 					}
 				`}
 			/>
-			<div css={buttonWrapperStyles}>
+			<div css={blurAndTextWrapperStyles}>
 				<div css={textAndButtonWrapperStyles}>
 					{!!text && <h2 css={textStyles}>{text}</h2>}
 					<LinkButton

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -27,20 +27,21 @@ const blurStyles = css`
 	backdrop-filter: blur(12px) brightness(0.5);
 	@supports not (backdrop-filter: blur(12px)) {
 		background-color: linear-gradient(
-			${transparentColour(sourcePalette.neutral[10], 0.7)},
-			0
+			to top,
+			${transparentColour(sourcePalette.neutral[10], 0.99)},
+			${transparentColour(sourcePalette.neutral[10], 0.95)},
+			${transparentColour(sourcePalette.neutral[10], 0.85)},
+			${transparentColour(sourcePalette.neutral[10], 0.75)},
+			transparent
 		);
 	}
 	mask-image: linear-gradient(
-		transparent 0px,
-		rgba(0, 0, 0, 0.0381) 8px,
-		rgba(0, 0, 0, 0.1464) 16px,
-		rgba(0, 0, 0, 0.3087) 24px,
-		rgba(0, 0, 0, 0.5) 32px,
-		rgba(0, 0, 0, 0.6913) 40px,
-		rgba(0, 0, 0, 0.8536) 48px,
-		rgba(0, 0, 0, 0.9619) 56px,
-		rgb(0, 0, 0) 64px
+		to top,
+		${transparentColour(sourcePalette.neutral[10], 0.99)},
+		${transparentColour(sourcePalette.neutral[10], 0.95)},
+		${transparentColour(sourcePalette.neutral[10], 0.85)},
+		${transparentColour(sourcePalette.neutral[10], 0.75)},
+		transparent
 	);
 
 	${from.tablet} {
@@ -131,7 +132,6 @@ export const CallToActionAtom = ({
 						size="small"
 						icon={<SvgExternal />}
 						theme={{
-							// We also still need to implement the dark mode based on the provided designs which should be the same as not providing an accent colour.
 							textPrimary: accentColor
 								? sourcePalette.neutral[100]
 								: sourcePalette.neutral[0],

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -30,10 +30,9 @@ const blurStyles = css`
 	}
 	mask-image: linear-gradient(
 		to top,
-		${transparentColour(sourcePalette.neutral[10], 0.95)},
-		${transparentColour(sourcePalette.neutral[10], 0.9)},
-		${transparentColour(sourcePalette.neutral[10], 0.8)},
-		${transparentColour(sourcePalette.neutral[10], 0.7)},
+		${transparentColour(sourcePalette.neutral[10], 0.99)},
+		${transparentColour(sourcePalette.neutral[10], 0.96)},
+		${transparentColour(sourcePalette.neutral[10], 0.89)},
 		transparent
 	);
 `;

--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -18,54 +18,32 @@ type CallToActionProps = {
 	accentColor?: string;
 };
 
-const overlayMaskGradientStyles = (angle: string, startPosition: number) => {
-	const positions = [0, 8, 16, 24, 32, 40, 48, 56, 64].map(
-		(offset) => startPosition + offset,
-	);
-	return css`
-		mask-image: linear-gradient(
-			${angle},
-			transparent ${positions[0]}px,
-			rgba(0, 0, 0, 0.0381) ${positions[1]}px,
-			rgba(0, 0, 0, 0.1464) ${positions[2]}px,
-			rgba(0, 0, 0, 0.3087) ${positions[3]}px,
-			rgba(0, 0, 0, 0.5) ${positions[4]}px,
-			rgba(0, 0, 0, 0.6913) ${positions[5]}px,
-			rgba(0, 0, 0, 0.8536) ${positions[6]}px,
-			rgba(0, 0, 0, 0.9619) ${positions[7]}px,
-			rgb(0, 0, 0) ${positions[8]}px
-		);
-	`;
-};
-
 const blurStyles = css`
 	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+
 	inset: 0;
 	backdrop-filter: blur(12px) brightness(0.5);
 	@supports not (backdrop-filter: blur(12px)) {
-		background-color: ${transparentColour(sourcePalette.neutral[10], 0.7)};
+		background-color: linear-gradient(
+			${transparentColour(sourcePalette.neutral[10], 0.7)},
+			0
+		);
 	}
-	${overlayMaskGradientStyles('180deg', 0)};
-
-	${from.mobileLandscape} {
-		${overlayMaskGradientStyles('180deg', 20)};
-	}
-
-	${from.tablet} {
-		${overlayMaskGradientStyles('180deg', 80)};
-	}
-
-	${from.desktop} {
-		${overlayMaskGradientStyles('180deg', 100)};
-	}
-
-	${from.leftCol} {
-		${overlayMaskGradientStyles('180deg', 210)};
-	}
+	/* This might need adjusting a little! */
+	mask-image: linear-gradient(
+		to top,
+		${transparentColour(sourcePalette.neutral[10], 0.95)},
+		${transparentColour(sourcePalette.neutral[10], 0.9)},
+		${transparentColour(sourcePalette.neutral[10], 0.85)},
+		transparent
+	);
 `;
 
 const buttonWrapperStyles = css`
-	${blurStyles}
 	display: flex;
 	position: absolute;
 	flex-direction: column;
@@ -135,24 +113,32 @@ export const CallToActionAtom = ({
 				`}
 			/>
 			<div css={buttonWrapperStyles}>
-				{!!text && <h2 css={textStyles}>{text}</h2>}
-				<LinkButton
-					href={linkUrl}
-					iconSide="right"
-					size="small"
-					icon={<SvgExternal />}
-					theme={{
-						// We also still need to implement the dark mode based on the provided designs which should be the same as not providing an accent colour.
-						textPrimary: accentColor
-							? sourcePalette.neutral[100]
-							: sourcePalette.neutral[0],
-						backgroundPrimary: buttonBgColour,
-						backgroundPrimaryHover:
-							calculateHoverColour(buttonBgColour),
-					}}
+				<div
+					css={css`
+						z-index: 1;
+					`}
 				>
-					{buttonText ?? 'Learn more'}
-				</LinkButton>
+					{!!text && <h2 css={textStyles}>{text}</h2>}
+					<LinkButton
+						href={linkUrl}
+						iconSide="right"
+						size="small"
+						icon={<SvgExternal />}
+						theme={{
+							// We also still need to implement the dark mode based on the provided designs which should be the same as not providing an accent colour.
+							textPrimary: accentColor
+								? sourcePalette.neutral[100]
+								: sourcePalette.neutral[0],
+							backgroundPrimary: buttonBgColour,
+							backgroundPrimaryHover:
+								calculateHoverColour(buttonBgColour),
+						}}
+					>
+						{buttonText ?? 'Learn more'}
+					</LinkButton>
+				</div>
+				{/* blur overlay */}
+				<div aria-hidden="true" css={blurStyles} />
 			</div>
 		</picture>
 	);


### PR DESCRIPTION
## What does this change?

This PR updates the CTA image blur for Hosted Content so it wouldn't hide a big chunk of the CTA image and we have the overlay to be slightly higher than the text and button. 

We used CSS to accomplish this by having a parent div and two children: one contains the text and button and the other is for the blur effect. The blur is connected to the text and button height so in the case of having two lines of text we would be able to accommodate that. Thanks to @cemms1 for exploring this further in order to achieve the required styling ✨

The changes works well from tablet but there will be a separate PR for mobile as currently the blur hides almost all the image so we are waiting for the designers to confirm on the best design approach.

## Why?

Better user experience as currently the blur hides more than it needs of the CTA image. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |
| ![before5][] | ![after5][] |

[before]: https://github.com/user-attachments/assets/93e88d48-4992-4236-b611-2a9f1709eb05
[after]: https://github.com/user-attachments/assets/b418d26c-fde7-4c2b-9a61-7ae15e5c8569

[before2]: https://github.com/user-attachments/assets/31aefc08-5417-4aad-9e5d-d04df56ab9ed
[after2]: https://github.com/user-attachments/assets/ce89e555-4ca6-415c-a6e8-a320afe4aa58

[before3]: https://github.com/user-attachments/assets/7667c399-c039-4bf7-ba2e-75c23165d44b
[after3]: https://github.com/user-attachments/assets/3c512a4a-ac9b-4853-bb16-4186ba97df46

[before4]: https://github.com/user-attachments/assets/c0ae444f-f8e7-464e-af92-9f128407f969
[after4]: https://github.com/user-attachments/assets/ced03909-5777-49a6-90a0-a0eadd3a0ad9

[before5]: https://github.com/user-attachments/assets/48211a5c-f7b1-4928-b232-8f2e8f55b9b3
[after5]: https://github.com/user-attachments/assets/6c691619-bf29-47b4-92f9-db317f71105d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214440020456683