### PR TITLE
Add Affiliate disclaimer back to standardlayout

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -395,27 +395,34 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 								</Hide>
 							</>
 						) : (
-							<ArticleMeta
-								branding={branding}
-								format={format}
-								pageId={article.pageId}
-								webTitle={article.webTitle}
-								byline={article.byline}
-								source={article.config.source}
-								tags={article.tags}
-								primaryDateline={
-									article.webPublicationDateDisplay
-								}
-								secondaryDateline={
-									article.webPublicationSecondaryDateDisplay
-								}
-								isCommentable={article.isCommentable}
-								discussionApiUrl={
-									article.config.discussionApiUrl
-								}
-								shortUrlId={article.config.shortUrlId}
-								mainMediaElements={article.mainMediaElements}
-							/>
+							<>
+								<ArticleMeta
+									branding={branding}
+									format={format}
+									pageId={article.pageId}
+									webTitle={article.webTitle}
+									byline={article.byline}
+									source={article.config.source}
+									tags={article.tags}
+									primaryDateline={
+										article.webPublicationDateDisplay
+									}
+									secondaryDateline={
+										article.webPublicationSecondaryDateDisplay
+									}
+									isCommentable={article.isCommentable}
+									discussionApiUrl={
+										article.config.discussionApiUrl
+									}
+									shortUrlId={article.config.shortUrlId}
+									mainMediaElements={
+										article.mainMediaElements
+									}
+								/>
+								{!!article.affiliateLinksDisclaimer && (
+									<AffiliateDisclaimer />
+								)}
+							</>
 						)}
 					</GridItem>
 					<GridItem area="body" layoutType={layoutType}>


### PR DESCRIPTION
## What does this change?

Adds the affiliate disclaimer leftcol component back to the standard layout after #15428 

## Why?

Editorial colleagues flagged that they could not see the disclaimer, this is important as it has legal ramifications. It is visible at smaller breakpoints (where AffiliateDisclaimerInline takes effect)

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="913" height="863" alt="image" src="https://github.com/user-attachments/assets/ed7f55e9-1fc4-4d81-95a5-d3ee85d072e5" />| <img width="935" height="858" alt="image" src="https://github.com/user-attachments/assets/25a605e5-95fd-4a7d-8549-42f4ca6b2fe8" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
