### PR TITLE
Roll out hosted content AB test to 50% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -77,7 +77,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-07-01",
 		type: "server",
 		status: "ON",
-		audienceSize: 20 / 100,
+		audienceSize: 50 / 100,
 		audienceSpace: "A",
 		groups: ["preview"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
## What does this change?

Increases the audience for previewing the new Hosted Content pages up to 50%

## Why?

Rolling out the DCR migration of Hosted Content pages

------

- 20%: #15992 
- 10%: #15985 
