### PR TITLE
Reduce notifications `useEffect` runs

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Notifications.tsx
@@ -85,7 +85,12 @@ const useAvailability = (
 	useEffect(() => {
 		getAvailability(
 			renderingTarget,
-			match,
+			match.kind,
+			match.paId,
+			match.homeTeam.name,
+			match.homeTeam.paID,
+			match.awayTeam.name,
+			match.awayTeam.paID,
 			environment,
 			liveActivities,
 			matchNotifications,
@@ -107,7 +112,12 @@ const useAvailability = (
 			});
 	}, [
 		renderingTarget,
-		match,
+		match.kind,
+		match.paId,
+		match.homeTeam.name,
+		match.homeTeam.paID,
+		match.awayTeam.name,
+		match.awayTeam.paID,
 		environment,
 		liveActivities,
 		matchNotifications,
@@ -118,30 +128,35 @@ const useAvailability = (
 
 const getAvailability = async (
 	renderingTarget: RenderingTarget,
-	match: FootballMatch,
+	matchKind: FootballMatch['kind'],
+	matchId: FootballMatch['paId'],
+	homeTeamName: FootballMatch['homeTeam']['name'],
+	homeTeamId: FootballMatch['homeTeam']['paID'],
+	awayTeamName: FootballMatch['awayTeam']['name'],
+	awayTeamId: FootballMatch['awayTeam']['paID'],
 	environment: EnvironmentClient,
 	liveActivities: LiveActivitiesClient,
 	matchNotifications: MatchNotificationsClient,
 ): Promise<Availability> => {
-	if (renderingTarget !== 'Apps' || match.kind === 'Result') {
+	if (renderingTarget !== 'Apps' || matchKind === 'Result') {
 		return { kind: 'none' };
 	}
 
 	if (
 		(await hasLiveActivitiesSupport(environment)) &&
-		(await liveActivities.isAvailable('football-match', match.paId))
+		(await liveActivities.isAvailable('football-match', matchId))
 	) {
 		return { kind: 'liveActivities' };
 	}
 
 	const notificationsAvailability = await matchNotifications.isAvailable({
 		homeTeam: {
-			paId: match.homeTeam.paID,
-			name: match.homeTeam.name,
+			paId: homeTeamId,
+			name: homeTeamName,
 		},
 		awayTeam: {
-			paId: match.awayTeam.paID,
-			name: match.awayTeam.name,
+			paId: awayTeamId,
+			name: awayTeamName,
 		},
 	});
 


### PR DESCRIPTION
In the football match header, the notifications component can show different things depending on what features the app has available. It might show a live activities button, or a notifications button, or a message explaining why notifications aren't available, or nothing (#16046).

To determine what to show, the component has to check with the app via Bridget when it first renders, which it does with a `useEffect` hook[^1]. This `useEffect` has five dependencies:

1. The `renderingTarget`
2. The football `match`
3. The Bridget `Environment` client
4. The Bridget `LiveActivities` client
5. The Bridget `MatchNotifications` client

If any of these dependencies change, the `useEffect` setup function will re-run, causing additional Bridget calls. Dependency 1 should never change, and neither should 3, 4 or 5. However, dependency 2, the match, will change regularly because we're polling for new match data on an interval. In fact, it will change every time we poll, even if the match data is the same, as `useEffect` uses `Object.is` for comparison[^2] and the match will always be stored in a new object (via SWR).

We can mitigate this by splitting up the `match` object in the dependencies list, instead passing some of the values stored in this object. As these are all `string`s, `Object.is` will consider them to be the same if they contain the same data (rather than requiring them to reference the same object in memory). Therefore `useEffect` re-runs will be limited to scenarios where the relevant match data actually changes, e.g. the match `kind` updating from "Fixture" to "Result".

This should reduce the number of Bridget calls.

Thanks to @arelra for a discussion on solutions to this problem.

Part of https://github.com/guardian/bridget/issues/252

[^1]: https://react.dev/reference/react/useEffect
[^2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
