### PR TITLE
turn commercial-teads-prebid swithc to off

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -140,7 +140,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-06-11",
 		type: "client",
-		status: "ON",
+		status: "OFF",
 		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],


### PR DESCRIPTION
## What does this change?
Sets the AB test config for commercial-teads-prebid to `off`.
## Why?
Our Ab test for commercial-teads-prebid is not needed at the moment and expired, until further notice.
