### PR TITLE
add actions: write permission to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 6 * * *'
 
 permissions:
+  actions: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Why?
The action needs to be able to delete cache entries, currently it's getting 403 errors in the logs:
```
##[debug]remove cache "_state"
Warning: Error delete _state: [403]
```
[link](https://github.com/guardian/dotcom-rendering/actions/runs/26019968004/job/76495260212)
[docs recommend this permission](https://github.com/actions/stale#recommended-permissions)