### PR TITLE
Expand self-hosted video milestone tracking

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1153,7 +1153,6 @@ export const SelfHostedVideo = ({
 
 		if (playerState === 'PLAYING') {
 			setCurrentTime(video.currentTime);
-
 			/**
 			 * We only want to track milestone events for "long-form"
 			 * videos, not loops or cinemagraphs.
@@ -1162,6 +1161,10 @@ export const SelfHostedVideo = ({
 				currentTime: video.currentTime,
 				duration: video.duration,
 			});
+
+			if (video.currentTime < 1) {
+				resetMilestones();
+			}
 		}
 	};
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -557,7 +557,7 @@ export const SelfHostedVideo = ({
 		currentTime,
 	});
 
-	const trackMilestones = useVideoMilestoneTracking(sendOphanTrackingEvent);
+	const [trackMilestones] = useVideoMilestoneTracking(sendOphanTrackingEvent);
 
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
@@ -1158,7 +1158,10 @@ export const SelfHostedVideo = ({
 			 * videos, not loops or cinemagraphs.
 			 */
 			if (videoStyle === 'Default') {
-				trackMilestones(video.currentTime, video.duration);
+				trackMilestones({
+					currentTime: video.currentTime,
+					duration: video.duration,
+				});
 			}
 		}
 	};

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -558,6 +558,7 @@ export const SelfHostedVideo = ({
 
 	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
 		sendOphanTrackingEvent,
+		videoStyle === 'Default',
 	);
 
 	const playVideo = useCallback(async () => {

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -623,7 +623,7 @@ export const SelfHostedVideo = ({
 			}
 		} else {
 			void playVideo();
-			if (playerState !== 'ENDED') {
+			if (playerState !== 'NOT_STARTED' && playerState !== 'ENDED') {
 				sendOphanTrackingEvent('resume');
 			}
 		}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -440,7 +440,6 @@ export const SelfHostedVideo = ({
 		null,
 	);
 	const [hasPageBecomeActive, setHasPageBecomeActive] = useState(false);
-	const [hasTrackedPlay, setHasTrackedPlay] = useState(false);
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
@@ -557,7 +556,9 @@ export const SelfHostedVideo = ({
 		currentTime,
 	});
 
-	const [trackMilestones] = useVideoMilestoneTracking(sendOphanTrackingEvent);
+	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
+		sendOphanTrackingEvent,
+	);
 
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
@@ -621,10 +622,8 @@ export const SelfHostedVideo = ({
 			}
 		} else {
 			void playVideo();
-			if (hasTrackedPlay) {
+			if (playerState !== 'ENDED') {
 				sendOphanTrackingEvent('resume');
-			} else {
-				sendOphanTrackingEvent('play');
 			}
 		}
 	};
@@ -986,11 +985,7 @@ export const SelfHostedVideo = ({
 	 * Track the first successful video play in Ophan.
 	 */
 	const handlePlaying = () => {
-		if (hasTrackedPlay) {
-			return;
-		}
-		sendOphanTrackingEvent('play');
-		setHasTrackedPlay(true);
+		trackMilestones({ started: true });
 	};
 
 	const showControlsAndStartTimer = () => {
@@ -1103,6 +1098,12 @@ export const SelfHostedVideo = ({
 		pauseVideo('PAUSED_BY_BROWSER');
 	};
 
+	const handleEnded = () => {
+		trackMilestones({ ended: true });
+		resetMilestones();
+		setPlayerState('ENDED');
+	};
+
 	/**
 	 * If the video could not be loaded due to an error, report to
 	 * Sentry and log in the console.
@@ -1157,12 +1158,10 @@ export const SelfHostedVideo = ({
 			 * We only want to track milestone events for "long-form"
 			 * videos, not loops or cinemagraphs.
 			 */
-			if (videoStyle === 'Default') {
-				trackMilestones({
-					currentTime: video.currentTime,
-					duration: video.duration,
-				});
-			}
+			trackMilestones({
+				currentTime: video.currentTime,
+				duration: video.duration,
+			});
 		}
 	};
 
@@ -1282,6 +1281,7 @@ export const SelfHostedVideo = ({
 						handleKeyDown={handleKeyDown}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
+						handleEnded={handleEnded}
 						updateCurrentTime={updateCurrentTime}
 						onError={onError}
 						preloadPartialData={!!shouldAutoplay}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1156,7 +1156,8 @@ export const SelfHostedVideo = ({
 			setCurrentTime(video.currentTime);
 			/**
 			 * We only want to track milestone events for "long-form"
-			 * videos, not loops or cinemagraphs.
+			 * videos, not loops or cinemagraphs. We expect these to be
+			 * too short to be worth tracking progress milestones.
 			 */
 			trackMilestones({
 				currentTime: video.currentTime,

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -98,6 +98,7 @@ export const PLAYER_STATES = [
 	 * For example, iOS devices in low power mode will suspend playback on autoplaying videos.
 	 */
 	'PAUSED_BY_BROWSER',
+	'ENDED',
 ] as const;
 
 export type PlayerStates = (typeof PLAYER_STATES)[number];
@@ -124,6 +125,7 @@ export type Props = {
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	handlePause: (event: SyntheticEvent) => void;
 	handleFullscreenClick: (event: SyntheticEvent) => void;
+	handleEnded?: (event: SyntheticEvent) => void;
 	updateCurrentTime: (time: number) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	posterImage?: string;
@@ -179,6 +181,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handleTimeUpdate,
 			handlePause,
 			handleFullscreenClick,
+			handleEnded,
 			updateCurrentTime,
 			onError,
 			preloadPartialData,
@@ -240,6 +243,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onClick={handlePlayPauseClick}
 					onKeyDown={handleKeyDown}
 					onError={onError}
+					onEnded={handleEnded}
 					disablePictureInPicture={true}
 				>
 					{sources.map(({ src, mimeType }) => (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -625,6 +625,7 @@ export const YoutubeAtomPlayer = ({
 			origin,
 			playerReadyCallback,
 			renderingTarget,
+			resetMilestones,
 			trackMilestones,
 			uniqueId,
 			videoId,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -47,7 +47,6 @@ type Props = {
 
 type ProgressEvents = {
 	hasSentPlayEvent: boolean;
-	hasSentEndEvent: boolean;
 };
 
 /**
@@ -196,7 +195,7 @@ const createOnStateChangeListener =
 		uniqueId: string,
 		progressEvents: ProgressEvents,
 		sendOphanTrackingEvent: (event: VideoEventKey) => void,
-		trackMilestones: (currentTime: number, duration: number) => void,
+		trackMilestones: ReturnType<typeof useVideoMilestoneTracking>[0],
 	): YT.PlayerEventHandler<YT.OnStateChangeEvent> =>
 	(event) => {
 		const loggerFrom = 'YoutubeAtomPlayer onStateChange';
@@ -245,7 +244,10 @@ const createOnStateChangeListener =
 			}
 
 			const checkProgress = () => {
-				trackMilestones(player.getCurrentTime(), player.getDuration());
+				trackMilestones({
+					currentTime: player.getCurrentTime(),
+					duration: player.getDuration(),
+				});
 
 				if (player.getPlayerState() !== YT.PlayerState.ENDED) {
 					/**
@@ -281,20 +283,9 @@ const createOnStateChangeListener =
 			progressEvents.hasSentPlayEvent = false;
 		}
 
-		if (
-			event.data === YT.PlayerState.ENDED &&
-			!progressEvents.hasSentEndEvent
-		) {
+		if (event.data === YT.PlayerState.ENDED) {
 			dispatchCustomPauseEvent(uniqueId);
-
-			log('dotcom', {
-				from: loggerFrom,
-				videoId,
-				msg: 'ended',
-				event,
-			});
-			sendOphanTrackingEvent('end');
-			progressEvents.hasSentEndEvent = true;
+			trackMilestones({ ended: true });
 			progressEvents.hasSentPlayEvent = false;
 		}
 	};
@@ -441,11 +432,10 @@ export const YoutubeAtomPlayer = ({
 		},
 		[eventEmitters],
 	);
-	const trackMilestones = useVideoMilestoneTracking(sendOphanTrackingEvent);
+	const [trackMilestones] = useVideoMilestoneTracking(sendOphanTrackingEvent);
 
 	const progressEvents = useRef<ProgressEvents>({
 		hasSentPlayEvent: false,
-		hasSentEndEvent: false,
 	});
 
 	const [playerReady, setPlayerReady] = useState<boolean>(false);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -45,10 +45,6 @@ type Props = {
 	renderingTarget: RenderingTarget;
 };
 
-type ProgressEvents = {
-	hasSentPlayEvent: boolean;
-};
-
 /**
  *  Player listeners e.g.
  *  name: onReady, onStateChange, etc...
@@ -193,9 +189,10 @@ const createOnStateChangeListener =
 	(
 		videoId: string,
 		uniqueId: string,
-		progressEvents: ProgressEvents,
+		playerState: { paused: boolean },
 		sendOphanTrackingEvent: (event: VideoEventKey) => void,
 		trackMilestones: ReturnType<typeof useVideoMilestoneTracking>[0],
+		resetMilestones: () => void,
 	): YT.PlayerEventHandler<YT.OnStateChangeEvent> =>
 	(event) => {
 		const loggerFrom = 'YoutubeAtomPlayer onStateChange';
@@ -217,31 +214,19 @@ const createOnStateChangeListener =
 			 */
 			dispatchCustomPlayEvent(uniqueId);
 
-			if (!progressEvents.hasSentPlayEvent) {
-				log('dotcom', {
-					from: loggerFrom,
-					videoId,
-					msg: 'start play',
-					event,
-				});
-				sendOphanTrackingEvent('play');
-				progressEvents.hasSentPlayEvent = true;
-
-				/**
-				 * Set a timeout to check progress again in the future
-				 */
-				setTimeout(() => {
-					checkProgress();
-				}, 3000);
-			} else {
-				log('dotcom', {
-					from: loggerFrom,
-					videoId,
-					msg: 'resume',
-					event,
-				});
+			trackMilestones({ started: true });
+			if (playerState.paused) {
 				sendOphanTrackingEvent('resume');
 			}
+
+			playerState.paused = false;
+
+			/**
+			 * Set a timeout to check progress in the future
+			 */
+			setTimeout(() => {
+				checkProgress();
+			}, 3000);
 
 			const checkProgress = () => {
 				trackMilestones({
@@ -270,6 +255,7 @@ const createOnStateChangeListener =
 				event,
 			});
 			sendOphanTrackingEvent('pause');
+			playerState.paused = true;
 		}
 
 		if (event.data === YT.PlayerState.CUED) {
@@ -280,13 +266,12 @@ const createOnStateChangeListener =
 				event,
 			});
 			sendOphanTrackingEvent('cued');
-			progressEvents.hasSentPlayEvent = false;
 		}
 
 		if (event.data === YT.PlayerState.ENDED) {
 			dispatchCustomPauseEvent(uniqueId);
 			trackMilestones({ ended: true });
-			progressEvents.hasSentPlayEvent = false;
+			resetMilestones();
 		}
 	};
 
@@ -432,11 +417,12 @@ export const YoutubeAtomPlayer = ({
 		},
 		[eventEmitters],
 	);
-	const [trackMilestones] = useVideoMilestoneTracking(sendOphanTrackingEvent);
-
-	const progressEvents = useRef<ProgressEvents>({
-		hasSentPlayEvent: false,
-	});
+	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
+		sendOphanTrackingEvent,
+	);
+	const playerPauseState = useRef<{
+		paused: boolean;
+	}>({ paused: false });
 
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
 	const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
@@ -475,9 +461,10 @@ export const YoutubeAtomPlayer = ({
 				const onStateChangeListener = createOnStateChangeListener(
 					videoId,
 					uniqueId,
-					progressEvents.current,
+					playerPauseState.current,
 					sendOphanTrackingEvent,
 					trackMilestones,
+					resetMilestones,
 				);
 
 				/**

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -189,7 +189,10 @@ const createOnStateChangeListener =
 	(
 		videoId: string,
 		uniqueId: string,
-		playerState: { paused: boolean },
+		playerState: {
+			paused: boolean;
+			progressIntervalId: ReturnType<typeof setInterval> | undefined;
+		},
 		sendOphanTrackingEvent: (event: VideoEventKey) => void,
 		trackMilestones: ReturnType<typeof useVideoMilestoneTracking>[0],
 		resetMilestones: () => void,
@@ -221,28 +224,17 @@ const createOnStateChangeListener =
 
 			playerState.paused = false;
 
-			/**
-			 * Set a timeout to check progress in the future
-			 */
-			setTimeout(() => {
-				checkProgress();
-			}, 3000);
-
-			const checkProgress = () => {
+			clearInterval(playerState.progressIntervalId);
+			playerState.progressIntervalId = setInterval(() => {
 				trackMilestones({
 					currentTime: player.getCurrentTime(),
 					duration: player.getDuration(),
 				});
 
-				if (player.getPlayerState() !== YT.PlayerState.ENDED) {
-					/**
-					 * Set a timeout to check progress again in the future
-					 */
-					setTimeout(() => checkProgress(), 3000);
+				if (player.getPlayerState() === YT.PlayerState.ENDED) {
+					clearInterval(playerState.progressIntervalId);
 				}
-
-				return null;
-			};
+			}, 3000);
 		}
 
 		if (event.data === YT.PlayerState.PAUSED) {
@@ -256,6 +248,7 @@ const createOnStateChangeListener =
 			});
 			sendOphanTrackingEvent('pause');
 			playerState.paused = true;
+			clearInterval(playerState.progressIntervalId);
 		}
 
 		if (event.data === YT.PlayerState.CUED) {
@@ -270,6 +263,7 @@ const createOnStateChangeListener =
 
 		if (event.data === YT.PlayerState.ENDED) {
 			dispatchCustomPauseEvent(uniqueId);
+			clearInterval(playerState.progressIntervalId);
 			trackMilestones({ ended: true });
 			resetMilestones();
 		}
@@ -422,7 +416,8 @@ export const YoutubeAtomPlayer = ({
 	);
 	const playerPauseState = useRef<{
 		paused: boolean;
-	}>({ paused: false });
+		progressIntervalId: ReturnType<typeof setInterval> | undefined;
+	}>({ paused: false, progressIntervalId: undefined });
 
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
 	const [isFullscreen, setIsFullscreen] = useState<boolean>(false);

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
 
 type Milestones = {
+	hasSentPlay: boolean;
 	hasSent25: boolean;
 	hasSent50: boolean;
 	hasSent75: boolean;
@@ -17,11 +18,15 @@ export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,
 ): [
 	(
-		progress: { currentTime: number; duration: number } | { ended: true },
+		progress:
+			| { currentTime: number; duration: number }
+			| { started: true }
+			| { ended: true },
 	) => void,
 	() => void,
 ] => {
 	const clearMilestones = () => ({
+		hasSentPlay: false,
 		hasSent25: false,
 		hasSent50: false,
 		hasSent75: false,
@@ -34,6 +39,7 @@ export const useVideoMilestoneTracking = (
 		(
 			progress:
 				| { currentTime: number; duration: number }
+				| { started: true }
 				| { ended: true },
 		) => {
 			let percent = 0;
@@ -42,6 +48,11 @@ export const useVideoMilestoneTracking = (
 				percent = 100;
 			} else if ('duration' in progress && progress.duration > 0) {
 				percent = (progress.currentTime / progress.duration) * 100;
+			}
+
+			if (!milestones.current.hasSentPlay && percent >= 0) {
+				onMilestone('play');
+				milestones.current.hasSentPlay = true;
 			}
 
 			if (!milestones.current.hasSent25 && percent >= 25) {

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -11,8 +11,8 @@ type Milestones = {
 
 /**
  * Returns a function that should be called on each time update.
- * It tracks when a video crosses the 25%, 50% and 75% milestones and
- * calls the provided callback for each.
+ * It tracks when a video begins, ends or crosses the 25%, 50% and 75%
+ * milestones. On each milestone the provided callback is triggered.
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,
@@ -35,6 +35,12 @@ export const useVideoMilestoneTracking = (
 
 	const milestones = useRef<Milestones>(clearMilestones());
 
+	/**
+	 * Sends tracking events when video milestones are hit.
+	 * Uses hook state to prevent duplicate tracking events from being fired.
+	 * Can be called on start, end or timestamp update events using the
+	 * appropriate parameters.
+	 */
 	const trackMilestone = useCallback(
 		(
 			progress:
@@ -78,8 +84,14 @@ export const useVideoMilestoneTracking = (
 		[onMilestone],
 	);
 
+	/**
+	 * Resets the milestones, allowing further tracking events to be triggered.
+	 * Will not reset if the video has not reached the end.
+	 */
 	const resetMilestones = () => {
-		milestones.current = clearMilestones();
+		if (milestones.current.hasSentEnd) {
+			milestones.current = clearMilestones();
+		}
 	};
 
 	return [trackMilestone, resetMilestones];

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -70,7 +70,7 @@ export const useVideoMilestoneTracking = (
 				milestones.current.hasSent75 = true;
 			}
 
-			if (!milestones.current.hasSentEnd && percent >= 100) {
+			if (!milestones.current.hasSentEnd && percent >= 99) {
 				onMilestone('end');
 				milestones.current.hasSentEnd = true;
 			}

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -5,6 +5,7 @@ type Milestones = {
 	hasSent25: boolean;
 	hasSent50: boolean;
 	hasSent75: boolean;
+	hasSentEnd: boolean;
 };
 
 /**
@@ -14,18 +15,34 @@ type Milestones = {
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,
-): ((currentTime: number, duration: number) => void) => {
-	const milestones = useRef<Milestones>({
+): [
+	(
+		progress: { currentTime: number; duration: number } | { ended: true },
+	) => void,
+	() => void,
+] => {
+	const clearMilestones = () => ({
 		hasSent25: false,
 		hasSent50: false,
 		hasSent75: false,
+		hasSentEnd: false,
 	});
 
-	return useCallback(
-		(currentTime: number, duration: number) => {
-			if (duration <= 0) return;
+	const milestones = useRef<Milestones>(clearMilestones());
 
-			const percent = (currentTime / duration) * 100;
+	const trackMilestone = useCallback(
+		(
+			progress:
+				| { currentTime: number; duration: number }
+				| { ended: true },
+		) => {
+			let percent = 0;
+
+			if ('ended' in progress) {
+				percent = 100;
+			} else if ('duration' in progress && progress.duration > 0) {
+				percent = (progress.currentTime / progress.duration) * 100;
+			}
 
 			if (!milestones.current.hasSent25 && percent >= 25) {
 				onMilestone('25');
@@ -41,7 +58,18 @@ export const useVideoMilestoneTracking = (
 				onMilestone('75');
 				milestones.current.hasSent75 = true;
 			}
+
+			if (!milestones.current.hasSentEnd && percent >= 100) {
+				onMilestone('end');
+				milestones.current.hasSentEnd = true;
+			}
 		},
 		[onMilestone],
 	);
+
+	const resetMilestones = () => {
+		milestones.current = clearMilestones();
+	};
+
+	return [trackMilestone, resetMilestones];
 };

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -14,7 +14,7 @@ type Milestones = {
  * It tracks when a video begins, ends or crosses the 25%, 50% and 75%
  * milestones. On each milestone the provided callback is triggered.
  * The second function can be used to reset the internal state of the hook,
- * allowing milestones to be again if a video is played multiple times.
+ * allowing milestones to be tracked again if a video is played multiple times.
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -16,6 +16,7 @@ type Milestones = {
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,
+	trackPercentageMilestones: boolean = true,
 ): [
 	(
 		progress:
@@ -61,19 +62,21 @@ export const useVideoMilestoneTracking = (
 				milestones.current.hasSentPlay = true;
 			}
 
-			if (!milestones.current.hasSent25 && percent >= 25) {
-				onMilestone('25');
-				milestones.current.hasSent25 = true;
-			}
+			if (trackPercentageMilestones) {
+				if (!milestones.current.hasSent25 && percent >= 25) {
+					onMilestone('25');
+					milestones.current.hasSent25 = true;
+				}
 
-			if (!milestones.current.hasSent50 && percent >= 50) {
-				onMilestone('50');
-				milestones.current.hasSent50 = true;
-			}
+				if (!milestones.current.hasSent50 && percent >= 50) {
+					onMilestone('50');
+					milestones.current.hasSent50 = true;
+				}
 
-			if (!milestones.current.hasSent75 && percent >= 75) {
-				onMilestone('75');
-				milestones.current.hasSent75 = true;
+				if (!milestones.current.hasSent75 && percent >= 75) {
+					onMilestone('75');
+					milestones.current.hasSent75 = true;
+				}
 			}
 
 			if (!milestones.current.hasSentEnd && percent >= 99) {
@@ -81,7 +84,7 @@ export const useVideoMilestoneTracking = (
 				milestones.current.hasSentEnd = true;
 			}
 		},
-		[onMilestone],
+		[onMilestone, trackPercentageMilestones],
 	);
 
 	/**

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -52,11 +52,20 @@ export const useVideoMilestoneTracking = (
 				| { ended: true },
 		) => {
 			let percent = 0;
+			let reachedEnd = false;
 
 			if ('ended' in progress) {
-				percent = 100;
+				reachedEnd = true;
 			} else if ('duration' in progress && progress.duration > 0) {
 				percent = (progress.currentTime / progress.duration) * 100;
+
+				/**
+				 * If a video reaches the last half a second considered it to have reached the end.
+				 * This is important for shorter videos where percentage updates will be less granular.
+				 */
+				if (Math.abs(progress.duration - progress.currentTime) < 0.5) {
+					reachedEnd = true;
+				}
 			}
 
 			if (!milestones.current.hasSentPlay && percent >= 0) {
@@ -81,7 +90,7 @@ export const useVideoMilestoneTracking = (
 				}
 			}
 
-			if (!milestones.current.hasSentEnd && percent >= 99) {
+			if (!milestones.current.hasSentEnd && reachedEnd) {
 				onMilestone('end');
 				milestones.current.hasSentEnd = true;
 			}

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -10,9 +10,11 @@ type Milestones = {
 };
 
 /**
- * Returns a function that should be called on each time update.
+ * Returns two functions, the first of which should be called on each time update.
  * It tracks when a video begins, ends or crosses the 25%, 50% and 75%
  * milestones. On each milestone the provided callback is triggered.
+ * The second function can be used to reset the internal state of the hook,
+ * allowing milestones to be again if a video is played multiple times.
  */
 export const useVideoMilestoneTracking = (
 	onMilestone: (event: VideoEventKey) => void,


### PR DESCRIPTION
## What does this change?
Continues the work of #15916 and uses the hook for tracking `PLAY` and `END` (new for the self-hosted player) milestone events.  Furthermore it allows `PLAY` and other milestones to be called multiple times for a single atom by introducing a `resetMilestones` function. When this is called milestones tracking events will be triggered again when reached.

Using the hook to store the `hasSentX` reduces boilerplate and makes the consuming code cleaner as it has fewer concerns. It should also provide stronger guarantees of consistent tracking behaviour between the YouTube and SelfHosted videos.

## Testing

I have tested across the major browsers, Chrome, Safari and Firefox. I noticed some issues on Firefox with `END` event requests seemingly not firing inconsistently. I'm not sure if this was an issue with the developer tools or the implementation. I would value a second opinion.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
