### PR TITLE
Refactor hosted onwards component

### DIFF
--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -15,22 +15,21 @@ type HostedContentOnwardsProps = {
 	accentColor?: string;
 };
 
-const headerStyles = (accentColor?: string) => css`
+const headerStyles = css`
 	margin-bottom: ${space[1]}px;
-	border-top: ${space[2]}px solid
-		${accentColor ? accentColor : sourcePalette.neutral[7]};
-
-	span {
-		${textSansBold20}
-		display: block;
-		color: ${accentColor ? accentColor : sourcePalette.neutral[7]};
-	}
+	border-top: ${space[2]}px solid var(--accent-colour);
 `;
 
 const headingStyles = css`
 	${textSans17}
 	padding-top: ${space[2]}px;
 	color: ${sourcePalette.neutral[7]};
+
+	span {
+		${textSansBold20}
+		display: block;
+		color: var(--accent-colour);
+	}
 `;
 
 const stackedCardsStyles = css`
@@ -55,24 +54,27 @@ export const HostedContentOnwards = ({
 	accentColor,
 }: HostedContentOnwardsProps) => {
 	return (
-		<div>
-			<header css={headerStyles(accentColor)}>
+		<div
+			css={css`
+				--accent-colour: ${accentColor ?? sourcePalette.neutral[7]};
+			`}
+		>
+			<header css={headerStyles}>
 				<h2 css={headingStyles}>
 					More from
-					<span> {brandName}</span>
+					<span>{brandName}</span>
 				</h2>
 			</header>
-			<main>
-				<div css={stackedCardsStyles}>
-					{trails.map((trail) => {
-						return (
-							<div key={trail.url} css={stackedCardWrapper}>
-								<HostedContentOnwardsCard trail={trail} />
-							</div>
-						);
-					})}
-				</div>
-			</main>
+
+			<ul css={stackedCardsStyles}>
+				{trails.map((trail) => {
+					return (
+						<li key={trail.url} css={stackedCardWrapper}>
+							<HostedContentOnwardsCard trail={trail} />
+						</li>
+					);
+				})}
+			</ul>
 		</div>
 	);
 };

--- a/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
@@ -46,7 +46,8 @@ const hoverStyles = css`
 const linkStyles = css`
 	display: flex;
 	flex-direction: row-reverse;
-	justify-content: flex-start;
+	/* Needed due to row-reverse direction */
+	justify-content: flex-end;
 	align-items: flex-start;
 	text-decoration: none;
 	gap: ${space[2]}px;

--- a/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
@@ -17,11 +17,6 @@ const imageStyles = css`
 	width: 120px;
 `;
 
-const imageWrapperStyles = css`
-	position: relative;
-	order: 1;
-`;
-
 const mediaOverlayContainerStyles = css`
 	position: absolute;
 	top: 0;
@@ -50,6 +45,7 @@ const hoverStyles = css`
 
 const linkStyles = css`
 	display: flex;
+	flex-direction: row-reverse;
 	justify-content: flex-start;
 	align-items: flex-start;
 	text-decoration: none;
@@ -62,19 +58,18 @@ const linkStyles = css`
 const headingStyles = css`
 	${textSansBold15}
 	color: ${palette('--card-headline')};
-	order: 2;
 `;
 
 const CardPicture = ({ image, alt }: CardPictureProps) => {
 	return (
-		<div css={imageWrapperStyles}>
+		<>
 			<picture>
 				<img alt={alt} src={image} css={imageStyles} />
 			</picture>
 			<div css={mediaOverlayContainerStyles}>
 				<div className="media-overlay" />
 			</div>
-		</div>
+		</>
 	);
 };
 
@@ -85,7 +80,7 @@ export const HostedContentOnwardsCard = ({ trail }: Props) => {
 			{!!trail.image && (
 				<CardPicture
 					image={trail.image.src}
-					alt={trail.image.altText || trail.headline}
+					alt={trail.image.altText || ''}
 				/>
 			)}
 		</a>


### PR DESCRIPTION
## What does this change?

Improves accessibility of the `HostedContentOnwards` component by:
- removing the additional `main` tag
- ensuring the onward cards are marked as list items
- removing the backup value for alt text, to avoid the headline being repeated twice by screen readers

Refactoring in other areas done to make the code easier for other developers to understand
- Sets the accent colour once at the top of the component in a CSS variable for use in the areas that need it underneath
- Uses `flex-direction: row-reverse` in the cards themselves rather than explicitly setting an order for each part

## Why?

Addressing some accessibility concerns raised in our screen reader review

_Tested with VoiceOver on MacOS_