### PR TITLE
Fix interscroller stacking context

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { adSizes, constants } from '@guardian/commercial-core';
 import { from, textSans12, until } from '@guardian/source/foundations';
 import { palette } from '../palette';
+import { getZIndex } from './getZIndex';
 
 const labelHeight = constants.AD_LABEL_HEIGHT;
 
@@ -137,6 +138,7 @@ const spacefinderAdSlotContainerStyles = css`
 			/* this fixes inter-scrollers stealing mouse events */
 			overflow: hidden;
 			position: relative;
+			z-index: ${getZIndex('interscrollerAd')};
 
 			/* position the iframe absolutely (relative to the slot) so that it is in the correct position to detect viewability */
 			.ad-slot__content {

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -57,6 +57,9 @@ const indices = [
 	// Edition selector in nav - needs to be below stickyAdWrapper
 	'editionDropdown',
 
+	// Interscroller ads need their own stacking context to force the background image below the ad to stop it capturing mouse events
+	'interscrollerAd',
+
 	// The content displayed by the Details component
 	'summaryDetails',
 


### PR DESCRIPTION
## What does this change?

Fix interscroller stacking context

## Why?

Interscrollers became invisible following this grid update to standard layout: #15428

Interscrollers background images are larger than their ad slot container. We have custom logic to show a windowed view of the background image as the user scrolls:

https://github.com/guardian/commercial/blob/ef41ae52f5927fa1d995da510d383d83b31e6bab/bundle/src/lib/messenger/background.ts

Previously interscrollers set the background image `z-index: -1`, I believe to force the background image behind the ad slot container to prevent it from capturing mouse events outside of the ad container. However with the new grid  layout the `z-index: -1` has forced it behind the main content.

This update uses the `getZIndex` util to create a new stacking context on the ad container and keeps `z-index: -1` on the background image. But it should now sit in its own stacking context.

## Screenshots

### Before

https://github.com/user-attachments/assets/e6f0cafb-b075-4140-9cf5-a67ae7d92254

### After

https://github.com/user-attachments/assets/9b0c460a-a5dc-4998-a7b1-520969c9bfa5

