### PR TITLE
Prod endpoint `AppsFootballMatchSummaryPage` uses POST route handler

### DIFF
--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -71,7 +71,7 @@ export const prodServer = (): void => {
 	app.post('/EditionsCrossword', handleEditionsCrossword);
 	app.post('/AppsHostedContent', handleAppsHostedContent);
 	app.post('/AppsComponent/thrasher/:name', handleAppsThrasher);
-	app.use('/AppsFootballMatchSummaryPage', handleAppsFootballMatchPage);
+	app.post('/AppsFootballMatchSummaryPage', handleAppsFootballMatchPage);
 
 	app.get('/assets/rendered-items-assets', handleAppsAssets);
 


### PR DESCRIPTION
## What does this change?

Prod endpoint `AppsFootballMatchSummaryPage` uses POST route handler

## Why?

Align with other routes


