### PR TITLE
Top hat options for interactive layout

### DIFF
--- a/dotcom-rendering/src/components/GridItem.tsx
+++ b/dotcom-rendering/src/components/GridItem.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, type SerializedStyles } from '@emotion/react';
 import { getZIndex } from '../lib/getZIndex';
 
 type Props = {
@@ -8,6 +8,7 @@ type Props = {
 	 * The element type to use.
 	 */
 	element?: 'div' | 'article' | 'main' | 'aside' | 'section';
+	customCss?: SerializedStyles;
 };
 
 const rightColumnStyles = css`
@@ -36,12 +37,14 @@ export const GridItem = ({
 	children,
 	area,
 	element: Element = 'div',
+	customCss,
 }: Props) => (
 	<Element
 		css={[
 			area === 'body' && bodyStyles,
 			area === 'right-column' && rightColumnStyles,
 			gridArea,
+			customCss,
 		]}
 		style={{
 			'--grid-area': area,

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -54,7 +54,13 @@ import {
 } from './lib/interactiveLegacyStyling';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
-const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
+const InteractiveGrid = ({
+	children,
+	topHat,
+}: {
+	children: React.ReactNode;
+	topHat: 'regular' | 'fullWidth';
+}) => (
 	<div
 		className={interactiveLegacyClasses.contentInteractiveGrid}
 		css={css`
@@ -78,84 +84,104 @@ const InteractiveGrid = ({ children }: { children: React.ReactNode }) => (
 
 				grid-column-gap: 10px;
 
-				/*
-					Explanation of each unit of grid-template-columns
-
-					Left Column (220 - 1px border)
-					Vertical grey border
-					Main content
-				*/
 				${from.wide} {
 					grid-template-columns: 219px 1px 1020px;
-
-					grid-template-areas:
-						'title  border  headline'
-						'.      border  standfirst'
-						'.      border  media'
-						'.      border  media'
-						'.      border  lines'
-						'.      border  meta'
-						'body   body    body'
-						'.      .       .';
+					grid-template-areas: ${topHat === 'fullWidth'
+						? `'media  media   media'
+						   'title  border  headline'
+						   '.      border  standfirst'
+						   '.      border  lines'
+						   '.      border  meta'
+						   'body   body    body'
+						   '.      .       .'`
+						: `'title  border  headline'
+						   '.      border  standfirst'
+						   '.      border  media'
+						   '.      border  media'
+						   '.      border  lines'
+						   '.      border  meta'
+						   'body   body    body'
+						   '.      .       .'`};
 				}
 
-				/*
-					Explanation of each unit of grid-template-columns
-
-					Left Column (220 - 1px border)
-					Vertical grey border
-					Main content
-				*/
 				${until.wide} {
 					grid-template-columns: 140px 1px 940px;
-
-					grid-template-areas:
-						'title  border  headline'
-						'.      border  standfirst'
-						'.      border  media'
-						'.      border  media'
-						'.      border  lines'
-						'.      border  meta'
-						'body   body    body'
-						'.      .       .';
+					grid-template-areas: ${topHat === 'fullWidth'
+						? `'media  media   media'
+						   'title  border  headline'
+						   '.      border  standfirst'
+						   '.      border  lines'
+						   '.      border  meta'
+						   'body   body    body'
+						   '.      .       .'`
+						: `'title  border  headline'
+						   '.      border  standfirst'
+						   '.      border  media'
+						   '.      border  media'
+						   '.      border  lines'
+						   '.      border  meta'
+						   'body   body    body'
+						   '.      .       .'`};
 				}
 
 				${until.leftCol} {
-					grid-template-columns: 100%; /* Main content */
-					grid-template-areas:
-						'title'
-						'headline'
-						'standfirst'
-						'media'
-						'lines'
-						'meta'
-						'body'
-						'.';
+					grid-template-columns: 100%;
+					grid-template-areas: ${topHat === 'fullWidth'
+						? `'media'
+						   'title'
+						   'headline'
+						   'standfirst'
+						   'lines'
+						   'meta'
+						   'body'
+						   '.'`
+						: `'title'
+						   'headline'
+						   'standfirst'
+						   'media'
+						   'lines'
+						   'meta'
+						   'body'
+						   '.'`};
 				}
 
 				${until.desktop} {
-					grid-template-columns: 100%; /* Main content */
-					grid-template-areas:
-						'title'
-						'headline'
-						'standfirst'
-						'media'
-						'lines'
-						'meta'
-						'body';
+					grid-template-columns: 100%;
+					grid-template-areas: ${topHat === 'fullWidth'
+						? `'media'
+						   'title'
+						   'headline'
+						   'standfirst'
+						   'lines'
+						   'meta'
+						   'body'`
+						: `'title'
+						   'headline'
+						   'standfirst'
+						   'media'
+						   'lines'
+						   'meta'
+						   'body'`};
 				}
 
 				${until.tablet} {
 					grid-column-gap: 0px;
-					grid-template-columns: 100%; /* Main content */
-					grid-template-areas:
-						'media'
-						'title'
-						'headline'
-						'standfirst'
-						'lines'
-						'meta'
-						'body';
+					grid-template-columns: 100%;
+					grid-template-areas: ${topHat === 'fullWidth'
+						? `'media'
+						   'title'
+						   'headline'
+						   'standfirst'
+						   'lines'
+						   'meta'
+						   'body'`
+						: `'media'
+						   'title'
+						   'headline'
+						   'standfirst'
+						   'lines'
+						   'meta'
+						   'body'`};
 				}
 			}
 		`}
@@ -231,6 +257,8 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 			return role === 'fullWidth';
 		}),
 	);
+
+	const topHat: 'regular' | 'fullWidth' = 'fullWidth';
 
 	return (
 		<>
@@ -326,24 +354,39 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 					<div
 						className={interactiveLegacyClasses.contentInteractive}
 					>
-						<InteractiveGrid>
-							<GridItem area="media">
-								<div css={maxWidth}>
-									<MainMedia
-										format={format}
-										elements={article.mainMediaElements}
-										host={host}
-										pageId={article.pageId}
-										webTitle={article.webTitle}
-										ajaxUrl={article.config.ajaxUrl}
-										abTests={article.config.abTests}
-										switches={article.config.switches}
-										isAdFreeUser={article.isAdFreeUser}
-										isSensitive={article.config.isSensitive}
-										editionId={article.editionId}
-										shouldHideAds={article.shouldHideAds}
-									/>
-								</div>
+						<InteractiveGrid topHat={topHat}>
+							<GridItem
+								area="media"
+								customCss={
+									topHat === 'fullWidth'
+										? css`
+												width: calc(100vw);
+												position: relative;
+												left: 50%;
+												right: 50%;
+												margin-left: -50vw;
+												margin-right: -50vw;
+												aspect-ratio: 16 / 9;
+												object-fit: cover;
+												overflow: hidden;
+										  `
+										: undefined
+								}
+							>
+								<MainMedia
+									format={format}
+									elements={article.mainMediaElements}
+									host={host}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									ajaxUrl={article.config.ajaxUrl}
+									abTests={article.config.abTests}
+									switches={article.config.switches}
+									isAdFreeUser={article.isAdFreeUser}
+									isSensitive={article.config.isSensitive}
+									editionId={article.editionId}
+									shouldHideAds={article.shouldHideAds}
+								/>
 							</GridItem>
 							<GridItem area="title" element="aside">
 								<div


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
