### PR TITLE
Fix app worldcup navigation link opening in the browser

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
@@ -438,8 +438,9 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 		},
 	});
 
-	const boldSmallLink = css({
+	const selectedLink = css({
 		...textSansBold14Object,
+		pointerEvents: 'none',
 	});
 
 	return (
@@ -471,7 +472,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 									smallLink,
 									primaryLinkStyles,
 									!isApps && primaryLinkHoverStyles,
-									pageId === config.title.id && boldSmallLink,
+									pageId === config.title.id && selectedLink,
 								]}
 							>
 								{config.titleIcon}
@@ -486,7 +487,7 @@ export const DirectoryPageNav = ({ pageId, pageTags }: Props) => {
 								css={[
 									smallLink,
 									!isApps && smallLinkWeb,
-									pageId === link.id && boldSmallLink,
+									pageId === link.id && selectedLink,
 								]}
 							>
 								{link.label}


### PR DESCRIPTION
## What does this change?
Disabling pointer event will prevent the app from opening the link if it's the current page, it's never a useful link so it's fine to do this no matter what.

## Why?
In the app, if you click on a link in the nav that's the same page it opens in the browser, easier to fix in DCAR than in the app.

Fixes https://github.com/guardian/dotcom-rendering/issues/16067
