### PR TITLE
Fix an aspect ratio for main media on hosted article pages

### DIFF
--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -17,6 +17,9 @@ import type { Loading } from './CardPicture';
 
 export type Orientation = 'portrait' | 'landscape';
 
+// Hosted content main media images require a 'banner' style aspect ratio
+type HostedAspectRatio = '13:4';
+
 type PictureRoleType =
 	| RoleType
 	// Custom image role types that are used but do not come from CAPI / FE
@@ -40,7 +43,7 @@ type Props = {
 export type ImageWidthType = {
 	breakpoint: number;
 	width: number;
-	aspectRatio?: AspectRatio;
+	aspectRatio?: AspectRatio | HostedAspectRatio;
 	cropOffset?: { x: number; y: number };
 };
 
@@ -199,12 +202,18 @@ const decideImageWidths = ({
 				{
 					breakpoint: breakpoints.desktop,
 					width: breakpoints.leftCol,
+					aspectRatio: '13:4',
 				},
 				{
 					breakpoint: breakpoints.leftCol,
 					width: breakpoints.wide,
+					aspectRatio: '13:4',
 				},
-				{ breakpoint: breakpoints.wide, width: breakpoints.wide },
+				{
+					breakpoint: breakpoints.wide,
+					width: breakpoints.wide,
+					aspectRatio: '13:4',
+				},
 			];
 		}
 		switch (format.display) {


### PR DESCRIPTION
## What does this change?

This fixes a 13:4 aspect ratio for the main media image on hosted article pages.

## Why?

The frontend implementation uses CSS background image positioning to centre the (often large) main media images in the wide but short, banner-like space available on these pages. Requesting a specific aspect ratio enables us to retain the same visual on DCR alongside the benefits of using an actual picture element.

## Screenshots

**Frontend - old implementation**
<img width="3024" height="1494" alt="Screenshot 2026-05-20 at 12-03-44 Advertiser content hosted by the Guardian Fortnite 101 The Guardian" src="https://github.com/user-attachments/assets/c116b0f1-91e0-4d9f-bdef-98a5a69d31aa" />

**Current DCR**
<img width="3024" height="1494" alt="Screenshot 2026-05-20 at 12-03-54 Fortnite 101 Epic Games Safety The Guardian" src="https://github.com/user-attachments/assets/8de0d09f-d260-4958-91ea-2737dd044de8" />

**DCR - fixed aspect Ratio**
<img width="3024" height="1494" alt="Screenshot 2026-05-20 at 12-04-05 Fortnite 101 Epic Games Safety The Guardian" src="https://github.com/user-attachments/assets/101c1048-52a7-479c-aa29-39cb34ad16b8" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214440020456673