### PR TITLE
Refactor newsletter signup tracking to support new variant and update component IDs

### DIFF
--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
@@ -1,10 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { submitComponentEvent } from '../client/ophan/ophan';
-import {
-	AB_TEST_NAME,
-	NEWSLETTER_SIGNUP_COMPONENT_ID,
-} from '../lib/newsletterSignupTracking';
+import { AB_TEST_NAME } from '../lib/newsletterSignupTracking';
 import { useAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
@@ -86,10 +83,12 @@ const renderWrapper = (props = {}, renderingTarget: 'Web' | 'Apps' = 'Web') =>
 		</ConfigProvider>,
 	);
 
-const mockAbTests = (isInVariant: boolean) => {
+const mockAbTests = (
+	variant: 'control' | 'variantIllustratedCard' | 'variantNewField',
+) => {
 	(useAB as jest.Mock).mockReturnValue({
 		getParticipations: () => ({
-			[AB_TEST_NAME]: isInVariant ? 'variantIllustratedCard' : 'control',
+			[AB_TEST_NAME]: variant,
 		}),
 	});
 };
@@ -117,7 +116,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('renders nothing when the user is already subscribed', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(true);
 			const { container } = renderWrapper({
 				hideNewsletterSignupComponentForSubscribers: true,
@@ -126,7 +125,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('renders the legacy EmailSignup when the user is not subscribed', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			renderWrapper();
 			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
 			expect(screen.getByTestId('secure-signup')).toBeInTheDocument();
@@ -151,7 +150,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('renders the legacy EmailSignup for users in the control group', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
 			expect(
@@ -160,7 +159,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('renders NewsletterSignupCardContainer for users in the variant group', () => {
-			mockAbTests(true);
+			mockAbTests('variantIllustratedCard');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 			expect(
 				screen.getByTestId('newsletter-signup-card-container'),
@@ -173,8 +172,18 @@ describe('EmailSignUpWrapper', () => {
 			).not.toBeInTheDocument();
 		});
 
+		it('renders the legacy EmailSignup for users in the variantNewField group', () => {
+			mockAbTests('variantNewField');
+			renderWrapper({ showNewNewsletterSignupCard: true });
+			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
+			expect(screen.getByTestId('secure-signup')).toBeInTheDocument();
+			expect(
+				screen.queryByTestId('newsletter-signup-card-container'),
+			).not.toBeInTheDocument();
+		});
+
 		it('does not hide the variant for already-subscribed users (subscription handled inside the card)', () => {
-			mockAbTests(true);
+			mockAbTests('variantIllustratedCard');
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(true);
 			renderWrapper({
 				showNewNewsletterSignupCard: true,
@@ -211,16 +220,14 @@ describe('EmailSignUpWrapper', () => {
 
 	describe('VIEW tracking', () => {
 		it('fires a VIEW event with the correct control component id and ab metadata', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 
 			expect(submitComponentEvent).toHaveBeenCalledWith(
 				expect.objectContaining({
 					component: {
 						componentType: 'NEWSLETTER_SUBSCRIPTION',
-						id: NEWSLETTER_SIGNUP_COMPONENT_ID.control(
-							defaultProps.identityName,
-						),
+						id: 'AR SecureSignup the-recap',
 					},
 					action: 'VIEW',
 					abTest: { name: AB_TEST_NAME, variant: 'control' },
@@ -230,16 +237,14 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('fires a VIEW event with the correct variant component id and ab metadata', () => {
-			mockAbTests(true);
+			mockAbTests('variantIllustratedCard');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 
 			expect(submitComponentEvent).toHaveBeenCalledWith(
 				expect.objectContaining({
 					component: {
 						componentType: 'NEWSLETTER_SUBSCRIPTION',
-						id: NEWSLETTER_SIGNUP_COMPONENT_ID.variantIllustratedCard(
-							defaultProps.identityName,
-						),
+						id: 'AR NewsletterSignupForm the-recap - variantIllustratedCard',
 					},
 					action: 'VIEW',
 					abTest: {
@@ -251,16 +256,34 @@ describe('EmailSignUpWrapper', () => {
 			);
 		});
 
+		it('fires a VIEW event with the correct variantNewField component id and ab metadata', () => {
+			mockAbTests('variantNewField');
+			renderWrapper({ showNewNewsletterSignupCard: true });
+
+			expect(submitComponentEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					component: {
+						componentType: 'NEWSLETTER_SUBSCRIPTION',
+						id: 'AR SecureSignup the-recap - variantNewField',
+					},
+					action: 'VIEW',
+					abTest: {
+						name: AB_TEST_NAME,
+						variant: 'variantNewField',
+					},
+				}),
+				'Web',
+			);
+		});
+
 		it('fires a VIEW event with the control component id when the flag is off', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: false });
 
 			expect(submitComponentEvent).toHaveBeenCalledWith(
 				expect.objectContaining({
 					component: expect.objectContaining({
-						id: NEWSLETTER_SIGNUP_COMPONENT_ID.control(
-							defaultProps.identityName,
-						),
+						id: 'AR SecureSignup the-recap',
 					}),
 					action: 'VIEW',
 				}),
@@ -269,14 +292,14 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('fires the VIEW event exactly once on mount', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 
 			expect(submitComponentEvent).toHaveBeenCalledTimes(1);
 		});
 
 		it('does not fire a VIEW event while subscription status is loading', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(undefined);
 			renderWrapper({ showNewNewsletterSignupCard: true });
 
@@ -291,7 +314,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('does not fire a VIEW event for control users who are already subscribed', () => {
-			mockAbTests(false);
+			mockAbTests('control');
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(true);
 			renderWrapper({
 				showNewNewsletterSignupCard: true,
@@ -302,7 +325,7 @@ describe('EmailSignUpWrapper', () => {
 		});
 
 		it('does not fire a VIEW event for variant users who are already subscribed', () => {
-			mockAbTests(true);
+			mockAbTests('variantIllustratedCard');
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(true);
 			renderWrapper({
 				showNewNewsletterSignupCard: true,

--- a/dotcom-rendering/src/components/SecureSignup.island.test.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { forwardRef, useImperativeHandle } from 'react';
-import { sendNewsletterSignupEvent } from '../lib/newsletterSignupTracking';
+import { type ComponentProps, forwardRef, useImperativeHandle } from 'react';
+import * as newsletterSignupTracking from '../lib/newsletterSignupTracking';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
 import { useBrowserId } from '../lib/useBrowserId';
 import { useCountryCode } from '../lib/useCountryCode';
 import { ConfigProvider } from './ConfigContext';
 import { SecureSignup } from './SecureSignup.island';
+
+jest.mock('../lib/newsletterSignupTracking', () => ({
+	...jest.requireActual('../lib/newsletterSignupTracking'),
+	sendNewsletterSignupEvent: jest.fn(),
+}));
 
 jest.mock('../lib/useAuthStatus', () => ({
 	useAuthStatus: jest.fn(),
@@ -25,11 +30,7 @@ jest.mock('../lib/fetchEmail', () => ({
 	lazyFetchEmailWithTimeout: jest.fn(() => () => Promise.resolve(null)),
 }));
 
-jest.mock('../lib/newsletterSignupTracking', () => ({
-	EVENT_DESCRIPTION_TO_ACTION: {},
-	NEWSLETTER_SIGNUP_COMPONENT_ID: { control: () => 'test-id' },
-	sendNewsletterSignupEvent: jest.fn(),
-}));
+let sendNewsletterSignupEventSpy: jest.SpyInstance;
 
 type RecaptchaProps = {
 	// eslint-disable-next-line react/no-unused-prop-types -- false positive
@@ -62,7 +63,9 @@ jest.mock('react-google-recaptcha', () => ({
 	),
 }));
 
-const secureSignupElement = () => (
+const secureSignupElement = (
+	props?: Partial<ComponentProps<typeof SecureSignup>>,
+) => (
 	<ConfigProvider
 		value={{
 			renderingTarget: 'Web',
@@ -74,11 +77,14 @@ const secureSignupElement = () => (
 		<SecureSignup
 			newsletterId="morning-briefing"
 			successDescription="You'll receive Morning Briefing every weekday."
+			{...props}
 		/>
 	</ConfigProvider>
 );
 
-const renderSecureSignup = () => render(secureSignupElement());
+const renderSecureSignup = (
+	props?: Partial<ComponentProps<typeof SecureSignup>>,
+) => render(secureSignupElement(props));
 
 const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
 	const [, requestInit] = (global.fetch as jest.Mock).mock.calls[
@@ -89,8 +95,7 @@ const getRequestBodyParams = (callIndex = 0): URLSearchParams => {
 };
 
 const getTrackingPayloadForEvent = (eventDescription: string) => {
-	const trackingCalls = (sendNewsletterSignupEvent as jest.Mock).mock
-		.calls as Array<
+	const trackingCalls = sendNewsletterSignupEventSpy.mock.calls as Array<
 		[
 			{
 				value: {
@@ -110,6 +115,27 @@ const getTrackingPayloadForEvent = (eventDescription: string) => {
 	return undefined;
 };
 
+const getTrackingCallForEvent = (eventDescription: string) => {
+	const trackingCalls = sendNewsletterSignupEventSpy.mock.calls as Array<
+		[
+			{
+				componentId: string;
+				value: {
+					eventDescription: string;
+				};
+			},
+		]
+	>;
+
+	for (const [payload] of trackingCalls) {
+		if (payload.value.eventDescription === eventDescription) {
+			return payload;
+		}
+	}
+
+	return undefined;
+};
+
 describe('SecureSignup — US marketing toggle hiding', () => {
 	const pageConfig = window.guardian.config
 		.page as typeof window.guardian.config.page & {
@@ -118,6 +144,10 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		sendNewsletterSignupEventSpy = jest.spyOn(
+			newsletterSignupTracking,
+			'sendNewsletterSignupEvent',
+		);
 
 		recaptchaBehaviour = (_handle, props) =>
 			props.onChange?.('test-recaptcha-token');
@@ -255,5 +285,70 @@ describe('SecureSignup — US marketing toggle hiding', () => {
 				'Get updates about our journalism and ways to support and enjoy our work.',
 			),
 		).toBeInTheDocument();
+	});
+});
+
+describe('SecureSignup tracking component id', () => {
+	const submitSignupForm = async (
+		testUser: ReturnType<typeof user.setup>,
+	) => {
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', { name: 'Sign up' }),
+			).toBeInTheDocument();
+		});
+		await testUser.type(
+			screen.getByLabelText('Enter your email address'),
+			'reader@example.com',
+		);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		sendNewsletterSignupEventSpy = jest.spyOn(
+			newsletterSignupTracking,
+			'sendNewsletterSignupEvent',
+		);
+
+		recaptchaBehaviour = (_handle, props) =>
+			props.onChange?.('test-recaptcha-token');
+
+		(useIsSignedIn as jest.Mock).mockReturnValue(false);
+		(useAuthStatus as jest.Mock).mockReturnValue({ kind: 'SignedOut' });
+		(useBrowserId as jest.Mock).mockReturnValue('test-browser-id');
+		(useCountryCode as jest.Mock).mockReturnValue('GB');
+
+		window.guardian.config.switches['usSignupHideMarketingToggle'] = false;
+		global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+	});
+
+	it('uses the control component id when no abTest variant is provided', async () => {
+		const testUser = user.setup();
+		renderSecureSignup();
+		await submitSignupForm(testUser);
+
+		await waitFor(() => {
+			expect(
+				getTrackingCallForEvent('form-submission')?.componentId,
+			).toBe('AR SecureSignup morning-briefing');
+		});
+	});
+
+	it('uses the variantNewField component id when variant is variantNewField', async () => {
+		const testUser = user.setup();
+		renderSecureSignup({
+			abTest: {
+				name: 'test-ab',
+				variant: 'variantNewField',
+			},
+		});
+		await submitSignupForm(testUser);
+
+		await waitFor(() => {
+			expect(
+				getTrackingCallForEvent('form-submission')?.componentId,
+			).toBe('AR SecureSignup morning-briefing - variantNewField');
+		});
 	});
 });

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -254,10 +254,15 @@ const sendTracking = (
 	abTest?: AbTest,
 	extraDetails?: Record<string, unknown>,
 ): void => {
+	const componentId =
+		abTest?.variant === 'variantNewField'
+			? NEWSLETTER_SIGNUP_COMPONENT_ID.variantNewField(newsletterId)
+			: NEWSLETTER_SIGNUP_COMPONENT_ID.control(newsletterId);
+
 	sendNewsletterSignupEvent({
 		action: EVENT_DESCRIPTION_TO_ACTION[eventDescription],
 		identityName: newsletterId,
-		componentId: NEWSLETTER_SIGNUP_COMPONENT_ID.control(newsletterId),
+		componentId,
 		renderingTarget,
 		value: {
 			...extraDetails,

--- a/dotcom-rendering/src/lib/newsletterSignupTracking.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupTracking.ts
@@ -41,7 +41,7 @@ export const EVENT_DESCRIPTION_TO_ACTION = {
 export const NEWSLETTER_SIGNUP_COMPONENT_ID = {
 	control: (identityName: string) => `AR SecureSignup ${identityName}`,
 	variantNewField: (identityName: string) =>
-		`AR NewsletterSignupForm ${identityName} - variantNewField`,
+		`AR SecureSignup ${identityName} - variantNewField`,
 	variantIllustratedCard: (identityName: string) =>
 		`AR NewsletterSignupForm ${identityName} - variantIllustratedCard`,
 } as const;


### PR DESCRIPTION
## What does this change?

Correctly sets the component id based on the ab test variant

## Why?

Originally the Secure signup without the variant information was being passed through

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
