### PR TITLE
`before` for football header borders

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -257,7 +257,7 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 					'&:first-of-type::before': {
 						content: '""',
 						top: 0,
-						left: -11,
+						left: -10,
 						width: 1,
 						backgroundColor: 'var(--border-left-colour)',
 						position: 'absolute',

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -246,21 +246,27 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 				flex: '1 1 50%',
 				wordBreak: 'break-word',
 				borderLeftStyle: 'solid',
+				borderLeftColor: 'var(--border-left-colour)',
 				'&:last-of-type': {
 					paddingLeft: space[2],
 					borderLeftWidth: 1,
 				},
 				[from.leftCol]: {
-					paddingLeft: space[2],
-					borderLeftWidth: 1,
 					paddingTop: space[3],
-					'&:first-of-type': {
-						marginLeft: `-10px`,
+					position: 'relative',
+					'&:first-of-type::before': {
+						content: '""',
+						top: 0,
+						left: -11,
+						width: 1,
+						backgroundColor: 'var(--border-left-colour)',
+						position: 'absolute',
+						height: '100%',
 					},
 				},
 			}}
 			style={{
-				borderLeftColor: palette(border(props.match.kind)),
+				'--border-left-colour': palette(border(props.match.kind)),
 			}}
 		>
 			<TeamName name={props.team.name} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -334,21 +334,27 @@ const Team = (props: {
 			flex: '1 1 50%',
 			wordBreak: 'break-word',
 			borderLeftStyle: 'solid',
+			borderLeftColor: 'var(--border-left-colour)',
 			'&:last-of-type': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
-				paddingLeft: space[2],
-				borderLeftWidth: 1,
 				paddingTop: space[3],
-				'&:first-of-type': {
-					marginLeft: `-10px`,
+				position: 'relative',
+				'&:first-of-type::before': {
+					content: '""',
+					top: 0,
+					left: -11,
+					width: 1,
+					backgroundColor: 'var(--border-left-colour)',
+					position: 'absolute',
+					height: '100%',
 				},
 			},
 		}}
 		style={{
-			borderLeftColor: palette(border(props.match.kind)),
+			'--border-left-colour': palette(border(props.match.kind)),
 		}}
 	>
 		<TeamName name={props.match[props.team].name} />

--- a/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/FootballMatchHeader.tsx
@@ -345,7 +345,7 @@ const Team = (props: {
 				'&:first-of-type::before': {
 					content: '""',
 					top: 0,
-					left: -11,
+					left: -10,
 					width: 1,
 					backgroundColor: 'var(--border-left-colour)',
 					position: 'absolute',

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -113,21 +113,27 @@ const Tab = (props: {
 			// Ensures that if there are only two tabs they take up exactly 50%
 			flex: '1 1 50%',
 			borderLeftStyle: 'solid',
+			borderLeftColor: 'var(--border-left-colour)',
 			'&:not(:first-of-type)': {
 				paddingLeft: space[2],
 				borderLeftWidth: 1,
 			},
 			[from.leftCol]: {
-				paddingLeft: space[2],
-				borderLeftWidth: 1,
 				flex: '0 0 auto',
-				'&:first-of-type': {
-					marginLeft: `-10px`,
+				position: 'relative',
+				'&:first-of-type::before': {
+					content: '""',
+					top: 0,
+					left: -11,
+					width: 1,
+					backgroundColor: 'var(--border-left-colour)',
+					position: 'absolute',
+					height: '100%',
 				},
 			},
 		}}
 		style={{
-			borderLeftColor: palette(border(props.matchKind)),
+			'--border-left-colour': palette(border(props.matchKind)),
 		}}
 	>
 		<TabText href={props.href} matchKind={props.matchKind}>

--- a/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeader/Tabs.tsx
@@ -124,7 +124,7 @@ const Tab = (props: {
 				'&:first-of-type::before': {
 					content: '""',
 					top: 0,
-					left: -11,
+					left: -10,
 					width: 1,
 					backgroundColor: 'var(--border-left-colour)',
 					position: 'absolute',


### PR DESCRIPTION
This ensures that parts of the design, such as the central border, remain aligned with other parts of the page.

**Note:** This is a PR opened into #16127.

## Screenshots

The green line is added to demonstrate the alignment, it doesn't appear in the page.

| Before | After |
|--------|--------|
| <img width="3639" height="1624" alt="border-before" src="https://github.com/user-attachments/assets/5c0ba32a-f61d-4743-97ab-0a961efb40e7" /> | <img width="3639" height="1641" alt="border-after" src="https://github.com/user-attachments/assets/6abfcb64-e0d7-4303-9e79-e354057919d7" /> |
