### PR TITLE
Use separate page component for Hosted Content 

### DIFF
--- a/dotcom-rendering/src/components/HostedContentPage.tsx
+++ b/dotcom-rendering/src/components/HostedContentPage.tsx
@@ -1,0 +1,150 @@
+import { Global } from '@emotion/react';
+import { StrictMode } from 'react';
+import { HostedArticleLayout } from '../layouts/HostedArticleLayout';
+import { HostedGalleryLayout } from '../layouts/HostedGalleryLayout';
+import { HostedVideoLayout } from '../layouts/HostedVideoLayout';
+import { ArticleDesign } from '../lib/articleFormat';
+import { rootStyles } from '../lib/rootStyles';
+import { filterABTestSwitches } from '../model/enhance-switches';
+import type { Article } from '../types/article';
+import type { RenderingTarget } from '../types/renderingTarget';
+import { AlreadyVisited } from './AlreadyVisited.island';
+import { useConfig } from './ConfigContext';
+import { DarkModeMessage } from './DarkModeMessage';
+import { FocusStyles } from './FocusStyles.island';
+import { Island } from './Island';
+import { Lightbox } from './Lightbox';
+import { Metrics } from './Metrics.island';
+import { SetABTests } from './SetABTests.island';
+import { SkipTo } from './SkipTo';
+
+interface BaseProps {
+	article: Article;
+	renderingTarget: RenderingTarget;
+}
+interface WebProps extends BaseProps {
+	renderingTarget: 'Web';
+}
+interface AppProps extends BaseProps {
+	renderingTarget: 'Apps';
+}
+
+/**
+ * @description
+ * HostedContentPage is a high level wrapper for hosted content pages on Dotcom. Sets strict mode and some globals
+ */
+export const HostedContentPage = (props: WebProps | AppProps) => {
+	const {
+		article: { design, display, theme, frontendData },
+		renderingTarget,
+	} = props;
+
+	const isWeb = renderingTarget === 'Web';
+	const { darkModeAvailable } = useConfig();
+
+	const format = {
+		design,
+		display,
+		theme,
+	};
+
+	const decideLayout = () => {
+		switch (format.design) {
+			case ArticleDesign.HostedVideo:
+				return (
+					<HostedVideoLayout
+						content={props.article}
+						format={format}
+						renderingTarget={renderingTarget}
+					/>
+				);
+			case ArticleDesign.HostedGallery:
+				return (
+					<HostedGalleryLayout
+						content={props.article}
+						format={format}
+						renderingTarget={renderingTarget}
+					/>
+				);
+			case ArticleDesign.HostedArticle:
+				return (
+					<HostedArticleLayout
+						content={props.article}
+						format={format}
+						renderingTarget={renderingTarget}
+					/>
+				);
+			default:
+				return null;
+		}
+	};
+
+	return (
+		<StrictMode>
+			<Global styles={rootStyles(format, darkModeAvailable)} />
+			{isWeb && <SkipTo id="maincontent" label="Skip to main content" />}
+			<Lightbox
+				format={format}
+				switches={frontendData.config.switches}
+				{...(renderingTarget === 'Web'
+					? {
+							lightboxImages: frontendData.imagesForLightbox,
+							renderingTarget,
+					  }
+					: {
+							lightboxImages: frontendData.imagesForAppsLightbox,
+							renderingTarget,
+					  })}
+			/>
+			<Island priority="enhancement" defer={{ until: 'idle' }}>
+				<FocusStyles />
+			</Island>
+
+			{renderingTarget === 'Web' && (
+				<>
+					<Island priority="feature" defer={{ until: 'idle' }}>
+						<AlreadyVisited />
+					</Island>
+					<Island priority="critical">
+						<Metrics
+							commercialMetricsEnabled={
+								!!frontendData.config.switches.commercialMetrics
+							}
+							tests={frontendData.config.abTests}
+						/>
+					</Island>
+
+					<Island priority="critical">
+						<SetABTests
+							abTestSwitches={filterABTestSwitches(
+								frontendData.config.switches,
+							)}
+							pageIsSensitive={frontendData.config.isSensitive}
+							isDev={!!frontendData.config.isDev}
+							serverSideTests={frontendData.config.abTests}
+							serverSideABTests={
+								frontendData.config.serverSideABTests
+							}
+						/>
+					</Island>
+				</>
+			)}
+			{renderingTarget === 'Web' && darkModeAvailable && (
+				<DarkModeMessage>
+					Dark mode is a work-in-progress.
+					<br />
+					You can{' '}
+					<a
+						style={{ color: 'inherit' }}
+						href="/ab-tests/opt-out/webx-dark-mode-web"
+					>
+						opt out anytime
+					</a>{' '}
+					if anything is unreadable or odd.
+				</DarkModeMessage>
+			)}
+
+			{decideLayout()}
+		</StrictMode>
+	);
+};

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -167,9 +167,16 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 						/>
 					);
 				case ArticleDesign.HostedArticle:
