### PR TITLE
extends intentIQ test to 10% of the audience

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -128,7 +128,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-06-18",
 		type: "client",
 		status: "ON",
-		audienceSize: 0 / 100,
+		audienceSize: 10 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,


### PR DESCRIPTION
## What does this change?
Extends the audience size of the AB Test for `intentIQ` to 10%.
## Why?
We are happy with the integration of intentIQ config with Prebid and are now happy to extend to 10% of the audience.
