### PR TITLE
extends expiry date for intentIQ ABTest

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -126,7 +126,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module.",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-05-21",
+		expirationDate: "2026-06-18",
 		type: "client",
 		status: "ON",
 		audienceSize: 0 / 100,


### PR DESCRIPTION
## What does this change?
Extends the expiry date for the `commercial-user-module-intentIq`
## Why?
We need to extend the expiry to next month in order to facilitate the testing from 0% to 10% and ultimately to our 95% hod back test. A month should cover the required time for all of these to acquire the data we need.
