### PR TITLE
Make centre rule configurable in grid module

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
@@ -304,12 +304,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 	});
 
 	const navWeb = css({
-		'&': css(
-			grid.paddedContainer,
-			grid.verticalRules({
-				color: borderColor,
-			}),
-		),
+		'&': css(grid.paddedContainer, grid.verticalRules(borderColor)),
 	});
 
 	const largeLinkStyles = css({

--- a/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
@@ -304,7 +304,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 	});
 
 	const navWeb = css({
-		'&': css(grid.paddedContainer, grid.verticalRules(borderColor)),
+		'&': css(grid.paddedContainer, grid.outerRules(borderColor)),
 	});
 
 	const largeLinkStyles = css({

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -31,34 +31,10 @@ const styles = css`
 
 	${between.desktop.and.leftCol} {
 		${grid.column.right}
-
-		position: relative; /* allows the ::before to be positioned relative to this */
-
-		&::before {
-			content: '';
-			position: absolute;
-			left: -10px; /* 10px to the left of this element */
-			top: 0;
-			bottom: 0;
-			width: 1px;
-			background-color: ${palette('--article-border')};
-		}
 	}
 
 	${from.leftCol} {
 		${grid.column.left}
-
-		position: relative; /* allows the ::before to be positioned relative to this */
-
-		&::after {
-			content: '';
-			position: absolute;
-			right: -11px;
-			top: -12px;
-			bottom: 0;
-			width: 1px;
-			background-color: ${palette('--article-border')};
-		}
 	}
 `;
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { from, space, until } from '@guardian/source/foundations';
+import { between, from, space, until } from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { type ArticleFormat } from '../lib/articleFormat';
 import { getImage } from '../lib/image';
@@ -39,6 +39,10 @@ const styles = css`
 				padding-top: ${space[3]}px;
 			}
 		}
+	}
+
+	${between.desktop.and.leftCol} {
+		${grid.verticalRules({ plusChild: 2 })}
 	}
 `;
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 const styles = css`
 	${grid.paddedContainer}
-	${grid.verticalRules()}
+	${grid.outerRules()}
 	grid-auto-flow: row dense;
 	background-color: ${palette('--article-inner-background')};
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -39,10 +39,10 @@ const styles = css`
 	}
 
 	${between.desktop.and.leftCol} {
-		${grid.verticalRules({ centreRuleOnChildElement: 2 })}
+		${grid.centreRule(2)}
 	}
 	${from.leftCol} {
-		${grid.verticalRules({ centreRuleOnChildElement: 1 })}
+		${grid.centreRule(1)}
 	}
 `;
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -22,9 +22,8 @@ type Props = {
 };
 
 const styles = css`
-	overflow: hidden;
 	${grid.paddedContainer}
-	${grid.verticalRules({ plusChild: 1 })}
+	${grid.verticalRules()}
 	grid-auto-flow: row dense;
 	background-color: ${palette('--article-inner-background')};
 
@@ -34,15 +33,16 @@ const styles = css`
 	}
 
 	${from.desktop} {
-		&:first-of-type {
-			& > * {
-				padding-top: ${space[3]}px;
-			}
+		&:first-of-type > * {
+			padding-top: ${space[3]}px;
 		}
 	}
 
 	${between.desktop.and.leftCol} {
-		${grid.verticalRules({ plusChild: 2 })}
+		${grid.verticalRules({ centreRuleOnChildElement: 2 })}
+	}
+	${from.leftCol} {
+		${grid.verticalRules({ centreRuleOnChildElement: 1 })}
 	}
 `;
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -22,8 +22,9 @@ type Props = {
 };
 
 const styles = css`
+	overflow: hidden;
 	${grid.paddedContainer}
-	${grid.verticalRules()}
+	${grid.verticalRules({ plusChild: 1 })}
 	grid-auto-flow: row dense;
 	background-color: ${palette('--article-inner-background')};
 
@@ -34,7 +35,9 @@ const styles = css`
 
 	${from.desktop} {
 		&:first-of-type {
-			padding-top: ${space[3]}px;
+			& > * {
+				padding-top: ${space[3]}px;
+			}
 		}
 	}
 `;

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -88,36 +88,58 @@ const paddedContainer = `
 // ----- Vertical Rules ----- //
 
 type VerticalRuleOptions = {
-	centre?: boolean;
 	color?: string;
+	plusChild?: number;
 };
 
 /**
  * Render Guardian grid vertical rules.
  *
  * Left and right rules are always present.
- * A centre rule can optionally be enabled.
+ * A centre rule can optionally be enabled, anchored to the nth
+ * child of the grid container as specified by the `plusChild` option
  *
  * Usage:
  * css([grid.container, grid.verticalRules()])
- * css([grid.container, grid.verticalRules({ centre: true })])
+ * css([grid.container, grid.verticalRules({ plusChild: 3 })])
  */
-const optionalCentreRule = `/* CENTRE RULE */
-    & > *:first-child::before {
-      grid-column: centre-column-start;
-      transform: translateX(-${columnGap});
-	  ${fromBreakpoint.leftCol} {
-		transform: translateX(calc(-${columnGap} / 2));
-	  }
+
+// The centre rule is self-contained on the nth child element rather than on
+// the grid container, so that `top: 0` aligns to that element's top edge.
+// `bottom` uses a large negative value to extend the rule down to the
+// container's bottom; ensure `overflow: hidden` is set on the container
+const optionalCentreRule = (
+	nth: number,
+	color?: string,
+): string => `/* CENTRE RULE */
+    & > *:nth-child(${nth}) {
+      position: relative;
+
+      &::before {
+        position: absolute;
+        top: 0;
+        bottom: -9999px;
+        width: 1px;
+        background-color: ${color ?? palette('--article-border')};
+        content: '';
+        grid-column: centre-column-start;
+        transform: translateX(-${columnGap});
+
+        ${fromBreakpoint.leftCol} {
+          transform: translateX(calc(-${columnGap} / 2));
+        }
+      }
     }`;
 
-const verticalRules = (options: VerticalRuleOptions = {}): string => `
+const verticalRules = (options: VerticalRuleOptions = {}): string => {
+	const { plusChild, color } = options;
+
+	return `
   ${fromBreakpoint.tablet} {
     position: relative;
 
     &::before,
-    &::after
-    ${options.centre ? ', & > *:first-child::before' : ''} {
+    &::after {
       position: absolute;
       top: 0;
       bottom: 0;
@@ -146,8 +168,9 @@ const verticalRules = (options: VerticalRuleOptions = {}): string => `
       }
     }
 
