### PR TITLE
Self-hosted video: thumb controls and not pausing without controls

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -44,7 +44,15 @@ import type { OphanVideoStyle } from './YoutubeAtom/eventEmitters';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import type { VideoEventKey } from './YoutubeAtom/YoutubeAtom';
 
+/**
+ * The fraction of the video required to be visible in the viewport to be considered "in view".
+ */
 const VISIBILITY_THRESHOLD = 0.5;
+
+/**
+ * The duration in ms for which controls are displayed before fading out.
+ */
+const CONTROLS_FADE_DELAY = 2700;
 
 const cardStyles = (
 	isInteractive: boolean,
@@ -185,7 +193,7 @@ const hideControlsStyles = css`
 		transition:
 			visibility 0.3s,
 			opacity 0.3s ease-in-out;
-		transition-delay: 2.7s;
+		transition-delay: ${CONTROLS_FADE_DELAY}ms;
 	}
 
 	@media (hover: hover) {
@@ -420,6 +428,7 @@ export const SelfHostedVideo = ({
 	const { renderingTarget } = useConfig();
 	const vidRef = useRef<HTMLVideoElement>(null);
 	const playerContainerRef = useRef<HTMLDivElement>(null);
+	const showControlsTimer = useRef<number | null>(null);
 	const [isPlayable, setIsPlayable] = useState(false);
 	const [isMuted, setIsMuted] = useState(true);
 	const [showPosterImage, setShowPosterImage] = useState<boolean>(false);
@@ -435,6 +444,10 @@ export const SelfHostedVideo = ({
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
 	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
+	/** Whether the video should show controls */
+	const [showControls, setShowControls] = useState(true);
+	/** Whether the video is currently showing controls */
+	const [isShowingControls, setIsShowingControls] = useState(true);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -899,6 +912,41 @@ export const SelfHostedVideo = ({
 		};
 	}, [sendOphanTrackingEvent]);
 
+	/**
+	 * When the video starts playing, start a timer to hide the controls after a few seconds.
+	 * If there is any user interaction while the video is playing, restart the timer.
+	 * The controls will fade out after a period of no user interaction.
+	 */
+	useEffect(() => {
+		if (playerState !== 'PLAYING') {
+			return;
+		}
+
+		/**
+		 * We currently use this piece of state `showControls` as a self-resetting trigger.
+		 * It's switched on to show the controls -> it's then immediately switched off to start
+		 * the transition to hide the controls.
+		 */
+		setTimeout(() => {
+			setShowControls(false);
+		}, 0);
+
+		if (showControlsTimer.current !== null) {
+			window.clearTimeout(showControlsTimer.current);
+		}
+
+		showControlsTimer.current = window.setTimeout(() => {
+			setIsShowingControls(false);
+		}, CONTROLS_FADE_DELAY);
+
+		return () => {
+			if (showControlsTimer.current !== null) {
+				window.clearTimeout(showControlsTimer.current);
+				showControlsTimer.current = null;
+			}
+		};
+	}, [showControls, playerState]);
+
 	if (adapted) {
 		return FallbackImageComponent;
 	}
@@ -941,8 +989,29 @@ export const SelfHostedVideo = ({
 		setHasTrackedPlay(true);
 	};
 
+	const showControlsAndStartTimer = () => {
+		if (!videoStyleSettings.hideControlsWhenNotInteractedWith) return;
+
+		setShowControls(true);
+		setIsShowingControls(true);
+	};
+
 	const handlePlayPauseClick = (event: React.SyntheticEvent) => {
 		if (!videoStyleSettings.isInteractive) {
+			return;
+		}
+
+		/**
+		 * If we're on a touch device and the controls aren't showing,
+		 * show the controls instead of pausing the video.
+		 * Note that hovering with a mouse shows controls on non-touch devices.
+		 */
+		if (
+			videoStyleSettings.hideControlsWhenNotInteractedWith &&
+			playerState === 'PLAYING' &&
+			!isShowingControls
+		) {
+			showControlsAndStartTimer();
 			return;
 		}
 
@@ -959,6 +1028,8 @@ export const SelfHostedVideo = ({
 
 		event.stopPropagation(); // Don't pause the video
 
+		showControlsAndStartTimer(); // Show controls when a button is clicked
+
 		if (isMuted) {
 			// Emit video play audio event so other components are aware when a video is played with sound
 			dispatchCustomPlayAudioEvent(uniqueId);
@@ -971,6 +1042,8 @@ export const SelfHostedVideo = ({
 	const handleFullscreenClick = (event: React.SyntheticEvent) => {
 		void submitClickComponentEvent(event.currentTarget, renderingTarget);
 		event.stopPropagation(); // Don't pause the video
+
+		showControlsAndStartTimer(); // Show controls when a button is clicked
 
 		const video = vidRef.current;
 		if (!video) {
@@ -1160,14 +1233,16 @@ export const SelfHostedVideo = ({
 						),
 						fullscreenStyles,
 						videoStyleSettings.hideControlsWhenNotInteractedWith &&
-							(playerState === 'NOT_STARTED' ||
-								playerState === 'PLAYING') &&
+							!showControls &&
+							playerState === 'PLAYING' &&
 							hideControlsStyles,
 						videoStyleSettings.hideControlsWhenNotInteractedWith &&
+							showControls &&
 							(playerState === 'PAUSED_BY_USER' ||
 								playerState === 'PAUSED_BY_BROWSER') &&
 							showControlsStyles,
 					]}
+					onMouseOver={showControlsAndStartTimer}
 				>
 					<SelfHostedVideoPlayer
 						sources={optimisedSources}
@@ -1190,9 +1265,6 @@ export const SelfHostedVideo = ({
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
 						handleKeyDown={handleKeyDown}
-						useLongFormProgressBar={
-							!!videoStyleSettings.useInteractiveProgressBar
-						}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
 						updateCurrentTime={updateCurrentTime}
@@ -1200,6 +1272,10 @@ export const SelfHostedVideo = ({
 						preloadPartialData={!!shouldAutoplay}
 						showPlayPauseIcon={showPlayPauseIcon}
 						showProgressBar={showProgressBar}
+						useLongFormProgressBar={
+							!!videoStyleSettings.useInteractiveProgressBar
+						}
+						handleProgressBarInput={showControlsAndStartTimer}
 						showSubtitles={videoStyleSettings.canShowSubtitles}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -120,9 +120,10 @@ export type Props = {
 	handlePlayPauseClick: (event: SyntheticEvent) => void;
 	handleAudioClick: (event: SyntheticEvent) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+	handleProgressBarInput: (event: React.FormEvent<HTMLInputElement>) => void;
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	handlePause: (event: SyntheticEvent) => void;
-	handleFullscreenClick?: (event: SyntheticEvent) => void;
+	handleFullscreenClick: (event: SyntheticEvent) => void;
 	updateCurrentTime: (time: number) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	posterImage?: string;
@@ -174,6 +175,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handlePlayPauseClick,
 			handleAudioClick,
 			handleKeyDown,
+			handleProgressBarInput,
 			handleTimeUpdate,
 			handlePause,
 			handleFullscreenClick,
@@ -282,9 +284,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 							<VideoProgressBarInteractive
 								videoId={videoId}
 								currentTime={currentTime}
-								updateCurrentTime={updateCurrentTime}
 								duration={ref.current!.duration}
+								updateCurrentTime={updateCurrentTime}
 								handleKeyDown={handleKeyDown}
+								handleInput={handleProgressBarInput}
 							/>
 						) : (
 							<VideoProgressBar
@@ -312,8 +315,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 							)}
 							{hasAudio && (
 								<AudioIconComponent
-									handleClick={handleAudioClick}
 									isMuted={isMuted}
+									handleClick={handleAudioClick}
 								/>
 							)}
 						</div>

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -38,6 +38,7 @@ const trackStyles = css`
 const thumbStyles = css`
 	-webkit-appearance: none;
 	appearance: none;
+	pointer-events: auto;
 	width: 14px;
 	height: 14px;
 	border: none;
@@ -49,9 +50,9 @@ const thumbStyles = css`
 
 const progressBarStyles = (roundedProgressPercentage: number) => css`
 	width: 100%;
-	cursor: pointer;
 	height: 5px;
 	margin: 0;
+	cursor: pointer;
 	-webkit-appearance: none; /* Hides the slider so that custom slider can be made */
 	appearance: none;
 	/* The colour to the left of the thumb is different to the right to indicate progress */
@@ -66,6 +67,15 @@ const progressBarStyles = (roundedProgressPercentage: number) => css`
 		)} ${roundedProgressPercentage}%,
 		${palette('--video-progress-bar-interactive-background')} 100%
 	)`};
+
+	/**
+	 * Prevent touches on the progress bar on touch devices from changing the time.
+	 * Only the thumb can be used to change the time on touch devices.
+	 */
+	pointer-events: none;
+	@media (hover: hover) {
+		pointer-events: auto;
+	}
 
 	/* We don't use the default focus ring as it includes the thumb, which looks odd. */
 	:focus-visible {
@@ -124,9 +134,10 @@ const handleChange = (
 type Props = {
 	videoId: string;
 	currentTime: number;
+	duration: number;
 	updateCurrentTime: (time: number) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-	duration: number;
+	handleInput: (event: React.FormEvent<HTMLInputElement>) => void;
 };
 
 /**
@@ -138,9 +149,10 @@ type Props = {
 export const VideoProgressBarInteractive = ({
 	videoId,
 	currentTime,
+	duration,
 	updateCurrentTime,
 	handleKeyDown,
-	duration,
+	handleInput,
 }: Props) => {
 	if (duration <= 0) {
 		return null;
@@ -170,13 +182,14 @@ export const VideoProgressBarInteractive = ({
 				max={100}
 				step={0.01}
 				tabIndex={0}
-				onChange={(event) =>
+				onChange={(event) => {
 					handleChange(
 						event.target.value,
 						duration,
 						updateCurrentTime,
-					)
-				}
+					);
+				}}
+				onInput={handleInput}
 				onKeyDown={handleKeyDown}
 			/>
 		</div>


### PR DESCRIPTION
## What does this change?

- On touch devices, only the thumb can be used to update the progress bar 
- Don't pause video on touch devices if controls not showing

## Why?

- Request from design. Stops the user from accidentally updating the video time when scrolling.
- Allows the user to unmute/fullscreen without pausing the video.

## Screenshots

### Touch device

https://github.com/user-attachments/assets/2f8d26b2-daa2-4575-8b75-83bb66f15157

### With mouse

https://github.com/user-attachments/assets/f0d2be93-79e5-429c-ad38-71b4f035bdb2
