### PR TITLE
Prefer M3U8 sources for long-form video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -35,7 +35,7 @@ export const SelfHostedVideoInArticle = ({
 	caption,
 }: SelfHostedVideoInArticleProps) => {
 	const posterImageUrl = element.posterImage?.[0]?.url;
-	const sources = extractValidSourcesFromAssets(element.assets);
+	const sources = extractValidSourcesFromAssets(element.assets, videoStyle);
 	const aspectRatio = getAspectRatioFromSources(sources);
 	const firstVideoSource = sources[0];
 

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -93,7 +93,10 @@ describe('video', () => {
 		it('should drop unsupported assets', () => {
 			const assets = [mp4Asset480w, m3u8Asset720h, unsupportedAsset];
 			const expected = [mp4Src480w, m3u8Src720h];
-			expect(extractValidSourcesFromAssets(assets)).toEqual(expected);
+
+			expect(extractValidSourcesFromAssets(assets, 'Loop')).toEqual(
+				expected,
+			);
 		});
 
 		it('should reorder sources by supportedVideoFileTypes order', () => {
@@ -111,7 +114,36 @@ describe('video', () => {
 				m3u8Src720h,
 				m3u8Src720h,
 			];
-			expect(extractValidSourcesFromAssets(assets)).toEqual(expected);
+			expect(extractValidSourcesFromAssets(assets, 'Loop')).toEqual(
+				expected,
+			);
+		});
+
+		it('should prefer M3U8 sources with Default video style', () => {
+			const assets = [mp4Asset480w, m3u8Asset720h, mp4Asset720h];
+			const expected = [m3u8Src720h, mp4Src480w, mp4Src720h];
+
+			expect(extractValidSourcesFromAssets(assets, 'Default')).toEqual(
+				expected,
+			);
+		});
+
+		it('should prefer MP4 sources with Loop video style', () => {
+			const assets = [mp4Asset480w, m3u8Asset720h, mp4Asset720h];
+			const expected = [mp4Src480w, mp4Src720h, m3u8Src720h];
+
+			expect(extractValidSourcesFromAssets(assets, 'Loop')).toEqual(
+				expected,
+			);
+		});
+
+		it('should prefer MP4 sources with Cinemagraph video style', () => {
+			const assets = [mp4Asset480w, m3u8Asset720h, mp4Asset720h];
+			const expected = [mp4Src480w, mp4Src720h, m3u8Src720h];
+
+			expect(
+				extractValidSourcesFromAssets(assets, 'Cinemagraph'),
+			).toEqual(expected);
 		});
 	});
 

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -1,5 +1,6 @@
 import type { FEMediaAsset } from '../frontend/feFront';
 import type { VideoAssets } from '../types/content';
+import type { VideoPlayerFormat } from '../types/mainMedia';
 
 export type CustomPlayEventDetail = { uniqueId: string };
 
@@ -25,13 +26,27 @@ export type Source = {
 /**
  * Order is important here - the browser will use the first type it supports.
  */
-export const supportedVideoFileTypes = [
-	'video/mp4', // MP4 format
+const m3u8FileTypes = [
 	'application/x-mpegURL', // HLS format
 	'application/vnd.apple.mpegurl', // Alternative HLS format
 ] as const;
 
-export type SupportedVideoFileType = (typeof supportedVideoFileTypes)[number];
+const mp4FileTypes = [
+	'video/mp4', // MP4 format
+] as const;
+
+const allSupportedVideoFileTypes = [...mp4FileTypes, ...m3u8FileTypes] as const;
+
+export const supportedFileTypesPreferM3U8 = Array.from(
+	new Set([...m3u8FileTypes, ...allSupportedVideoFileTypes]),
+);
+
+export const supportedFileTypesPreferMp4 = Array.from(
+	new Set([...mp4FileTypes, ...allSupportedVideoFileTypes]),
+);
+
+export type SupportedVideoFileType =
+	(typeof allSupportedVideoFileTypes)[number];
 
 /**
  * The looping video player types its `sources` attribute as `Sources`.
@@ -41,12 +56,17 @@ export type SupportedVideoFileType = (typeof supportedVideoFileTypes)[number];
  */
 export const extractValidSourcesFromAssets = (
 	assets: VideoAssets[],
-): Source[] =>
+	videoStyle: VideoPlayerFormat,
+): Source[] => {
 	/**
-	 * Ensure sources are ordered by the order that MIME types are specified in
-	 * `supportedVideoFileTypes` as the browser picks the first one that it supports.
+	 * Sources are ordered because the browser will use the first source that it supports.
 	 */
-	supportedVideoFileTypes.reduce<Source[]>((acc, type) => {
+	const orderedMimeTypes =
+		videoStyle === 'Default'
+			? supportedFileTypesPreferM3U8
+			: supportedFileTypesPreferMp4;
+
+	return orderedMimeTypes.reduce<Source[]>((acc, type) => {
 		const sourcesByType = assets.filter(
 			({ mimeType }) => mimeType === type,
 		);
@@ -65,6 +85,7 @@ export const extractValidSourcesFromAssets = (
 		}
 		return acc;
 	}, []);
+};
 
 export const convertFEMediaAssetsToVideoAssets = (
 	assets: FEMediaAsset[],
@@ -145,7 +166,11 @@ export const findOptimisedSourcePerMimeType = (
 	sources: Source[],
 	screenWidth: number,
 ): Source[] => {
-	return supportedVideoFileTypes.reduce<Source[]>((acc, type) => {
+	const uniqueMimeTypes = Array.from(
+		new Set(sources.map(({ mimeType }) => mimeType)),
+	);
+
+	return uniqueMimeTypes.reduce<Source[]>((acc, type) => {
 		const sourcesForMimeType = sources.filter(
 			({ mimeType }) => mimeType === type,
 		);

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -232,15 +232,21 @@ export const getActiveMediaAtom = (
 				cardTrailImage,
 			);
 
+			const videoStyle = mediaAtom.videoPlayerFormat ?? 'Loop';
+
 			const videoAssets =
 				convertFEMediaAssetsToVideoAssets(selfHostedAssets);
-			const sources = extractValidSourcesFromAssets(videoAssets);
+
+			const sources = extractValidSourcesFromAssets(
+				videoAssets,
+				videoStyle,
+			);
 
 			const aspectRatio = getAspectRatioFromSources(sources);
 
 			return {
 				type: 'SelfHostedVideo',
-				videoStyle: mediaAtom.videoPlayerFormat ?? 'Loop',
+				videoStyle,
 				atomId: mediaAtom.id,
 				sources,
 				subtitleSource: subtitleAsset?.id,


### PR DESCRIPTION
## What does this change?

For self-hosted long-form (Default style) video, reorder the sources so that the browser will prefer to use an M3U8 source if one is available.

## Why?

Following [an investigation](https://docs.google.com/document/d/1cQmqY1EDiOAhWb2_a7fv3xopvg83lFlsdHaStXAZmqU/edit?tab=t.0#heading=h.q6qdaohvpr47), we have decided to prefer to use M3U8 sources for long-form video, whilst still prefering MP4s for loops and cinemagraphs.

## Screenshots

### M3U8

<img width="1126" height="809" alt="image" src="https://github.com/user-attachments/assets/08fa6d7e-525c-4d0b-9286-1cbe52ea7345" />

### MP4

<img width="1133" height="638" alt="image" src="https://github.com/user-attachments/assets/9c513c2a-60b8-4a88-9f91-4e76564dc78d" />


