### PR TITLE
Group dependabot svelte dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,11 @@ updates:
       storybook:
         patterns:
           - '*storybook*'
+      svelte:
+        patterns:
+          - '@sveltejs/*'
+          - 'svelte'
+          - 'svelte-check'
       swc:
         patterns:
           - '@swc/*'


### PR DESCRIPTION
## What does this change?
Group dependabot svelte dependencies

## Why?
We generally want to update svelte dependencies together
