### PR TITLE
Slightly more stable check for audio embed

### DIFF
--- a/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/article.embeds.e2e.spec.ts
@@ -7,7 +7,7 @@ import { expectToBeVisible } from '../lib/locators';
 
 test.describe('Embeds', () => {
 	test.describe('WEB', function () {
-		test.skip('should render the click to view overlay revealing the embed when clicked', async ({
+		test('should render the click to view overlay revealing the embed when clicked', async ({
 			page,
 		}) => {
 			await loadPage({
@@ -26,12 +26,12 @@ test.describe('Embeds', () => {
 				.locator('button[data-testid="click-to-view-button"]')
 				.click();
 
-			await expect(
-				await getIframeBody(
-					page,
-					'div[data-testid="embed-block"] > div > iframe',
-				),
-			).toContainText('Radiolab');
+			const iframeBodyLocator = await getIframeBody(
+				page,
+				'div[data-testid="embed-block"] > div > iframe',
+			);
+
+			await expect(iframeBodyLocator.locator('audio')).toBeAttached();
 		});
 
 		test('should render the interactive 1', async ({ page }) => {


### PR DESCRIPTION
## What does this change?

I've made this test more generic and less prone to failure. It now tests for the existence of an audio element rather than a text string within the embed.

However since it still requires the third party to behave in an expected way, this is still not guaranteed to work forever, as the expected behaviour is outside of our control.

## Why?

There is an end to end test for a "third party content" banner that must be clicked before a third party embed is downloaded. This test was failing because the third party embed is no longer available – the expected text string was not appearing. 
