### PR TITLE
Use `<time>` for dateline in Filter articles

### DIFF
--- a/dotcom-rendering/src/components/ArticleMeta.web.tsx
+++ b/dotcom-rendering/src/components/ArticleMeta.web.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import { between, from, space, until } from '@guardian/source/foundations';
 import { StraightLines } from '@guardian/source-development-kitchen/react-components';
 import type { CSSProperties } from 'react';
@@ -35,6 +36,7 @@ import { Island } from './Island';
 import { PodcastMeta } from './PodcastMeta';
 import { PreferredSourceButton } from './PreferredSourceButton';
 import { ShareButton } from './ShareButton.island';
+import { TimeDateline } from './TimeDateline';
 
 type Props = {
 	format: ArticleFormat;
@@ -45,6 +47,7 @@ type Props = {
 	tags: TagType[];
 	primaryDateline: string;
 	secondaryDateline: string;
+	webPublicationDate?: string;
 	branding?: BrandingType;
 	discussionApiUrl: string;
 	shortUrlId: string;
@@ -280,6 +283,7 @@ export const ArticleMeta = ({
 	tags,
 	primaryDateline,
 	secondaryDateline,
+	webPublicationDate,
 	discussionApiUrl,
 	shortUrlId,
 	isCommentable,
@@ -307,6 +311,12 @@ export const ArticleMeta = ({
 	const audioData = getAudioData(mainMediaElements);
 	const podcast = getPodcast(tags);
 	const rssFeedUrl = getRssFeedUrl(tags);
+
+	const isFilterArticle = tags.some(
+		(tag) =>
+			tag.id === 'tracking/commissioningdesk/the-filter' ||
+			tag.id === 'tracking/commissioningdesk/filter-us',
+	);
 
 	return (
 		<div
@@ -375,11 +385,21 @@ export const ArticleMeta = ({
 								/>
 							)}
 
-							<Dateline
-								primaryDateline={primaryDateline}
-								secondaryDateline={secondaryDateline}
-								format={format}
-							/>
+							{!isUndefined(webPublicationDate) &&
+							isFilterArticle ? (
+								<TimeDateline
+									primaryDateline={primaryDateline}
+									secondaryDateline={secondaryDateline}
+									webPublicationDate={webPublicationDate}
+									format={format}
+								/>
+							) : (
+								<Dateline
+									primaryDateline={primaryDateline}
+									secondaryDateline={secondaryDateline}
+									format={format}
+								/>
+							)}
 						</div>
 					</>
 				</RowBelowLeftCol>

--- a/dotcom-rendering/src/components/TimeDateline.tsx
+++ b/dotcom-rendering/src/components/TimeDateline.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/react';
+import { textSans12, until } from '@guardian/source/foundations';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
+import { palette } from '../palette';
+
+const datelineStyles = css`
+	${textSans12};
+	color: ${palette('--dateline')};
+	padding-top: 2px;
+	margin-bottom: 6px;
+
+	${until.desktop} {
+		color: var(--mobile-colour);
+	}
+`;
+
+const primaryStyles = css`
+	list-style: none;
+	cursor: pointer;
+	&::-webkit-details-marker {
+		display: none;
+	}
+`;
+
+const hoverUnderline = css`
+	:hover {
+		text-decoration: underline;
+	}
+`;
+
+type Props = {
+	primaryDateline: string;
+	secondaryDateline: string;
+	webPublicationDate: string;
+	format: ArticleFormat;
+};
+
+export const TimeDateline = ({
+	primaryDateline,
+	secondaryDateline,
+	webPublicationDate,
+	format,
+}: Props) => {
+	const isLiveBlog = format.design === ArticleDesign.LiveBlog;
+
+	// for liveblog smaller breakpoints article meta is located in the same
+	// container as standfirst and needs the same styling as standfirst on web
+	const mobileColour = {
+		'--mobile-colour': isLiveBlog
+			? palette('--standfirst-text')
+			: palette('--dateline'),
+	};
+	if (secondaryDateline && !secondaryDateline.includes(primaryDateline)) {
+		return (
+			<details
+				css={datelineStyles}
+				style={mobileColour}
+				data-gu-name="dateline"
+			>
+				<summary css={primaryStyles}>
+					<time dateTime={webPublicationDate} css={hoverUnderline}>
+						{primaryDateline}
+					</time>
+				</summary>
+				{secondaryDateline}
+			</details>
+		);
+	}
+	return (
+		<time
+			dateTime={webPublicationDate}
+			css={datelineStyles}
+			style={mobileColour}
+			data-gu-name="dateline"
+		>
+			{primaryDateline}
+		</time>
+	);
+};

--- a/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
+++ b/dotcom-rendering/src/layouts/ShowcaseLayout.tsx
@@ -505,6 +505,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 												secondaryDateline={
 													article.webPublicationSecondaryDateDisplay
 												}
+												webPublicationDate={
+													article.webPublicationDate
+												}
 												isCommentable={
 													article.isCommentable
 												}
@@ -535,6 +538,9 @@ export const ShowcaseLayout = (props: WebProps | AppsProps) => {
 											}
 											secondaryDateline={
 												article.webPublicationSecondaryDateDisplay
+											}
+											webPublicationDate={
+												article.webPublicationDate
 											}
 											isCommentable={
 												article.isCommentable

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -602,6 +602,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 												secondaryDateline={
 													article.webPublicationSecondaryDateDisplay
 												}
+												webPublicationDate={
+													article.webPublicationDate
+												}
 												isCommentable={
 													article.isCommentable
 												}
@@ -637,6 +640,9 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 										}
 										secondaryDateline={
 											article.webPublicationSecondaryDateDisplay
+										}
+										webPublicationDate={
+											article.webPublicationDate
 										}
 										isCommentable={article.isCommentable}
 										discussionApiUrl={


### PR DESCRIPTION
## What does this change?

Adds a component that renders published dates with a tag of `<time>`. This change only applies to Filter articles, as determined by the commissioning desk.

## Why?

Filter articles are sometimes intended as evergreen content, and may be republished at a later date. This is reflected in the article but not in Google search results. (This in turn affects rankings and clickthrough, etc.)

<img width="1122" height="413" alt="image" src="https://github.com/user-attachments/assets/0907a44c-60e3-4763-9fa4-54c109d3c936" />

<img width="705" height="161" alt="image" src="https://github.com/user-attachments/assets/a3211b8d-204d-4c4a-8e06-2bf63ef04217" />

We hope that by using the `<time>` tag this extra hint will help Google reindex with the correct published date. If this does not work we will build on this, for example by hiding the other date on the page to avoid confusion.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="392" height="218" alt="image" src="https://github.com/user-attachments/assets/6fa8c88c-7a0d-45b5-a9e8-dc16eeda994b" /> | <img width="393" height="218" alt="image" src="https://github.com/user-attachments/assets/c4ecf34e-dfc7-4002-a68d-4e7850dada78" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214979949940253