### PR TITLE
Update test setup for fronts-and-curation-loop-click-through

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -163,10 +163,11 @@ const ABTests: ABTest[] = [
 		description:
 			"Test impact of click to article via loop videos on fronts",
 		owners: ["fronts.and.curation@guardian.co.uk"],
-		status: "ON",
+		status: "OFF",
 		expirationDate: "2026-06-19",
 		type: "server",
-		audienceSize: 0 / 100,
+		audienceSize: 5 / 100,
+		audienceSpace: "A",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: false,
 	},


### PR DESCRIPTION
## What does this change?
increases the audience size to 5% and turn off test
## Why?
To prepare for the release of the test of the 9th


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215341563514143