### PR TITLE
Turn ON fronts-and-curation-loop-click-through test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -163,7 +163,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Test impact of click to article via loop videos on fronts",
 		owners: ["fronts.and.curation@guardian.co.uk"],
-		status: "OFF",
+		status: "ON",
 		expirationDate: "2026-06-19",
 		type: "server",
 		audienceSize: 5 / 100,


### PR DESCRIPTION
🚨 **do not merge until 9th June**🚨

## What does this change?
Turns the status of the fronts-and-curation-loop-click-through to `ON`

## Why?
For test go live on the 9th June


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215341563514149