### PR TITLE
Fix scrollable highlights to only hide newsletter sign up articles

### DIFF
--- a/dotcom-rendering/fixtures/manual/highlights-trails.ts
+++ b/dotcom-rendering/fixtures/manual/highlights-trails.ts
@@ -283,7 +283,7 @@ export const trails: Array<DCRFrontCard> = [
 	},
 ];
 
-export const newsletterCard: DCRFrontCard = {
+export const newsletterSignupCard: DCRFrontCard = {
 	format: {
 		theme: Pillar.News,
 		design: ArticleDesign.Standard,
@@ -307,6 +307,7 @@ export const newsletterCard: DCRFrontCard = {
 	isBoosted: false,
 	isCrossword: false,
 	isNewsletter: true,
+	isNewsletterSignup: true,
 	showQuotedHeadline: false,
 	showLivePlayable: false,
 	avatarUrl: undefined,

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { from } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-import { newsletterCard } from '../../../../fixtures/manual/highlights-trails';
+import { newsletterSignupCard } from '../../../../fixtures/manual/highlights-trails';
 import {
 	ArticleDesign,
 	ArticleDisplay,
@@ -40,11 +40,11 @@ const meta = {
 			design: ArticleDesign.Standard,
 			theme: Pillar.News,
 		},
-		newsletter: newsletterCard.newsletterData!,
-		headlineText: newsletterCard.headline,
-		linkTo: newsletterCard.url,
+		newsletter: newsletterSignupCard.newsletterData!,
+		headlineText: newsletterSignupCard.headline,
+		linkTo: newsletterSignupCard.url,
 		dataLinkName: 'highlights-newsletter-card | open-signup',
-		image: newsletterCard.image,
+		image: newsletterSignupCard.image,
 		imageLoading: 'eager',
 		renderingTarget: 'Web',
 	},

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { newsletterCard } from '../../../../fixtures/manual/highlights-trails';
+import { newsletterSignupCard } from '../../../../fixtures/manual/highlights-trails';
 import { sendNewsletterSignupEvent } from '../../../lib/newsletterSignupTracking';
 import { useIsInView } from '../../../lib/useIsInView';
 import { ConfigProvider } from '../../ConfigContext';
@@ -37,12 +37,12 @@ jest.mock('./HighlightsNewsletterSignupModal', () => ({
 }));
 
 const defaultProps: React.ComponentProps<typeof HighlightsNewsletterCard> = {
-	format: newsletterCard.format,
-	newsletter: newsletterCard.newsletterData!,
-	headlineText: newsletterCard.headline,
-	linkTo: newsletterCard.url,
+	format: newsletterSignupCard.format,
+	newsletter: newsletterSignupCard.newsletterData!,
+	headlineText: newsletterSignupCard.headline,
+	linkTo: newsletterSignupCard.url,
 	dataLinkName: 'highlights-newsletter-card | open-signup',
-	image: newsletterCard.image,
+	image: newsletterSignupCard.image,
 	renderingTarget: 'Web',
 };
 

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.stories.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.stories.tsx
@@ -1,12 +1,12 @@
 import { mocked } from 'storybook/test';
 import preview from '../../../../.storybook/preview';
-import { newsletterCard } from '../../../../fixtures/manual/highlights-trails';
+import { newsletterSignupCard } from '../../../../fixtures/manual/highlights-trails';
 import { lazyFetchEmailWithTimeout } from '../../../lib/fetchEmail';
 import { useIsSignedIn } from '../../../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../../../lib/useNewsletterSubscription';
 import { HighlightsNewsletterSignupModal } from './HighlightsNewsletterSignupModal';
 
-const newsletter = newsletterCard.newsletterData!;
+const newsletter = newsletterSignupCard.newsletterData!;
 
 const meta = preview.meta({
 	title: 'Components/Masthead/HighlightsNewsletterSignupModal',

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.test.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { newsletterCard } from '../../../../fixtures/manual/highlights-trails';
+import { newsletterSignupCard } from '../../../../fixtures/manual/highlights-trails';
 import { useNewsletterSubscription } from '../../../lib/useNewsletterSubscription';
 import { ConfigProvider } from '../../ConfigContext';
 import { HighlightsNewsletterSignupModal } from './HighlightsNewsletterSignupModal';
@@ -28,7 +28,7 @@ const mockUseNewsletterSubscription =
 		typeof useNewsletterSubscription
 	>;
 
-const newsletter = newsletterCard.newsletterData!;
+const newsletter = newsletterSignupCard.newsletterData!;
 
 const renderModal = (onClose = jest.fn()) =>
 	render(

--- a/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import {
 	defaultCard,
-	newsletterCard,
+	newsletterSignupCard,
 	trails,
 } from '../../fixtures/manual/highlights-trails';
 import { ConfigProvider } from './ConfigContext';
@@ -35,8 +35,17 @@ const renderHighlights = (
 		</ConfigProvider>,
 	);
 
-const newsletterCardWithoutData = {
-	...newsletterCard,
+/** A signup card where newsletterData is missing — should still be hidden when the switch is off. */
+const newsletterSignupCardWithoutData = {
+	...newsletterSignupCard,
+	newsletterData: undefined,
+};
+
+/** An article tagged with a newsletter topic but NOT a signup card — should always be shown. */
+const newsletterTaggedArticle = {
+	...newsletterSignupCard,
+	isNewsletter: true,
+	isNewsletterSignup: false,
 	newsletterData: undefined,
 };
 
@@ -47,31 +56,41 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 
 	describe('when user is in the "enable" group', () => {
 		it('renders the HighlightsNewsletterCard for a newsletter trail', () => {
-			renderHighlights([newsletterCard], true);
+			renderHighlights([newsletterSignupCard], true);
 
 			expect(
 				screen.getByRole('link', {
-					name: newsletterCard.headline,
+					name: newsletterSignupCard.headline,
 				}),
 			).toBeInTheDocument();
 		});
 
-		it('does not render a newsletter card when newsletterData is missing', () => {
-			renderHighlights([newsletterCardWithoutData], true);
+		it('does not render a newsletter signup card when newsletterData is missing', () => {
+			renderHighlights([newsletterSignupCardWithoutData], true);
 
 			expect(
 				screen.queryByRole('link', {
-					name: newsletterCardWithoutData.headline,
+					name: newsletterSignupCardWithoutData.headline,
 				}),
 			).not.toBeInTheDocument();
 		});
 
-		it('still renders regular cards alongside the newsletter card', () => {
-			renderHighlights([newsletterCard, defaultCard], true);
+		it('renders a newsletter-tagged article (isNewsletter) even when newsletterData is missing', () => {
+			renderHighlights([newsletterTaggedArticle], true);
 
 			expect(
 				screen.getByRole('link', {
-					name: `${newsletterCard.headline}`,
+					name: newsletterTaggedArticle.headline,
+				}),
+			).toBeInTheDocument();
+		});
+
+		it('still renders regular cards alongside the newsletter card', () => {
+			renderHighlights([newsletterSignupCard, defaultCard], true);
+
+			expect(
+				screen.getByRole('link', {
+					name: `${newsletterSignupCard.headline}`,
 				}),
 			).toBeInTheDocument();
 			expect(screen.getByText(defaultCard.headline)).toBeInTheDocument();
@@ -79,22 +98,32 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 	});
 
 	describe('when user is NOT in the "enable" group', () => {
-		it('does not render a newsletter card when newsletterData is missing', () => {
-			renderHighlights([newsletterCardWithoutData], false);
+		it('does not render a newsletter signup card when newsletterData is missing', () => {
+			renderHighlights([newsletterSignupCardWithoutData], false);
 
 			expect(
 				screen.queryByRole('link', {
-					name: newsletterCardWithoutData.headline,
+					name: newsletterSignupCardWithoutData.headline,
 				}),
 			).not.toBeInTheDocument();
 		});
 
+		it('renders a newsletter-tagged article (isNewsletter) even when newsletterData is missing', () => {
+			renderHighlights([newsletterTaggedArticle], false);
+
+			expect(
+				screen.getByRole('link', {
+					name: newsletterTaggedArticle.headline,
+				}),
+			).toBeInTheDocument();
+		});
+
 		it('does not render a newsletter card at all', () => {
-			renderHighlights([newsletterCard], false);
+			renderHighlights([newsletterSignupCard], false);
 
 			expect(
 				screen.queryByRole('link', {
-					name: newsletterCard.headline,
+					name: newsletterSignupCard.headline,
 				}),
 			).not.toBeInTheDocument();
 
@@ -104,11 +133,11 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 		});
 
 		it('does not render a newsletter trail when newsletterData is missing', () => {
-			renderHighlights([newsletterCardWithoutData], false);
+			renderHighlights([newsletterSignupCardWithoutData], false);
 
 			expect(
 				screen.queryByRole('link', {
-					name: newsletterCardWithoutData.headline,
+					name: newsletterSignupCardWithoutData.headline,
 				}),
 			).not.toBeInTheDocument();
 			expect(
@@ -117,7 +146,7 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 		});
 
 		it('still renders non-newsletter cards normally', () => {
-			renderHighlights([newsletterCard, defaultCard], false);
+			renderHighlights([newsletterSignupCard, defaultCard], false);
 
 			expect(screen.getByText(defaultCard.headline)).toBeInTheDocument();
 		});

--- a/dotcom-rendering/src/components/ScrollableHighlights.island.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.island.tsx
@@ -220,7 +220,7 @@ export const ScrollableHighlights = ({
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 
 	const visibleTrails = trails.filter((trail) => {
-		if (trail.isNewsletter !== true) return true;
+		if (trail.isNewsletterSignup !== true) return true;
 		return isNewsletterSignupCardEnabled && Boolean(trail.newsletterData);
 	});
 	const carouselLength = visibleTrails.length;

--- a/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
@@ -2,7 +2,7 @@ import { breakpoints } from '@guardian/source/foundations';
 import preview from '../../.storybook/preview';
 import {
 	defaultCard,
-	newsletterCard,
+	newsletterSignupCard,
 	trails,
 } from '../../fixtures/manual/highlights-trails';
 import { ScrollableHighlights } from './ScrollableHighlights.island';
@@ -118,7 +118,7 @@ export const withNewsletterCardVariant = meta.story({
 	...Default.input,
 	name: 'With Newsletter Signup Card (AB enabled)',
 	args: {
-		trails: [newsletterCard, ...Default.input.args.trails],
+		trails: [newsletterSignupCard, ...Default.input.args.trails],
 		isNewsletterSignupCardEnabled: true,
 	},
 });

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -416,6 +416,11 @@ export const enhanceCards = (
 				(type === 'Tone' && id === 'tone/newsletter-tone'),
 		);
 
+		const isNewsletterSignup = tags.some(
+			({ id, type }) =>
+				type === 'Keyword' && id === 'info/newsletter-sign-up',
+		);
+
 		const branding = faciaCard.properties.editionBrandings.find(
 			(editionBranding) => editionBranding.edition.id === editionId,
 		)?.branding;
@@ -481,6 +486,7 @@ export const enhanceCards = (
 			isImmersive: !!faciaCard.display.isImmersive,
 			isCrossword: faciaCard.properties.isCrossword,
 			isNewsletter,
+			isNewsletterSignup,
 			newsletterData: faciaCard.properties.newsletterData,
 			showQuotedHeadline: faciaCard.display.showQuotedHeadline,
 			// show latest 3 updates from a live blog

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -92,6 +92,7 @@ export type DCRFrontCard = {
 	isImmersive: boolean;
 	isCrossword?: boolean;
 	isNewsletter?: boolean;
+	isNewsletterSignup?: boolean;
 	newsletterData?: Newsletter;
 	discussionId?: string;
 	byline?: string;


### PR DESCRIPTION
## What does this change?

Only articles tagged as newsletter sign ups (rather than newsletter related) are hidden from the highlights

## Why?

Previously articles tagged as newsletter related were being hidden in the highlights

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
