### PR TITLE
update intentIQ holdback test group size and split

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -128,9 +128,9 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-06-18",
 		type: "client",
 		status: "ON",
-		audienceSize: 5 / 100,
+		audienceSize: 10 / 100,
 		audienceSpace: "A",
-		groups: ["holdback"],
+		groups: ["control", "holdback"],
 		shouldForceMetricsCollection: true,
 	},
 	{


### PR DESCRIPTION
## What does this change?
Updates the test gate for the `commercial-user-module-intentIq-us-region` AB test.

## Why?
We would like to measure and collate date for groups: control - 5% and holdback -5% 

Related PR: https://github.com/guardian/commercial/pull/2575


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215418692909313