### PR TITLE
Revert "Don't check for front container when determining audio media"

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -257,6 +257,7 @@ const getMedia = ({
 	slideshowImages,
 	mainMedia,
 	canPlayInline,
+	isFrontContainer,
 }: {
 	imageUrl?: string;
 	imageAltText?: string;
@@ -265,6 +266,7 @@ const getMedia = ({
 	slideshowImages?: DCRSlideshowImage[];
 	mainMedia?: MainMedia;
 	canPlayInline?: boolean;
+	isFrontContainer: boolean;
 }) => {
 	if (mainMedia?.type === 'SelfHostedVideo' && canPlayInline) {
 		let type: CardMediaType;
@@ -301,7 +303,11 @@ const getMedia = ({
 		return { type: 'avatar', avatarUrl } as const;
 	}
 
-	if (mainMedia?.type === 'Audio' && mainMedia.podcastImage) {
+	if (
+		mainMedia?.type === 'Audio' &&
+		mainMedia.podcastImage &&
+		isFrontContainer
+	) {
 		return {
 			...mainMedia,
 			type: 'podcast',
@@ -528,6 +534,7 @@ export const Card = ({
 		slideshowImages,
 		mainMedia,
 		canPlayInline,
+		isFrontContainer,
 	});
 
 	const isSelfHostedVideo =


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#15975. 

This check is in fact still required to ensure podcasts pages display correctly