-    ${options.centre ? optionalCentreRule : ''}
-`;
+    ${plusChild !== undefined ? optionalCentreRule(plusChild, color) : ''}
+  }`;
+};
 
 // ----- API ----- //
 

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -87,33 +87,28 @@ const paddedContainer = `
 
 // ----- Vertical Rules ----- //
 
-type VerticalRuleOptions = {
-	color?: string;
-	centreRuleOnChildElement?: number;
-};
-
 /**
- * Render Guardian grid vertical rules.
+ * CSS for a centre vertical rule anchored to the top of the nth child of the
+ * grid container.
  *
- * Left and right rules are always present.
- * A centre rule can optionally be enabled, anchored to the nth
- * child of the grid container as specified by the `centreRuleOnChildElement` option
+ * The rule is self-contained on the nth child element rather than on the grid
+ * container, so that `top: 0` aligns to that element's top edge. `bottom`
+ * uses a large negative value to extend the rule down to the container's
+ * bottom, so ensure `overflow: hidden` is set on the container.
  *
- * The centre rule is self-contained on the nth child element rather than on
- * the grid container, so that `top: 0` aligns to that element's top edge.
- * `bottom` uses a large negative value to extend the rule down to the
- * container's bottom so `overflow: hidden` is set on the container.
+ * @example
+ * css`
+ *   overflow: hidden;
+ *   ${grid.container}
+ *   ${grid.verticalRules()}
+ *   ${grid.centreRule(1)}
  *
