### PR TITLE
adds prebid price floor holdback AB test config

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -108,16 +108,16 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
-		name: "commercial-prebid-price-floor",
+		name: "commercial-prebid-price-floor-holdback",
 		description:
-			"Measure the impact on bid response rate of enforcing a minimum $0.10 bid floor on all Prebid ad slots.",
+			"This test will be the 5% holdback group for the prebid price floor",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-05-15",
+		expirationDate: "2026-06-17",
 		type: "client",
-		status: "OFF",
-		audienceSize: 10 / 100,
+		status: "ON",
+		audienceSize: 5 / 100,
 		audienceSpace: "A",
-		groups: ["control", "variant"],
+		groups: ["variant"],
 		shouldForceMetricsCollection: true,
 	},
 	{

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -117,7 +117,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		audienceSize: 5 / 100,
 		audienceSpace: "A",
-		groups: ["variant"],
+		groups: ["holdback"],
 		shouldForceMetricsCollection: true,
 	},
 	{


### PR DESCRIPTION
## What does this change?
We are creating an AB test config for `commercial-prebid-price-floor-holdback` as a 5% holdback test and ensured this is part of Group "A".
## Why?
We would initially like to release Prebid Price floors incrementally and test as we go along. This ensures we "holdback" 5% of the same user Groups without any price floors applied.
