### PR TITLE
us-newsletter-hide-soft-opt-in

### DIFF
--- a/dotcom-rendering/.storybook/preview.ts
+++ b/dotcom-rendering/.storybook/preview.ts
@@ -30,6 +30,8 @@ sb.mock(import('../src/lib/fetchEmail.ts'), { spy: true });
 sb.mock(import('../src/lib/useNewsletterSignupForm.ts'), { spy: true });
 // @ts-ignore -- Storybook wants the file extension, TS does not.
 sb.mock(import('../src/lib/useAB.ts'), { spy: true });
+// @ts-ignore -- Storybook wants the file extension, TS does not.
+sb.mock(import('../src/lib/useCountryCode.ts'), { spy: true });
 
 // Prevent components being lazy rendered when we're taking Chromatic snapshots
 Lazy.disabled = isChromatic();

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.test.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import {
+	reportTrackingEvent,
+	requestMultipleSignUps,
+} from '../lib/newsletter-sign-up-requests';
+import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useCountryCode } from '../lib/useCountryCode';
+import { ConfigProvider } from './ConfigContext';
+import { ManyNewsletterSignUp } from './ManyNewsletterSignUp.island';
+import { BUTTON_ROLE } from './NewsletterCard';
+
+const NEWSLETTER_IDENTITY_NAME = 'morning-briefing';
+const NEWSLETTER_LIST_ID = 1234;
+const TEST_EMAIL = 'reader@example.com';
+const SIGN_UP_BUTTON_NAME = 'Sign up for the newsletter you selected';
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useAuthStatus: jest.fn().mockReturnValue({ kind: 'SignedOut' }),
+	useIsSignedIn: jest.fn(),
+}));
+
+jest.mock('../lib/useCountryCode', () => ({
+	useCountryCode: jest.fn(),
+}));
+
+jest.mock('../lib/newsletterSubscriptionCache', () => ({
+	clearSubscriptionCache: jest.fn(),
+}));
+
+jest.mock('../lib/newsletter-sign-up-requests', () => ({
+	reportTrackingEvent: jest.fn().mockResolvedValue(undefined),
+	requestMultipleSignUps: jest.fn(),
+}));
+
+jest.mock('react-google-recaptcha', () => ({
+	__esModule: true,
+	default: jest.fn().mockImplementation(() => null),
+}));
+
+const renderSignupForm = () =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<ManyNewsletterSignUp useReCaptcha={false} />
+		</ConfigProvider>,
+	);
+
+/**
+ * Adds a fake newsletter toggle button to the document body so that
+ * ManyNewsletterSignUp can discover it via its DOM event listeners.
+ * Must be added before renderSignupForm() so the useEffect attaches listeners.
+ */
+const addNewsletterButton = (
+	identityName: string,
+	listId: number,
+): HTMLButtonElement => {
+	const button = document.createElement('button');
+	button.setAttribute('data-role', BUTTON_ROLE);
+	button.setAttribute('data-identity-name', identityName);
+	button.setAttribute('data-list-id', String(listId));
+	document.body.appendChild(button);
+	return button;
+};
+
+const openSignupForm = async (
+	testUser: ReturnType<typeof user.setup>,
+): Promise<void> => {
+	const newsletterButton = addNewsletterButton(
+		NEWSLETTER_IDENTITY_NAME,
+		NEWSLETTER_LIST_ID,
+	);
+	renderSignupForm();
+	await testUser.click(newsletterButton);
+
+	await waitFor(() => {
+		expect(screen.getByLabelText('Enter your email')).toBeInTheDocument();
+	});
+};
+
+const submitForm = async (
+	testUser: ReturnType<typeof user.setup>,
+	email = TEST_EMAIL,
+): Promise<void> => {
+	await testUser.type(screen.getByLabelText('Enter your email'), email);
+	await testUser.click(
+		screen.getByRole('button', { name: SIGN_UP_BUTTON_NAME }),
+	);
+};
+
+describe('ManyNewsletterSignUp', () => {
+	const pageConfig = window.guardian.config
+		.page as typeof window.guardian.config.page & {
+		ajaxUrl?: string;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(useIsSignedIn as jest.Mock).mockReturnValue(false);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
+		(useCountryCode as jest.Mock).mockReturnValue(undefined);
+
+		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			false;
+
+		(requestMultipleSignUps as jest.Mock).mockResolvedValue({ ok: true });
+	});
+
+	afterEach(() => {
+		for (const el of document.querySelectorAll(
+			`[data-role=${BUTTON_ROLE}]`,
+		)) {
+			el.remove();
+		}
+	});
+
+	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+		beforeEach(() => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				true;
+		});
+
+		it('switch on + US + signed out: hides marketing checkbox, sends marketingOptInHidden=true', async () => {
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			await openSignupForm(testUser);
+
+			expect(
+				screen.queryByLabelText(/Get updates about our journalism/),
+			).not.toBeInTheDocument();
+
+			await submitForm(testUser);
+
+			await waitFor(() => {
+				expect(requestMultipleSignUps).toHaveBeenCalledWith(
+					TEST_EMAIL,
+					[NEWSLETTER_IDENTITY_NAME],
+					'',
+					true,
+					true,
+				);
+			});
+		});
+
+		it('switch on + US + signed out: tracking uses similar-guardian-products-optin-hidden-us', async () => {
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			await openSignupForm(testUser);
+			await submitForm(testUser);
+
+			await waitFor(() => {
+				expect(reportTrackingEvent).toHaveBeenCalledWith(
+					'ManyNewsletterSignUp',
+					'success-response',
+					expect.anything(),
+					expect.objectContaining({
+						marketingOptInType:
+							'similar-guardian-products-optin-hidden-us',
+					}),
+				);
+			});
+		});
+
+		it('switch on + non-US + signed out: shows checkbox, no marketingOptInHidden', async () => {
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue('GB');
+			await openSignupForm(testUser);
+
+			expect(
+				await screen.findByLabelText(
+					/Get updates about our journalism/,
+				),
+			).toBeInTheDocument();
+
+			await submitForm(testUser);
+
+			await waitFor(() => {
+				expect(requestMultipleSignUps).toHaveBeenCalledWith(
+					TEST_EMAIL,
+					[NEWSLETTER_IDENTITY_NAME],
+					'',
+					true,
+					undefined,
+				);
+			});
+		});
+
+		it('switch on + pending country (undefined) + signed out: shows checkbox', async () => {
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue(undefined);
+			await openSignupForm(testUser);
+
+			expect(
+				await screen.findByLabelText(
+					/Get updates about our journalism/,
+				),
+			).toBeInTheDocument();
+		});
+
+		it('switch on + US + signed in: checkbox not shown (signed-in), no marketingOptInHidden', async () => {
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			(useIsSignedIn as jest.Mock).mockReturnValue(true);
+			(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedIn' });
+			await openSignupForm(testUser);
+
+			expect(
+				screen.queryByLabelText(/Get updates about our journalism/),
+			).not.toBeInTheDocument();
+
+			await submitForm(testUser);
+
+			await waitFor(() => {
+				expect(requestMultipleSignUps).toHaveBeenCalledWith(
+					TEST_EMAIL,
+					[NEWSLETTER_IDENTITY_NAME],
+					'',
+					undefined,
+					undefined,
+				);
+			});
+		});
+
+		it('switch off + US + signed out: shows checkbox', async () => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				false;
+			const testUser = user.setup();
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			await openSignupForm(testUser);
+
+			expect(
+				await screen.findByLabelText(
+					/Get updates about our journalism/,
+				),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.test.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.test.tsx
@@ -108,8 +108,7 @@ describe('ManyNewsletterSignUp', () => {
 		(useCountryCode as jest.Mock).mockReturnValue(undefined);
 
 		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
-			false;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
 
 		(requestMultipleSignUps as jest.Mock).mockResolvedValue({ ok: true });
 	});
@@ -122,9 +121,9 @@ describe('ManyNewsletterSignUp', () => {
 		}
 	});
 
-	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+	describe('US hide marketing toggle (usSignupHideMarketingToggle switch)', () => {
 		beforeEach(() => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				true;
 		});
 
@@ -230,7 +229,7 @@ describe('ManyNewsletterSignUp', () => {
 		});
 
 		it('switch off + US + signed out: shows checkbox', async () => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				false;
 			const testUser = user.setup();
 			(useCountryCode as jest.Mock).mockReturnValue('US');

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -140,7 +140,7 @@ export const ManyNewsletterSignUp = ({
 	const authStatus = useAuthStatus();
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
 	/** True when the marketing toggle is hidden for this user due to country policy. */
-	const marketingOptInHidden = hideMarketingToggle && isSignedIn === false;
+	const marketingOptInHidden = hideMarketingToggle && isSignedIn !== true;
 
 	const [newslettersToSignUpFor, setNewslettersToSignUpFor] = useState<
 		Array<{
@@ -226,7 +226,7 @@ export const ManyNewsletterSignUp = ({
 	}, [status]);
 
 	useEffect(() => {
-		if (isSignedIn !== 'Pending' && !isSignedIn) {
+		if (isSignedIn !== true) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);
@@ -433,7 +433,7 @@ export const ManyNewsletterSignUp = ({
 							}}
 							newsletterCount={newslettersToSignUpFor.length}
 							marketingOptIn={
-								marketingOptInHidden
+								marketingOptInHidden || isSignedIn === true
 									? undefined
 									: marketingOptIn
 							}

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -19,6 +19,7 @@ import {
 } from '../lib/newsletter-sign-up-requests';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useHideMarketingToggleForCountry } from '../lib/useHideMarketingToggleForCountry';
 import { useConfig } from './ConfigContext';
 import { Flex } from './Flex';
 import { ManyNewslettersForm } from './ManyNewslettersForm';
@@ -137,6 +138,9 @@ export const ManyNewsletterSignUp = ({
 }: Props) => {
 	const isSignedIn = useIsSignedIn();
 	const authStatus = useAuthStatus();
+	const hideMarketingToggle = useHideMarketingToggleForCountry();
+	/** True when the marketing toggle is hidden for this user due to country policy. */
+	const marketingOptInHidden = hideMarketingToggle && isSignedIn === false;
 
 	const [newslettersToSignUpFor, setNewslettersToSignUpFor] = useState<
 		Array<{
@@ -248,6 +252,11 @@ export const ManyNewsletterSignUp = ({
 		const listIds = newslettersToSignUpFor.map(
 			(newsletter) => newsletter.listId,
 		);
+		const effectiveMarketingOptIn = marketingOptInHidden
+			? true
+			: marketingOptIn;
+		const shouldTrackMarketingOptInType =
+			marketingOptInHidden || marketingOptIn !== undefined;
 
 		void reportTrackingEvent(
 			'ManyNewsletterSignUp',
@@ -262,12 +271,15 @@ export const ManyNewsletterSignUp = ({
 			email,
 			identityNames,
 			reCaptchaToken,
-			marketingOptIn,
+			effectiveMarketingOptIn,
+			marketingOptInHidden ? true : undefined,
 		).catch(() => {
 			return undefined;
 		});
 
-		const marketingOptInType = marketingOptIn
+		const marketingOptInType = marketingOptInHidden
+			? 'similar-guardian-products-optin-hidden-us'
+			: effectiveMarketingOptIn
 			? 'similar-guardian-products-optin'
 			: 'similar-guardian-products-optout';
 
@@ -281,7 +293,9 @@ export const ManyNewsletterSignUp = ({
 				renderingTarget,
 				{
 					listIds,
-					...(marketingOptIn !== undefined && { marketingOptInType }),
+					...(shouldTrackMarketingOptInType && {
+						marketingOptInType,
+					}),
 					// If the backend handles the failure and responds with an informative
 					// error message (E.G. "Service unavailable", "Invalid email" etc) this
 					// should be included in the event data.
@@ -300,7 +314,7 @@ export const ManyNewsletterSignUp = ({
 			renderingTarget,
 			{
 				listIds,
-				...(marketingOptIn !== undefined && { marketingOptInType }),
+				...(shouldTrackMarketingOptInType && { marketingOptInType }),
 			},
 		);
 
@@ -418,7 +432,11 @@ export const ManyNewsletterSignUp = ({
 								status,
 							}}
 							newsletterCount={newslettersToSignUpFor.length}
-							marketingOptIn={marketingOptIn}
+							marketingOptIn={
+								marketingOptInHidden
+									? undefined
+									: marketingOptIn
+							}
 							setMarketingOptIn={setMarketingOptIn}
 							useReCaptcha={useReCaptcha}
 							captchaSiteKey={captchaSiteKey}

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -14,6 +14,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 // Use the default export instead.
 import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import {
+	getEffectiveMarketingOptIn,
+	getMarketingOptInType,
+} from '../lib/newsletter-marketing-opt-in';
+import {
 	reportTrackingEvent,
 	requestMultipleSignUps,
 } from '../lib/newsletter-sign-up-requests';
@@ -140,7 +144,8 @@ export const ManyNewsletterSignUp = ({
 	const authStatus = useAuthStatus();
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
 	/** True when the marketing toggle is hidden for this user due to country policy. */
-	const marketingOptInHidden = hideMarketingToggle && isSignedIn !== true;
+	const marketingOptInHiddenForCountry =
+		hideMarketingToggle && isSignedIn !== true;
 
 	const [newslettersToSignUpFor, setNewslettersToSignUpFor] = useState<
 		Array<{
@@ -252,11 +257,16 @@ export const ManyNewsletterSignUp = ({
 		const listIds = newslettersToSignUpFor.map(
 			(newsletter) => newsletter.listId,
 		);
-		const effectiveMarketingOptIn = marketingOptInHidden
-			? true
-			: marketingOptIn;
-		const shouldTrackMarketingOptInType =
-			marketingOptInHidden || marketingOptIn !== undefined;
+		const effectiveMarketingOptIn = getEffectiveMarketingOptIn({
+			marketingOptInHiddenForCountry,
+			isSignedIn,
+			marketingOptIn,
+		});
+		const marketingOptInType = getMarketingOptInType({
+			marketingOptInHiddenForCountry,
+			isSignedIn,
+			effectiveMarketingOptIn,
+		});
 
 		void reportTrackingEvent(
 			'ManyNewsletterSignUp',
@@ -272,16 +282,10 @@ export const ManyNewsletterSignUp = ({
 			identityNames,
 			reCaptchaToken,
 			effectiveMarketingOptIn,
-			marketingOptInHidden ? true : undefined,
+			marketingOptInHiddenForCountry ? true : undefined,
 		).catch(() => {
 			return undefined;
 		});
-
-		const marketingOptInType = marketingOptInHidden
-			? 'similar-guardian-products-optin-hidden-us'
-			: effectiveMarketingOptIn
-			? 'similar-guardian-products-optin'
-			: 'similar-guardian-products-optout';
 
 		if (!response?.ok) {
 			const responseText = response
@@ -293,14 +297,9 @@ export const ManyNewsletterSignUp = ({
 				renderingTarget,
 				{
 					listIds,
-					...(shouldTrackMarketingOptInType && {
+					...(marketingOptInType !== undefined && {
 						marketingOptInType,
 					}),
-					// If the backend handles the failure and responds with an informative
-					// error message (E.G. "Service unavailable", "Invalid email" etc) this
-					// should be included in the event data.
-					// If not, the response text will be the HTML for the default error page
-					// which would not be helpful to include it in the tracking data.
 					responseText: responseText.substring(0, 100),
 				},
 			);
@@ -314,7 +313,7 @@ export const ManyNewsletterSignUp = ({
 			renderingTarget,
 			{
 				listIds,
-				...(shouldTrackMarketingOptInType && { marketingOptInType }),
+				...(marketingOptInType !== undefined && { marketingOptInType }),
 			},
 		);
 
@@ -433,7 +432,8 @@ export const ManyNewsletterSignUp = ({
 							}}
 							newsletterCount={newslettersToSignUpFor.length}
 							marketingOptIn={
-								marketingOptInHidden || isSignedIn === true
+								marketingOptInHiddenForCountry ||
+								isSignedIn === true
 									? undefined
 									: marketingOptIn
 							}

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -231,7 +231,7 @@ export const ManyNewsletterSignUp = ({
 	}, [status]);
 
 	useEffect(() => {
-		if (isSignedIn === false) {
+		if (isSignedIn !== true) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -145,7 +145,7 @@ export const ManyNewsletterSignUp = ({
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
 	/** True when the marketing toggle is hidden for this user due to country policy. */
 	const marketingOptInHiddenForCountry =
-		hideMarketingToggle && isSignedIn !== true;
+		hideMarketingToggle && isSignedIn === false;
 
 	const [newslettersToSignUpFor, setNewslettersToSignUpFor] = useState<
 		Array<{
@@ -231,7 +231,7 @@ export const ManyNewsletterSignUp = ({
 	}, [status]);
 
 	useEffect(() => {
-		if (isSignedIn !== true) {
+		if (isSignedIn === false) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);

--- a/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
+++ b/dotcom-rendering/src/components/ManyNewsletterSignUp.island.tsx
@@ -231,7 +231,7 @@ export const ManyNewsletterSignUp = ({
 	}, [status]);
 
 	useEffect(() => {
-		if (isSignedIn !== true) {
+		if (isSignedIn !== 'Pending' && !isSignedIn) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -82,7 +82,7 @@ const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
 	isInteracted: false,
 	showMarketingToggle: false,
 	marketingOptIn: undefined,
-	marketingOptInHidden: false,
+	marketingOptInHiddenForCountry: false,
 	isWaitingForResponse: false,
 	responseOk: undefined,
 	errorMessage: undefined,

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -2,6 +2,7 @@ import { createRef } from 'react';
 import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { fn, mocked } from 'storybook/test';
 import preview from '../../.storybook/preview';
+import { useCountryCode } from '../lib/useCountryCode';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import type { NewsletterSignupFormState } from '../lib/useNewsletterSignupForm';
 import type { NewsletterPreviewAction } from './NewsletterPreviewButton';
@@ -81,6 +82,7 @@ const mockForm = (state: Partial<NewsletterSignupFormState>) => ({
 	isInteracted: false,
 	showMarketingToggle: false,
 	marketingOptIn: undefined,
+	marketingOptInHidden: false,
 	isWaitingForResponse: false,
 	responseOk: undefined,
 	errorMessage: undefined,
@@ -241,5 +243,31 @@ export const AlreadySubscribed = meta.story({
 	parameters: { isSignedIn: true },
 	beforeEach() {
 		mocked(useNewsletterSignupForm).mockReturnValue(mockForm({}));
+	},
+});
+
+/**
+ * US user — marketing toggle is hidden and the user is silently enrolled in
+ * similar_guardian_products.
+ */
+export const USHideMarketingToggle = meta.story({
+	args: defaultArgs,
+	beforeEach() {
+		mocked(useCountryCode).mockReturnValue('US');
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			true;
+		mocked(useNewsletterSignupForm).mockReturnValue(
+			mockForm({
+				userEmail: 'reader@example.com',
+				isInteracted: true,
+				showMarketingToggle: false,
+				marketingOptIn: true,
+			}),
+		);
+	},
+	afterEach() {
+		mocked(useCountryCode).mockReset();
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			false;
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.stories.tsx
@@ -254,8 +254,7 @@ export const USHideMarketingToggle = meta.story({
 	args: defaultArgs,
 	beforeEach() {
 		mocked(useCountryCode).mockReturnValue('US');
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
-			true;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = true;
 		mocked(useNewsletterSignupForm).mockReturnValue(
 			mockForm({
 				userEmail: 'reader@example.com',
@@ -267,7 +266,6 @@ export const USHideMarketingToggle = meta.story({
 	},
 	afterEach() {
 		mocked(useCountryCode).mockReset();
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
-			false;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
 	},
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -6,6 +6,7 @@ import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
 import { useBrowserId } from '../lib/useBrowserId';
+import { useCountryCode } from '../lib/useCountryCode';
 import { ConfigProvider } from './ConfigContext';
 import { NewsletterSignupForm } from './NewsletterSignupForm.island';
 
@@ -28,6 +29,10 @@ jest.mock('../lib/useAuthStatus', () => ({
 
 jest.mock('../lib/useBrowserId', () => ({
 	useBrowserId: jest.fn(),
+}));
+
+jest.mock('../lib/useCountryCode', () => ({
+	useCountryCode: jest.fn(),
 }));
 
 type RecaptchaProps = {
@@ -95,6 +100,26 @@ const getTrackedEventDescription = (call: unknown[]): string => {
 	return value.eventDescription;
 };
 
+const getTrackedPayloadForEvent = (
+	eventDescription: string,
+): { eventDescription: string; marketingOptInType?: string } | undefined => {
+	const trackingCalls = (submitComponentEvent as jest.Mock).mock
+		.calls as Array<[{ value: string }]>;
+
+	for (const [payload] of trackingCalls) {
+		const parsed = JSON.parse(payload.value) as {
+			eventDescription: string;
+			marketingOptInType?: string;
+		};
+
+		if (parsed.eventDescription === eventDescription) {
+			return parsed;
+		}
+	}
+
+	return undefined;
+};
+
 const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
 	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
 		callIndex
@@ -136,6 +161,7 @@ describe('NewsletterSignupForm', () => {
 		(useIsSignedIn as jest.Mock).mockReturnValue(false);
 		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
 		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
+		(useCountryCode as jest.Mock).mockReturnValue(undefined);
 		(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
 			Promise.resolve(null),
 		);
@@ -144,6 +170,8 @@ describe('NewsletterSignupForm', () => {
 		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
 		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			false;
 		if (window.guardian.ophan) {
 			window.guardian.ophan.pageViewId = 'test-page-view-id';
 		}
@@ -192,6 +220,13 @@ describe('NewsletterSignupForm', () => {
 			'form-submission',
 			'submission-confirmed',
 		]);
+		expect(
+			getTrackedPayloadForEvent('form-submission')?.marketingOptInType,
+		).toBe('similar-guardian-products-optin');
+		expect(
+			getTrackedPayloadForEvent('submission-confirmed')
+				?.marketingOptInType,
+		).toBe('similar-guardian-products-optin');
 	});
 
 	it('supports tab order from email input to marketing toggle to sign up', async () => {
@@ -230,6 +265,13 @@ describe('NewsletterSignupForm', () => {
 
 		const params = getRequestBodyParams();
 		expect(params.get('marketing')).toBe('false');
+		expect(
+			getTrackedPayloadForEvent('form-submission')?.marketingOptInType,
+		).toBe('similar-guardian-products-optout');
+		expect(
+			getTrackedPayloadForEvent('submission-confirmed')
+				?.marketingOptInType,
+		).toBe('similar-guardian-products-optout');
 	});
 
 	it('supports keyboard interaction for marketing toggle and submit button', async () => {
@@ -443,5 +485,135 @@ describe('NewsletterSignupForm', () => {
 		expect(
 			screen.getByRole('button', { name: 'Sign up' }),
 		).toBeInTheDocument();
+	});
+
+	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+		beforeEach(() => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				true;
+		});
+
+		it('switch on + US + signed out: hides toggle, sends marketing=true and marketingOptInHidden=true', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			const testUser = user.setup();
+			renderForm();
+
+			await typeEmailAddress(testUser);
+
+			expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+
+			await testUser.click(
+				screen.getByRole('button', { name: 'Sign up' }),
+			);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			const params = getRequestBodyParams();
+			expect(params.get('marketing')).toBe('true');
+			expect(params.get('marketingOptInHidden')).toBe('true');
+			expect(
+				getTrackedPayloadForEvent('form-submission')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin-hidden-us');
+			expect(
+				getTrackedPayloadForEvent('submission-confirmed')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin-hidden-us');
+		});
+
+		it('switch on + non-US + signed out: shows toggle, does not send marketingOptInHidden', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('GB');
+			const testUser = user.setup();
+			renderForm();
+
+			await typeEmailAddress(testUser);
+
+			expect(screen.getByRole('switch')).toBeInTheDocument();
+
+			await testUser.click(
+				screen.getByRole('button', { name: 'Sign up' }),
+			);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			expect(
+				getRequestBodyParams().get('marketingOptInHidden'),
+			).toBeNull();
+			expect(
+				getTrackedPayloadForEvent('form-submission')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin');
+			expect(
+				getTrackedPayloadForEvent('submission-confirmed')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin');
+		});
+
+		it('switch on + pending country (undefined) + signed out: shows toggle', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue(undefined);
+			const testUser = user.setup();
+			renderForm();
+
+			await typeEmailAddress(testUser);
+
+			expect(screen.getByRole('switch')).toBeInTheDocument();
+		});
+
+		it('switch on + US + signed in: toggle not shown (signed-in behaviour), no marketingOptInHidden', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			(useIsSignedIn as jest.Mock).mockReturnValue(true);
+			(useAuthStatus as jest.Mock).mockReturnValue({
+				kind: 'SignedIn',
+				accessToken: { accessToken: 'token' },
+				idToken: { claims: { email: 'signed.in@example.com' } },
+			});
+			(lazyFetchEmailWithTimeout as jest.Mock).mockReturnValue(() =>
+				Promise.resolve('signed.in@example.com'),
+			);
+
+			renderForm();
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole('button', { name: 'Sign up' }),
+				).toBeInTheDocument();
+			});
+
+			expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+
+			const testUser = user.setup();
+			await testUser.click(
+				screen.getByRole('button', { name: 'Sign up' }),
+			);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			expect(
+				getRequestBodyParams().get('marketingOptInHidden'),
+			).toBeNull();
+			expect(
+				getTrackedPayloadForEvent('form-submission')
+					?.marketingOptInType,
+			).toBeUndefined();
+			expect(
+				getTrackedPayloadForEvent('submission-confirmed')
+					?.marketingOptInType,
+			).toBeUndefined();
+		});
+
+		it('switch off + US + signed out: shows toggle', async () => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				false;
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			const testUser = user.setup();
+			renderForm();
+
+			await typeEmailAddress(testUser);
+
+			expect(screen.getByRole('switch')).toBeInTheDocument();
+		});
 	});
 });

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -170,8 +170,7 @@ describe('NewsletterSignupForm', () => {
 		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
 		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
-			false;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
 		if (window.guardian.ophan) {
 			window.guardian.ophan.pageViewId = 'test-page-view-id';
 		}
@@ -487,9 +486,9 @@ describe('NewsletterSignupForm', () => {
 		).toBeInTheDocument();
 	});
 
-	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+	describe('US hide marketing toggle (usSignupHideMarketingToggle switch)', () => {
 		beforeEach(() => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				true;
 		});
 
@@ -605,7 +604,7 @@ describe('NewsletterSignupForm', () => {
 		});
 
 		it('switch off + US + signed out: shows toggle', async () => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				false;
 			(useCountryCode as jest.Mock).mockReturnValue('US');
 			const testUser = user.setup();

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -17,6 +17,7 @@ import { ToggleSwitch } from '@guardian/source-development-kitchen/react-compone
 // Use the default export instead.
 import type { ChangeEvent } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
+import { useHideMarketingToggleForCountry } from '../lib/useHideMarketingToggleForCountry';
 import { useNewsletterSignupForm } from '../lib/useNewsletterSignupForm';
 import { palette } from '../palette';
 import { useConfig } from './ConfigContext';
@@ -273,6 +274,7 @@ const NewsletterSignupFormActive = ({
 	abTest,
 }: Omit<Props, 'isAlreadySubscribed'>) => {
 	const { renderingTarget } = useConfig();
+	const hideMarketingToggle = useHideMarketingToggleForCountry();
 
 	const {
 		userEmail,
@@ -295,7 +297,12 @@ const NewsletterSignupFormActive = ({
 		handleSubmit,
 		handleSubmitButtonClick,
 		handleReset,
-	} = useNewsletterSignupForm(newsletterId, renderingTarget, abTest);
+	} = useNewsletterSignupForm(
+		newsletterId,
+		renderingTarget,
+		abTest,
+		hideMarketingToggle,
+	);
 
 	const hasResponse = typeof responseOk === 'boolean';
 	const hasNonValidationError = !!errorMessage && !isValidationError;

--- a/dotcom-rendering/src/components/SecureSignup.island.test.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.test.tsx
@@ -1,0 +1,273 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { forwardRef, useImperativeHandle } from 'react';
+import { sendNewsletterSignupEvent } from '../lib/newsletterSignupTracking';
+import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
+import { useBrowserId } from '../lib/useBrowserId';
+import { useCountryCode } from '../lib/useCountryCode';
+import { ConfigProvider } from './ConfigContext';
+import { SecureSignup } from './SecureSignup.island';
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useAuthStatus: jest.fn(),
+	useIsSignedIn: jest.fn(),
+}));
+
+jest.mock('../lib/useBrowserId', () => ({
+	useBrowserId: jest.fn(),
+}));
+
+jest.mock('../lib/useCountryCode', () => ({
+	useCountryCode: jest.fn(),
+}));
+
+jest.mock('../lib/fetchEmail', () => ({
+	lazyFetchEmailWithTimeout: jest.fn(() => () => Promise.resolve(null)),
+}));
+
+jest.mock('../lib/newsletterSignupTracking', () => ({
+	EVENT_DESCRIPTION_TO_ACTION: {},
+	NEWSLETTER_SIGNUP_COMPONENT_ID: { control: () => 'test-id' },
+	sendNewsletterSignupEvent: jest.fn(),
+}));
+
+type RecaptchaProps = {
+	// eslint-disable-next-line react/no-unused-prop-types -- false positive
+	onChange?: (token: string | null) => void;
+	// eslint-disable-next-line react/no-unused-prop-types -- false positive
+	onError?: () => void;
+};
+type RecaptchaHandle = { execute: () => void; reset: () => void };
+
+// The default mock resolves the captcha immediately with a valid token.
+let recaptchaBehaviour: (
+	handle: RecaptchaHandle,
+	props: RecaptchaProps,
+) => void = (_handle, props) => props.onChange?.('test-recaptcha-token');
+
+jest.mock('react-google-recaptcha', () => ({
+	__esModule: true,
+	default: forwardRef<RecaptchaHandle, RecaptchaProps>(
+		function MockRecaptcha(props, ref) {
+			useImperativeHandle(ref, () => ({
+				execute: () =>
+					recaptchaBehaviour(
+						{ execute: () => undefined, reset: () => undefined },
+						props,
+					),
+				reset: () => undefined,
+			}));
+			return null;
+		},
+	),
+}));
+
+const renderSecureSignup = () =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<SecureSignup
+				newsletterId="morning-briefing"
+				successDescription="You'll receive Morning Briefing every weekday."
+			/>
+		</ConfigProvider>,
+	);
+
+const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
+	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
+		callIndex
+	] as [string, RequestInit];
+	// eslint-disable-next-line @typescript-eslint/no-base-to-string -- just a test
+	return new URLSearchParams(requestInit.body?.toString() ?? '');
+};
+
+const getTrackingPayloadForEvent = (eventDescription: string) => {
+	const trackingCalls = (sendNewsletterSignupEvent as jest.Mock).mock
+		.calls as Array<
+		[
+			{
+				value: {
+					eventDescription: string;
+					marketingOptInType?: string;
+				};
+			},
+		]
+	>;
+
+	for (const [payload] of trackingCalls) {
+		if (payload.value.eventDescription === eventDescription) {
+			return payload.value;
+		}
+	}
+
+	return undefined;
+};
+
+describe('SecureSignup — US marketing toggle hiding', () => {
+	const pageConfig = window.guardian.config
+		.page as typeof window.guardian.config.page & {
+		ajaxUrl?: string;
+		idApiUrl?: string;
+		googleRecaptchaSiteKey?: string;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		recaptchaBehaviour = (_handle, props) =>
+			props.onChange?.('test-recaptcha-token');
+
+		(useIsSignedIn as jest.Mock).mockReturnValue(false);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
+		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
+		(useCountryCode as jest.Mock).mockReturnValue(undefined);
+
+		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
+		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
+		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			false;
+		if (window.guardian.ophan) {
+			window.guardian.ophan.pageViewId = 'test-page-view-id';
+		}
+		global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+	});
+
+	// captchaSiteKey is set in a useEffect — wait for the reCAPTCHA widget
+	// to mount before typing and submitting.
+	const typeEmailAndSubmit = async (
+		testUser: ReturnType<typeof user.setup>,
+	) => {
+		await waitFor(() =>
+			expect(
+				screen.getByRole('button', { name: 'Sign up' }),
+			).toBeInTheDocument(),
+		);
+		await testUser.type(
+			screen.getByLabelText('Enter your email address'),
+			'reader@example.com',
+		);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+	};
+
+	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+		beforeEach(() => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				true;
+		});
+
+		it('switch on + US + signed out: hides marketing checkbox, sends marketing=true and marketingOptInHidden=true', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			const testUser = user.setup();
+
+			renderSecureSignup();
+
+			expect(
+				screen.queryByLabelText(
+					'Get updates about our journalism and ways to support and enjoy our work.',
+				),
+			).not.toBeInTheDocument();
+
+			await typeEmailAndSubmit(testUser);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			const params = getRequestBodyParams();
+			expect(params.get('marketing')).toBe('true');
+			expect(params.get('marketingOptInHidden')).toBe('true');
+			expect(
+				getTrackingPayloadForEvent('form-submission')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin-hidden-us');
+			expect(
+				getTrackingPayloadForEvent('submission-confirmed')
+					?.marketingOptInType,
+			).toBe('similar-guardian-products-optin-hidden-us');
+		});
+
+		it('switch on + non-US + signed out: shows marketing checkbox, no marketingOptInHidden', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('GB');
+			const testUser = user.setup();
+
+			renderSecureSignup();
+
+			expect(
+				screen.getByLabelText(
+					'Get updates about our journalism and ways to support and enjoy our work.',
+				),
+			).toBeInTheDocument();
+
+			await typeEmailAndSubmit(testUser);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			expect(
+				getRequestBodyParams().get('marketingOptInHidden'),
+			).toBeNull();
+		});
+
+		it('switch on + pending country (undefined) + signed out: shows marketing checkbox', () => {
+			(useCountryCode as jest.Mock).mockReturnValue(undefined);
+			renderSecureSignup();
+
+			expect(
+				screen.getByLabelText(
+					'Get updates about our journalism and ways to support and enjoy our work.',
+				),
+			).toBeInTheDocument();
+		});
+
+		it('switch on + US + signed in: checkbox hidden by signed-in, no marketingOptInHidden', async () => {
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			(useIsSignedIn as jest.Mock).mockReturnValue(true);
+			(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedIn' });
+			const testUser = user.setup();
+
+			renderSecureSignup();
+
+			expect(
+				screen.queryByLabelText(
+					'Get updates about our journalism and ways to support and enjoy our work.',
+				),
+			).not.toBeInTheDocument();
+
+			await typeEmailAndSubmit(testUser);
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalled();
+			});
+
+			expect(
+				getRequestBodyParams().get('marketingOptInHidden'),
+			).toBeNull();
+			expect(
+				getTrackingPayloadForEvent('form-submission')
+					?.marketingOptInType,
+			).toBeUndefined();
+			expect(
+				getTrackingPayloadForEvent('submission-confirmed')
+					?.marketingOptInType,
+			).toBeUndefined();
+		});
+
+		it('switch off + US + signed out: shows marketing checkbox', () => {
+			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+				false;
+			(useCountryCode as jest.Mock).mockReturnValue('US');
+			renderSecureSignup();
+
+			expect(
+				screen.getByLabelText(
+					'Get updates about our journalism and ways to support and enjoy our work.',
+				),
+			).toBeInTheDocument();
+		});
+	});
+});

--- a/dotcom-rendering/src/components/SecureSignup.island.test.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.test.tsx
@@ -62,22 +62,23 @@ jest.mock('react-google-recaptcha', () => ({
 	),
 }));
 
-const renderSecureSignup = () =>
-	render(
-		<ConfigProvider
-			value={{
-				renderingTarget: 'Web',
-				darkModeAvailable: false,
-				assetOrigin: '/',
-				editionId: 'UK',
-			}}
-		>
-			<SecureSignup
-				newsletterId="morning-briefing"
-				successDescription="You'll receive Morning Briefing every weekday."
-			/>
-		</ConfigProvider>,
-	);
+const secureSignupElement = () => (
+	<ConfigProvider
+		value={{
+			renderingTarget: 'Web',
+			darkModeAvailable: false,
+			assetOrigin: '/',
+			editionId: 'UK',
+		}}
+	>
+		<SecureSignup
+			newsletterId="morning-briefing"
+			successDescription="You'll receive Morning Briefing every weekday."
+		/>
+	</ConfigProvider>
+);
+
+const renderSecureSignup = () => render(secureSignupElement());
 
 const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
 	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[

--- a/dotcom-rendering/src/components/SecureSignup.island.test.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.test.tsx
@@ -132,8 +132,7 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
 		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
 		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
-			false;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
 		if (window.guardian.ophan) {
 			window.guardian.ophan.pageViewId = 'test-page-view-id';
 		}
@@ -157,9 +156,9 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
 	};
 
-	describe('US hide marketing toggle (us-signup-hide-marketing-toggle switch)', () => {
+	describe('US hide marketing toggle (usSignupHideMarketingToggle switch)', () => {
 		beforeEach(() => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				true;
 		});
 
@@ -259,7 +258,7 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 		});
 
 		it('switch off + US + signed out: shows marketing checkbox', () => {
-			window.guardian.config.switches['us-signup-hide-marketing-toggle'] =
+			window.guardian.config.switches['usSignupHideMarketingToggle'] =
 				false;
 			(useCountryCode as jest.Mock).mockReturnValue('US');
 			renderSecureSignup();

--- a/dotcom-rendering/src/components/SecureSignup.island.test.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.test.tsx
@@ -113,8 +113,6 @@ const getTrackingPayloadForEvent = (eventDescription: string) => {
 describe('SecureSignup — US marketing toggle hiding', () => {
 	const pageConfig = window.guardian.config
 		.page as typeof window.guardian.config.page & {
-		ajaxUrl?: string;
-		idApiUrl?: string;
 		googleRecaptchaSiteKey?: string;
 	};
 
@@ -129,8 +127,6 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
 		(useCountryCode as jest.Mock).mockReturnValue(undefined);
 
-		pageConfig.ajaxUrl = 'https://api.nextgen.guardianapps.co.uk';
-		pageConfig.idApiUrl = 'https://idapi.nextgen.guardianapps.co.uk';
 		pageConfig.googleRecaptchaSiteKey = 'test-site-key';
 		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
 		if (window.guardian.ophan) {
@@ -156,118 +152,108 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
 	};
 
-	describe('US hide marketing toggle (usSignupHideMarketingToggle switch)', () => {
-		beforeEach(() => {
-			window.guardian.config.switches['usSignupHideMarketingToggle'] =
-				true;
+	beforeEach(() => {
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = true;
+	});
+
+	it('switch on + US + signed out: hides marketing checkbox, sends marketing=true and marketingOptInHidden=true', async () => {
+		(useCountryCode as jest.Mock).mockReturnValue('US');
+		const testUser = user.setup();
+
+		renderSecureSignup();
+
+		expect(
+			screen.queryByLabelText(
+				'Get updates about our journalism and ways to support and enjoy our work.',
+			),
+		).not.toBeInTheDocument();
+
+		await typeEmailAndSubmit(testUser);
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalled();
 		});
 
-		it('switch on + US + signed out: hides marketing checkbox, sends marketing=true and marketingOptInHidden=true', async () => {
-			(useCountryCode as jest.Mock).mockReturnValue('US');
-			const testUser = user.setup();
+		const params = getRequestBodyParams();
+		expect(params.get('marketing')).toBe('true');
+		expect(params.get('marketingOptInHidden')).toBe('true');
+		expect(
+			getTrackingPayloadForEvent('form-submission')?.marketingOptInType,
+		).toBe('similar-guardian-products-optin-hidden-us');
+		expect(
+			getTrackingPayloadForEvent('submission-confirmed')
+				?.marketingOptInType,
+		).toBe('similar-guardian-products-optin-hidden-us');
+	});
 
-			renderSecureSignup();
+	it('switch on + non-US + signed out: shows marketing checkbox, no marketingOptInHidden', async () => {
+		(useCountryCode as jest.Mock).mockReturnValue('GB');
+		const testUser = user.setup();
 
-			expect(
-				screen.queryByLabelText(
-					'Get updates about our journalism and ways to support and enjoy our work.',
-				),
-			).not.toBeInTheDocument();
+		renderSecureSignup();
 
-			await typeEmailAndSubmit(testUser);
-			await waitFor(() => {
-				expect(global.fetch).toHaveBeenCalled();
-			});
+		expect(
+			screen.getByLabelText(
+				'Get updates about our journalism and ways to support and enjoy our work.',
+			),
+		).toBeInTheDocument();
 
-			const params = getRequestBodyParams();
-			expect(params.get('marketing')).toBe('true');
-			expect(params.get('marketingOptInHidden')).toBe('true');
-			expect(
-				getTrackingPayloadForEvent('form-submission')
-					?.marketingOptInType,
-			).toBe('similar-guardian-products-optin-hidden-us');
-			expect(
-				getTrackingPayloadForEvent('submission-confirmed')
-					?.marketingOptInType,
-			).toBe('similar-guardian-products-optin-hidden-us');
+		await typeEmailAndSubmit(testUser);
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalled();
 		});
 
-		it('switch on + non-US + signed out: shows marketing checkbox, no marketingOptInHidden', async () => {
-			(useCountryCode as jest.Mock).mockReturnValue('GB');
-			const testUser = user.setup();
+		expect(getRequestBodyParams().get('marketingOptInHidden')).toBeNull();
+	});
 
-			renderSecureSignup();
+	it('switch on + pending country (undefined) + signed out: shows marketing checkbox', () => {
+		(useCountryCode as jest.Mock).mockReturnValue(undefined);
+		renderSecureSignup();
 
-			expect(
-				screen.getByLabelText(
-					'Get updates about our journalism and ways to support and enjoy our work.',
-				),
-			).toBeInTheDocument();
+		expect(
+			screen.getByLabelText(
+				'Get updates about our journalism and ways to support and enjoy our work.',
+			),
+		).toBeInTheDocument();
+	});
 
-			await typeEmailAndSubmit(testUser);
-			await waitFor(() => {
-				expect(global.fetch).toHaveBeenCalled();
-			});
+	it('switch on + US + signed in: checkbox hidden by signed-in, no marketingOptInHidden', async () => {
+		(useCountryCode as jest.Mock).mockReturnValue('US');
+		(useIsSignedIn as jest.Mock).mockReturnValue(true);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedIn' });
+		const testUser = user.setup();
 
-			expect(
-				getRequestBodyParams().get('marketingOptInHidden'),
-			).toBeNull();
+		renderSecureSignup();
+
+		expect(
+			screen.queryByLabelText(
+				'Get updates about our journalism and ways to support and enjoy our work.',
+			),
+		).not.toBeInTheDocument();
+
+		await typeEmailAndSubmit(testUser);
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalled();
 		});
 
-		it('switch on + pending country (undefined) + signed out: shows marketing checkbox', () => {
-			(useCountryCode as jest.Mock).mockReturnValue(undefined);
-			renderSecureSignup();
+		expect(getRequestBodyParams().get('marketingOptInHidden')).toBeNull();
+		expect(
+			getTrackingPayloadForEvent('form-submission')?.marketingOptInType,
+		).toBeUndefined();
+		expect(
+			getTrackingPayloadForEvent('submission-confirmed')
+				?.marketingOptInType,
+		).toBeUndefined();
+	});
 
-			expect(
-				screen.getByLabelText(
-					'Get updates about our journalism and ways to support and enjoy our work.',
-				),
-			).toBeInTheDocument();
-		});
+	it('switch off + US + signed out: shows marketing checkbox', () => {
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
+		(useCountryCode as jest.Mock).mockReturnValue('US');
+		renderSecureSignup();
 
-		it('switch on + US + signed in: checkbox hidden by signed-in, no marketingOptInHidden', async () => {
-			(useCountryCode as jest.Mock).mockReturnValue('US');
-			(useIsSignedIn as jest.Mock).mockReturnValue(true);
-			(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedIn' });
-			const testUser = user.setup();
-
-			renderSecureSignup();
-
-			expect(
-				screen.queryByLabelText(
-					'Get updates about our journalism and ways to support and enjoy our work.',
-				),
-			).not.toBeInTheDocument();
-
-			await typeEmailAndSubmit(testUser);
-			await waitFor(() => {
-				expect(global.fetch).toHaveBeenCalled();
-			});
-
-			expect(
-				getRequestBodyParams().get('marketingOptInHidden'),
-			).toBeNull();
-			expect(
-				getTrackingPayloadForEvent('form-submission')
-					?.marketingOptInType,
-			).toBeUndefined();
-			expect(
-				getTrackingPayloadForEvent('submission-confirmed')
-					?.marketingOptInType,
-			).toBeUndefined();
-		});
-
-		it('switch off + US + signed out: shows marketing checkbox', () => {
-			window.guardian.config.switches['usSignupHideMarketingToggle'] =
-				false;
-			(useCountryCode as jest.Mock).mockReturnValue('US');
-			renderSecureSignup();
-
-			expect(
-				screen.getByLabelText(
-					'Get updates about our journalism and ways to support and enjoy our work.',
-				),
-			).toBeInTheDocument();
-		});
+		expect(
+			screen.getByLabelText(
+				'Get updates about our journalism and ways to support and enjoy our work.',
+			),
+		).toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -305,16 +305,12 @@ export const SecureSignup = ({
 	}, []);
 
 	useEffect(() => {
-		if (isSignedIn !== true) {
-			setUserEmail(undefined);
-			setHideEmailInput(false);
-			return;
+		if (isSignedIn === true) {
+			void resolveEmailForSignedInUser(isSignedIn).then((email) => {
+				setUserEmail(email);
+				setHideEmailInput(isString(email));
+			});
 		}
-
-		void resolveEmailForSignedInUser(isSignedIn).then((email) => {
-			setUserEmail(email);
-			setHideEmailInput(isString(email));
-		});
 	}, [isSignedIn]);
 	const { renderingTarget } = useConfig();
 	const browserId = useBrowserId();

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -275,7 +275,7 @@ export const SecureSignup = ({
 		hideMarketingToggle && isSignedIn === false;
 
 	useEffect(() => {
-		if (isSignedIn !== true) {
+		if (isSignedIn !== 'Pending' && !isSignedIn) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -253,8 +253,8 @@ const sendTracking = (
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.control(newsletterId),
 		renderingTarget,
 		value: {
-			eventDescription,
 			...extraDetails,
+			eventDescription,
 		},
 		abTest,
 	});
@@ -326,6 +326,8 @@ export const SecureSignup = ({
 			document.querySelector('input[type="email"]') ?? null;
 		const emailAddress: string = input?.value ?? '';
 		const effectiveMarketingOptIn = marketingOptInHidden
+			? true
+			: isSignedIn === false && marketingOptIn === undefined
 			? true
 			: marketingOptIn;
 		const marketingOptInType = getMarketingOptInType({

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -272,7 +272,7 @@ export const SecureSignup = ({
 	const authStatus = useAuthStatus();
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
 	const marketingOptInHiddenForCountry =
-		hideMarketingToggle && isSignedIn !== true;
+		hideMarketingToggle && isSignedIn === false;
 
 	useEffect(() => {
 		if (isSignedIn !== 'Pending' && !isSignedIn) {

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -275,7 +275,7 @@ export const SecureSignup = ({
 		hideMarketingToggle && isSignedIn === false;
 
 	useEffect(() => {
-		if (isSignedIn !== 'Pending' && !isSignedIn) {
+		if (isSignedIn !== true) {
 			setMarketingOptIn(true);
 		}
 	}, [isSignedIn]);

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -292,7 +292,7 @@ export const SecureSignup = ({
 	const isSignedIn = useIsSignedIn();
 	const authStatus = useAuthStatus();
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
-	const marketingOptInHidden = hideMarketingToggle && isSignedIn === false;
+	const marketingOptInHidden = hideMarketingToggle && isSignedIn !== true;
 
 	useEffect(() => {
 		if (isSignedIn !== 'Pending' && !isSignedIn) {
@@ -323,7 +323,7 @@ export const SecureSignup = ({
 		const emailAddress: string = input?.value ?? '';
 		const effectiveMarketingOptIn = marketingOptInHidden
 			? true
-			: isSignedIn === false && marketingOptIn === undefined
+			: isSignedIn !== true && marketingOptIn === undefined
 			? true
 			: marketingOptIn;
 		const marketingOptInType = getMarketingOptInType({
@@ -453,7 +453,7 @@ export const SecureSignup = ({
 					value={userEmail ?? ''}
 					onChange={(e) => setUserEmail(e.target.value)}
 				/>
-				{isSignedIn === false && !marketingOptInHidden && (
+				{isSignedIn !== true && !marketingOptInHidden && (
 					<CheckboxGroup
 						name="marketing-preferences"
 						label="Marketing preferences"

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -21,6 +21,10 @@ import { useEffect, useRef, useState } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import {
+	getEffectiveMarketingOptIn,
+	getMarketingOptInType,
+} from '../lib/newsletter-marketing-opt-in';
+import {
 	EVENT_DESCRIPTION_TO_ACTION,
 	NEWSLETTER_SIGNUP_COMPONENT_ID,
 	type NewsletterEventDescription,
@@ -142,7 +146,7 @@ const buildFormData = (
 	token: string,
 	marketingOptIn?: boolean,
 	browserId?: string,
-	marketingOptInHidden?: boolean,
+	marketingOptInHiddenForCountry?: boolean,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -162,7 +166,7 @@ const buildFormData = (
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
 	}
 
-	if (marketingOptInHidden === true) {
+	if (marketingOptInHiddenForCountry === true) {
 		formData.append('marketingOptInHidden', 'true');
 	}
 
@@ -171,31 +175,6 @@ const buildFormData = (
 	}
 
 	return formData;
-};
-
-type MarketingOptInType =
-	| 'similar-guardian-products-optin-hidden-us'
-	| 'similar-guardian-products-optin'
-	| 'similar-guardian-products-optout';
-
-const getMarketingOptInType = ({
-	isSignedIn,
-	marketingOptIn,
-	marketingOptInHidden,
-}: {
-	isSignedIn: boolean | 'Pending';
-	marketingOptIn: boolean | undefined;
-	marketingOptInHidden: boolean;
-}): MarketingOptInType | undefined => {
-	if (isSignedIn !== false) {
-		return;
-	}
-	if (marketingOptInHidden) {
-		return 'similar-guardian-products-optin-hidden-us';
-	}
-	return marketingOptIn
-		? 'similar-guardian-products-optin'
-		: 'similar-guardian-products-optout';
 };
 
 const resolveEmailForSignedInUser = async (
@@ -292,7 +271,8 @@ export const SecureSignup = ({
 	const isSignedIn = useIsSignedIn();
 	const authStatus = useAuthStatus();
 	const hideMarketingToggle = useHideMarketingToggleForCountry();
-	const marketingOptInHidden = hideMarketingToggle && isSignedIn !== true;
+	const marketingOptInHiddenForCountry =
+		hideMarketingToggle && isSignedIn !== true;
 
 	useEffect(() => {
 		if (isSignedIn !== 'Pending' && !isSignedIn) {
@@ -321,15 +301,15 @@ export const SecureSignup = ({
 		const input: HTMLInputElement | null =
 			document.querySelector('input[type="email"]') ?? null;
 		const emailAddress: string = input?.value ?? '';
-		const effectiveMarketingOptIn = marketingOptInHidden
-			? true
-			: isSignedIn !== true && marketingOptIn === undefined
-			? true
-			: marketingOptIn;
-		const marketingOptInType = getMarketingOptInType({
+		const effectiveMarketingOptIn = getEffectiveMarketingOptIn({
+			marketingOptInHiddenForCountry,
 			isSignedIn,
-			marketingOptIn: effectiveMarketingOptIn,
-			marketingOptInHidden,
+			marketingOptIn,
+		});
+		const marketingOptInType = getMarketingOptInType({
+			marketingOptInHiddenForCountry,
+			isSignedIn,
+			effectiveMarketingOptIn,
 		});
 
 		sendTracking(
@@ -346,7 +326,7 @@ export const SecureSignup = ({
 			token,
 			effectiveMarketingOptIn,
 			browserId,
-			marketingOptInHidden ? true : undefined,
+			marketingOptInHiddenForCountry ? true : undefined,
 		);
 
 		const response = await postFormData(
@@ -453,7 +433,7 @@ export const SecureSignup = ({
 					value={userEmail ?? ''}
 					onChange={(e) => setUserEmail(e.target.value)}
 				/>
-				{isSignedIn !== true && !marketingOptInHidden && (
+				{isSignedIn !== true && !marketingOptInHiddenForCountry && (
 					<CheckboxGroup
 						name="marketing-preferences"
 						label="Marketing preferences"

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -29,6 +29,7 @@ import {
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
 import { useBrowserId } from '../lib/useBrowserId';
+import { useHideMarketingToggleForCountry } from '../lib/useHideMarketingToggleForCountry';
 import { palette } from '../palette';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { useConfig } from './ConfigContext';
@@ -141,6 +142,7 @@ const buildFormData = (
 	token: string,
 	marketingOptIn?: boolean,
 	browserId?: string,
+	marketingOptInHidden?: boolean,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -160,6 +162,10 @@ const buildFormData = (
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
 	}
 
+	if (marketingOptInHidden === true) {
+		formData.append('marketingOptInHidden', 'true');
+	}
+
 	if (browserId !== undefined) {
 		formData.append('browserId', browserId);
 	}
@@ -167,7 +173,37 @@ const buildFormData = (
 	return formData;
 };
 
-const resolveEmailIfSignedIn = async (): Promise<string | undefined> => {
+type MarketingOptInType =
+	| 'similar-guardian-products-optin-hidden-us'
+	| 'similar-guardian-products-optin'
+	| 'similar-guardian-products-optout';
+
+const getMarketingOptInType = ({
+	isSignedIn,
+	marketingOptIn,
+	marketingOptInHidden,
+}: {
+	isSignedIn: boolean | 'Pending';
+	marketingOptIn: boolean | undefined;
+	marketingOptInHidden: boolean;
+}): MarketingOptInType | undefined => {
+	if (isSignedIn !== false) {
+		return;
+	}
+	if (marketingOptInHidden) {
+		return 'similar-guardian-products-optin-hidden-us';
+	}
+	return marketingOptIn
+		? 'similar-guardian-products-optin'
+		: 'similar-guardian-products-optout';
+};
+
+const resolveEmailForSignedInUser = async (
+	isSignedIn: boolean | 'Pending',
+): Promise<string | undefined> => {
+	if (isSignedIn !== true) {
+		return;
+	}
 	const { idApiUrl } = window.guardian.config.page;
 	if (!idApiUrl) {
 		return;
@@ -209,13 +245,17 @@ const sendTracking = (
 	eventDescription: NewsletterEventDescription,
 	renderingTarget: RenderingTarget,
 	abTest?: AbTest,
+	extraDetails?: Record<string, unknown>,
 ): void => {
 	sendNewsletterSignupEvent({
 		action: EVENT_DESCRIPTION_TO_ACTION[eventDescription],
 		identityName: newsletterId,
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.control(newsletterId),
 		renderingTarget,
-		value: { eventDescription },
+		value: {
+			eventDescription,
+			...extraDetails,
+		},
 		abTest,
 	});
 };
@@ -251,6 +291,8 @@ export const SecureSignup = ({
 	);
 	const isSignedIn = useIsSignedIn();
 	const authStatus = useAuthStatus();
+	const hideMarketingToggle = useHideMarketingToggleForCountry();
+	const marketingOptInHidden = hideMarketingToggle && isSignedIn === false;
 
 	useEffect(() => {
 		if (isSignedIn !== 'Pending' && !isSignedIn) {
@@ -260,11 +302,20 @@ export const SecureSignup = ({
 
 	useEffect(() => {
 		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
-		void resolveEmailIfSignedIn().then((email) => {
+	}, []);
+
+	useEffect(() => {
+		if (isSignedIn !== true) {
+			setUserEmail(undefined);
+			setHideEmailInput(false);
+			return;
+		}
+
+		void resolveEmailForSignedInUser(isSignedIn).then((email) => {
 			setUserEmail(email);
 			setHideEmailInput(isString(email));
 		});
-	}, []);
+	}, [isSignedIn]);
 	const { renderingTarget } = useConfig();
 	const browserId = useBrowserId();
 
@@ -274,15 +325,30 @@ export const SecureSignup = ({
 		const input: HTMLInputElement | null =
 			document.querySelector('input[type="email"]') ?? null;
 		const emailAddress: string = input?.value ?? '';
+		const effectiveMarketingOptIn = marketingOptInHidden
+			? true
+			: marketingOptIn;
+		const marketingOptInType = getMarketingOptInType({
+			isSignedIn,
+			marketingOptIn: effectiveMarketingOptIn,
+			marketingOptInHidden,
+		});
 
-		sendTracking(newsletterId, 'form-submission', renderingTarget, abTest);
+		sendTracking(
+			newsletterId,
+			'form-submission',
+			renderingTarget,
+			abTest,
+			marketingOptInType ? { marketingOptInType } : undefined,
+		);
 
 		const formData = buildFormData(
 			emailAddress,
 			newsletterId,
 			token,
-			marketingOptIn,
+			effectiveMarketingOptIn,
 			browserId,
+			marketingOptInHidden ? true : undefined,
 		);
 
 		const response = await postFormData(
@@ -306,6 +372,7 @@ export const SecureSignup = ({
 			response.ok ? 'submission-confirmed' : 'submission-failed',
 			renderingTarget,
 			abTest,
+			marketingOptInType ? { marketingOptInType } : undefined,
 		);
 	};
 
@@ -388,7 +455,7 @@ export const SecureSignup = ({
 					value={userEmail ?? ''}
 					onChange={(e) => setUserEmail(e.target.value)}
 				/>
-				{isSignedIn === false && (
+				{isSignedIn === false && !marketingOptInHidden && (
 					<CheckboxGroup
 						name="marketing-preferences"
 						label="Marketing preferences"

--- a/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
+++ b/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
@@ -9,8 +9,8 @@ type MarketingOptInType =
  * - If the toggle is hidden due to country (US soft opt-in) and the user is
  *   confirmed signed out, always submit `true`.
  * - If the user is signed in, omit marketing from the payload (`undefined`).
- * - If the user has made an explicit choice, use that.
- * - Otherwise (signed out or pending with no choice yet), default to `true`.
+ * - Otherwise (signed out or auth still pending), use the user's explicit
+ *   choice if set, defaulting to `true` (opted-in).
  */
 export const getEffectiveMarketingOptIn = ({
 	marketingOptInHiddenForCountry,
@@ -28,7 +28,7 @@ export const getEffectiveMarketingOptIn = ({
 	if (isSignedIn === true) {
 		return undefined;
 	}
-	// Signed out or pending — use explicit choice, or default to true
+	// Signed out or pending — show as opted-in by default, or use explicit choice
 	return marketingOptIn ?? true;
 };
 

--- a/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
+++ b/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
@@ -23,7 +23,7 @@ export const getEffectiveMarketingOptIn = ({
 	isSignedIn: boolean | 'Pending';
 	marketingOptIn: boolean | undefined;
 }): boolean | undefined => {
-	// Only apply the US soft opt-in when we know the user is signed out
+	// Only apply the hide opt-in when we know the user is signed out
 	if (marketingOptInHiddenForCountry && isSignedIn === false) {
 		return true;
 	}

--- a/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
+++ b/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
@@ -1,0 +1,58 @@
+type MarketingOptInType =
+	| 'similar-guardian-products-optin-hidden-us'
+	| 'similar-guardian-products-optin'
+	| 'similar-guardian-products-optout';
+
+/**
+ * Returns the marketing opt-in value that should be submitted with the form.
+ *
+ * - If the toggle is hidden due to country (US soft opt-in), always submit `true`.
+ * - If the user is signed in, omit marketing from the payload (`undefined`).
+ * - If the user has made an explicit choice, use that.
+ * - Otherwise (signed out or pending with no choice yet), default to `true`.
+ */
+export const getEffectiveMarketingOptIn = ({
+	marketingOptInHiddenForCountry,
+	isSignedIn,
+	marketingOptIn,
+}: {
+	marketingOptInHiddenForCountry: boolean;
+	isSignedIn: boolean | 'Pending';
+	marketingOptIn: boolean | undefined;
+}): boolean | undefined => {
+	if (marketingOptInHiddenForCountry) {
+		return true;
+	}
+	if (isSignedIn === true) {
+		return undefined;
+	}
+	// Signed out or pending — use explicit choice, or default to true
+	return marketingOptIn ?? true;
+};
+
+/**
+ * Returns the Ophan tracking string for the marketing opt-in outcome,
+ * or `undefined` if tracking should be omitted (e.g. signed-in users).
+ */
+export const getMarketingOptInType = ({
+	marketingOptInHiddenForCountry,
+	isSignedIn,
+	effectiveMarketingOptIn,
+}: {
+	marketingOptInHiddenForCountry: boolean;
+	isSignedIn: boolean | 'Pending';
+	effectiveMarketingOptIn: boolean | undefined;
+}): MarketingOptInType | undefined => {
+	if (isSignedIn === true) {
+		return undefined;
+	}
+	if (marketingOptInHiddenForCountry) {
+		return 'similar-guardian-products-optin-hidden-us';
+	}
+	if (effectiveMarketingOptIn === undefined) {
+		return undefined;
+	}
+	return effectiveMarketingOptIn
+		? 'similar-guardian-products-optin'
+		: 'similar-guardian-products-optout';
+};

--- a/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
+++ b/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
@@ -11,6 +11,8 @@ type MarketingOptInType =
  * - If the user is signed in, omit marketing from the payload (`undefined`).
  * - Otherwise (signed out or auth still pending), use the user's explicit
  *   choice if set, defaulting to `true` (opted-in).
+ * - If auth is `'Pending'`, defer by returning `undefined` — wait until we
+ *   know the user's auth state before submitting a marketing preference.
  */
 export const getEffectiveMarketingOptIn = ({
 	marketingOptInHiddenForCountry,
@@ -28,7 +30,11 @@ export const getEffectiveMarketingOptIn = ({
 	if (isSignedIn === true) {
 		return undefined;
 	}
-	// Signed out or pending — show as opted-in by default, or use explicit choice
+	// Pending — don't submit marketing until we know auth state
+	if (isSignedIn === 'Pending') {
+		return undefined;
+	}
+	// Signed out — use explicit choice or default to opted-in
 	return marketingOptIn ?? true;
 };
 

--- a/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
+++ b/dotcom-rendering/src/lib/newsletter-marketing-opt-in.ts
@@ -6,7 +6,8 @@ type MarketingOptInType =
 /**
  * Returns the marketing opt-in value that should be submitted with the form.
  *
- * - If the toggle is hidden due to country (US soft opt-in), always submit `true`.
+ * - If the toggle is hidden due to country (US soft opt-in) and the user is
+ *   confirmed signed out, always submit `true`.
  * - If the user is signed in, omit marketing from the payload (`undefined`).
  * - If the user has made an explicit choice, use that.
  * - Otherwise (signed out or pending with no choice yet), default to `true`.
@@ -20,7 +21,8 @@ export const getEffectiveMarketingOptIn = ({
 	isSignedIn: boolean | 'Pending';
 	marketingOptIn: boolean | undefined;
 }): boolean | undefined => {
-	if (marketingOptInHiddenForCountry) {
+	// Only apply the US soft opt-in when we know the user is signed out
+	if (marketingOptInHiddenForCountry && isSignedIn === false) {
 		return true;
 	}
 	if (isSignedIn === true) {
@@ -46,7 +48,8 @@ export const getMarketingOptInType = ({
 	if (isSignedIn === true) {
 		return undefined;
 	}
-	if (marketingOptInHiddenForCountry) {
+	// Only report the US hidden opt-in when we know the user is signed out
+	if (marketingOptInHiddenForCountry && isSignedIn === false) {
 		return 'similar-guardian-products-optin-hidden-us';
 	}
 	if (effectiveMarketingOptIn === undefined) {

--- a/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
+++ b/dotcom-rendering/src/lib/newsletter-sign-up-requests.ts
@@ -7,6 +7,7 @@ const buildNewsletterSignUpFormData = (
 	newsletterIdOrList: string | string[],
 	recaptchaToken: string,
 	marketingOptIn?: boolean,
+	marketingOptInHidden?: boolean,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -32,6 +33,10 @@ const buildNewsletterSignUpFormData = (
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (marketingOptInHidden === true) {
+		formData.append('marketingOptInHidden', 'true');
 	}
 
 	return formData;
@@ -67,12 +72,14 @@ export const requestMultipleSignUps = async (
 	newsletterIds: string[],
 	recaptchaToken: string,
 	marketingOptIn?: boolean,
+	marketingOptInHidden?: boolean,
 ): Promise<Response> => {
 	const data = buildNewsletterSignUpFormData(
 		emailAddress,
 		newsletterIds,
 		recaptchaToken,
 		marketingOptIn,
+		marketingOptInHidden,
 	);
 
 	return await postFormData(

--- a/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
+++ b/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
@@ -1,0 +1,22 @@
+import { useCountryCode } from './useCountryCode';
+
+/**
+ * Returns `true` when the marketing opt-in toggle should be hidden for this
+ * user's country.
+ *
+ * Currently implements US-only hiding, gated behind the
+ * `us-signup-hide-marketing-toggle` switch. The hook name is country-agnostic
+ * so future countries can be added without renaming.
+ *
+ * - Returns `false` while the country code is still being resolved (`undefined`).
+ * - Returns `false` if the switch is off.
+ * - Returns `true` only when the switch is on **and** `countryCode === 'US'`.
+ */
+export const useHideMarketingToggleForCountry = (): boolean => {
+	const countryCode = useCountryCode('useHideMarketingToggleForCountry');
+	const switchEnabled =
+		window.guardian.config.switches['us-signup-hide-marketing-toggle'] ===
+		true;
+
+	return switchEnabled && countryCode === 'US';
+};

--- a/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
+++ b/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
@@ -5,7 +5,7 @@ import { useCountryCode } from './useCountryCode';
  * user's country.
  *
  * Currently implements US-only hiding, gated behind the
- * `us-signup-hide-marketing-toggle` switch. The hook name is country-agnostic
+ * `usSignupHideMarketingToggle` switch. The hook name is country-agnostic
  * so future countries can be added without renaming.
  *
  * - Returns `false` while the country code is still being resolved (`undefined`).
@@ -16,8 +16,7 @@ export const useHideMarketingToggleForCountry = (): boolean => {
 	const countryCode = useCountryCode('useHideMarketingToggleForCountry');
 	const switchEnabled =
 		typeof window !== 'undefined' &&
-		window.guardian.config.switches['us-signup-hide-marketing-toggle'] ===
-			true;
+		window.guardian.config.switches['usSignupHideMarketingToggle'] === true;
 
 	return switchEnabled && countryCode === 'US';
 };

--- a/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
+++ b/dotcom-rendering/src/lib/useHideMarketingToggleForCountry.ts
@@ -15,8 +15,9 @@ import { useCountryCode } from './useCountryCode';
 export const useHideMarketingToggleForCountry = (): boolean => {
 	const countryCode = useCountryCode('useHideMarketingToggleForCountry');
 	const switchEnabled =
+		typeof window !== 'undefined' &&
 		window.guardian.config.switches['us-signup-hide-marketing-toggle'] ===
-		true;
+			true;
 
 	return switchEnabled && countryCode === 'US';
 };

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -300,7 +300,7 @@ export const useNewsletterSignupForm = (
 		async (emailAddress: string, token: string): Promise<void> => {
 			const marketingOptInHiddenForCountry =
 				hideMarketingToggleRef.current &&
-				isSignedInRef.current !== true;
+				isSignedInRef.current === false;
 			const effectiveMarketingOptIn = getEffectiveMarketingOptIn({
 				marketingOptInHiddenForCountry,
 				isSignedIn: isSignedInRef.current,
@@ -499,7 +499,7 @@ export const useNewsletterSignupForm = (
 		showMarketingToggle: isSignedIn !== true && !hideMarketingToggle,
 		marketingOptIn,
 		marketingOptInHiddenForCountry:
-			hideMarketingToggle && isSignedIn !== true,
+			hideMarketingToggle && isSignedIn === false,
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -24,14 +24,21 @@ import { useBrowserId } from './useBrowserId';
 // Helpers (kept local — not part of the public API)
 // ---------------------------------------------------------------------------
 
-const buildFormData = (
-	emailAddress: string,
-	newsletterId: string,
-	token: string,
-	marketingOptIn?: boolean,
-	browserId?: string,
-	marketingOptInHiddenForCountry?: boolean,
-): FormData => {
+const buildFormData = ({
+	emailAddress,
+	newsletterId,
+	token,
+	marketingOptIn,
+	browserId,
+	marketingOptInHiddenForCountry,
+}: {
+	emailAddress: string;
+	newsletterId: string;
+	token: string;
+	marketingOptIn?: boolean;
+	browserId?: string;
+	marketingOptInHiddenForCountry?: boolean;
+}): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
 
@@ -328,14 +335,16 @@ export const useNewsletterSignupForm = (
 				marketingOptInType ? { marketingOptInType } : undefined,
 			);
 
-			const formData = buildFormData(
+			const formData = buildFormData({
 				emailAddress,
 				newsletterId,
 				token,
-				effectiveMarketingOptIn,
-				browserIdRef.current,
-				marketingOptInHiddenForCountry ? true : undefined,
-			);
+				marketingOptIn: effectiveMarketingOptIn,
+				browserId: browserIdRef.current,
+				marketingOptInHiddenForCountry: marketingOptInHiddenForCountry
+					? true
+					: undefined,
+			});
 
 			const response = await postFormData(
 				window.guardian.config.page.ajaxUrl + '/email',

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -112,8 +112,8 @@ const sendTracking = (
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.variant(newsletterId),
 		renderingTarget,
 		value: {
-			eventDescription,
 			...extraDetails,
+			eventDescription,
 		},
 		abTest,
 	});
@@ -298,6 +298,9 @@ export const useNewsletterSignupForm = (
 				hideMarketingToggleRef.current &&
 				isSignedInRef.current === false;
 			const effectiveMarketingOptIn = marketingOptInHidden
+				? true
+				: isSignedInRef.current === false &&
+				  marketingOptInRef.current === undefined
 				? true
 				: marketingOptInRef.current;
 			const marketingOptInType =

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -26,6 +26,7 @@ const buildFormData = (
 	token: string,
 	marketingOptIn?: boolean,
 	browserId?: string,
+	marketingOptInHidden?: boolean,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -43,6 +44,10 @@ const buildFormData = (
 
 	if (marketingOptIn !== undefined) {
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
+	}
+
+	if (marketingOptInHidden === true) {
+		formData.append('marketingOptInHidden', 'true');
 	}
 
 	if (browserId !== undefined) {
@@ -99,13 +104,17 @@ const sendTracking = (
 	eventDescription: NewsletterEventDescription,
 	renderingTarget: RenderingTarget,
 	abTest?: AbTest,
+	extraDetails?: Record<string, unknown>,
 ): void => {
 	sendNewsletterSignupEvent({
 		action: EVENT_DESCRIPTION_TO_ACTION[eventDescription],
 		identityName: newsletterId,
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.variant(newsletterId),
 		renderingTarget,
-		value: { eventDescription },
+		value: {
+			eventDescription,
+			...extraDetails,
+		},
 		abTest,
 	});
 };
@@ -135,6 +144,12 @@ export type NewsletterSignupFormState = {
 	/** `true` for signed-out users — shows the marketing opt-in toggle. */
 	showMarketingToggle: boolean;
 	marketingOptIn: boolean | undefined;
+	/**
+	 * `true` when the marketing toggle is hidden by country policy (switch on,
+	 * US, signed out). Included in the sign-up payload so the backend knows
+	 * the opt-in was implicit.
+	 */
+	marketingOptInHidden: boolean;
 
 	/** `true` while the POST request is in-flight. */
 	isWaitingForResponse: boolean;
@@ -186,6 +201,7 @@ export const useNewsletterSignupForm = (
 	newsletterId: string,
 	renderingTarget: RenderingTarget,
 	abTest?: AbTest,
+	hideMarketingToggle = false,
 ): NewsletterSignupFormState => {
 	const recaptchaRef = useRef<ReactGoogleRecaptcha>(null);
 	const [captchaSiteKey, setCaptchaSiteKey] = useState<string>();
@@ -215,6 +231,8 @@ export const useNewsletterSignupForm = (
 	const marketingOptInRef = useRef(marketingOptIn);
 	const browserIdRef = useRef(browserId);
 	const authStatusRef = useRef(authStatus);
+	const isSignedInRef = useRef(isSignedIn);
+	const hideMarketingToggleRef = useRef(hideMarketingToggle);
 	useEffect(() => {
 		marketingOptInRef.current = marketingOptIn;
 	}, [marketingOptIn]);
@@ -224,6 +242,12 @@ export const useNewsletterSignupForm = (
 	useEffect(() => {
 		authStatusRef.current = authStatus;
 	}, [authStatus]);
+	useEffect(() => {
+		isSignedInRef.current = isSignedIn;
+	}, [isSignedIn]);
+	useEffect(() => {
+		hideMarketingToggleRef.current = hideMarketingToggle;
+	}, [hideMarketingToggle]);
 
 	// The email address that was validated at submit-time. We stash it in a
 	// ref and read it back when the captcha resolves, so it can't change out
@@ -270,19 +294,36 @@ export const useNewsletterSignupForm = (
 
 	const submitForm = useCallback(
 		async (emailAddress: string, token: string): Promise<void> => {
+			const marketingOptInHidden =
+				hideMarketingToggleRef.current &&
+				isSignedInRef.current === false;
+			const effectiveMarketingOptIn = marketingOptInHidden
+				? true
+				: marketingOptInRef.current;
+			const marketingOptInType =
+				isSignedInRef.current === false
+					? marketingOptInHidden
+						? 'similar-guardian-products-optin-hidden-us'
+						: effectiveMarketingOptIn
+						? 'similar-guardian-products-optin'
+						: 'similar-guardian-products-optout'
+					: undefined;
+
 			sendTracking(
 				newsletterId,
 				'form-submission',
 				renderingTarget,
 				abTest,
+				marketingOptInType ? { marketingOptInType } : undefined,
 			);
 
 			const formData = buildFormData(
 				emailAddress,
 				newsletterId,
 				token,
-				marketingOptInRef.current,
+				effectiveMarketingOptIn,
 				browserIdRef.current,
+				marketingOptInHidden ? true : undefined,
 			);
 
 			const response = await postFormData(
@@ -307,6 +348,7 @@ export const useNewsletterSignupForm = (
 				response.ok ? 'submission-confirmed' : 'submission-failed',
 				renderingTarget,
 				abTest,
+				marketingOptInType ? { marketingOptInType } : undefined,
 			);
 		},
 		[abTest, newsletterId, renderingTarget],
@@ -451,8 +493,9 @@ export const useNewsletterSignupForm = (
 		userEmail,
 		isSignedIn: hasPrefilledEmail,
 		isInteracted,
-		showMarketingToggle: isSignedIn === false,
+		showMarketingToggle: isSignedIn === false && !hideMarketingToggle,
 		marketingOptIn,
+		marketingOptInHidden: hideMarketingToggle && isSignedIn === false,
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -296,10 +296,10 @@ export const useNewsletterSignupForm = (
 		async (emailAddress: string, token: string): Promise<void> => {
 			const marketingOptInHidden =
 				hideMarketingToggleRef.current &&
-				isSignedInRef.current === false;
+				isSignedInRef.current !== true;
 			const effectiveMarketingOptIn = marketingOptInHidden
 				? true
-				: isSignedInRef.current === false &&
+				: isSignedInRef.current !== true &&
 				  marketingOptInRef.current === undefined
 				? true
 				: marketingOptInRef.current;
@@ -496,9 +496,9 @@ export const useNewsletterSignupForm = (
 		userEmail,
 		isSignedIn: hasPrefilledEmail,
 		isInteracted,
-		showMarketingToggle: isSignedIn === false && !hideMarketingToggle,
+		showMarketingToggle: isSignedIn !== true && !hideMarketingToggle,
 		marketingOptIn,
-		marketingOptInHidden: hideMarketingToggle && isSignedIn === false,
+		marketingOptInHidden: hideMarketingToggle && isSignedIn !== true,
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -237,6 +237,11 @@ export const useNewsletterSignupForm = (
 	const authStatusRef = useRef(authStatus);
 	const isSignedInRef = useRef(isSignedIn);
 	const hideMarketingToggleRef = useRef(hideMarketingToggle);
+	// Single source of truth for the submit handler — derived from the same
+	// inputs as the UI value so they can never diverge due to a timing race.
+	const marketingOptInHiddenForCountryRef = useRef(
+		hideMarketingToggle && isSignedIn === false,
+	);
 	useEffect(() => {
 		marketingOptInRef.current = marketingOptIn;
 	}, [marketingOptIn]);
@@ -252,6 +257,10 @@ export const useNewsletterSignupForm = (
 	useEffect(() => {
 		hideMarketingToggleRef.current = hideMarketingToggle;
 	}, [hideMarketingToggle]);
+	useEffect(() => {
+		marketingOptInHiddenForCountryRef.current =
+			hideMarketingToggle && isSignedIn === false;
+	}, [hideMarketingToggle, isSignedIn]);
 
 	// The email address that was validated at submit-time. We stash it in a
 	// ref and read it back when the captcha resolves, so it can't change out
@@ -299,8 +308,7 @@ export const useNewsletterSignupForm = (
 	const submitForm = useCallback(
 		async (emailAddress: string, token: string): Promise<void> => {
 			const marketingOptInHiddenForCountry =
-				hideMarketingToggleRef.current &&
-				isSignedInRef.current === false;
+				marketingOptInHiddenForCountryRef.current;
 			const effectiveMarketingOptIn = getEffectiveMarketingOptIn({
 				marketingOptInHiddenForCountry,
 				isSignedIn: isSignedInRef.current,

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -7,6 +7,10 @@ import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { lazyFetchEmailWithTimeout } from './fetchEmail';
 import {
+	getEffectiveMarketingOptIn,
+	getMarketingOptInType,
+} from './newsletter-marketing-opt-in';
+import {
 	EVENT_DESCRIPTION_TO_ACTION,
 	NEWSLETTER_SIGNUP_COMPONENT_ID,
 	type NewsletterEventDescription,
@@ -26,7 +30,7 @@ const buildFormData = (
 	token: string,
 	marketingOptIn?: boolean,
 	browserId?: string,
-	marketingOptInHidden?: boolean,
+	marketingOptInHiddenForCountry?: boolean,
 ): FormData => {
 	const pageRef = window.location.origin + window.location.pathname;
 	const refViewId = window.guardian.ophan?.pageViewId ?? '';
@@ -46,7 +50,7 @@ const buildFormData = (
 		formData.append('marketing', marketingOptIn ? 'true' : 'false');
 	}
 
-	if (marketingOptInHidden === true) {
+	if (marketingOptInHiddenForCountry === true) {
 		formData.append('marketingOptInHidden', 'true');
 	}
 
@@ -149,7 +153,7 @@ export type NewsletterSignupFormState = {
 	 * US, signed out). Included in the sign-up payload so the backend knows
 	 * the opt-in was implicit.
 	 */
-	marketingOptInHidden: boolean;
+	marketingOptInHiddenForCountry: boolean;
 
 	/** `true` while the POST request is in-flight. */
 	isWaitingForResponse: boolean;
@@ -294,23 +298,19 @@ export const useNewsletterSignupForm = (
 
 	const submitForm = useCallback(
 		async (emailAddress: string, token: string): Promise<void> => {
-			const marketingOptInHidden =
+			const marketingOptInHiddenForCountry =
 				hideMarketingToggleRef.current &&
 				isSignedInRef.current !== true;
-			const effectiveMarketingOptIn = marketingOptInHidden
-				? true
-				: isSignedInRef.current !== true &&
-				  marketingOptInRef.current === undefined
-				? true
-				: marketingOptInRef.current;
-			const marketingOptInType =
-				isSignedInRef.current === false
-					? marketingOptInHidden
-						? 'similar-guardian-products-optin-hidden-us'
-						: effectiveMarketingOptIn
-						? 'similar-guardian-products-optin'
-						: 'similar-guardian-products-optout'
-					: undefined;
+			const effectiveMarketingOptIn = getEffectiveMarketingOptIn({
+				marketingOptInHiddenForCountry,
+				isSignedIn: isSignedInRef.current,
+				marketingOptIn: marketingOptInRef.current,
+			});
+			const marketingOptInType = getMarketingOptInType({
+				marketingOptInHiddenForCountry,
+				isSignedIn: isSignedInRef.current,
+				effectiveMarketingOptIn,
+			});
 
 			sendTracking(
 				newsletterId,
@@ -326,7 +326,7 @@ export const useNewsletterSignupForm = (
 				token,
 				effectiveMarketingOptIn,
 				browserIdRef.current,
-				marketingOptInHidden ? true : undefined,
+				marketingOptInHiddenForCountry ? true : undefined,
 			);
 
 			const response = await postFormData(
@@ -498,7 +498,8 @@ export const useNewsletterSignupForm = (
 		isInteracted,
 		showMarketingToggle: isSignedIn !== true && !hideMarketingToggle,
 		marketingOptIn,
-		marketingOptInHidden: hideMarketingToggle && isSignedIn !== true,
+		marketingOptInHiddenForCountry:
+			hideMarketingToggle && isSignedIn !== true,
 		isWaitingForResponse,
 		responseOk,
 		errorMessage,


### PR DESCRIPTION
# US newsletter marketing soft opt-in

## What does this change?

Implements the UI logic for hiding the marketing consent toggle for signed-out US users when the `usSignupHideMarketingToggle` switch is enabled.

- Adds a `useHideMarketingToggleForCountry` hook that checks the switch and the user's country code via `useCountryCode`
- When the switch is **on** and `countryCode === 'US'` and the user is **signed out**, the marketing toggle is hidden and `marketing=true` is always included in the sign-up payload
- When the switch is **off**, or the user is signed in, or the country is anything other than `US` (including `undefined` while resolving), existing behaviour is unchanged
- A `marketingOptInHidden: true` field is appended to the sign-up request payload in the hidden case so the backend can identify implicit opt-ins
- `marketingOptInType` is included in Ophan tracking events on all three surfaces:
    - `similar-guardian-products-optin-hidden-us` — toggle hidden (US soft opt-in)
    - `similar-guardian-products-optin` — toggle visible, user opted in
    - `similar-guardian-products-optout` — toggle visible, user opted out
    - Omitted entirely for signed-in users
- Applies consistently across all three sign-up surfaces: `SecureSignup`, `NewsletterSignupForm`, and `ManyNewsletterSignUp`
- Mocks `useCountryCode` in Storybook preview and adds a `USHideMarketingToggle` story to `NewsletterSignupForm`

## Why?

US consumer protection regulations mean we should not present a marketing opt-in toggle to US newsletter sign-ups. Instead, users are silently enrolled in `similar_guardian_products` — i.e. a soft opt-in. This is gated behind a switch so it can be enabled/disabled independently of a deploy.

Parent issue: [guardian/email-rendering#930](https://github.com/guardian/email-rendering/issues/930)

## Screenshots

_No visible UI change for non-US users. For US signed-out users, the marketing toggle is hidden — no before/after screenshot is provided as this is switch-gated._

| Before | After |
| ------ | ----- |
| Marketing toggle visible for all signed-out users | Marketing toggle hidden for signed-out US users (switch on) |

