### PR TITLE
Minor self-hosted video improvements

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -45,7 +45,7 @@ import type { VideoEventKey } from './YoutubeAtom/YoutubeAtom';
 
 const VISIBILITY_THRESHOLD = 0.5;
 
-const videoContainerStyles = (
+const cardStyles = (
 	isInteractive: boolean,
 	aspectRatioOfVisibleVideo: number,
 	containerAspectRatioMobile?: number,
@@ -74,7 +74,7 @@ const videoContainerStyles = (
 	}
 `;
 
-const figureStyles = (
+const videoContainerStyles = (
 	aspectRatio: number,
 	aspectRatioOfVisibleVideo: number,
 	greyBarsAtSidesOnDesktop: boolean,
@@ -437,10 +437,12 @@ export const SelfHostedVideo = ({
 	}
 
 	/** The aspect ratio of the video will be clamped within the specified range */
-	const aspectRatioOfVisibleVideo = getAspectRatioOfVisibleVideo(
-		aspectRatio,
-		minAspectRatio,
-		maxAspectRatio,
+	const aspectRatioOfVisibleVideo = Number(
+		getAspectRatioOfVisibleVideo(
+			aspectRatio,
+			minAspectRatio,
+			maxAspectRatio,
+		).toFixed(3),
 	);
 
 	const isVideoCroppedAtTopBottom = aspectRatio < aspectRatioOfVisibleVideo;
@@ -995,7 +997,7 @@ export const SelfHostedVideo = ({
 			<div
 				ref={setNode}
 				css={[
-					videoContainerStyles(
+					cardStyles(
 						videoStyleSettings.isInteractive,
 						aspectRatioOfVisibleVideo,
 						containerAspectRatioMobile,
@@ -1005,7 +1007,7 @@ export const SelfHostedVideo = ({
 			>
 				<div
 					css={[
-						figureStyles(
+						videoContainerStyles(
 							aspectRatio,
 							aspectRatioOfVisibleVideo,
 							isGreyBarsAtSidesOnDesktop,

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -140,7 +140,6 @@ export type Props = {
 	handleAudioClick: (event: SyntheticEvent) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
-	useLongFormProgressBar: boolean;
 	handlePause: (event: SyntheticEvent) => void;
 	handleFullscreenClick?: (event: SyntheticEvent) => void;
 	updateCurrentTime: (time: number) => void;
@@ -148,6 +147,7 @@ export type Props = {
 	posterImage?: string;
 	preloadPartialData: boolean;
 	showProgressBar: boolean;
+	useLongFormProgressBar: boolean;
 	showPlayPauseIcon: 'play' | 'pause' | null;
 	showIcons: boolean;
 	showFullscreenIcon: boolean;
@@ -195,13 +195,13 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handleAudioClick,
 			handleKeyDown,
 			handleTimeUpdate,
-			useLongFormProgressBar,
 			handlePause,
 			handleFullscreenClick,
 			updateCurrentTime,
 			onError,
 			preloadPartialData,
 			showProgressBar: canShowProgressBar,
+			useLongFormProgressBar,
 			showPlayPauseIcon,
 			showIcons: canShowIcons,
 			showFullscreenIcon,

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -15,6 +15,7 @@ const buttonStyles = css`
 	background: none;
 	padding: 0;
 	cursor: pointer;
+	-webkit-tap-highlight-color: transparent;
 `;
 
 const iconContainerStyles = css`

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -26,6 +26,7 @@ const containerStyles = css`
 		${sourcePalette.neutral[0]} 0%,
 		transparent 100%
 	);
+	-webkit-tap-highlight-color: transparent;
 `;
 
 const trackStyles = css`


### PR DESCRIPTION
## What does this change?

- Rename self-hosted video css style names
- Round aspect ratio to 3 decimal places.
- Don't highlight interactive progress bar or play icon when tapped on webkit devices

## Why?

A few very minor improvements batched together

## Screenshots

| <img width=100/> | Before | After |
| - | - | - |
| Progress bar | ![desktop-before] | ![desktop-after] |
| Play icon | ![mobile-before] | ![mobile-after] |

[mobile-before]: https://github.com/user-attachments/assets/1582bf6a-1a1c-4885-9123-0a8678d2de2d
[desktop-before]: https://github.com/user-attachments/assets/43638f37-1f77-4b68-8721-1a5391790083
[mobile-after]: https://github.com/user-attachments/assets/26fad398-6c65-474c-ba13-bf48d87d2944
[desktop-after]: https://github.com/user-attachments/assets/41aed0c5-c8de-417d-8772-df0fc127cf9f