### PR TITLE
Change card border top dark colour

### DIFF
--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2520,8 +2520,7 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 };
 
 const cardBorderTopLight: PaletteFunction = () => sourcePalette.neutral[73];
-const cardBorderTopDark: PaletteFunction = (format) =>
-	cardBorderTopLight(format);
+const cardBorderTopDark: PaletteFunction = () => sourcePalette.neutral[46];
 
 const cardBorderSupportingLight: PaletteFunction = () =>
 	sourcePalette.neutral[86];


### PR DESCRIPTION
Little dark mode issue (I think) I spotted where the the top border colour of cards doesn't look quite right. It was the same in light and dark mode - now it mirrors other card border colours.

If the palette as is is what's intended feel free to close this PR.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="891" height="383" alt="image" src="https://github.com/user-attachments/assets/b31689e5-f320-4823-8283-dbc00401568a" /> | <img width="921" height="362" alt="image" src="https://github.com/user-attachments/assets/e6884e46-92c3-430d-96d5-d249c81ed8e7" /> |