### PR TITLE
Update VS Code settings - Replace deprecated settings and add ab-testing to eslint working directories

### DIFF
--- a/.vscode/settings.json.recommended
+++ b/.vscode/settings.json.recommended
@@ -6,7 +6,7 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"eslint.workingDirectories": ["./dotcom-rendering"],
+	"eslint.workingDirectories": ["./dotcom-rendering", "./ab-testing"],
 	"files.watcherExclude": {
 		"**/target": true
 	},

--- a/.vscode/settings.json.required
+++ b/.vscode/settings.json.required
@@ -7,5 +7,5 @@
 	"deno.unstable": false,
 	"js/ts.tsdk.path": "./dotcom-rendering/node_modules/typescript/lib",
 	"git.branchProtection": ["main"],
-	"eslint.workingDirectories": ["./dotcom-rendering"]
+	"eslint.workingDirectories": ["./dotcom-rendering", "./ab-testing"]
 }

--- a/.vscode/settings.json.required
+++ b/.vscode/settings.json.required
@@ -5,7 +5,7 @@
 	"deno.enablePaths": ["scripts/deno"],
 	"deno.lint": true,
 	"deno.unstable": false,
-	"typescript.tsdk": "node_modules/typescript/lib",
+	"js/ts.tsdk.path": "./dotcom-rendering/node_modules/typescript/lib",
 	"git.branchProtection": ["main"],
 	"eslint.workingDirectories": ["./dotcom-rendering"]
 }


### PR DESCRIPTION
## What does this change?

Update VS Code settings:

1. Add `ab-testing` to eslint working directories
2. Replace and fix deprecated TypeScript settings 

## Why?

1. Linting in VS Code was not working on the `ab-testing` project.
2. When attempting to use the [workspace TypeScript version](https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-the-workspace-version-of-typescript) (not VS Code's), the following errors were thrown:
    - deprecation of `typescript.tsdk` property in favour of `js/ts.tsdk.path`
    - the path of the setting could not be found. Replacing this with `./dotcom-rendering/node_modules/typescript/lib` fixes the issue as it does not exist at the root level. I opted to _not_ reference the actual symlinked target in `./node_modules/.pnpm/` as that location is versioned and is not stable.

## Post Merge

> [!NOTE]    
> To take effect each developer will need to copy these settings from `‎.vscode/settings.json.required` to their `.vscode/settings.json` as per:
https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/README.md#settings

As a follow up:

Is there a better way to share project settings that we want all developers to apply to avoid misconfiguration and confusion? Perhaps workspace settings?

https://code.visualstudio.com/docs/configure/settings#_workspace-settings

## Screenshots

| | Before      | After      |
| -- | ----------- | ---------- |
| ab-testing linting | ![lbefore][] | ![lafter][] |
| TypeScript | [<img width="300" alt="Screenshot 2026-05-29 at 17 36 27" src="https://github.com/user-attachments/assets/e3eda9be-7b3f-4a43-aaa4-a02e7274c654" />]() [<img width="200" alt="Screenshot 2026-05-29 at 17 36 27" src="https://github.com/user-attachments/assets/897a58d0-a4ac-4e2d-9535-a82f0a077280" />]() [<img width="300" alt="Screenshot 2026-05-29 at 17 36 27" src="https://github.com/user-attachments/assets/22687f20-edad-472a-9740-94b1aa111ecf"/>]() | [<img width="200" alt="Screenshot 2026-05-29 at 17 36 27" src="https://github.com/user-attachments/assets/ea3e1533-fcc7-4aba-8e57-a3b333f51726" />]()  |

[lbefore]: https://github.com/user-attachments/assets/1046c554-964a-461a-88fc-5561c4eb40bf
[lafter]: https://github.com/user-attachments/assets/6d9b89bb-ed8e-4d63-beb7-eface867f5c5

[tafter]: https://github.com/user-attachments/assets/ea3e1533-fcc7-4aba-8e57-a3b333f51726

[tbefore]: https://github.com/user-attachments/assets/e3eda9be-7b3f-4a43-aaa4-a02e7274c654
[t2before]: https://github.com/user-attachments/assets/c3f9269a-8ba5-4fa1-9fe5-e39117be802b
[t3before]: https://github.com/user-attachments/assets/22687f20-edad-472a-9740-94b1aa111ecf
