### PR TITLE
Allow all videoPlayerFormats to render with selfhostedvideo player

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -80,23 +80,17 @@ const cardStyles = (
  * to the viewport, which can happen for portrait or narrow aspect-ratio videos
  * rendered inside article layouts.
  *
- * The video height is capped to the smaller of:
- * - the provided pixel height
- * - 70% of the small viewport height (`70svh`)
+ * The video height is capped to 80% of the small viewport height (`80svh`) on tablet and above.
  *
  * The width is then derived from the constrained height, so the visible video
  * maintains its aspect ratio without distortion.
  */
 
-const maxHeightStyles = (
-	height: number,
-	aspectRatioOfVisibleVideo: number,
-) => css`
-	max-height: min(${height}px, 70svh);
-	width: min(
-		100%,
-		calc(min(${height}px, 70svh) * ${aspectRatioOfVisibleVideo})
-	);
+const maxHeightStyles = (aspectRatioOfVisibleVideo: number) => css`
+	${from.tablet} {
+		max-height: 80svh;
+		width: min(100%, calc(80svh * ${aspectRatioOfVisibleVideo}));
+	}
 `;
 const videoContainerStyles = (
 	aspectRatio: number,
@@ -1036,7 +1030,7 @@ export const SelfHostedVideo = ({
 						containerAspectRatioDesktop,
 					),
 					!isUndefined(maxHeight) &&
-						maxHeightStyles(maxHeight, aspectRatioOfVisibleVideo),
+						maxHeightStyles(aspectRatioOfVisibleVideo),
 				]}
 			>
 				<div

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -75,6 +75,19 @@ const cardStyles = (
 	}
 `;
 
+/**
+ * Prevent the video from being greater in height than the viewport height,
+ * which can cause issues in article when the video is allowed to grow to an unlimited size.
+ * The width will adjust accordingly to maintain the aspect ratio.
+ */
+
+const maxHeightStyles = (
+	height: number,
+	aspectRatioOfVisibleVideo: number,
+) => css`
+	max-height: ${height}px;
+	width: min(100%, calc(${height}px * ${aspectRatioOfVisibleVideo}));
+`;
 const videoContainerStyles = (
 	aspectRatio: number,
 	aspectRatioOfVisibleVideo: number,
@@ -341,6 +354,7 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
+	maxHeight?: number;
 };
 
 export const SelfHostedVideo = ({
@@ -369,6 +383,7 @@ export const SelfHostedVideo = ({
 	isMainMedia,
 	role,
 	posterImageAspectRatio,
+	maxHeight,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1010,6 +1025,8 @@ export const SelfHostedVideo = ({
 						containerAspectRatioMobile,
 						containerAspectRatioDesktop,
 					),
+					!isUndefined(maxHeight) &&
+						maxHeightStyles(maxHeight, aspectRatioOfVisibleVideo),
 				]}
 			>
 				<div

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -76,17 +76,27 @@ const cardStyles = (
 `;
 
 /**
- * Prevent the video from being greater in height than the viewport height,
- * which can cause issues in article when the video is allowed to grow to an unlimited size.
- * The width will adjust accordingly to maintain the aspect ratio.
+ * Constrain the video height so it never becomes excessively tall relative
+ * to the viewport, which can happen for portrait or narrow aspect-ratio videos
+ * rendered inside article layouts.
+ *
+ * The video height is capped to the smaller of:
+ * - the provided pixel height
+ * - 70% of the small viewport height (`70svh`)
+ *
+ * The width is then derived from the constrained height, so the visible video
+ * maintains its aspect ratio without distortion.
  */
 
 const maxHeightStyles = (
 	height: number,
 	aspectRatioOfVisibleVideo: number,
 ) => css`
-	max-height: ${height}px;
-	width: min(100%, calc(${height}px * ${aspectRatioOfVisibleVideo}));
+	max-height: min(${height}px, 70svh);
+	width: min(
+		100%,
+		calc(min(${height}px, 70svh) * ${aspectRatioOfVisibleVideo})
+	);
 `;
 const videoContainerStyles = (
 	aspectRatio: number,

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -18,10 +18,10 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {
-	clampAspectRatio,
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePlayEventName,
 	findOptimisedSourcePerMimeType,
+	roundAspectRatio,
 } from '../lib/video';
 import type { VideoStyleSettings } from '../lib/videoStyleSettings';
 import { videoSettingsMap } from '../lib/videoStyleSettings';
@@ -463,7 +463,7 @@ export const SelfHostedVideo = ({
 	}
 
 	/** The aspect ratio of the video will be clamped within the specified range */
-	const aspectRatioOfVisibleVideo = clampAspectRatio(
+	const aspectRatioOfVisibleVideo = roundAspectRatio(
 		getAspectRatioOfVisibleVideo(
 			aspectRatio,
 			minAspectRatio,

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -81,9 +81,7 @@ const cardStyles = (
  * rendered inside article layouts.
  *
  * The video height is capped to 80% of the small viewport height (`80svh`) on tablet and above.
- *
  */
-
 const maxHeightStyles = css`
 	${from.tablet} {
 		max-height: 80svh;

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -355,7 +355,7 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
-	maxHeight?: number;
+	maxHeightDesktop?: number;
 };
 
 export const SelfHostedVideo = ({
@@ -384,7 +384,7 @@ export const SelfHostedVideo = ({
 	isMainMedia,
 	role,
 	posterImageAspectRatio,
-	maxHeight,
+	maxHeightDesktop,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1026,7 +1026,7 @@ export const SelfHostedVideo = ({
 						containerAspectRatioMobile,
 						containerAspectRatioDesktop,
 					),
-					!isUndefined(maxHeight) && maxHeightStyles,
+					!isUndefined(maxHeightDesktop) && maxHeightStyles,
 				]}
 			>
 				<div

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -82,14 +82,11 @@ const cardStyles = (
  *
  * The video height is capped to 80% of the small viewport height (`80svh`) on tablet and above.
  *
- * The width is then derived from the constrained height, so the visible video
- * maintains its aspect ratio without distortion.
  */
 
-const maxHeightStyles = (aspectRatioOfVisibleVideo: number) => css`
+const maxHeightStyles = css`
 	${from.tablet} {
 		max-height: 80svh;
-		width: min(100%, calc(80svh * ${aspectRatioOfVisibleVideo}));
 	}
 `;
 const videoContainerStyles = (
@@ -1029,8 +1026,7 @@ export const SelfHostedVideo = ({
 						containerAspectRatioMobile,
 						containerAspectRatioDesktop,
 					),
-					!isUndefined(maxHeight) &&
-						maxHeightStyles(aspectRatioOfVisibleVideo),
+					!isUndefined(maxHeight) && maxHeightStyles,
 				]}
 			>
 				<div

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -18,6 +18,7 @@ import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {
+	clampAspectRatio,
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePlayEventName,
 	findOptimisedSourcePerMimeType,
@@ -437,12 +438,12 @@ export const SelfHostedVideo = ({
 	}
 
 	/** The aspect ratio of the video will be clamped within the specified range */
-	const aspectRatioOfVisibleVideo = Number(
+	const aspectRatioOfVisibleVideo = clampAspectRatio(
 		getAspectRatioOfVisibleVideo(
 			aspectRatio,
 			minAspectRatio,
 			maxAspectRatio,
-		).toFixed(3),
+		),
 	);
 
 	const isVideoCroppedAtTopBottom = aspectRatio < aspectRatioOfVisibleVideo;

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -60,7 +60,7 @@ export const SelfHostedVideoInArticle = ({
 				format={format}
 				isMainMedia={isMainMedia}
 				role={role}
-				maxHeight={firstVideoSource?.height}
+				maxHeightDesktop={firstVideoSource?.height}
 			/>
 		</Island>
 	);

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -60,6 +60,7 @@ export const SelfHostedVideoInArticle = ({
 				format={format}
 				isMainMedia={isMainMedia}
 				role={role}
+				maxHeight={firstVideoSource?.height}
 			/>
 		</Island>
 	);

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -503,10 +503,7 @@ export const renderElement = ({
 				</Island>
 			);
 		case 'model.dotcomrendering.pageElements.MediaAtomBlockElement':
-			if (
-				element.videoPlayerFormat &&
-				['Loop', 'Cinemagraph'].includes(element.videoPlayerFormat)
-			) {
+			if (element.videoPlayerFormat) {
 				return (
 					<SelfHostedVideoInArticle
 						element={element}

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -182,7 +182,12 @@ describe('video', () => {
 				aspectRatio: '5:3',
 				hasAudio: true,
 			};
-			expect(getAspectRatioFromSources([testSource])).toEqual(5 / 3);
+
+			const fiveThreeAspectRatio = 1.667;
+
+			expect(getAspectRatioFromSources([testSource])).toEqual(
+				fiveThreeAspectRatio,
+			);
 		});
 
 		it('should calculate the aspect ratio from the width and height if aspect ratio is missing', () => {
@@ -193,7 +198,12 @@ describe('video', () => {
 				aspectRatio: undefined,
 				hasAudio: true,
 			};
-			expect(getAspectRatioFromSources([testSource])).toEqual(2 / 3);
+
+			const twoThreeAspectRatio = 0.667;
+
+			expect(getAspectRatioFromSources([testSource])).toEqual(
+				twoThreeAspectRatio,
+			);
 		});
 
 		it('should return the default aspect ratio if the aspect ratio is undefined and width is 0', () => {

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -9,6 +9,7 @@ import {
 	findOptimisedSourcePerMimeType,
 	formatTimeForDisplay,
 	getAspectRatioFromSources,
+	roundAspectRatio,
 } from './video';
 
 const mp4Asset480w: VideoAssets = {
@@ -355,6 +356,21 @@ describe('video', () => {
 			({ timeInSeconds, expectedFormattedTime }) => {
 				expect(formatTimeForDisplay(timeInSeconds)).toEqual(
 					expectedFormattedTime,
+				);
+			},
+		);
+	});
+	describe('roundAspectRatio', () => {
+		it.each([
+			{ aspectRatio: 0.56938445, expectedRoundedAspectRatio: 0.569 },
+			{ aspectRatio: 1.277777, expectedRoundedAspectRatio: 1.278 },
+			{ aspectRatio: 1.25, expectedRoundedAspectRatio: 1.25 },
+			{ aspectRatio: 0.8, expectedRoundedAspectRatio: 0.8 },
+		])(
+			'should return the correct aspect ratio rounded to 3 decimal places',
+			({ aspectRatio, expectedRoundedAspectRatio }) => {
+				expect(roundAspectRatio(aspectRatio)).toEqual(
+					expectedRoundedAspectRatio,
 				);
 			},
 		);

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -77,15 +77,15 @@ export const convertFEMediaAssetsToVideoAssets = (
 	}));
 
 /**
- * Clamps an aspect ratio value to 3 decimal places.
+ * Round an aspect ratio value to 3 decimal places.
  *
  * This helps avoid floating point precision issues and ensures
  * consistent aspect ratio values for rendering and comparisons.
  *
- * @param aspectRatio - The raw aspect ratio value to clamp.
+ * @param aspectRatio - The raw aspect ratio value to round up.
  * @returns The aspect ratio rounded to 3 decimal places.
  * */
-export const clampAspectRatio = (aspectRatio: number): number => {
+export const roundAspectRatio = (aspectRatio: number): number => {
 	return Number(aspectRatio.toFixed(3));
 };
 
@@ -108,7 +108,7 @@ export const getAspectRatioFromSources = (sources: Source[]): number => {
 			width > 0 &&
 			height > 0
 		) {
-			return clampAspectRatio(width / height);
+			return roundAspectRatio(width / height);
 		}
 	}
 
@@ -116,7 +116,7 @@ export const getAspectRatioFromSources = (sources: Source[]): number => {
 		return DEFAULT_ASPECT_RATIO;
 	}
 
-	return clampAspectRatio(firstSource.width / firstSource.height);
+	return roundAspectRatio(firstSource.width / firstSource.height);
 };
 
 export const getSubtitleAsset = (assets: VideoAssets[]): string | undefined =>

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -77,6 +77,19 @@ export const convertFEMediaAssetsToVideoAssets = (
 	}));
 
 /**
+ * Clamps an aspect ratio value to 3 decimal places.
+ *
+ * This helps avoid floating point precision issues and ensures
+ * consistent aspect ratio values for rendering and comparisons.
+ *
+ * @param aspectRatio - The raw aspect ratio value to clamp.
+ * @returns The aspect ratio rounded to 3 decimal places.
+ * */
+export const clampAspectRatio = (aspectRatio: number): number => {
+	return Number(aspectRatio.toFixed(3));
+};
+
+/**
  * Aspect ratio is needed for self-hosted video so that the browser knows how much
  * space the video will take up: width and height are unknown when the page first
  * renders, as there can be multiple sources available with different dimensions.
@@ -95,7 +108,7 @@ export const getAspectRatioFromSources = (sources: Source[]): number => {
 			width > 0 &&
 			height > 0
 		) {
-			return width / height;
+			return clampAspectRatio(width / height);
 		}
 	}
 
@@ -103,7 +116,7 @@ export const getAspectRatioFromSources = (sources: Source[]): number => {
 		return DEFAULT_ASPECT_RATIO;
 	}
 
-	return firstSource.width / firstSource.height;
+	return clampAspectRatio(firstSource.width / firstSource.height);
 };
 
 export const getSubtitleAsset = (assets: VideoAssets[]): string | undefined =>


### PR DESCRIPTION
## What does this change?
Allows all self hosted video elements with a videoPlayerFormat ("Loop" , "Cinemagraph" and now "Default") to be rendered with the self hosted video player in article.

As well as this, this PR introduces the ability to pass a max height through to the self hosted video player, with the width adjusting accordingly to maintain the aspect ratio. If a max height is provided, the  max-height of the player is set in css to be capped at 80% of the small viewport, from tablet and above. This helps ensure the video never exceeds the height of the viewport. 

### Why only apply a max height sometimes? 
The player is used in 2 contexts 
1. On a front 
Here the video is contained within a front container (eg flexible/general, scrollable/feature) which have fixed heights and aspect-ratios. In this scenario. We do not want to apply a max height as we want the video to fit its container.

2. In an article
Here, videos are allowed to assume their full aspect ratio, uncontained. This is a particular problem for `Default` self hosted videos. This is because Default videos are regularly 9:16 and a 9:16 video in a ~700px wide article column will be ~1244px tall, exceeding the viewport height.

## Why?
This is to support the rollout of "default" videos across platforms

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/64e18460-903c-47a7-a969-0b7f47527077
[after]: https://github.com/user-attachments/assets/4c6c5953-9e88-4ef4-86c5-baa82b99eaef

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.
<img width="1776" height="620" alt="Screenshot 2026-05-15 at 16 30 48" src="https://github.com/user-attachments/assets/f3b808c7-901c-4b63-9eb8-0d32d8a8bd67" />

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
