### PR TITLE
Drop baseurl from tsconfig

### DIFF
--- a/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/ophan.e2e.spec.ts
@@ -4,7 +4,7 @@ import {
 	ADDITIONAL_REQUEST_PATH,
 	IMPRESSION_REQUEST_PATH,
 	interceptOphanRequest,
-} from 'playwright/lib/ophan';
+} from '../../playwright/lib/ophan';
 import {
 	allowRejectAll,
 	cmpAcceptAll,

--- a/dotcom-rendering/tsconfig.json
+++ b/dotcom-rendering/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@guardian/tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,
-		"baseUrl": "./",
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "react-jsx",
 		"jsxImportSource": "@emotion/react",
@@ -11,10 +10,6 @@
 		"noEmit": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedIndexedAccess": true,
-		"paths": {
-			/* Aliases should also be added to the webpack and jest configurations */
-			"*": ["node_modules/@types/*", "*"] // Make sure that package linking doesn't confuse things https://github.com/microsoft/TypeScript/issues/11916#issuecomment-257130001
-		},
 		"preserveConstEnums": true,
 		"types": [
 			"node",
@@ -31,7 +26,6 @@
 			"chai"
 		]
 	},
-	"include": ["**/*", ".storybook/mocks/bridgetApi.ts"],
 	"exclude": [
 		"storybook-static",
 		"target",


### PR DESCRIPTION
## What does this change?
Drop `baseUrl` from `tsconfig.json`, the `paths` entries are non-relative so don't work without the `baseUrl` but aren't needed anymore anyway, the `include` entry is also doing nothing.


## Why?
[`baseUrl` has been deprecated](https://github.com/microsoft/TypeScript/issues/62207), and will be removed in TS6+
