### PR TITLE
Fix selector for Match Day app dark mode styles

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -90,9 +90,9 @@ const containerCss = css`
 	flex-direction: column;
 	gap: ${space[2]}px;
 
-	.ios,
-	.android {
-		@media (prefers-color-scheme: dark) {
+	@media (prefers-color-scheme: dark) {
+		.ios &,
+		.android & {
 			--match-day-text: ${neutral[86]};
 			--match-day-text-live: ${neutral[7]};
 			--match-day-text-result: ${neutral[97]};


### PR DESCRIPTION
## What does this change?

Fixes the selector used to apply the dark mode styles if the atom is rendered in the native app

## Why?

The `ios` or `android` class is applied to a higher level element outside of the component, but this would not be matched by the existing selector