### PR TITLE
Restrict height of self hosted video in the main media

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -71,9 +71,7 @@ export const SelfHostedVideoInArticle = ({
 					format={format}
 					isMainMedia={isMainMedia}
 					role={role}
-					restrictHeightOnDesktop={
-						!isMainMedia && !isInteractive(format.design)
-					}
+					restrictHeightOnDesktop={!isInteractive(format.design)}
 				/>
 			</Island>
 		</div>


### PR DESCRIPTION
## What does this change?
Applies a height restriction for self hosted video in the main media 

## Why?
Without this, videos with a 9:16 aspect ratio far exceed the view port. This also restricts the height of videos in video pages as the video is the main media. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before1][] | ![after1][] |

[before]: https://github.com/user-attachments/assets/29366fdc-69c5-427c-bdd2-9368c10fc364
[after]: https://github.com/user-attachments/assets/642b2b29-af95-40ce-b8a5-647f6dad0aa6
[before1]: https://github.com/user-attachments/assets/35a34a5d-7fb0-49bd-a126-1d177f5a92b5
[after1]: https://github.com/user-attachments/assets/486a46ea-7589-4e32-b13c-c1358fc8b711

 
<!--


You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
