### PR TITLE
Don't autoplay long-form video on article pages

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -958,6 +958,7 @@ export const Card = ({
 									subtitleSize={subtitleSize}
 									minAspectRatio={3 / 4}
 									containerAspectRatioDesktop={5 / 4}
+									preventAutoplay={false}
 									cardLink={{
 										headlineText,
 										dataLinkName: resolvedDataLinkName,

--- a/dotcom-rendering/src/components/FeatureCard.tsx
+++ b/dotcom-rendering/src/components/FeatureCard.tsx
@@ -638,6 +638,7 @@ export const FeatureCard = ({
 											controlsPosition="top"
 											minAspectRatio={aspectRatioNumber}
 											maxAspectRatio={aspectRatioNumber}
+											preventAutoplay={false}
 											cardLink={{
 												headlineText,
 												dataLinkName:

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -372,6 +372,7 @@ type Props = {
 	format?: ArticleFormat;
 	isMainMedia?: boolean;
 	role?: RoleType;
+	preventAutoplay: boolean;
 	restrictHeightOnDesktop?: boolean;
 	cardLink?: {
 		headlineText: string;
@@ -388,6 +389,7 @@ export const SelfHostedVideo = ({
 	videoStyle,
 	aspectRatio,
 	posterImage,
+	posterImageAspectRatio,
 	fallbackImage,
 	fallbackImageSize,
 	fallbackImageLoading,
@@ -406,7 +408,7 @@ export const SelfHostedVideo = ({
 	format,
 	isMainMedia,
 	role,
-	posterImageAspectRatio,
+	preventAutoplay,
 	restrictHeightOnDesktop = false,
 	cardLink,
 	isInLoopClickTestVariant,
@@ -446,7 +448,14 @@ export const SelfHostedVideo = ({
 
 	const videoStyleSettings: VideoStyleSettings = videoSettingsMap[videoStyle];
 
-	const shouldAutoplay = videoStyleSettings.autoplay && isAutoplayAllowed;
+	/**
+	 * The video will autoplay if all of the following are true:
+	 * - the style of video allows autoplay
+	 * - the parent allows autoplay, i.e. we may not want to autoplay on certain page types
+	 * - autoplay is allowed by the browser, e.g. if "reduce motion" is enabled then we don't autoplay
+	 */
+	const shouldAutoplay =
+		videoStyleSettings.autoplay && !preventAutoplay && isAutoplayAllowed;
 
 	const showProgressBar =
 		!hideProgressBar &&

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -71,6 +71,7 @@ export const SelfHostedVideoInArticle = ({
 					format={format}
 					isMainMedia={isMainMedia}
 					role={role}
+					preventAutoplay={videoStyle === 'Default'}
 					restrictHeightOnDesktop={!isInteractive(format.design)}
 				/>
 			</Island>


### PR DESCRIPTION
## What does this change?

Don't autoplay Default-style video on article pages. This includes video pages.

## Why?

Request from stakeholders

## Screenshares

### Articles

#### Before

https://github.com/user-attachments/assets/09e5bfcc-d53b-4deb-badc-06222cbec491

#### After

https://github.com/user-attachments/assets/08dc46aa-5041-4847-8c11-9e5be7f2fb6c

### Fronts 

(no change)

https://github.com/user-attachments/assets/f5735cc5-17de-4a5a-8d5a-6a0e053781cf

