### PR TITLE
Submit component attention time via bridget for apps

### DIFF
--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
+import { log } from '@guardian/libs';
+import { getVideoClient } from './bridgetApi';
 
 /**
  * How often attention time is reported to Ophan, matching the interval used
@@ -96,9 +98,12 @@ export const useVideoAttentionTracking = (
 						});
 					});
 				} else {
-					/**
-					 * Report component attention time via Bridget.
-					 */
+					const attentionTime = new Map<string, number>();
+					attentionTime.set(
+						componentName,
+						Math.round(totalAttentionMsRef.current),
+					);
+					void getVideoClient().sendVideoAttentionTime(attentionTime);
 				}
 
 				reportedAttentionMsRef.current = totalAttentionMsRef.current;

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -98,14 +98,14 @@ export const useVideoAttentionTracking = (
 						});
 					});
 				} else {
-					if (await hasMinimumBridgetVersion('8.11.0-2026-06-02"')) {
-						const attentionTime = new Map<string, number>();
-						attentionTime.set(
+					if (await hasMinimumBridgetVersion('8.12.0')) {
+						const attentionTimeMap = new Map<string, number>();
+						attentionTimeMap.set(
 							componentName,
 							Math.round(totalAttentionMsRef.current),
 						);
-						void getVideoClient().sendVideoAttentionTime(
-							attentionTime,
+						void getVideoClient().sendVideoAttentionTimes(
+							attentionTimeMap,
 						);
 					}
 				}
@@ -115,7 +115,7 @@ export const useVideoAttentionTracking = (
 		};
 
 		const intervalId = window.setInterval(
-			() => void report,
+			() => void report(),
 			REPORTING_INTERVAL_MS,
 		);
 

--- a/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoAttentionTracking.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { getOphan } from '../client/ophan/ophan';
 import type { RenderingTarget } from '../types/renderingTarget';
-import { log } from '@guardian/libs';
 import { getVideoClient } from './bridgetApi';
+import { hasMinimumBridgetVersion } from './useIsBridgetCompatible';
 
 /**
  * How often attention time is reported to Ophan, matching the interval used
@@ -82,7 +82,7 @@ export const useVideoAttentionTracking = (
 			}
 		};
 
-		const report = () => {
+		const report = async () => {
 			accumulateAttention();
 			if (
 				totalAttentionMsRef.current !== reportedAttentionMsRef.current
@@ -98,19 +98,26 @@ export const useVideoAttentionTracking = (
 						});
 					});
 				} else {
-					const attentionTime = new Map<string, number>();
-					attentionTime.set(
-						componentName,
-						Math.round(totalAttentionMsRef.current),
-					);
-					void getVideoClient().sendVideoAttentionTime(attentionTime);
+					if (await hasMinimumBridgetVersion('8.11.0-2026-06-02"')) {
+						const attentionTime = new Map<string, number>();
+						attentionTime.set(
+							componentName,
+							Math.round(totalAttentionMsRef.current),
+						);
+						void getVideoClient().sendVideoAttentionTime(
+							attentionTime,
+						);
+					}
 				}
 
 				reportedAttentionMsRef.current = totalAttentionMsRef.current;
 			}
 		};
 
-		const intervalId = window.setInterval(report, REPORTING_INTERVAL_MS);
+		const intervalId = window.setInterval(
+			() => void report,
+			REPORTING_INTERVAL_MS,
+		);
 
 		return () => {
 			window.clearInterval(intervalId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16596,7 +16596,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-set@2.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16596,7 +16596,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.2
 
   is-set@2.0.3: {}
 


### PR DESCRIPTION
## What does this change?

When DCAR is running in App, the `useVideoAttentionTracking` hook will submit attention times via the newly added Bridget function: https://github.com/guardian/bridget/pull/254

## Why?

This will allow DCAR in Apps to track attention times on videos, once the function is implemented in Apps. 