-				case ArticleDesign.HostedVideo:
 					return (
 						<HostedArticleLayout
+							content={article}
+							format={format}
+							renderingTarget={renderingTarget}
+						/>
+					);
+				case ArticleDesign.HostedVideo:
+					return (
+						<HostedVideoLayout
 							content={article}
 							format={format}
 							renderingTarget={renderingTarget}

--- a/dotcom-rendering/src/server/handler.article.web.ts
+++ b/dotcom-rendering/src/server/handler.article.web.ts
@@ -5,12 +5,16 @@ import { validateAsBlock, validateAsFEArticle } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
-import { renderBlocks, renderHtml } from './render.article.web';
+import {
+	renderArticle,
+	renderBlocks,
+	renderHostedContent,
+} from './render.article.web';
 
 export const handleArticle: RequestHandler = ({ body }, res) => {
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Web');
-	const { html, prefetchScripts } = renderHtml({
+	const { html, prefetchScripts } = renderArticle({
 		article,
 	});
 
@@ -20,7 +24,7 @@ export const handleArticle: RequestHandler = ({ body }, res) => {
 export const handleInteractive: RequestHandler = ({ body }, res) => {
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Web');
-	const { html, prefetchScripts } = renderHtml({
+	const { html, prefetchScripts } = renderArticle({
 		article,
 	});
 
@@ -30,7 +34,7 @@ export const handleInteractive: RequestHandler = ({ body }, res) => {
 export const handleHostedContent: RequestHandler = ({ body }, res) => {
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Web');
-	const { html, prefetchScripts } = renderHtml({
+	const { html, prefetchScripts } = renderHostedContent({
 		article,
 	});
 

--- a/dotcom-rendering/src/server/render.article.apps.tsx
+++ b/dotcom-rendering/src/server/render.article.apps.tsx
@@ -1,6 +1,7 @@
 import { isString } from '@guardian/libs';
 import { ArticlePage } from '../components/ArticlePage';
 import { ConfigProvider } from '../components/ConfigContext';
+import { HostedContentPage } from '../components/HostedContentPage';
 import { LiveBlogRenderer } from '../components/LiveBlogRenderer';
 import {
 	ArticleDesign,
@@ -202,4 +203,123 @@ export const renderAppsBlocks = ({
 	);
 
 	return `${extractedCss}${html}`;
+};
+
+export const renderHostedContent = (
+	article: Article,
+): {
+	prefetchScripts: string[];
+	html: string;
+} => {
+	const { design, frontendData, theme } = article;
+	const renderingTarget = 'Apps';
+	const config: Config = {
+		renderingTarget,
+		darkModeAvailable: true,
+		assetOrigin: ASSET_ORIGIN,
+		editionId: frontendData.editionId,
+	};
+
+	const { html, extractedCss } = renderToStringWithEmotion(
+		<ConfigProvider value={config}>
+			<HostedContentPage
+				article={article}
+				renderingTarget={renderingTarget}
+			/>
+		</ConfigProvider>,
+	);
+
+	// We want to only insert script tags for the elements or main media elements on this page view
+	// so we need to check what elements we have and use the mapping to the the chunk name
+	const elements: FEElement[] = frontendData.blocks
+		.map((block) => block.elements)
+		.flat();
+	const pageHasTweetElements = elements.some(
+		(element) =>
+			element._type ===
+			'model.dotcomrendering.pageElements.TweetBlockElement',
+	);
+	const pageHasNonBootInteractiveElements = elements.some(
+		(element) =>
+			element._type ===
+				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
+			element.scriptUrl !==
+				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
+	);
+
+	const clientScripts = [
+		getPathFromManifest('client.apps', 'index.js'),
+		pageHasNonBootInteractiveElements &&
+			`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
+	].filter(isString);
+	const scriptTags = generateScriptTags([...clientScripts]);
+
+	const initTwitter = `
+<script>
+// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+window.twttr = (function(d, s, id) {
+	var js, fjs = d.getElementsByTagName(s)[0],
+	t = window.twttr || {};
+	if (d.getElementById(id)) return t;
+	js = d.createElement(s);
+	js.id = id;
+	js.src = "https://platform.twitter.com/widgets.js";
+	fjs.parentNode.insertBefore(js, fjs);
+
+	t._e = [];
+	t.ready = function(f) {
+	t._e.push(f);
+	};
+
+	return t;
+}(document, "script", "twitter-wjs"));
+</script>`;
+
+	const guardian = createGuardian({
+		editionId: frontendData.editionId,
+		stage: frontendData.config.stage,
+		frontendAssetsFullURL: frontendData.config.frontendAssetsFullURL,
+		revisionNumber: frontendData.config.revisionNumber,
+		sentryPublicApiKey: frontendData.config.sentryPublicApiKey,
+		sentryHost: frontendData.config.sentryHost,
+		keywordIds: frontendData.config.keywordIds,
+		dfpAccountId: frontendData.config.dfpAccountId,
+		adUnit: frontendData.config.adUnit,
+		ajaxUrl: frontendData.config.ajaxUrl,
+		googletagUrl: frontendData.config.googletagUrl,
+		switches: frontendData.config.switches,
+		abTests: frontendData.config.abTests,
+		serverSideABTests: frontendData.config.serverSideABTests,
+		isPaidContent: frontendData.pageType.isPaidContent,
+		contentType: frontendData.contentType,
+		googleRecaptchaSiteKey: frontendData.config.googleRecaptchaSiteKey,
+		unknownConfig: frontendData.config,
+	});
+
+	const renderedPage = htmlPageTemplate({
+		css: extractedCss,
+		html,
+		title: frontendData.webTitle,
+		scriptTags,
+		guardian,
+		renderingTarget: 'Apps',
+		weAreHiring: !!frontendData.config.switches.weAreHiring,
+		canonicalUrl: frontendData.canonicalUrl,
+		initTwitter:
+			pageHasTweetElements || design === ArticleDesign.LiveBlog
+				? initTwitter
+				: undefined,
+		config,
+		dataAttributes: {
+			'rendering-target': 'apps',
+			...(getArticleThemeString(theme) && {
+				'article-theme': getArticleThemeString(theme)!,
+			}),
+		},
+	});
+
+	return {
+		prefetchScripts: clientScripts,
+		html: renderedPage,
+	};
 };

--- a/dotcom-rendering/src/server/render.article.web.tsx
+++ b/dotcom-rendering/src/server/render.article.web.tsx
@@ -1,6 +1,7 @@
 import { isString } from '@guardian/libs';
 import { ArticlePage } from '../components/ArticlePage';
 import { ConfigProvider } from '../components/ConfigContext';
+import { HostedContentPage } from '../components/HostedContentPage';
 import { LiveBlogRenderer } from '../components/LiveBlogRenderer';
 import {
 	ArticleDesign,
@@ -38,7 +39,7 @@ const decideTitle = ({ theme, frontendData }: Article): string => {
 	return `${frontendData.headline} | ${frontendData.sectionLabel} | The Guardian`;
 };
 
-export const renderHtml = ({
+export const renderArticle = ({
 	article,
 }: Props): { html: string; prefetchScripts: string[] } => {
 	const { design, frontendData, theme } = article;
@@ -293,4 +294,161 @@ export const renderBlocks = ({
 	);
 
 	return `${extractedCss}${html}`;
+};
+
+export const renderHostedContent = ({
+	article,
+}: Props): { html: string; prefetchScripts: string[] } => {
+	const { frontendData } = article;
+
+	const title = decideTitle(article);
+	const linkedData = frontendData.linkedData;
+
+	const darkModeAvailable =
+		frontendData.config.serverSideABTests['webx-dark-mode-web'] ===
+		'enable';
+
+	const renderingTarget = 'Web';
+	const config: Config = {
+		renderingTarget,
+		darkModeAvailable,
+		assetOrigin: ASSET_ORIGIN,
+		editionId: frontendData.editionId,
+	};
+
+	const { html, extractedCss } = renderToStringWithEmotion(
+		<ConfigProvider value={config}>
+			<HostedContentPage
+				article={article}
+				renderingTarget={renderingTarget}
+			/>
+		</ConfigProvider>,
+	);
+
+	// We want to only insert script tags for the elements or main media elements on this page view
+	// so we need to check what elements we have and use the mapping to the the chunk name
+	const elements: FEElement[] = frontendData.blocks
+		.map((block) => block.elements)
+		.flat();
+
+	/**
+	 *
+	 * See InteractiveBlockComponent.island.tsx for the full reasoning behind this logic:
+	 * https://github.com/guardian/dotcom-rendering/blob/69688c53604d28017f52c420d23609c758c68088/dotcom-rendering/src/components/InteractiveBlockComponent.island.tsx#L33-L90
+	 *
+	 * For the few interactive elements that do not load the standard boot.js but instead load a custom script,
+	 * we set `pageHasNonBootInteractiveElements` to true to dynamically add an AMD require function to the window
+	 * via `curl-with-js-and-domReady.js` so custom scripts can load themselves.
+	 */
+	const pageHasNonBootInteractiveElements = elements.some(
+		(element) =>
+			element._type ===
+				'model.dotcomrendering.pageElements.InteractiveBlockElement' &&
+			element.scriptUrl !==
+				'https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js', // We have rewritten this standard behaviour into Dotcom Rendering
+	);
+
+	const pageHasTweetElements = elements.some(
+		(element) =>
+			element._type ===
+			'model.dotcomrendering.pageElements.TweetBlockElement',
+	);
+
+	const build = getModulesBuild({
+		tests: frontendData.config.abTests,
+		switches: frontendData.config.switches,
+	});
+
+	/**
+	 * The highest priority scripts.
+	 * These scripts have a considerable impact on site performance.
+	 * Only scripts critical to application execution may go in here.
+	 * Please talk to the dotcom platform team before adding more.
+	 * Scripts will be executed in the order they appear in this array
+	 */
+	const prefetchScripts = [
+		polyfillIO,
+		getPathFromManifest(build, 'frameworks.js'),
+		getPathFromManifest(build, 'index.js'),
+		process.env.COMMERCIAL_BUNDLE_URL ??
+			frontendData.config.commercialBundleUrl,
+		pageHasNonBootInteractiveElements &&
+			`${ASSET_ORIGIN}static/frontend/js/curl-with-js-and-domReady.js`,
+	].filter(isString);
+
+	const scriptTags = generateScriptTags(prefetchScripts);
+
+	/**
+	 * We escape windowGuardian here to prevent errors when the data
+	 * is placed in a script tag on the page
+	 */
+	const guardian = createWindowGuardian({
+		editionId: frontendData.editionId,
+		stage: frontendData.config.stage,
+		frontendAssetsFullURL: frontendData.config.frontendAssetsFullURL,
+		revisionNumber: frontendData.config.revisionNumber,
+		sentryPublicApiKey: frontendData.config.sentryPublicApiKey,
+		sentryHost: frontendData.config.sentryHost,
+		keywordIds: frontendData.config.keywordIds,
+		dfpAccountId: frontendData.config.dfpAccountId,
+		adUnit: frontendData.config.adUnit,
+		ajaxUrl: frontendData.config.ajaxUrl,
+		googletagUrl: frontendData.config.googletagUrl,
+		switches: frontendData.config.switches,
+		abTests: frontendData.config.abTests,
+		serverSideABTests: frontendData.config.serverSideABTests,
+		brazeApiKey: frontendData.config.brazeApiKey,
+		isPaidContent: frontendData.pageType.isPaidContent,
+		contentType: frontendData.contentType,
+		shouldHideReaderRevenue: frontendData.shouldHideReaderRevenue,
+		googleRecaptchaSiteKey: frontendData.config.googleRecaptchaSiteKey,
+		// Until we understand exactly what config we need to make available client-side,
+		// add everything we haven't explicitly typed as unknown config
+		unknownConfig: frontendData.config,
+	});
+
+	const { openGraphData, twitterData } = frontendData;
+	const section = frontendData.config.section;
+	const initTwitter = `
+<script>
+// https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
+window.twttr = (function(d, s, id) {
+	var js, fjs = d.getElementsByTagName(s)[0],
+	t = window.twttr || {};
+	if (d.getElementById(id)) return t;
+	js = d.createElement(s);
+	js.id = id;
+	js.src = "https://platform.twitter.com/widgets.js";
+	fjs.parentNode.insertBefore(js, fjs);
+
+	t._e = [];
+	t.ready = function(f) {
+	t._e.push(f);
+	};
+
+	return t;
+}(document, "script", "twitter-wjs"));
+</script>`;
+
+	const pageHtml = htmlPageTemplate({
+		linkedData,
+		scriptTags,
+		css: extractedCss,
+		html,
+		title,
+		description: frontendData.trailText,
+		guardian,
+		openGraphData,
+		twitterData,
+		section,
+		initTwitter: pageHasTweetElements ? initTwitter : undefined,
+		canonicalUrl: frontendData.canonicalUrl,
+		renderingTarget: 'Web',
+		weAreHiring: !!frontendData.config.switches.weAreHiring,
+		config,
+		hasLiveBlogTopAd: !!frontendData.config.hasLiveBlogTopAd,
+		hasSurveyAd: !!frontendData.config.hasSurveyAd,
+	});
+
+	return { html: pageHtml, prefetchScripts };
 };


### PR DESCRIPTION
## What does this change?

- Adds new page component for hosted content pages
- Uses this in the `render.article` files when the request is for hosted content and update this in the `handler.article` files
  - The new `renderHostedContent` function is largely a duplicate of `renderArticle`

## Why?

We don't want the `skip to navigation` link to appear for Hosted Content pages since there is no real nav to navigate to.

We also don't need the navigation object as a whole and so we can strip this out of the request too, as well as removing certain parts of the page structure which aren't necessary for hosted content pages, like page targeting etc.
