### PR TITLE
Add `Popover` component to the Hosted Content header

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -44,7 +44,7 @@
 		"@guardian/react-crossword": "17.1.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "12.2.1",
-		"@guardian/source-development-kitchen": "18.1.1",
+		"@guardian/source-development-kitchen": "0.0.0-canary-20260515144636",
 		"@guardian/support-dotcom-components": "9.0.1",
 		"@guardian/tsconfig": "catalog:",
 		"@playwright/test": "1.58.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -44,7 +44,7 @@
 		"@guardian/react-crossword": "17.1.0",
 		"@guardian/shimport": "1.0.2",
 		"@guardian/source": "12.2.1",
-		"@guardian/source-development-kitchen": "0.0.0-canary-20260515144636",
+		"@guardian/source-development-kitchen": "28.1.0",
 		"@guardian/support-dotcom-components": "9.0.1",
 		"@guardian/tsconfig": "catalog:",
 		"@playwright/test": "1.58.0",

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -81,7 +81,7 @@ const advertiserContentStyles = css`
 	justify-content: space-around;
 	align-items: center;
 	${textSans12};
-	padding: 0 2px;
+	padding-left: ${space[1]}px;
 `;
 
 const logoStyles = css`

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -180,8 +180,6 @@ export const HostedContentHeader = ({ branding }: Props) => {
 	const [shouldFadeLogo, setShouldFadeLogo] = useState<boolean>(false);
 
 	const handleButtonClick = () => setIsPopoverExpanded(!isPopoverExpanded);
-	// Logo fading is an exclusive feature for hosted video pages at certain breakpoints
-	// This component only needs rehydration on the video layout
 	const fadeLogo = () => setShouldFadeLogo(true);
 	const unfadeLogo = () => setShouldFadeLogo(false);
 
@@ -262,7 +260,7 @@ export const HostedContentHeader = ({ branding }: Props) => {
 								}}
 								hideLabel={true}
 								onClick={handleButtonClick}
-								aria-label="More information about advertiser content"
+								aria-label="Information about advertiser content"
 								aria-haspopup="dialog"
 							/>
 						}

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -142,10 +142,10 @@ const badgeWrapperFadeStyles = css`
 const POPOVER_WIDTH = '280px';
 const popoverOverrides = css`
 	${until.tablet} {
-		left: calc(-${POPOVER_WIDTH} + ${space[5]}px);
+		left: calc(-${POPOVER_WIDTH} + ${space[8]}px);
 		transform: translateX(50%);
 		::after {
-			left: calc(50% - ${space[6]}px);
+			left: calc(50% - ${space[8]}px);
 		}
 	}
 `;

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import {
 	breakpoints,
+	calculateHoverColour,
 	from,
+	palette,
 	palette as sourcePalette,
 	space,
 	textSans12,
@@ -12,9 +14,11 @@ import {
 } from '@guardian/source/foundations';
 import {
 	Button,
+	LinkButton,
 	SvgGuardianLogo,
 	SvgInfoRound,
 } from '@guardian/source/react-components';
+import { Popover } from '@guardian/source-development-kitchen/react-components';
 import { useEffect, useState } from 'react';
 import { nestedOphanComponents } from '../lib/ophan-helpers';
 import {
@@ -78,11 +82,6 @@ const advertiserContentStyles = css`
 	align-items: center;
 	${textSans12};
 	padding: 0 2px;
-
-	button {
-		width: 16px;
-		height: 16px;
-	}
 `;
 
 const logoStyles = css`
@@ -140,6 +139,17 @@ const badgeWrapperFadeStyles = css`
 	}
 `;
 
+const POPOVER_WIDTH = '280px';
+const popoverOverrides = css`
+	${until.tablet} {
+		left: calc(-${POPOVER_WIDTH} + ${space[5]}px);
+		transform: translateX(50%);
+		::after {
+			left: calc(50% - ${space[6]}px);
+		}
+	}
+`;
+
 /**
  * Can't reuse general Logo.tsx until we add a new palette to work with hosted.
  * The color doesn't work with palette --masthead-nav-link-text
@@ -166,8 +176,10 @@ const GuardianLogo = () => (
 export const HostedContentHeader = ({ branding }: Props) => {
 	const accentColor =
 		branding.hostedCampaignColour ?? sourcePalette.neutral[38];
+	const [isPopoverExpanded, setIsPopoverExpanded] = useState<boolean>(false);
 	const [shouldFadeLogo, setShouldFadeLogo] = useState<boolean>(false);
 
+	const handleButtonClick = () => setIsPopoverExpanded(!isPopoverExpanded);
 	// Logo fading is an exclusive feature for hosted video pages at certain breakpoints
 	// This component only needs rehydration on the video layout
 	const fadeLogo = () => setShouldFadeLogo(true);
@@ -194,17 +206,67 @@ export const HostedContentHeader = ({ branding }: Props) => {
 					style={{ backgroundColor: accentColor }}
 				>
 					<p>Advertiser content</p>
-					{/** TODO - add button action ie on click/on hover handlers */}
-					<Button
-						size="xsmall"
-						icon={<SvgInfoRound />}
-						hideLabel={true}
-						priority="subdued"
+					<Popover
+						title="Advertiser content"
+						position="bottom"
+						showPointer={true}
 						theme={{
-							textSubdued: sourcePalette.neutral[97],
+							text: palette.neutral[97],
+							background: palette.neutral[10],
+							dismissButtonText: palette.neutral[100],
+							dismissButtonBackground: palette.neutral[20],
+							dismissButtonBackgroundHover: palette.neutral[38],
 						}}
-						aria-label="More information about advertiser content"
-					/>
+						width={POPOVER_WIDTH}
+						anchorElement={
+							<Button
+								id="info-icon"
+								icon={<SvgInfoRound />}
+								size="xsmall"
+								priority="subdued"
+								theme={{
+									textSubdued: sourcePalette.neutral[97],
+								}}
+								hideLabel={true}
+								onClick={handleButtonClick}
+								aria-label="More information about advertiser content"
+							>
+								More information
+							</Button>
+						}
+						isOpen={isPopoverExpanded}
+						handleClose={() => setIsPopoverExpanded(false)}
+						cssOverrides={popoverOverrides}
+					>
+						<span>
+							This content is paid for and produced by the
+							advertiser. It is regulated by the Advertising
+							Standards Authority. Guardian staff had no
+							involvement in its creation.
+						</span>
+						<div
+							css={css`
+								margin-top: ${space[3]}px;
+							`}
+						>
+							<LinkButton
+								priority="primary"
+								size="xsmall"
+								href="https://www.theguardian.com/info/2016/jan/25/content-funding"
+								theme={{
+									textPrimary: palette.brand[100],
+									backgroundPrimary: palette.brand[800],
+									backgroundPrimaryHover:
+										calculateHoverColour(
+											palette.brand[800],
+										),
+								}}
+								aria-label="Learn more about advertiser content"
+							>
+								Learn more
+							</LinkButton>
+						</div>
+					</Popover>
 				</div>
 
 				<div

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -208,6 +208,39 @@ export const HostedContentHeader = ({ branding }: Props) => {
 					<p>Advertiser content</p>
 					<Popover
 						title="Advertiser content"
+						content={
+							<>
+								<span>
+									This content is paid for and produced by the
+									advertiser. It is regulated by the
+									Advertising Standards Authority. Guardian
+									staff had no involvement in its creation.
+								</span>
+								<div
+									css={css`
+										margin-top: ${space[3]}px;
+									`}
+								>
+									<LinkButton
+										priority="primary"
+										size="xsmall"
+										href="https://www.theguardian.com/info/2016/jan/25/content-funding"
+										theme={{
+											textPrimary: palette.brand[100],
+											backgroundPrimary:
+												palette.brand[800],
+											backgroundPrimaryHover:
+												calculateHoverColour(
+													palette.brand[800],
+												),
+										}}
+										aria-label="Learn more about advertiser content"
+									>
+										Learn more
+									</LinkButton>
+								</div>
+							</>
+						}
 						position="bottom"
 						showPointer={true}
 						theme={{
@@ -218,7 +251,7 @@ export const HostedContentHeader = ({ branding }: Props) => {
 							dismissButtonBackgroundHover: palette.neutral[38],
 						}}
 						width={POPOVER_WIDTH}
-						anchorElement={
+						trigger={
 							<Button
 								id="info-icon"
 								icon={<SvgInfoRound />}
@@ -230,43 +263,13 @@ export const HostedContentHeader = ({ branding }: Props) => {
 								hideLabel={true}
 								onClick={handleButtonClick}
 								aria-label="More information about advertiser content"
-							>
-								More information
-							</Button>
+								aria-haspopup="dialog"
+							/>
 						}
 						isOpen={isPopoverExpanded}
 						handleClose={() => setIsPopoverExpanded(false)}
 						cssOverrides={popoverOverrides}
-					>
-						<span>
-							This content is paid for and produced by the
-							advertiser. It is regulated by the Advertising
-							Standards Authority. Guardian staff had no
-							involvement in its creation.
-						</span>
-						<div
-							css={css`
-								margin-top: ${space[3]}px;
-							`}
-						>
-							<LinkButton
-								priority="primary"
-								size="xsmall"
-								href="https://www.theguardian.com/info/2016/jan/25/content-funding"
-								theme={{
-									textPrimary: palette.brand[100],
-									backgroundPrimary: palette.brand[800],
-									backgroundPrimaryHover:
-										calculateHoverColour(
-											palette.brand[800],
-										),
-								}}
-								aria-label="Learn more about advertiser content"
-							>
-								Learn more
-							</LinkButton>
-						</div>
-					</Popover>
+					/>
 				</div>
 
 				<div

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -213,7 +213,9 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 						padSides={false}
 						element="header"
 					>
-						<HostedContentHeader branding={branding} />
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<HostedContentHeader branding={branding} />
+						</Island>
 					</Section>
 				</Stuck>
 			) : null}

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -61,7 +61,9 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						padSides={true}
 						element="header"
 					>
-						<HostedContentHeader branding={branding} />
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<HostedContentHeader branding={branding} />
+						</Island>
 					</Section>
 				</Stuck>
 			) : null}

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -198,10 +198,7 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 						padSides={true}
 						element="header"
 					>
-						<Island
-							priority="enhancement"
-							defer={{ until: 'idle' }}
-						>
+						<Island priority="feature" defer={{ until: 'visible' }}>
 							<HostedContentHeader branding={branding} />
 						</Island>
 					</Section>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: 12.2.1
         version: 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/source-development-kitchen':
-        specifier: 0.0.0-canary-20260515144636
-        version: 0.0.0-canary-20260515144636(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
+        specifier: 28.1.0
+        version: 28.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/support-dotcom-components':
         specifier: 9.0.1
         version: 9.0.1(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/ophan-tracker-js@3.0.0)(zod@4.1.12)
@@ -2568,8 +2568,8 @@ packages:
   '@guardian/shimport@1.0.2':
     resolution: {integrity: sha512-o35TxvMFfpQTGL6flW0ggIfU4tPlXp0PqY9vPL2Fx+68qy+s+uX4T0+dN3+JeoBad9QrRZoHfZPALvZlrRWfHw==}
 
-  '@guardian/source-development-kitchen@0.0.0-canary-20260515144636':
-    resolution: {integrity: sha512-XJMnRFjKpg12Y999xiCTKWggY4EMqEZ71ZASmhHw7Z+lQqz1Hq8n+Gdkwl9+gXXlizF9S7m8mh1Sw1IdcCjriA==}
+  '@guardian/source-development-kitchen@28.1.0':
+    resolution: {integrity: sha512-Rh8xDIvQXNVD3j71wn3D4tYgUf0bIAD+K9n2WYsMUA5x2sXzYMimZ29NcFbq0tket+5CNM4Hae3cBN7MpmEZpQ==}
     peerDependencies:
       '@emotion/react': ^11.11.4
       '@guardian/libs': ^32.0.0
@@ -11828,7 +11828,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@guardian/source-development-kitchen@0.0.0-canary-20260515144636(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)':
+  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)':
     dependencies:
       '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: 12.2.1
         version: 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/source-development-kitchen':
-        specifier: 18.1.1
-        version: 18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
+        specifier: 0.0.0-canary-20260515144636
+        version: 0.0.0-canary-20260515144636(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/support-dotcom-components':
         specifier: 9.0.1
         version: 9.0.1(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/ophan-tracker-js@3.0.0)(zod@4.1.12)
@@ -2568,16 +2568,16 @@ packages:
   '@guardian/shimport@1.0.2':
     resolution: {integrity: sha512-o35TxvMFfpQTGL6flW0ggIfU4tPlXp0PqY9vPL2Fx+68qy+s+uX4T0+dN3+JeoBad9QrRZoHfZPALvZlrRWfHw==}
 
-  '@guardian/source-development-kitchen@18.1.1':
-    resolution: {integrity: sha512-wuMULnVjValyEz6YjrOPt054tXJkutkAbPdeV/KQHoSCSjAJnd0Cp3SZeoVog77HE/iZ0mnKaiVkK+QXpRVtCQ==}
+  '@guardian/source-development-kitchen@0.0.0-canary-20260515144636':
+    resolution: {integrity: sha512-XJMnRFjKpg12Y999xiCTKWggY4EMqEZ71ZASmhHw7Z+lQqz1Hq8n+Gdkwl9+gXXlizF9S7m8mh1Sw1IdcCjriA==}
     peerDependencies:
       '@emotion/react': ^11.11.4
-      '@guardian/libs': ^22.0.0
-      '@guardian/source': ^10.0.0
+      '@guardian/libs': ^32.0.0
+      '@guardian/source': ^12.0.0
       '@types/react': ^18.2.79
       react: ^18.2.0
-      tslib: ^2.6.2
-      typescript: ~5.5.2
+      tslib: ^2.8.1
+      typescript: ~5.9.3
     peerDependenciesMeta:
       '@emotion/react':
         optional: true
@@ -11828,7 +11828,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@guardian/source-development-kitchen@18.1.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)':
+  '@guardian/source-development-kitchen@0.0.0-canary-20260515144636(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)':
     dependencies:
       '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.9.3)
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)


### PR DESCRIPTION
## What does this change?

Includes the `Popover` component from `source-development-kitchen` in the `HostedContentHeader`, allowing the popover to display when clicking on the information icon next to the "Advertiser content" label

## Why?

As part of the Hosted Content migration from frontend to DCR.
The `Popover` component was developed in `@guardian/source-development-kitchen` and will eventually be moved to the main `@guardian/source` package.

This PR utilises this new shared component within the Hosted Content header as per the designs.

⚠️ _The copy inside the popover still needs confirming_

## Screenshots

| Hosted Article Page | Hosted Video Page|
| ----------- | ---------- |
| ![ha_mobile][] | ![hv_mobile][] |
| ![ha_desktop][] | ![hv_desktop][] |

[ha_mobile]: https://github.com/user-attachments/assets/fa8773da-d4e0-4343-8fd4-7c5629397c91
[ha_desktop]: https://github.com/user-attachments/assets/f84f8893-30ad-4e8a-83e5-c30b8e49804d
[hv_mobile]: https://github.com/user-attachments/assets/e85fdb44-9c67-4f79-a982-050cba77603d
[hv_desktop]: https://github.com/user-attachments/assets/f54a818d-f1ab-4887-8e79-9c803fd7ec8a

