### PR TITLE
create and add CTA button in Hosted Content Gallery article

### DIFF
--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -17,6 +17,11 @@ type CallToActionProps = {
 	buttonText?: string;
 	accentColor?: string;
 };
+type CallToActionButtonProps = {
+	linkUrl: string;
+	buttonText?: string;
+	accentColor?: string;
+};
 
 const blurStyles = css`
 	position: absolute;
@@ -98,8 +103,6 @@ export const CallToActionAtom = ({
 	buttonText,
 	accentColor,
 }: CallToActionProps) => {
-	const buttonBgColour = accentColor ?? sourcePalette.neutral[100];
-
 	return (
 		<picture
 			css={css`
@@ -126,26 +129,41 @@ export const CallToActionAtom = ({
 			<div css={blurAndTextWrapperStyles}>
 				<div css={textAndButtonWrapperStyles}>
 					{!!text && <h2 css={textStyles}>{text}</h2>}
-					<LinkButton
-						href={linkUrl}
-						iconSide="right"
-						size="small"
-						icon={<SvgExternal />}
-						theme={{
-							textPrimary: accentColor
-								? sourcePalette.neutral[100]
-								: sourcePalette.neutral[0],
-							backgroundPrimary: buttonBgColour,
-							backgroundPrimaryHover:
-								calculateHoverColour(buttonBgColour),
-						}}
-					>
-						{buttonText ?? 'Learn more'}
-					</LinkButton>
+					<CallToActionButton
+						linkUrl={linkUrl}
+						buttonText={buttonText}
+						accentColor={accentColor}
+					/>
 				</div>
 				{/* blur overlay */}
 				<div aria-hidden="true" css={blurStyles} />
 			</div>
 		</picture>
+	);
+};
+
+export const CallToActionButton = ({
+	linkUrl,
+	buttonText,
+	accentColor,
+}: CallToActionButtonProps) => {
+	const buttonBgColour = accentColor ?? sourcePalette.neutral[100];
+
+	return (
+		<LinkButton
+			href={linkUrl}
+			iconSide="right"
+			size="small"
+			icon={<SvgExternal />}
+			theme={{
+				textPrimary: accentColor
+					? sourcePalette.neutral[100]
+					: sourcePalette.neutral[0],
+				backgroundPrimary: buttonBgColour,
+				backgroundPrimaryHover: calculateHoverColour(buttonBgColour),
+			}}
+		>
+			{buttonText ?? 'Learn more'}
+		</LinkButton>
 	);
 };

