### PR TITLE
Match Day component style updates

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -65,7 +65,11 @@ export const FootballMatchDay = ({
 			href={`${guardianBaseUrl}/football/${competitionTag}/overview`}
 			css={fixtureLinkCss}
 		>
-			See all fixtures <SvgChevronRightSingleSmall size="xsmall" />
+			See all fixtures{' '}
+			<SvgChevronRightSingleSmall
+				size="xsmall"
+				theme={{ fill: 'currentColor' }}
+			/>
 		</a>
 	</section>
 );
@@ -78,6 +82,7 @@ export const FootballMatchDay = ({
 
 const paletteCss = css`
 	--match-day-text: ${neutral[7]};
+	--match-day-text-live: ${neutral[7]};
 	--match-day-text-result: ${neutral[97]};
 	--match-day-background: ${sport[800]};
 	--match-day-background-live: ${brandAlt[400]};
@@ -88,6 +93,22 @@ const paletteCss = css`
 	--match-day-kicker: ${sport[400]};
 	--match-day-border: ${neutral[86]};
 	--match-day-crest: ${neutral[100]};
+
+	.ios,
+	.android {
+		@media (prefers-color-scheme: dark) {
+			--match-day-text: ${neutral[86]};
+			--match-day-text-live: ${neutral[7]};
+			--match-day-text-result: ${neutral[97]};
+			--match-day-background: ${neutral[20]};
+			--match-day-background-live: ${brandAlt[200]};
+			--match-day-background-result: ${sport[100]};
+			--match-day-comment: ${neutral[86]};
+			--match-day-comment-live: ${neutral[10]};
+			--match-day-live: ${sport[100]};
+			--match-day-kicker: ${sport[500]};
+		}
+	}
 `;
 
 const kickerCss = css`
@@ -111,7 +132,7 @@ const fixtureLinkCss = css`
 	align-items: center;
 	float: right;
 	margin-top: ${space[3]}px;
-	color: inherit;
+	color: var(--match-day-text);
 	text-decoration: none;
 	&:hover {
 		text-decoration: underline;
@@ -150,8 +171,9 @@ const Match = ({
 const matchTextColour = (matchKind: FootballMatch['kind']): string => {
 	switch (matchKind) {
 		case 'Fixture':
-		case 'Live':
 			return 'var(--match-day-text)';
+		case 'Live':
+			return 'var(--match-day-text-live)';
 		case 'Result':
 			return 'var(--match-day-text-result)';
 	}

--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -41,6 +41,9 @@ export const FootballMatchDay = ({
 	edition,
 }: Props) => (
 	<section>
+		{matches[0]?.competitions[0]?.name && (
+			<h3 css={kickerCss}>{matches[0].competitions[0].name} matchday</h3>
+		)}
 		{matches.length > 0 ? (
 			<ul
 				css={css`
@@ -72,6 +75,12 @@ export const FootballMatchDay = ({
 		</a>
 	</section>
 );
+
+const kickerCss = css`
+	${textSans15}
+	color: ${sport[400]};
+	margin-bottom: ${space[2]}px;
+`;
 
 const noMatchesCss = css`
 	${headlineMedium14}

--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -21,12 +21,6 @@ import {
 } from '../lib/edition';
 import { FootballCrest } from './FootballCrest';
 
-/**
- * Note: this component does not use the global colour palette declarations as
- * it is currently rendered in isolation via a dedicated endpoint where these
- * are unavailable. (And it would be undesirable to output the full palette.)
- */
-
 type Props = {
 	competitionTag: string;
 	matches: FootballMatches;
@@ -40,7 +34,7 @@ export const FootballMatchDay = ({
 	guardianBaseUrl,
 	edition,
 }: Props) => (
-	<section>
+	<section css={paletteCss}>
 		{matches[0]?.competitions[0]?.name && (
 			<h3 css={kickerCss}>{matches[0].competitions[0].name} matchday</h3>
 		)}
@@ -76,9 +70,29 @@ export const FootballMatchDay = ({
 	</section>
 );
 
+/**
+ * Note: this component does not use the global colour palette declarations as
+ * it is currently rendered in isolation via a dedicated endpoint where these
+ * are unavailable. (And it would be undesirable to output the full palette.)
+ */
+
+const paletteCss = css`
+	--match-day-text: ${neutral[7]};
+	--match-day-text-result: ${neutral[97]};
+	--match-day-background: ${sport[800]};
+	--match-day-background-live: ${brandAlt[400]};
+	--match-day-background-result: ${sport[300]};
+	--match-day-comment: ${neutral[86]};
+	--match-day-comment-live: ${neutral[10]};
+	--match-day-live: ${sport[300]};
+	--match-day-kicker: ${sport[400]};
+	--match-day-border: ${neutral[86]};
+	--match-day-crest: ${neutral[100]};
+`;
+
 const kickerCss = css`
 	${textSans15}
-	color: ${sport[400]};
+	color: var(--match-day-kicker);
 	margin-bottom: ${space[2]}px;
 `;
 
@@ -87,8 +101,8 @@ const noMatchesCss = css`
 	margin: 0;
 	padding: 11px ${space[2]}px;
 	text-align: center;
-	color: ${neutral[7]};
-	background-color: ${sport[800]};
+	color: var(--match-day-text);
+	background-color: var(--match-day-background);
 `;
 
 const fixtureLinkCss = css`
@@ -137,20 +151,20 @@ const matchTextColour = (matchKind: FootballMatch['kind']): string => {
 	switch (matchKind) {
 		case 'Fixture':
 		case 'Live':
-			return neutral[7];
+			return 'var(--match-day-text)';
 		case 'Result':
-			return neutral[97];
+			return 'var(--match-day-text-result)';
 	}
 };
 
 const matchBackgroundColour = (matchKind: FootballMatch['kind']): string => {
 	switch (matchKind) {
 		case 'Fixture':
-			return sport[800];
+			return 'var(--match-day-background)';
 		case 'Live':
-			return brandAlt[400];
+			return 'var(--match-day-background-live)';
 		case 'Result':
-			return sport[300];
+			return 'var(--match-day-background-result)';
 	}
 };
 
@@ -158,7 +172,7 @@ const matchCss = (matchKind: FootballMatch['kind']) => css`
 	color: ${matchTextColour(matchKind)};
 	background-color: ${matchBackgroundColour(matchKind)};
 	& + & {
-		border-top: 1px dashed ${neutral[86]};
+		border-top: 1px dashed var(--match-day-border);
 	}
 `;
 
@@ -245,7 +259,7 @@ const statusCss = css`
 const liveCss = css`
 	${textSansBold14}
 	position: relative;
-	color: ${sport[300]};
+	color: var(--match-day-live);
 	&::before {
 		display: inline-block;
 		content: '';
@@ -324,7 +338,7 @@ const Crest = ({ teamId }: { teamId: string }) => (
 			height: ${space[5]}px;
 			padding: ${space[1]}px;
 			border-radius: 100%;
-			background-color: ${neutral[100]};
+			background-color: var(--match-day-crest);
 		`}
 	>
 		<FootballCrest
@@ -352,5 +366,7 @@ const commentCss = (matchKind: FootballMatch['kind']) => css`
 	${textSansItalic12}
 	grid-area: comment;
 	text-align: center;
-	color: ${matchKind === 'Live' ? neutral[10] : neutral[86]};
+	color: ${matchKind === 'Live'
+		? 'var(--match-day-comment-live)'
+		: 'var(--match-day-comment)'};
 `;

--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -178,6 +178,10 @@ const wrapperCss = css`
 		grid-area: away;
 		justify-self: end;
 	}
+
+	&:hover {
+		text-decoration: none;
+	}
 `;
 
 const kickOffFormatterForEdition = (edition: EditionId): Intl.DateTimeFormat =>

--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -39,14 +39,7 @@ export const FootballMatchDay = ({
 			<h3 css={kickerCss}>{matches[0].competitions[0].name} matchday</h3>
 		)}
 		{matches.length > 0 ? (
-			<ul
-				css={css`
-					${textSans12}
-					list-style: none;
-					margin: 0;
-					padding: 0;
-				`}
-			>
+			<ul css={matchesCss}>
 				{matches.map(
 					(day) =>
 						day.competitions[0]?.matches.map((match) => (
@@ -115,6 +108,13 @@ const kickerCss = css`
 	${textSans15}
 	color: var(--match-day-kicker);
 	margin-bottom: ${space[2]}px;
+`;
+
+const matchesCss = css`
+	${textSans12}
+	list-style: none;
+	margin: 0;
+	padding: 0;
 `;
 
 const noMatchesCss = css`
@@ -193,7 +193,7 @@ const matchBackgroundColour = (matchKind: FootballMatch['kind']): string => {
 const matchCss = (matchKind: FootballMatch['kind']) => css`
 	color: ${matchTextColour(matchKind)};
 	background-color: ${matchBackgroundColour(matchKind)};
-	& + & {
+	:not(:first-of-type) {
 		border-top: 1px dashed var(--match-day-border);
 	}
 `;


### PR DESCRIPTION
## What does this change?

Styling updates and fixes for Match Day component:

- Adds 'kicker' with competition name
- Removes underline on hover (this is visible when the atom is published and added to a front)
- Updates border styles so border is added between different match kinds
- Adds dark mode palette for apps

## Screenshots

| Light      | Dark      |
| ----------- | ---------- |
| ![light][] | ![dark][] |

[light]: https://github.com/user-attachments/assets/0e4ce907-5cb5-4e80-a834-ea315ffcdd6f
[dark]: https://github.com/user-attachments/assets/4fb3f2cd-8f2c-43af-9035-7a55803a4061
