### PR TITLE
README update: Add steps to set VS Code TypeScript version and minor updates

### DIFF
--- a/dotcom-rendering/README.md
+++ b/dotcom-rendering/README.md
@@ -124,27 +124,27 @@ If you're trying to integrate with other applications, we also have a more [deta
 
 ## VS Code
 
-We recommend using [VSCode](https://code.visualstudio.com/).
+We recommend using [VS Code](https://code.visualstudio.com/).
 
 ### Settings
 
-We have configured a collection of _required_ VS Code settings in the file `.vscode/settings.json.required`.
+Required VS Code settings are in the file `.vscode/settings.json.required`.
 
-We have configured a collection of _recommended_ VS Code settings in the file `.vscode/settings.json.recommended`.
+Recommended VS Code settings are in the file `.vscode/settings.json.recommended`.
 
 Copy the required settings and any recommended settings you wish to use over to `.vscode/settings.json` to activate them.
 
 The `settings.json` file is git ignored to prevent it from overriding any indivdiual developer's settings.
 
-### Extensions
+### TypeScript Version
 
-VSCode should prompt you to install our recommended extensions when you open the project.
+Configure VS Code to use the workspace version of TypeScript and not its own bundled version using the following instructions:
 
-You can also find these extensions by searching for `@recommended` in the extensions pane.
+https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-the-workspace-version-of-typescript
 
 ### Auto fix on save
 
-We recommend you update your workspace settings to automatically fix formatting and linting errors on save, this avoids code style validation failures. These instructions assume you have installed the `esbenp.prettier-vscode` VSCode plugin:
+We recommend you update your workspace settings to automatically fix formatting and linting errors on save, this avoids code style validation failures. These instructions assume you have installed the `esbenp.prettier-vscode` extension:
 
 1. Open the Command Palette (`shift + cmd + P`) and select:
 
@@ -159,14 +159,20 @@ We recommend you update your workspace settings to automatically fix formatting 
     }
     ```
 
+### Extensions
+
+VS Code should prompt you to install our recommended extensions when you open the project.
+
+You can also find these extensions by searching for `@recommended` in the extensions pane.
+
 ## Technologies
 
 | Technology                                                                                                                 | Description                                                                                                                                                                                                                                                                                                                                       |
 | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <img alt="Typescript" src="./docs/images/logo-typescript.png" width="350" />                                               | DCR is written in [TypeScript](https://www.typescriptlang.org/)                                                                                                                                                                                                                                                                                   |
-| <img alt="Preact" src="./docs/images/logo-preact.jpg" width="350" />                                                       | DCR is rendered on the server with Preact and uses Preact as the Client-side framework. We use preact-compat to ensure compatability with React modules.                                                                                                                                                                                          |
-| <img alt="Emotion CSS-in-JS" src="./docs/images/logo-emotion.png" width="350" />                                           | [Emotion](https://emotion.sh) is css-in-js library, DCR uses the `css` tagged template literal style to allow CSS copy-pasting.                                                                                                                                                                                                                   |
-| <img alt="Express" src="./docs/images/logo-express.png" width="350" />                                                     | We use [Express](https://expressjs.com/) as a very thin server to communicate with the Frontend endpoint.                                                                                                                                                                                                                                         |
+| <img alt="Preact" src="./docs/images/logo-preact.jpg" width="350" />                                                       | DCR is rendered on the server with Preact and uses Preact as the Client-side framework. We use preact-compat to ensure compatability with React.                                                                                                                                                                                                  |
+| <img alt="Emotion CSS-in-JS" src="./docs/images/logo-emotion.png" width="350" />                                           | [Emotion](https://emotion.sh) is a [css-in-js library](https://en.wikipedia.org/wiki/CSS-in-JS). DCR uses the [css](https://emotion.sh/docs/css-prop#string-styles) tagged template literal style to enable the use of vanilla CSS properties.                                                                                                    |
+| <img alt="Express" src="./docs/images/logo-express.png" width="350" />                                                     | We use [Express](https://expressjs.com/) as a thin server to handle requests from Frontend.                                                                                                                                                                                                                                                       |
 | <img alt="Webpack" src="./docs/images/logo-webpack.png" width="350" />                                                     | [Webpack](https://webpack.js.org/) is used for its dev server and as a bundler for our production code.                                                                                                                                                                                                                                           |
 | <img alt="SWC" src="./docs/images/logo-swc.png" width="350" />                                                             | [SWC](https://swc.rs/) is used as a Webpack loader that allows for very fast compilation.                                                                                                                                                                                                                                                         |
 | <img alt="Storybook" src="./docs/images/logo-storybook.jpg" width="350" />                                                 | We use [Storybook](https://storybook.js.org/) to generate [component variations](https://main--63e251470cfbe61776b0ef19.chromatic.com) that are then visual regression tested in [Chromatic](https://www.chromatic.com/). You'll notice `.stories.` files in the repository that define the component variations.                                 |


### PR DESCRIPTION
## What does this change?

README update: Add steps to set VS Code TypeScript version to the workspace and minor updates

New section:

https://github.com/guardian/dotcom-rendering/blob/9e587477003edace69efb4199908c84be1b2768f/dotcom-rendering/README.md#typescript-version

## Why?

Keep documentation up to date