--- a/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
@@ -21,7 +21,7 @@ export const WithAccentColour = () => {
 		<CallToActionButton
 			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
 			buttonText="Explore more"
-			accentColor="#d71920"
+			accentColor="#0077B6"
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
@@ -1,0 +1,29 @@
+import { CallToActionButton } from './CallToActionAtom';
+
+export default {
+	component: CallToActionButton,
+	title: 'Components/CallToActionButton',
+};
+
+export const Default = () => {
+	return (
+		<CallToActionButton
+			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
+			buttonText="Explore more"
+		/>
+	);
+};
+
+Default.storyName = 'default';
+
+export const WithAccentColour = () => {
+	return (
+		<CallToActionButton
+			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
+			buttonText="Explore more"
+			accentColor="#d71920"
+		/>
+	);
+};
+
+WithAccentColour.storyName = 'with accent colour';

--- a/dotcom-rendering/src/components/HostedContentPage.tsx
+++ b/dotcom-rendering/src/components/HostedContentPage.tsx
@@ -33,6 +33,7 @@ interface AppProps extends BaseProps {
  * HostedContentPage is a high level wrapper for hosted content pages on Dotcom. Sets strict mode and some globals
  */
 export const HostedContentPage = (props: WebProps | AppProps) => {
+	const { article } = props;
 	const {
 		article: { design, display, theme, frontendData },
 		renderingTarget,
@@ -48,11 +49,11 @@ export const HostedContentPage = (props: WebProps | AppProps) => {
 	};
 
 	const decideLayout = () => {
-		switch (format.design) {
+		switch (article.design) {
 			case ArticleDesign.HostedVideo:
 				return (
 					<HostedVideoLayout
-						content={props.article}
+						content={article}
 						format={format}
 						renderingTarget={renderingTarget}
 					/>
@@ -60,7 +61,7 @@ export const HostedContentPage = (props: WebProps | AppProps) => {
 			case ArticleDesign.HostedGallery:
 				return (
 					<HostedGalleryLayout
-						content={props.article}
+						content={article}
 						format={format}
 						renderingTarget={renderingTarget}
 					/>
@@ -68,7 +69,7 @@ export const HostedContentPage = (props: WebProps | AppProps) => {
 			case ArticleDesign.HostedArticle:
 				return (
 					<HostedArticleLayout
-						content={props.article}
+						content={article}
 						format={format}
 						renderingTarget={renderingTarget}
 					/>

--- a/dotcom-rendering/src/components/OnwardsUpper.island.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.island.tsx
@@ -318,7 +318,9 @@ export const OnwardsUpper = ({
 	const showCuratedContainer =
 		!!curatedDataUrl && !isPaidContent && canHaveCuratedContent;
 
-	const isGalleryArticle = format.design === ArticleDesign.Gallery;
+	const isGalleryArticle =
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery;
 
 	return (
 		<div css={onwardsWrapper}>

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
@@ -27,9 +27,15 @@ const format = {
 	display: ArticleDisplay.Standard,
 };
 
+const appsArticle = enhanceArticleType(hostedGallery, 'Apps');
+
+if (appsArticle.design !== ArticleDesign.HostedGallery) {
+	throw new Error('Expected hosted gallery');
+}
+
 export const Apps = meta.story({
 	args: {
-		content: enhanceArticleType(hostedGallery, 'Apps'),
+		content: appsArticle,
 		format,
 		renderingTarget: 'Apps',
 	},
@@ -40,9 +46,15 @@ export const Apps = meta.story({
 	},
 });
 
+const webArticle = enhanceArticleType(hostedGallery, 'Web');
+
+if (webArticle.design !== ArticleDesign.HostedGallery) {
+	throw new Error('Expected hosted gallery');
+}
+
 export const Web = meta.story({
 	args: {
-		content: enhanceArticleType(hostedGallery, 'Web'),
+		content: webArticle,
 		format,
 		renderingTarget: 'Web',
 	},

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -5,21 +5,18 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
-import { ArticleMetaApps } from '../components/ArticleMeta.apps';
-import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
-import { Caption } from '../components/Caption';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
-import { MainMediaGallery } from '../components/MainMediaGallery';
+import { OnwardsUpper } from '../components/OnwardsUpper.island';
 import { Section } from '../components/Section';
+import { ShareButton } from '../components/ShareButton.island';
 import { Standfirst } from '../components/Standfirst';
 import { grid } from '../grid';
 import type { ArticleFormat } from '../lib/articleFormat';
-import { decideMainMediaCaption } from '../lib/decide-caption';
 import { palette } from '../palette';
-import type { ArticleDeprecated, Gallery } from '../types/article';
+import type { Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
@@ -47,20 +44,34 @@ const headerStyles = css`
 	}
 `;
 
+const metaStyles = css`
+	${grid.column.centre}
+	grid-row-start: 3;
+
+	${from.desktop} {
+		grid-row-start: 2;
+	}
+
+	${from.leftCol} {
+		${grid.column.left}
+	}
+`;
+
+const shareButtonStyles = css`
+	margin-top: ${space[4]}px;
+	padding: ${space[1]}px;
+`;
+
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const { content, renderingTarget, format } = props;
+	const { content, renderingTarget, format, serverTime } = props;
 	const { frontendData } = content;
 	const { commercialProperties, editionId } = frontendData;
 
 	const { branding } = commercialProperties[editionId];
 
-	const isWeb = renderingTarget === 'Web';
-
-	const captionText = decideMainMediaCaption(content.mainMedia);
-
 	return (
 		<>
-			{isWeb && branding ? (
+			{branding ? (
 				<Stuck>
 					<Section
 						fullWidth={true}
@@ -84,11 +95,6 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 				}}
 			>
 				<header css={headerStyles}>
-					<MainMediaGallery
-						mainMedia={content.mainMedia}
-						format={format}
-						renderingTarget={props.renderingTarget}
-					/>
 					<ArticleTitle
 						format={format}
 						tags={frontendData.tags}
@@ -109,16 +115,24 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						format={format}
 						standfirst={frontendData.standfirst}
 					/>
-					<Caption
-						captionText={captionText}
-						format={format}
-						isMainMedia={true}
-					/>
-					<Meta
-						renderingTarget={renderingTarget}
-						format={format}
-						frontendData={frontendData}
-					/>
+
+					<div data-print-layout="hide" css={metaStyles}>
+						{renderingTarget === 'Web' && (
+							<div css={shareButtonStyles}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<ShareButton
+										pageId={frontendData.pageId}
+										webTitle={frontendData.webTitle}
+										format={format}
+										context="ArticleMeta"
+									/>
+								</Island>
+							</div>
+						)}
+					</div>
 				</header>
 				<GalleryBody
 					renderingTarget={renderingTarget}
@@ -128,78 +142,31 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					webTitle={frontendData.webTitle}
 				/>
 			</main>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<OnwardsUpper
+					ajaxUrl={frontendData.config.ajaxUrl}
+					hasRelated={frontendData.hasRelated}
+					hasStoryPackage={frontendData.hasStoryPackage}
+					isAdFreeUser={frontendData.isAdFreeUser}
+					pageId={frontendData.pageId}
+					isPaidContent={!!frontendData.config.isPaidContent}
+					showRelatedContent={frontendData.config.showRelatedContent}
+					keywordIds={frontendData.config.keywordIds}
+					contentType={frontendData.contentType}
+					tags={frontendData.tags}
+					format={format}
+					pillar={format.theme}
+					editionId={frontendData.editionId}
+					shortUrlId={frontendData.config.shortUrlId}
+					discussionApiUrl={frontendData.config.discussionApiUrl}
+					serverTime={serverTime}
+					renderingTarget={renderingTarget}
+					webURL={frontendData.webURL}
+				/>
+			</Island>
 		</>
 	);
 };
-
-const Meta = ({
-	renderingTarget,
-	format,
-	frontendData,
-}: {
-	renderingTarget: RenderingTarget;
-	format: ArticleFormat;
-	frontendData: ArticleDeprecated;
-}) => (
-	<div
-		css={{
-			'&': css(grid.column.centre),
-			paddingBottom: space[6],
-			[from.tablet]: {
-				position: 'relative',
-				'&::before': {
-					content: '""',
-					position: 'absolute',
-					left: -10,
-					top: 0,
-					bottom: 0,
-					width: 1,
-					backgroundColor: palette('--article-border'),
-				},
-			},
-		}}
-	>
-		{renderingTarget === 'Web' ? (
-			<ArticleMeta
-				branding={
-					frontendData.commercialProperties[frontendData.editionId]
-						.branding
-				}
-				format={format}
-				pageId={frontendData.pageId}
-				webTitle={frontendData.webTitle}
-				byline={frontendData.byline}
-				tags={frontendData.tags}
-				primaryDateline={frontendData.webPublicationDateDisplay}
-				secondaryDateline={
-					frontendData.webPublicationSecondaryDateDisplay
-				}
-				isCommentable={frontendData.isCommentable}
-				discussionApiUrl={frontendData.config.discussionApiUrl}
-				shortUrlId={frontendData.config.shortUrlId}
-			/>
-		) : null}
-		{renderingTarget === 'Apps' ? (
-			<ArticleMetaApps
-				branding={
-					frontendData.commercialProperties[frontendData.editionId]
-						.branding
-				}
-				format={format}
-				pageId={frontendData.pageId}
-				byline={frontendData.byline}
-				tags={frontendData.tags}
-				primaryDateline={frontendData.webPublicationDateDisplay}
-				secondaryDateline={
-					frontendData.webPublicationSecondaryDateDisplay
-				}
-				isCommentable={frontendData.isCommentable}
-				discussionApiUrl={frontendData.config.discussionApiUrl}
-				shortUrlId={frontendData.config.shortUrlId}
-			/>
-		) : null}
-	</div>
-);
 
 const GalleryBody = (props: {
 	renderingTarget: RenderingTarget;

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -4,20 +4,30 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
+import { ArticleHeadline } from '../components/ArticleHeadline';
+import { ArticleMetaApps } from '../components/ArticleMeta.apps';
+import { ArticleMeta } from '../components/ArticleMeta.web';
+import { ArticleTitle } from '../components/ArticleTitle';
+import { Caption } from '../components/Caption';
+import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
+import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Section } from '../components/Section';
-import { ShareButton } from '../components/ShareButton.island';
+import { Standfirst } from '../components/Standfirst';
 import { grid } from '../grid';
 import type { ArticleFormat } from '../lib/articleFormat';
-import type { Article } from '../types/article';
+import { decideMainMediaCaption } from '../lib/decide-caption';
+import { palette } from '../palette';
+import type { ArticleDeprecated, Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
-	content: Article;
+	content: Gallery;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
+	serverTime?: number;
 }
 
 interface WebProps extends Props {
@@ -28,29 +38,29 @@ interface AppProps extends Props {
 	renderingTarget: 'Apps';
 }
 
-const border = css`
-	border: 1px solid black;
-`;
+const headerStyles = css`
+	${grid.container}
+	background-color: ${palette('--article-inner-background')};
 
-const metaFlex = css`
-	margin-bottom: ${space[3]}px;
-	display: flex;
-	justify-content: space-between;
-	flex-wrap: wrap;
+	${from.tablet} {
+		border-bottom: 1px solid ${palette('--article-border')};
+	}
 `;
 
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const {
-		content: { frontendData },
-		format,
-	} = props;
+	const { content, renderingTarget, format } = props;
+	const { frontendData } = content;
+	const { commercialProperties, editionId } = frontendData;
 
-	const { branding } =
-		frontendData.commercialProperties[frontendData.editionId];
+	const { branding } = commercialProperties[editionId];
+
+	const isWeb = renderingTarget === 'Web';
+
+	const captionText = decideMainMediaCaption(content.mainMedia);
 
 	return (
 		<>
-			{props.renderingTarget === 'Web' && branding ? (
+			{isWeb && branding ? (
 				<Stuck>
 					<Section
 						fullWidth={true}
@@ -67,54 +77,154 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					</Section>
 				</Stuck>
 			) : null}
-			<main>
-				<header css={[grid.container, border]}>
-					<div
-						css={[grid.between('centre-column-start', 'grid-end')]}
-					>
-						{props.content.frontendData.headline}
-					</div>
-				</header>
-				<div css={[grid.container]}>
-					<article css={[grid.column.all]}>
-						<div css={border}>Gallery</div>
-						<div css={border}>Onward</div>
-					</article>
-				</div>
-				<div
-					css={[
-						grid.container,
-						border,
-						css`
-							padding: ${space[2]}px;
 
-							${from.desktop} {
-								padding: ${space[4]}px ${space[8]}px;
-							}
-						`,
-					]}
-				>
-					<div css={[grid.column.all]}>
-						<div css={[grid.column.left]}>
-							<div data-print-layout="hide" css={metaFlex}>
-								{props.renderingTarget === 'Web' && (
-									<Island
-										priority="feature"
-										defer={{ until: 'visible' }}
-									>
-										<ShareButton
-											pageId={frontendData.pageId}
-											webTitle={frontendData.webTitle}
-											format={format}
-											context="ArticleMeta"
-										/>
-									</Island>
-								)}
-							</div>
-						</div>
-					</div>
-				</div>
+			<main
+				css={{
+					backgroundColor: palette('--article-background'),
+				}}
+			>
+				<header css={headerStyles}>
+					<MainMediaGallery
+						mainMedia={content.mainMedia}
+						format={format}
+						renderingTarget={props.renderingTarget}
+					/>
+					<ArticleTitle
+						format={format}
+						tags={frontendData.tags}
+						sectionLabel={frontendData.sectionLabel}
+						sectionUrl={frontendData.sectionUrl}
+						guardianBaseURL={frontendData.guardianBaseURL}
+					/>
+					<ArticleHeadline
+						format={format}
+						headlineString={frontendData.headline}
+						tags={frontendData.tags}
+						byline={frontendData.byline}
+						webPublicationDateDeprecated={
+							frontendData.webPublicationDateDeprecated
+						}
+					/>
+					<Standfirst
+						format={format}
+						standfirst={frontendData.standfirst}
+					/>
+					<Caption
+						captionText={captionText}
+						format={format}
+						isMainMedia={true}
+					/>
+					<Meta
+						renderingTarget={renderingTarget}
+						format={format}
+						frontendData={frontendData}
+					/>
+				</header>
+				<GalleryBody
+					renderingTarget={renderingTarget}
+					format={format}
+					bodyElements={content.bodyElements}
+					pageId={frontendData.pageId}
+					webTitle={frontendData.webTitle}
+				/>
 			</main>
 		</>
 	);
 };
+
+const Meta = ({
+	renderingTarget,
+	format,
+	frontendData,
+}: {
+	renderingTarget: RenderingTarget;
+	format: ArticleFormat;
+	frontendData: ArticleDeprecated;
+}) => (
+	<div
+		css={{
+			'&': css(grid.column.centre),
+			paddingBottom: space[6],
+			[from.tablet]: {
+				position: 'relative',
+				'&::before': {
+					content: '""',
+					position: 'absolute',
+					left: -10,
+					top: 0,
+					bottom: 0,
+					width: 1,
+					backgroundColor: palette('--article-border'),
+				},
+			},
+		}}
+	>
+		{renderingTarget === 'Web' ? (
+			<ArticleMeta
+				branding={
+					frontendData.commercialProperties[frontendData.editionId]
+						.branding
+				}
+				format={format}
+				pageId={frontendData.pageId}
+				webTitle={frontendData.webTitle}
+				byline={frontendData.byline}
+				tags={frontendData.tags}
+				primaryDateline={frontendData.webPublicationDateDisplay}
+				secondaryDateline={
+					frontendData.webPublicationSecondaryDateDisplay
+				}
+				isCommentable={frontendData.isCommentable}
+				discussionApiUrl={frontendData.config.discussionApiUrl}
+				shortUrlId={frontendData.config.shortUrlId}
+			/>
+		) : null}
+		{renderingTarget === 'Apps' ? (
+			<ArticleMetaApps
+				branding={
+					frontendData.commercialProperties[frontendData.editionId]
+						.branding
+				}
+				format={format}
+				pageId={frontendData.pageId}
+				byline={frontendData.byline}
+				tags={frontendData.tags}
+				primaryDateline={frontendData.webPublicationDateDisplay}
+				secondaryDateline={
+					frontendData.webPublicationSecondaryDateDisplay
+				}
+				isCommentable={frontendData.isCommentable}
+				discussionApiUrl={frontendData.config.discussionApiUrl}
+				shortUrlId={frontendData.config.shortUrlId}
+			/>
+		) : null}
+	</div>
+);
+
+const GalleryBody = (props: {
+	renderingTarget: RenderingTarget;
+	format: ArticleFormat;
+	bodyElements: Gallery['bodyElements'];
+	pageId: string;
+	webTitle: string;
+}) => (
+	<>
+		{props.bodyElements.map((element) => {
+			switch (element._type) {
+				case 'model.dotcomrendering.pageElements.ImageBlockElement':
+					return (
+						<GalleryImage
+							image={element}
+							format={props.format}
+							pageId={props.pageId}
+							webTitle={props.webTitle}
+							renderingTarget={props.renderingTarget}
+							key={element.elementId}
+						/>
+					);
+				default:
+					return null;
+			}
+		})}
+	</>
+);

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -6,6 +6,7 @@ import {
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { ArticleTitle } from '../components/ArticleTitle';
+import { CallToActionButton } from '../components/CallToActionAtom';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
@@ -57,8 +58,13 @@ const metaStyles = css`
 	}
 `;
 
+const metaContentStyles = css`
+	display: flex;
+	align-items: center;
+	gap: 0.3rem;
+`;
+
 const shareButtonStyles = css`
-	margin-top: ${space[4]}px;
 	padding: ${space[1]}px;
 `;
 
@@ -118,19 +124,28 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 
 					<div data-print-layout="hide" css={metaStyles}>
 						{renderingTarget === 'Web' && (
-							<div css={shareButtonStyles}>
-								<Island
-									priority="feature"
-									defer={{ until: 'visible' }}
-								>
-									<ShareButton
-										pageId={frontendData.pageId}
-										webTitle={frontendData.webTitle}
-										format={format}
-										context="ArticleMeta"
+							<>
+								<div css={metaContentStyles}>
+									<CallToActionButton
+										linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
+										buttonText="Explore more"
+										accentColor="#0077B6"
 									/>
-								</Island>
-							</div>
+									<div css={shareButtonStyles}>
+										<Island
+											priority="feature"
+											defer={{ until: 'visible' }}
+										>
+											<ShareButton
+												pageId={frontendData.pageId}
+												webTitle={frontendData.webTitle}
+												format={format}
+												context="ArticleMeta"
+											/>
+										</Island>
+									</div>
+								</div>
+							</>
 						)}
 					</div>
 				</header>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -107,6 +107,7 @@ const headlineTextLight: PaletteFunction = ({ design, display, theme }) => {
 					}
 				}
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[100];
 				case ArticleDesign.LiveBlog: {
 					switch (theme) {
@@ -179,6 +180,7 @@ const headlineTextDark: PaletteFunction = ({ design, display, theme }) => {
 					}
 				}
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[97];
@@ -211,6 +213,7 @@ const headlineBackgroundLight: PaletteFunction = ({
 		case ArticleDisplay.Standard:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[7];
 				case ArticleDesign.Interview:
 					return sourcePalette.neutral[7];
@@ -249,6 +252,7 @@ const headlineBackgroundDark: PaletteFunction = ({
 					return sourcePalette.neutral[20];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -359,6 +363,7 @@ const headlineBylineDark: PaletteFunction = ({ design, display, theme }) => {
 const bylineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -509,6 +514,7 @@ const bylineBackgroundDark: PaletteFunction = ({ design, theme }) => {
 const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
@@ -619,6 +625,7 @@ const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 const bylineAnchorDark: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
@@ -979,6 +986,7 @@ export const tabs = {
 const datelineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[86];
@@ -1196,6 +1204,7 @@ const avatarDark: PaletteFunction = () => sourcePalette.neutral[93];
 const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.Picture:
@@ -1212,6 +1221,7 @@ const followTextDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[100];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[86];
@@ -1242,6 +1252,7 @@ const followIconBackgroundLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.news[800];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
@@ -1303,6 +1314,7 @@ const followIconBackgroundDark: PaletteFunction = ({ theme, design }) => {
 const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case Pillar.Opinion:
 					return sourcePalette.opinion[500];
@@ -1976,6 +1988,7 @@ const appsFooterBackgroundLight: PaletteFunction = () =>
 const appsFooterBackgroundDark: PaletteFunction = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 		default:
 			return sourcePalette.neutral[0];
@@ -2010,6 +2023,7 @@ const brandingLabelLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[20];
@@ -2135,6 +2149,7 @@ const standfirstBulletDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[86];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			switch (theme) {
 				case Pillar.News:
@@ -2265,6 +2280,7 @@ const standfirstBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[93];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		default:
 			return articleBackgroundLight({ design, display, theme });
@@ -2308,6 +2324,7 @@ const standfirstBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[10];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -2374,6 +2391,7 @@ const standfirstLinkTextLight: PaletteFunction = ({ design, theme }) => {
 			}
 		case ArticleDesign.Audio:
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			switch (theme) {
@@ -2405,6 +2423,7 @@ const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Video:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		case ArticleDesign.Picture:
 			switch (theme) {
 				case Pillar.News:
@@ -2463,6 +2482,7 @@ const standfirstTextLight: PaletteFunction = (format) => {
 					return sourcePalette.neutral[86];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			if (
@@ -2481,6 +2501,7 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[93];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -2730,6 +2751,7 @@ const captionTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[46];
@@ -2758,6 +2780,7 @@ const captionTextDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[60];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[60];
@@ -2769,6 +2792,7 @@ const captionMainMediaTextLight: PaletteFunction = (format) => {
 		case ArticleDesign.PhotoEssay:
 			return sourcePalette.neutral[46];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
 					return captionTextLight(format);
@@ -2797,6 +2821,7 @@ const captionLink: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.NewsletterSignup:
 			return sourcePalette.neutral[0];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			switch (theme) {
@@ -3154,6 +3179,7 @@ const articleBackgroundLight: PaletteFunction = ({
 		case ArticleDesign.FullPageInteractive:
 			return 'transparent';
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return '#0d0d0d';
 		default:
 			switch (theme) {
@@ -3199,6 +3225,7 @@ const articleBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[10];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -3215,6 +3242,7 @@ const articleInnerBackgroundLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[0];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 
 		default:
@@ -3233,6 +3261,7 @@ const articleInnerBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[0];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 
 		default:
@@ -3360,7 +3389,12 @@ const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 		return sourcePalette.neutral[46];
 	}
 
-	if (design === ArticleDesign.Gallery) return sourcePalette.neutral[46];
+	if (
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery
+	) {
+		return sourcePalette.neutral[46];
+	}
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
@@ -3386,7 +3420,6 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 			return sourcePalette.neutral[20];
 		case ArticleDesign.Comment:
-			return sourcePalette.neutral[20];
 		case ArticleDesign.Interactive:
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[46];
@@ -3532,7 +3565,10 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 };
 
 const articleSectionBorderLight: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.Gallery) {
+	if (
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[86];
 	}
 
@@ -3554,7 +3590,10 @@ const footerBorderDark: PaletteFunction = () => {
 const articleBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 
 const straightLinesLight: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.Gallery) {
+	if (
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[20];
 	}
 	if (format.theme === ArticleSpecial.SpecialReportAlt) {
@@ -3799,7 +3838,6 @@ const shareButtonHoverLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
 		case ArticleDesign.HostedArticle:
-		case ArticleDesign.HostedGallery:
 		case ArticleDesign.HostedVideo:
 			switch (theme) {
 				case ArticleSpecial.Labs:
@@ -3808,6 +3846,7 @@ const shareButtonHoverLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		default:
 			return sourcePalette.neutral[100];
@@ -3836,6 +3875,7 @@ const shareButtonBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 const shareButtonBorderMetaLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[38];
 		default:
 			return sourcePalette.neutral[86];
@@ -3851,6 +3891,7 @@ const shareButtonBorderXSmallLight: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[46];
 		default:
 			return sourcePalette.neutral[86];
@@ -3863,6 +3904,7 @@ const shareButtonCopiedLight: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[7];
@@ -3874,12 +3916,12 @@ const shareButtonCopiedDark: PaletteFunction = () => sourcePalette.neutral[86];
 const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
 		case ArticleDesign.HostedArticle:
-		case ArticleDesign.HostedGallery:
 		case ArticleDesign.HostedVideo:
 			switch (theme) {
 				case ArticleSpecial.Labs:
@@ -4026,7 +4068,10 @@ const liveBlockBorderBottomDark: PaletteFunction = () =>
 const subMetaLabelTextLight: PaletteFunction = ({ theme, design }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
-			if (design === ArticleDesign.Gallery) {
+			if (
+				design === ArticleDesign.Gallery ||
+				design === ArticleDesign.HostedGallery
+			) {
 				return sourcePalette.neutral[60];
 			}
 			return sourcePalette.neutral[7];
@@ -4098,6 +4143,7 @@ const subMetaBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 
 		default:
@@ -4153,6 +4199,7 @@ const subMetaTextLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleSpecial.Labs:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[7];
@@ -4165,6 +4212,7 @@ const subMetaTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				case ArticleDesign.DeadBlog:
 				case ArticleDesign.LiveBlog:
@@ -4217,6 +4265,7 @@ const subMetaTextDark: PaletteFunction = ({ design, theme }) => {
 			switch (design) {
 				case ArticleDesign.Picture:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return pillarPalette(theme, 500);
@@ -4230,10 +4279,12 @@ const subMetaTextHoverLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					switch (design) {
 						case ArticleDesign.Gallery:
+						case ArticleDesign.HostedGallery:
 							return sourcePalette.neutral[7];
 						default:
 							return sourcePalette.neutral[100];
@@ -4931,6 +4982,7 @@ const seriesTitleBackgroundLight: PaletteFunction = ({
 		default:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					switch (theme) {
 						case Pillar.Opinion:
 						case Pillar.News:
@@ -4956,6 +5008,7 @@ const seriesTitleBackgroundDark: PaletteFunction = ({
 }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case Pillar.Opinion:
 				case Pillar.News:
@@ -5040,7 +5093,10 @@ const seriesTitleTextLight: PaletteFunction = ({ theme, display, design }) => {
 		return sourcePalette.specialReport[300];
 	}
 
-	if (design === ArticleDesign.Gallery) {
+	if (
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[100];
 	}
 
@@ -5131,6 +5187,7 @@ const seriesTitleTextDark: PaletteFunction = ({ design, theme, display }) => {
 	if (display === ArticleDisplay.Immersive) return sourcePalette.neutral[100];
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[100];
 		case ArticleDesign.Analysis:
 			switch (theme) {

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -47,8 +47,10 @@ export type ArticleFields = {
 	serverTime?: number | undefined;
 };
 
+export type GalleryDesign = ArticleDesign.Gallery | ArticleDesign.HostedGallery;
+
 export type Gallery = ArticleFields & {
-	design: ArticleDesign.Gallery;
+	design: GalleryDesign;
 	bodyElements: (ImageBlockElement | AdPlaceholderBlockElement)[];
 	mainMedia?: ImageBlockElement;
 };
@@ -120,13 +122,14 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
-	const storyPackage = parseStoryPackage(
-		data.storyPackage,
-		format.design === ArticleDesign.Gallery,
-	);
+	const isGalleryPage =
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery;
 
-	if (format.design === ArticleDesign.Gallery) {
-		const design = ArticleDesign.Gallery;
+	const storyPackage = parseStoryPackage(data.storyPackage, isGalleryPage);
+
+	if (isGalleryPage) {
+		const { design } = format;
 
 		return {
 			frontendData: {

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -56,7 +56,7 @@ export type Gallery = ArticleFields & {
 };
 
 export type OtherArticles = ArticleFields & {
-	design: Exclude<ArticleDesign, ArticleDesign.Gallery>;
+	design: Exclude<ArticleDesign, GalleryDesign>;
 };
 
 export type Article = Gallery | OtherArticles;

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -122,13 +122,18 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
-	const isGalleryPage =
-		format.design === ArticleDesign.Gallery ||
-		format.design === ArticleDesign.HostedGallery;
+	const isGalleryPage = (
+		design: ArticleDesign,
+	): design is ArticleDesign.Gallery | ArticleDesign.HostedGallery =>
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery;
 
-	const storyPackage = parseStoryPackage(data.storyPackage, isGalleryPage);
+	const storyPackage = parseStoryPackage(
+		data.storyPackage,
+		isGalleryPage(format.design),
+	);
 
-	if (isGalleryPage) {
+	if (isGalleryPage(format.design)) {
 		const { design } = format;
 
 		return {


### PR DESCRIPTION
## What does this change?
This PR builds on the initial Hosted Content Gallery redesign work from the branch cemms1/hosted-gallery.

- Introduces a reusable CTA button component that can be used on its own or inside CallToActionAtom.
- Adds Storybook coverage for the CTA component.
- Adds the CTA next to the share button in the Hosted Gallery layout, with updated spacing and positioning styles.

## Why?
We are rolling out a new Hosted Content Gallery design and layout.

This PR adds a standalone CTA button for Hosted Content Gallery pages, where we only need the button behavior and not the full CallToActionAtom component.



## Screenshots

| CTA Button      | Next to 'share' button in Hosted Content Gallery Article |
| ----------- | ---------- |
| <img width="482" height="188" alt="Screenshot 2026-06-04 at 14 18 06" src="https://github.com/user-attachments/assets/94685b18-8544-4a6d-bd58-654f68552dda" /> | <img width="474" height="87" alt="Screenshot 2026-06-04 at 14 18 42" src="https://github.com/user-attachments/assets/f5524467-fc55-44d6-a492-f36aff561cef" />|


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
