### PR TITLE
Removed Auxia control AB test

### DIFF
--- a/dotcom-rendering/src/components/SignInGate/types.ts
+++ b/dotcom-rendering/src/components/SignInGate/types.ts
@@ -137,7 +137,6 @@ export interface AuxiaProxyGetTreatmentsPayload {
 	showDefaultGate: ShowGateValues; // [3]
 	gateDisplayCount: number;
 	hideSupportMessagingTimestamp: number | undefined; // [4]
-	isInAuxiaControlGroup: boolean;
 }
 
 // [1]

--- a/dotcom-rendering/src/components/StickyBottomBanner.island.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.island.tsx
@@ -19,7 +19,7 @@ import type {
 	SlotConfig,
 } from '../lib/messagePicker';
 import { pickMessage } from '../lib/messagePicker';
-import { useAB, useBetaAB } from '../lib/useAB';
+import { useBetaAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import { useCountryCode } from '../lib/useCountryCode';
@@ -278,12 +278,7 @@ export const StickyBottomBanner = ({
 	const countryCode = useCountryCode('sticky-bottom-banner');
 	const isSignedIn = useIsSignedIn();
 	const ophanPageViewId = usePageViewId(renderingTarget);
-	const abTestAPI = useAB()?.api;
 	const abTests = useBetaAB();
-	const isInAuxiaControlGroup = !!abTestAPI?.isUserInVariant(
-		'NoAuxiaSignInGate',
-		'control',
-	);
 	const inAuxiaVariant =
 		abTests?.isUserInTestGroup('growth-auxia-banner', 'variant') ?? false;
 
@@ -369,7 +364,6 @@ export const StickyBottomBanner = ({
 				pageId,
 				contributionsServiceUrl,
 				editionId,
-				isInAuxiaControlGroup,
 			},
 			host,
 		);
@@ -436,7 +430,6 @@ export const StickyBottomBanner = ({
 		ophanPageViewId,
 		pageId,
 		host,
-		isInAuxiaControlGroup,
 		braze,
 		abTests,
 		inAuxiaVariant,

--- a/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.test.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.test.tsx
@@ -22,7 +22,6 @@ const canShowProps: CanShowSignInGateProps = {
 	isPreview: false,
 	pageId: 'page-id',
 	contributionsServiceUrl: 'https://contributions.local',
-	isInAuxiaControlGroup: false,
 	editionId: 'UK',
 	contentType: 'Article',
 	sectionId: 'section',

--- a/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner/SignInGatePortal.tsx
@@ -146,7 +146,6 @@ export interface CanShowSignInGateProps {
 	isPreview: boolean;
 	pageId: string;
 	contributionsServiceUrl: string;
-	isInAuxiaControlGroup: boolean;
 	editionId?: EditionId;
 	contentType?: string;
 	sectionId?: string;
@@ -158,7 +157,6 @@ export const canShowSignInGatePortal = async ({
 	isPreview,
 	pageId,
 	contributionsServiceUrl,
-	isInAuxiaControlGroup,
 	editionId,
 	contentType,
 	sectionId,
@@ -203,7 +201,6 @@ export const canShowSignInGatePortal = async ({
 			sectionId,
 			tags,
 			retrieveLastGateDismissedCount('AuxiaSignInGate'),
-			isInAuxiaControlGroup,
 		);
 
 		return {

--- a/dotcom-rendering/src/lib/auxia.ts
+++ b/dotcom-rendering/src/lib/auxia.ts
@@ -125,7 +125,6 @@ const fetchProxyGetTreatments = async (
 	showDefaultGate: ShowGateValues,
 	gateDisplayCount: number,
 	hideSupportMessagingTimestamp: number | undefined,
-	isInAuxiaControlGroup: boolean,
 ): Promise<AuxiaProxyGetTreatmentsResponse> => {
 	const articleIdentifier = `www.theguardian.com/${pageId}`;
 	const url = `${contributionsServiceUrl}/auxia/get-treatments`;
@@ -148,7 +147,6 @@ const fetchProxyGetTreatments = async (
 		showDefaultGate,
 		gateDisplayCount,
 		hideSupportMessagingTimestamp,
-		isInAuxiaControlGroup,
 	};
 
 	const params = { method: 'POST', headers, body: JSON.stringify(payload) };
@@ -217,7 +215,6 @@ export const buildAuxiaGateDisplayData = async (
 	sectionId: string,
 	tags: TagType[],
 	gateDismissCount: number,
-	isInAuxiaControlGroup: boolean,
 ): Promise<AuxiaGateDisplayData | undefined> => {
 	const readerPersonalData = await decideAuxiaProxyReaderPersonalData();
 	const tagIds = tags.map((tag) => tag.id);
@@ -245,7 +242,6 @@ export const buildAuxiaGateDisplayData = async (
 		showDefaultGate,
 		gateDisplayCount,
 		hideSupportMessagingTimestamp,
-		isInAuxiaControlGroup,
 	);
 
 	if (response.status && response.data) {


### PR DESCRIPTION
## What does this change?

Removes the Ab test for the auxia control group. This was originally added here: 

https://github.com/guardian/dotcom-rendering/pull/14775

## Why?

The business no longer needs the AB test. 

We tested by checking that sign in gate requests are still being made.