### PR TITLE
Provides DCAR App media events with the full Ophan media ID

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
+++ b/dotcom-rendering/src/components/YoutubeAtom/eventEmitters.ts
@@ -74,7 +74,7 @@ const ophanTrackerApps = (id: string, videoStyle: OphanVideoStyle) => {
 		void getAppsMediaEvent(trackingEvent).then((appsMediaEvent) => {
 			if (!isUndefined(appsMediaEvent)) {
 				const event = {
-					videoId: id,
+					videoId: `gu-video-${videoStyle}-${id}`,
 					event: appsMediaEvent,
 				};
 				log('dotcom', {


### PR DESCRIPTION
## What does this change?

Uses the full Ophan media ID when sending media events via the Bridget interface. Currently iOS and Android assume the video is being rendered using the YouTube player:

- [iOS APP](https://github.com/guardian/ios-live/blob/0916477052bc814fa41f328b2686e9fc5ae59353/GLA/GLA/Classes/Bridget/VideoService.swift#L48)
- [Android App](https://github.com/guardian/android-news-app/blob/1581707425fa16b44949c4423f6b6bb495c71ea7/android-news-app/src/main/java/com/guardian/feature/renderedarticle/bridget/VideosFactory.kt#L41)

These will both need to be changed to reflect that DCAR will add the prefix. However, I'm not sure how to orchestrate this change to ensure that during the interim, the prefix may added twice  (merge this PR first) OR completely dropped (merge Apps PRs first). 

## Why?

To ensure we tracking video component IDs consistently across platforms. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215541361154877