### PR TITLE
Move world cup nav above the football match header

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -228,6 +228,10 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					</Section>
 				</Stuck>
 			)}
+			<DirectoryPageNavIsland
+				pageId={article.pageId}
+				pageTags={article.tags}
+			/>
 
 			<MatchHeaderContainer
 				isMatchReport={isMatchReport}
@@ -248,10 +252,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 						<AdPortals />
 					</Island>
 				)}
-				<DirectoryPageNavIsland
-					pageId={article.pageId}
-					pageTags={article.tags}
-				/>
+
 				{/* GridItem order matters — mobile layout relies on DOM order for grid placement.
     See furnitureArrangements.ts if reordering. */}
 				<article


### PR DESCRIPTION
## What does this change?
Move world cup nav above the match header

## Why?
It should always be under the main nav

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0472adb2-e458-4b91-9a0c-007cdb59b472
[after]: https://github.com/user-attachments/assets/ed32ae31-9fcf-4eeb-8ae6-e55768faecf5


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
