### PR TITLE
Update Marketing and Braze components in CODEOWNERS to MarTech team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,9 +21,9 @@
 /dotcom-rendering/src/components/AdSlot*        @guardian/commercial-dev
 /dotcom-rendering/src/components/Labs*       	@guardian/commercial-dev
 /dotcom-rendering/src/components/AdP*           @guardian/commercial-dev
-/dotcom-rendering/src/components/marketing/     @guardian/growth
+/dotcom-rendering/src/components/marketing/     @guardian/martech
 /dotcom-rendering/src/server/                   @guardian/dotcom-platform
-/dotcom-rendering/src/lib/braze/                @guardian/value
+/dotcom-rendering/src/lib/braze/                @guardian/martech
 /dotcom-rendering/webpack/                      @guardian/dotcom-platform
 /scripts/                                       @guardian/dotcom-platform
 /ab-testing/                                    @guardian/commercial-dev


### PR DESCRIPTION
## What does this change?

Updates CODEOWNERS file to reflect that marketing and braze components are now owned by @guardian/martech (formerly known as growth)