### PR TITLE
Add support for live activities

### DIFF
--- a/dotcom-rendering/.storybook/mocks/bridgetApi.ts
+++ b/dotcom-rendering/.storybook/mocks/bridgetApi.ts
@@ -120,6 +120,15 @@ export const getMatchNotificationsClient: BridgetApi<
 	isAvailable: async () => ({ isAvailable: true }),
 });
 
+export const getLiveActivitiesClient: BridgetApi<
+	'getLiveActivitiesClient'
+> = () => ({
+	isAvailable: async () => true,
+	isFollowing: async () => false,
+	follow: async () => false,
+	unfollow: async () => false,
+});
+
 export const ensure_all_exports_are_present = {
 	getUserClient,
 	getAcquisitionsClient,
@@ -140,6 +149,7 @@ export const ensure_all_exports_are_present = {
 	getAudioClient,
 	getNativeABTestingClient,
 	getMatchNotificationsClient,
+	getLiveActivitiesClient,
 } satisfies {
 	[Method in keyof BridgeModule]: BridgetApi<Method>;
 };

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -29,7 +29,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "22.2.0",
-		"@guardian/bridget": "8.13.0",
+		"@guardian/bridget": "8.13.1",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "catalog:",
 		"@guardian/consent-manager": "1.0.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -29,7 +29,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "22.2.0",
-		"@guardian/bridget": "8.11.0",
+		"@guardian/bridget": "8.11.0-2026-06-01",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "catalog:",
 		"@guardian/consent-manager": "1.0.0",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -29,7 +29,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "22.2.0",
-		"@guardian/bridget": "8.11.0-2026-06-01",
+		"@guardian/bridget": "8.13.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "catalog:",
 		"@guardian/consent-manager": "1.0.0",

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 import { SWRConfig } from 'swr';
 import preview from '../../../.storybook/preview';
 import {
@@ -7,13 +7,46 @@ import {
 	matchResult,
 } from '../../../fixtures/manual/footballMatches';
 import type { FEFootballMatchHeader } from '../../frontend/feFootballMatchHeader';
-import type { MatchNotificationsClient } from '../../lib/bridgetApi';
+import type {
+	EnvironmentClient,
+	LiveActivitiesClient,
+	MatchNotificationsClient,
+} from '../../lib/bridgetApi';
 import { NotificationsToggle } from '../NotificationsToggle.stories';
 import { FootballMatchHeader as FootballMatchHeaderComponent } from './FootballMatchHeader';
 
 const mockMatchNotificationsClient: MatchNotificationsClient = {
 	isAvailable: () => Promise.resolve({ isAvailable: true }),
 };
+
+const mockEnvironmentClient: EnvironmentClient = {
+	isMyGuardianEnabled: () => Promise.resolve(false),
+	nativeThriftPackageVersion: () => Promise.resolve('8.13.0'),
+};
+
+const mockLiveActivitiesClient: LiveActivitiesClient = (() => {
+	let following = false;
+
+	return {
+		isAvailable: fn(() => {
+			return Promise.resolve(true);
+		}),
+
+		follow: fn(() => {
+			following = true;
+			return Promise.resolve(true);
+		}),
+
+		unfollow: fn(() => {
+			following = false;
+			return Promise.resolve(true);
+		}),
+
+		isFollowing: fn(() => {
+			return Promise.resolve(following);
+		}),
+	};
+})();
 
 const meta = preview.meta({
 	component: FootballMatchHeaderComponent,
@@ -75,6 +108,8 @@ export const FixtureWeb = meta.story({
 		renderingTarget: 'Web',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 		matchNotificationsClient: mockMatchNotificationsClient,
+		environmentClient: mockEnvironmentClient,
+		liveActivitiesClient: mockLiveActivitiesClient,
 	},
 	play: async ({ canvas, canvasElement, step }) => {
 		const nav = canvas.getByRole('navigation');
@@ -125,6 +160,8 @@ export const LiveApps = meta.story({
 		renderingTarget: 'Apps',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 		matchNotificationsClient: mockMatchNotificationsClient,
+		environmentClient: mockEnvironmentClient,
+		liveActivitiesClient: mockLiveActivitiesClient,
 	},
 	play: async ({ canvas, canvasElement, step }) => {
 		await step(
@@ -178,6 +215,8 @@ export const ResultWeb = meta.story({
 		renderingTarget: 'Web',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 		matchNotificationsClient: mockMatchNotificationsClient,
+		environmentClient: mockEnvironmentClient,
+		liveActivitiesClient: mockLiveActivitiesClient,
 	},
 
 	play: async ({ canvas, canvasElement, step }) => {
@@ -225,6 +264,8 @@ export const ResultApps = meta.story({
 		renderingTarget: 'Apps',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
 		matchNotificationsClient: mockMatchNotificationsClient,
+		environmentClient: mockEnvironmentClient,
+		liveActivitiesClient: mockLiveActivitiesClient,
 	},
 
 	play: async ({ canvas, canvasElement, step }) => {

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -20,6 +20,8 @@ import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import type {
+	EnvironmentClient,
+	LiveActivitiesClient,
 	MatchNotificationsClient,
 	NotificationsClient,
 } from '../../lib/bridgetApi';
@@ -58,6 +60,8 @@ type Props = FootballMatchHeaderProps & {
 	refreshInterval: number;
 	notificationsClient: NotificationsClient;
 	matchNotificationsClient: MatchNotificationsClient;
+	environmentClient: EnvironmentClient;
+	liveActivitiesClient: LiveActivitiesClient;
 };
 
 export const FootballMatchHeader = (props: Props) => {
@@ -134,6 +138,8 @@ export const FootballMatchHeader = (props: Props) => {
 					match={match}
 					notificationsClient={props.notificationsClient}
 					matchNotificationsClient={props.matchNotificationsClient}
+					environmentClient={props.environmentClient}
+					liveActivitiesClient={props.liveActivitiesClient}
 				/>
 				<Hr borderStyle="solid" borderColour={border(match.kind)} />
 				<Tabs {...tabs} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.stories.tsx
@@ -7,10 +7,6 @@ import { background } from './colours';
 import { FixtureWeb } from './FootballMatchHeader.stories';
 import { Notifications } from './Notifications';
 
-const mockMatchNotificationsClient: MatchNotificationsClient = {
-	isAvailable: () => Promise.resolve({ isAvailable: true }),
-};
-
 const meta = preview.meta({
 	component: Notifications,
 });
@@ -20,7 +16,10 @@ export const Fixture = meta.story({
 		match: FixtureWeb.input.args.initialData.match,
 		edition: 'UK',
 		notificationsClient: NotificationsToggle.args.notificationsClient,
-		matchNotificationsClient: mockMatchNotificationsClient,
+		matchNotificationsClient:
+			FixtureWeb.input.args.matchNotificationsClient,
+		environmentClient: FixtureWeb.input.args.environmentClient,
+		liveActivitiesClient: FixtureWeb.input.args.liveActivitiesClient,
 	},
 	decorators: [gridContainerDecorator],
 	parameters: {

--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -5,6 +5,8 @@ import { useEffect, useMemo, useState } from 'react';
 import type { FootballMatch } from '../../footballMatchV2';
 import { grid } from '../../grid';
 import type {
+	EnvironmentClient,
+	LiveActivitiesClient,
 	MatchNotificationsClient,
 	NotificationsClient,
 } from '../../lib/bridgetApi';
@@ -13,8 +15,11 @@ import {
 	getLocaleFromEdition,
 	getTimeZoneFromEdition,
 } from '../../lib/edition';
+import { hasMinimumBridgetVersionWithClient } from '../../lib/useIsBridgetCompatible';
 import { palette } from '../../palette';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import { useConfig } from '../ConfigContext';
+import { LiveActivitiesToggle } from '../LiveActivitiesToggle';
 import { NotificationsToggle } from '../NotificationsToggle';
 import { background, border, primaryText } from './colours';
 import { Hr } from './Hr';
@@ -24,43 +29,68 @@ type Props = {
 	edition: EditionId;
 	notificationsClient: NotificationsClient;
 	matchNotificationsClient: MatchNotificationsClient;
+	environmentClient: EnvironmentClient;
+	liveActivitiesClient: LiveActivitiesClient;
 };
 
 export const Notifications = (props: Props) => {
 	const { renderingTarget } = useConfig();
-	const [isAvailable, setIsAvailable] = useState<boolean | undefined>(
-		undefined,
+	const availability = useAvailability(
+		renderingTarget,
+		props.match,
+		props.environmentClient,
+		props.liveActivitiesClient,
+		props.matchNotificationsClient,
 	);
-	const [unavailableReason, setUnavailableReason] = useState<
-		string | undefined
-	>(undefined);
 
-	// useMemo to limit constructions of `Intl.DateTimeFormat`
-	const displayName = useMemo(
-		() => notificationDisplayName(props.edition),
-		[props.edition],
-	);
+	switch (availability.kind) {
+		case 'liveActivities':
+			return (
+				<LiveActivities
+					match={props.match}
+					client={props.liveActivitiesClient}
+				/>
+			);
+		case 'matchNotifications':
+			return (
+				<MatchNotifications
+					match={props.match}
+					client={props.notificationsClient}
+					edition={props.edition}
+				/>
+			);
+		case 'noneWithReason':
+			return (
+				<NoneWithReason
+					matchKind={props.match.kind}
+					reason={availability.reason}
+				/>
+			);
+		case 'none':
+			return null;
+	}
+};
+
+const useAvailability = (
+	renderingTarget: RenderingTarget,
+	match: FootballMatch,
+	environment: EnvironmentClient,
+	liveActivities: LiveActivitiesClient,
+	matchNotifications: MatchNotificationsClient,
+): Availability => {
+	const [availability, setAvailability] = useState<Availability>({
+		kind: 'none',
+	});
 
 	useEffect(() => {
-		if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
-			return;
-		}
-
-		void props.matchNotificationsClient
-			.isAvailable({
-				homeTeam: {
-					paId: props.match.homeTeam.paID,
-					name: props.match.homeTeam.name,
-				},
-				awayTeam: {
-					paId: props.match.awayTeam.paID,
-					name: props.match.awayTeam.name,
-				},
-			})
-			.then((availability) => {
-				setIsAvailable(availability.isAvailable);
-				setUnavailableReason(availability.unavailableReason);
-			})
+		getAvailability(
+			renderingTarget,
+			match,
+			environment,
+			liveActivities,
+			matchNotifications,
+		)
+			.then(setAvailability)
 			.catch((error: unknown) => {
 				window.guardian.modules.sentry.reportError(
 					error instanceof Error ? error : new Error(String(error)),
@@ -73,95 +103,87 @@ export const Notifications = (props: Props) => {
 				);
 				// Hide the button on error as we can't confirm notifications
 				// are available and the button may not work
-				setIsAvailable(false);
+				setAvailability({ kind: 'none' });
 			});
 	}, [
 		renderingTarget,
-		props.match.kind,
-		props.match.homeTeam.paID,
-		props.match.homeTeam.name,
-		props.match.awayTeam.paID,
-		props.match.awayTeam.name,
-		props.matchNotificationsClient,
+		match,
+		environment,
+		liveActivities,
+		matchNotifications,
 	]);
 
-	if (renderingTarget !== 'Apps' || props.match.kind === 'Result') {
-		return null;
-	}
-
-	const Description = ({ children }: { children: string | undefined }) =>
-		children === undefined ? null : (
-			<p
-				css={{
-					...textSans14Object,
-					'&': css(grid.column.centre),
-					paddingTop: space[2],
-					paddingBottom: space[3],
-					paddingLeft: 6,
-					paddingRight: 6,
-				}}
-				style={{
-					color: palette(primaryText(props.match.kind)),
-				}}
-			>
-				{children}
-			</p>
-		);
-
-	switch (isAvailable) {
-		case false:
-			return (
-				<>
-					<Hr
-						borderStyle="solid"
-						borderColour={border(props.match.kind)}
-					/>
-					<Description>{unavailableReason}</Description>
-				</>
-			);
-		case true:
-			return (
-				<>
-					<Hr
-						borderStyle="solid"
-						borderColour={border(props.match.kind)}
-					/>
-					<Description>
-						Be notified about the lineup, kick-off time, goals,
-						half-time and full time scores
-					</Description>
-					<NotificationsToggle
-						displayName={displayName(props.match)}
-						id={props.match.paId}
-						notificationType="football-match"
-						notificationsClient={props.notificationsClient}
-						colour={primaryText(props.match.kind)}
-						backgroundColour={background(props.match.kind)}
-						iconColour={primaryText(props.match.kind)}
-						css={{
-							'&': css(grid.column.centre),
-							paddingLeft: 6,
-							paddingRight: 6,
-							paddingBottom: space[4],
-						}}
-					/>
-				</>
-			);
-		case undefined:
-			return (
-				<>
-					<Hr
-						borderStyle="solid"
-						borderColour={border(props.match.kind)}
-					/>
-					<Description>
-						Be notified about the lineup, kick-off time, goals,
-						half-time and full time scores
-					</Description>
-				</>
-			);
-	}
+	return availability;
 };
+
+const getAvailability = async (
+	renderingTarget: RenderingTarget,
+	match: FootballMatch,
+	environment: EnvironmentClient,
+	liveActivities: LiveActivitiesClient,
+	matchNotifications: MatchNotificationsClient,
+): Promise<Availability> => {
+	if (renderingTarget !== 'Apps' || match.kind === 'Result') {
+		return { kind: 'none' };
+	}
+
+	if (
+		(await hasLiveActivitiesSupport(environment)) &&
+		(await liveActivities.isAvailable('football-match', match.paId))
+	) {
+		return { kind: 'liveActivities' };
+	}
+
+	const notificationsAvailability = await matchNotifications.isAvailable({
+		homeTeam: {
+			paId: match.homeTeam.paID,
+			name: match.homeTeam.name,
+		},
+		awayTeam: {
+			paId: match.awayTeam.paID,
+			name: match.awayTeam.name,
+		},
+	});
+
+	if (notificationsAvailability.isAvailable) {
+		return { kind: 'matchNotifications' };
+	}
+
+	if (notificationsAvailability.unavailableReason !== undefined) {
+		return {
+			kind: 'noneWithReason',
+			reason: notificationsAvailability.unavailableReason,
+		};
+	}
+
+	return { kind: 'none' };
+};
+
+/**
+ * If the app supports live activities, and a particular live activity is
+ * available for this match, we want to allow the user to turn it on or off.
+ * If not, we want to check if match notifications are available instead, and
+ * show a button for that. If these aren't available either, the app might tell
+ * us the reason why (e.g. the user has already subscribed to notifications by
+ * following a team), and we show that information to the user. If none of these
+ * features are available, or we're not in the app at all, we show nothing.
+ */
+type Availability =
+	| {
+			kind: 'liveActivities';
+	  }
+	| {
+			kind: 'matchNotifications';
+	  }
+	| {
+			kind: 'noneWithReason';
+			reason: string;
+	  }
+	| {
+			kind: 'none';
+	  };
+
+const hasLiveActivitiesSupport = hasMinimumBridgetVersionWithClient('8.13.0');
 
 /**
  * Exported for the tests.
@@ -184,3 +206,118 @@ const matchDayFormatterForEdition = (edition: EditionId): Intl.DateTimeFormat =>
 		timeZoneName: 'short',
 		timeZone: getTimeZoneFromEdition(edition),
 	});
+
+const LiveActivities = (props: {
+	match: FootballMatch;
+	client: LiveActivitiesClient;
+}) => (
+	<>
+		<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
+		<LiveActivityDescription matchKind={props.match.kind} />
+		<LiveActivitiesToggle
+			id={props.match.paId}
+			activityType="football-match"
+			liveActivitiesClient={props.client}
+			colour={primaryText(props.match.kind)}
+			backgroundColour={background(props.match.kind)}
+			iconColour={primaryText(props.match.kind)}
+			css={{
+				'&': css(grid.column.centre),
+				paddingLeft: 6,
+				paddingRight: 6,
+				paddingBottom: space[4],
+			}}
+		/>
+	</>
+);
+
+const MatchNotifications = (props: {
+	match: FootballMatch;
+	client: NotificationsClient;
+	edition: EditionId;
+}) => {
+	// useMemo to limit constructions of `Intl.DateTimeFormat`
+	const displayName = useMemo(
+		() => notificationDisplayName(props.edition),
+		[props.edition],
+	);
+
+	return (
+		<>
+			<Hr borderStyle="solid" borderColour={border(props.match.kind)} />
+			<Description matchKind={props.match.kind}>
+				Be notified about the lineup, kick-off time, goals, half-time
+				and full time scores
+			</Description>
+			<NotificationsToggle
+				displayName={displayName(props.match)}
+				id={props.match.paId}
+				notificationType="football-match"
+				notificationsClient={props.client}
+				colour={primaryText(props.match.kind)}
+				backgroundColour={background(props.match.kind)}
+				iconColour={primaryText(props.match.kind)}
+				css={{
+					'&': css(grid.column.centre),
+					paddingLeft: 6,
+					paddingRight: 6,
+					paddingBottom: space[4],
+				}}
+			/>
+		</>
+	);
+};
+
+const NoneWithReason = (props: {
+	matchKind: FootballMatch['kind'];
+	reason: string;
+}) => (
+	<>
+		<Hr borderStyle="solid" borderColour={border(props.matchKind)} />
+		<Description matchKind={props.matchKind}>{props.reason}</Description>
+	</>
+);
+
+const LiveActivityDescription = (props: {
+	matchKind: FootballMatch['kind'];
+}) => {
+	switch (props.matchKind) {
+		case 'Fixture':
+			return (
+				<Description matchKind={props.matchKind}>
+					Get match updates on your lock screen including kick-off
+					time, lineups, goals, half-time and full-time scores.
+				</Description>
+			);
+		case 'Live':
+			return (
+				<Description matchKind={props.matchKind}>
+					Get live updates on your lock screen throughout the match
+				</Description>
+			);
+		case 'Result':
+			return null;
+	}
+};
+
+const Description = (props: {
+	children: string | undefined;
+	matchKind: FootballMatch['kind'];
+}) =>
+	props.children === undefined ? null : (
+		<p
+			css={{
+				...textSans14Object,
+				'&': css(grid.column.centre),
+				paddingTop: space[2],
+				paddingBottom: space[3],
+				paddingLeft: 6,
+				paddingRight: 6,
+			}}
+			style={{
+				color: palette(primaryText(props.matchKind)),
+			}}
+		>
+			{props.children}
+		</p>
+	);

--- a/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
@@ -35,11 +35,7 @@ export const FootballMatchHeaderWrapper = (props: Props) => (
 		renderingTarget={props.renderingTarget}
 		notificationsClient={getNotificationsClient()}
 		matchNotificationsClient={getMatchNotificationsClient()}
-		environmentClient={{
-			...getEnvironmentClient(),
-			// Hardcoded for testing, before this version is published.
-			nativeThriftPackageVersion: () => Promise.resolve('8.13.0'),
-		}}
+		environmentClient={getEnvironmentClient()}
 		liveActivitiesClient={getLiveActivitiesClient()}
 	/>
 );

--- a/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
@@ -1,4 +1,6 @@
 import {
+	getEnvironmentClient,
+	getLiveActivitiesClient,
 	getMatchNotificationsClient,
 	getNotificationsClient,
 } from '../lib/bridgetApi';
@@ -33,6 +35,12 @@ export const FootballMatchHeaderWrapper = (props: Props) => (
 		renderingTarget={props.renderingTarget}
 		notificationsClient={getNotificationsClient()}
 		matchNotificationsClient={getMatchNotificationsClient()}
+		environmentClient={{
+			...getEnvironmentClient(),
+			// Hardcoded for testing, before this version is published.
+			nativeThriftPackageVersion: () => Promise.resolve('8.13.0'),
+		}}
+		liveActivitiesClient={getLiveActivitiesClient()}
 	/>
 );
 

--- a/dotcom-rendering/src/components/LiveActivitiesToggle.tsx
+++ b/dotcom-rendering/src/components/LiveActivitiesToggle.tsx
@@ -1,0 +1,126 @@
+import { log } from '@guardian/libs';
+import {
+	SvgNotificationsOff,
+	SvgNotificationsOn,
+} from '@guardian/source/react-components';
+import { useEffect, useState } from 'react';
+import type { LiveActivitiesClient } from '../lib/bridgetApi';
+import type { ColourName } from '../paletteDeclarations';
+import { ToggleButton } from './ToggleButton';
+
+type Props = {
+	id: string;
+	activityType: 'football-match';
+	liveActivitiesClient: LiveActivitiesClient;
+	colour: ColourName;
+	backgroundColour: ColourName;
+	iconColour: ColourName;
+	className?: string;
+};
+
+export const LiveActivitiesToggle = (props: Props) => {
+	const [isFollowing, setIsFollowing] = useIsFollowing(
+		props.id,
+		props.activityType,
+		props.liveActivitiesClient,
+	);
+
+	return (
+		<ToggleButton
+			colour={props.colour}
+			icon={
+				isFollowing ? (
+					<SvgNotificationsOn size="xsmall" />
+				) : (
+					<SvgNotificationsOff size="xsmall" />
+				)
+			}
+			iconBackground={isFollowing ? props.iconColour : undefined}
+			iconBorder={props.iconColour}
+			iconFill={isFollowing ? props.backgroundColour : props.iconColour}
+			onClick={toggleLiveActivity(
+				props.id,
+				props.activityType,
+				props.liveActivitiesClient,
+				isFollowing,
+				setIsFollowing,
+			)}
+			className={props.className}
+		>
+			Live match updates {isFollowing ? 'on' : 'off'}
+		</ToggleButton>
+	);
+};
+
+/**
+ * Retrieves information about whether the user is following a particular live
+ * activity, via Bridget, and stores it in a state variable for use in the rest
+ * of the component. Also supplies a setter to update that state, similar to
+ * `useState`.
+ */
+const useIsFollowing = (
+	id: string,
+	activityType: Props['activityType'],
+	liveActivitiesClient: Props['liveActivitiesClient'],
+): [
+	boolean | undefined,
+	React.Dispatch<React.SetStateAction<boolean | undefined>>,
+] => {
+	const [isFollowing, setIsFollowing] = useState<boolean | undefined>(
+		undefined,
+	);
+
+	useEffect(() => {
+		void liveActivitiesClient
+			.isFollowing(activityType, id)
+			.then(setIsFollowing)
+			.catch(handleError('isFollowing'));
+	}, [id, activityType, liveActivitiesClient]);
+
+	return [isFollowing, setIsFollowing];
+};
+
+const toggleLiveActivity = (
+	id: string,
+	activityType: Props['activityType'],
+	liveActivitiesClient: Props['liveActivitiesClient'],
+	isFollowing: boolean | undefined,
+	setIsFollowing: (a: boolean) => void,
+): (() => void) =>
+	isFollowing === undefined
+		? () => undefined
+		: () => {
+				if (isFollowing) {
+					void liveActivitiesClient
+						.unfollow(activityType, id)
+						.then((success) => {
+							if (success) {
+								setIsFollowing(false);
+							}
+						})
+						.catch(handleError('unfollow'));
+				} else {
+					void liveActivitiesClient
+						.follow(activityType, id)
+						.then((success) => {
+							if (success) {
+								setIsFollowing(true);
+							}
+						})
+						.catch(handleError('follow'));
+				}
+		  };
+
+const handleError =
+	(methodName: 'follow' | 'unfollow' | 'isFollowing') =>
+	(error: any): void => {
+		window.guardian.modules.sentry.reportError(
+			error,
+			`bridget-getLiveActivitiesClient-${methodName}-error`,
+		);
+		log(
+			'dotcom',
+			`Bridget getLiveActivitiesClient.${methodName} Error:`,
+			error,
+		);
+	};

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -1,4 +1,5 @@
 import type { ThriftClient } from '@creditkarma/thrift-server-core';
+import { LiveActivities } from '@guardian/bridget';
 import * as AbTesting from '@guardian/bridget/AbTesting';
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Analytics from '@guardian/bridget/Analytics';
@@ -30,9 +31,11 @@ type BridgetClient<Client extends ThriftClient> = Omit<
 	| '_methodParameters'
 >;
 
-let environmentClient: Environment.Client<void> | undefined = undefined;
-export const getEnvironmentClient = (): Environment.Client<void> => {
-	if (isUndefined(environmentClient)) {
+export type EnvironmentClient = BridgetClient<Environment.Client>;
+
+let environmentClient: EnvironmentClient | undefined = undefined;
+export const getEnvironmentClient = (): EnvironmentClient => {
+	if (!environmentClient) {
 		environmentClient = createAppClient<Environment.Client<void>>(
 			Environment.Client,
 			'buffered',
@@ -253,4 +256,18 @@ export const getMatchNotificationsClient = (): MatchNotificationsClient => {
 		>(MatchNotifications.Client, 'buffered', 'compact');
 	}
 	return matchNotificationsClient;
+};
+
+export type LiveActivitiesClient = BridgetClient<LiveActivities.Client>;
+
+let liveActivitiesClient: LiveActivitiesClient | undefined = undefined;
+export const getLiveActivitiesClient = (): LiveActivitiesClient => {
+	if (!liveActivitiesClient) {
+		liveActivitiesClient = createAppClient<LiveActivities.Client<void>>(
+			LiveActivities.Client,
+			'buffered',
+			'compact',
+		);
+	}
+	return liveActivitiesClient;
 };

--- a/dotcom-rendering/src/lib/bridgetApi.ts
+++ b/dotcom-rendering/src/lib/bridgetApi.ts
@@ -1,5 +1,4 @@
 import type { ThriftClient } from '@creditkarma/thrift-server-core';
-import { LiveActivities } from '@guardian/bridget';
 import * as AbTesting from '@guardian/bridget/AbTesting';
 import * as Acquisitions from '@guardian/bridget/Acquisitions';
 import * as Analytics from '@guardian/bridget/Analytics';
@@ -11,6 +10,7 @@ import * as Gallery from '@guardian/bridget/Gallery';
 import * as Interaction from '@guardian/bridget/Interaction';
 import * as Interactives from '@guardian/bridget/Interactives';
 import * as ListenToArticle from '@guardian/bridget/ListenToArticle';
+import * as LiveActivities from '@guardian/bridget/LiveActivities';
 import * as MatchNotifications from '@guardian/bridget/MatchNotifications';
 import * as Metrics from '@guardian/bridget/Metrics';
 import * as Navigation from '@guardian/bridget/Navigation';

--- a/dotcom-rendering/src/lib/useIsBridgetCompatible.ts
+++ b/dotcom-rendering/src/lib/useIsBridgetCompatible.ts
@@ -1,6 +1,6 @@
 import { compare } from 'compare-versions';
 import { useEffect, useState } from 'react';
-import { getEnvironmentClient } from './bridgetApi';
+import { type EnvironmentClient, getEnvironmentClient } from './bridgetApi';
 
 export const useIsBridgetCompatible = (
 	requiredVersion = '2.0.0',
@@ -15,19 +15,30 @@ export const useIsBridgetCompatible = (
 	return isCompatible;
 };
 
+export const hasMinimumBridgetVersionWithClient =
+	(requiredVersion: string) =>
+	(client: EnvironmentClient): Promise<boolean> =>
+		client
+			.nativeThriftPackageVersion()
+			.then((bridgetVersion) => {
+				return compare(
+					bridgetVersion.replace(/^v/i, ''),
+					requiredVersion.replace(/^v/i, ''),
+					'>=',
+				);
+			})
+			.catch((error) => {
+				console.log('nativeThriftPackageVersion', { error });
+				return false;
+			});
+
+/**
+ * A version of {@linkcode hasMinimumBridgetVersionWithClient} that
+ * automatically uses the production Bridget API client. Prefer using that over
+ * this function, as it allows you to pass different clients in different
+ * environments (e.g. a mock client in tests or stories).
+ */
 export const hasMinimumBridgetVersion = (
 	requiredVersion: string,
 ): Promise<boolean> =>
-	getEnvironmentClient()
-		.nativeThriftPackageVersion()
-		.then((bridgetVersion) => {
-			return compare(
-				bridgetVersion.replace(/^v/i, ''),
-				requiredVersion.replace(/^v/i, ''),
-				'>=',
-			);
-		})
-		.catch((error) => {
-			console.log('nativeThriftPackageVersion', { error });
-			return false;
-		});
+	hasMinimumBridgetVersionWithClient(requiredVersion)(getEnvironmentClient());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 22.2.0
         version: 22.2.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.1)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.11.0-2026-06-01
-        version: 8.11.0-2026-06-01
+        specifier: 8.13.0
+        version: 8.13.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2462,8 +2462,8 @@ packages:
       '@guardian/source': ^9.0.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.11.0-2026-06-01':
-    resolution: {integrity: sha512-KmvT5Lvb37PV+8DbtN7DBZHE4I2s+teIbQ0f61pHdr8ErD7ePGRM495DCQoLVYff4bOiNIrCvL6jvhvYV7S3vw==}
+  '@guardian/bridget@8.13.0':
+    resolution: {integrity: sha512-FqODvwmBZvZXz3GEiGejJcjQ3sDQHKJLlE/BIycHX11ZsG38D3/FZnkrTuSRAcU7sF9+JkQJzpoxxRAc9jhxQQ==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -11679,7 +11679,7 @@ snapshots:
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.11.0-2026-06-01': {}
+  '@guardian/bridget@8.13.0': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 22.2.0
         version: 22.2.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.1)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.11.0
-        version: 8.11.0
+        specifier: 8.11.0-2026-06-01
+        version: 8.11.0-2026-06-01
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2462,8 +2462,8 @@ packages:
       '@guardian/source': ^9.0.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.11.0':
-    resolution: {integrity: sha512-vtjclCZg+sFMTnWj5mq2hTf1yeCHyb0ZeXtnG3MNPV1aA7jm5EkW/Up/xQ4CwKFLYFIiFwR3aPGzyYGMrYwdfA==}
+  '@guardian/bridget@8.11.0-2026-06-01':
+    resolution: {integrity: sha512-KmvT5Lvb37PV+8DbtN7DBZHE4I2s+teIbQ0f61pHdr8ErD7ePGRM495DCQoLVYff4bOiNIrCvL6jvhvYV7S3vw==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -11679,7 +11679,7 @@ snapshots:
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.11.0': {}
+  '@guardian/bridget@8.11.0-2026-06-01': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 22.2.0
         version: 22.2.0(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.1)(tslib@2.6.2)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.13.0
-        version: 8.13.0
+        specifier: 8.13.1
+        version: 8.13.1
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2462,8 +2462,8 @@ packages:
       '@guardian/source': ^9.0.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.13.0':
-    resolution: {integrity: sha512-FqODvwmBZvZXz3GEiGejJcjQ3sDQHKJLlE/BIycHX11ZsG38D3/FZnkrTuSRAcU7sF9+JkQJzpoxxRAc9jhxQQ==}
+  '@guardian/bridget@8.13.1':
+    resolution: {integrity: sha512-aSza9vG5hPqB0x3mX0ZUTBWbT1vB3k567KWGy6tVoWPw7vSolFD82qo03YcUYqE7AJbe/XHwJp74PaSMsG//Ow==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -11679,7 +11679,7 @@ snapshots:
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.9.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.13.0': {}
+  '@guardian/bridget@8.13.1': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:


### PR DESCRIPTION
If the app supports live activities, and a particular live activity is available for this match, we want to allow the user to turn it on or off. If not, we want to check if match notifications are available instead, and show a button for that. If these aren't available either, the app might tell us the reason why (e.g. the user has already subscribed to notifications by following a team), and we show that information to the user. If none of these features are available, or we're not in the app at all, we show nothing.

The majority of this change involves refactoring the `Notifications` sub-component of `FootballMatchHeader` to support this, and updating the stories.

Part of https://github.com/guardian/bridget/issues/252

## Screenshots

### Live Activities

If live activities are supported.

| | Off | On |
|--------|--------|--------|
| Fixture | <img width="1179" height="909" alt="fixture-off" src="https://github.com/user-attachments/assets/bceeef32-67fd-406a-86ab-f57df6144fbd" /> | <img width="1179" height="909" alt="fixture-on" src="https://github.com/user-attachments/assets/9e090247-cacf-49c6-8ea0-18541d6b43ea" /> |
| Live | <img width="1179" height="909" alt="live-off" src="https://github.com/user-attachments/assets/508cbc79-0c37-45ac-ae7d-0056d4865abf" /> | <img width="1179" height="909" alt="live-on" src="https://github.com/user-attachments/assets/06cad782-77d9-43bd-a619-623435785c64" /> | 

### Notifications

If live activities aren't supported, but notifications are.

| | Off | On |
|--------|--------|--------|
| Fixture | <img width="1179" height="909" alt="notifications-fixture-off" src="https://github.com/user-attachments/assets/a906bb17-efb4-4eff-8bc1-5f4912102a7c" /> | <img width="1179" height="909" alt="notifications-fixture-on" src="https://github.com/user-attachments/assets/cb4659ad-401c-4fd5-bdcb-0eaa49ec6492" /> |
| Live | <img width="1179" height="909" alt="notifications-live-off" src="https://github.com/user-attachments/assets/c3f9eeae-87a2-4a30-9a1a-880647361728" /> | <img width="1179" height="909" alt="notifications-live-on" src="https://github.com/user-attachments/assets/11e3c777-1cf8-4bf2-a382-4e80b2bf4a9f" /> | 

### Unavailable With Reason

Live activities aren't available, and notifications aren't available because you follow at least one of the teams already.

| Fixture | Live |
|--------|--------|
| <img width="1179" height="792" alt="notifications-unavailable-fixture" src="https://github.com/user-attachments/assets/f2139ca6-1542-408f-ae36-b430566cc9d7" /> | <img width="1179" height="792" alt="notifications-unavailable-live" src="https://github.com/user-attachments/assets/67d3a7df-0e75-48d7-b804-f68538328000" /> |

### Unavailable

Neither live activities nor notifications are available, and we have no explanation as to why.

| Fixture | Live |
|--------|--------|
| <img width="1179" height="609" alt="no-notifications-fixture" src="https://github.com/user-attachments/assets/325d7830-6210-4a1e-84b7-b177aea9d843" /> | <img width="1179" height="609" alt="no-notifications-live" src="https://github.com/user-attachments/assets/5e56e9ac-c55c-46d4-9371-1a1a44048721" /> | 
