### PR TITLE
Do not cap the height of main media videos

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -386,7 +386,7 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
-	maxHeightDesktop?: number;
+	restrictHeightOnDesktop?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -415,7 +415,7 @@ export const SelfHostedVideo = ({
 	isMainMedia,
 	role,
 	posterImageAspectRatio,
-	maxHeightDesktop,
+	restrictHeightOnDesktop = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1154,7 +1154,7 @@ export const SelfHostedVideo = ({
 						containerAspectRatioMobile,
 						containerAspectRatioDesktop,
 					),
-					!isUndefined(maxHeightDesktop) && maxHeightStyles,
+					restrictHeightOnDesktop && maxHeightStyles,
 				]}
 			>
 				<div

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/source/foundations';
 import type { FEAspectRatio } from '../frontend/feFront';
+import { isInteractive } from '../layouts/lib/interactiveLegacyStyling';
 import type { ArticleFormat } from '../lib/articleFormat';
 import {
 	extractValidSourcesFromAssets,
@@ -70,7 +71,9 @@ export const SelfHostedVideoInArticle = ({
 					format={format}
 					isMainMedia={isMainMedia}
 					role={role}
-					maxHeightDesktop={firstVideoSource?.height}
+					restrictHeightOnDesktop={
+						!isMainMedia && !isInteractive(format.design)
+					}
 				/>
 			</Island>
 		</div>


### PR DESCRIPTION
## What does this change?
[PR15885](https://github.com/guardian/dotcom-rendering/pull/15885) recently introduced a max height for self hosted videos in article to prevent 9:16 videos exceeding the viewport height. However, this has broken the design of interactive articles. 

This PR adds additional checks to make sure that the we do not restrict the height of self hosted main media videos or videos within an interactive article. In either of these cases, we want them to take up as much space as they'd like.

## Why?
Capping the height of the main media videos was breaking the design of interactive articles such as https://www.theguardian.com/lifeandstyle/ng-interactive/2026/may/21/lund-point-tower-block-east-london and https://www.theguardian.com/world/ng-interactive/2026/feb/20/a-war-foretold-cia-mi6-putin-ukraine-plans-russia.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/119a13e4-f498-4c23-b754-606850ad079a
[after]: https://github.com/user-attachments/assets/cdfde094-5b62-4578-a036-08132fb6c340


<!--

You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
