### PR TITLE
Adjust grid centre rule clipping

### DIFF
--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -94,7 +94,7 @@ const paddedContainer = `
  * The rule is self-contained on the nth child element rather than on the grid
  * container, so that `top: 0` aligns to that element's top edge. `bottom`
  * uses a large negative value to extend the rule down to the container's
- * bottom, so `overflow: hidden` is applied to the container.
+ * bottom, so `contain: paint` is applied to the container.
  *
  * @example
  * css`
@@ -108,7 +108,7 @@ const paddedContainer = `
  * `
  */
 const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
-	overflow: hidden;
+	contain: paint;
 
     & > *:nth-child(${n}) {
       position: relative;


### PR DESCRIPTION
This addresses a bug where the `overflow: hidden` property applied to containers using the grid module's `centreRule()` doesn't play nicely with lightbox. Changing the container property [`contain: paint`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/contain) does the trick and is more semantically correct anyway a grid container's vertical rules should stay in their box.