### PR TITLE
Add video progress milestone tracking hook

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -16,6 +16,7 @@ import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
+import { useVideoMilestoneTracking } from '../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {
 	customSelfHostedVideoPlayAudioEventName,
@@ -542,6 +543,8 @@ export const SelfHostedVideo = ({
 		playerState,
 		currentTime,
 	});
+
+	const trackMilestones = useVideoMilestoneTracking(sendOphanTrackingEvent);
 
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
@@ -1075,6 +1078,10 @@ export const SelfHostedVideo = ({
 
 		if (playerState === 'PLAYING') {
 			setCurrentTime(video.currentTime);
+
+			if (videoStyle === 'Default') {
+				trackMilestones(video.currentTime, video.duration);
+			}
 		}
 	};
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1079,6 +1079,10 @@ export const SelfHostedVideo = ({
 		if (playerState === 'PLAYING') {
 			setCurrentTime(video.currentTime);
 
+			/**
+			 * We only want to track milestone events for "long-form"
+			 * videos, not loops or cinemagraphs.
+			 */
 			if (videoStyle === 'Default') {
 				trackMilestones(video.currentTime, video.duration);
 			}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -13,6 +13,7 @@ import { getVideoClient } from '../../lib/bridgetApi';
 import { getZIndex } from '../../lib/getZIndex';
 import { getAuthStatus } from '../../lib/identity';
 import type { CustomPlayEventDetail } from '../../lib/video';
+import { useVideoMilestoneTracking } from '../../lib/useVideoMilestoneTracking';
 import {
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePauseEventName,
@@ -46,9 +47,6 @@ type Props = {
 
 type ProgressEvents = {
 	hasSentPlayEvent: boolean;
-	hasSent25Event: boolean;
-	hasSent50Event: boolean;
-	hasSent75Event: boolean;
 	hasSentEndEvent: boolean;
 };
 
@@ -198,6 +196,7 @@ const createOnStateChangeListener =
 		uniqueId: string,
 		progressEvents: ProgressEvents,
 		eventEmitters: Props['eventEmitters'],
+		trackMilestones: (currentTime: number, duration: number) => void,
 	): YT.PlayerEventHandler<YT.OnStateChangeEvent> =>
 	(event) => {
 		const loggerFrom = 'YoutubeAtomPlayer onStateChange';
@@ -257,46 +256,7 @@ const createOnStateChangeListener =
 					return;
 				}
 
-				const percentPlayed = (currentTime / duration) * 100;
-
-				if (!progressEvents.hasSent25Event && 25 < percentPlayed) {
-					log('dotcom', {
-						from: loggerFrom,
-						videoId,
-						msg: 'played 25%',
-						event,
-					});
-					for (const eventEmitter of eventEmitters) {
-						eventEmitter('25');
-					}
-					progressEvents.hasSent25Event = true;
-				}
-
-				if (!progressEvents.hasSent50Event && 50 < percentPlayed) {
-					log('dotcom', {
-						from: loggerFrom,
-						videoId,
-						msg: 'played 50%',
-						event,
-					});
-					for (const eventEmitter of eventEmitters) {
-						eventEmitter('50');
-					}
-					progressEvents.hasSent50Event = true;
-				}
-
-				if (!progressEvents.hasSent75Event && 75 < percentPlayed) {
-					log('dotcom', {
-						from: loggerFrom,
-						videoId,
-						msg: 'played 75%',
-						event,
-					});
-					for (const eventEmitter of eventEmitters) {
-						eventEmitter('75');
-					}
-					progressEvents.hasSent75Event = true;
-				}
+				trackMilestones(currentTime, duration);
 
 				const currentPlayerState = player.getPlayerState();
 
@@ -492,11 +452,14 @@ export const YoutubeAtomPlayer = ({
 	 * Does not cause re-renders on update
 	 */
 	const player = useRef<YouTubePlayer>();
+	const trackMilestones = useVideoMilestoneTracking((event) => {
+		for (const eventEmitter of eventEmitters) {
+			eventEmitter(event);
+		}
+	});
+
 	const progressEvents = useRef<ProgressEvents>({
 		hasSentPlayEvent: false,
-		hasSent25Event: false,
-		hasSent50Event: false,
-		hasSent75Event: false,
 		hasSentEndEvent: false,
 	});
 
@@ -539,6 +502,7 @@ export const YoutubeAtomPlayer = ({
 					uniqueId,
 					progressEvents.current,
 					eventEmitters,
+					trackMilestones,
 				);
 
 				/**

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -12,8 +12,8 @@ import {
 import { getVideoClient } from '../../lib/bridgetApi';
 import { getZIndex } from '../../lib/getZIndex';
 import { getAuthStatus } from '../../lib/identity';
-import type { CustomPlayEventDetail } from '../../lib/video';
 import { useVideoMilestoneTracking } from '../../lib/useVideoMilestoneTracking';
+import type { CustomPlayEventDetail } from '../../lib/video';
 import {
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePauseEventName,
@@ -195,7 +195,7 @@ const createOnStateChangeListener =
 		videoId: string,
 		uniqueId: string,
 		progressEvents: ProgressEvents,
-		eventEmitters: Props['eventEmitters'],
+		sendOphanTrackingEvent: (event: VideoEventKey) => void,
 		trackMilestones: (currentTime: number, duration: number) => void,
 	): YT.PlayerEventHandler<YT.OnStateChangeEvent> =>
 	(event) => {
@@ -225,9 +225,7 @@ const createOnStateChangeListener =
 					msg: 'start play',
 					event,
 				});
-				for (const eventEmitter of eventEmitters) {
-					eventEmitter('play');
-				}
+				sendOphanTrackingEvent('play');
 				progressEvents.hasSentPlayEvent = true;
 
 				/**
@@ -243,24 +241,13 @@ const createOnStateChangeListener =
 					msg: 'resume',
 					event,
 				});
-				for (const eventEmitter of eventEmitters) {
-					eventEmitter('resume');
-				}
+				sendOphanTrackingEvent('resume');
 			}
 
 			const checkProgress = () => {
-				const currentTime = player.getCurrentTime();
-				const duration = player.getDuration();
+				trackMilestones(player.getCurrentTime(), player.getDuration());
 
-				if (!duration || !currentTime) {
-					return;
-				}
-
-				trackMilestones(currentTime, duration);
-
-				const currentPlayerState = player.getPlayerState();
-
-				if (currentPlayerState !== YT.PlayerState.ENDED) {
+				if (player.getPlayerState() !== YT.PlayerState.ENDED) {
 					/**
 					 * Set a timeout to check progress again in the future
 					 */
@@ -280,9 +267,7 @@ const createOnStateChangeListener =
 				msg: 'pause',
 				event,
 			});
-			for (const eventEmitter of eventEmitters) {
-				eventEmitter('pause');
-			}
+			sendOphanTrackingEvent('resume');
 		}
 
 		if (event.data === YT.PlayerState.CUED) {
@@ -292,9 +277,7 @@ const createOnStateChangeListener =
 				msg: 'cued',
 				event,
 			});
-			for (const eventEmitter of eventEmitters) {
-				eventEmitter('cued');
-			}
+			sendOphanTrackingEvent('cued');
 			progressEvents.hasSentPlayEvent = false;
 		}
 
@@ -310,9 +293,7 @@ const createOnStateChangeListener =
 				msg: 'ended',
 				event,
 			});
-			for (const eventEmitter of eventEmitters) {
-				eventEmitter('end');
-			}
+			sendOphanTrackingEvent('end');
 			progressEvents.hasSentEndEvent = true;
 			progressEvents.hasSentPlayEvent = false;
 		}
