### PR TITLE
Fix Hosted Content dark mode colours

### DIFF
--- a/dotcom-rendering/src/components/ArticleBody.tsx
+++ b/dotcom-rendering/src/components/ArticleBody.tsx
@@ -57,7 +57,6 @@ type Props = {
 	shouldHideAds: boolean;
 	serverTime?: number;
 	idApiUrl?: string;
-	accentColor?: string;
 };
 
 const globalOlStyles = () => css`
@@ -101,20 +100,6 @@ const globalStrongStyles = css`
 const bodyPadding = css`
 	${between.tablet.and.desktop} {
 		padding-right: 80px;
-	}
-`;
-
-const hostedContentLinkStyles = (accentColor?: string) => css`
-	a:not([data-ignore='global-link-styling']) {
-		text-decoration: none;
-		border-bottom: 1px solid ${themePalette('--article-link-border')};
-		color: ${accentColor ?? themePalette('--article-link-text')};
-
-		:hover {
-			color: ${accentColor ?? themePalette('--article-link-text-hover')};
-			border-bottom: 1px solid
-				${accentColor ?? themePalette('--article-link-border-hover')};
-		}
 	}
 `;
 
@@ -164,7 +149,6 @@ export const ArticleBody = ({
 	shouldHideAds,
 	serverTime,
 	idApiUrl,
-	accentColor,
 }: Props) => {
 	const isInteractiveContent =
 		format.design === ArticleDesign.Interactive ||
@@ -262,10 +246,7 @@ export const ArticleBody = ({
 					globalOlStyles(),
 					globalStrongStyles,
 					globalLinkStyles(),
-					isHostedContent && [
-						hostedContentH2Styles,
-						hostedContentLinkStyles(accentColor),
-					],
+					isHostedContent && [hostedContentH2Styles],
 				]}
 				lang={language}
 				dir={languageDirection}

--- a/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
+++ b/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
@@ -31,7 +31,6 @@ export const FetchHostedOnwards = ({ branding, url }: Props) => {
 		<HostedContentOnwards
 			trails={trails}
 			brandName={branding?.sponsorName ?? ''}
-			accentColor={branding?.hostedCampaignColour}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
@@ -22,7 +22,6 @@ export const WithAccentColour = () => {
 		<HostedContentOnwards
 			trails={hostedOnwardsTrails}
 			brandName="TrendAI"
-			accentColor="#FF0000"
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -12,18 +12,26 @@ import { HostedContentOnwardsCard } from './HostedContentOnwardsCard';
 type HostedContentOnwardsProps = {
 	trails: TrailType[];
 	brandName: string;
-	accentColor?: string;
 };
 
 const headerStyles = css`
 	margin-bottom: ${space[1]}px;
-	border-top: ${space[2]}px solid var(--accent-colour);
+	border-top: ${space[2]}px solid
+		var(--accent-colour, ${sourcePalette.neutral[86]});
 `;
 
 const headingStyles = css`
 	${textSans17}
 	padding-top: ${space[2]}px;
 	color: ${sourcePalette.neutral[7]};
+
+	@media (prefers-color-scheme: dark) {
+		color: ${sourcePalette.neutral[86]};
+	}
+
+	[data-color-scheme='dark'] & {
+		color: ${sourcePalette.neutral[86]};
+	}
 
 	span {
 		${textSansBold20}
@@ -51,14 +59,9 @@ const stackedCardWrapper = css`
 export const HostedContentOnwards = ({
 	trails,
 	brandName,
-	accentColor,
 }: HostedContentOnwardsProps) => {
 	return (
-		<div
-			css={css`
-				--accent-colour: ${accentColor ?? sourcePalette.neutral[7]};
-			`}
-		>
+		<>
 			<header css={headerStyles}>
 				<h2 css={headingStyles}>
 					More from
@@ -75,6 +78,6 @@ export const HostedContentOnwards = ({
 					);
 				})}
 			</ul>
-		</div>
+		</>
 	);
 };

--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -23,14 +23,14 @@ const headerStyles = css`
 const headingStyles = css`
 	${textSans17}
 	padding-top: ${space[2]}px;
-	color: ${sourcePalette.neutral[7]};
+	color: ${palette('--hosted-content-onwards-heading')};
 
 	@media (prefers-color-scheme: dark) {
-		color: ${sourcePalette.neutral[86]};
+		color: ${palette('--hosted-content-onwards-heading')};
 	}
 
 	[data-color-scheme='dark'] & {
-		color: ${sourcePalette.neutral[86]};
+		color: ${palette('--hosted-content-onwards-heading')};
 	}
 
 	span {

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -200,6 +200,16 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 		),
 	}));
 
