### PR TITLE
Hide Share button on Hosted Gallery

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { between, from, space, textSans14 } from '@guardian/source/foundations';
 import { grid } from '../grid';
-import { type ArticleFormat } from '../lib/articleFormat';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
 import { CaptionText } from './CaptionText';
 import { Island } from './Island';
@@ -50,6 +50,8 @@ export const GalleryCaption = ({
 	const emptyCaption = captionHtml === undefined || captionHtml.trim() === '';
 	const hideCredit =
 		displayCredit === false || credit === undefined || credit === '';
+	const shouldIncludeShareButton =
+		format.design !== ArticleDesign.HostedGallery;
 
 	if (emptyCaption && hideCredit) {
 		return null;
@@ -73,19 +75,21 @@ export const GalleryCaption = ({
 					padding-top: ${space[2]}px;
 				`}
 			>
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<ShareButton
-						format={format}
-						pageId={pageId}
-						webTitle={webTitle}
-						context="ImageCaption"
-						hash={
-							typeof position === 'number'
-								? `img-${position}`
-								: undefined
-						}
-					/>
-				</Island>
+				{shouldIncludeShareButton && (
+					<Island priority="feature" defer={{ until: 'visible' }}>
+						<ShareButton
+							format={format}
+							pageId={pageId}
+							webTitle={webTitle}
+							context="ImageCaption"
+							hash={
+								typeof position === 'number'
+									? `img-${position}`
+									: undefined
+							}
+						/>
+					</Island>
+				)}
 			</div>
 		</figcaption>
 	);


### PR DESCRIPTION
## What does this change?
Hides the Share button in image captions for Hosted Gallery, while keeping it visible for non-Hosted Gallery types (including Labs Gallery).

## Why?
As part of the Hosted Content redesign, Hosted Gallery pages reuse the Gallery/Labs Gallery body structure, which includes image captions with a Share button.
For Hosted Gallery pages, this caption-level Share button is not required.
This change removes it only for Hosted Gallery and preserves existing behaviour elsewhere.

**Note:** This is an isolated PR created from branch `cemms1/hosted-gallery` so Hosted Gallery behaviour can be tested before that work is in production.
The change is intentionally scoped to Hosted Gallery logic only and does not affect current production Labs Gallery behaviour.


## Screenshots
Tested on Hosted Gallery using branch `cemms1/hosted-gallery`
| Before      | After      |
| ----------- | ---------- |
| <img width="762" height="356" alt="Screenshot 2026-06-11 at 10 41 53" src="https://github.com/user-attachments/assets/7e6ee800-ea69-4b15-b467-4a0d0f161e0f" />| <img width="846" height="350" alt="Screenshot 2026-06-11 at 10 41 30" src="https://github.com/user-attachments/assets/372ce7d8-4660-4bf1-9300-f0088ea07110" />|

The current behaviour for Labs Gallery which still need the `share` button are successfully unaffected
| Labs Gallery still has share button | 
| ----------- | 
| <img width="400" alt="Screenshot 2026-06-11 at 10 42 42" src="https://github.com/user-attachments/assets/824803b0-c734-40da-8670-967745f53d1a" /> | 



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
