### PR TITLE
Re-enable track manipulation

### DIFF
--- a/dotcom-rendering/src/lib/useSubtitles.ts
+++ b/dotcom-rendering/src/lib/useSubtitles.ts
@@ -34,6 +34,13 @@ export const useSubtitles = ({
 			/* We currently only support one text track per video, so we are OK to access [0] here. */
 			if (!track) return;
 
+			/* Keep track in 'showing' mode for iOS reliability.
+			 * We'll hide the native subtitles with CSS instead
+			 */
+			if (track.mode !== 'showing') {
+				track.mode = 'showing';
+			}
+
 			setActiveTrack(track);
 		};
 
@@ -62,6 +69,13 @@ export const useSubtitles = ({
 			return;
 		}
 
+		/* Keep track in 'showing' mode.
+		 * this makes iOS more reliable with cuechange events and activeCues
+		 */
+		if (track.mode !== 'showing') {
+			track.mode = 'showing';
+		}
+
 		/* listen to cuechange and set the active cue */
 		const onCueChange = () => {
 			const list = track.activeCues;
@@ -84,6 +98,8 @@ export const useSubtitles = ({
 
 		return () => {
 			track.removeEventListener('cuechange', onCueChange);
+			/* Keep it showing even on cleanup for consistency */
+			track.mode = 'showing';
 		};
 	}, [activeTrack, shouldShow, currentTime]);
 


### PR DESCRIPTION
## What does this change?
Re-enable track manipulation that was removed in https://github.com/guardian/dotcom-rendering/pull/15846.

## Why?
This is still required for rendering custom overlay.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/e18e391c-a62b-437b-b2fc-2d273f211f84
[after]: https://github.com/user-attachments/assets/a3710d30-e18d-420f-a81b-ca3c2e839763


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