+	const overridePaletteDeclarationsToUseAccentColor = (
+		accentColor?: string,
+	) => css`
+		@media (prefers-color-scheme: light) {
+			--article-link-text: ${accentColor ?? 'inherit'};
+			--article-link-text-hover: ${accentColor ?? 'inherit'};
+			--article-link-border-hover: ${accentColor ?? 'inherit'};
+		}
+	`;
+
 	return (
 		<>
 			{branding ? (
@@ -220,7 +230,12 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			) : null}
 
-			<main data-layout="HostedArticleLayout">
+			<main
+				data-layout="HostedArticleLayout"
+				css={overridePaletteDeclarationsToUseAccentColor(
+					branding?.hostedCampaignColour,
+				)}
+			>
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>
 						<MainMedia
@@ -321,7 +336,6 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 									isRightToLeftLang={
 										frontendData.isRightToLeftLang
 									}
-									accentColor={branding?.hostedCampaignColour}
 								/>
 								<HostedContentDisclaimer />
 							</ArticleContainer>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -168,6 +168,26 @@ const sideBorders = css`
 	}
 `;
 
+export const overridePaletteDeclarationsToUseAccentColor = (
+	accentColor?: string,
+) => {
+	return css`
+		@media (prefers-color-scheme: light) {
+			--article-link-text: ${accentColor ?? 'inherit'};
+			--article-link-text-hover: ${accentColor ?? 'inherit'};
+			--article-link-border-hover: ${accentColor ?? 'inherit'};
+			--accent-colour: ${accentColor ?? `${sourcePalette.neutral[38]}`};
+		}
+		/* The following styles are to reflect the current accentColor behaviour in storybook as well so we maintain consistency */
+		[data-color-scheme='dark'] & {
+			--article-link-text: inherit;
+			--article-link-text-hover: inherit;
+			--article-link-border-hover: inherit;
+			--accent-colour: ${sourcePalette.neutral[86]};
+		}
+	`;
+};
+
 export const HostedArticleLayout = (props: WebProps | AppProps) => {
 	const {
 		content: { frontendData },
@@ -199,27 +219,6 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 				'model.dotcomrendering.pageElements.CallToActionAtomBlockElement',
 		),
 	}));
