### PR TITLE
Fix default self-hosted video progress bar: unreliable clicks

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -19,6 +19,7 @@ import { useVideoAttentionTracking } from '../lib/useVideoAttentionTracking';
 import { useVideoMilestoneTracking } from '../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {
+	convertProgressPercentageToCurrentTime,
 	customSelfHostedVideoPlayAudioEventName,
 	customYoutubePlayEventName,
 	findOptimisedSourcePerMimeType,
@@ -442,6 +443,7 @@ export const SelfHostedVideo = ({
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
 	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
+	const [isProgressBarSeeking, setIsProgressBarSeeking] = useState(false);
 	/** Whether the video should show controls */
 	const [showControls, setShowControls] = useState(true);
 	/** Whether the video is currently showing controls */
@@ -1136,7 +1138,10 @@ export const SelfHostedVideo = ({
 		}
 
 		if (playerState === 'PLAYING') {
-			setCurrentTime(video.currentTime);
+			if (!isProgressBarSeeking) {
+				setCurrentTime(video.currentTime);
+			}
+
 			/**
 			 * We only want to track milestone events for "long-form"
 			 * videos, not loops or cinemagraphs. We expect these to be
@@ -1177,6 +1182,28 @@ export const SelfHostedVideo = ({
 				setMutedState({ value: !isMuted });
 				break;
 		}
+	};
+
+	const handleProgressBarInput = (
+		event: React.FormEvent<HTMLInputElement>,
+	) => {
+		if (duration === undefined) {
+			return;
+		}
+
+		showControlsAndStartTimer();
+
+		const percentage = Number(event.currentTarget.value);
+		const time = convertProgressPercentageToCurrentTime(
+			percentage,
+			duration,
+		);
+
+		if (time === null) {
+			return;
+		}
+
+		updateCurrentTime(time);
 	};
 
 	/**
@@ -1268,10 +1295,16 @@ export const SelfHostedVideo = ({
 						handleAudioClick={handleAudioClick}
 						handleTimeUpdate={handleTimeUpdate}
 						handleKeyDown={handleKeyDown}
+						handleProgressBarInput={handleProgressBarInput}
+						handleProgressBarSeekStart={() => {
+							setIsProgressBarSeeking(true);
+						}}
+						handleProgressBarSeekEnd={() => {
+							setIsProgressBarSeeking(false);
+						}}
 						handlePause={handlePause}
 						handleFullscreenClick={handleFullscreenClick}
 						handleEnded={handleEnded}
-						updateCurrentTime={updateCurrentTime}
 						onError={onError}
 						preloadPartialData={shouldAutoplay === true}
 						showPlayPauseIcon={showPlayPauseIcon}
@@ -1280,7 +1313,6 @@ export const SelfHostedVideo = ({
 							videoStyleSettings.useInteractiveProgressBar ===
 							true
 						}
-						handleProgressBarInput={showControlsAndStartTimer}
 						showSubtitles={videoStyleSettings.canShowSubtitles}
 						subtitleSource={subtitleSource}
 						subtitleSize={subtitleSize}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -130,11 +130,12 @@ export type Props = {
 	handleAudioClick: (event: SyntheticEvent) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 	handleProgressBarInput: (event: React.FormEvent<HTMLInputElement>) => void;
+	handleProgressBarSeekStart: () => void;
+	handleProgressBarSeekEnd: () => void;
 	handleTimeUpdate: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	handlePause: (event: SyntheticEvent) => void;
 	handleFullscreenClick: (event: SyntheticEvent) => void;
 	handleEnded?: (event: SyntheticEvent) => void;
-	updateCurrentTime: (time: number) => void;
 	onError: (event: SyntheticEvent<HTMLVideoElement>) => void;
 	posterImage?: string;
 	preloadPartialData: boolean;
@@ -195,11 +196,12 @@ export const SelfHostedVideoPlayer = forwardRef(
 			handleAudioClick,
 			handleKeyDown,
 			handleProgressBarInput,
+			handleProgressBarSeekStart,
+			handleProgressBarSeekEnd,
 			handleTimeUpdate,
 			handlePause,
 			handleFullscreenClick,
 			handleEnded,
-			updateCurrentTime,
 			onError,
 			preloadPartialData,
 			showProgressBar,
@@ -329,9 +331,10 @@ export const SelfHostedVideoPlayer = forwardRef(
 								videoId={videoId}
 								currentTime={currentTime}
 								duration={duration}
-								updateCurrentTime={updateCurrentTime}
 								handleKeyDown={handleKeyDown}
 								handleInput={handleProgressBarInput}
+								onSeekStart={handleProgressBarSeekStart}
+								onSeekEnd={handleProgressBarSeekEnd}
 							/>
 						) : (
 							<VideoProgressBar

--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -7,7 +7,6 @@ import {
 import { getZIndex } from '../lib/getZIndex';
 import {
 	convertCurrentTimeToProgressPercentage,
-	convertProgressPercentageToCurrentTime,
 	formatTimeForDisplay,
 } from '../lib/video';
 import { palette } from '../palette';
@@ -116,28 +115,14 @@ const progressBarStyles = (roundedProgressPercentage: number) => css`
 	}
 `;
 
-const handleChange = (
-	value: string,
-	duration: Props['duration'],
-	updateCurrentTime: Props['updateCurrentTime'],
-) => {
-	const percentage = Number(value);
-	const time = convertProgressPercentageToCurrentTime(percentage, duration);
-
-	if (time === null) {
-		return;
-	}
-
-	updateCurrentTime(time);
-};
-
 type Props = {
 	videoId: string;
 	currentTime: number;
 	duration: number;
-	updateCurrentTime: (time: number) => void;
 	handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 	handleInput: (event: React.FormEvent<HTMLInputElement>) => void;
+	onSeekStart: () => void;
+	onSeekEnd: () => void;
 };
 
 /**
@@ -150,9 +135,10 @@ export const VideoProgressBarInteractive = ({
 	videoId,
 	currentTime,
 	duration,
-	updateCurrentTime,
 	handleKeyDown,
 	handleInput,
+	onSeekStart,
+	onSeekEnd,
 }: Props) => {
 	if (duration <= 0) {
 		return null;
@@ -182,15 +168,12 @@ export const VideoProgressBarInteractive = ({
 				max={100}
 				step={0.01}
 				tabIndex={0}
-				onChange={(event) => {
-					handleChange(
-						event.target.value,
-						duration,
-						updateCurrentTime,
-					);
-				}}
 				onInput={handleInput}
 				onKeyDown={handleKeyDown}
+				onPointerDown={onSeekStart}
+				onPointerUp={onSeekEnd}
+				onPointerCancel={onSeekEnd}
+				onBlur={onSeekEnd}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

On desktop, ensures that any clicks on the progress bar updates the time to the correct point.
On mobile, ensures that the drag functionality works correctly.

When the user is seeking, stop the video from updating its current time. When the user stops seeking, pass back control of the time to the video. This is controlled by the new `isSeeking` state.

## Why?

Clicks (desktop) and drags (desktop & mobile) were only updating the current time sometimes. Often, a user action was ignored by the video, or not updating to the correct time.

There looks to have been a race condition. The video updates its current time as the video progresses, which was overwriting the click/drag from the user.

## Screenshots

### Desktop

https://github.com/user-attachments/assets/87385141-aac8-44ef-86a8-d1ce3fa29ebe

### Mobile

https://github.com/user-attachments/assets/652768eb-bc4b-4a82-9f64-815674a7bb74

