### PR TITLE
Increase the frequency of the football match-header client side calls…

### DIFF
--- a/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
+++ b/dotcom-rendering/src/components/FootballMatchHeaderWrapper.island.tsx
@@ -31,7 +31,7 @@ export const FootballMatchHeaderWrapper = (props: Props) => (
 		article={props.article}
 		format={props.format}
 		getHeaderData={getHeaderData}
-		refreshInterval={16_000}
+		refreshInterval={10_000}
 		renderingTarget={props.renderingTarget}
 		notificationsClient={getNotificationsClient()}
 		matchNotificationsClient={getMatchNotificationsClient()}


### PR DESCRIPTION
Co-authored-by: Ravi <7014230+arelra@users.noreply.github.com>

## What does this change?
Increase the frequency of the football match-header client side calls to improve liveness

Fixes part of https://github.com/guardian/dotcom-rendering/issues/16148