### PR TITLE
Run ab test CI on change to pnpm-workspace.yaml

### DIFF
--- a/.github/workflows/ab-testing-ci.yml
+++ b/.github/workflows/ab-testing-ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'ab-testing/**'
       - '.github/workflows/ab-testing-ci.yml'
+      - 'pnpm-workspace.yaml'
 
 jobs:
   ab-testing-checks:


### PR DESCRIPTION
## Why?
As we now use pnpm catalog as of #15894, changes to this file could cause issues that we'd want to find in CI first