### PR TITLE
adds new AB test config for intentIQ users in US region

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -134,6 +134,19 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-user-module-intentIq-us-region",
+		description:
+			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module for users in the US",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-06-18",
+		type: "client",
+		status: "ON",
+		audienceSize: 5 / 100,
+		audienceSpace: "A",
+		groups: ["holdback"],
+		shouldForceMetricsCollection: true,
+	},
+	{
 		name: "commercial-teads-prebid",
 		description:
 			"Test to measure the impact of adding Teads as a bidder in prebid .",


### PR DESCRIPTION
## What does this change?
Adds a new AB test configuration for commercial-user-module-intentIq-us-region with a 5% holdback cohort.

## Why?
IntentIQ is already enabled via the existing cross-region experiment.
For US traffic, we want a dedicated holdback model to measure impact more clearly while keeping audience allocation in Group A low.

This test is configured so that:

95% of US users are exposed to IntentIQ
5% of US users are kept in holdback (control)
To support this setup, DCR will use inverted test logic for this experiment: users not in the holdback group receive the feature.
