### PR TITLE
Tweak modal overlay slide up on iOS

### DIFF
--- a/dotcom-rendering/scripts/jest/setup.ts
+++ b/dotcom-rendering/scripts/jest/setup.ts
@@ -109,5 +109,22 @@ if (!isServer) {
 global.TextEncoder = TextEncoder as unknown as typeof global.TextEncoder;
 global.TextDecoder = TextDecoder as unknown as typeof global.TextDecoder;
 
+if (!isServer) {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: (query: string): MediaQueryList =>
+			({
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: () => {},
+				removeListener: () => {},
+				addEventListener: () => {},
+				removeEventListener: () => {},
+				dispatchEvent: () => false,
+			}) as MediaQueryList,
+	});
+}
+
 // Mocks the version number used by CDK, we don't want our tests to fail every time we update our cdk dependency.
 jest.mock('@guardian/cdk/lib/constants/tracking-tag');

--- a/dotcom-rendering/src/components/ModalOverlay.test.tsx
+++ b/dotcom-rendering/src/components/ModalOverlay.test.tsx
@@ -48,12 +48,12 @@ describe('ModalOverlay', () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onClose when the overlay backdrop receives a mousedown', () => {
+	it('calls onClose when the overlay backdrop receives a pointerdown', () => {
 		const onClose = jest.fn();
 		renderOverlay(onClose);
 
 		const overlay = screen.getByRole('dialog').parentElement!;
-		fireEvent.mouseDown(overlay);
+		fireEvent.pointerDown(overlay);
 
 		act(() => {
 			jest.runAllTimers();
@@ -62,11 +62,11 @@ describe('ModalOverlay', () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
-	it('does not call onClose when the dialog itself receives a mousedown', () => {
+	it('does not call onClose when the dialog itself receives a pointerdown', () => {
 		const onClose = jest.fn();
 		renderOverlay(onClose);
 
-		fireEvent.mouseDown(screen.getByRole('dialog'));
+		fireEvent.pointerDown(screen.getByRole('dialog'));
 
 		act(() => {
 			jest.runAllTimers();

--- a/dotcom-rendering/src/components/ModalOverlay.tsx
+++ b/dotcom-rendering/src/components/ModalOverlay.tsx
@@ -14,6 +14,10 @@ import { getZIndex } from '../lib/getZIndex';
 const OPEN_ANIMATION_DURATION_MS = 300;
 const CLOSE_ANIMATION_DURATION_MS = 225;
 
+const prefersReducedMotion = (): boolean =>
+	typeof window !== 'undefined' &&
+	window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 const ModalRequestCloseContext = createContext<(() => void) | null>(null);
 
 export const useModalRequestClose = (): (() => void) => {
@@ -130,19 +134,16 @@ export const ModalOverlay = ({
 	const overlayRef = useRef<HTMLDivElement>(null);
 	const dialogRef = useRef<HTMLDivElement>(null);
 	const closeTimeoutRef = useRef<number | null>(null);
-	const [isVisible, setIsVisible] = useState(false);
+
+	const [isVisible, setIsVisible] = useState(() => prefersReducedMotion());
 
 	const requestClose = useCallback(() => {
 		if (closeTimeoutRef.current !== null) {
 			return;
 		}
 
-		const prefersReducedMotion =
-			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ??
-			false;
-
-		if (prefersReducedMotion) {
-			closeTimeoutRef.current = 0;
+		if (prefersReducedMotion()) {
+			closeTimeoutRef.current = -1;
 			onClose();
 			return;
 		}
@@ -156,21 +157,19 @@ export const ModalOverlay = ({
 
 	// Trigger open animation on mount
 	useEffect(() => {
-		const prefersReducedMotion =
-			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ??
-			false;
-
-		if (prefersReducedMotion) {
-			setIsVisible(true);
+		if (prefersReducedMotion()) {
 			return;
 		}
-
-		const animationFrameId = window.requestAnimationFrame(() => {
-			setIsVisible(true);
+		let innerAnimationFrameId: number = 0;
+		const outerAnimationFrameId = window.requestAnimationFrame(() => {
+			innerAnimationFrameId = window.requestAnimationFrame(() => {
+				setIsVisible(true);
+			});
 		});
 
 		return () => {
-			window.cancelAnimationFrame(animationFrameId);
+			window.cancelAnimationFrame(outerAnimationFrameId);
+			window.cancelAnimationFrame(innerAnimationFrameId);
 		};
 	}, []);
 
@@ -282,18 +281,21 @@ export const ModalOverlay = ({
 			return;
 		}
 
-		const handleOverlayMouseDown = (event: MouseEvent) => {
+		const handleOverlayPointerDown = (event: PointerEvent) => {
 			if (event.target === overlayElement) {
 				requestClose();
 			}
 		};
 
-		overlayElement.addEventListener('mousedown', handleOverlayMouseDown);
+		overlayElement.addEventListener(
+			'pointerdown',
+			handleOverlayPointerDown,
+		);
 
 		return () => {
 			overlayElement.removeEventListener(
-				'mousedown',
-				handleOverlayMouseDown,
+				'pointerdown',
+				handleOverlayPointerDown,
 			);
 		};
 	}, [requestClose]);
@@ -305,7 +307,6 @@ export const ModalOverlay = ({
 	return createPortal(
 		<div ref={overlayRef} css={overlayStyles(isVisible)}>
 			<div
-				/* PRISTINE JSX: No hacky touch handlers needed anymore */
 				ref={dialogRef}
 				role="dialog"
 				aria-modal="true"

--- a/dotcom-rendering/src/components/ModalOverlay.tsx
+++ b/dotcom-rendering/src/components/ModalOverlay.tsx
@@ -143,9 +143,6 @@ export const ModalOverlay = ({
 		}
 
 		if (prefersReducedMotion()) {
-			// Use -1 as a sentinel to block re-entrant calls. 0 is a valid
-			// setTimeout ID and must not be used here.
-			closeTimeoutRef.current = -1;
 			onClose();
 			return;
 		}

--- a/dotcom-rendering/src/components/ModalOverlay.tsx
+++ b/dotcom-rendering/src/components/ModalOverlay.tsx
@@ -160,16 +160,13 @@ export const ModalOverlay = ({
 		if (prefersReducedMotion()) {
 			return;
 		}
-		let innerAnimationFrameId: number = 0;
-		const outerAnimationFrameId = window.requestAnimationFrame(() => {
-			innerAnimationFrameId = window.requestAnimationFrame(() => {
-				setIsVisible(true);
-			});
+
+		const animationFrameId = window.requestAnimationFrame(() => {
+			setIsVisible(true);
 		});
 
 		return () => {
-			window.cancelAnimationFrame(outerAnimationFrameId);
-			window.cancelAnimationFrame(innerAnimationFrameId);
+			window.cancelAnimationFrame(animationFrameId);
 		};
 	}, []);
 
@@ -204,7 +201,9 @@ export const ModalOverlay = ({
 				? document.activeElement
 				: null;
 
-		dialogElement.focus();
+		// preventScroll stops iOS Safari from jerking the viewport to bring
+		// the off-screen element into view before the slide-up animation runs.
+		dialogElement.focus({ preventScroll: true });
 
 		return () => {
 			if (
@@ -283,6 +282,7 @@ export const ModalOverlay = ({
 
 		const handleOverlayPointerDown = (event: PointerEvent) => {
 			if (event.target === overlayElement) {
+				event.preventDefault();
 				requestClose();
 			}
 		};


### PR DESCRIPTION
## What does this change?

Fixes a visual jump when the modal opens on iOS Safari, and addresses several other latent bugs found during investigation.
iOS open animation — adds { preventScroll: true } to the initial .focus() call, stopping iOS Safari from scrolling the viewport to chase the off-screen element before the slide-up transition runs
Backdrop tap-to-close on iOS — switches from mousedown to pointerdown, which fires reliably for touch input
prefersReducedMotion initialisation — state is now initialised lazily via useState(() => prefersReducedMotion()) rather than set synchronously inside an effect, removing a cascading-render lint violation
Close sentinel value — uses -1 instead of 0 as the "close in progress" marker, since 0 is a valid setTimeout return value
SSR guard placement — moved the typeof document === 'undefined' check to after all hooks to comply with the rules of hooks

## Why?

The modal was visibly jumping on iOS when opening rather than sliding up smoothly. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
