### PR TITLE
Fix issue with 'skip to main content' on hosted pages

### DIFF
--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -220,7 +220,7 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			) : null}
 
-			<main id="maincontent" data-layout="HostedArticleLayout">
+			<main data-layout="HostedArticleLayout">
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>
 						<MainMedia

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -220,7 +220,7 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			) : null}
 
-			<main data-layout="HostedArticleLayout">
+			<main id="maincontent" data-layout="HostedArticleLayout">
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>
 						<MainMedia

--- a/dotcom-rendering/src/lib/articleFormat.ts
+++ b/dotcom-rendering/src/lib/articleFormat.ts
@@ -192,7 +192,7 @@ const isTheme = (theme: string | ArticleTheme): theme is ArticleTheme =>
 const isDesign = (design: string | ArticleDesign): design is ArticleDesign =>
 	!isString(design);
 
-const isHostedContentDesign = (design: ArticleDesign): boolean =>
+export const isHostedContentDesign = (design: ArticleDesign): boolean =>
 	[
 		ArticleDesign.HostedArticle,
 		ArticleDesign.HostedVideo,

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -6,13 +6,14 @@ import {
 } from '@guardian/source/foundations';
 import { paletteDeclarations } from '../paletteDeclarations';
 import { rootAdStyles } from './adStyles';
-import { isHostedContentDesign, type ArticleFormat } from './articleFormat';
+import { type ArticleFormat, isHostedContentDesign } from './articleFormat';
 
 const hostedHeaderOffset = (format: ArticleFormat) => {
 	if (isHostedContentDesign(format.design)) {
 		return css`
+			/* Brute force fix for the fixed hosted header causing odd behaviour on skip to main content */
 			${from.tablet} {
-				scroll-padding-top: 200px;
+				scroll-padding-top: 250px;
 			}
 		`;
 	}

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -5,7 +5,20 @@ import {
 } from '@guardian/source/foundations';
 import { paletteDeclarations } from '../paletteDeclarations';
 import { rootAdStyles } from './adStyles';
-import type { ArticleFormat } from './articleFormat';
+import { isHostedContentDesign, type ArticleFormat } from './articleFormat';
+
+const hostedHeaderOffset = (format: ArticleFormat) => {
+	console.log(format.design);
+
+	if (isHostedContentDesign(format.design)) {
+		return css`
+			html {
+				scroll-margin-top: 100px;
+			}
+		`;
+	}
+	return '';
+};
 
 /**
  * Global styles for pages:
@@ -39,6 +52,7 @@ export const rootStyles = (
 					}
 			  `
 			: ''}
+		${hostedHeaderOffset(format)}
 	}
 	/* Crude but effective mechanism. Specific components may need to improve on this behaviour. */
 	/* The not(.src...) selector is to work with Source's FocusStyleManager. */

--- a/dotcom-rendering/src/lib/rootStyles.ts
+++ b/dotcom-rendering/src/lib/rootStyles.ts
@@ -1,6 +1,7 @@
 import { css, type SerializedStyles } from '@emotion/react';
 import {
 	focusHalo,
+	from,
 	palette as sourcePalette,
 } from '@guardian/source/foundations';
 import { paletteDeclarations } from '../paletteDeclarations';
@@ -8,12 +9,10 @@ import { rootAdStyles } from './adStyles';
 import { isHostedContentDesign, type ArticleFormat } from './articleFormat';
 
 const hostedHeaderOffset = (format: ArticleFormat) => {
-	console.log(format.design);
-
 	if (isHostedContentDesign(format.design)) {
 		return css`
-			html {
-				scroll-margin-top: 100px;
+			${from.tablet} {
+				scroll-padding-top: 200px;
 			}
 		`;
 	}


### PR DESCRIPTION
## What does this change?

This adds a `scroll-padding-top` value on hosted pages to avoid the header overlapping when using the 'skip to main content' link. The value is somewhat arbitrary but seems to work the best across breakpoints testing on both Chrome and Firefox. I attempted to instead set a `scroll-margin-top` on the skip link target or various parent elements but it simply did not work, possibly due to an interaction with an `overflow` property somewhere. The value is only set at tablet and above as smaller devices should only interact with the skip link via a screen reader.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214906441275804