- * Usage:
- * css([grid.container, grid.verticalRules()])
- * css([grid.container, grid.verticalRules({ centreRuleOnChildElement: 3 })])
+ *   ${from.leftCol} {
+ *     ${grid.centreRule(3)}
+ *   }
+ * `
  */
-const optionalCentreRule = (
-	n: number,
-	color?: string,
-): string => `/* CENTRE RULE */
-	overflow: hidden;
-
+const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
     & > *:nth-child(${n}) {
       position: relative;
 
@@ -133,10 +128,21 @@ const optionalCentreRule = (
       }
     }`;
 
-const verticalRules = (options: VerticalRuleOptions = {}): string => {
-	const { centreRuleOnChildElement, color } = options;
+/**
+ * CSS for the left and right Guardian grid vertical rules.
+ *
+ * Use `grid.centreRule` separately to add a centre rule anchored to a
+ * specific child element.
+ *
+ * @example
+ * css`
+ *   ${grid.container}
+ *   ${grid.verticalRules()}
+ * `
+ */
+const verticalRules = (color?: string): string => `
+  overflow: hidden;
 
-	return `
   ${fromBreakpoint.tablet} {
     position: relative;
 
@@ -146,7 +152,7 @@ const verticalRules = (options: VerticalRuleOptions = {}): string => {
       top: 0;
       bottom: 0;
       width: 1px;
-      background-color: ${options.color ?? palette('--article-border')};
+      background-color: ${color ?? palette('--article-border')};
       content: '';
     }
 
@@ -169,14 +175,7 @@ const verticalRules = (options: VerticalRuleOptions = {}): string => {
         grid-column: centre-column-end;
       }
     }
-
-    ${
-		centreRuleOnChildElement !== undefined
-			? optionalCentreRule(centreRuleOnChildElement, color)
-			: ''
-	}
   }`;
-};
 
 // ----- API ----- //
 
@@ -277,10 +276,23 @@ const grid = {
 	 * breakpoint.
 	 */
 	mobileColumnGap,
-
+	/**
+	 * CSS for the left and right vertical rules. Use `grid.centreRule`
+	 * separately to add a centre rule anchored to a specific child element.
+	 */
 	verticalRules,
+	/**
+	 * CSS for a centre vertical rule anchored to the top of the nth child of
+	 * the grid container. Can be called multiple times within different
+	 * breakpoint contexts to vary which child the rule anchors to.
+	 */
+	centreRule,
 } as const;
+
+// ----- Types ----- //
+type ColumnPreset = keyof typeof grid.column;
 
 // ----- Exports ----- //
 
+export type { Line, ColumnPreset };
 export { grid };

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -94,11 +94,10 @@ const paddedContainer = `
  * The rule is self-contained on the nth child element rather than on the grid
  * container, so that `top: 0` aligns to that element's top edge. `bottom`
  * uses a large negative value to extend the rule down to the container's
- * bottom, so ensure `overflow: hidden` is set on the container.
+ * bottom, so `overflow: hidden` is applied to the container.
  *
  * @example
  * css`
- *   overflow: hidden;
  *   ${grid.container}
  *   ${grid.verticalRules()}
  *   ${grid.centreRule(1)}
@@ -109,6 +108,8 @@ const paddedContainer = `
  * `
  */
 const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
