### PR TITLE
Reduce size of sign up button on NewsletterSignupForm to fit content

### DIFF
--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.tsx
@@ -52,7 +52,7 @@ const formStyles = css`
 `;
 
 const signedOutLayoutStyles = css`
-	grid-template-columns: minmax(0, 1fr) 160px;
+	grid-template-columns: minmax(0, 1fr) auto;
 	grid-template-areas: 'email submit';
 
 	${until.tablet} {
@@ -88,13 +88,15 @@ const submitButtonContainerStyles = css`
 	width: 100%;
 	display: flex;
 	gap: ${space[2]}px;
+	${from.tablet} {
+		width: auto;
+	}
 `;
 
 const submitButtonStyles = css`
-	flex: 1;
 	width: 100%;
 	${from.tablet} {
-		max-width: 220px;
+		width: auto;
 	}
 `;
 


### PR DESCRIPTION
## What does this change?

Reduces the width of the Sign up button on the newsletter sign up card to fit the content

## Why?

On request from design team

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7b5de5fc-e711-4c94-873a-bd3decbc2d3b
[after]: https://github.com/user-attachments/assets/cf227e53-b7e1-414d-8ed9-66fdff09f67a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
