### PR TITLE
Remove white line above video

### DIFF
--- a/dotcom-rendering/fixtures/manual/trails.ts
+++ b/dotcom-rendering/fixtures/manual/trails.ts
@@ -809,6 +809,49 @@ export const selfHostedLoopVideo169Card = {
 	},
 } satisfies DCRFrontCard;
 
+export const selfHostedDefaultVideo54Card = {
+	...selfHostedLoopVideo54Card,
+	headline: 'Self-hosted 5:4 default video card',
+	mainMedia: {
+		...selfHostedLoopVideo54Card.mainMedia,
+		videoStyle: 'Default',
+	},
+} satisfies DCRFrontCard;
+
+export const selfHostedDefaultVideo45Card = {
+	...selfHostedLoopVideo45Card,
+	headline: 'Self-hosted 4:5 default video card',
+	mainMedia: {
+		...selfHostedLoopVideo45Card.mainMedia,
+		videoStyle: 'Default',
+	},
+} satisfies DCRFrontCard;
+
+export const selfHostedDefaultVideo53Card = {
+	...selfHostedLoopVideo53Card,
+	headline: 'Self-hosted 5:3 default video card',
+	mainMedia: {
+		...selfHostedLoopVideo53Card.mainMedia,
+		videoStyle: 'Default',
+	},
+} satisfies DCRFrontCard;
+
+export const selfHostedDefaultVideo916Card = {
+	...selfHostedLoopVideo916Card,
+	mainMedia: {
+		...selfHostedLoopVideo916Card.mainMedia,
+		videoStyle: 'Default',
+	},
+} satisfies DCRFrontCard;
+
+export const selfHostedDefaultVideo169Card = {
+	...selfHostedLoopVideo169Card,
+	mainMedia: {
+		...selfHostedLoopVideo169Card.mainMedia,
+		videoStyle: 'Default',
+	},
+} satisfies DCRFrontCard;
+
 export const slideshowCard: DCRFrontCard = {
 	...defaultCardProps,
 	dataLinkName: 'news | group-0 | card-@2',

--- a/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
+++ b/dotcom-rendering/src/components/FlexibleGeneral.stories.tsx
@@ -6,6 +6,11 @@ import {
 	galleryTrails,
 	getSublinks,
 	opinionTrails,
+	selfHostedDefaultVideo169Card,
+	selfHostedDefaultVideo45Card,
+	selfHostedDefaultVideo53Card,
+	selfHostedDefaultVideo54Card,
+	selfHostedDefaultVideo916Card,
 	selfHostedLoopVideo169Card,
 	selfHostedLoopVideo45Card,
 	selfHostedLoopVideo53Card,
@@ -531,8 +536,7 @@ export const ImmersiveCardsSplashAndStandard: Story = {
 	},
 };
 
-export const SelfHostedVideoCardsInSplashSlots: Story = {
-	name: 'Self-hosted video cards in Splash slots',
+export const SelfHostedLoopVideoCardsInSplashSlots: Story = {
 	render: (args) => {
 		const Section = ({
 			title,
@@ -560,6 +564,53 @@ export const SelfHostedVideoCardsInSplashSlots: Story = {
 			selfHostedLoopVideo53Card,
 			selfHostedLoopVideo916Card,
 			selfHostedLoopVideo169Card,
+		];
+
+		return (
+			<>
+				{videos.map((video) =>
+					boostLevels.map((boostLevel) => (
+						<Section
+							key={`${video.headline}-${boostLevel}`}
+							title={boostLevel}
+							video={video}
+							boostLevel={boostLevel}
+						/>
+					)),
+				)}
+			</>
+		);
+	},
+};
+
+export const SelfHostedDefaultVideoCardsInSplashSlots: Story = {
+	render: (args) => {
+		const Section = ({
+			title,
+			video,
+			boostLevel,
+		}: {
+			title: string;
+			video: DCRFrontCard;
+			boostLevel?: BoostLevel;
+		}) => (
+			<FrontSection title={title} editionId="UK" showTopBorder={false}>
+				<FlexibleGeneral
+					{...args}
+					groupedTrails={{
+						...emptyGroupedTrails,
+						splash: [{ ...video, boostLevel }],
+					}}
+				/>
+			</FrontSection>
+		);
+
+		const videos = [
+			selfHostedDefaultVideo54Card,
+			selfHostedDefaultVideo45Card,
+			selfHostedDefaultVideo53Card,
+			selfHostedDefaultVideo916Card,
+			selfHostedDefaultVideo169Card,
 		];
 
 		return (

--- a/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoPlayer.tsx
@@ -30,6 +30,7 @@ const videoStyles = (aspectRatio: number) => css`
 	display: block;
 	height: auto;
 	width: 100%;
+	object-fit: cover;
 	-webkit-tap-highlight-color: transparent;
 
 	/* Prevents CLS by letting the browser know the space the video will take up. */


### PR DESCRIPTION
## What does this change?

Adds `object-fit: cover` to video element.

Adds Default video stories in Flexible General.

## Why?

So that the video fills it's container across browser when it's height in pixels is not a whole number.

Why does `object-fit: cover` work?
 - _The replaced content is sized to maintain its aspect ratio while filling the element's entire content box[^1]._
     - This means that the browser will fill up these partial pixels with the video, hiding the white lines.
     - The video container may be taller, but the width is the same and the aspect ratio is maintained with `object-fit: cover`. This means that we won't have a situation where the video is made too large for its visible area.

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-fit

## Screenshots

Notice the white line above the video. Chrome on Mac.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/306c256a-058f-4a05-9edc-f6baf7df9009
[after]: https://github.com/user-attachments/assets/82e22606-f818-4528-bf38-21a9ce8b2ebc
