### PR TITLE
Use specific background colour rather than article background for world cup nav

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
@@ -136,7 +136,7 @@ const configs = [
 		textHoverColor: themePalette('--masthead-nav-link-text-hover'),
 		backgroundColor: {
 			web: themePalette('--masthead-nav-background'),
-			app: themePalette('--article-background'),
+			app: themePalette('--apps-directory-page-nav-background'),
 		},
 		borderColor: {
 			web: themePalette('--masthead-nav-lines'),


### PR DESCRIPTION
## Why?
transparent doesn't work on the bracketology interactive which has a blue background.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/ffd94375-e841-449b-a58e-8b89245e656d
[after]: https://github.com/user-attachments/assets/cf9492fa-5a98-4fc1-8c1e-2d5d478be8f9

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
