### PR TITLE
Mute self-hosted video when page restored from BFCache

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -748,6 +748,7 @@ export const SelfHostedVideo = ({
 					setIsAutoplayAllowed(doesUserPermitAutoplayOnWeb());
 				}
 				setHasPageBecomeActive(true);
+				setMutedState({ value: false });
 			} else {
 				setHasPageBecomeActive(false);
 			}


### PR DESCRIPTION
## What does this change?

When a user plays audio from a self-hosted video, clicks a link to another page, then goes back to the original page with the self hosted video, if the browsers BFCache is triggered, then mute all self-hosted video on the page.

This change affects any DCAR rendered page.

## Why?

We should not play audio from a video when a page is loaded. This included when a user returns to a page.