### PR TITLE
create separate CTA button for Hosted Content gallery articles

### DIFF
--- a/dotcom-rendering/src/components/CallToActionAtom.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtom.tsx
@@ -17,6 +17,11 @@ type CallToActionProps = {
 	buttonText?: string;
 	accentColor?: string;
 };
+type CallToActionButtonProps = {
+	linkUrl: string;
+	buttonText?: string;
+	accentColor?: string;
+};
 
 const blurStyles = css`
 	position: absolute;
@@ -98,8 +103,6 @@ export const CallToActionAtom = ({
 	buttonText,
 	accentColor,
 }: CallToActionProps) => {
-	const buttonBgColour = accentColor ?? sourcePalette.neutral[100];
-
 	return (
 		<picture
 			css={css`
@@ -126,26 +129,41 @@ export const CallToActionAtom = ({
 			<div css={blurAndTextWrapperStyles}>
 				<div css={textAndButtonWrapperStyles}>
 					{!!text && <h2 css={textStyles}>{text}</h2>}
-					<LinkButton
-						href={linkUrl}
-						iconSide="right"
-						size="small"
-						icon={<SvgExternal />}
-						theme={{
-							textPrimary: accentColor
-								? sourcePalette.neutral[100]
-								: sourcePalette.neutral[0],
-							backgroundPrimary: buttonBgColour,
-							backgroundPrimaryHover:
-								calculateHoverColour(buttonBgColour),
-						}}
-					>
-						{buttonText ?? 'Learn more'}
-					</LinkButton>
+					<CallToActionButton
+						linkUrl={linkUrl}
+						buttonText={buttonText}
+						accentColor={accentColor}
+					/>
 				</div>
 				{/* blur overlay */}
 				<div aria-hidden="true" css={blurStyles} />
 			</div>
 		</picture>
+	);
+};
+
+export const CallToActionButton = ({
+	linkUrl,
+	buttonText,
+	accentColor,
+}: CallToActionButtonProps) => {
+	const buttonBgColour = accentColor ?? sourcePalette.neutral[100];
+
+	return (
+		<LinkButton
+			href={linkUrl}
+			iconSide="right"
+			size="small"
+			icon={<SvgExternal />}
+			theme={{
+				textPrimary: accentColor
+					? sourcePalette.neutral[100]
+					: sourcePalette.neutral[0],
+				backgroundPrimary: buttonBgColour,
+				backgroundPrimaryHover: calculateHoverColour(buttonBgColour),
+			}}
+		>
+			{buttonText ?? 'Learn more'}
+		</LinkButton>
 	);
 };

--- a/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
@@ -21,7 +21,7 @@ export const WithAccentColour = () => {
 		<CallToActionButton
 			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
 			buttonText="Explore more"
-			accentColor="#d71920"
+			accentColor="#0077B6"
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
+++ b/dotcom-rendering/src/components/CallToActionAtomButton.stories.tsx
@@ -1,0 +1,29 @@
+import { CallToActionButton } from './CallToActionAtom';
+
+export default {
+	component: CallToActionButton,
+	title: 'Components/CallToActionButton',
+};
+
+export const Default = () => {
+	return (
+		<CallToActionButton
+			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
+			buttonText="Explore more"
+		/>
+	);
+};
+
+Default.storyName = 'default';
+
+export const WithAccentColour = () => {
+	return (
+		<CallToActionButton
+			linkUrl="https://www.trendmicro.com/vinfo/gb/security/research-and-analysis/predictions/the-ai-fication-of-cyberthreats-trend-micro-security-predictions-for-2026?utm_source=guardian&utm_medium=referral&utm_campaign=ent_cyber+risk_aw_e_ukie_int_guardian&utm_content=ghb"
+			buttonText="Explore more"
+			accentColor="#d71920"
+		/>
+	);
+};
+
+WithAccentColour.storyName = 'with accent colour';


### PR DESCRIPTION
## What does this change?
This PR builds on the initial Hosted Content Gallery redesign work from the branch cemms1/hosted-gallery.

- Introduces a reusable CTA button component that can be used on its own or inside CallToActionAtom.
- Adds Storybook coverage for the CTA component.

## Why?
We are rolling out a new Hosted Content Gallery design and layout.

This PR adds a standalone CTA button for Hosted Content Gallery pages, where we only need the button component and not the full CallToActionAtom component.

This will now ready the next phase of importing as a component for the HC Gallery Article.

## Screenshots

| CTA Button      | 
| ----------- | 
| <img width="482" height="188" alt="Screenshot 2026-06-04 at 14 18 06" src="https://github.com/user-attachments/assets/94685b18-8544-4a6d-bd58-654f68552dda" /> |