### PR TITLE
Fix the rendering of a Vimeo video in a Hosted content article

### DIFF
--- a/dotcom-rendering/src/components/HostedEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/components/HostedEmbedBlockComponent.tsx
@@ -3,8 +3,8 @@ import { parseHtml } from '../lib/domUtils';
 type Props = {
 	html: string;
 	alt: string;
-	height?: number;
 	width?: number;
+	height?: number;
 };
 
 const getIframeDimension = (
@@ -19,22 +19,21 @@ const getIframeDimension = (
 export const HostedEmbedBlockComponent = ({
 	html,
 	alt,
-	height: heightProp,
 	width: widthProp,
+	height: heightProp,
 }: Props) => {
-	const iframe = parseHtml(html).querySelector<HTMLIFrameElement>('iframe');
+	const iframeFromEmbed =
+		parseHtml(html).querySelector<HTMLIFrameElement>('iframe');
 
-	const height = heightProp ?? getIframeDimension(iframe, 'height');
-	const width = widthProp ?? getIframeDimension(iframe, 'width');
-
-	if (height === undefined) return null;
+	const height = heightProp ?? getIframeDimension(iframeFromEmbed, 'height');
+	const width = widthProp ?? getIframeDimension(iframeFromEmbed, 'width');
 
 	return (
 		<iframe
 			title={alt}
 			srcDoc={html}
 			width={width ?? '100%'}
-			height={height}
+			height={height ?? '349px'}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/HostedEmbedBlockComponent.tsx
+++ b/dotcom-rendering/src/components/HostedEmbedBlockComponent.tsx
@@ -1,11 +1,25 @@
+import { css } from '@emotion/react';
+import { updateIframeHeight } from '../client/updateIframeHeight';
 import { parseHtml } from '../lib/domUtils';
+import type { RoleType } from '../types/content';
+import { ClickToView } from './ClickToView';
 
 type Props = {
 	html: string;
 	alt: string;
+	index: number;
+	role?: RoleType;
+	isTracking: boolean;
+	isMainMedia?: boolean;
+	source?: string;
+	sourceDomain?: string;
 	width?: number;
 	height?: number;
 };
+
+const fullWidthStyles = css`
+	width: 100%;
+`;
 
 const getIframeDimension = (
 	iframe: HTMLIFrameElement | null,
@@ -19,21 +33,56 @@ const getIframeDimension = (
 export const HostedEmbedBlockComponent = ({
 	html,
 	alt,
+	index,
+	role,
+	isTracking,
+	isMainMedia,
+	source,
+	sourceDomain,
 	width: widthProp,
 	height: heightProp,
 }: Props) => {
-	const iframeFromEmbed =
-		parseHtml(html).querySelector<HTMLIFrameElement>('iframe');
+	if (source === 'The Guardian') {
+		const iframeFromEmbed =
+			parseHtml(html).querySelector<HTMLIFrameElement>('iframe');
 
-	const height = heightProp ?? getIframeDimension(iframeFromEmbed, 'height');
-	const width = widthProp ?? getIframeDimension(iframeFromEmbed, 'width');
+		const height =
+			heightProp ?? getIframeDimension(iframeFromEmbed, 'height');
+		const width = widthProp ?? getIframeDimension(iframeFromEmbed, 'width');
 
+		return (
+			<iframe
+				title={alt}
+				srcDoc={html}
+				width={width ?? '100%'}
+				height={height}
+			/>
+		);
+	}
 	return (
-		<iframe
-			title={alt}
-			srcDoc={html}
-			width={width ?? '100%'}
-			height={height ?? '349px'}
-		/>
+		<ClickToView
+			role={role}
+			isTracking={isTracking}
+			isMainMedia={isMainMedia}
+			source={source}
+			sourceDomain={sourceDomain}
+			onAccept={() =>
+				updateIframeHeight(`iframe[name="hosted-embed-${index}"]`)
+			}
+		>
+			<iframe
+				css={fullWidthStyles}
+				className="js-embed__iframe"
+				title={alt}
+				// name is used to identify each unique iframe on the page to resize
+				// we therefore use the "hosted-embed-" prefix followed by index to
+				// construct a unique ID
+				name={`hosted-embed-${index}`}
+				data-testid="embed-block"
+				srcDoc={`${html}
+				<script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+				<gu-script>iframeMessenger.enableAutoResize();</gu-script>`}
+			/>
+		</ClickToView>
 	);
 };

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -327,10 +327,17 @@ export const renderElement = ({
 				if (format.design === ArticleDesign.HostedArticle) {
 					return (
 						<HostedEmbedBlockComponent
+							key={index}
 							html={element.html}
 							alt={element.alt ?? ''}
-							height={element.height}
+							index={index}
+							role={element.role}
+							isTracking={element.isThirdPartyTracking}
+							isMainMedia={isMainMedia}
+							source={element.source}
+							sourceDomain={element.sourceDomain}
 							width={element.width}
+							height={element.height}
 						/>
 					);
 				}

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -326,14 +326,12 @@ export const renderElement = ({
 
 				if (format.design === ArticleDesign.HostedArticle) {
 					return (
-						<Island priority="feature" defer={{ until: 'visible' }}>
-							<HostedEmbedBlockComponent
-								html={element.html}
-								alt={element.alt ?? ''}
-								height={element.height}
-								width={element.width}
-							/>
-						</Island>
+						<HostedEmbedBlockComponent
+							html={element.html}
+							alt={element.alt ?? ''}
+							height={element.height}
+							width={element.width}
+						/>
 					);
 				}
 

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -326,12 +326,14 @@ export const renderElement = ({
 
 				if (format.design === ArticleDesign.HostedArticle) {
 					return (
-						<HostedEmbedBlockComponent
-							html={element.html}
-							alt={element.alt ?? ''}
-							height={element.height}
-							width={element.width}
-						/>
+						<Island priority="feature" defer={{ until: 'visible' }}>
+							<HostedEmbedBlockComponent
+								html={element.html}
+								alt={element.alt ?? ''}
+								height={element.height}
+								width={element.width}
+							/>
+						</Island>
 					);
 				}
 

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -12,7 +12,7 @@ export const enhanceEmbeds = (elements: FEElement[]): FEElement[] =>
 				const iframe = dom.querySelector('iframe');
 				if (iframe && element.alt) {
 					iframe.setAttribute('title', element.alt);
-					if (element.source === 'Vimeo') {
+					if (element.alt.includes('Vimeo video of Business')) {
 						return {
 							...element,
 						};

--- a/dotcom-rendering/src/model/enhance-embeds.ts
+++ b/dotcom-rendering/src/model/enhance-embeds.ts
@@ -12,6 +12,11 @@ export const enhanceEmbeds = (elements: FEElement[]): FEElement[] =>
 				const iframe = dom.querySelector('iframe');
 				if (iframe && element.alt) {
 					iframe.setAttribute('title', element.alt);
+					if (element.source === 'Vimeo') {
+						return {
+							...element,
+						};
+					}
 					return {
 						...element,
 						...{


### PR DESCRIPTION
## What does this change?

This PR fixes the `EmbedBlockElement` Vimeo video which exists in a Hosted Content article in DCAR as it's currently not visible on the page or in the DOM. 

There are two different scenarios in Hosted Content:

- An `EmbedBlockElement` that shows a map or something similar. 
- An `EmbedBlockElement` which could be a video like Vimeo 

We need to check in the first case if we have a width coming from the data and if not we set a fallback of 100% and the height will be adjusted accordingly. 

The second case we need to update the iframe height based on the viewport which what some existing components do as well to adjust the height of the embed. 

There might be more edge cases coming along the way and we just need to update our logic to accommodate as much scenarios as possible.

## Why?

Show Vimeo videos rendered as `EmbedBlockElement` in Hosted Content DCAR. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/0fbb2606-b69c-4c50-bbcf-64b12917af5a
[after]: https://github.com/user-attachments/assets/e1b604ef-4bc0-41f8-a775-77a0523b1a96

[before2]: https://github.com/user-attachments/assets/c013af89-2e6d-4fd7-9114-0c1568746794
[after2]: https://github.com/user-attachments/assets/74578d44-ee45-4803-89cc-6a332ec2393a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
