### PR TITLE
Address critical accessibility issues identified by Chromatic

### DIFF
--- a/dotcom-rendering/src/components/CalloutEmbed/FormFields/FieldLabel.tsx
+++ b/dotcom-rendering/src/components/CalloutEmbed/FormFields/FieldLabel.tsx
@@ -30,7 +30,7 @@ type Props = {
 export const FieldLabel = ({ formField, hideLabel }: Props) => (
 	<label
 		css={[fieldLabelStyles, hideLabel && visuallyHidden]}
-		htmlFor={formField.name}
+		htmlFor={formField.id}
 		hidden={formField.hideLabel}
 	>
 		{formField.label}

--- a/dotcom-rendering/src/components/HostedContentHeader.island.tsx
+++ b/dotcom-rendering/src/components/HostedContentHeader.island.tsx
@@ -203,6 +203,7 @@ export const HostedContentHeader = ({ branding }: Props) => {
 						theme={{
 							textSubdued: sourcePalette.neutral[97],
 						}}
+						aria-label="More information about advertiser content"
 					/>
 				</div>
 

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/SearchBar.tsx
@@ -88,8 +88,7 @@ const searchSubmit = css`
 	}
 `;
 
-export const SearchBar = () => {
-	const searchId = 'gu-search';
+export const SearchBar = ({ searchId = 'gu-search' }: { searchId: string }) => {
 	return (
 		<form css={searchBar} action="https://www.google.co.uk/search">
 			<TextInput

--- a/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
+++ b/dotcom-rendering/src/components/Masthead/Titlepiece/ExpandedNav/Sections.tsx
@@ -144,7 +144,7 @@ export const Sections = ({ nav, editionId, hasPageSkin }: Props) => {
 
 			<Hide from="desktop">
 				<li role="none">
-					<SearchBar />
+					<SearchBar searchId="gu-search-mobile" />
 				</li>
 			</Hide>
 			<div css={lineStyle}></div>
@@ -164,7 +164,7 @@ export const Sections = ({ nav, editionId, hasPageSkin }: Props) => {
 
 			{/* Desktop only Brand Extensions list*/}
 			<li css={desktopBrandExtensionColumn} role="none">
-				<SearchBar />
+				<SearchBar searchId="gu-search-desktop" />
 
 				<ul
 					css={[


### PR DESCRIPTION
## What does this change?

- ensure form field labels (used in e.g. the Callout Embed) are correctly connected to the ID of the form field input using the `htmlFor`
- add an `aria-label` to the Hosted Content Header information icon, to ensure it is announced by screen readers and other AT
- the search field is added to the page twice to support different breakpoints – we need to pass a unique ID for each instance, in order to better support AT

## Screenshots

**Callout embed form**

<img width="625" height="430" alt="Screenshot 2026-05-19 at 09 50 45" src="https://github.com/user-attachments/assets/a352bde5-a547-4f72-be4f-cf6e7f025eec" />


**Hosted Content Header information icon**

<img width="135" height="85" alt="Screenshot 2026-05-19 at 09 47 37" src="https://github.com/user-attachments/assets/233fccd6-1f55-48c6-adeb-12d7c2f3dcec" />

**Search field (desktop)**

<img width="463" height="238" alt="Screenshot 2026-05-19 at 09 54 27" src="https://github.com/user-attachments/assets/3f80517d-bd29-424e-b38c-a0870af0c07b" />

**Search field (mobile)**

<img width="250" height="229" alt="Screenshot 2026-05-19 at 09 54 40" src="https://github.com/user-attachments/assets/335e7dff-1f36-428d-a889-87ca5267dd6a" />
