### PR TITLE
Add Hosted Gallery Layout

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -888,7 +888,8 @@ export const ArticleHeadline = ({
 							</h1>
 						</div>
 					);
-				case ArticleDesign.Gallery: {
+				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery: {
 					return (
 						<div css={galleryStyles}>
 							<WithAgeWarning

--- a/dotcom-rendering/src/components/ArticleTitle.tsx
+++ b/dotcom-rendering/src/components/ArticleTitle.tsx
@@ -65,7 +65,9 @@ export const ArticleTitle = ({
 }: Props) => (
 	<div
 		css={[
-			format.design === ArticleDesign.Gallery && galleryStyles,
+			[ArticleDesign.Gallery, ArticleDesign.HostedGallery].includes(
+				format.design,
+			) && galleryStyles,
 			sectionStyles,
 		]}
 	>

--- a/dotcom-rendering/src/components/HostedContentPage.tsx
+++ b/dotcom-rendering/src/components/HostedContentPage.tsx
@@ -28,55 +28,52 @@ interface AppProps extends BaseProps {
 	renderingTarget: 'Apps';
 }
 
+const decideLayout = (article: Article, renderingTarget: 'Web' | 'Apps') => {
+	const format = {
+		design: article.design,
+		display: article.display,
+		theme: article.theme,
+	};
+	switch (article.design) {
+		case ArticleDesign.HostedGallery:
+			return (
+				<HostedGalleryLayout
+					gallery={article}
+					format={format}
+					renderingTarget={renderingTarget}
+				/>
+			);
+		case ArticleDesign.HostedVideo:
+			return (
+				<HostedVideoLayout
+					content={article}
+					format={article}
+					renderingTarget={renderingTarget}
+				/>
+			);
+		case ArticleDesign.HostedArticle:
+			return (
+				<HostedArticleLayout
+					content={article}
+					format={format}
+					renderingTarget={renderingTarget}
+				/>
+			);
+		default:
+			return null;
+	}
+};
+
 /**
  * @description
  * HostedContentPage is a high level wrapper for hosted content pages on Dotcom. Sets strict mode and some globals
  */
 export const HostedContentPage = (props: WebProps | AppProps) => {
-	const {
-		article: { design, display, theme, frontendData },
-		renderingTarget,
-	} = props;
-
+	const { article, renderingTarget } = props;
+	const { frontendData, design, display, theme } = article;
 	const isWeb = renderingTarget === 'Web';
 	const { darkModeAvailable } = useConfig();
-
-	const format = {
-		design,
-		display,
-		theme,
-	};
-
-	const decideLayout = () => {
-		switch (format.design) {
-			case ArticleDesign.HostedVideo:
-				return (
-					<HostedVideoLayout
-						content={props.article}
-						format={format}
-						renderingTarget={renderingTarget}
-					/>
-				);
-			case ArticleDesign.HostedGallery:
-				return (
-					<HostedGalleryLayout
-						content={props.article}
-						format={format}
-						renderingTarget={renderingTarget}
-					/>
-				);
-			case ArticleDesign.HostedArticle:
-				return (
-					<HostedArticleLayout
-						content={props.article}
-						format={format}
-						renderingTarget={renderingTarget}
-					/>
-				);
-			default:
-				return null;
-		}
-	};
+	const format = { design, display, theme };
 
 	return (
 		<StrictMode>
@@ -137,7 +134,7 @@ export const HostedContentPage = (props: WebProps | AppProps) => {
 				</DarkModeMessage>
 			)}
 
-			{decideLayout()}
+			{decideLayout(article, renderingTarget)}
 		</StrictMode>
 	);
 };

--- a/dotcom-rendering/src/components/MainMediaGallery.tsx
+++ b/dotcom-rendering/src/components/MainMediaGallery.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { from } from '@guardian/source/foundations';
 import { grid } from '../grid';
-import { type ArticleFormat } from '../lib/articleFormat';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { getImage } from '../lib/image';
 import { type ImageBlockElement } from '../types/content';
 import { type RenderingTarget } from '../types/renderingTarget';
@@ -27,11 +27,24 @@ const styles = css`
 	}
 `;
 
+/**
+ * We don't show main media on hosted gallery pages
+ * but need to do this to keep the rest of the grid layout happy
+ */
+const hostedStyles = css`
+	${grid.column.all}
+	grid-row: 1/8;
+	height: 0;
+`;
+
 export const MainMediaGallery = ({
 	mainMedia,
 	format,
 	renderingTarget,
 }: Props) => {
+	if (format.design === ArticleDesign.HostedGallery) {
+		return <div css={hostedStyles}></div>;
+	}
 	// This is to support some galleries created in 2007 where mainMedia is missing
 	if (isUndefined(mainMedia)) {
 		return <div css={styles}></div>;

--- a/dotcom-rendering/src/components/OnwardsUpper.island.tsx
+++ b/dotcom-rendering/src/components/OnwardsUpper.island.tsx
@@ -318,7 +318,9 @@ export const OnwardsUpper = ({
 	const showCuratedContainer =
 		!!curatedDataUrl && !isPaidContent && canHaveCuratedContent;
 
-	const isGalleryArticle = format.design === ArticleDesign.Gallery;
+	const isGalleryArticle =
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery;
 
 	return (
 		<div css={onwardsWrapper}>

--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -83,6 +83,7 @@ const decideFont = ({ display, design, theme }: ArticleFormat) => {
 	const isLabs = theme === ArticleSpecial.Labs;
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			if (isLabs) {
 				return css`
 					${textSansBold15};
@@ -322,6 +323,7 @@ const standfirstStyles = ({ display, design, theme }: ArticleFormat) => {
 						color: ${palette('--standfirst-text')};
 					`;
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return css`
 						${grid.span('centre-column-start', 5)}
 						color: ${palette('--standfirst-text')};

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -185,7 +185,7 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 				case ArticleDesign.HostedGallery:
 					return (
 						<HostedGalleryLayout
-							content={article}
+							gallery={article}
 							format={format}
 							renderingTarget={renderingTarget}
 						/>
@@ -398,7 +398,7 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 				case ArticleDesign.HostedGallery:
 					return (
 						<HostedGalleryLayout
-							content={article}
+							gallery={article}
 							format={format}
 							renderingTarget={renderingTarget}
 						/>

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
@@ -28,8 +28,8 @@ const format = {
 };
 
 const appsHostedGallery = enhanceArticleType(hostedGallery, 'Apps');
-if (appsHostedGallery.design !== ArticleDesign.Gallery) {
-	throw new Error('Expected gallery');
+if (appsHostedGallery.design !== ArticleDesign.HostedGallery) {
+	throw new Error('Expected hosted gallery');
 }
 export const Apps = meta.story({
 	args: {
@@ -45,8 +45,8 @@ export const Apps = meta.story({
 });
 
 const webHostedGallery = enhanceArticleType(hostedGallery, 'Web');
-if (webHostedGallery.design !== ArticleDesign.Gallery) {
-	throw new Error('Expected gallery');
+if (webHostedGallery.design !== ArticleDesign.HostedGallery) {
+	throw new Error('Expected hosted gallery');
 }
 export const Web = meta.story({
 	args: {

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
@@ -27,9 +27,13 @@ const format = {
 	display: ArticleDisplay.Standard,
 };
 
+const appsHostedGallery = enhanceArticleType(hostedGallery, 'Apps');
+if (appsHostedGallery.design !== ArticleDesign.Gallery) {
+	throw new Error('Expected gallery');
+}
 export const Apps = meta.story({
 	args: {
-		content: enhanceArticleType(hostedGallery, 'Apps'),
+		gallery: appsHostedGallery,
 		format,
 		renderingTarget: 'Apps',
 	},
@@ -40,9 +44,13 @@ export const Apps = meta.story({
 	},
 });
 
+const webHostedGallery = enhanceArticleType(hostedGallery, 'Web');
+if (webHostedGallery.design !== ArticleDesign.Gallery) {
+	throw new Error('Expected gallery');
+}
 export const Web = meta.story({
 	args: {
-		content: enhanceArticleType(hostedGallery, 'Web'),
+		gallery: webHostedGallery,
 		format,
 		renderingTarget: 'Web',
 	},

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -5,21 +5,18 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
-import { ArticleMetaApps } from '../components/ArticleMeta.apps';
-import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
-import { Caption } from '../components/Caption';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
-import { MainMediaGallery } from '../components/MainMediaGallery';
+import { OnwardsUpper } from '../components/OnwardsUpper.island';
 import { Section } from '../components/Section';
+import { ShareButton } from '../components/ShareButton.island';
 import { Standfirst } from '../components/Standfirst';
 import { grid } from '../grid';
 import type { ArticleFormat } from '../lib/articleFormat';
-import { decideMainMediaCaption } from '../lib/decide-caption';
 import { palette } from '../palette';
-import type { ArticleDeprecated, Gallery } from '../types/article';
+import type { Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
@@ -47,20 +44,34 @@ const headerStyles = css`
 	}
 `;
 
+const metaStyles = css`
+	${grid.column.centre}
+	grid-row-start: 3;
+
+	${from.desktop} {
+		grid-row-start: 2;
+	}
+
+	${from.leftCol} {
+		${grid.column.left}
+	}
+`;
+
+const shareButtonStyles = css`
+	margin-top: ${space[4]}px;
+	padding: ${space[1]}px;
+`;
+
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const { content, renderingTarget, format } = props;
+	const { content, renderingTarget, format, serverTime } = props;
 	const { frontendData } = content;
 	const { commercialProperties, editionId } = frontendData;
 
 	const { branding } = commercialProperties[editionId];
 
-	const isWeb = renderingTarget === 'Web';
-
-	const captionText = decideMainMediaCaption(content.mainMedia);
-
 	return (
 		<>
-			{isWeb && branding ? (
+			{branding ? (
 				<Stuck>
 					<Section
 						fullWidth={true}
@@ -84,11 +95,6 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 				}}
 			>
 				<header css={headerStyles}>
-					<MainMediaGallery
-						mainMedia={content.mainMedia}
-						format={format}
-						renderingTarget={props.renderingTarget}
-					/>
 					<ArticleTitle
 						format={format}
 						tags={frontendData.tags}
@@ -109,16 +115,24 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						format={format}
 						standfirst={frontendData.standfirst}
 					/>
-					<Caption
-						captionText={captionText}
-						format={format}
-						isMainMedia={true}
-					/>
-					<Meta
-						renderingTarget={renderingTarget}
-						format={format}
-						frontendData={frontendData}
-					/>
+
+					<div data-print-layout="hide" css={metaStyles}>
+						{renderingTarget === 'Web' && (
+							<div css={shareButtonStyles}>
+								<Island
+									priority="feature"
+									defer={{ until: 'visible' }}
+								>
+									<ShareButton
+										pageId={frontendData.pageId}
+										webTitle={frontendData.webTitle}
+										format={format}
+										context="ArticleMeta"
+									/>
+								</Island>
+							</div>
+						)}
+					</div>
 				</header>
 				<GalleryBody
 					renderingTarget={renderingTarget}
@@ -128,78 +142,31 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					webTitle={frontendData.webTitle}
 				/>
 			</main>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<OnwardsUpper
+					ajaxUrl={frontendData.config.ajaxUrl}
+					hasRelated={frontendData.hasRelated}
+					hasStoryPackage={frontendData.hasStoryPackage}
+					isAdFreeUser={frontendData.isAdFreeUser}
+					pageId={frontendData.pageId}
+					isPaidContent={!!frontendData.config.isPaidContent}
+					showRelatedContent={frontendData.config.showRelatedContent}
+					keywordIds={frontendData.config.keywordIds}
+					contentType={frontendData.contentType}
+					tags={frontendData.tags}
+					format={format}
+					pillar={format.theme}
+					editionId={frontendData.editionId}
+					shortUrlId={frontendData.config.shortUrlId}
+					discussionApiUrl={frontendData.config.discussionApiUrl}
+					serverTime={serverTime}
+					renderingTarget={renderingTarget}
+					webURL={frontendData.webURL}
+				/>
+			</Island>
 		</>
 	);
 };
-
-const Meta = ({
-	renderingTarget,
-	format,
-	frontendData,
-}: {
-	renderingTarget: RenderingTarget;
-	format: ArticleFormat;
-	frontendData: ArticleDeprecated;
-}) => (
-	<div
-		css={{
-			'&': css(grid.column.centre),
-			paddingBottom: space[6],
-			[from.tablet]: {
-				position: 'relative',
-				'&::before': {
-					content: '""',
-					position: 'absolute',
-					left: -10,
-					top: 0,
-					bottom: 0,
-					width: 1,
-					backgroundColor: palette('--article-border'),
-				},
-			},
-		}}
-	>
-		{renderingTarget === 'Web' ? (
-			<ArticleMeta
-				branding={
-					frontendData.commercialProperties[frontendData.editionId]
-						.branding
-				}
-				format={format}
-				pageId={frontendData.pageId}
-				webTitle={frontendData.webTitle}
-				byline={frontendData.byline}
-				tags={frontendData.tags}
-				primaryDateline={frontendData.webPublicationDateDisplay}
-				secondaryDateline={
-					frontendData.webPublicationSecondaryDateDisplay
-				}
-				isCommentable={frontendData.isCommentable}
-				discussionApiUrl={frontendData.config.discussionApiUrl}
-				shortUrlId={frontendData.config.shortUrlId}
-			/>
-		) : null}
-		{renderingTarget === 'Apps' ? (
-			<ArticleMetaApps
-				branding={
-					frontendData.commercialProperties[frontendData.editionId]
-						.branding
-				}
-				format={format}
-				pageId={frontendData.pageId}
-				byline={frontendData.byline}
-				tags={frontendData.tags}
-				primaryDateline={frontendData.webPublicationDateDisplay}
-				secondaryDateline={
-					frontendData.webPublicationSecondaryDateDisplay
-				}
-				isCommentable={frontendData.isCommentable}
-				discussionApiUrl={frontendData.config.discussionApiUrl}
-				shortUrlId={frontendData.config.shortUrlId}
-			/>
-		) : null}
-	</div>
-);
 
 const GalleryBody = (props: {
 	renderingTarget: RenderingTarget;

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -21,7 +21,7 @@ import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
-	content: Gallery;
+	gallery: Gallery;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
 	serverTime?: number;
@@ -63,8 +63,8 @@ const shareButtonStyles = css`
 `;
 
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const { content, renderingTarget, format, serverTime } = props;
-	const { frontendData } = content;
+	const { gallery, renderingTarget, format, serverTime } = props;
+	const { frontendData } = gallery;
 	const { commercialProperties, editionId } = frontendData;
 
 	const { branding } = commercialProperties[editionId];
@@ -137,7 +137,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 				<GalleryBody
 					renderingTarget={renderingTarget}
 					format={format}
-					bodyElements={content.bodyElements}
+					bodyElements={gallery.bodyElements}
 					pageId={frontendData.pageId}
 					webTitle={frontendData.webTitle}
 				/>

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -9,6 +9,7 @@ import { ArticleTitle } from '../components/ArticleTitle';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
+import { MainMediaGallery } from '../components/MainMediaGallery';
 import { OnwardsUpper } from '../components/OnwardsUpper.island';
 import { Section } from '../components/Section';
 import { ShareButton } from '../components/ShareButton.island';
@@ -41,19 +42,6 @@ const headerStyles = css`
 
 	${from.tablet} {
 		border-bottom: 1px solid ${palette('--article-border')};
-	}
-`;
-
-const metaStyles = css`
-	${grid.column.centre}
-	grid-row-start: 3;
-
-	${from.desktop} {
-		grid-row-start: 2;
-	}
-
-	${from.leftCol} {
-		${grid.column.left}
 	}
 `;
 
@@ -95,6 +83,11 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 				}}
 			>
 				<header css={headerStyles}>
+					<MainMediaGallery
+						mainMedia={gallery.mainMedia}
+						format={format}
+						renderingTarget={props.renderingTarget}
+					/>
 					<ArticleTitle
 						format={format}
 						tags={frontendData.tags}
@@ -116,8 +109,27 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						standfirst={frontendData.standfirst}
 					/>
 
-					<div data-print-layout="hide" css={metaStyles}>
-						{renderingTarget === 'Web' && (
+					{renderingTarget === 'Web' && (
+						<div
+							data-print-layout="hide"
+							css={{
+								'&': css(grid.column.centre),
+								paddingBottom: space[6],
+								[from.tablet]: {
+									position: 'relative',
+									'&::before': {
+										content: '""',
+										position: 'absolute',
+										left: -10,
+										top: 0,
+										bottom: 0,
+										width: 1,
+										backgroundColor:
+											palette('--article-border'),
+									},
+								},
+							}}
+						>
 							<div css={shareButtonStyles}>
 								<Island
 									priority="feature"
@@ -131,8 +143,8 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 									/>
 								</Island>
 							</div>
-						)}
-					</div>
+						</div>
+					)}
 				</header>
 				<GalleryBody
 					renderingTarget={renderingTarget}

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -4,20 +4,30 @@ import {
 	palette as sourcePalette,
 	space,
 } from '@guardian/source/foundations';
+import { ArticleHeadline } from '../components/ArticleHeadline';
+import { ArticleMetaApps } from '../components/ArticleMeta.apps';
+import { ArticleMeta } from '../components/ArticleMeta.web';
+import { ArticleTitle } from '../components/ArticleTitle';
+import { Caption } from '../components/Caption';
+import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
+import { MainMediaGallery } from '../components/MainMediaGallery';
 import { Section } from '../components/Section';
-import { ShareButton } from '../components/ShareButton.island';
+import { Standfirst } from '../components/Standfirst';
 import { grid } from '../grid';
 import type { ArticleFormat } from '../lib/articleFormat';
-import type { Article } from '../types/article';
+import { decideMainMediaCaption } from '../lib/decide-caption';
+import { palette } from '../palette';
+import type { ArticleDeprecated, Gallery } from '../types/article';
 import type { RenderingTarget } from '../types/renderingTarget';
 import { Stuck } from './lib/stickiness';
 
 interface Props {
-	content: Article;
+	content: Gallery;
 	format: ArticleFormat;
 	renderingTarget: RenderingTarget;
+	serverTime?: number;
 }
 
 interface WebProps extends Props {
@@ -28,29 +38,29 @@ interface AppProps extends Props {
 	renderingTarget: 'Apps';
 }
 
-const border = css`
-	border: 1px solid black;
-`;
+const headerStyles = css`
+	${grid.container}
+	background-color: ${palette('--article-inner-background')};
 
-const metaFlex = css`
-	margin-bottom: ${space[3]}px;
-	display: flex;
-	justify-content: space-between;
-	flex-wrap: wrap;
+	${from.tablet} {
+		border-bottom: 1px solid ${palette('--article-border')};
+	}
 `;
 
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const {
-		content: { frontendData },
-		format,
-	} = props;
+	const { content, renderingTarget, format } = props;
+	const { frontendData } = content;
+	const { commercialProperties, editionId } = frontendData;
 
-	const { branding } =
-		frontendData.commercialProperties[frontendData.editionId];
+	const { branding } = commercialProperties[editionId];
+
+	const isWeb = renderingTarget === 'Web';
+
+	const captionText = decideMainMediaCaption(content.mainMedia);
 
 	return (
 		<>
-			{props.renderingTarget === 'Web' && branding ? (
+			{isWeb && branding ? (
 				<Stuck>
 					<Section
 						fullWidth={true}
@@ -67,54 +77,154 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					</Section>
 				</Stuck>
 			) : null}
-			<main>
-				<header css={[grid.container, border]}>
-					<div
-						css={[grid.between('centre-column-start', 'grid-end')]}
-					>
-						{props.content.frontendData.headline}
-					</div>
-				</header>
-				<div css={[grid.container]}>
-					<article css={[grid.column.all]}>
-						<div css={border}>Gallery</div>
-						<div css={border}>Onward</div>
-					</article>
-				</div>
-				<div
-					css={[
-						grid.container,
-						border,
-						css`
-							padding: ${space[2]}px;
 
-							${from.desktop} {
-								padding: ${space[4]}px ${space[8]}px;
-							}
-						`,
-					]}
-				>
-					<div css={[grid.column.all]}>
-						<div css={[grid.column.left]}>
-							<div data-print-layout="hide" css={metaFlex}>
-								{props.renderingTarget === 'Web' && (
-									<Island
-										priority="feature"
-										defer={{ until: 'visible' }}
-									>
-										<ShareButton
-											pageId={frontendData.pageId}
-											webTitle={frontendData.webTitle}
-											format={format}
-											context="ArticleMeta"
-										/>
-									</Island>
-								)}
-							</div>
-						</div>
-					</div>
-				</div>
+			<main
+				css={{
+					backgroundColor: palette('--article-background'),
+				}}
+			>
+				<header css={headerStyles}>
+					<MainMediaGallery
+						mainMedia={content.mainMedia}
+						format={format}
+						renderingTarget={props.renderingTarget}
+					/>
+					<ArticleTitle
+						format={format}
+						tags={frontendData.tags}
+						sectionLabel={frontendData.sectionLabel}
+						sectionUrl={frontendData.sectionUrl}
+						guardianBaseURL={frontendData.guardianBaseURL}
+					/>
+					<ArticleHeadline
+						format={format}
+						headlineString={frontendData.headline}
+						tags={frontendData.tags}
+						byline={frontendData.byline}
+						webPublicationDateDeprecated={
+							frontendData.webPublicationDateDeprecated
+						}
+					/>
+					<Standfirst
+						format={format}
+						standfirst={frontendData.standfirst}
+					/>
+					<Caption
+						captionText={captionText}
+						format={format}
+						isMainMedia={true}
+					/>
+					<Meta
+						renderingTarget={renderingTarget}
+						format={format}
+						frontendData={frontendData}
+					/>
+				</header>
+				<GalleryBody
+					renderingTarget={renderingTarget}
+					format={format}
+					bodyElements={content.bodyElements}
+					pageId={frontendData.pageId}
+					webTitle={frontendData.webTitle}
+				/>
 			</main>
 		</>
 	);
 };
+
+const Meta = ({
+	renderingTarget,
+	format,
+	frontendData,
+}: {
+	renderingTarget: RenderingTarget;
+	format: ArticleFormat;
+	frontendData: ArticleDeprecated;
+}) => (
+	<div
+		css={{
+			'&': css(grid.column.centre),
+			paddingBottom: space[6],
+			[from.tablet]: {
+				position: 'relative',
+				'&::before': {
+					content: '""',
+					position: 'absolute',
+					left: -10,
+					top: 0,
+					bottom: 0,
+					width: 1,
+					backgroundColor: palette('--article-border'),
+				},
+			},
+		}}
+	>
+		{renderingTarget === 'Web' ? (
+			<ArticleMeta
+				branding={
+					frontendData.commercialProperties[frontendData.editionId]
+						.branding
+				}
+				format={format}
+				pageId={frontendData.pageId}
+				webTitle={frontendData.webTitle}
+				byline={frontendData.byline}
+				tags={frontendData.tags}
+				primaryDateline={frontendData.webPublicationDateDisplay}
+				secondaryDateline={
+					frontendData.webPublicationSecondaryDateDisplay
+				}
+				isCommentable={frontendData.isCommentable}
+				discussionApiUrl={frontendData.config.discussionApiUrl}
+				shortUrlId={frontendData.config.shortUrlId}
+			/>
+		) : null}
+		{renderingTarget === 'Apps' ? (
+			<ArticleMetaApps
+				branding={
+					frontendData.commercialProperties[frontendData.editionId]
+						.branding
+				}
+				format={format}
+				pageId={frontendData.pageId}
+				byline={frontendData.byline}
+				tags={frontendData.tags}
+				primaryDateline={frontendData.webPublicationDateDisplay}
+				secondaryDateline={
+					frontendData.webPublicationSecondaryDateDisplay
+				}
+				isCommentable={frontendData.isCommentable}
+				discussionApiUrl={frontendData.config.discussionApiUrl}
+				shortUrlId={frontendData.config.shortUrlId}
+			/>
+		) : null}
+	</div>
+);
+
+const GalleryBody = (props: {
+	renderingTarget: RenderingTarget;
+	format: ArticleFormat;
+	bodyElements: Gallery['bodyElements'];
+	pageId: string;
+	webTitle: string;
+}) => (
+	<>
+		{props.bodyElements.map((element) => {
+			switch (element._type) {
+				case 'model.dotcomrendering.pageElements.ImageBlockElement':
+					return (
+						<GalleryImage
+							image={element}
+							format={props.format}
+							pageId={props.pageId}
+							webTitle={props.webTitle}
+							renderingTarget={props.renderingTarget}
+							key={element.elementId}
+						/>
+					);
+				default:
+					return null;
+			}
+		})}
+	</>
+);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -107,6 +107,7 @@ const headlineTextLight: PaletteFunction = ({ design, display, theme }) => {
 					}
 				}
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[100];
 				case ArticleDesign.LiveBlog: {
 					switch (theme) {
@@ -179,6 +180,7 @@ const headlineTextDark: PaletteFunction = ({ design, display, theme }) => {
 					}
 				}
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[97];
@@ -211,6 +213,7 @@ const headlineBackgroundLight: PaletteFunction = ({
 		case ArticleDisplay.Standard:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[7];
 				case ArticleDesign.Interview:
 					return sourcePalette.neutral[7];
@@ -249,6 +252,7 @@ const headlineBackgroundDark: PaletteFunction = ({
 					return sourcePalette.neutral[20];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
@@ -359,6 +363,7 @@ const headlineBylineDark: PaletteFunction = ({ design, display, theme }) => {
 const bylineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -509,6 +514,7 @@ const bylineBackgroundDark: PaletteFunction = ({ design, theme }) => {
 const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
@@ -619,6 +625,7 @@ const bylineAnchorLight: PaletteFunction = ({ design, theme, display }) => {
 const bylineAnchorDark: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Analysis:
 			switch (theme) {
@@ -979,6 +986,7 @@ export const tabs = {
 const datelineLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					return sourcePalette.neutral[86];
@@ -1196,6 +1204,7 @@ const avatarDark: PaletteFunction = () => sourcePalette.neutral[93];
 const followTextLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.Picture:
@@ -1212,6 +1221,7 @@ const followTextDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[100];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[86];
@@ -1242,6 +1252,7 @@ const followIconBackgroundLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.news[800];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		case ArticleDesign.Comment:
 		case ArticleDesign.Letter:
@@ -1303,6 +1314,7 @@ const followIconBackgroundDark: PaletteFunction = ({ theme, design }) => {
 const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case Pillar.Opinion:
 					return sourcePalette.opinion[500];
@@ -1976,6 +1988,7 @@ const appsFooterBackgroundLight: PaletteFunction = () =>
 const appsFooterBackgroundDark: PaletteFunction = (format: ArticleFormat) => {
 	switch (format.design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 		default:
 			return sourcePalette.neutral[0];
@@ -2010,6 +2023,7 @@ const brandingLabelLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[20];
@@ -2135,6 +2149,7 @@ const standfirstBulletDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[86];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			switch (theme) {
 				case Pillar.News:
@@ -2265,6 +2280,7 @@ const standfirstBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[93];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		default:
 			return articleBackgroundLight({ design, display, theme });
@@ -2308,6 +2324,7 @@ const standfirstBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[10];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -2374,6 +2391,7 @@ const standfirstLinkTextLight: PaletteFunction = ({ design, theme }) => {
 			}
 		case ArticleDesign.Audio:
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			switch (theme) {
@@ -2405,6 +2423,7 @@ const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Video:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		case ArticleDesign.Picture:
 			switch (theme) {
 				case Pillar.News:
@@ -2463,6 +2482,7 @@ const standfirstTextLight: PaletteFunction = (format) => {
 					return sourcePalette.neutral[86];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			if (
@@ -2481,6 +2501,7 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[93];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
@@ -2729,6 +2750,7 @@ const captionTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[46];
@@ -2757,6 +2779,7 @@ const captionTextDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[60];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[60];
@@ -2768,6 +2791,7 @@ const captionMainMediaTextLight: PaletteFunction = (format) => {
 		case ArticleDesign.PhotoEssay:
 			return sourcePalette.neutral[46];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (format.theme) {
 				case ArticleSpecial.Labs:
 					return captionTextLight(format);
@@ -2796,6 +2820,7 @@ const captionLink: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.NewsletterSignup:
 			return sourcePalette.neutral[0];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			switch (theme) {
@@ -3153,6 +3178,7 @@ const articleBackgroundLight: PaletteFunction = ({
 		case ArticleDesign.FullPageInteractive:
 			return 'transparent';
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return '#0d0d0d';
 		default:
 			switch (theme) {
@@ -3198,6 +3224,7 @@ const articleBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[10];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 		default:
 			return sourcePalette.neutral[10];
 	}
@@ -3214,6 +3241,7 @@ const articleInnerBackgroundLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[0];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 
 		default:
@@ -3232,6 +3260,7 @@ const articleInnerBackgroundDark: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[0];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 
 		default:
@@ -3359,7 +3388,12 @@ const articleLinkBorderLight: PaletteFunction = ({ design, theme }) => {
 		return sourcePalette.neutral[46];
 	}
 
-	if (design === ArticleDesign.Gallery) return sourcePalette.neutral[46];
+	if (
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery
+	) {
+		return sourcePalette.neutral[46];
+	}
 	if (theme === ArticleSpecial.Labs) return sourcePalette.neutral[60];
 	if (theme === ArticleSpecial.SpecialReport) {
 		return sourcePalette.specialReport[300];
@@ -3385,7 +3419,6 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 			return sourcePalette.neutral[20];
 		case ArticleDesign.Comment:
-			return sourcePalette.neutral[20];
 		case ArticleDesign.Interactive:
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[46];
@@ -3531,7 +3564,10 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 };
 
 const articleSectionBorderLight: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.Gallery) {
+	if (
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[86];
 	}
 
@@ -3553,7 +3589,10 @@ const footerBorderDark: PaletteFunction = () => {
 const articleBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 
 const straightLinesLight: PaletteFunction = (format) => {
-	if (format.design === ArticleDesign.Gallery) {
+	if (
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[20];
 	}
 	if (format.theme === ArticleSpecial.SpecialReportAlt) {
@@ -3798,7 +3837,6 @@ const shareButtonHoverLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
 		case ArticleDesign.HostedArticle:
-		case ArticleDesign.HostedGallery:
 		case ArticleDesign.HostedVideo:
 			switch (theme) {
 				case ArticleSpecial.Labs:
@@ -3807,6 +3845,7 @@ const shareButtonHoverLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		default:
 			return sourcePalette.neutral[100];
@@ -3835,6 +3874,7 @@ const shareButtonBorderDark: PaletteFunction = () => sourcePalette.neutral[20];
 const shareButtonBorderMetaLight: PaletteFunction = ({ design }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[38];
 		default:
 			return sourcePalette.neutral[86];
@@ -3850,6 +3890,7 @@ const shareButtonBorderXSmallLight: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[46];
 		default:
 			return sourcePalette.neutral[86];
@@ -3862,6 +3903,7 @@ const shareButtonCopiedLight: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		default:
 			return sourcePalette.neutral[7];
@@ -3873,12 +3915,12 @@ const shareButtonCopiedDark: PaletteFunction = () => sourcePalette.neutral[86];
 const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[86];
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
 		case ArticleDesign.HostedArticle:
-		case ArticleDesign.HostedGallery:
 		case ArticleDesign.HostedVideo:
 			switch (theme) {
 				case ArticleSpecial.Labs:
@@ -4025,7 +4067,10 @@ const liveBlockBorderBottomDark: PaletteFunction = () =>
 const subMetaLabelTextLight: PaletteFunction = ({ theme, design }) => {
 	switch (theme) {
 		case ArticleSpecial.Labs:
-			if (design === ArticleDesign.Gallery) {
+			if (
+				design === ArticleDesign.Gallery ||
+				design === ArticleDesign.HostedGallery
+			) {
 				return sourcePalette.neutral[60];
 			}
 			return sourcePalette.neutral[7];
@@ -4097,6 +4142,7 @@ const subMetaBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[7];
 			}
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 
 		default:
@@ -4152,6 +4198,7 @@ const subMetaTextLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleSpecial.Labs:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return sourcePalette.neutral[7];
@@ -4164,6 +4211,7 @@ const subMetaTextLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.Video:
 				case ArticleDesign.Audio:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				case ArticleDesign.DeadBlog:
 				case ArticleDesign.LiveBlog:
@@ -4216,6 +4264,7 @@ const subMetaTextDark: PaletteFunction = ({ design, theme }) => {
 			switch (design) {
 				case ArticleDesign.Picture:
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[86];
 				default:
 					return pillarPalette(theme, 500);
@@ -4229,10 +4278,12 @@ const subMetaTextHoverLight: PaletteFunction = ({ design, theme }) => {
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
 		case ArticleDesign.Picture:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case ArticleSpecial.Labs:
 					switch (design) {
 						case ArticleDesign.Gallery:
+						case ArticleDesign.HostedGallery:
 							return sourcePalette.neutral[7];
 						default:
 							return sourcePalette.neutral[100];
@@ -4930,6 +4981,7 @@ const seriesTitleBackgroundLight: PaletteFunction = ({
 		default:
 			switch (design) {
 				case ArticleDesign.Gallery:
+				case ArticleDesign.HostedGallery:
 					switch (theme) {
 						case Pillar.Opinion:
 						case Pillar.News:
@@ -4955,6 +5007,7 @@ const seriesTitleBackgroundDark: PaletteFunction = ({
 }) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			switch (theme) {
 				case Pillar.Opinion:
 				case Pillar.News:
@@ -5039,7 +5092,10 @@ const seriesTitleTextLight: PaletteFunction = ({ theme, display, design }) => {
 		return sourcePalette.specialReport[300];
 	}
 
-	if (design === ArticleDesign.Gallery) {
+	if (
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery
+	) {
 		return sourcePalette.neutral[100];
 	}
 
@@ -5130,6 +5186,7 @@ const seriesTitleTextDark: PaletteFunction = ({ design, theme, display }) => {
 	if (display === ArticleDisplay.Immersive) return sourcePalette.neutral[100];
 	switch (design) {
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[100];
 		case ArticleDesign.Analysis:
 			switch (theme) {

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -3419,6 +3419,7 @@ const articleMetaLinesDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.Audio:
 			return sourcePalette.neutral[20];
 		case ArticleDesign.Comment:
+			return sourcePalette.neutral[20];
 		case ArticleDesign.Interactive:
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[46];

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -47,8 +47,10 @@ export type ArticleFields = {
 	serverTime?: number | undefined;
 };
 
+export type GalleryDesign = ArticleDesign.Gallery | ArticleDesign.HostedGallery;
+
 export type Gallery = ArticleFields & {
-	design: ArticleDesign.Gallery;
+	design: GalleryDesign;
 	bodyElements: (ImageBlockElement | AdPlaceholderBlockElement)[];
 	mainMedia?: ImageBlockElement;
 };
@@ -120,13 +122,14 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
-	const storyPackage = parseStoryPackage(
-		data.storyPackage,
-		format.design === ArticleDesign.Gallery,
-	);
+	const isGalleryPage =
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery;
 
-	if (format.design === ArticleDesign.Gallery) {
-		const design = ArticleDesign.Gallery;
+	const storyPackage = parseStoryPackage(data.storyPackage, isGalleryPage);
+
+	if (isGalleryPage) {
+		const { design } = format;
 
 		return {
 			frontendData: {

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -122,13 +122,18 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
-	const isGalleryPage =
-		format.design === ArticleDesign.Gallery ||
-		format.design === ArticleDesign.HostedGallery;
+	const isGalleryPage = (
+		design: ArticleDesign,
+	): design is ArticleDesign.Gallery | ArticleDesign.HostedGallery =>
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery;
 
-	const storyPackage = parseStoryPackage(data.storyPackage, isGalleryPage);
+	const storyPackage = parseStoryPackage(
+		data.storyPackage,
+		isGalleryPage(format.design),
+	);
 
-	if (isGalleryPage) {
+	if (isGalleryPage(format.design)) {
 		const { design } = format;
 
 		return {

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -56,7 +56,7 @@ export type Gallery = ArticleFields & {
 };
 
 export type OtherArticles = ArticleFields & {
-	design: Exclude<ArticleDesign, ArticleDesign.Gallery>;
+	design: Exclude<ArticleDesign, GalleryDesign>;
 };
 
 export type Article = Gallery | OtherArticles;
@@ -122,15 +122,13 @@ export const enhanceArticleType = (
 		data.main,
 	)(data.mainMediaElements);
 
-	const isGalleryPage = (
-		design: ArticleDesign,
-	): design is ArticleDesign.Gallery | ArticleDesign.HostedGallery =>
+	const isGalleryPage = (design: ArticleDesign): design is GalleryDesign =>
 		design === ArticleDesign.Gallery ||
 		design === ArticleDesign.HostedGallery;
 
 	const storyPackage = parseStoryPackage(
 		data.storyPackage,
-		isGalleryPage(format.design),
+		format.design === ArticleDesign.Gallery,
 	);
 
 	if (isGalleryPage(format.design)) {


### PR DESCRIPTION
## What does this change?

Adds a basic layout for Hosted Gallery pages that largely tracks the editorial Gallery Layout, apart from omitting the main media

## Why?

As part of the Hosted Content migration, this is to allow us to use the Standard Gallery layout for Hosted Gallery pages and eventually serve these pages using dotcom rendering instead of frontend

There are still parts missing from this but these will be addressed in future updates

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fedb5abd-3623-4af3-b0d1-13f99a5e98bf
[after]: https://github.com/user-attachments/assets/370b6138-a4a4-4abf-b0cc-20426832090d
