### PR TITLE
Mute video when using bfcache

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -736,7 +736,7 @@ export const SelfHostedVideo = ({
 					setIsAutoplayAllowed(doesUserPermitAutoplayOnWeb());
 				}
 				setHasPageBecomeActive(true);
-				setMutedState({ value: false });
+				setMutedState({ value: true });
 			} else {
 				setHasPageBecomeActive(false);
 			}


### PR DESCRIPTION
## What does this change?

Mutes all self-hosted video when using [bfcache](https://developer.mozilla.org/en-US/docs/Glossary/bfcache). Currently, all self-hosted video with available audio are unmuted when the page is restored from the cache!

## Why?

Fixes bug introduced here: https://github.com/guardian/dotcom-rendering/pull/16003
