### PR TITLE
updated cleanTeamName function to replace Czech Republic with Czechia

### DIFF
--- a/dotcom-rendering/src/footballMatches.test.ts
+++ b/dotcom-rendering/src/footballMatches.test.ts
@@ -121,6 +121,7 @@ describe('footballMatches', () => {
 			'Bosnia-Herzegovina': 'Bosnia and Herzegovina',
 			'Congo DR': 'DR Congo',
 			Curacao: 'Curaçao',
+			'Czech Republic': 'Czechia',
 		};
 
 		for (const [uncleanName, cleanName] of Object.entries(

--- a/dotcom-rendering/src/sportDataPage.ts
+++ b/dotcom-rendering/src/sportDataPage.ts
@@ -101,5 +101,6 @@ export const cleanTeamName = (teamName: string): string => {
 		.replace('Union Saint Gilloise', 'Union Saint-Gilloise')
 		.replace('Bosnia-Herzegovina', 'Bosnia and Herzegovina')
 		.replace('Congo DR', 'DR Congo')
-		.replace('Curacao', 'Curaçao');
+		.replace('Curacao', 'Curaçao')
+		.replace('Czech Republic', 'Czechia');
 };


### PR DESCRIPTION
## What does this change?
Much like https://github.com/guardian/dotcom-rendering/pull/15519, this PR updates football team name normalisation, replacing Czech Republic with Czechia.

## Why?
Resolves https://github.com/guardian/dotcom-rendering/issues/15847

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/c373f7c9-d9d0-4a15-8bf6-7a451a28cfa7
[after]: https://github.com/user-attachments/assets/031d84be-65d1-4c56-b390-1c7001dd8be0


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

