### PR TITLE
Handle long home team names in Match Day component

### DIFF
--- a/dotcom-rendering/fixtures/manual/footballData.ts
+++ b/dotcom-rendering/fixtures/manual/footballData.ts
@@ -98,7 +98,7 @@ export const matchDayWorldCup: FootballMatches = [
 							score: 0,
 						},
 						awayTeam: {
-							name: 'Bosnia-Herzegovina',
+							name: 'Bosnia and Herzegovina',
 							id: '7531',
 							score: 0,
 						},

--- a/dotcom-rendering/src/components/FootballMatchDay.tsx
+++ b/dotcom-rendering/src/components/FootballMatchDay.tsx
@@ -317,6 +317,10 @@ const teamCss = css`
 	display: flex;
 	align-items: center;
 	gap: ${space[1]}px;
+	text-align: right;
+	${from.phablet} {
+		padding-left: 8ch;
+	}
 `;
 
 const awayTeamCss = css`
@@ -324,6 +328,10 @@ const awayTeamCss = css`
 	flex-direction: row-reverse;
 	justify-self: start;
 	padding-right: ${space[4]}px;
+	text-align: left;
+	${from.phablet} {
+		padding-left: 0;
+	}
 `;
 
 const Score = ({ match }: { match: FootballMatch }) => {


### PR DESCRIPTION
## What does this change?

Improves handling of home teams with long names by adding padding to avoid the match status on the left and aligning text to the right. Padding is only applied at the phablet breakpoint as below this the match status moves to its own row above the team names.

## Why?

Generally this isn't an issue as the match status doesn't occupy the same row on small viewports. However, it was noted that editorial have placed the atom into a half-width container which doesn't trigger the small viewport layout as it relies on a media query. This change helps to ensure the layout still works in this scenario without the match status overlapping longer team names.

## Screenshots

[_Nooit opgeven altijd doorzetten, Aangenaam door vermaak en nuttig door ontspanning, Combinatie Breda_ is better known as _NAC Breda_](https://en.wikipedia.org/wiki/NAC_Breda)

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/00f8ddda-ca9f-4960-8b27-89468204b6bf
[after]: https://github.com/user-attachments/assets/0ae75529-b36b-4ac1-aed3-12e89a4e3617

On small viewports the match status is relocated so the padding is not required:

<img width="379" height="364" alt="Screenshot 2026-06-11 at 17 02 56" src="https://github.com/user-attachments/assets/ef4e7b44-3f85-40e4-a3f7-521741e131bb" />
