### PR TITLE
Pause video on apps when user leaves page

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -606,27 +606,30 @@ export const SelfHostedVideo = ({
 		}
 	}, []);
 
-	const pauseVideo = (
-		pauseReason: Extract<
-			PlayerStates,
-			| 'PAUSED_BY_USER'
-			| 'PAUSED_BY_INTERSECTION_OBSERVER'
-			| 'PAUSED_BY_BROWSER'
-		>,
-	) => {
-		const video = vidRef.current;
-		if (!video) {
-			return;
-		}
+	const pauseVideo = useCallback(
+		(
+			pauseReason: Extract<
+				PlayerStates,
+				| 'PAUSED_BY_USER'
+				| 'PAUSED_BY_INTERSECTION_OBSERVER'
+				| 'PAUSED_BY_BROWSER'
+			>,
+		) => {
+			const video = vidRef.current;
+			if (!video) {
+				return;
+			}
 
-		if (pauseReason === 'PAUSED_BY_INTERSECTION_OBSERVER') {
-			setMutedState({ value: true, track: false });
-		}
+			if (pauseReason === 'PAUSED_BY_INTERSECTION_OBSERVER') {
+				setMutedState({ value: true, track: false });
+			}
 
-		setPlayerState(pauseReason);
+			setPlayerState(pauseReason);
 
-		void video.pause();
-	};
+			void video.pause();
+		},
+		[setMutedState],
+	);
 
 	const playPauseVideo = () => {
 		if (playerState === 'PLAYING') {
@@ -778,6 +781,9 @@ export const SelfHostedVideo = ({
 			if (document.visibilityState === 'visible') {
 				handlePageBecomesVisible();
 			}
+			if (renderingTarget === 'Apps' && document.hidden) {
+				pauseVideo('PAUSED_BY_BROWSER');
+			}
 		});
 
 		return () => {
@@ -796,7 +802,7 @@ export const SelfHostedVideo = ({
 				handlePageBecomesVisible();
 			});
 		};
-	}, [setMutedState, uniqueId, sources, renderingTarget]);
+	}, [setMutedState, uniqueId, sources, renderingTarget, pauseVideo]);
 
 	/* Creates video-specific event listeners to handle fullscreen behaviour */
 	useEffect(() => {


### PR DESCRIPTION
## What does this change?

Pauses the video on Apps when a user leaves the page.

## Why?

On iOS, the video keeps playing (including audio!) despite the user going to a new page. Videos should not continue to play when a user exits the page in which the video is on.

Mimics a similar change to fix [the same issue in the interactives repo](https://github.com/guardian/interactives/pull/3004/changes/aa2d48ac5c4bdfc434e361014110cf804e2e9c50#diff-4a0fdcd62b6228cd7ef8fac47821bb93c03aa136ec0b8baf36ea02fe31496befR79-R92): 

## Testing

This needs to be tested on a simulator
