### PR TITLE
A11y: deduplicate skip to nav shortcuts for articles

### DIFF
--- a/dotcom-rendering/src/components/ArticlePage.tsx
+++ b/dotcom-rendering/src/components/ArticlePage.tsx
@@ -103,7 +103,6 @@ export const ArticlePage = (props: WebProps | AppProps) => {
 			)}
 			{renderingTarget === 'Web' && (
 				<>
-					<SkipTo id="navigation" label="Skip to navigation" />
 					<Island priority="feature" defer={{ until: 'idle' }}>
 						<AlreadyVisited />
 					</Island>


### PR DESCRIPTION
## What does this change?

Removes the duplicate `skip to navigation` shortcut link from the top of article pages 

## Why?

This link currently appears twice and you have to tab twice to move through these two options. This is confusing for screen readers.

We only need one of these links and we only need this for web articles as apps articles don't use the nav