### PR TITLE
Fix AB test links in Card's in loop click through AB test

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -412,16 +412,18 @@ export const Card = ({
 	contentSpacing,
 }: Props) => {
 	const ab = useAB();
-	const isInLoopClickTestControl =
+	const isInLoopClickTestControl = Boolean(
 		ab?.isUserInTestGroup(
 			'fronts-and-curation-loop-click-through',
 			'control',
-		) ?? false;
-	const isInLoopClickTestVariant =
+		),
+	);
+	const isInLoopClickTestVariant = Boolean(
 		ab?.isUserInTestGroup(
 			'fronts-and-curation-loop-click-through',
 			'variant',
-		) ?? false;
+		),
+	);
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 	const sublinkPosition = decideSublinkPosition(
@@ -801,10 +803,14 @@ export const Card = ({
 		);
 	};
 
-	const isInLoopClickTest =
-		isSelfHostedVideo &&
-		media.mainMedia.videoStyle === 'Loop' &&
-		(isInLoopClickTestControl || isInLoopClickTestVariant);
+	const isLoopAndInLoopClickTestControl = Boolean(
+		media?.type === 'loop-video' && isInLoopClickTestControl,
+	);
+	const isLoopAndInLoopClickTestVariant = Boolean(
+		media?.type === 'loop-video' && isInLoopClickTestVariant,
+	);
+	const isLoopAndInLoopClickTest =
+		isLoopAndInLoopClickTestControl || isLoopAndInLoopClickTestVariant;
 
 	return (
 		<CardWrapper
@@ -823,10 +829,8 @@ export const Card = ({
 				headlineText={headlineText}
 				dataLinkName={resolvedDataLinkName}
 				isExternalLink={isExternalLink}
-				isLoopClickThroughTest={Boolean(isInLoopClickTest)}
-				isLoopClickThroughTestVariant={Boolean(
-					isInLoopClickTestVariant,
-				)}
+				isLoopAndInLoopClickTest={isLoopAndInLoopClickTest}
+				shouldRaiseZIndexForAbTest={false} // The z-index is raised in a new CardLink in the SelfHostedVideo island.
 			/>
 			{headlinePosition === 'outer' && (
 				<div
@@ -960,7 +964,7 @@ export const Card = ({
 										isExternalLink,
 									}}
 									isInLoopClickTestVariant={
-										isInLoopClickTestVariant
+										isLoopAndInLoopClickTestVariant
 									}
 								/>
 							</Island>

--- a/dotcom-rendering/src/components/Card/components/CardLink.tsx
+++ b/dotcom-rendering/src/components/Card/components/CardLink.tsx
@@ -4,7 +4,6 @@ import { getZIndex } from '../../../lib/getZIndex';
 
 const fauxLinkStyles = css`
 	position: absolute;
-	z-index: ${getZIndex('card-link')};
 	top: 0;
 	right: 0;
 	bottom: 0;
@@ -16,7 +15,11 @@ const fauxLinkStyles = css`
 	}
 `;
 
-const videoCardLinkStyles = css`
+const zIndexStyles = css`
+	z-index: ${getZIndex('card-link')};
+`;
+
+const abTestZIndexStyles = css`
 	z-index: ${getZIndex('video-card-link')};
 `;
 
@@ -25,27 +28,30 @@ type Props = {
 	headlineText: string;
 	dataLinkName?: string;
 	isExternalLink: boolean;
-	isLoopClickThroughTest: boolean;
-	isLoopClickThroughTestVariant: boolean;
+	isLoopAndInLoopClickTest: boolean;
+	/**
+	 * Refers to the AB test with name: fronts-and-curation-loop-click-through
+	 */
+	shouldRaiseZIndexForAbTest: boolean;
 };
 
 const InternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
-	isLoopClickThroughTestVariant,
+	shouldRaiseZIndexForAbTest,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
-	isLoopClickThroughTestVariant: boolean;
+	shouldRaiseZIndexForAbTest: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
 			css={[
 				fauxLinkStyles,
-				isLoopClickThroughTestVariant && videoCardLinkStyles,
+				shouldRaiseZIndexForAbTest ? abTestZIndexStyles : zIndexStyles,
 			]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText}
@@ -57,19 +63,19 @@ const ExternalLink = ({
 	linkTo,
 	headlineText,
 	dataLinkName,
-	isLoopClickThroughTestVariant,
+	shouldRaiseZIndexForAbTest,
 }: {
 	linkTo: string;
 	headlineText: string;
 	dataLinkName?: string;
-	isLoopClickThroughTestVariant: boolean;
+	shouldRaiseZIndexForAbTest: boolean;
 }) => {
 	return (
 		<a
 			href={linkTo}
 			css={[
 				fauxLinkStyles,
-				isLoopClickThroughTestVariant && videoCardLinkStyles,
+				shouldRaiseZIndexForAbTest ? abTestZIndexStyles : zIndexStyles,
 			]}
 			data-link-name={dataLinkName}
 			aria-label={headlineText + ' (opens in new tab)'}
@@ -84,11 +90,14 @@ export const CardLink = ({
 	headlineText,
 	dataLinkName = 'article', //this makes sense if the link is to an article, but should this say something like "external" if it's an external link? are there any other uses/alternatives?
 	isExternalLink,
-	isLoopClickThroughTest,
-	isLoopClickThroughTestVariant,
+	isLoopAndInLoopClickTest,
+	shouldRaiseZIndexForAbTest,
 }: Props) => {
-	/* if we are in the loop click through test, we add a unique string to the data link name tracking so clicks to article can be diffrentiated from other clicks on the card */
-	const clickThroughLinkName = isLoopClickThroughTest
+	/**
+	 * If we are in the loop click through test, we add a unique string to the data link name
+	 * tracking so clicks to article can be diffrentiated from other clicks on the card
+	 */
+	const clickThroughLinkName = isLoopAndInLoopClickTest
 		? `${dataLinkName} | card-link-clickthrough`
 		: dataLinkName;
 
@@ -99,9 +108,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={clickThroughLinkName}
-					isLoopClickThroughTestVariant={
-						isLoopClickThroughTestVariant
-					}
+					shouldRaiseZIndexForAbTest={shouldRaiseZIndexForAbTest}
 				/>
 			)}
 			{!isExternalLink && (
@@ -109,9 +116,7 @@ export const CardLink = ({
 					linkTo={linkTo}
 					headlineText={headlineText}
 					dataLinkName={clickThroughLinkName}
-					isLoopClickThroughTestVariant={
-						isLoopClickThroughTestVariant
-					}
+					shouldRaiseZIndexForAbTest={shouldRaiseZIndexForAbTest}
 				/>
 			)}
 		</>

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -439,16 +439,18 @@ export const FeatureCard = ({
 	articleMedia,
 }: Props) => {
 	const ab = useAB();
-	const isInLoopClickTestControl =
+	const isInLoopClickTestControl = Boolean(
 		ab?.isUserInTestGroup(
 			'fronts-and-curation-loop-click-through',
 			'control',
-		) ?? false;
-	const isInLoopClickTestVariant =
+		),
+	);
+	const isInLoopClickTestVariant = Boolean(
 		ab?.isUserInTestGroup(
 			'fronts-and-curation-loop-click-through',
 			'variant',
-		) ?? false;
+		),
+	);
 
 	const hasSublinks = supportingContent && supportingContent.length > 0;
 
@@ -467,10 +469,14 @@ export const FeatureCard = ({
 		return null;
 	}
 
-	const isInLoopClickTest =
-		media.style &&
-		media.style === 'loop-video' &&
-		(isInLoopClickTestControl || isInLoopClickTestVariant);
+	const isLoopAndInLoopClickTestControl = Boolean(
+		media.style === 'loop-video' && isInLoopClickTestControl,
+	);
+	const isLoopAndInLoopClickTestVariant = Boolean(
+		media.style === 'loop-video' && isInLoopClickTestVariant,
+	);
+	const isLoopAndInLoopClickTest =
+		isLoopAndInLoopClickTestControl || isLoopAndInLoopClickTestVariant;
 
 	const mediaType =
 		media.type === 'self-hosted-video' ? media.style : media.type;
@@ -520,9 +526,9 @@ export const FeatureCard = ({
 							headlineText={headlineText}
 							dataLinkName={resolvedDataLinkName}
 							isExternalLink={isExternalLink}
-							isLoopClickThroughTest={isInLoopClickTest === true}
-							isLoopClickThroughTestVariant={
-								isInLoopClickTestVariant
+							isLoopAndInLoopClickTest={isLoopAndInLoopClickTest}
+							shouldRaiseZIndexForAbTest={
+								isLoopAndInLoopClickTestVariant
 							}
 						/>
 					)}
@@ -739,11 +745,11 @@ export const FeatureCard = ({
 												headlineText={headlineText}
 												dataLinkName={dataLinkName}
 												isExternalLink={isExternalLink}
-												isLoopClickThroughTest={
-													isInLoopClickTest === true
+												isLoopAndInLoopClickTest={
+													isLoopAndInLoopClickTest
 												}
-												isLoopClickThroughTestVariant={
-													isInLoopClickTestVariant
+												shouldRaiseZIndexForAbTest={
+													isLoopAndInLoopClickTestVariant
 												}
 											/>
 										)}

--- a/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/HighlightsCard.tsx
@@ -152,8 +152,8 @@ export const HighlightsCard = ({
 					headlineText={headlineText}
 					dataLinkName={dataLinkName}
 					isExternalLink={isExternalLink}
-					isLoopClickThroughTest={false}
-					isLoopClickThroughTestVariant={false}
+					isLoopAndInLoopClickTest={false}
+					shouldRaiseZIndexForAbTest={false}
 				/>
 
 				<div css={[content, shouldJustifyContent && spaceBetween]}>

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1320,9 +1320,9 @@ export const SelfHostedVideo = ({
 						isWebKitFullscreen={isWebKitFullscreen}
 						linkTo={linkTo}
 						cardLink={cardLink}
-						isLoopClickThroughTestVariant={
-							isLoopClickThroughTestVariant
-						}
+						isLoopAndInLoopClickTestVariant={Boolean(
+							isLoopClickThroughTestVariant,
+						)}
 					/>
 				</div>
 			</div>

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -161,7 +161,7 @@ export type Props = {
 		dataLinkName?: string;
 		isExternalLink: boolean;
 	};
-	isLoopClickThroughTestVariant?: boolean;
+	isLoopAndInLoopClickTestVariant: boolean;
 };
 
 /**
@@ -220,7 +220,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 			isWebKitFullscreen,
 			linkTo,
 			cardLink,
-			isLoopClickThroughTestVariant,
+			isLoopAndInLoopClickTestVariant,
 		}: Props,
 		ref: React.ForwardedRef<HTMLVideoElement>,
 	) => {
@@ -231,14 +231,14 @@ export const SelfHostedVideoPlayer = forwardRef(
 
 		return (
 			<>
-				{cardLink && isLoopClickThroughTestVariant === true && (
+				{cardLink && isLoopAndInLoopClickTestVariant && (
 					<CardLink
 						linkTo={linkTo}
 						headlineText={cardLink.headlineText}
 						dataLinkName={cardLink.dataLinkName}
 						isExternalLink={cardLink.isExternalLink}
-						isLoopClickThroughTest={true}
-						isLoopClickThroughTestVariant={true}
+						isLoopAndInLoopClickTest={true}
+						shouldRaiseZIndexForAbTest={true}
 					/>
 				)}
 				<video
@@ -269,7 +269,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 					onTimeUpdate={handleTimeUpdate}
 					onPause={handlePause}
 					onClick={
-						isLoopClickThroughTestVariant === true
+						isLoopAndInLoopClickTestVariant
 							? undefined
 							: handlePlayPauseClick
 					}
@@ -311,11 +311,11 @@ export const SelfHostedVideoPlayer = forwardRef(
 					className="controls-container"
 					css={[
 						videoControlsStyles,
-						isLoopClickThroughTestVariant === true &&
+						isLoopAndInLoopClickTestVariant &&
 							videoControlsZIndexStyles,
 					]}
 				>
-					{!isLoopClickThroughTestVariant &&
+					{!isLoopAndInLoopClickTestVariant &&
 						showPlayPauseIcon !== null && (
 							<PlayPauseIcon
 								type={showPlayPauseIcon}
@@ -344,7 +344,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 							/>
 						))}
 					{((showIcons && (showFullscreenIcon || hasAudio)) ||
-						isLoopClickThroughTestVariant === true) && (
+						isLoopAndInLoopClickTestVariant) && (
 						<div
 							css={[
 								iconsContainerStyles,
@@ -356,7 +356,7 @@ export const SelfHostedVideoPlayer = forwardRef(
 									iconsTopPositionStyles,
 							]}
 						>
-							{isLoopClickThroughTestVariant === true && (
+							{isLoopAndInLoopClickTestVariant && (
 								<PlayPauseIcon
 									type={showPlayPauseIcon ?? 'pause'}
 									atomId={atomId}


### PR DESCRIPTION
## What does this change?

A new `<CardLink />` is in the `SelfHostedVideoPlayer` component that includes a high z-index for users in the variant of the test. This is so that users that click the video will be taken through to the article. However, we were also using this new z-index for the pre-existing `<CardLink />`, which meant that this upper link was stealing all of the clicks.

Fixes issue where long-form video clicks were taking the user through to the article.

## Screenshots

### Before

https://github.com/user-attachments/assets/6b859b3a-5d3c-4396-92cf-9804c1ffa1ec

### After

https://github.com/user-attachments/assets/b48a2ab8-2698-405d-bc08-620b9408bb4f
