### PR TITLE
updated team name colours and added darkmode colour

### DIFF
--- a/dotcom-rendering/src/components/CricketScorecardNew.tsx
+++ b/dotcom-rendering/src/components/CricketScorecardNew.tsx
@@ -253,11 +253,11 @@ const teamNameStyles = css`
 `;
 
 const homeTeamNameStyles = css`
-	color: ${palette('--cricket-scorecard-first-team-color')};
+	color: ${palette('--cricket-scorecard-first-team-lineup-color')};
 `;
 
 const awayTeamNameStyles = css`
-	color: ${palette('--cricket-scorecard-second-team-color')};
+	color: ${palette('--cricket-scorecard-second-team-lineup-color')};
 `;
 
 const playerListStyles = css`

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -6914,16 +6914,24 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[86],
 	},
 	'--cricket-scorecard-first-team-color': {
-		light: () => '#22721a',
-		dark: () => '#4aad42',
+		light: () => sourcePalette.sport[400],
+		dark: () => sourcePalette.sport[400],
+	},
+	'--cricket-scorecard-first-team-lineup-color': {
+		light: () => sourcePalette.sport[400],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--cricket-scorecard-innings-heading-text': {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[100],
 	},
 	'--cricket-scorecard-second-team-color': {
-		light: () => '#071b3c',
-		dark: () => '#4878c0',
+		light: () => sourcePalette.sport[100],
+		dark: () => sourcePalette.sport[100],
+	},
+	'--cricket-scorecard-second-team-lineup-color': {
+		light: () => sourcePalette.sport[100],
+		dark: () => sourcePalette.neutral[86],
 	},
 	'--crossword-anagram-helper-background': {
 		light: crosswordAnagramHelperBackgroundLight,


### PR DESCRIPTION
## What does this change?

Updating team name colours to match these designs: https://www.figma.com/design/LdZ45aKMlJ1isivv89xp4a/Sports-live-blogs?node-id=1567-14230&t=ldimxtdYmtPUtyU4-1

Specifically this involved introducing a pair of variables for the team names in the lineups section as those colours need to change for darkmode whereas the main team names do not.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before1][] | ![after1][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before1]: https://github.com/user-attachments/assets/e8ca233b-f4e7-4744-9212-9d9f7234296e
[after1]: https://github.com/user-attachments/assets/8657ac50-710c-4305-8406-96373b032b53

[before2]: https://github.com/user-attachments/assets/b6670b41-84f8-4b68-b3b5-aeeda5b673f7
[after2]: https://github.com/user-attachments/assets/c931efc4-1d92-493f-9754-f4571098f75e

[before3]: https://github.com/user-attachments/assets/7ae0d543-8c17-4fe3-bbde-42d32b65c8e3
[after3]: https://github.com/user-attachments/assets/cb59e2fe-9cb4-42d4-9cdb-44d4de523fb7