### PR TITLE
Loop click through to article test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -158,6 +158,18 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: "fronts-and-curation-loop-click-through",
+		description:
+			"Test impact of click to article via loop videos on fronts",
+		owners: ["fronts.and.curation@guardian.co.uk"],
+		status: "OFF",
+		expirationDate: "2026-06-19",
+		type: "server",
+		audienceSize: 0 / 100,
+		groups: ["enable"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -167,7 +167,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-06-19",
 		type: "server",
 		audienceSize: 0 / 100,
-		groups: ["enable"],
+		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},
 ];

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -12,7 +12,7 @@ import { isWithinTwelveHours, secondsToDuration } from '../../lib/formatTime';
 import { appendLinkNameMedia } from '../../lib/getDataLinkName';
 import { getZIndex } from '../../lib/getZIndex';
 import { getOphanComponents } from '../../lib/labs';
-import { useBetaAB } from '../../lib/useAB';
+import { useAB } from '../../lib/useAB';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { palette } from '../../palette';
 import type { Branding } from '../../types/branding';
@@ -411,15 +411,17 @@ export const Card = ({
 	articleMedia,
 	contentSpacing,
 }: Props) => {
-	const ab = useBetaAB();
-	const isInLoopClickTestControl = ab?.isUserInTestGroup(
-		'fronts-and-curation-loop-click-through',
-		'control',
-	);
-	const isInLoopClickTestVariant = ab?.isUserInTestGroup(
-		'fronts-and-curation-loop-click-through',
-		'variant',
-	);
+	const ab = useAB();
+	const isInLoopClickTestControl =
+		ab?.isUserInTestGroup(
+			'fronts-and-curation-loop-click-through',
+			'control',
+		) ?? false;
+	const isInLoopClickTestVariant =
+		ab?.isUserInTestGroup(
+			'fronts-and-curation-loop-click-through',
+			'variant',
+		) ?? false;
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -932,6 +932,9 @@ export const Card = ({
 									subtitleSize={subtitleSize}
 									minAspectRatio={3 / 4}
 									containerAspectRatioDesktop={5 / 4}
+									headlineText={headlineText}
+									dataLinkName={resolvedDataLinkName}
+									isExternalLink={isExternalLink}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -932,9 +932,11 @@ export const Card = ({
 									subtitleSize={subtitleSize}
 									minAspectRatio={3 / 4}
 									containerAspectRatioDesktop={5 / 4}
-									headlineText={headlineText}
-									dataLinkName={resolvedDataLinkName}
-									isExternalLink={isExternalLink}
+									cardLink={{
+										headlineText,
+										dataLinkName,
+										isExternalLink,
+									}}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -821,7 +821,7 @@ export const Card = ({
 				headlineText={headlineText}
 				dataLinkName={resolvedDataLinkName}
 				isExternalLink={isExternalLink}
-				isLoopClickThroughTest={isInLoopClickTest}
+				isLoopClickThroughTest={!!isInLoopClickTest}
 			/>
 			{headlinePosition === 'outer' && (
 				<div

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -12,6 +12,7 @@ import { isWithinTwelveHours, secondsToDuration } from '../../lib/formatTime';
 import { appendLinkNameMedia } from '../../lib/getDataLinkName';
 import { getZIndex } from '../../lib/getZIndex';
 import { getOphanComponents } from '../../lib/labs';
+import { useBetaAB } from '../../lib/useAB';
 import { DISCUSSION_ID_DATA_ATTRIBUTE } from '../../lib/useCommentCount';
 import { palette } from '../../palette';
 import type { Branding } from '../../types/branding';
@@ -410,6 +411,16 @@ export const Card = ({
 	articleMedia,
 	contentSpacing,
 }: Props) => {
+	const ab = useBetaAB();
+	const isInLoopClickTestControl = ab?.isUserInTestGroup(
+		'fronts-and-curation-loop-click-through',
+		'control',
+	);
+	const isInLoopClickTestVariant = ab?.isUserInTestGroup(
+		'fronts-and-curation-loop-click-through',
+		'variant',
+	);
+
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
 		supportingContent,
@@ -531,9 +542,9 @@ export const Card = ({
 			media.type === 'cinemagraph');
 
 	const resolvedDataLinkName =
-		media && dataLinkName
+		media && !isUndefined(dataLinkName)
 			? appendLinkNameMedia(dataLinkName, media.type)
-			: dataLinkName;
+			: undefined;
 
 	/**
 	 * For opinion type cards with avatars (which aren't onwards content)
@@ -788,6 +799,11 @@ export const Card = ({
 		);
 	};
 
+	const isInLoopClickTest =
+		isSelfHostedVideo &&
+		media.mainMedia.videoStyle === 'Loop' &&
+		(isInLoopClickTestControl || isInLoopClickTestVariant);
+
 	return (
 		<CardWrapper
 			format={format}
@@ -805,6 +821,7 @@ export const Card = ({
 				headlineText={headlineText}
 				dataLinkName={resolvedDataLinkName}
 				isExternalLink={isExternalLink}
+				isLoopClickThroughTest={isInLoopClickTest}
 			/>
 			{headlinePosition === 'outer' && (
 				<div
@@ -937,6 +954,9 @@ export const Card = ({
 										dataLinkName: resolvedDataLinkName,
 										isExternalLink,
 									}}
+									isInLoopClickTestVariant={
+										isInLoopClickTestVariant
+									}
 								/>
 							</Island>
 						)}

--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -934,7 +934,7 @@ export const Card = ({
 									containerAspectRatioDesktop={5 / 4}
 									cardLink={{
 										headlineText,
-										dataLinkName,
+										dataLinkName: resolvedDataLinkName,
 										isExternalLink,
 									}}
 								/>

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -85,13 +85,17 @@ export const CardLink = ({
 	isExternalLink,
 	isLoopClickThroughTest,
 }: Props) => {
+	const amendedLinkName = isLoopClickThroughTest
+		? `${dataLinkName} | article-link`
+		: dataLinkName;
+
 	return (
 		<>
 			{isExternalLink && (
 				<ExternalLink
 					linkTo={linkTo}
 					headlineText={headlineText}
-					dataLinkName={dataLinkName}
+					dataLinkName={amendedLinkName}
 					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}
@@ -99,7 +103,7 @@ export const CardLink = ({
 				<InternalLink
 					linkTo={linkTo}
 					headlineText={headlineText}
-					dataLinkName={dataLinkName}
+					dataLinkName={amendedLinkName}
 					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -25,24 +25,27 @@ type Props = {
 	headlineText: string;
 	dataLinkName?: string;
 	isExternalLink: boolean;
-	isVideoCard?: boolean;
+	isLoopClickThroughTest?: boolean;
 };
 
 const InternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
-	isVideoCard,
+	isLoopClickThroughTest,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
-	isVideoCard?: boolean;
+	isLoopClickThroughTest?: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
-			css={[fauxLinkStyles, isVideoCard && videoCardLinkStyles]}
+			css={[
+				fauxLinkStyles,
+				isLoopClickThroughTest && videoCardLinkStyles,
+			]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText}
 		/>
@@ -53,17 +56,20 @@ const ExternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
-	isVideoCard,
+	isLoopClickThroughTest,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
-	isVideoCard: boolean;
+	isLoopClickThroughTest: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
-			css={[fauxLinkStyles, isVideoCard && videoCardLinkStyles]}
+			css={[
+				fauxLinkStyles,
+				isLoopClickThroughTest && videoCardLinkStyles,
+			]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText + ' (opens in new tab)'}
 			target="_blank"
@@ -77,7 +83,7 @@ export const CardLink = ({
 	headlineText,
 	dataLinkName = 'article', //this makes sense if the link is to an article, but should this say something like "external" if it's an external link? are there any other uses/alternatives?
 	isExternalLink,
-	isVideoCard,
+	isLoopClickThroughTest,
 }: Props) => {
 	return (
 		<>
@@ -86,7 +92,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
-					isVideoCard={!!isVideoCard}
+					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}
 			{!isExternalLink && (
@@ -94,7 +100,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
-					isVideoCard={!!isVideoCard}
+					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -85,8 +85,9 @@ export const CardLink = ({
 	isExternalLink,
 	isLoopClickThroughTest,
 }: Props) => {
-	const amendedLinkName = isLoopClickThroughTest
-		? `${dataLinkName} | article-link`
+	/* if we are in the loop click through test, we are adding a unique string to the data link name tracking so clicks to article can be diffrentiated from other clicks on the card */
+	const clickThroughLinkName = isLoopClickThroughTest
+		? `${dataLinkName} | card-link-clickthrough`
 		: dataLinkName;
 
 	return (
@@ -95,7 +96,7 @@ export const CardLink = ({
 				<ExternalLink
 					linkTo={linkTo}
 					headlineText={headlineText}
-					dataLinkName={amendedLinkName}
+					dataLinkName={clickThroughLinkName}
 					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}
@@ -103,7 +104,7 @@ export const CardLink = ({
 				<InternalLink
 					linkTo={linkTo}
 					headlineText={headlineText}
-					dataLinkName={amendedLinkName}
+					dataLinkName={clickThroughLinkName}
 					isLoopClickThroughTest={isLoopClickThroughTest === true}
 				/>
 			)}

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -25,7 +25,7 @@ type Props = {
 	headlineText: string;
 	dataLinkName?: string;
 	isExternalLink: boolean;
-	isLoopClickThroughTest?: boolean;
+	isLoopClickThroughTest: boolean;
 };
 
 const InternalLink = ({
@@ -97,7 +97,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={clickThroughLinkName}
-					isLoopClickThroughTest={isLoopClickThroughTest === true}
+					isLoopClickThroughTest={isLoopClickThroughTest}
 				/>
 			)}
 			{!isExternalLink && (
@@ -105,7 +105,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={clickThroughLinkName}
-					isLoopClickThroughTest={isLoopClickThroughTest === true}
+					isLoopClickThroughTest={isLoopClickThroughTest}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -16,26 +16,33 @@ const fauxLinkStyles = css`
 	}
 `;
 
+const videoCardLinkStyles = css`
+	z-index: ${getZIndex('video-card-link')};
+`;
+
 type Props = {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
 	isExternalLink: boolean;
+	isVideoCard?: boolean;
 };
 
 const InternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
+	isVideoCard,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
+	isVideoCard?: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
-			css={fauxLinkStyles}
+			css={[fauxLinkStyles, isVideoCard && videoCardLinkStyles]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText}
 		/>
@@ -46,15 +53,17 @@ const ExternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
+	isVideoCard,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
+	isVideoCard: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
-			css={fauxLinkStyles}
+			css={[fauxLinkStyles, isVideoCard && videoCardLinkStyles]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText + ' (opens in new tab)'}
 			target="_blank"
@@ -68,6 +77,7 @@ export const CardLink = ({
 	headlineText,
 	dataLinkName = 'article', //this makes sense if the link is to an article, but should this say something like "external" if it's an external link? are there any other uses/alternatives?
 	isExternalLink,
+	isVideoCard,
 }: Props) => {
 	return (
 		<>
@@ -76,6 +86,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
+					isVideoCard={!!isVideoCard}
 				/>
 			)}
 			{!isExternalLink && (
@@ -83,6 +94,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
+					isVideoCard={!!isVideoCard}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -85,7 +85,7 @@ export const CardLink = ({
 	isExternalLink,
 	isLoopClickThroughTest,
 }: Props) => {
-	/* if we are in the loop click through test, we are adding a unique string to the data link name tracking so clicks to article can be diffrentiated from other clicks on the card */
+	/* if we are in the loop click through test, we add a unique string to the data link name tracking so clicks to article can be diffrentiated from other clicks on the card */
 	const clickThroughLinkName = isLoopClickThroughTest
 		? `${dataLinkName} | card-link-clickthrough`
 		: dataLinkName;

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -17,6 +17,7 @@ import { appendLinkNameMedia } from '../lib/getDataLinkName';
 import { getZIndex } from '../lib/getZIndex';
 import { getOphanComponents } from '../lib/labs';
 import { transparentColour } from '../lib/transparentColour';
+import { useBetaAB } from '../lib/useAB';
 import { palette } from '../palette';
 import type { Branding } from '../types/branding';
 import type { StarRating as Rating, RatingSizeType } from '../types/content';
@@ -437,6 +438,16 @@ export const FeatureCard = ({
 	starRatingSize,
 	articleMedia,
 }: Props) => {
+	const ab = useBetaAB();
+	const isInLoopClickTestControl = ab?.isUserInTestGroup(
+		'fronts-and-curation-loop-click-through',
+		'control',
+	);
+	const isInLoopClickTestVariant = ab?.isUserInTestGroup(
+		'fronts-and-curation-loop-click-through',
+		'variant',
+	);
+
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
 	/**
@@ -453,6 +464,11 @@ export const FeatureCard = ({
 	if (!media) {
 		return null;
 	}
+
+	const isInLoopClickTest =
+		media.style &&
+		media.style === 'loop-video' &&
+		(isInLoopClickTestControl || isInLoopClickTestVariant);
 
 	const mediaType =
 		media.type === 'self-hosted-video' ? media.style : media.type;
@@ -502,6 +518,7 @@ export const FeatureCard = ({
 							headlineText={headlineText}
 							dataLinkName={resolvedDataLinkName}
 							isExternalLink={isExternalLink}
+							isLoopClickThroughTest={isInLoopClickTest}
 						/>
 					)}
 					<div css={contentStyles}>
@@ -616,6 +633,9 @@ export const FeatureCard = ({
 													resolvedDataLinkName,
 												isExternalLink,
 											}}
+											isInLoopClickTestVariant={
+												isInLoopClickTestVariant
+											}
 										/>
 									</Island>
 								)}

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -13,6 +13,7 @@ import {
 	ArticleSpecial,
 } from '../lib/articleFormat';
 import { secondsToDuration } from '../lib/formatTime';
+import { appendLinkNameMedia } from '../lib/getDataLinkName';
 import { getZIndex } from '../lib/getZIndex';
 import { getOphanComponents } from '../lib/labs';
 import { transparentColour } from '../lib/transparentColour';
@@ -453,6 +454,13 @@ export const FeatureCard = ({
 		return null;
 	}
 
+	const mediaType =
+		media.type === 'self-hosted-video' ? media.style : media.type;
+
+	const resolvedDataLinkName = !isUndefined(dataLinkName)
+		? appendLinkNameMedia(dataLinkName, mediaType)
+		: undefined;
+
 	const showCardAge =
 		webPublicationDate !== undefined && showClock !== undefined;
 
@@ -492,7 +500,7 @@ export const FeatureCard = ({
 						<CardLink
 							linkTo={linkTo}
 							headlineText={headlineText}
-							dataLinkName={dataLinkName}
+							dataLinkName={resolvedDataLinkName}
 							isExternalLink={isExternalLink}
 						/>
 					)}
@@ -604,7 +612,8 @@ export const FeatureCard = ({
 											maxAspectRatio={aspectRatioNumber}
 											cardLink={{
 												headlineText,
-												dataLinkName,
+												dataLinkName:
+													resolvedDataLinkName,
 												isExternalLink,
 											}}
 										/>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -17,7 +17,7 @@ import { appendLinkNameMedia } from '../lib/getDataLinkName';
 import { getZIndex } from '../lib/getZIndex';
 import { getOphanComponents } from '../lib/labs';
 import { transparentColour } from '../lib/transparentColour';
-import { useBetaAB } from '../lib/useAB';
+import { useAB } from '../lib/useAB';
 import { palette } from '../palette';
 import type { Branding } from '../types/branding';
 import type { StarRating as Rating, RatingSizeType } from '../types/content';
@@ -438,15 +438,17 @@ export const FeatureCard = ({
 	starRatingSize,
 	articleMedia,
 }: Props) => {
-	const ab = useBetaAB();
-	const isInLoopClickTestControl = ab?.isUserInTestGroup(
-		'fronts-and-curation-loop-click-through',
-		'control',
-	);
-	const isInLoopClickTestVariant = ab?.isUserInTestGroup(
-		'fronts-and-curation-loop-click-through',
-		'variant',
-	);
+	const ab = useAB();
+	const isInLoopClickTestControl =
+		ab?.isUserInTestGroup(
+			'fronts-and-curation-loop-click-through',
+			'control',
+		) ?? false;
+	const isInLoopClickTestVariant =
+		ab?.isUserInTestGroup(
+			'fronts-and-curation-loop-click-through',
+			'variant',
+		) ?? false;
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -518,7 +518,7 @@ export const FeatureCard = ({
 							headlineText={headlineText}
 							dataLinkName={resolvedDataLinkName}
 							isExternalLink={isExternalLink}
-							isLoopClickThroughTest={isInLoopClickTest}
+							isLoopClickThroughTest={!!isInLoopClickTest}
 						/>
 					)}
 					<div css={contentStyles}>
@@ -734,6 +734,9 @@ export const FeatureCard = ({
 												headlineText={headlineText}
 												dataLinkName={dataLinkName}
 												isExternalLink={isExternalLink}
+												isLoopClickThroughTest={
+													!!isInLoopClickTest
+												}
 											/>
 										)}
 

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -174,6 +174,7 @@ const overlayStyles = css`
 	 * Ensure the waveform is behind the other elements, e.g. headline, pill.
 	 * Links define their own z-index.
 	 */
+
 	> :not(.waveform):not(a) {
 		z-index: 1;
 	}
@@ -601,6 +602,11 @@ export const FeatureCard = ({
 											controlsPosition="top"
 											minAspectRatio={aspectRatioNumber}
 											maxAspectRatio={aspectRatioNumber}
+											cardLink={{
+												headlineText,
+												dataLinkName,
+												isExternalLink,
+											}}
 										/>
 									</Island>
 								)}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -152,6 +152,7 @@ export const HighlightsCard = ({
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
 					isExternalLink={isExternalLink}
+					isLoopClickThroughTest={false}
 				/>
 
 				<div css={[content, shouldJustifyContent && spaceBetween]}>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -395,6 +395,9 @@ type Props = {
 	isMainMedia?: boolean;
 	role?: RoleType;
 	restrictHeightOnDesktop?: boolean;
+	headlineText: string;
+	dataLinkName?: string;
+	isExternalLink: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -424,6 +427,9 @@ export const SelfHostedVideo = ({
 	role,
 	posterImageAspectRatio,
 	restrictHeightOnDesktop = false,
+	headlineText,
+	dataLinkName,
+	isExternalLink,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1309,6 +1315,10 @@ export const SelfHostedVideo = ({
 						}
 						isInteractive={videoStyleSettings.isInteractive}
 						isWebKitFullscreen={isWebKitFullscreen}
+						linkTo={linkTo}
+						headlineText={headlineText}
+						dataLinkName={dataLinkName}
+						isExternalLink={isExternalLink}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -44,6 +44,7 @@ import type { SubtitlesPosition } from './SubtitleOverlay';
 import type { OphanVideoStyle } from './YoutubeAtom/eventEmitters';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import type { VideoEventKey } from './YoutubeAtom/YoutubeAtom';
+import { useBetaAB } from '../lib/useAB';
 
 /**
  * The fraction of the video required to be visible in the viewport to be considered "in view".
@@ -166,6 +167,7 @@ const fullscreenStyles = css`
 
 		/* Override the fixed aspect-ratio + width:100% on the video so it
 		   fits within the screen while preserving its aspect ratio. */
+
 		video {
 			width: 100%;
 			height: 100%;
@@ -457,6 +459,12 @@ export const SelfHostedVideo = ({
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
+
+	const ab = useBetaAB();
+
+	const isLoopClickThroughTest =
+		videoStyle === 'Loop' &&
+		ab?.isUserInTest('fronts-and-curation-loop-click-through');
 
 	const videoStyleSettings: VideoStyleSettings = videoSettingsMap[videoStyle];
 
@@ -1319,6 +1327,7 @@ export const SelfHostedVideo = ({
 						headlineText={headlineText}
 						dataLinkName={dataLinkName}
 						isExternalLink={isExternalLink}
+						isLoopClickThroughTest={isLoopClickThroughTest}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -11,7 +11,6 @@ import type { ArticleFormat } from '../lib/articleFormat';
 import { getVideoClient } from '../lib/bridgetApi';
 import { getZIndex } from '../lib/getZIndex';
 import { generateImageURL } from '../lib/image';
-import { useBetaAB } from '../lib/useAB';
 import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
@@ -402,6 +401,7 @@ type Props = {
 		dataLinkName?: string;
 		isExternalLink: boolean;
 	};
+	isInLoopClickTestVariant?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -432,6 +432,7 @@ export const SelfHostedVideo = ({
 	posterImageAspectRatio,
 	restrictHeightOnDesktop = false,
 	cardLink,
+	isInLoopClickTestVariant,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -460,11 +461,8 @@ export const SelfHostedVideo = ({
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
 
-	const ab = useBetaAB();
-
 	const isLoopClickThroughTest =
-		videoStyle === 'Loop' &&
-		ab?.isUserInTest('fronts-and-curation-loop-click-through');
+		videoStyle === 'Loop' && isInLoopClickTestVariant;
 
 	const videoStyleSettings: VideoStyleSettings = videoSettingsMap[videoStyle];
 

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -11,6 +11,7 @@ import type { ArticleFormat } from '../lib/articleFormat';
 import { getVideoClient } from '../lib/bridgetApi';
 import { getZIndex } from '../lib/getZIndex';
 import { generateImageURL } from '../lib/image';
+import { useBetaAB } from '../lib/useAB';
 import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
@@ -44,7 +45,6 @@ import type { SubtitlesPosition } from './SubtitleOverlay';
 import type { OphanVideoStyle } from './YoutubeAtom/eventEmitters';
 import { ophanTrackerApps, ophanTrackerWeb } from './YoutubeAtom/eventEmitters';
 import type { VideoEventKey } from './YoutubeAtom/YoutubeAtom';
-import { useBetaAB } from '../lib/useAB';
 
 /**
  * The fraction of the video required to be visible in the viewport to be considered "in view".
@@ -397,9 +397,11 @@ type Props = {
 	isMainMedia?: boolean;
 	role?: RoleType;
 	restrictHeightOnDesktop?: boolean;
-	headlineText: string;
-	dataLinkName?: string;
-	isExternalLink: boolean;
+	cardLink?: {
+		headlineText: string;
+		dataLinkName?: string;
+		isExternalLink: boolean;
+	};
 };
 
 export const SelfHostedVideo = ({
@@ -429,9 +431,7 @@ export const SelfHostedVideo = ({
 	role,
 	posterImageAspectRatio,
 	restrictHeightOnDesktop = false,
-	headlineText,
-	dataLinkName,
-	isExternalLink,
+	cardLink,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1324,9 +1324,7 @@ export const SelfHostedVideo = ({
 						isInteractive={videoStyleSettings.isInteractive}
 						isWebKitFullscreen={isWebKitFullscreen}
 						linkTo={linkTo}
-						headlineText={headlineText}
-						dataLinkName={dataLinkName}
-						isExternalLink={isExternalLink}
+						cardLink={cardLink}
 						isLoopClickThroughTest={isLoopClickThroughTest}
 					/>
 				</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -338,7 +338,8 @@ export const SelfHostedVideoPlayer = forwardRef(
 								duration={ref.current!.duration}
 							/>
 						))}
-					{showIcons && (showFullscreenIcon || hasAudio) && (
+					{((showIcons && (showFullscreenIcon || hasAudio)) ||
+						isLoopClickThroughTest) && (
 						<div
 							css={[
 								iconsContainerStyles,

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -7,9 +7,11 @@ import {
 } from '@guardian/source/foundations';
 import type { ReactElement, SyntheticEvent } from 'react';
 import { forwardRef } from 'react';
+import { getZIndex } from '../lib/getZIndex';
 import type { ActiveCue } from '../lib/useSubtitles';
 import type { Source } from '../lib/video';
 import { palette } from '../palette';
+import { CardLink } from './Card/components/CardLink';
 import {
 	AudioIcon as AudioIconComponent,
 	FullscreenIcon,
@@ -44,6 +46,10 @@ const videoControlsStyles = css`
 	& > * {
 		pointer-events: auto;
 	}
+`;
+
+const videoControlsZIndexStyles = css`
+	z-index: ${getZIndex('video-controls-container')};
 `;
 
 const interactiveStyles = css`
@@ -145,6 +151,11 @@ export type Props = {
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
 	isWebKitFullscreen: boolean;
+	/* used by the card link component for click through to article functionality */
+	linkTo: string;
+	headlineText: string;
+	dataLinkName?: string;
+	isExternalLink: boolean;
 };
 
 /**
@@ -199,6 +210,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 			iconsPosition,
 			subtitlesPosition,
 			isWebKitFullscreen,
+			linkTo,
+			headlineText,
+			dataLinkName,
+			isExternalLink,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -211,8 +226,23 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
+		/*
+		 *
+		 * DO NOT MERGE TO PROD
+		 * TODO: update to ab test value
+		 * Temporary value whilst test is defined
+		 * */
+		const isInTest = true;
 		return (
 			<>
+				<CardLink
+					linkTo={linkTo}
+					headlineText={headlineText}
+					dataLinkName={dataLinkName}
+					isExternalLink={isExternalLink}
+					isVideoCard={true}
+				/>
+
 				<video
 					id={videoId}
 					css={[

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -154,9 +154,11 @@ export type Props = {
 	isWebKitFullscreen: boolean;
 	/* used by the card link component for click through to article functionality */
 	linkTo: string;
-	headlineText: string;
-	dataLinkName?: string;
-	isExternalLink: boolean;
+	cardLink?: {
+		headlineText: string;
+		dataLinkName?: string;
+		isExternalLink: boolean;
+	};
 	isLoopClickThroughTest?: boolean;
 };
 
@@ -213,9 +215,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			subtitlesPosition,
 			isWebKitFullscreen,
 			linkTo,
-			headlineText,
-			dataLinkName,
-			isExternalLink,
+			cardLink,
 			isLoopClickThroughTest,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
@@ -231,12 +231,12 @@ export const SelfHostedVideoPlayer = forwardRef(
 
 		return (
 			<>
-				{isLoopClickThroughTest && (
+				{cardLink && isLoopClickThroughTest && (
 					<CardLink
 						linkTo={linkTo}
-						headlineText={headlineText}
-						dataLinkName={dataLinkName}
-						isExternalLink={isExternalLink}
+						headlineText={cardLink.headlineText}
+						dataLinkName={cardLink.dataLinkName}
+						isExternalLink={cardLink.isExternalLink}
 						isLoopClickThroughTest={true}
 					/>
 				)}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -43,6 +43,7 @@ const videoControlsStyles = css`
 	top: 0;
 	left: 0;
 	pointer-events: none;
+
 	& > * {
 		pointer-events: auto;
 	}
@@ -156,6 +157,7 @@ export type Props = {
 	headlineText: string;
 	dataLinkName?: string;
 	isExternalLink: boolean;
+	isLoopClickThroughTest?: boolean;
 };
 
 /**
@@ -214,6 +216,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			headlineText,
 			dataLinkName,
 			isExternalLink,
+			isLoopClickThroughTest,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -226,23 +229,18 @@ export const SelfHostedVideoPlayer = forwardRef(
 		const showProgressBar = canShowProgressBar && currentRefExists;
 		const showIcons = canShowIcons && currentRefExists;
 
-		/*
-		 *
-		 * DO NOT MERGE TO PROD
-		 * TODO: update to ab test value
-		 * Temporary value whilst test is defined
-		 * */
-		const isInTest = true;
 		return (
 			<>
-				<CardLink
-					linkTo={linkTo}
-					headlineText={headlineText}
-					dataLinkName={dataLinkName}
-					isExternalLink={isExternalLink}
-					isVideoCard={true}
-				/>
-
+				$
+				{isLoopClickThroughTest && (
+					<CardLink
+						linkTo={linkTo}
+						headlineText={headlineText}
+						dataLinkName={dataLinkName}
+						isExternalLink={isExternalLink}
+						isLoopClickThroughTest={true}
+					/>
+				)}
 				<video
 					id={videoId}
 					css={[
@@ -270,7 +268,11 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onPlaying={handlePlaying}
 					onTimeUpdate={handleTimeUpdate}
 					onPause={handlePause}
-					onClick={isInTest ? undefined : handlePlayPauseClick}
+					onClick={
+						isLoopClickThroughTest === true
+							? undefined
+							: handlePlayPauseClick
+					}
 					onKeyDown={handleKeyDown}
 					onError={onError}
 					onEnded={handleEnded}
@@ -309,15 +311,15 @@ export const SelfHostedVideoPlayer = forwardRef(
 					className="controls-container"
 					css={[
 						videoControlsStyles,
-						isInTest && videoControlsZIndexStyles,
+						isLoopClickThroughTest && videoControlsZIndexStyles,
 					]}
 				>
-					{!isInTest && showPlayPauseIcon !== null && (
+					{!!isLoopClickThroughTest && showPlayPauseIcon !== null && (
 						<PlayPauseIcon
 							type={showPlayPauseIcon}
 							atomId={atomId}
 							handleClick={handlePlayPauseClick}
-							isInTest={false}
+							isLoopClickThroughTest={false}
 						/>
 					)}
 					{showProgressBar &&
@@ -349,12 +351,12 @@ export const SelfHostedVideoPlayer = forwardRef(
 									iconsTopPositionStyles,
 							]}
 						>
-							{isInTest && (
+							{isLoopClickThroughTest && (
 								<PlayPauseIcon
 									type={showPlayPauseIcon ?? 'pause'}
 									atomId={atomId}
 									handleClick={handlePlayPauseClick}
-									isInTest={true}
+									isLoopClickThroughTest={true}
 								/>
 							)}
 							{showFullscreenIcon && (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -231,7 +231,6 @@ export const SelfHostedVideoPlayer = forwardRef(
 
 		return (
 			<>
-				$
 				{isLoopClickThroughTest && (
 					<CardLink
 						linkTo={linkTo}
@@ -314,7 +313,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 						isLoopClickThroughTest && videoControlsZIndexStyles,
 					]}
 				>
-					{!!isLoopClickThroughTest && showPlayPauseIcon !== null && (
+					{!isLoopClickThroughTest && showPlayPauseIcon !== null && (
 						<PlayPauseIcon
 							type={showPlayPauseIcon}
 							atomId={atomId}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -270,7 +270,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onPlaying={handlePlaying}
 					onTimeUpdate={handleTimeUpdate}
 					onPause={handlePause}
-					onClick={handlePlayPauseClick}
+					onClick={isInTest ? undefined : handlePlayPauseClick}
 					onKeyDown={handleKeyDown}
 					onError={onError}
 					onEnded={handleEnded}
@@ -305,12 +305,19 @@ export const SelfHostedVideoPlayer = forwardRef(
 						position={subtitlesPosition}
 					/>
 				)}
-				<div className="controls-container" css={videoControlsStyles}>
-					{showPlayPauseIcon !== null && (
+				<div
+					className="controls-container"
+					css={[
+						videoControlsStyles,
+						isInTest && videoControlsZIndexStyles,
+					]}
+				>
+					{!isInTest && showPlayPauseIcon !== null && (
 						<PlayPauseIcon
 							type={showPlayPauseIcon}
 							atomId={atomId}
 							handleClick={handlePlayPauseClick}
+							isInTest={false}
 						/>
 					)}
 					{showProgressBar &&
@@ -342,6 +349,14 @@ export const SelfHostedVideoPlayer = forwardRef(
 									iconsTopPositionStyles,
 							]}
 						>
+							{isInTest && (
+								<PlayPauseIcon
+									type={showPlayPauseIcon ?? 'pause'}
+									atomId={atomId}
+									handleClick={handlePlayPauseClick}
+									isInTest={true}
+								/>
+							)}
 							{showFullscreenIcon && (
 								<FullscreenIcon
 									handleClick={handleFullscreenClick}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -90,12 +90,14 @@ type PlayPauseIconProps = {
 	type: 'play' | 'pause';
 	atomId: SelfHostedVideoPlayerProps['atomId'];
 	handleClick: SelfHostedVideoPlayerProps['handlePlayPauseClick'];
+	isInTest: boolean;
 };
 
 export const PlayPauseIcon = ({
 	type,
 	atomId,
 	handleClick,
+	isInTest,
 }: PlayPauseIconProps) => {
 	const IconComponent =
 		type === 'play' ? SvgMediaControlsPlay : SvgMediaControlsPause;
@@ -104,7 +106,10 @@ export const PlayPauseIcon = ({
 		<button
 			type="button"
 			onClick={handleClick}
-			css={[buttonStyles, playPauseButtonStyles]}
+			css={[
+				buttonStyles,
+				isInTest ? iconContainerStyles : playPauseButtonStyles,
+			]}
 			data-link-name={`gu-video-loop-${type}-${atomId}`}
 			data-testid={`${type}-icon`}
 		>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -90,14 +90,14 @@ type PlayPauseIconProps = {
 	type: 'play' | 'pause';
 	atomId: SelfHostedVideoPlayerProps['atomId'];
 	handleClick: SelfHostedVideoPlayerProps['handlePlayPauseClick'];
-	isInTest: boolean;
+	isLoopClickThroughTest: boolean;
 };
 
 export const PlayPauseIcon = ({
 	type,
 	atomId,
 	handleClick,
-	isInTest,
+	isLoopClickThroughTest,
 }: PlayPauseIconProps) => {
 	const IconComponent =
 		type === 'play' ? SvgMediaControlsPlay : SvgMediaControlsPause;
@@ -108,7 +108,9 @@ export const PlayPauseIcon = ({
 			onClick={handleClick}
 			css={[
 				buttonStyles,
-				isInTest ? iconContainerStyles : playPauseButtonStyles,
+				isLoopClickThroughTest
+					? iconContainerStyles
+					: playPauseButtonStyles,
 			]}
 			data-link-name={`gu-video-loop-${type}-${atomId}`}
 			data-testid={`${type}-icon`}

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -92,6 +92,8 @@ const indices = [
 	// Self-hosted video
 	'video-progress-bar-foreground',
 	'video-progress-bar-background',
+	'video-controls-container',
+	'video-card-link',
 	'video-container',
 
 	// Main media


### PR DESCRIPTION
## What does this change?
Allows loop videos on front cards to click through to article via the video. Previously, the only click through link was on the card content (headline, standfirst etc). 

The video controls are still available to play/pause and mute/unmute. This has been achieve by adding a card link component as a sibling to the video component with a lower zindex than the video controls. 

This is only for users in the ab test and only for looping videos on fronts via feature or standard cards.

The test is currently configured to be a 0% test.

### Tracking
Currently, all card click interactions are tracked identically in Ophan, regardless of whether the user clicked through to the article or interacted with another element within the card (for example, video controls).

To allow us to compare click-through behaviour between the control and variant groups, this change appends an additional identifier to the dataLinkName on the primary card link for users participating in the experiment. This enables click-through interactions to be distinguished and analysed separately in Ophan.

## Why?
We would like to test the impact of click through to article via loop videos. Previously these videos have not been a link as in order to prioritise the UX of the video controls


## Testing 
append `?ab-fronts-and-curation-loop-click-through=variant` locally to force yourself into this test

## Screenshots

### Feature cards 

https://github.com/user-attachments/assets/68fb3780-eae5-4740-aad8-bc13d4c82af1

### Standard cards

https://github.com/user-attachments/assets/e140ef8d-5f35-4364-805c-2c994db52c8c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
