### PR TITLE
Do not throw when a StandardButton receives an invalid URL

### DIFF
--- a/dotcom-rendering/src/components/Button/utils.test.tsx
+++ b/dotcom-rendering/src/components/Button/utils.test.tsx
@@ -1,0 +1,20 @@
+import { isExternalLink } from './utils';
+
+describe('isExternalLink', () => {
+	it('correctly identifies an external link', () => {
+		expect(isExternalLink('https://www.theguardian.com/a/path')).toBe(
+			false,
+		);
+		expect(isExternalLink('https://code.dev-theguardian.com/dsa')).toBe(
+			false,
+		);
+		expect(isExternalLink('https://m.code.dev-theguardian.com/dsa')).toBe(
+			false,
+		);
+		expect(isExternalLink('https://bbc.co.uk')).toBe(true);
+	});
+
+	it('does not throw when the passed string is not a link', () => {
+		expect(isExternalLink('im-from-the-internet')).toBe(false);
+	});
+});

--- a/dotcom-rendering/src/components/Button/utils.tsx
+++ b/dotcom-rendering/src/components/Button/utils.tsx
@@ -2,14 +2,20 @@ import { SvgArrowRightStraight } from '@guardian/source/react-components';
 
 const platformHostnames = [
 	// CODE
-	'https://code.dev-theguardian.com/',
-	'https://m.code.dev-theguardian.com/',
+	'code.dev-theguardian.com',
+	'm.code.dev-theguardian.com',
 	// PROD
 	'www.theguardian.com',
 ];
 
-export const isExternalLink = (url: string) =>
-	!platformHostnames.includes(new URL(url).hostname);
+export const isExternalLink = (url: string) => {
+	try {
+		return !platformHostnames.includes(new URL(url).hostname);
+	} catch (_e) {
+		// It's not an external link. It's also ... not a link.
+		return false;
+	}
+};
 
 export const getPropsForLinkUrl = (label: string) =>
 	({


### PR DESCRIPTION
## What does this change?

Do not throw when a `StandardButton` contains an invalid URL — or none at all.

## Why?

Buttons of this sort start out life without a URL, so this is a common state and we shouldn't blow up when we see it 😅 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="332" height="322" alt="Screenshot 2026-05-22 at 15 12 49" src="https://github.com/user-attachments/assets/998d7c8d-b325-44ea-91b4-ccb52c14ad26" /> | <img width="334" height="241" alt="Screenshot 2026-05-22 at 15 13 37" src="https://github.com/user-attachments/assets/bc08a2ca-1f07-48d8-bf94-4e5a56a4df7b" /> |