### PR TITLE
forced key event link to have 1px underline

### DIFF
--- a/dotcom-rendering/src/components/KeyEventCard.tsx
+++ b/dotcom-rendering/src/components/KeyEventCard.tsx
@@ -49,6 +49,7 @@ const linkStyles = css`
 		div {
 			text-decoration: underline ${palette('--key-event-text')};
 			text-underline-offset: 1px;
+			text-decoration-thickness: 1px;
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

The thickness of the underline on key events.

## Why?

It was noticed that the underlines on key event dates and titles didn't match each other so they have been adjusted to match the style of links in regular text.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b6f3d02a-9be3-455c-8a21-5067758e94d2
[after]: https://github.com/user-attachments/assets/a7449bce-0477-4180-ba08-b8871d89c681


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
