### PR TITLE
Adds PAUSE and RESUME tracking events to self hosted player

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -30,7 +30,7 @@
 		"@guardian/ab-core": "8.0.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "22.2.0",
-		"@guardian/bridget": "8.9.2",
+		"@guardian/bridget": "8.11.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "62.6.1",
 		"@guardian/consent-manager": "1.0.0",

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -808,6 +808,12 @@ export const SelfHostedVideo = ({
 			return;
 		}
 
+		if (playerState === 'PLAYING') {
+			sendOphanTrackingEvent('pause');
+		} else if (hasTrackedPlay) {
+			sendOphanTrackingEvent('resume');
+		}
+
 		event.preventDefault();
 		playPauseVideo();
 	};
@@ -1033,7 +1039,6 @@ export const SelfHostedVideo = ({
 						aspectRatio={aspectRatio}
 						width={width}
 						height={height}
-						videoStyle={videoStyle}
 						posterImage={optimisedPosterImage}
 						FallbackImageComponent={FallbackImageComponent}
 						currentTime={currentTime}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -553,9 +553,15 @@ export const SelfHostedVideo = ({
 		if (playerState === 'PLAYING') {
 			if (isInView) {
 				void pauseVideo('PAUSED_BY_USER');
+				sendOphanTrackingEvent('pause');
 			}
 		} else {
 			void playVideo();
+			if (hasTrackedPlay) {
+				sendOphanTrackingEvent('resume');
+			} else {
+				sendOphanTrackingEvent('play');
+			}
 		}
 	};
 
@@ -806,12 +812,6 @@ export const SelfHostedVideo = ({
 	const handlePlayPauseClick = (event: React.SyntheticEvent) => {
 		if (!videoStyleSettings.isInteractive) {
 			return;
-		}
-
-		if (playerState === 'PLAYING') {
-			sendOphanTrackingEvent('pause');
-		} else if (hasTrackedPlay) {
-			sendOphanTrackingEvent('resume');
 		}
 
 		event.preventDefault();

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -10,7 +10,6 @@ import { forwardRef } from 'react';
 import type { ActiveCue } from '../lib/useSubtitles';
 import type { Source } from '../lib/video';
 import { palette } from '../palette';
-import type { VideoPlayerFormat } from '../types/mainMedia';
 import {
 	AudioIcon as AudioIconComponent,
 	FullscreenIcon,
@@ -127,7 +126,6 @@ export type Props = {
 	height?: number;
 	width?: number;
 	aspectRatio: number;
-	videoStyle: VideoPlayerFormat;
 	FallbackImageComponent: ReactElement;
 	currentTime: number;
 	hasAudio: boolean;
@@ -181,7 +179,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 			height,
 			width,
 			aspectRatio,
-			videoStyle,
 			FallbackImageComponent,
 			posterImage,
 			currentTime,
@@ -225,10 +222,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
-		const dataLinkName = `gu-video-${videoStyle.toLowerCase()}-${
-			showPlayPauseIcon === 'play' ? 'play' : 'pause'
-		}-${atomId}`;
-
 		return (
 			<div ref={playerContainerRef} css={playerContainerStyles}>
 				{}
@@ -245,7 +238,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 					data-testid="self-hosted-video-player"
 					height={height}
 					width={width}
-					data-link-name={dataLinkName}
 					data-chromatic="ignore"
 					preload={preloadPartialData ? 'metadata' : 'none'}
 					loop={shouldLoop}

--- a/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
@@ -25,7 +25,7 @@ const getAppsMediaEvent = async (
 		default:
 	}
 
-	if (await hasMinimumBridgetVersion('8.9.2')) {
+	if (await hasMinimumBridgetVersion('8.11.0')) {
 		switch (trackingEvent) {
 			case 'pause':
 				return MediaEvent.pause;
@@ -40,7 +40,7 @@ const getAppsMediaEvent = async (
 			case 'view':
 				return MediaEvent.view;
 			case 'resume':
-				return MediaEvent.pause;
+				return MediaEvent.resume;
 			default:
 		}
 	}

--- a/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
@@ -39,6 +39,8 @@ const getAppsMediaEvent = async (
 				return MediaEvent.exit_fullscreen;
 			case 'view':
 				return MediaEvent.view;
+			case 'resume':
+				return MediaEvent.pause;
 			default:
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,8 +255,8 @@ importers:
         specifier: 22.2.0
         version: 22.2.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.6.2)(typescript@5.5.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.9.2
-        version: 8.9.2
+        specifier: 8.11.0
+        version: 8.11.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2400,8 +2400,8 @@ packages:
       '@guardian/source': ^9.0.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.9.2':
-    resolution: {integrity: sha512-BRQ4vlJkUl39kKL86JrVbwPKiVXvEIkKvyYuv3MNePVdUVbsCMjoRwO/sxY2/F3iWAGqeg15JWi/rVGRxKJ0LQ==}
+  '@guardian/bridget@8.11.0':
+    resolution: {integrity: sha512-vtjclCZg+sFMTnWj5mq2hTf1yeCHyb0ZeXtnG3MNPV1aA7jm5EkW/Up/xQ4CwKFLYFIiFwR3aPGzyYGMrYwdfA==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -11797,7 +11797,7 @@ snapshots:
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.5.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.9.2': {}
+  '@guardian/bridget@8.11.0': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:


### PR DESCRIPTION
## What does this change?
This change tracks PAUSE and RESUME interactions i.e. when a user specifically interacts with the video to pause or resume the video. 

This does not include when the video is paused due to being scrolled out-of-view. It also tracks RESUME separately to PLAY. PLAY and RESUME are tracked exclusively, a RESUME is intended to mean the opposite of PAUSE.

## Why?

Tracking these interactions will help us to understand how readers react to self hosted video.