@@ -452,11 +433,15 @@ export const YoutubeAtomPlayer = ({
 	 * Does not cause re-renders on update
 	 */
 	const player = useRef<YouTubePlayer>();
-	const trackMilestones = useVideoMilestoneTracking((event) => {
-		for (const eventEmitter of eventEmitters) {
-			eventEmitter(event);
-		}
-	});
+	const sendOphanTrackingEvent = useCallback(
+		(event: VideoEventKey) => {
+			for (const eventEmitter of eventEmitters) {
+				eventEmitter(event);
+			}
+		},
+		[eventEmitters],
+	);
+	const trackMilestones = useVideoMilestoneTracking(sendOphanTrackingEvent);
 
 	const progressEvents = useRef<ProgressEvents>({
 		hasSentPlayEvent: false,
@@ -501,7 +486,7 @@ export const YoutubeAtomPlayer = ({
 					videoId,
 					uniqueId,
 					progressEvents.current,
-					eventEmitters,
+					sendOphanTrackingEvent,
 					trackMilestones,
 				);
 
@@ -654,15 +639,16 @@ export const YoutubeAtomPlayer = ({
 			adTargeting,
 			autoPlay,
 			consentState,
-			enableAds,
-			eventEmitters,
 			deactivateVideo,
+			enableAds,
+			sendOphanTrackingEvent,
 			height,
 			id,
 			onReady,
 			origin,
 			playerReadyCallback,
 			renderingTarget,
+			trackMilestones,
 			uniqueId,
 			videoId,
 			width,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -267,7 +267,7 @@ const createOnStateChangeListener =
 				msg: 'pause',
 				event,
 			});
-			sendOphanTrackingEvent('resume');
+			sendOphanTrackingEvent('pause');
 		}
 
 		if (event.data === YT.PlayerState.CUED) {

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -5,15 +5,12 @@ type Milestones = {
 	hasSent25: boolean;
 	hasSent50: boolean;
 	hasSent75: boolean;
-	hasReachedEnd: boolean;
 };
 
 /**
  * Returns a function that should be called on each time update.
  * It tracks when a video crosses the 25%, 50% and 75% milestones and
- * calls the provided callback for each. Milestone state is reset when the
- * video completes and then restarts (i.e. currentTime drops back toward 0
- * after the end has been reached).
+ * calls the provided callback for each.
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,
@@ -22,21 +19,10 @@ export const useVideoMilestoneTracking = (
 		hasSent25: false,
 		hasSent50: false,
 		hasSent75: false,
-		hasReachedEnd: false,
 	});
 
 	return (currentTime: number, duration: number) => {
 		if (duration <= 0) return;
-
-		// Detect a restart: video has reached the end and currentTime has reset
-		if (milestones.current.hasReachedEnd && currentTime < 1) {
-			milestones.current = {
-				hasSent25: false,
-				hasSent50: false,
-				hasSent75: false,
-				hasReachedEnd: false,
-			};
-		}
 
 		const percent = (currentTime / duration) * 100;
 
@@ -53,10 +39,6 @@ export const useVideoMilestoneTracking = (
 		if (!milestones.current.hasSent75 && percent >= 75) {
 			onMilestone('75');
 			milestones.current.hasSent75 = true;
-		}
-
-		if (!milestones.current.hasReachedEnd && percent >= 99) {
-			milestones.current.hasReachedEnd = true;
 		}
 	};
 };

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -1,0 +1,62 @@
+import { useRef } from 'react';
+import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
+
+type Milestones = {
+	hasSent25: boolean;
+	hasSent50: boolean;
+	hasSent75: boolean;
+	hasReachedEnd: boolean;
+};
+
+/**
+ * Returns a function that should be called on each time update.
+ * It tracks when a video crosses the 25%, 50% and 75% milestones and
+ * calls the provided callback for each. Milestone state is reset when the
+ * video completes and then restarts (i.e. currentTime drops back toward 0
+ * after the end has been reached).
+ */
+export const useVideoMilestoneTracking = (
+	onMilestone: (event: VideoEventKey) => void,
+): ((currentTime: number, duration: number) => void) => {
+	const milestones = useRef<Milestones>({
+		hasSent25: false,
+		hasSent50: false,
+		hasSent75: false,
+		hasReachedEnd: false,
+	});
+
+	return (currentTime: number, duration: number) => {
+		if (duration <= 0) return;
+
+		// Detect a restart: video has reached the end and currentTime has reset
+		if (milestones.current.hasReachedEnd && currentTime < 1) {
+			milestones.current = {
+				hasSent25: false,
+				hasSent50: false,
+				hasSent75: false,
+				hasReachedEnd: false,
+			};
+		}
+
+		const percent = (currentTime / duration) * 100;
+
+		if (!milestones.current.hasSent25 && percent >= 25) {
+			onMilestone('25');
+			milestones.current.hasSent25 = true;
+		}
+
+		if (!milestones.current.hasSent50 && percent >= 50) {
+			onMilestone('50');
+			milestones.current.hasSent50 = true;
+		}
+
+		if (!milestones.current.hasSent75 && percent >= 75) {
+			onMilestone('75');
+			milestones.current.hasSent75 = true;
+		}
+
+		if (!milestones.current.hasReachedEnd && percent >= 99) {
+			milestones.current.hasReachedEnd = true;
+		}
+	};
+};

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
 
 type Milestones = {
@@ -21,24 +21,27 @@ export const useVideoMilestoneTracking = (
 		hasSent75: false,
 	});
 
-	return (currentTime: number, duration: number) => {
-		if (duration <= 0) return;
+	return useCallback(
+		(currentTime: number, duration: number) => {
+			if (duration <= 0) return;
 
-		const percent = (currentTime / duration) * 100;
+			const percent = (currentTime / duration) * 100;
 
-		if (!milestones.current.hasSent25 && percent >= 25) {
-			onMilestone('25');
-			milestones.current.hasSent25 = true;
-		}
+			if (!milestones.current.hasSent25 && percent >= 25) {
+				onMilestone('25');
+				milestones.current.hasSent25 = true;
+			}
 
-		if (!milestones.current.hasSent50 && percent >= 50) {
-			onMilestone('50');
-			milestones.current.hasSent50 = true;
-		}
+			if (!milestones.current.hasSent50 && percent >= 50) {
+				onMilestone('50');
+				milestones.current.hasSent50 = true;
+			}
 
-		if (!milestones.current.hasSent75 && percent >= 75) {
-			onMilestone('75');
-			milestones.current.hasSent75 = true;
-		}
-	};
+			if (!milestones.current.hasSent75 && percent >= 75) {
+				onMilestone('75');
+				milestones.current.hasSent75 = true;
+			}
+		},
+		[onMilestone],
+	);
 };


### PR DESCRIPTION
## What does this change?

This change implements video progress milestone tracking using a React hook and updates both the SelfHosted and YouTube players to use it. It will send events to Ophan when the video has progressed 25/50/75 percent through the video. If a user skips forward, tracking events will be sent for all milestones they have surpassed. 

Current YouTube Atom Player implementation:

https://github.com/guardian/dotcom-rendering/blob/20bd1ecaa72e71c2050b7d00c44edfc3aa77babb/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx#L252-L311

## Why?

Implementing this tracking for long-form video will help inform us how far through videos readers progressed. 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
