### PR TITLE
Fix prettier issue

### DIFF
--- a/dotcom-rendering/src/components/LiveActivitiesToggle.tsx
+++ b/dotcom-rendering/src/components/LiveActivitiesToggle.tsx
@@ -109,7 +109,7 @@ const toggleLiveActivity = (
 						})
 						.catch(handleError('follow'));
 				}
-		  };
+			};
 
 const handleError =
 	(methodName: 'follow' | 'unfollow' | 'isFollowing') =>


### PR DESCRIPTION
Prettier wants some spaces to be converted to a tab. This issue ended up in `main` because a Prettier upgrade was merged (#16022) just before another branch that contained these spaces (#16046). The older version of Prettier did not mark this as an issue, so CI passed on the branch, but then failed in `main`.
