### PR TITLE
Roll out hosted content AB test to 10% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -77,7 +77,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-07-01",
 		type: "server",
 		status: "ON",
-		audienceSize: 0 / 100,
+		audienceSize: 10 / 100,
 		audienceSpace: "A",
 		groups: ["preview"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?

Rolls out the hosted article and video pages to 10% of the audience by upping the AB test percentage

## Why?

We're ready to roll out these pages. We'll be doing this in stages and the first step is going to 10%