### PR TITLE
add teads prebid 0% AB test configuration

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -145,6 +145,19 @@ const ABTests: ABTest[] = [
 		groups: ["enable"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-teads-prebid",
+		description:
+			"Test to measure the impact of adding Teads as a bidder in prebid .",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-06-04",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?
Adds a 0% AB test configuration for adding Teads to prebid as a bidder in commercial. 
## Why?
We want to be able to place the new Teads integration with Prebid as a bidder initally behind a 0% test to ensure of no adverse affects. See related PR in commercial: https://github.com/guardian/commercial/pull/2567


Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
