### PR TITLE
Align match header inner rules with article

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -246,21 +246,27 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 				flex: '1 1 50%',
 				wordBreak: 'break-word',
 				borderLeftStyle: 'solid',
+				borderLeftColor: 'var(--border-left-colour)',
 				'&:last-of-type': {
 					paddingLeft: space[2],
 					borderLeftWidth: 1,
 				},
 				[from.leftCol]: {
-					paddingLeft: space[2],
-					borderLeftWidth: 1,
 					paddingTop: space[3],
-					'&:first-of-type': {
-						marginLeft: `-10px`,
+					position: 'relative',
+					'&:first-of-type::before': {
+						content: '""',
+						top: 0,
+						left: -10,
+						width: 1,
+						backgroundColor: 'var(--border-left-colour)',
+						position: 'absolute',
+						height: '100%',
 					},
 				},
 			}}
 			style={{
-				borderLeftColor: palette(border(props.match.kind)),
+				'--border-left-colour': palette(border(props.match.kind)),
 			}}
 		>
 			<TeamName name={props.team.name} />

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -57,14 +57,18 @@ export const CricketMatchHeader = (props: Props) => {
 		>
 			<div
 				css={{
-					'&': css(grid.paddedContainer),
+					'&': css(
+						grid.paddedContainer,
+						grid.outerRules(
+							palette(
+								'--football-match-header-fixture-result-border',
+							),
+						),
+					),
 					[from.tablet]: {
 						borderColor: palette(
 							'--football-match-header-fixture-result-border',
 						),
-						borderStyle: 'solid',
-						borderLeftWidth: 1,
-						borderRightWidth: 1,
 					},
 				}}
 			>
@@ -250,6 +254,9 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 					paddingLeft: space[2],
 					borderLeftWidth: 1,
 					paddingTop: space[3],
+					'&:first-of-type': {
+						marginLeft: `-10px`,
+					},
 				},
 			}}
 			style={{

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -113,14 +113,28 @@ export const FootballMatchHeader = (props: Props) => {
 		>
 			<div
 				css={{
-					'&': css(grid.paddedContainer),
+					'&': css(
+						grid.paddedContainer,
+						grid.outerRules(
+							palette(
+								'--football-match-header-fixture-result-border',
+							),
+						),
+						css`
+							${from.leftCol} {
+								${grid.centreRule(
+									3,
+									palette(
+										'--football-match-header-fixture-result-border',
+									),
+								)}
+							}
+						`,
+					),
 					[from.tablet]: {
 						borderColor: palette(
 							'--football-match-header-fixture-result-border',
 						),
-						borderStyle: 'solid',
-						borderLeftWidth: 1,
-						borderRightWidth: 1,
 					},
 				}}
 			>
@@ -329,10 +343,10 @@ const Team = (props: {
 		css={{
 			flex: '1 1 50%',
 			wordBreak: 'break-word',
-			borderLeftStyle: 'solid',
 			'&:last-of-type': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
+				borderLeftStyle: 'solid',
 			},
 			[from.leftCol]: {
 				paddingLeft: space[2],

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -334,21 +334,27 @@ const Team = (props: {
 			flex: '1 1 50%',
 			wordBreak: 'break-word',
 			borderLeftStyle: 'solid',
+			borderLeftColor: 'var(--border-left-colour)',
 			'&:last-of-type': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
-				paddingLeft: space[2],
-				borderLeftWidth: 1,
 				paddingTop: space[3],
-				'&:first-of-type': {
-					marginLeft: `-10px`,
+				position: 'relative',
+				'&:first-of-type::before': {
+					content: '""',
+					top: 0,
+					left: -10,
+					width: 1,
+					backgroundColor: 'var(--border-left-colour)',
+					position: 'absolute',
+					height: '100%',
 				},
 			},
 		}}
 		style={{
-			borderLeftColor: palette(border(props.match.kind)),
+			'--border-left-colour': palette(border(props.match.kind)),
 		}}
 	>
 		<TeamName name={props.match[props.team].name} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -120,16 +120,6 @@ export const FootballMatchHeader = (props: Props) => {
 								'--football-match-header-fixture-result-border',
 							),
 						),
-						css`
-							${from.leftCol} {
-								${grid.centreRule(
-									3,
-									palette(
-										'--football-match-header-fixture-result-border',
-									),
-								)}
-							}
-						`,
 					),
 					[from.tablet]: {
 						borderColor: palette(
@@ -343,15 +333,18 @@ const Team = (props: {
 		css={{
 			flex: '1 1 50%',
 			wordBreak: 'break-word',
+			borderLeftStyle: 'solid',
 			'&:last-of-type': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
-				borderLeftStyle: 'solid',
 			},
 			[from.leftCol]: {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
 				paddingTop: space[3],
+				'&:first-of-type': {
+					marginLeft: `-10px`,
+				},
 			},
 		}}
 		style={{

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -118,7 +118,12 @@ const Tab = (props: {
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
+				paddingLeft: space[2],
+				borderLeftWidth: 1,
 				flex: '0 0 auto',
+				'&:first-of-type': {
+					marginLeft: `-10px`,
+				},
 			},
 		}}
 		style={{

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -113,21 +113,27 @@ const Tab = (props: {
 			// Ensures that if there are only two tabs they take up exactly 50%
 			flex: '1 1 50%',
 			borderLeftStyle: 'solid',
+			borderLeftColor: 'var(--border-left-colour)',
 			'&:not(:first-of-type)': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
-				paddingLeft: space[2],
-				borderLeftWidth: 1,
 				flex: '0 0 auto',
-				'&:first-of-type': {
-					marginLeft: `-10px`,
+				position: 'relative',
+				'&:first-of-type::before': {
+					content: '""',
+					top: 0,
+					left: -10,
+					width: 1,
+					backgroundColor: 'var(--border-left-colour)',
+					position: 'absolute',
+					height: '100%',
 				},
 			},
 		}}
 		style={{
-			borderLeftColor: palette(border(props.matchKind)),
+			'--border-left-colour': palette(border(props.matchKind)),
 		}}
 	>
 		<TabText href={props.href} matchKind={props.matchKind}>

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -118,8 +118,6 @@ const Tab = (props: {
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
-				paddingLeft: space[2],
-				borderLeftWidth: 1,
 				flex: '0 0 auto',
 			},
 		}}


### PR DESCRIPTION
Came across what I think is an unrelated bug while browsing around to check #6390 rolled out ok. The vertical rules on the football and cricket match headers don't align with the article/masthead from leftCol upwards. This rejigs it to use the verticalRules section of the grid module and line everything up.

Also for the sake of consistency I've switched to `grid.outerRules()` for the outer lines.

### Before

<img width="1258" height="439" alt="image" src="https://github.com/user-attachments/assets/5fc4c016-fbfe-4c51-b131-380bc031a55c" />

### After

<img width="1228" height="319" alt="image" src="https://github.com/user-attachments/assets/d0727f8c-5cca-4eb7-b5b8-8ea085e5ecf8" />

Maybe the way it is is how we want it but thought I'd raise a quick PR in case it's not.