### PR TITLE
Add isSignedIn parameter and click on input field to newsletter signup tracking events

### DIFF
--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -20,18 +20,20 @@ const sendPreviewTracking = ({
 	eventDescription,
 	renderingTarget,
 	renderUrl,
+	isSignedIn,
 }: {
 	identityName: string;
 	eventDescription: PreviewEventDescription;
 	renderingTarget: RenderingTarget;
 	renderUrl: string;
+	isSignedIn?: boolean | 'Pending';
 }) => {
 	sendNewsletterSignupEvent({
 		action: eventDescription === 'preview-open' ? 'EXPAND' : 'CLOSE',
 		identityName,
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.variant(identityName),
 		renderingTarget,
-		value: { eventDescription, renderUrl },
+		value: { eventDescription, renderUrl, isSignedIn },
 	});
 };
 
@@ -90,12 +92,13 @@ export const NewsletterSignupCardContainer = ({
 					eventDescription: 'preview-open',
 					renderingTarget,
 					renderUrl,
+					isSignedIn,
 				});
 			}
 
 			return true;
 		});
-	}, [identityName, renderingTarget, renderUrl]);
+	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const trackPreviewLinkOpen = useCallback(() => {
 		if (!renderUrl) {
@@ -107,8 +110,9 @@ export const NewsletterSignupCardContainer = ({
 			eventDescription: 'preview-open',
 			renderingTarget,
 			renderUrl,
+			isSignedIn,
 		});
-	}, [identityName, renderingTarget, renderUrl]);
+	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const closePreview = useCallback(() => {
 		setIsPreviewOpen((isOpen) => {
@@ -118,12 +122,13 @@ export const NewsletterSignupCardContainer = ({
 					eventDescription: 'preview-close',
 					renderingTarget,
 					renderUrl,
+					isSignedIn,
 				});
 			}
 
 			return false;
 		});
-	}, [identityName, renderingTarget, renderUrl]);
+	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const previewAction = hasPreviewUrl
 		? renderingTarget === 'Apps'

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -186,6 +186,7 @@ describe('NewsletterSignupForm', () => {
 		expect(params.get('browserId')).toBe('test-browser-id');
 
 		expectTrackedEventDescriptions([
+			'email-input-focused',
 			'click-button',
 			'open-captcha',
 			'captcha-passed',
@@ -368,6 +369,7 @@ describe('NewsletterSignupForm', () => {
 		});
 
 		expectTrackedEventDescriptions([
+			'email-input-focused',
 			'click-button',
 			'open-captcha',
 			'captcha-passed',
@@ -402,6 +404,7 @@ describe('NewsletterSignupForm', () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 
 		expectTrackedEventDescriptions([
+			'email-input-focused',
 			'click-button',
 			'open-captcha',
 			'captcha-not-passed',
@@ -433,6 +436,7 @@ describe('NewsletterSignupForm', () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 
 		expectTrackedEventDescriptions([
+			'email-input-focused',
 			'click-button',
 			'open-captcha',
 			'captcha-load-error',

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -208,6 +208,7 @@ const sendTracking = (
 	newsletterId: string,
 	eventDescription: NewsletterEventDescription,
 	renderingTarget: RenderingTarget,
+	isSignedIn: boolean | 'Pending',
 	abTest?: AbTest,
 ): void => {
 	sendNewsletterSignupEvent({
@@ -215,7 +216,7 @@ const sendTracking = (
 		identityName: newsletterId,
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.control(newsletterId),
 		renderingTarget,
-		value: { eventDescription },
+		value: { eventDescription, isSignedIn },
 		abTest,
 	});
 };
@@ -275,7 +276,13 @@ export const SecureSignup = ({
 			document.querySelector('input[type="email"]') ?? null;
 		const emailAddress: string = input?.value ?? '';
 
-		sendTracking(newsletterId, 'form-submission', renderingTarget, abTest);
+		sendTracking(
+			newsletterId,
+			'form-submission',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
 
 		const formData = buildFormData(
 			emailAddress,
@@ -305,6 +312,7 @@ export const SecureSignup = ({
 			newsletterId,
 			response.ok ? 'submission-confirmed' : 'submission-failed',
 			renderingTarget,
+			isSignedIn,
 			abTest,
 		);
 	};
@@ -320,6 +328,7 @@ export const SecureSignup = ({
 			newsletterId,
 			'captcha-load-error',
 			renderingTarget,
+			isSignedIn,
 			abTest,
 		);
 		setErrorMessage(`Sorry, the reCAPTCHA failed to load.`);
@@ -332,11 +341,18 @@ export const SecureSignup = ({
 				newsletterId,
 				'captcha-not-passed',
 				renderingTarget,
+				isSignedIn,
 				abTest,
 			);
 			return;
 		}
-		sendTracking(newsletterId, 'captcha-passed', renderingTarget, abTest);
+		sendTracking(
+			newsletterId,
+			'captcha-passed',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
 		setIsWaitingForResponse(true);
 		submitForm(token).catch((error) => {
 			console.error(error);
@@ -344,6 +360,7 @@ export const SecureSignup = ({
 				newsletterId,
 				'form-submit-error',
 				renderingTarget,
+				isSignedIn,
 				abTest,
 			);
 			setErrorMessage(`Sorry, there was an error signing you up.`);
@@ -352,7 +369,23 @@ export const SecureSignup = ({
 	};
 
 	const handleClick = (): void => {
-		sendTracking(newsletterId, 'click-button', renderingTarget, abTest);
+		sendTracking(
+			newsletterId,
+			'click-button',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
+	};
+
+	const handleEmailFocus = (): void => {
+		sendTracking(
+			newsletterId,
+			'email-input-focused',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
 	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
@@ -361,7 +394,13 @@ export const SecureSignup = ({
 			return;
 		}
 		setErrorMessage(undefined);
-		sendTracking(newsletterId, 'open-captcha', renderingTarget, abTest);
+		sendTracking(
+			newsletterId,
+			'open-captcha',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
 		recaptchaRef.current?.execute();
 	};
 
@@ -387,6 +426,7 @@ export const SecureSignup = ({
 					type="email"
 					value={userEmail ?? ''}
 					onChange={(e) => setUserEmail(e.target.value)}
+					onFocus={handleEmailFocus}
 				/>
 				{isSignedIn === false && (
 					<CheckboxGroup

--- a/dotcom-rendering/src/lib/newsletterSignupTracking.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupTracking.ts
@@ -6,6 +6,7 @@ export const AB_TEST_NAME = 'newsletters-newsletter-signup-card';
 
 export type NewsletterEventDescription =
 	| 'click-button'
+	| 'email-input-focused'
 	| 'form-submission'
 	| 'submission-confirmed'
 	| 'submission-failed'
@@ -17,6 +18,7 @@ export type NewsletterEventDescription =
 
 export const EVENT_DESCRIPTION_TO_ACTION = {
 	'click-button': 'CLICK',
+	'email-input-focused': 'EXPAND',
 	'form-submission': 'ANSWER',
 	'captcha-not-passed': 'ANSWER',
 	'captcha-passed': 'ANSWER',

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -98,6 +98,7 @@ const sendTracking = (
 	newsletterId: string,
 	eventDescription: NewsletterEventDescription,
 	renderingTarget: RenderingTarget,
+	isSignedIn: boolean | 'Pending',
 	abTest?: AbTest,
 ): void => {
 	sendNewsletterSignupEvent({
@@ -105,7 +106,7 @@ const sendTracking = (
 		identityName: newsletterId,
 		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.variant(newsletterId),
 		renderingTarget,
-		value: { eventDescription },
+		value: { eventDescription, isSignedIn },
 		abTest,
 	});
 };
@@ -274,6 +275,7 @@ export const useNewsletterSignupForm = (
 				newsletterId,
 				'form-submission',
 				renderingTarget,
+				isSignedIn,
 				abTest,
 			);
 
@@ -306,10 +308,11 @@ export const useNewsletterSignupForm = (
 				newsletterId,
 				response.ok ? 'submission-confirmed' : 'submission-failed',
 				renderingTarget,
+				isSignedIn,
 				abTest,
 			);
 		},
-		[abTest, newsletterId, renderingTarget],
+		[abTest, isSignedIn, newsletterId, renderingTarget],
 	);
 
 	const handleCaptchaComplete = useCallback(
@@ -319,6 +322,7 @@ export const useNewsletterSignupForm = (
 					newsletterId,
 					'captcha-not-passed',
 					renderingTarget,
+					isSignedIn,
 					abTest,
 				);
 				setIsValidationError(false);
@@ -331,6 +335,7 @@ export const useNewsletterSignupForm = (
 				newsletterId,
 				'captcha-passed',
 				renderingTarget,
+				isSignedIn,
 				abTest,
 			);
 			// Read the email that was validated at submit-time — not the
@@ -344,6 +349,7 @@ export const useNewsletterSignupForm = (
 						newsletterId,
 						'form-submit-error',
 						renderingTarget,
+						isSignedIn,
 						abTest,
 					);
 					setIsValidationError(false);
@@ -356,7 +362,7 @@ export const useNewsletterSignupForm = (
 					setIsWaitingForResponse(false);
 				});
 		},
-		[abTest, newsletterId, renderingTarget, submitForm],
+		[abTest, isSignedIn, newsletterId, renderingTarget, submitForm],
 	);
 
 	const handleCaptchaLoadError = useCallback((): void => {
@@ -364,13 +370,14 @@ export const useNewsletterSignupForm = (
 			newsletterId,
 			'captcha-load-error',
 			renderingTarget,
+			isSignedIn,
 			abTest,
 		);
 		setIsValidationError(false);
 		setErrorMessage('Sorry, the reCAPTCHA failed to load.');
 		setIsWaitingForResponse(false);
 		recaptchaRef.current?.reset();
-	}, [abTest, newsletterId, renderingTarget]);
+	}, [abTest, isSignedIn, newsletterId, renderingTarget]);
 
 	const handleSubmit = useCallback(
 		(event: FormEvent<HTMLFormElement>): void => {
@@ -388,11 +395,18 @@ export const useNewsletterSignupForm = (
 			setIsValidationError(false);
 			setErrorMessage(undefined);
 			setIsWaitingForResponse(true);
-			sendTracking(newsletterId, 'open-captcha', renderingTarget, abTest);
+			sendTracking(
+				newsletterId,
+				'open-captcha',
+				renderingTarget,
+				isSignedIn,
+				abTest,
+			);
 			recaptchaRef.current?.execute();
 		},
 		[
 			abTest,
+			isSignedIn,
 			isWaitingForResponse,
 			newsletterId,
 			renderingTarget,
@@ -409,7 +423,14 @@ export const useNewsletterSignupForm = (
 
 	const handleEmailFocus = useCallback((): void => {
 		setIsInteracted(true);
-	}, []);
+		sendTracking(
+			newsletterId,
+			'email-input-focused',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
+	}, [abTest, isSignedIn, newsletterId, renderingTarget]);
 
 	const handleEmailInvalid = useCallback<
 		React.FormEventHandler<HTMLInputElement>
@@ -434,8 +455,14 @@ export const useNewsletterSignupForm = (
 
 	const handleSubmitButtonClick = useCallback((): void => {
 		hasAttemptedSubmitRef.current = true;
-		sendTracking(newsletterId, 'click-button', renderingTarget, abTest);
-	}, [abTest, newsletterId, renderingTarget]);
+		sendTracking(
+			newsletterId,
+			'click-button',
+			renderingTarget,
+			isSignedIn,
+			abTest,
+		);
+	}, [abTest, isSignedIn, newsletterId, renderingTarget]);
 
 	const handleReset = useCallback<
 		ReactEventHandler<HTMLButtonElement>


### PR DESCRIPTION
## What does this change?
- Adds isSignedIn (real auth state from useIsSignedIn()) to the value payload on every tracking event in both useNewsletterSignupForm (variant) and SecureSignup (control)
- Adds a new email-input-focused event fired on email input focus in both branches, covering the missing signed-out funnel step between VIEW and click-button
- Adds isSignedIn to the preview-open / preview-close events in NewsletterSignupCardContainer

## Why?
So we can measure the impact of subsequent UX changes with better data — segmenting by sign-in state and seeing the full signed-out funnel: VIEW → email-input-focused → click-button → open-captcha → submission-confirmed.



## Screenshots
No visual changes — tracking only.