### PR TITLE
rename intentIQ test name for GAM reportning

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -121,7 +121,7 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-user-module-intentIq-us-region",
+		name: "commercial-user-module-intentIq-us",
 		description:
 			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module for users in the US",
 		owners: ["commercial.dev@guardian.co.uk"],


### PR DESCRIPTION
## What does this change?
Renames the US IntentIQ experiment key from commercial-user-module-intentIq-us-region to commercial-user-module-intentIq-us.
## Why?
The previous key is too long for reliable GAM reporting breakout.
Shortening the key allows GAM to report this experiment dimension correctly while keeping behavior unchanged.

Related PR in commercial: https://github.com/guardian/commercial/pull/2577