-
-	const overridePaletteDeclarationsToUseAccentColor = (
-		accentColor?: string,
-	) => {
-		return css`
-			@media (prefers-color-scheme: light) {
-				--article-link-text: ${accentColor ?? 'inherit'};
-				--article-link-text-hover: ${accentColor ?? 'inherit'};
-				--article-link-border-hover: ${accentColor ?? 'inherit'};
-				--accent-colour: ${accentColor ??
-				`${sourcePalette.neutral[38]}`};
-			}
-
-			[data-color-scheme='dark'] & {
-				--article-link-text: inherit;
-				--article-link-text-hover: inherit;
-				--article-link-border-hover: inherit;
-				--accent-colour: ${sourcePalette.neutral[86]};
-			}
-		`;
-	};
 
 	return (
 		<>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -168,9 +168,12 @@ const sideBorders = css`
 	}
 `;
 
-export const overridePaletteDeclarationsToUseAccentColor = (
-	accentColor?: string,
-) => {
+/**
+ * Overrides palette declarations in light mode to use the accent color for the hosted content.
+ * @param accentColor - The accentColor to use for the hosted content in light mode.
+ * @returns A CSS string with the overridden palette declarations.
+ */
+export const overridePaletteColours = (accentColor?: string) => {
 	return css`
 		@media (prefers-color-scheme: light) {
 			--article-link-text: ${accentColor ?? 'inherit'};
@@ -183,6 +186,7 @@ export const overridePaletteDeclarationsToUseAccentColor = (
 			--article-link-text: inherit;
 			--article-link-text-hover: inherit;
 			--article-link-border-hover: inherit;
+			/* This CSS variable only exists in the scope of hosted content and it isn't defined in the paletteDeclarations.ts */
 			--accent-colour: ${sourcePalette.neutral[86]};
 		}
 	`;
@@ -242,9 +246,7 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="HostedArticleLayout"
-				css={overridePaletteDeclarationsToUseAccentColor(
-					branding?.hostedCampaignColour,
-				)}
+				css={overridePaletteColours(branding?.hostedCampaignColour)}
 			>
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.tsx
@@ -202,13 +202,24 @@ export const HostedArticleLayout = (props: WebProps | AppProps) => {
 
 	const overridePaletteDeclarationsToUseAccentColor = (
 		accentColor?: string,
-	) => css`
-		@media (prefers-color-scheme: light) {
-			--article-link-text: ${accentColor ?? 'inherit'};
-			--article-link-text-hover: ${accentColor ?? 'inherit'};
-			--article-link-border-hover: ${accentColor ?? 'inherit'};
-		}
-	`;
+	) => {
+		return css`
+			@media (prefers-color-scheme: light) {
+				--article-link-text: ${accentColor ?? 'inherit'};
+				--article-link-text-hover: ${accentColor ?? 'inherit'};
+				--article-link-border-hover: ${accentColor ?? 'inherit'};
+				--accent-colour: ${accentColor ??
+				`${sourcePalette.neutral[38]}`};
+			}
+
+			[data-color-scheme='dark'] & {
+				--article-link-text: inherit;
+				--article-link-text-hover: inherit;
+				--article-link-border-hover: inherit;
+				--accent-colour: ${sourcePalette.neutral[86]};
+			}
+		`;
+	};
 
 	return (
 		<>

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -185,6 +185,16 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 		elements: block.elements.filter((element) => !isCtaElement(element)),
 	}));
 
+	const overridePaletteDeclarationsToUseAccentColor = (
+		accentColor?: string,
+	) => css`
+		@media (prefers-color-scheme: light) {
+			--article-link-text: ${accentColor ?? 'inherit'};
+			--article-link-text-hover: ${accentColor ?? 'inherit'};
+			--article-link-border-hover: ${accentColor ?? 'inherit'};
+		}
+	`;
+
 	return (
 		<>
 			{branding ? (
@@ -205,7 +215,12 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 				</Stuck>
 			) : null}
 
-			<main data-layout="HostedVideoLayout">
+			<main
+				data-layout="HostedVideoLayout"
+				css={overridePaletteDeclarationsToUseAccentColor(
+					branding?.hostedCampaignColour,
+				)}
+			>
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>
 						<MainMedia
@@ -298,7 +313,6 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 									isRightToLeftLang={
 										frontendData.isRightToLeftLang
 									}
-									accentColor={branding?.hostedCampaignColour}
 								/>
 								<HostedContentDisclaimer />
 							</ArticleContainer>

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -26,6 +26,7 @@ import type { Article } from '../types/article';
 import type { Block } from '../types/blocks';
 import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
+import { overridePaletteDeclarationsToUseAccentColor } from './HostedArticleLayout';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -185,16 +186,6 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 		elements: block.elements.filter((element) => !isCtaElement(element)),
 	}));
 
