### PR TITLE
Hf/tweak world cup nav

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -3,13 +3,10 @@ import {
 	type Breakpoint,
 	breakpoints,
 	from,
-	headlineBold15Object,
-	headlineBold17Object,
 	headlineBold24Object,
 	headlineBold42Object,
-	headlineMedium15Object,
-	headlineMedium17Object,
 	palette,
+	textSans14Object,
 } from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { generateImageURL } from '../lib/image';
@@ -25,6 +22,7 @@ interface DirectoryPageNavConfig {
 	tagIds: string[];
 	textColor: string;
 	backgroundColor: string;
+	titleIconImage: string;
 	title: { label: string; id: string };
 	links: { label: string; id: string }[];
 	backgroundImages?: {
@@ -33,6 +31,7 @@ interface DirectoryPageNavConfig {
 		phablet: string;
 		tablet: string;
 		desktop: string;
+		wide?: string;
 	};
 }
 
@@ -51,6 +50,8 @@ const configs = [
 			label: 'World Cup',
 			id: 'football/world-cup-2026',
 		},
+		titleIconImage:
+			'data:image/svg+xml,%3Csvg%20width%3D%2240%22%20height%3D%2246%22%20viewBox%3D%220%200%2040%2046%22%20fill%3D%22none%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Crect%20width%3D%2212.3697%22%20height%3D%2232.4706%22%20fill%3D%22%23D71921%22/%3E%3Crect%20x%3D%2213.5294%22%20y%3D%2213.5295%22%20width%3D%2212.3697%22%20height%3D%2232.4706%22%20fill%3D%22white%22/%3E%3Crect%20x%3D%2227.059%22%20width%3D%2212.3697%22%20height%3D%2232.4706%22%20fill%3D%22%23007E46%22/%3E%3Ccircle%20cx%3D%2219.7142%22%20cy%3D%226.18487%22%20r%3D%226.18487%22%20fill%3D%22white%22/%3E%3C/svg%3E',
 		links: [
 			{
 				label: 'Match centre',
@@ -73,16 +74,17 @@ const configs = [
 				id: 'football',
 			},
 		],
-		// backgroundImages: {
-		// 	mobile: '',
-		// 	mobileLandscape:
-		// 		'',
-		// 	phablet:
-		// 		'',
-		// 	tablet: '',
-		// 	desktop:
-		// 		'',
-		// },
+		backgroundImages: {
+			mobile: 'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
+			mobileLandscape:
+				'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
+			phablet:
+				'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
+			tablet: 'https://media.guim.co.uk/861646115875f3f246313036f754b2f5f1480b1a/0_0_1480_276/1480.jpg',
+			desktop:
+				'https://media.guim.co.uk/167bec4a208bfc7fdc6b2127186b9bb183932259/0_0_1960_276/1960.jpg',
+			wide: 'https://media.guim.co.uk/4e44f9a88fcc9a3b1b5294f7e581644baa75c904/0_0_2600_276/2600.jpg',
+		},
 	},
 	// Winter Olympics 2026
 	{
@@ -99,6 +101,7 @@ const configs = [
 			label: 'Winter Olympics 2026',
 			id: 'sport/winter-olympics-2026',
 		},
+		titleIconImage: '',
 		links: [
 			{
 				label: 'Schedule',
@@ -142,6 +145,7 @@ const configs = [
 			label: 'Winter Paralympics 2026',
 			id: 'sport/winter-paralympics-2026',
 		},
+		titleIconImage: '',
 		links: [
 			{
 				label: 'Results',
@@ -188,14 +192,20 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 		backgroundColor,
 		'&': css(grid.paddedContainer),
 		alignContent: 'space-between',
+		position: 'relative',
 	});
 
 	const largeLinkStyles = css({
+		position: 'absolute',
+		top: '4px',
+		left: 0,
 		...headlineBold24Object,
 		color: textColor,
 		textDecoration: 'none',
 		'&': css(grid.column.centre),
 		gridRow: 1,
+		display: 'flex',
+		alignItems: 'flex-start',
 		[from.tablet]: headlineBold42Object,
 		[from.leftCol]: css(
 			grid.between('left-column-start', 'right-column-end'),
@@ -204,35 +214,38 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 
 	const list = css({
 		display: 'flex',
-		flexWrap: 'wrap',
 		'&': css(grid.column.all),
-		gridRow: 2,
 		alignSelf: 'end',
 		position: 'relative',
 		'--top-border-gap': '1.55rem',
+		overflowX: 'scroll',
+		scrollbarWidth: 'none',
+		padding: '10px 10px',
+		borderTop: '1px solid',
+		borderColor: palette.brand[600],
+		height: '100%',
 		[from.mobileLandscape]: {
-			paddingLeft: 10,
+			padding: '10px 20px',
 		},
 		[from.tablet]: {
 			'--top-border-gap': '3rem',
 		},
-		backgroundImage: `
-			linear-gradient(
-				${textColor} 0,
-				${textColor} 1px,
-				transparent 1px,
-				transparent var(--top-border-gap),
-				${textColor} var(--top-border-gap),
-				${textColor} calc(var(--top-border-gap) + 1px),
-				transparent 1px,
-				transparent var(--top-border-gap)
-			)
-		`,
+		'&:after': {
+			content: '""',
+			position: 'sticky',
+			right: '-10px',
+			top: '-10px',
+			height: '100%',
+			minWidth: 40,
+			background: `linear-gradient(to left, ${backgroundColor}, transparent)`,
+			[from.mobileLandscape]: {
+				right: '-20px',
+			},
+		},
 	});
 
 	const selectedStyles = {
-		'--selected-height': '4px',
-		'--selected-opacity': '1',
+		fontWeight: 'bold',
 	};
 
 	const listItem = css({
@@ -249,47 +262,38 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 			backgroundColor: textColor,
 			transition: 'height 0.3s ease-in-out, opacity 0.05s 0.1s linear',
 		},
-		'&:hover': selectedStyles,
+		[from.desktop]: {
+			'&:hover a': {
+				textDecoration: 'underline',
+				color: 'var(--masthead-nav-link-text-hover)',
+			},
+		},
 		[from.leftCol]: {
 			flexBasis: 160,
 		},
 	});
 
 	const smallLink = css({
-		...headlineBold15Object,
-		padding: '4px 10px 6px',
+		...textSans14Object,
+		padding: '4px 12px 6px 0',
 		display: 'block',
 		lineHeight: 1,
 		color: textColor,
 		textDecoration: 'none',
-		'&::after': {
-			content: '""',
-			display: 'block',
-			position: 'absolute',
-			top: 0,
-			right: 0,
-			width: 1,
-			height: '1.3rem',
-			backgroundColor: textColor,
-		},
-		[from.tablet]: headlineBold17Object,
+		whiteSpace: 'nowrap',
 		[from.leftCol]: {
 			padding: '9px 10px 10px',
 		},
 	});
 
-	const lastSmallLink = css(smallLink, {
-		...headlineMedium15Object,
-		lineHeight: 1,
-		[from.tablet]: headlineMedium17Object,
-	});
-
 	return (
 		<nav css={[nav, heightStyles]}>
-			<BackgroundImage images={config.backgroundImages} />
 			<a href={`/${config.title.id}`} css={largeLinkStyles}>
+				<TitleIconImage src={config.titleIconImage} />
 				{config.title.label}
 			</a>
+			<BackgroundImage images={config.backgroundImages} />
+
 			<ul css={list}>
 				{config.links.map((link, i) => (
 					<li
@@ -297,14 +301,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 						css={listItem}
 						style={pageId === link.id ? selectedStyles : {}}
 					>
-						<a
-							href={`/${link.id}`}
-							css={
-								i === config.links.length - 1
-									? lastSmallLink
-									: smallLink
-							}
-						>
+						<a href={`/${link.id}`} css={smallLink}>
 							{link.label}
 						</a>
 					</li>
@@ -315,14 +312,33 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 };
 
 const heightStyles = css({
-	height: 116,
+	height: '',
 	[from.tablet]: {
-		height: 140,
+		height: '',
 	},
 	[from.desktop]: {
-		height: 150,
+		height: '',
 	},
 });
+
+const TitleIconImage = (props: { src: string }) => {
+	if (!props.src) {
+		return null;
+	}
+
+	return (
+		<img
+			src={props.src}
+			alt=""
+			css={{
+				height: 40,
+				width: 'auto',
+				marginRight: 8,
+				objectFit: 'cover',
+			}}
+		/>
+	);
+};
 
 const BackgroundImage = (props: {
 	images: DirectoryPageNavConfig['backgroundImages'];
@@ -399,8 +415,9 @@ const breakpointToImageSize = (breakpoint: Breakpoint): ImageSize => {
 			return 'tablet';
 		case 'desktop':
 		case 'leftCol':
-		case 'wide':
 			return 'desktop';
+		case 'wide':
+			return 'wide';
 	}
 };
 

--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -291,7 +291,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 			<BackgroundImage images={config.backgroundImages} />
 
 			<ul css={list}>
-				{config.links.map((link, i) => (
+				{config.links.map((link) => (
 					<li
 						key={link.label}
 						css={listItem}

--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -77,9 +77,9 @@ const configs = [
 		backgroundImages: {
 			mobile: 'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
 			mobileLandscape:
-				'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
+				'https://media.guim.co.uk/8e1356cc926c6bbfcdb3da5908252ba0b4cbd3bb/0_0_960_376/960.jpg',
 			phablet:
-				'https://media.guim.co.uk/4ba0caac6d18c1fe6a5a3267b270d8c21ae6f940/0_0_750_376/750.jpg',
+				'https://media.guim.co.uk/ed4fe540c6a114db35c1f73fc41ee802c3fea7d3/0_0_1320_282/1320.jpg',
 			tablet: 'https://media.guim.co.uk/861646115875f3f246313036f754b2f5f1480b1a/0_0_1480_276/1480.jpg',
 			desktop:
 				'https://media.guim.co.uk/167bec4a208bfc7fdc6b2127186b9bb183932259/0_0_1960_276/1960.jpg',
@@ -270,9 +270,6 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 				color: 'var(--masthead-nav-link-text-hover)',
 			},
 		},
-		[from.leftCol]: {
-			flexBasis: 160,
-		},
 	});
 
 	const smallLink = css({
@@ -283,9 +280,6 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 		color: textColor,
 		textDecoration: 'none',
 		whiteSpace: 'nowrap',
-		[from.leftCol]: {
-			padding: '9px 10px 10px',
-		},
 	});
 
 	return (
@@ -333,10 +327,15 @@ const TitleIconImage = (props: { src: string }) => {
 			src={props.src}
 			alt=""
 			css={{
-				height: 40,
 				width: 'auto',
+				height: 46,
+				marginTop: 5,
 				marginRight: 8,
 				objectFit: 'cover',
+				[from.tablet]: {
+					height: 79,
+					marginTop: 10,
+				},
 			}}
 		/>
 	);
@@ -376,7 +375,8 @@ const BackgroundImage = (props: {
 				alt="Winter Olympics background graphic"
 				css={{
 					width: '100%',
-					height: '100%',
+					height: 'auto',
+					display: 'block',
 					objectFit: 'cover',
 					objectPosition: 'top',
 				}}

--- a/dotcom-rendering/src/components/DirectoryPageNav.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.tsx
@@ -31,7 +31,7 @@ interface DirectoryPageNavConfig {
 		phablet: string;
 		tablet: string;
 		desktop: string;
-		wide?: string;
+		wide: string;
 	};
 }
 
@@ -129,6 +129,7 @@ const configs = [
 			tablet: 'https://uploads.guim.co.uk/2026/02/03/winter-olympics-740px-thin.jpg',
 			desktop:
 				'https://uploads.guim.co.uk/2026/02/03/winter-olympics-980px.jpg',
+			wide: 'https://uploads.guim.co.uk/2026/02/03/winter-olympics-980px.jpg',
 		},
 	},
 	// Winter Paralympics 2026
@@ -169,6 +170,7 @@ const configs = [
 			tablet: 'https://uploads.guim.co.uk/2026/03/03/winter-paralympics-740px-thin.jpg',
 			desktop:
 				'https://uploads.guim.co.uk/2026/03/03/winter-paralympics-980px.jpg',
+			wide: 'https://uploads.guim.co.uk/2026/03/03/winter-paralympics-980px.jpg',
 		},
 	},
 ] satisfies DirectoryPageNavConfig[];


### PR DESCRIPTION
## What does this change?
Updates the event header nav styles. 

## Why?
Link styles now match updated sublink design

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://github.com/user-attachments/assets/fa4b0603-4531-448d-a8a2-0a70b5f2124a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
