### PR TITLE
Video format testing

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -33,6 +33,7 @@ import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Caption } from './Caption';
 import { CardPicture, type Props as CardPictureProps } from './CardPicture';
 import { useConfig } from './ConfigContext';
+import { SelfHostedVideoDebugOverlay } from './SelfHostedVideoDebugOverlay';
 import type {
 	ControlsPosition,
 	PLAYER_STATES,
@@ -1298,6 +1299,10 @@ export const SelfHostedVideo = ({
 						isLoopClickThroughTestVariant={
 							isLoopClickThroughTestVariant
 						}
+					/>
+					<SelfHostedVideoDebugOverlay
+						videoRef={vidRef}
+						atomId={atomId}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -14,7 +14,7 @@ import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
-import { useSubtitles } from '../lib/useSubtitles';
+// import { useSubtitles } from '../lib/useSubtitles';
 import { useVideoAttentionTracking } from '../lib/useVideoAttentionTracking';
 import { useVideoMilestoneTracking } from '../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
@@ -552,11 +552,13 @@ export const SelfHostedVideo = ({
 		threshold: VISIBILITY_THRESHOLD,
 	});
 
-	const activeCue = useSubtitles({
-		video: vidRef.current,
-		playerState,
-		currentTime,
-	});
+	/*cues disabled for testing to avoid cors*/
+	const activeCue = null;
+	// const activeCue = useSubtitles({
+	// 	video: vidRef.current,
+	// 	playerState,
+	// 	currentTime,
+	// });
 
 	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
 		sendOphanTrackingEvent,
@@ -693,7 +695,6 @@ export const SelfHostedVideo = ({
 
 		const screenWidth = window.innerWidth;
 		const vidFormat = getVideoFormat();
-		console.log(vidFormat);
 		const filteredSources = findOptimisedSourcePerMimeType(
 			sources,
 			screenWidth,

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -22,6 +22,7 @@ import {
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePlayEventName,
 	findOptimisedSourcePerMimeType,
+	getVideoFormat,
 	roundAspectRatio,
 } from '../lib/video';
 import type { VideoStyleSettings } from '../lib/videoStyleSettings';
@@ -206,12 +207,12 @@ const hideTransitionStyles = css`
 
 const hideControlsStyles = css`
 	.controls-container {
-		${hideTransitionStyles}
+		${hideTransitionStyles};
 		transition-delay: ${CONTROLS_FADE_DELAY}ms;
 	}
 
 	.play-pause-icon {
-		${hideTransitionStyles}
+		${hideTransitionStyles};
 		transition-delay: ${PLAY_BUTTON_FADE_DELAY}ms;
 	}
 
@@ -690,10 +691,13 @@ export const SelfHostedVideo = ({
 		}
 
 		const screenWidth = window.innerWidth;
+		const vidFormat = getVideoFormat();
+		console.log(vidFormat);
 		const filteredSources = findOptimisedSourcePerMimeType(
 			sources,
 			screenWidth,
-		);
+		).filter((source) => source.mimeType === vidFormat);
+
 		setOptimisedSources(filteredSources);
 
 		/**

--- a/dotcom-rendering/src/components/SelfHostedVideoDebugOverlay.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoDebugOverlay.tsx
@@ -88,6 +88,40 @@ export const SelfHostedVideoDebugOverlay = ({ videoRef, atomId }: Props) => {
 
 		const rerender = () => force((n) => n + 1);
 
+		// iOS Safari often fires `loadstart` before this effect attaches its
+		// listener (the overlay mounts after the <video> element). In that
+		// case, seed loadStartRef from the resource timing entry's startTime
+		// so STARTUP can still be computed when `playing` / `timeupdate`
+		// eventually fires. Fall back to "now" if no entry is available.
+		const seedLoadStartFromResourceTiming = () => {
+			if (loadStartRef.current !== null) return;
+			const src = video.currentSrc;
+			if (src && typeof performance !== 'undefined') {
+				const entries = performance.getEntriesByName(
+					src,
+				) as PerformanceResourceTiming[];
+				const entry = entries[entries.length - 1];
+				if (entry) {
+					loadStartRef.current = entry.startTime;
+					return;
+				}
+			}
+			loadStartRef.current = performance.now();
+		};
+
+		const computeStartup = () => {
+			if (startupRef.current !== null) return;
+			if (loadStartRef.current === null) {
+				seedLoadStartFromResourceTiming();
+			}
+			if (loadStartRef.current !== null) {
+				startupRef.current = Math.max(
+					0,
+					Math.round(performance.now() - loadStartRef.current),
+				);
+			}
+		};
+
 		const onLoadStart = () => {
 			loadStartRef.current = performance.now();
 			startupRef.current = null;
@@ -95,22 +129,27 @@ export const SelfHostedVideoDebugOverlay = ({ videoRef, atomId }: Props) => {
 			rerender();
 		};
 		const onPlaying = () => {
-			if (
-				!hasPlayedRef.current &&
-				loadStartRef.current !== null &&
-				startupRef.current === null
-			) {
-				startupRef.current = Math.round(
-					performance.now() - loadStartRef.current,
-				);
+			if (!hasPlayedRef.current) {
+				computeStartup();
 			}
 			hasPlayedRef.current = true;
 			rerender();
 		};
+		// iOS Safari is unreliable about firing `playing`; the first
+		// `timeupdate` with currentTime > 0 is a robust fallback.
+		const onTimeUpdate = () => {
+			if (!hasPlayedRef.current && video.currentTime > 0) {
+				computeStartup();
+				hasPlayedRef.current = true;
+				rerender();
+			}
+		};
+
 		const passthrough = () => rerender();
 
 		video.addEventListener('loadstart', onLoadStart);
 		video.addEventListener('playing', onPlaying);
+		video.addEventListener('timeupdate', onTimeUpdate);
 		video.addEventListener('loadedmetadata', passthrough);
 		video.addEventListener('canplay', passthrough);
 		video.addEventListener('pause', passthrough);
@@ -118,12 +157,23 @@ export const SelfHostedVideoDebugOverlay = ({ videoRef, atomId }: Props) => {
 		video.addEventListener('ratechange', passthrough);
 		video.addEventListener('volumechange', passthrough);
 
+		// If the video already started loading (or is already playing) before
+		// we attached listeners (common on iOS Safari), backfill state now.
+		if (video.currentSrc || video.readyState > 0) {
+			seedLoadStartFromResourceTiming();
+		}
+		if (!video.paused && video.currentTime > 0) {
+			computeStartup();
+			hasPlayedRef.current = true;
+		}
+
 		// Re-render every second so connection / cache snapshots stay fresh
 		const interval = window.setInterval(rerender, 1000);
 
 		return () => {
 			video.removeEventListener('loadstart', onLoadStart);
 			video.removeEventListener('playing', onPlaying);
+			video.removeEventListener('timeupdate', onTimeUpdate);
 			video.removeEventListener('loadedmetadata', passthrough);
 			video.removeEventListener('canplay', passthrough);
 			video.removeEventListener('pause', passthrough);

--- a/dotcom-rendering/src/components/SelfHostedVideoDebugOverlay.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoDebugOverlay.tsx
@@ -1,0 +1,179 @@
+import { css } from '@emotion/react';
+import { headlineMedium14 } from '@guardian/source/foundations';
+import { useEffect, useRef, useState } from 'react';
+import { palette } from '../palette';
+
+/**
+ * A lightweight, intentionally disposable debug overlay for self-hosted video.
+ *
+ * Enable by appending `?videoDebug=1` (or `&videoDebug=1`) to the page URL.
+ *
+ * Surfaces:
+ *  - FORMAT: mime/extension of the selected source
+ *  - STARTUP: ms from `loadstart` to first `playing`
+ *  - CACHE: HIT / MISS / UNKNOWN, derived from Resource Timing
+ *  - STATE: current readyState / paused / muted
+ */
+
+type Props = {
+	videoRef: React.RefObject<HTMLVideoElement>;
+	atomId: string;
+};
+
+const overlayStyles = css`
+	position: absolute;
+	top: 8px;
+	left: 8px;
+	z-index: 2147483647;
+	padding: 8px 10px;
+	background: ${palette('--versus-change')};
+	color: ${palette('--uk-elections-scottish-national-party')};
+	${headlineMedium14};
+	white-space: pre;
+	pointer-events: none;
+	border-radius: 4px;
+	max-width: calc(100% - 16px);
+	overflow: hidden;
+	text-shadow: 0 0 2px ${palette('--versus-change')};
+`;
+
+const getCacheStatus = (src: string): 'HIT' | 'MISS' | 'UNKNOWN' => {
+	if (!src || typeof performance === 'undefined') return 'UNKNOWN';
+	const entries = performance.getEntriesByName(
+		src,
+	) as PerformanceResourceTiming[];
+	if (entries.length === 0) return 'UNKNOWN';
+	const entry = entries[entries.length - 1];
+	if (!entry) return 'UNKNOWN';
+
+	// transferSize === 0 typically means a memory/disk cache hit
+	// (but can also mean a cross-origin response without TAO header).
+	if (entry.transferSize === 0 && entry.decodedBodySize > 0) return 'HIT';
+	// Heuristic: very fast response start ⇒ likely cache
+	if (entry.responseStart - entry.requestStart < 5) return 'HIT';
+	return 'MISS';
+};
+
+const getFormat = (video: HTMLVideoElement | null): string => {
+	if (!video?.currentSrc) return '—';
+	const src = video.currentSrc;
+	const ext = src.split('?')[0]?.split('#')[0]?.split('.').pop();
+	if (!ext) return 'unknown';
+	if (ext.toLowerCase() === 'm3u8') return 'HLS';
+	return ext.toUpperCase();
+};
+
+const useQueryParam = (name: string): string | null => {
+	const [value, setValue] = useState<string | null>(null);
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+		const params = new URLSearchParams(window.location.search);
+		setValue(params.get(name));
+	}, [name]);
+	return value;
+};
+
+export const SelfHostedVideoDebugOverlay = ({ videoRef, atomId }: Props) => {
+	const enabled = useQueryParam('videoDebug');
+	const [, force] = useState(0);
+
+	const loadStartRef = useRef<number | null>(null);
+	const startupRef = useRef<number | null>(null);
+	const hasPlayedRef = useRef(false);
+
+	useEffect(() => {
+		if (enabled !== '1') return;
+		const video = videoRef.current;
+		if (!video) return;
+
+		const rerender = () => force((n) => n + 1);
+
+		const onLoadStart = () => {
+			loadStartRef.current = performance.now();
+			startupRef.current = null;
+			hasPlayedRef.current = false;
+			rerender();
+		};
+		const onPlaying = () => {
+			if (
+				!hasPlayedRef.current &&
+				loadStartRef.current !== null &&
+				startupRef.current === null
+			) {
+				startupRef.current = Math.round(
+					performance.now() - loadStartRef.current,
+				);
+			}
+			hasPlayedRef.current = true;
+			rerender();
+		};
+		const passthrough = () => rerender();
+
+		video.addEventListener('loadstart', onLoadStart);
+		video.addEventListener('playing', onPlaying);
+		video.addEventListener('loadedmetadata', passthrough);
+		video.addEventListener('canplay', passthrough);
+		video.addEventListener('pause', passthrough);
+		video.addEventListener('ended', passthrough);
+		video.addEventListener('ratechange', passthrough);
+		video.addEventListener('volumechange', passthrough);
+
+		// Re-render every second so connection / cache snapshots stay fresh
+		const interval = window.setInterval(rerender, 1000);
+
+		return () => {
+			video.removeEventListener('loadstart', onLoadStart);
+			video.removeEventListener('playing', onPlaying);
+			video.removeEventListener('loadedmetadata', passthrough);
+			video.removeEventListener('canplay', passthrough);
+			video.removeEventListener('pause', passthrough);
+			video.removeEventListener('ended', passthrough);
+			video.removeEventListener('ratechange', passthrough);
+			video.removeEventListener('volumechange', passthrough);
+			window.clearInterval(interval);
+		};
+	}, [enabled, videoRef]);
+
+	if (enabled !== '1') return null;
+
+	const video = videoRef.current;
+	const format = getFormat(video);
+	const cache = video?.currentSrc
+		? getCacheStatus(video.currentSrc)
+		: 'UNKNOWN';
+	const startup =
+		startupRef.current !== null ? `${startupRef.current}ms` : '—';
+
+	const readyState = (() => {
+		switch (video?.readyState) {
+			case 0:
+				return 'HAVE_NOTHING';
+			case 1:
+				return 'HAVE_METADATA';
+			case 2:
+				return 'HAVE_CURRENT_DATA';
+			case 3:
+				return 'HAVE_FUTURE_DATA';
+			case 4:
+				return 'HAVE_ENOUGH_DATA';
+			default:
+				return '—';
+		}
+	})();
+
+	const state = video
+		? `${readyState}${video.paused ? ' · paused' : ' · playing'}${
+				video.muted ? ' · muted' : ''
+		  }`
+		: '—';
+
+	const lines = [
+		`ATOM:    ${atomId}`,
+		`FORMAT:  ${format}`,
+		`STARTUP: ${startup}`,
+		`CACHE:   ${cache}`,
+		`STATE:   ${state}`,
+	];
+
+	return <div css={overlayStyles}>{lines.join('\n')}</div>;
+};

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -249,7 +249,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 						showSubtitles && subtitleFontStyles(subtitleSize),
 						showCustomSubtitles && hideNativeSubtitlesStyles,
 					]}
-					crossOrigin="anonymous"
 					ref={ref}
 					tabIndex={0}
 					data-testid="self-hosted-video-player"
@@ -282,22 +281,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 						<source
 							key={mimeType}
 							/* The start time is set to 1ms so that Safari will autoplay the video */
-							src={`${src}#t=0.001`}
+							src={`${src}?cache=break#t=0.001`}
 							type={mimeType}
 						/>
 					))}
-					{showSubtitles && (
-						<track
-							/**
-							 * On iOS/WebKit, `default` forces native subtitle rendering.
-							 * Disable it when custom subtitles are enabled.
-							 */
-							default={!showCustomSubtitles}
-							kind="subtitles"
-							src={subtitleSource}
-							srcLang="en"
-						/>
-					)}
 					{FallbackImageComponent}
 				</video>
 				{showCustomSubtitles && !!activeCue?.text && (

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -190,3 +190,19 @@ export const formatTimeForDisplay = (timeInSeconds: number): string => {
 
 	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 };
+
+export const getVideoFormat = (): SupportedVideoFileType => {
+	const param = new URLSearchParams(location.search).get('videoFormat');
+
+	switch (param) {
+		case 'mp4':
+			return 'video/mp4';
+		case 'hls':
+			return 'application/vnd.apple.mpegurl';
+
+		case 'hls-alt':
+			return 'application/x-mpegURL';
+		default:
+			return 'video/mp4';
+	}
+};


### PR DESCRIPTION
## What does this change?
A branch to test the performance of video types across browsers. 

Not for production
## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