-	const overridePaletteDeclarationsToUseAccentColor = (
-		accentColor?: string,
-	) => css`
-		@media (prefers-color-scheme: light) {
-			--article-link-text: ${accentColor ?? 'inherit'};
-			--article-link-text-hover: ${accentColor ?? 'inherit'};
-			--article-link-border-hover: ${accentColor ?? 'inherit'};
-		}
-	`;
-
 	return (
 		<>
 			{branding ? (
@@ -335,6 +326,7 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 								backgroundImage={cta.image}
 								text={cta.label}
 								buttonText={cta.btnText}
+								accentColor={branding?.hostedCampaignColour}
 							/>
 						</div>
 					)}

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -26,7 +26,7 @@ import type { Article } from '../types/article';
 import type { Block } from '../types/blocks';
 import type { FEElement } from '../types/content';
 import type { RenderingTarget } from '../types/renderingTarget';
-import { overridePaletteDeclarationsToUseAccentColor } from './HostedArticleLayout';
+import { overridePaletteColours } from './HostedArticleLayout';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
@@ -208,9 +208,7 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 
 			<main
 				data-layout="HostedVideoLayout"
-				css={overridePaletteDeclarationsToUseAccentColor(
-					branding?.hostedCampaignColour,
-				)}
+				css={overridePaletteColours(branding?.hostedCampaignColour)}
 			>
 				<article css={[containerStyles, sideBorders]}>
 					<div css={mainMediaStyles}>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7334,6 +7334,10 @@ const paletteColours = {
 		light: highlightContainerStartLight,
 		dark: highlightContainerStartDark,
 	},
+	'--hosted-content-onwards-heading': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--image-title-background': {
 		light: imageTitleBackground,
 		dark: imageTitleBackground,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -3864,6 +3864,9 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 const shareButtonDark: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedArticle:
+		case ArticleDesign.HostedGallery:
+		case ArticleDesign.HostedVideo:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:


### PR DESCRIPTION
## What does this change?

This PR overrides few palette declarations to use the `accentColor` if provided in light mode and use a neutral colour in dark mode. Thanks @cemms1 for your guidance on this!

The `overridePaletteDeclarationsToUseAccentColor` function overrides the values in light mode with accentColor if available. It also checks the data colour scheme if dark we inherit in these variables so we can have a consistent colours in production and in storybook thanks to @DanielCliftonGuardian. 

The changes are:
- Updated the `shareButtonDark` to be neutral for Hosted Content.
- The body links to have an accentColor in light mode and inherit in dark mode.
- Updated the "More from" in Onwards to a better colour contrast in dark mode.
- The border-top and the `brandName` in Onwards to neutral in dark mode.
- Removed redundant use of property accentColor in `ArticleBody` and `FetchHostedOnwards` components.
- Added CTA button accentColor to `HostedVideoLayout` as it was missing.   

Tested in CODE and it matches Storybook.

At the moment the only elements that should have an accentColor whether it's light mode or dark mode are the `advertiser-content` label and the CTA button. The body links and the Onwards border-top and the brandName should apply the accentColor in light mode but in dark mode they should have more of a neutral colour. 

We can iterate during the design team review of Hosted Content pages before we go live. 

## Why?

Better user experience in dark mode. 

## Screenshots

The following screenshots are when accentColor is provided for the first row and without accentColor for the second row.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/42b2d174-a5c6-4738-b809-0229ad1b2bdd
[after]: https://github.com/user-attachments/assets/d2c0b7db-4e49-4753-b8fc-35e2382434b3

[before2]: https://github.com/user-attachments/assets/e948d901-7abe-4ba1-9210-ce180b78e055
[after2]: https://github.com/user-attachments/assets/d905afba-412b-4465-a51c-285e66059fb3


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.



You can then reference the labels and map them to corresponding links.
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214616781153010