+	overflow: hidden;
+
     & > *:nth-child(${n}) {
       position: relative;
 
@@ -141,8 +142,6 @@ const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
  * `
  */
 const outerRules = (color?: string): string => `
-  overflow: hidden;
-
   ${fromBreakpoint.tablet} {
     position: relative;
 

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -89,7 +89,7 @@ const paddedContainer = `
 
 type VerticalRuleOptions = {
 	color?: string;
-	plusChild?: number;
+	centreRuleOnChildElement?: number;
 };
 
 /**
@@ -97,22 +97,24 @@ type VerticalRuleOptions = {
  *
  * Left and right rules are always present.
  * A centre rule can optionally be enabled, anchored to the nth
- * child of the grid container as specified by the `plusChild` option
+ * child of the grid container as specified by the `centreRuleOnChildElement` option
+ *
+ * The centre rule is self-contained on the nth child element rather than on
+ * the grid container, so that `top: 0` aligns to that element's top edge.
+ * `bottom` uses a large negative value to extend the rule down to the
+ * container's bottom so `overflow: hidden` is set on the container.
  *
  * Usage:
  * css([grid.container, grid.verticalRules()])
- * css([grid.container, grid.verticalRules({ plusChild: 3 })])
+ * css([grid.container, grid.verticalRules({ centreRuleOnChildElement: 3 })])
  */
-
-// The centre rule is self-contained on the nth child element rather than on
-// the grid container, so that `top: 0` aligns to that element's top edge.
-// `bottom` uses a large negative value to extend the rule down to the
-// container's bottom; ensure `overflow: hidden` is set on the container
 const optionalCentreRule = (
-	nth: number,
+	n: number,
 	color?: string,
 ): string => `/* CENTRE RULE */
-    & > *:nth-child(${nth}) {
+	overflow: hidden;
+
+    & > *:nth-child(${n}) {
       position: relative;
 
       &::before {
@@ -132,7 +134,7 @@ const optionalCentreRule = (
     }`;
 
 const verticalRules = (options: VerticalRuleOptions = {}): string => {
-	const { plusChild, color } = options;
+	const { centreRuleOnChildElement, color } = options;
 
 	return `
   ${fromBreakpoint.tablet} {
@@ -168,7 +170,11 @@ const verticalRules = (options: VerticalRuleOptions = {}): string => {
       }
     }
 
-    ${plusChild !== undefined ? optionalCentreRule(plusChild, color) : ''}
+    ${
+		centreRuleOnChildElement !== undefined
+			? optionalCentreRule(centreRuleOnChildElement, color)
+			: ''
+	}
   }`;
 };
 

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -140,7 +140,7 @@ const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
  *   ${grid.verticalRules()}
  * `
  */
-const verticalRules = (color?: string): string => `
+const outerRules = (color?: string): string => `
   overflow: hidden;
 
   ${fromBreakpoint.tablet} {
@@ -280,7 +280,7 @@ const grid = {
 	 * CSS for the left and right vertical rules. Use `grid.centreRule`
 	 * separately to add a centre rule anchored to a specific child element.
 	 */
-	verticalRules,
+	outerRules,
 	/**
 	 * CSS for a centre vertical rule anchored to the top of the nth child of
 	 * the grid container. Can be called multiple times within different
@@ -289,10 +289,6 @@ const grid = {
 	centreRule,
 } as const;
 
-// ----- Types ----- //
-type ColumnPreset = keyof typeof grid.column;
-
 // ----- Exports ----- //
 
-export type { Line, ColumnPreset };
 export { grid };

--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -125,7 +125,7 @@ const optionalCentreRule = (
         grid-column: centre-column-start;
         transform: translateX(-${columnGap});
 
-        ${fromBreakpoint.leftCol} {
+        ${fromBreakpoint.desktop} {
           transform: translateX(calc(-${columnGap} / 2));
         }
       }

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -579,7 +579,7 @@ const BodyAdSlot = (props: {
 const WebAdSlot = (props: { adIndex: number }) => (
 	<div
 		css={{
-			'&': css([grid.paddedContainer, grid.verticalRules()]),
+			'&': css([grid.paddedContainer, grid.outerRules()]),
 			gridAutoFlow: 'row dense',
 			backgroundColor: palette('--article-inner-background'),
 		}}


### PR DESCRIPTION
This rejigs the `verticalRules` option added to the `grid` module in #15760 so that its configurable to the nth child of the grid, rather than the first by default. This has come up while working on #15358 and #15922 and feels like a worthwhile change in its own right as the central rule is likely to align with different pieces of article furniture depending on the layout (and breakpoint).

Instead of a binary yes/no on the centre rule which applies to the first child regardless, this makes it more controlled by separating `verticalRules` and `centreRule` into separate options:


```ts
${grid.container}
${grid.outerRules()}
${grid.centreRule(1)}
 
${from.leftCol} {
	${grid.centreRule(3)}
}
```

As a proving ground this PR applies the new approach to the gallery layout, which was the first to adopt `grid`-based vertical rules in #15776. I've also applied it to https://github.com/guardian/dotcom-rendering/pull/15428 and it feels pretty tidy.