### PR TITLE
Affiliate links - consistent `rel` attribute

### DIFF
--- a/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/affiliate-links.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe('Affiliate links', () => {
 			await expect(disclaimerLocator).toContainText('affiliate link');
 		});
 
-		test.skip('skimlinks should have the attribute rel="sponsored noreferrer noopener"', async ({
+		test('skimlinks should have the attribute rel="sponsored noreferrer noopener"', async ({
 			page,
 		}) => {
 			await loadPage({

--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -2,7 +2,7 @@ import { css, jsx } from '@emotion/react';
 import { articleItalic17 } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
-import { isSkimlink } from '../lib/affiliateLinksUtils';
+import { isSkimlink, SKIMLINK_REL } from '../lib/affiliateLinksUtils';
 import { getAttrs, isElement, parseHtml } from '../lib/domUtils';
 import { palette } from '../palette';
 import { logger } from '../server/lib/logging';
@@ -103,7 +103,7 @@ const textElement =
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
 					rel: isSkimlink(href)
-						? 'sponsored noreferrer noopener'
+						? SKIMLINK_REL
 						: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,
 					children,

--- a/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
+++ b/dotcom-rendering/src/components/BlockquoteBlockComponent.tsx
@@ -103,7 +103,7 @@ const textElement =
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
 					rel: isSkimlink(href)
-						? 'sponsored'
+						? 'sponsored noreferrer noopener'
 						: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,
 					children,

--- a/dotcom-rendering/src/components/Button/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/Button/ProductLinkButton.tsx
@@ -5,6 +5,7 @@ import type {
 	ThemeButton,
 } from '@guardian/source/react-components';
 import { LinkButton } from '@guardian/source/react-components';
+import { SKIMLINK_REL } from '../../lib/affiliateLinksUtils';
 import { palette } from '../../palette';
 import { heightAutoStyle, wrapButtonTextStyle } from './styles';
 import { getPropsForLinkUrl } from './utils';
@@ -66,7 +67,7 @@ export const ProductLinkButton = ({
 		<LinkButton
 			{...getPropsForLinkUrl(label)}
 			href={url}
-			rel="sponsored noreferrer noopener"
+			rel={SKIMLINK_REL}
 			priority={priority}
 			theme={theme}
 			data-component={dataComponent}

--- a/dotcom-rendering/src/components/CaptionText.tsx
+++ b/dotcom-rendering/src/components/CaptionText.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { headlineMedium17, space } from '@guardian/source/foundations';
 import { type ReactNode } from 'react';
 import sanitise, { type IOptions } from 'sanitize-html';
-import { isSkimlink } from '../lib/affiliateLinksUtils';
+import { isSkimlink, SKIMLINK_REL } from '../lib/affiliateLinksUtils';
 import { getAttrs, parseHtml } from '../lib/domUtils';
 import { palette } from '../palette';
 
@@ -79,11 +79,7 @@ const renderTextElement = (node: Node, key: number): ReactNode => {
 					 * Affiliate links must have the rel attribute set to "sponsored"
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
-					rel={
-						isSkimlink(href)
-							? 'sponsored noreferrer noopener'
-							: undefined
-					}
+					rel={isSkimlink(href) ? SKIMLINK_REL : undefined}
 				>
 					{children}
 				</a>

--- a/dotcom-rendering/src/components/CaptionText.tsx
+++ b/dotcom-rendering/src/components/CaptionText.tsx
@@ -79,7 +79,11 @@ const renderTextElement = (node: Node, key: number): ReactNode => {
 					 * Affiliate links must have the rel attribute set to "sponsored"
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
-					rel={isSkimlink(href) ? 'sponsored' : undefined}
+					rel={
+						isSkimlink(href)
+							? 'sponsored noreferrer noopener'
+							: undefined
+					}
 				>
 					{children}
 				</a>

--- a/dotcom-rendering/src/components/ProductCardImage.tsx
+++ b/dotcom-rendering/src/components/ProductCardImage.tsx
@@ -40,7 +40,7 @@ export const ProductCardImage = ({
 				<a
 					href={url}
 					target="_blank"
-					rel="noopener noreferrer"
+					rel="sponsored noopener noreferrer"
 					data-link-name="product image link"
 					data-x-cust-component-id={xCustComponentId}
 					// this is needed to override global style

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -291,7 +291,7 @@ const buildElementTree =
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
 					rel: isSkimlink(href)
-						? 'sponsored'
+						? 'sponsored noreferrer noopener'
 						: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,
 					children,

--- a/dotcom-rendering/src/components/TextBlockComponent.tsx
+++ b/dotcom-rendering/src/components/TextBlockComponent.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from 'react';
 import { Fragment } from 'react';
 import type { IOptions } from 'sanitize-html';
 import sanitise from 'sanitize-html';
-import { isSkimlink } from '../lib/affiliateLinksUtils';
+import { isSkimlink, SKIMLINK_REL } from '../lib/affiliateLinksUtils';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -291,7 +291,7 @@ const buildElementTree =
 					 * @see https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links
 					 */
 					rel: isSkimlink(href)
-						? 'sponsored noreferrer noopener'
+						? SKIMLINK_REL
 						: getAttrs(node)?.getNamedItem('rel')?.value,
 					key,
 					children,

--- a/dotcom-rendering/src/lib/affiliateLinksUtils.ts
+++ b/dotcom-rendering/src/lib/affiliateLinksUtils.ts
@@ -1,5 +1,7 @@
 import type { ABParticipations } from '../experiments/lib/beta-ab-tests';
 
+export const SKIMLINK_REL = 'sponsored noreferrer noopener';
+
 /** A function to check if a URL represents an affiliate link */
 export const isSkimlink = (url?: string): boolean => {
 	try {


### PR DESCRIPTION
## What does this change?

Updates all affiliate (skimlinks) links to use the attribute `rel="sponsored noopener noreferer"`. We already use this value on the product link button.

## Why?

We are testing this exact value in our e2e tests assuming we'll find a product link button. This caused a [failure](https://github.com/guardian/dotcom-rendering/pull/15967) when the article was updated to include a skimlink in the opening body text. Making this consistent means the tests don't have to rely on the order in which the links might appear, and is correct as we should be applying the same attributes to all skimlinks.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1784" height="164" alt="image" src="https://github.com/user-attachments/assets/e38fc9e7-0d34-458f-a566-43689e60f491" /> | <img width="1773" height="304" alt="image" src="https://github.com/user-attachments/assets/8b814af0-6fce-4cf8-8f1b-cafef5214c7f" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215130095789192