### PR TITLE
Update Interactive Progress Bar gradient

### DIFF
--- a/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
+++ b/dotcom-rendering/src/components/VideoProgressBarInteractive.tsx
@@ -20,12 +20,22 @@ const containerStyles = css`
 	z-index: ${getZIndex('video-progress-bar-background')};
 	cursor: pointer;
 	padding: 0 12px;
+	-webkit-tap-highlight-color: transparent;
+`;
+
+const backgroundStyles = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	height: 52px;
+	width: 100%;
+	z-index: -1;
 	background: linear-gradient(
 		to top,
 		${sourcePalette.neutral[0]} 0%,
+		rgba(0, 0, 0, 0.7) 50%,
 		transparent 100%
 	);
-	-webkit-tap-highlight-color: transparent;
 `;
 
 const trackStyles = css`
@@ -175,6 +185,7 @@ export const VideoProgressBarInteractive = ({
 				onPointerCancel={onSeekEnd}
 				onBlur={onSeekEnd}
 			/>
+			<div css={backgroundStyles} />
 		</div>
 	);
 };


### PR DESCRIPTION
## What does this change?

The time on the interactive progress bar used in the long-form player can be hard to read on light backgrounds. This adds a new div which allows the gradient to be taller than the clickable area of the progress bar.

## Why?

So that the time is always visible

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/aa3af7f2-19f3-4bb7-a841-e228f67e3404
[after]: https://github.com/user-attachments/assets/4193c8c5-ef13-4b40-9c51-19bf61755f0c

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
