### PR TITLE
Remove flexible container check from card

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -924,7 +924,6 @@ export const Card = ({
 								imageSize={mediaSize}
 								imagePositionOnDesktop={mediaPositionOnDesktop}
 								imagePositionOnMobile={mediaPositionOnMobile}
-								isFlexibleContainer={isFlexibleContainer}
 							>
 								<Avatar
 									src={media.avatarUrl}

--- a/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
+++ b/dotcom-rendering/src/components/Card/components/AvatarContainer.tsx
@@ -7,7 +7,6 @@ type Props = {
 	imageSize: MediaSizeType;
 	imagePositionOnDesktop: MediaPositionType;
 	imagePositionOnMobile: MediaPositionType;
-	isFlexibleContainer: boolean;
 };
 
 const sideMarginStyles = css`
@@ -16,7 +15,6 @@ const sideMarginStyles = css`
 
 const sizingStyles = (
 	imageSize: MediaSizeType,
-	isFlexibleContainer: boolean,
 	isVerticalOnDesktop: boolean,
 	isVerticalOnMobile: boolean,
 ) => {
@@ -34,19 +32,10 @@ const sizingStyles = (
 	switch (imageSize) {
 		case 'small':
 		case 'scrollable-small':
-			return isFlexibleContainer
-				? css`
-						width: 90px;
-						height: 90px;
-						${until.tablet} {
-							height: 80px;
-							width: 80px;
-						}
-				  `
-				: css`
-						width: 80px;
-						height: 80px;
-				  `;
+			return css`
+				width: 80px;
+				height: 80px;
+			`;
 		case 'large':
 		case 'xlarge':
 			return css`
@@ -71,6 +60,13 @@ const sizingStyles = (
 				}
 			`;
 		case 'medium':
+		case 'carousel':
+		case 'scrollable-medium':
+		case 'podcast':
+		case 'highlights-card':
+		case 'feature':
+		case 'feature-large':
+		case 'feature-immersive':
 		default:
 			return css`
 				width: 90px;
@@ -88,7 +84,6 @@ export const AvatarContainer = ({
 	imageSize,
 	imagePositionOnDesktop,
 	imagePositionOnMobile,
-	isFlexibleContainer,
 }: Props) => {
 	const isVerticalOnDesktop =
 		imagePositionOnDesktop === 'top' || imagePositionOnDesktop === 'bottom';
@@ -101,7 +96,6 @@ export const AvatarContainer = ({
 				sideMarginStyles,
 				sizingStyles(
 					imageSize,
-					isFlexibleContainer,
 					isVerticalOnDesktop,
 					isVerticalOnMobile,
 				),


### PR DESCRIPTION
## What does this change?
Remove flexible container check from deciding avatar sizing. 

## Why?
If an image has a size of 'scrollable-small' it cannot be in a flexible general container, therefore this check is not needed and helps to reduce the amount of container checks in card. 

## Screenshots
This is a no-op change 

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
