### PR TITLE
Don't use floats in Match Day layout

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -34,7 +34,7 @@ export const FootballMatchDay = ({
 	guardianBaseUrl,
 	edition,
 }: Props) => (
-	<section css={paletteCss}>
+	<section css={containerCss}>
 		{matches[0]?.competitions[0]?.name && (
 			<h3 css={kickerCss}>{matches[0].competitions[0].name} matchday</h3>
 		)}
@@ -73,7 +73,7 @@ export const FootballMatchDay = ({
  * are unavailable. (And it would be undesirable to output the full palette.)
  */
 
-const paletteCss = css`
+const containerCss = css`
 	--match-day-text: ${neutral[7]};
 	--match-day-text-live: ${neutral[7]};
 	--match-day-text-result: ${neutral[97]};
@@ -86,6 +86,10 @@ const paletteCss = css`
 	--match-day-kicker: ${sport[400]};
 	--match-day-border: ${neutral[86]};
 	--match-day-crest: ${neutral[100]};
+
+	display: flex;
+	flex-direction: column;
+	gap: ${space[2]}px;
 
 	.ios,
 	.android {
@@ -107,7 +111,7 @@ const paletteCss = css`
 const kickerCss = css`
 	${textSans15}
 	color: var(--match-day-kicker);
-	margin-bottom: ${space[2]}px;
+	margin: 0;
 `;
 
 const matchesCss = css`
@@ -128,10 +132,9 @@ const noMatchesCss = css`
 
 const fixtureLinkCss = css`
 	${textSans15}
-	display: inline-flex;
+	display: flex;
 	align-items: center;
-	float: right;
-	margin-top: ${space[3]}px;
+	align-self: flex-end;
 	color: var(--match-day-text);
 	text-decoration: none;
 	&:hover {


### PR DESCRIPTION
## What does this change?

Updates layout to use flex and removes use of float to position 'all fixtures' link.

## Why?

When added to a front as a snap link the link floats outside the football atom container, picking up the wrong background colour. This could also be solved by applying `overflow: hidden` to the container, but using flex instead of a float feels more elegant and robust.

## Screenshots

The grey background behind the 'all fixtures' link is from the parent snap container.

<img width="685" height="160" alt="Screenshot 2026-06-01 at 18 11 23" src="https://github.com/user-attachments/assets/5f150c0b-971b-4d4a-bdcb-5c482cdace56" />
