### PR TITLE
Tweak chromatic CI logic

### DIFF
--- a/.github/workflows/check-chromatic-paths.yml
+++ b/.github/workflows/check-chromatic-paths.yml
@@ -35,3 +35,6 @@ jobs:
               - 'dotcom-rendering/package.json'
               - 'libs/**'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/dcr-chromatic.yml'
+              - '.github/workflows/check-chromatic-paths.yml'

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -59,7 +59,7 @@ jobs:
           exitOnceUploaded: true
           # Skip when no relevant UI files changed.
           # Chromatic will post a passing status without building Storybook.
-          skip: needs.check-paths.outputs.relevant != 'true'
+          skip: ${{ needs.check-paths.outputs.relevant != 'true' }}
 
   remove-label:
     # Only remove label when Chromatic actually ran (label present and relevant changes)

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -34,11 +34,6 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node environment
-        # Only needed for a full Chromatic run.
-        if: |
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'pull_request' &&
-            contains(github.event.pull_request.labels.*.name, 'run_chromatic'))
         uses: ./.github/actions/setup-node-env
 
         # If on push to main, always run the Chromatic step.

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -36,14 +36,23 @@ jobs:
       - name: Set up Node environment
         # Only needed for a full Chromatic run.
         if: |
-          needs.check-paths.outputs.relevant == 'true' &&
-          (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'run_chromatic'))
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'run_chromatic'))
         uses: ./.github/actions/setup-node-env
 
+        # If on push to main, always run the Chromatic step.
+        # If on a PR and the run_chromatic label is present, run the Chromatic step.
+        # If on a PR and no relevant files have been touched, run the Chromatic step with skip: true, so the check appears as skipped instead of absent.
       - name: Chromatic - DCR
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         uses: chromaui/action@v16.10.0
+        if: |
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'run_chromatic')) ||
+          (github.event_name == 'pull_request' && needs.check-paths.outputs.relevant != 'true')
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DOTCOM_RENDERING }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,9 +62,9 @@ jobs:
           workingDir: dotcom-rendering
           buildScriptName: 'build-storybook'
           exitOnceUploaded: true
-          # Skip when no relevant UI files changed, or (on a PR) when the run_chromatic label is absent.
+          # Skip when no relevant UI files changed.
           # Chromatic will post a passing status without building Storybook.
-          skip: ${{ needs.check-paths.outputs.relevant != 'true' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run_chromatic')) }}
+          skip: needs.check-paths.outputs.relevant != 'true'
 
   remove-label:
     # Only remove label when Chromatic actually ran (label present and relevant changes)

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -62,9 +62,9 @@ jobs:
           workingDir: dotcom-rendering
           buildScriptName: 'build-storybook'
           exitOnceUploaded: true
-          # Skip when no relevant UI files changed.
+          # Skip on PRs when no relevant UI files changed and the run_chromatic label isn't present (so that chromatic can still be run even if it's not required)
           # Chromatic will post a passing status without building Storybook.
-          skip: ${{ needs.check-paths.outputs.relevant != 'true' }}
+          skip: ${{ github.event_name == 'pull_request' && needs.check-paths.outputs.relevant != 'true' && !contains(github.event.pull_request.labels.*.name, 'run_chromatic') }}
 
   remove-label:
     # Only remove label when Chromatic actually ran (label present and relevant changes)

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -34,6 +34,11 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node environment
+        # Only needed for a full Chromatic run.
+        if: |
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'run_chromatic'))
         uses: ./.github/actions/setup-node-env
 
         # If on push to main, always run the Chromatic step.


### PR DESCRIPTION
## What does this change?
Added an `if` to the chromatic step so now chromatic should run with these conditions:

- If on push to main, always run the Chromatic step.
- If on a PR and the `run_chromatic` label is present, run the Chromatic step.
- If on a PR and no relevant files have been touched, run the Chromatic step with skip: true, so the check appears as skipped instead of absent.

Also have added `pnp-workspace.yaml` and the workflows themselves to the paths that require chromatic to run.

## Why?
Currently the chromatic check is skipping when it should not be, because it skips when the `run_chromatic` label is not present.

See the second to last commit checks with no relevant files changes - skips successfully, then final commit where I added the workflows to the paths that require chromatic and it requires chromatic as expected.