### PR TITLE
Age warning data attribute and testing

### DIFF
--- a/dotcom-rendering/src/components/AgeWarning.tsx
+++ b/dotcom-rendering/src/components/AgeWarning.tsx
@@ -5,7 +5,6 @@ import {
 	textSans17,
 	visuallyHidden,
 } from '@guardian/source/foundations';
-import { guDataAttribute } from '../lib/dataAttributes';
 import { palette } from '../palette';
 
 type Props = {
@@ -55,7 +54,7 @@ export const AgeWarning = ({ age, isScreenReader, size = 'medium' }: Props) => {
 		<div
 			css={ageWarningStyles(isSmall)}
 			aria-hidden="true"
-			{...guDataAttribute(guDataAttribute.ageWarning)}
+			data-gu-name="age-warning"
 		>
 			<svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor">
 				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>

--- a/dotcom-rendering/src/components/AgeWarning.tsx
+++ b/dotcom-rendering/src/components/AgeWarning.tsx
@@ -5,6 +5,7 @@ import {
 	textSans17,
 	visuallyHidden,
 } from '@guardian/source/foundations';
+import { guDataAttribute } from '../lib/dataAttributes';
 import { palette } from '../palette';
 
 type Props = {
@@ -51,7 +52,11 @@ export const AgeWarning = ({ age, isScreenReader, size = 'medium' }: Props) => {
 	}
 
 	return (
-		<div css={ageWarningStyles(isSmall)} aria-hidden="true">
+		<div
+			css={ageWarningStyles(isSmall)}
+			aria-hidden="true"
+			{...guDataAttribute(guDataAttribute.ageWarning)}
+		>
 			<svg width="11" height="11" viewBox="0 0 11 11" fill="currentColor">
 				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>
 			</svg>{' '}

--- a/dotcom-rendering/src/lib/dataAttributes.test.tsx
+++ b/dotcom-rendering/src/lib/dataAttributes.test.tsx
@@ -1,15 +1,12 @@
 import { render } from '@testing-library/react';
 import { AgeWarning } from '../components/AgeWarning';
-import { guDataAttribute } from './dataAttributes';
 
 describe('Data Attributes', () => {
-	it('Article age warning element has a data-gu-name attribute', () => {
+	it('Article age warning element has an "age-warning" data-gu-name attribute', () => {
 		const { container } = render(
 			<AgeWarning age="3 years old" isScreenReader={false} />,
 		);
-		const el = container.querySelector(
-			`[data-gu-name="${guDataAttribute.ageWarning}"]`,
-		);
+		const el = container.querySelector('[data-gu-name="age-warning"]');
 		expect(el).toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/lib/dataAttributes.test.tsx
+++ b/dotcom-rendering/src/lib/dataAttributes.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { AgeWarning } from '../components/AgeWarning';
+import { guDataAttribute } from './dataAttributes';
+
+describe('Data Attributes', () => {
+	it('Article age warning element has a data-gu-name attribute', () => {
+		const { container } = render(
+			<AgeWarning age="3 years old" isScreenReader={false} />,
+		);
+		const el = container.querySelector(
+			`[data-gu-name="${guDataAttribute.ageWarning}"]`,
+		);
+		expect(el).toBeInTheDocument();
+	});
+});

--- a/dotcom-rendering/src/lib/dataAttributes.ts
+++ b/dotcom-rendering/src/lib/dataAttributes.ts
@@ -1,0 +1,9 @@
+const guNames = {
+	ageWarning: 'age-warning',
+} as const;
+
+type GuName = (typeof guNames)[keyof typeof guNames];
+
+const attribute = (name: GuName) => ({ 'data-gu-name': name });
+
+export const guDataAttribute = Object.assign(attribute, guNames);

--- a/dotcom-rendering/src/lib/dataAttributes.ts
+++ b/dotcom-rendering/src/lib/dataAttributes.ts
@@ -1,9 +1,0 @@
-const guNames = {
-	ageWarning: 'age-warning',
-} as const;
-
-type GuName = (typeof guNames)[keyof typeof guNames];
-
-const attribute = (name: GuName) => ({ 'data-gu-name': name });
-
-export const guDataAttribute = Object.assign(attribute, guNames);


### PR DESCRIPTION
This adds a `data-gu-name` attribute to article age warnings to allow for interactive devs to explicitly target and style it. At the moment opaque nested CSS is required, which isn't ideal.

<img width="498" height="179" alt="image" src="https://github.com/user-attachments/assets/e6c53686-48ac-4a39-9e7e-d2e5dee286b7" />

I've also added a test to ensure that attribute stays on the element, with a view of adding more for other elements. I think testing would go a long way towards formalising the contract with interactive devs on what they can count on being targetable in the DOM. There are [a bunch of attributes](https://github.com/guardian/dotcom-rendering/pull/14407) that interactive devs depend on but their presence is not currently protected or tested for.