### PR TITLE
Stop discarding aspect ratio on M3U8 assets

### DIFF
--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -95,6 +95,7 @@ export interface FEMediaAsset {
 	platform: string;
 	mimeType?: string;
 	assetType: string;
+	aspectRatio?: string;
 	dimensions?: {
 		width: number;
 		height: number;

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -2960,6 +2960,9 @@
                 "assetType": {
                     "type": "string"
                 },
+                "aspectRatio": {
+                    "type": "string"
+                },
                 "dimensions": {
                     "type": "object",
                     "properties": {

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -1131,6 +1131,9 @@
                 "assetType": {
                     "type": "string"
                 },
+                "aspectRatio": {
+                    "type": "string"
+                },
                 "dimensions": {
                     "type": "object",
                     "properties": {

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -90,9 +90,10 @@ export const extractValidSourcesFromAssets = (
 export const convertFEMediaAssetsToVideoAssets = (
 	assets: FEMediaAsset[],
 ): VideoAssets[] =>
-	assets.map(({ id, mimeType, dimensions, hasAudio }) => ({
+	assets.map(({ id, mimeType, aspectRatio, dimensions, hasAudio }) => ({
 		url: id,
 		mimeType,
+		aspectRatio,
 		dimensions,
 		hasAudio,
 	}));


### PR DESCRIPTION
## What does this change?

Adds aspect ratio to the `FEMediaAsset` model and passes aspect ratio along when converting `FEMediaAssets` to `VideoAssets`.

## Why?

So we use the aspect ratio on the asset when dimensions are not given to calculate the aspect ratio for the video.

## Screenshots

Affects M3U8 videos where dimensions are not provided.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0194f831-9361-4627-995e-c25ba98ab772
[after]: https://github.com/user-attachments/assets/6f586f2a-6bdf-4a30-babd-f7d8f1850c0c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
