### PR TITLE
[WIP] add iab tags to FEArticle type to be recieved from frontend as data

### DIFF
--- a/dotcom-rendering/src/frontend/feArticle.ts
+++ b/dotcom-rendering/src/frontend/feArticle.ts
@@ -25,6 +25,29 @@ import type { FETrailType } from '../types/trails';
  * WARNING: run `gen-schema` task if changing this to update the associated JSON
  * schema definition.
  */
+
+type IabSegment = {
+	id: string;
+	name: string;
+};
+
+type IabTaxonomy = {
+	taxonomy: string;
+	segtax: number;
+	segments: IabSegment[];
+};
+
+type IabModel = {
+	model_id: string;
+	model_version: string;
+	description: string;
+	taxonomies: IabTaxonomy[];
+};
+
+export type IabTaxonomyCapiData = {
+	content_id: string;
+	models: IabModel[];
+};
 export interface FEArticle {
 	headline: string;
 	standfirst: string;
@@ -39,6 +62,7 @@ export interface FEArticle {
 	byline?: string;
 	/** @deprecated - will be removed in the next model version */
 	author?: unknown;
+	iabTaxonomyTags?: IabTaxonomyCapiData;
 
 	/**
 	 * @TJS-format date-time

--- a/dotcom-rendering/src/server/iab-taxonomy-sample.ts
+++ b/dotcom-rendering/src/server/iab-taxonomy-sample.ts
@@ -1,0 +1,47 @@
+const iabTaxonomyCAPIData = {
+	content_id: 'article-12345',
+	models: [
+		{
+			model_id: 'primary',
+			model_version: 'v1.0',
+			description: 'Primary tags only',
+			taxonomies: [
+				{
+					taxonomy: 'IAB_CONTENT_2_2',
+					segtax: 2,
+					segments: [{ id: 'IAB1-6', name: 'Movies' }],
+				},
+				{
+					taxonomy: 'IAB_CONTENT_3_0',
+					segtax: 6,
+					segments: [{ id: 'entertainment.movies', name: 'Movies' }],
+				},
+			],
+		},
+		{
+			model_id: 'primary_secondary',
+			model_version: 'v1.0',
+			description: 'Primary + secondary tags',
+			taxonomies: [
+				{
+					taxonomy: 'IAB_CONTENT_2_2',
+					segtax: 2,
+					segments: [
+						{ id: 'IAB1-6', name: 'Movies' },
+						{ id: 'IAB1', name: 'Arts & Entertainment' },
+					],
+				},
+				{
+					taxonomy: 'IAB_CONTENT_3_0',
+					segtax: 6,
+					segments: [
+						{ id: 'entertainment.movies', name: 'Movies' },
+						{ id: 'entertainment', name: 'Entertainment' },
+					],
+				},
+			],
+		},
+	],
+};
+
+export { iabTaxonomyCAPIData };

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -175,7 +175,7 @@ export const enhanceArticleType = (
 		storyPackage,
 		serverTime,
 		frontendData: {
-			...data,
+			...data, // this is the data coming in from frontend POST
 			mainMediaElements,
 			blocks,
 			pinnedPost: enhancePinnedPost(


### PR DESCRIPTION
## What does this change?
Adds IabTaxonomy nad related types to the `feArticle` module
## Why?
This is a WIP and designed to facilitate the incoming IAB content taxonomy tags from DCR so that we can process and transform and integrate these appropriately for Prebid
## Screenshots
<img width="203" height="417" alt="Screenshot 2026-07-08 at 10 52 26" src="https://github.com/user-attachments/assets/91ed47ab-75f6-4045-908b-16f41848fcc5" />
