### PR TITLE
Fix Youtube player on hosted content pages

### DIFF
--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -74,7 +74,11 @@ import {
 } from '../layouts/lib/interactiveLegacyStyling';
 import type { ServerSideTests, Switches } from '../types/config';
 import type { FEElement, RoleType, StarRating } from '../types/content';
-import { ArticleDesign, type ArticleFormat } from './articleFormat';
+import {
+	ArticleDesign,
+	type ArticleFormat,
+	isHostedContentDesign,
+} from './articleFormat';
 import type { EditionId } from './edition';
 import { getLargestImageSize } from './image';
 
@@ -180,11 +184,6 @@ export const renderElement = ({
 	const isBlog =
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
-
-	const isHostedContent =
-		format.design === ArticleDesign.HostedArticle ||
-		format.design === ArticleDesign.HostedVideo ||
-		format.design === ArticleDesign.HostedGallery;
 
 	const renderAds = !isAdFreeUser && !shouldHideAds;
 
@@ -974,7 +973,8 @@ export const renderElement = ({
 						altText={element.altText}
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
-						enableAds={!isHostedContent} // YT ads on by default on all pages apart from hosted content
+						// YT ads on by default on all pages apart from hosted content
+						enableAds={!isHostedContentDesign(format.design)}
 						hidePillOnMobile={false}
 						contentType={contentType}
 						contentLayout={contentLayout}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -181,6 +181,11 @@ export const renderElement = ({
 		format.design === ArticleDesign.LiveBlog ||
 		format.design === ArticleDesign.DeadBlog;
 
+	const isHostedContent =
+		format.design === ArticleDesign.HostedArticle ||
+		format.design === ArticleDesign.HostedVideo ||
+		format.design === ArticleDesign.HostedGallery;
+
 	const renderAds = !isAdFreeUser && !shouldHideAds;
 
 	switch (element._type) {
@@ -969,7 +974,7 @@ export const renderElement = ({
 						altText={element.altText}
 						origin={host}
 						stickyVideos={!!(isBlog && switches.stickyVideos)}
-						enableAds={true}
+						enableAds={!isHostedContent} // YT ads on by default on all pages apart from hosted content
 						hidePillOnMobile={false}
 						contentType={contentType}
 						contentLayout={contentLayout}


### PR DESCRIPTION
## What does this change?

Sets `enableAds` as false on the `YoutubeBlockComponent` for hosted content pages

## Why?

The Youtube player does not work on hosted content pages at the moment.
This seems to be because we expect ads to be allowed but we don't provide any ad targeting.

We don't want to show ads on youtube videos on these types of pages so we should explicitly turn ads off

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b2940b7a-26eb-440c-8065-d10cea3c7e1c
[after]: https://github.com/user-attachments/assets/a9fe99db-e802-4f35-9b9f-b2d6928e49d4