### PR TITLE
Update self-hosted video Play Icon transition timing

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -54,6 +54,7 @@ const VISIBILITY_THRESHOLD = 0.5;
  * The duration in ms for which controls are displayed before fading out.
  */
 const CONTROLS_FADE_DELAY = 2700;
+const PLAY_BUTTON_FADE_DELAY = 1700;
 
 const cardStyles = (
 	isInteractive: boolean,
@@ -178,24 +179,41 @@ const fullscreenStyles = css`
 	}
 `;
 
+const showTransitionStyles = css`
+	visibility: visible;
+	opacity: 1;
+	transition:
+		visibility 0.2s,
+		opacity 0.2s ease-in-out;
+`;
+
 const showControlsStyles = css`
 	.controls-container {
-		visibility: visible;
-		opacity: 1;
-		transition:
-			visibility 0.2s,
-			opacity 0.2s ease-in-out;
+		${showTransitionStyles};
 	}
+
+	.play-pause-icon {
+		${showTransitionStyles};
+	}
+`;
+
+const hideTransitionStyles = css`
+	visibility: hidden;
+	opacity: 0;
+	transition:
+		visibility 0.3s,
+		opacity 0.3s ease-in-out;
 `;
 
 const hideControlsStyles = css`
 	.controls-container {
-		visibility: hidden;
-		opacity: 0;
-		transition:
-			visibility 0.3s,
-			opacity 0.3s ease-in-out;
+		${hideTransitionStyles}
 		transition-delay: ${CONTROLS_FADE_DELAY}ms;
+	}
+
+	.play-pause-icon {
+		${hideTransitionStyles}
+		transition-delay: ${PLAY_BUTTON_FADE_DELAY}ms;
 	}
 
 	@media (hover: hover) {

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -106,6 +106,7 @@ export const PlayPauseIcon = ({
 		<button
 			type="button"
 			onClick={handleClick}
+			className="play-pause-icon"
 			css={[
 				buttonStyles,
 				isLoopClickThroughTest


### PR DESCRIPTION
## What does this change?

Update the transition time for the play icon to disappear to 2 seconds.

## Why?

Design request

## Screenshots

https://github.com/user-attachments/assets/05cf9d5a-0a54-45f1-a884-e20beea9a868

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
