### PR TITLE
Wire up dedicated renderer for hosted content on apps

### DIFF
--- a/dotcom-rendering/src/server/handler.article.apps.ts
+++ b/dotcom-rendering/src/server/handler.article.apps.ts
@@ -5,7 +5,11 @@ import { validateAsBlock, validateAsFEArticle } from '../model/validate';
 import { enhanceArticleType } from '../types/article';
 import type { FEBlocksRequest } from '../types/frontend';
 import { makePrefetchHeader } from './lib/header';
-import { renderAppsBlocks, renderArticle } from './render.article.apps';
+import {
+	renderAppsBlocks,
+	renderArticle,
+	renderHostedContent,
+} from './render.article.apps';
 
 export const handleAppsArticle: RequestHandler = ({ body }, res) => {
 	const frontendData = validateAsFEArticle(body);
@@ -27,7 +31,7 @@ export const handleAppsInteractive: RequestHandler = ({ body }, res) => {
 export const handleAppsHostedContent: RequestHandler = ({ body }, res) => {
 	const frontendData = validateAsFEArticle(body);
 	const article = enhanceArticleType(frontendData, 'Apps');
-	const { html, prefetchScripts } = renderArticle(article);
+	const { html, prefetchScripts } = renderHostedContent(article);
 
 	res.status(200).set('Link', makePrefetchHeader(prefetchScripts)).send(html);
 };


### PR DESCRIPTION
## What does this change?
This PR updates `handleAppsHostedContent` to call the correct `renderHostedContent` function instead of the standard `renderArticle` function.
## Why?
https://github.com/guardian/dotcom-rendering/pull/15937 introduced this so we should use this for apps articles

