### PR TITLE
Add video attnetion time tracking hook for self hosted videos

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -3,7 +3,6 @@ import { isUndefined, log, storage } from '@guardian/libs';
 import { from, space, until } from '@guardian/source/foundations';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-	getOphan,
 	submitClickComponentEvent,
 	submitComponentEvent,
 } from '../client/ophan/ophan';
@@ -16,6 +15,7 @@ import { useIsInView } from '../lib/useIsInView';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
+import { useVideoAttentionTracking } from '../lib/useVideoAttentionTracking';
 import { useVideoMilestoneTracking } from '../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {
@@ -29,7 +29,6 @@ import { videoSettingsMap } from '../lib/videoStyleSettings';
 import { palette } from '../palette';
 import type { RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { Caption } from './Caption';
 import { CardPicture, type Props as CardPictureProps } from './CardPicture';
 import { useConfig } from './ConfigContext';
@@ -229,28 +228,6 @@ const logAndReportError = (src: string, error: Error) => {
 	}
 
 	log('dotcom', message);
-};
-
-/**
- * Initiates attention tracking for ophan
- */
-const trackAttention = async (
-	videoElement: HTMLVideoElement,
-	atomId: string,
-	renderingTarget: RenderingTarget,
-	videoStyle: OphanVideoStyle,
-) => {
-	try {
-		const ophan = await getOphan(renderingTarget);
-		ophan.trackComponentAttention(
-			`gu-video-${videoStyle}-${atomId}`,
-			videoElement,
-			VISIBILITY_THRESHOLD,
-			true,
-		);
-	} catch (error) {
-		log('dotcom', 'Failed to track video attention:', error);
-	}
 };
 
 const dispatchOphanAttentionEvent = (
@@ -573,6 +550,13 @@ export const SelfHostedVideo = ({
 		videoStyle === 'Default',
 	);
 
+	useVideoAttentionTracking(
+		`gu-video-${ophanVideoStyle}-${atomId}`,
+		isInView,
+		playerState === 'PLAYING',
+		renderingTarget,
+	);
+
 	const playVideo = useCallback(async () => {
 		const video = vidRef.current;
 		if (!video) {
@@ -692,7 +676,6 @@ export const SelfHostedVideo = ({
 	 *
 	 * 1. Determine whether we can autoplay video.
 	 * 2. Use the best video size available for the user's screen size
-	 * 2. Initialise Ophan attention tracking.
 	 * 3. Creates event listeners to control playback when there are multiple videos.
 	 */
 	useEffect(() => {
@@ -708,18 +691,6 @@ export const SelfHostedVideo = ({
 			screenWidth,
 		);
 		setOptimisedSources(filteredSources);
-
-		/**
-		 * Initialise Ophan attention tracking
-		 */
-		if (vidRef.current) {
-			void trackAttention(
-				vidRef.current,
-				atomId,
-				renderingTarget,
-				ophanVideoStyle,
-			);
-		}
 
 		/**
 		 * Mutes the current video when another video is unmuted
@@ -808,14 +779,7 @@ export const SelfHostedVideo = ({
 				handlePageBecomesVisible();
 			});
 		};
-	}, [
-		setMutedState,
-		uniqueId,
-		atomId,
-		sources,
-		renderingTarget,
-		ophanVideoStyle,
-	]);
+	}, [setMutedState, uniqueId, sources, renderingTarget]);
 
 	/* Creates video-specific event listeners to handle fullscreen behaviour */
 	useEffect(() => {

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -573,7 +573,7 @@ export const SelfHostedVideo = ({
 					setPlayerState('PAUSED_BY_BROWSER');
 				});
 		}
-	}, [isWeb]);
+	}, []);
 
 	const pauseVideo = (
 		pauseReason: Extract<

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -230,13 +230,6 @@ const logAndReportError = (src: string, error: Error) => {
 	log('dotcom', message);
 };
 
-const dispatchOphanAttentionEvent = (
-	eventType: 'videoPlaying' | 'videoPause',
-) => {
-	const event = new Event(eventType, { bubbles: true });
-	document.dispatchEvent(event);
-};
-
 const getOptimisedPosterImage = (
 	mainImage: string,
 	aspectRatio: string,
@@ -571,9 +564,6 @@ export const SelfHostedVideo = ({
 			await startPlayPromise
 				.then(() => {
 					// Autoplay succeeded
-					if (isWeb) {
-						dispatchOphanAttentionEvent('videoPlaying');
-					}
 					setPlayerState('PLAYING');
 				})
 				.catch((error: Error) => {
@@ -603,10 +593,6 @@ export const SelfHostedVideo = ({
 		}
 
 		setPlayerState(pauseReason);
-
-		if (isWeb) {
-			dispatchOphanAttentionEvent('videoPause');
-		}
 
 		void video.pause();
 	};

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -1,3 +1,4 @@
+import type { EventPayload } from '@guardian/ophan-tracker-js';
 import { useEffect, useRef } from 'react';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
@@ -23,10 +24,7 @@ const dispatchOphanAttentionEvent = (
  * (`components.js` / `attention.js`), but managed within React so that
  * attention is only accumulated when the video is playing — not merely when
  * it is in view.
- *
- * Attention time is reported periodically via `ophan.record` using the same
- * `componentAttentionMs` payload format as ophan-tracker-js.
- *
+
  * @param componentName - The component name key used in the `componentAttentionMs` payload.
  *   Should follow the `gu-video-<style>-<atomId>` convention.
  * @param isInView - Whether the video element is sufficiently visible in the viewport.
@@ -41,8 +39,8 @@ export const useVideoAttentionTracking = (
 	renderingTarget: RenderingTarget,
 ): void => {
 	const totalAttentionMsRef = useRef(0);
+	const reportedAttentionMsRef = useRef(0);
 	const attentionStartedAtRef = useRef<number | null>(null);
-	const reportedAttentionMsRef = useRef<number | null>(null);
 
 	const isActive = isInView === true && isPlaying;
 
@@ -88,36 +86,30 @@ export const useVideoAttentionTracking = (
 			if (
 				totalAttentionMsRef.current !== reportedAttentionMsRef.current
 			) {
-				const attentionMs = Math.round(totalAttentionMsRef.current);
-				reportedAttentionMsRef.current = totalAttentionMsRef.current;
-
 				void getOphan(renderingTarget).then((ophan) => {
-					// `componentAttentionMs` is not part of the EventPayload TypeScript
-					// type definition, but it is the raw query-string key consumed by
-					// the Ophan backend — matching what attention.js sends via
-					// transmit.sendMore.
-					console.log(
-						'Submitting attention time:',
-						componentName,
-						attentionMs,
-					);
-					// ophan.record({
-					// 	attention: {
-					// 		attentionMs: 0,
-					// 		componentAttentionMs: {
-					// 			[componentName]: attentionMs,
-					// 		},
-					// 	},
-					// });
+					if (renderingTarget === 'Web') {
+						// EventPayload is current typed erroneously
+						ophan.record({
+							componentAttentionMs: {
+								[componentName]: Math.round(
+									totalAttentionMsRef.current,
+								),
+							},
+						} as unknown as EventPayload);
+					} else {
+						/**
+						 * Report component attention time via Bridget.
+						 */
+					}
 				});
+
+				reportedAttentionMsRef.current = totalAttentionMsRef.current;
 			}
 		};
 
-		const initialTimerId = window.setTimeout(report, 100);
 		const intervalId = window.setInterval(report, REPORTING_INTERVAL_MS);
 
 		return () => {
-			window.clearTimeout(initialTimerId);
 			window.clearInterval(intervalId);
 		};
 	}, [componentName, renderingTarget]);

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -88,8 +88,10 @@ export const useVideoAttentionTracking = (
 			) {
 				void getOphan(renderingTarget).then((ophan) => {
 					if (renderingTarget === 'Web') {
-						// EventPayload is current typed erroneously
+						// EventPayload is currently typed erroneously
 						ophan.record({
+							// AttentionMs value is currently required to avoid the event from being dropped
+							attentionMs: 0,
 							componentAttentionMs: {
 								[componentName]: Math.round(
 									totalAttentionMsRef.current,

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -1,0 +1,151 @@
+import { useEffect, useRef } from 'react';
+import { getOphan } from '../client/ophan/ophan';
+import type { RenderingTarget } from '../types/renderingTarget';
+
+/**
+ * How often attention time is reported to Ophan, matching the interval used
+ * by ophan-tracker-js internally.
+ */
+const REPORTING_INTERVAL_MS = 10_000;
+
+/**
+ * Tracks incremental video attention time whilst the video is both visible
+ * in the viewport and actively playing.
+ *
+ * Emulates the component attention tracking behaviour of ophan-tracker-js
+ * (`components.js` / `attention.js`), but managed within React so that
+ * attention is only accumulated when the video is playing — not merely when
+ * it is in view.
+ *
+ * Attention time is reported periodically via `ophan.record` using the same
+ * `componentAttentionMs` payload format as ophan-tracker-js.
+ *
+ * @param componentName - The component name key used in the `componentAttentionMs` payload.
+ *   Should follow the `gu-video-<style>-<atomId>` convention.
+ * @param isInView - Whether the video element is sufficiently visible in the viewport.
+ *   Typically sourced from `useIsInView`.
+ * @param isPlaying - Whether the video is currently playing.
+ * @param renderingTarget - Used to obtain the correct Ophan instance.
+ */
+export const useVideoAttentionTracking = (
+	componentName: string,
+	isInView: boolean | null,
+	isPlaying: boolean,
+	renderingTarget: RenderingTarget,
+): void => {
+	/** Accumulated attention time in milliseconds. */
+	const totalAttentionMsRef = useRef(0);
+
+	/**
+	 * The last value of `totalAttentionMsRef` that was reported to Ophan.
+	 * Initialised to `null` so the first report fires even when attention is 0ms,
+	 * matching the behaviour of attention.js.
+	 */
+	const reportedAttentionMsRef = useRef<number | null>(null);
+
+	/**
+	 * The `performance.now()` timestamp at which the current unrecorded attention
+	 * period began. `null` when attention is not being tracked.
+	 */
+	const attentionStartedAtRef = useRef<number | null>(null);
+
+	/**
+	 * Kept in refs so they can be read from the interval callback without
+	 * requiring it as a dependency or causing stale closures.
+	 */
+	const componentNameRef = useRef(componentName);
+	const renderingTargetRef = useRef(renderingTarget);
+	componentNameRef.current = componentName;
+	renderingTargetRef.current = renderingTarget;
+
+	/**
+	 * Attention is active when the video is both in view and playing.
+	 * Mirrors the condition in ophan-tracker-js where a video component only
+	 * accumulates attention when `visible && videoPlaying`.
+	 */
+	const isActive = isInView === true && isPlaying;
+
+	/**
+	 * React to changes in the active state:
+	 * - When becoming active, record the start timestamp.
+	 * - When becoming inactive, flush unrecorded time into the total and clear
+	 *   the start timestamp.
+	 */
+	useEffect(() => {
+		if (isActive) {
+			if (attentionStartedAtRef.current === null) {
+				attentionStartedAtRef.current = performance.now();
+			}
+		} else {
+			if (attentionStartedAtRef.current !== null) {
+				const now = performance.now();
+				totalAttentionMsRef.current += Math.min(
+					now - attentionStartedAtRef.current,
+					REPORTING_INTERVAL_MS,
+				);
+				attentionStartedAtRef.current = null;
+			}
+		}
+	}, [isActive]);
+
+	/**
+	 * Set up periodic reporting. Runs once on mount.
+	 *
+	 * Matches the reporting cadence of attention.js:
+	 * - An initial report fires after 100ms.
+	 * - Subsequent reports fire every `REPORTING_INTERVAL_MS`.
+	 *
+	 * Each report:
+	 * 1. Flushes any unrecorded time from the current attention period into the
+	 *    total (capped at `REPORTING_INTERVAL_MS` to avoid inflated values from
+	 *    suspended devices).
+	 * 2. Sends `componentAttentionMs` via `ophan.record` only when the total has
+	 *    changed since the last report.
+	 */
+	useEffect(() => {
+		const accumulateAttention = () => {
+			if (attentionStartedAtRef.current !== null) {
+				const now = performance.now();
+				totalAttentionMsRef.current += Math.min(
+					now - attentionStartedAtRef.current,
+					REPORTING_INTERVAL_MS,
+				);
+				// Reset to now so the next accumulation starts from here,
+				// matching the behaviour of incrementTotalAttentionTimeByUnrecordedAmount
+				// in components.js.
+				attentionStartedAtRef.current = now;
+			}
+		};
+
+		const report = () => {
+			accumulateAttention();
+			if (
+				totalAttentionMsRef.current !== reportedAttentionMsRef.current
+			) {
+				const attentionMs = Math.round(totalAttentionMsRef.current);
+				// Update before the async call to prevent duplicate reports if
+				// the interval fires again before the promise resolves.
+				reportedAttentionMsRef.current = totalAttentionMsRef.current;
+				void getOphan(renderingTargetRef.current).then((ophan) => {
+					// `componentAttentionMs` is not part of the EventPayload TypeScript
+					// type definition, but it is the raw query-string key consumed by
+					// the Ophan backend — matching what attention.js sends via
+					// transmit.sendMore.
+					ophan.record({
+						componentAttentionMs: {
+							[componentNameRef.current]: attentionMs,
+						},
+					} as Parameters<typeof ophan.record>[0]);
+				});
+			}
+		};
+
+		const initialTimerId = window.setTimeout(report, 100);
+		const intervalId = window.setInterval(report, REPORTING_INTERVAL_MS);
+
+		return () => {
+			window.clearTimeout(initialTimerId);
+			window.clearInterval(intervalId);
+		};
+	}, []);
+};

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -8,6 +8,13 @@ import type { RenderingTarget } from '../types/renderingTarget';
  */
 const REPORTING_INTERVAL_MS = 10_000;
 
+const dispatchOphanAttentionEvent = (
+	eventType: 'videoPlaying' | 'videoPause',
+) => {
+	const event = new Event(eventType, { bubbles: true });
+	document.dispatchEvent(event);
+};
+
 /**
  * Tracks incremental video attention time whilst the video is both visible
  * in the viewport and actively playing.
@@ -33,51 +40,27 @@ export const useVideoAttentionTracking = (
 	isPlaying: boolean,
 	renderingTarget: RenderingTarget,
 ): void => {
-	/** Accumulated attention time in milliseconds. */
 	const totalAttentionMsRef = useRef(0);
-
-	/**
-	 * The last value of `totalAttentionMsRef` that was reported to Ophan.
-	 * Initialised to `null` so the first report fires even when attention is 0ms,
-	 * matching the behaviour of attention.js.
-	 */
+	const attentionStartedAtRef = useRef<number | null>(null);
 	const reportedAttentionMsRef = useRef<number | null>(null);
 
-	/**
-	 * The `performance.now()` timestamp at which the current unrecorded attention
-	 * period began. `null` when attention is not being tracked.
-	 */
-	const attentionStartedAtRef = useRef<number | null>(null);
-
-	/**
-	 * Kept in refs so they can be read from the interval callback without
-	 * requiring it as a dependency or causing stale closures.
-	 */
-	const componentNameRef = useRef(componentName);
-	const renderingTargetRef = useRef(renderingTarget);
-	componentNameRef.current = componentName;
-	renderingTargetRef.current = renderingTarget;
-
-	/**
-	 * Attention is active when the video is both in view and playing.
-	 * Mirrors the condition in ophan-tracker-js where a video component only
-	 * accumulates attention when `visible && videoPlaying`.
-	 */
 	const isActive = isInView === true && isPlaying;
 
-	/**
-	 * React to changes in the active state:
-	 * - When becoming active, record the start timestamp.
-	 * - When becoming inactive, flush unrecorded time into the total and clear
-	 *   the start timestamp.
-	 */
 	useEffect(() => {
 		if (isActive) {
-			if (attentionStartedAtRef.current === null) {
-				attentionStartedAtRef.current = performance.now();
-			}
+			/**
+			 * Update Ophan to flag a video is playing. This will
+			 * mean attention time updates are continually sent.
+			 */
+			dispatchOphanAttentionEvent('videoPlaying');
+			attentionStartedAtRef.current ??= performance.now();
 		} else {
 			if (attentionStartedAtRef.current !== null) {
+				/**
+				 * Update Ophan to flag a video has stopped. This will
+				 * mean attention time updates are eventually stopped.
+				 */
+				dispatchOphanAttentionEvent('videoPause');
 				const now = performance.now();
 				totalAttentionMsRef.current += Math.min(
 					now - attentionStartedAtRef.current,
@@ -88,20 +71,6 @@ export const useVideoAttentionTracking = (
 		}
 	}, [isActive]);
 
-	/**
-	 * Set up periodic reporting. Runs once on mount.
-	 *
-	 * Matches the reporting cadence of attention.js:
-	 * - An initial report fires after 100ms.
-	 * - Subsequent reports fire every `REPORTING_INTERVAL_MS`.
-	 *
-	 * Each report:
-	 * 1. Flushes any unrecorded time from the current attention period into the
-	 *    total (capped at `REPORTING_INTERVAL_MS` to avoid inflated values from
-	 *    suspended devices).
-	 * 2. Sends `componentAttentionMs` via `ophan.record` only when the total has
-	 *    changed since the last report.
-	 */
 	useEffect(() => {
 		const accumulateAttention = () => {
 			if (attentionStartedAtRef.current !== null) {
@@ -110,9 +79,6 @@ export const useVideoAttentionTracking = (
 					now - attentionStartedAtRef.current,
 					REPORTING_INTERVAL_MS,
 				);
-				// Reset to now so the next accumulation starts from here,
-				// matching the behaviour of incrementTotalAttentionTimeByUnrecordedAmount
-				// in components.js.
 				attentionStartedAtRef.current = now;
 			}
 		};
@@ -123,19 +89,26 @@ export const useVideoAttentionTracking = (
 				totalAttentionMsRef.current !== reportedAttentionMsRef.current
 			) {
 				const attentionMs = Math.round(totalAttentionMsRef.current);
-				// Update before the async call to prevent duplicate reports if
-				// the interval fires again before the promise resolves.
 				reportedAttentionMsRef.current = totalAttentionMsRef.current;
-				void getOphan(renderingTargetRef.current).then((ophan) => {
+
+				void getOphan(renderingTarget).then((ophan) => {
 					// `componentAttentionMs` is not part of the EventPayload TypeScript
 					// type definition, but it is the raw query-string key consumed by
 					// the Ophan backend — matching what attention.js sends via
 					// transmit.sendMore.
-					ophan.record({
-						componentAttentionMs: {
-							[componentNameRef.current]: attentionMs,
-						},
-					} as Parameters<typeof ophan.record>[0]);
+					console.log(
+						'Submitting attention time:',
+						componentName,
+						attentionMs,
+					);
+					// ophan.record({
+					// 	attention: {
+					// 		attentionMs: 0,
+					// 		componentAttentionMs: {
+					// 			[componentName]: attentionMs,
+					// 		},
+					// 	},
+					// });
 				});
 			}
 		};
@@ -147,5 +120,5 @@ export const useVideoAttentionTracking = (
 			window.clearTimeout(initialTimerId);
 			window.clearInterval(intervalId);
 		};
-	}, []);
+	}, [componentName, renderingTarget]);
 };


### PR DESCRIPTION
## What does this change?

This changes replaces the `Tracker JS` implemented component attention time tracking for self hosted video, with a React hook which provides the equivalent functionality. 

> [!NOTE]
> Without changes to the Ophan pipeline, these events will currently be dropped. Ophan expects to receive both an `AttentionMs` and `ComponentAttentionMs` parameter. Without both, the event will be dropped: 
https://github.com/guardian/ophan/blob/5bd34881b544597ffb94b25cb0f0dbfb93c4079f/the-slab/app/extractors/AttentionTimeExtractor.scala#L19-L21   

## Why?

The current solution does not work with DCAR rendered content on Apps, as the Ophan functionality is not implemented: 

https://github.com/guardian/dotcom-rendering/blob/2dbfb7913ff8e14e827723bbcb57053ac14d40c9/dotcom-rendering/src/client/ophan/ophan.ts#L26

Replacing the internally implemented component attention tracking with a hook will allow us to choose how the data should be sent. Either via the tracking library function or Bridget. The implementation of the Bridget function can then send the tracking events to Ophan. 

Notably, the `Tracker JS` library code is only used by the self hosted video and nowhere else. 

## Testing

I have tested this on Chrome, Firefox and Safari. The functionality worked consistently across the three. 

To test the changes, play a video and observe the outgoing network traffic, filtering to `ophan componentattention`.
