### PR TITLE
Skip failing skimlinks e2e test

### DIFF
--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe('Affiliate links', () => {
 			await expect(disclaimerLocator).toContainText('affiliate link');
 		});
 
-		test('skimlinks should have the attribute rel="sponsored noreferrer noopener"', async ({
+		test.skip('skimlinks should have the attribute rel="sponsored noreferrer noopener"', async ({
 			page,
 		}) => {
 			await loadPage({


### PR DESCRIPTION
## What does this change?

Skip failing skimlinks e2e test

e.g.

https://github.com/guardian/dotcom-rendering/actions/runs/26425152688/job/77787318460?pr=15965

First failure:
https://github.com/guardian/dotcom-rendering/actions/runs/26295360985/attempts/1

Have alerted the filter team to investigate.

