### PR TITLE
Use the correct icon for exiting fullscreen

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -442,6 +442,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
+	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
 	const [isProgressBarSeeking, setIsProgressBarSeeking] = useState(false);
 	/** Whether the video should show controls */
@@ -862,38 +863,55 @@ export const SelfHostedVideo = ({
 
 		if (!playerContainer && !video) return;
 
-		const reportFullscreenEvent = () => {
-			const event =
-				document.fullscreenElement ||
-				(video &&
+		const updateStateAndReportFullscreenEvent = () => {
+			const isInFullscreenMode =
+				document.fullscreenElement !== null ||
+				(video !== null &&
 					'webkitDisplayingFullscreen' in video &&
-					Boolean(video.webkitDisplayingFullscreen))
-					? 'enter_fullscreen'
-					: 'exit_fullscreen';
+					Boolean(video.webkitDisplayingFullscreen));
+
+			if (isInFullscreenMode) {
+				setIsFullscreen(true);
+			} else {
+				setIsFullscreen(false);
+			}
+
+			const event = isInFullscreenMode
+				? 'enter_fullscreen'
+				: 'exit_fullscreen';
 
 			sendOphanTrackingEvent(event);
 		};
 
 		for (const event of fullscreenChangeEvents) {
 			if (video) {
-				video.addEventListener(event, reportFullscreenEvent);
+				video.addEventListener(
+					event,
+					updateStateAndReportFullscreenEvent,
+				);
 			}
 
 			if (playerContainer) {
-				playerContainer.addEventListener(event, reportFullscreenEvent);
+				playerContainer.addEventListener(
+					event,
+					updateStateAndReportFullscreenEvent,
+				);
 			}
 		}
 
 		return () => {
 			for (const event of fullscreenChangeEvents) {
 				if (video) {
-					video.removeEventListener(event, reportFullscreenEvent);
+					video.removeEventListener(
+						event,
+						updateStateAndReportFullscreenEvent,
+					);
 				}
 
 				if (playerContainer) {
 					playerContainer.removeEventListener(
 						event,
-						reportFullscreenEvent,
+						updateStateAndReportFullscreenEvent,
 					);
 				}
 			}
@@ -1325,6 +1343,7 @@ export const SelfHostedVideo = ({
 							videoStyleSettings.supportsFullscreen
 						}
 						isInteractive={videoStyleSettings.isInteractive}
+						isFullscreen={isFullscreen}
 						isWebKitFullscreen={isWebKitFullscreen}
 						linkTo={linkTo}
 						cardLink={cardLink}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -153,6 +153,7 @@ export type Props = {
 	isInteractive: boolean;
 	iconsPosition: ControlsPosition;
 	subtitlesPosition: SubtitlesPosition;
+	isFullscreen: boolean;
 	isWebKitFullscreen: boolean;
 	/* used by the card link component for click through to article functionality */
 	linkTo: string;
@@ -217,6 +218,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isInteractive,
 			iconsPosition,
 			subtitlesPosition,
+			isFullscreen,
 			isWebKitFullscreen,
 			linkTo,
 			cardLink,
@@ -366,6 +368,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 							)}
 							{showFullscreenIcon && (
 								<FullscreenIcon
+									isFullscreen={isFullscreen}
 									handleClick={handleFullscreenClick}
 								/>
 							)}

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayerIcons.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { palette as sourcePalette, space } from '@guardian/source/foundations';
 import {
+	SvgArrowContract,
 	SvgArrowExpand,
 	SvgAudio,
 	SvgAudioMute,
@@ -54,24 +55,32 @@ export const AudioIcon = ({ isMuted, handleClick }: AudioIconProps) => {
 };
 
 type FullscreenIconProps = {
+	isFullscreen: SelfHostedVideoPlayerProps['isFullscreen'];
 	handleClick: SelfHostedVideoPlayerProps['handleFullscreenClick'];
 };
 
-export const FullscreenIcon = ({ handleClick }: FullscreenIconProps) => (
-	<button
-		type="button"
-		onClick={handleClick}
-		css={[buttonStyles, iconContainerStyles]}
-		data-testid="fullscreen-icon"
-	>
-		<SvgArrowExpand
-			size="xsmall"
-			theme={{
-				fill: palette('--video-icon'),
-			}}
-		/>
-	</button>
-);
+export const FullscreenIcon = ({
+	isFullscreen,
+	handleClick,
+}: FullscreenIconProps) => {
+	const Icon = isFullscreen ? SvgArrowContract : SvgArrowExpand;
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			css={[buttonStyles, iconContainerStyles]}
+			data-testid="fullscreen-icon"
+		>
+			<Icon
+				size="xsmall"
+				theme={{
+					fill: palette('--video-icon'),
+				}}
+			/>
+		</button>
+	);
+};
 
 const buttonSize = 56;
 const playPauseButtonStyles = css`


### PR DESCRIPTION
## What does this change?

Use the "arrow contract SVG" in the button for exiting fullscreen.

This is a bit more involved than initially expected. We need to know when the user enters and exits fullscreen: not only does the fullscreen icon control this, the user can also use the escape key. Further, there may be other actions a user can use to exit fullscreen and also circumstances where the browser exits from fullscreen mode without user interaction. Therefore, we listen to the range of fullscreen events to keep our fullscreen state up-to-date.

## Why?

To match designs (and common sense!)

## Screenshots

In fullscreen mode

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/edc4130f-b89e-4794-99e0-d1e02b20a84b
[after]: https://github.com/user-attachments/assets/4a5bb8ef-fa4c-4030-9700-cfeeccea6621

## Screenshare

Testing both the button to exit fullscreen and pressing the escape key:

https://github.com/user-attachments/assets/235bf5b1-dea6-4491-9326-821d23c97ce2

