### PR TITLE
Address carousel accessibility violations identified by Chromatic

### DIFF
--- a/dotcom-rendering/src/components/Carousel.island.tsx
+++ b/dotcom-rendering/src/components/Carousel.island.tsx
@@ -927,9 +927,6 @@ export const Carousel = ({
 					]}
 					data-component={onwardsSource}
 					data-link={formatAttrString(heading)}
-					role="region"
-					aria-roledescription="carousel"
-					aria-label={heading}
 				>
 					<Header
 						heading={heading}
@@ -947,6 +944,9 @@ export const Carousel = ({
 					<ul
 						css={carouselStyle}
 						ref={carouselRef}
+						aria-label={heading}
+						role="region"
+						aria-roledescription="carousel"
 						data-component={`carousel-small | maxIndex-${maxIndex}`}
 						data-heatphan-type="carousel"
 						onTouchStart={isApps ? onTouchStart : undefined}

--- a/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
+++ b/dotcom-rendering/src/components/CarouselNavigationButtons.tsx
@@ -89,7 +89,7 @@ export const CarouselNavigationButtons = ({
 	return ReactDOM.createPortal(
 		<div
 			role="group"
-			aria-controls="carousel"
+			aria-controls={`${sectionId}-carousel`}
 			aria-label="carousel arrows"
 			css={buttonStyles}
 		>

--- a/dotcom-rendering/src/components/ScrollableCarousel.tsx
+++ b/dotcom-rendering/src/components/ScrollableCarousel.tsx
@@ -393,6 +393,7 @@ export const ScrollableCarousel = ({
 					),
 					stackedCardRowsStyles(shouldStackCards),
 				]}
+				id={`${sectionId}-carousel`}
 				data-heatphan-type="carousel"
 				onFocus={scrollToCardOnFocus}
 				{...(isBelowTabletBreakpoint && {

--- a/dotcom-rendering/src/components/ScrollableProduct.island.tsx
+++ b/dotcom-rendering/src/components/ScrollableProduct.island.tsx
@@ -302,6 +302,7 @@ export const ScrollableProduct = ({ products, format }: Props) => {
 					ref={carouselRef}
 					css={carouselStyles}
 					data-heatphan-type="carousel"
+					id="at-a-glance-carousel"
 				>
 					{products.map(
 						(product: ProductBlockElement, index: number) => (

--- a/dotcom-rendering/src/components/ScrollableProduct.island.tsx
+++ b/dotcom-rendering/src/components/ScrollableProduct.island.tsx
@@ -285,7 +285,7 @@ export const ScrollableProduct = ({ products, format }: Props) => {
 			<div css={carouselHeader}>
 				<Subheading
 					format={format}
-					id={'at-a-glance'}
+					id={'at-a-glance-title'}
 					topPadding={false}
 				>
 					At a glance


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
