### PR TITLE
Looping self-hosted video should not allow fullscreen

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -405,7 +405,7 @@ export const SelfHostedVideo = ({
 		sources.some((source) => source.hasAudio);
 
 	const showIcons =
-		(hasAudio || videoStyleSettings.showFullscreenIcon) &&
+		(hasAudio || videoStyleSettings.supportsFullscreen) &&
 		playerState !== 'NOT_STARTED';
 
 	const subtitlesPosition: SubtitlesPosition =
@@ -1068,7 +1068,7 @@ export const SelfHostedVideo = ({
 						activeCue={activeCue}
 						shouldLoop={videoStyleSettings.loop}
 						showFullscreenIcon={
-							videoStyleSettings.showFullscreenIcon
+							videoStyleSettings.supportsFullscreen
 						}
 						isInteractive={videoStyleSettings.isInteractive}
 					/>

--- a/dotcom-rendering/src/lib/videoStyleSettings.ts
+++ b/dotcom-rendering/src/lib/videoStyleSettings.ts
@@ -23,7 +23,7 @@ export type VideoStyleSettings = ProgessBarStyles & {
 	autoplay: boolean;
 	loop: boolean;
 	supportsAudio: boolean;
-	showFullscreenIcon: boolean;
+	supportsFullscreen: boolean;
 	/**
 	 * A play icon can be shown when the video is not playing
 	 */
@@ -45,7 +45,7 @@ const loopSettings: VideoStyleSettings = {
 	autoplay: true,
 	loop: true,
 	supportsAudio: true,
-	showFullscreenIcon: true,
+	supportsFullscreen: false,
 	showProgressBar: true,
 	useInteractiveProgressBar: false,
 	canShowPlayIcon: true,
@@ -63,7 +63,7 @@ const cinemagraphSettings: VideoStyleSettings = {
 	autoplay: true,
 	loop: true,
 	supportsAudio: false,
-	showFullscreenIcon: false,
+	supportsFullscreen: false,
 	showProgressBar: false,
 	useInteractiveProgressBar: false,
 	canShowPlayIcon: false,
@@ -81,7 +81,7 @@ const defaultSettings: VideoStyleSettings = {
 	autoplay: true,
 	loop: false,
 	supportsAudio: true,
-	showFullscreenIcon: true,
+	supportsFullscreen: true,
 	showProgressBar: true,
 	useInteractiveProgressBar: true,
 	canShowPlayIcon: true,


### PR DESCRIPTION
## What does this change?

Removes fullscreen functionality from looping self-hosted video. The fullscreen icon will no longer be displayed on loops.

Renames the setting to `supportsFullscreen`.

## Why?

Fullscreen is only supported in the default player. Loops and cinemagraphs do not support fullscreen.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/46bf4f56-e1e7-4d81-9094-17d98ae8372b
[after]: https://github.com/user-attachments/assets/78cac3d4-3d70-4ce3-a436-524c67baa7fb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
