### PR TITLE
Hide controls when mouse is stationary. Update transition timing values

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1269,7 +1269,6 @@ export const SelfHostedVideo = ({
 						showFadeableControls && hideControlsStyles,
 						hideFadeableControls && showControlsStyles,
 					]}
-					onMouseOver={showControlsAndStartTimer}
 					onMouseMove={showControlsAndStartTimer}
 				>
 					<SelfHostedVideoPlayer

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -53,8 +53,8 @@ const VISIBILITY_THRESHOLD = 0.5;
 /**
  * The duration in ms for which controls are displayed before fading out.
  */
-const CONTROLS_FADE_DELAY = 2700;
-const PLAY_BUTTON_FADE_DELAY = 1700;
+const CONTROLS_FADE_DELAY = 3_000;
+const PLAY_BUTTON_FADE_DELAY = 1_500;
 
 const cardStyles = (
 	isInteractive: boolean,
@@ -182,9 +182,6 @@ const fullscreenStyles = css`
 const showTransitionStyles = css`
 	visibility: visible;
 	opacity: 1;
-	transition:
-		visibility 0.2s,
-		opacity 0.2s ease-in-out;
 `;
 
 const showControlsStyles = css`
@@ -200,19 +197,22 @@ const showControlsStyles = css`
 const hideTransitionStyles = css`
 	visibility: hidden;
 	opacity: 0;
-	transition:
-		visibility 0.3s,
-		opacity 0.3s ease-in-out;
 `;
 
 const hideControlsStyles = css`
 	.controls-container {
 		${hideTransitionStyles}
+		transition:
+			visibility 500ms,
+			opacity 500ms ease-in-out;
 		transition-delay: ${CONTROLS_FADE_DELAY}ms;
 	}
 
 	.play-pause-icon {
 		${hideTransitionStyles}
+		transition:
+			visibility 400ms,
+			opacity 400ms ease-in-out;
 		transition-delay: ${PLAY_BUTTON_FADE_DELAY}ms;
 	}
 `;

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -215,12 +215,6 @@ const hideControlsStyles = css`
 		${hideTransitionStyles}
 		transition-delay: ${PLAY_BUTTON_FADE_DELAY}ms;
 	}
-
-	@media (hover: hover) {
-		:hover {
-			${showControlsStyles}
-		}
-	}
 `;
 
 /**
@@ -524,6 +518,17 @@ export const SelfHostedVideo = ({
 	const optimisedPosterImage = showPosterImage
 		? getOptimisedPosterImage(posterImage, posterImageAspectRatio)
 		: undefined;
+
+	const showFadeableControls =
+		videoStyleSettings.hideControlsWhenNotInteractedWith &&
+		!showControls &&
+		playerState === 'PLAYING';
+
+	const hideFadeableControls =
+		videoStyleSettings.hideControlsWhenNotInteractedWith &&
+		showControls &&
+		(playerState === 'PAUSED_BY_USER' ||
+			playerState === 'PAUSED_BY_BROWSER');
 
 	const ophanVideoStyle = videoStyle.toLowerCase() as OphanVideoStyle;
 
@@ -1261,15 +1266,8 @@ export const SelfHostedVideo = ({
 							containerAspectRatioDesktop,
 						),
 						fullscreenStyles,
-						videoStyleSettings.hideControlsWhenNotInteractedWith &&
-							!showControls &&
-							playerState === 'PLAYING' &&
-							hideControlsStyles,
-						videoStyleSettings.hideControlsWhenNotInteractedWith &&
-							showControls &&
-							(playerState === 'PAUSED_BY_USER' ||
-								playerState === 'PAUSED_BY_BROWSER') &&
-							showControlsStyles,
+						showFadeableControls && hideControlsStyles,
+						hideFadeableControls && showControlsStyles,
 					]}
 					onMouseOver={showControlsAndStartTimer}
 				>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1270,6 +1270,7 @@ export const SelfHostedVideo = ({
 						hideFadeableControls && showControlsStyles,
 					]}
 					onMouseOver={showControlsAndStartTimer}
+					onMouseMove={showControlsAndStartTimer}
 				>
 					<SelfHostedVideoPlayer
 						sources={optimisedSources}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -179,29 +179,22 @@ const fullscreenStyles = css`
 	}
 `;
 
-const showTransitionStyles = css`
-	visibility: visible;
-	opacity: 1;
-`;
-
 const showControlsStyles = css`
 	.controls-container {
-		${showTransitionStyles};
+		visibility: visible;
+		opacity: 1;
 	}
 
 	.play-pause-icon {
-		${showTransitionStyles};
+		visibility: visible;
+		opacity: 1;
 	}
-`;
-
-const hideTransitionStyles = css`
-	visibility: hidden;
-	opacity: 0;
 `;
 
 const hideControlsStyles = css`
 	.controls-container {
-		${hideTransitionStyles}
+		visibility: hidden;
+		opacity: 0;
 		transition:
 			visibility 500ms,
 			opacity 500ms ease-in-out;
@@ -209,7 +202,8 @@ const hideControlsStyles = css`
 	}
 
 	.play-pause-icon {
-		${hideTransitionStyles}
+		visibility: hidden;
+		opacity: 0;
 		transition:
 			visibility 400ms,
 			opacity 400ms ease-in-out;


### PR DESCRIPTION
## What does this change?

- Hide controls when hovering with a mouse and the cursor is not moving. The controls display again once the cursor moves over the video
- Updates transition values to bring consistency across platforms:
    - The pause icon fades after 1.5 seconds and takes 0.4 seconds to fade out. 
    - The controls fade after 3 seconds and take 0.5 seconds to fade out.
 
## Why?

- Design request
- Transition values are now the same as iOS and Android.

## Screenshares

https://github.com/user-attachments/assets/5306d8ce-1894-4e01-bb27-24a88dc934fa

