### PR TITLE
Render pagination links when the destinations are empty strings

### DIFF
--- a/dotcom-rendering/src/components/Pagination.test.tsx
+++ b/dotcom-rendering/src/components/Pagination.test.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { Pagination } from './Pagination';
+
+describe('Pagination', () => {
+	describe('newer and newest', () => {
+		it('does not render the newer/newest controls when the props are undefined', () => {
+			const { queryAllByText, queryByText } = render(
+				<Pagination
+					currentPage={2}
+					totalPages={3}
+					renderingTarget="Web"
+				/>,
+			);
+
+			expect(queryAllByText('Newest').length).toBe(0);
+			expect(queryByText('Previous')).toBeNull();
+		});
+
+		it('renders the newer/newest controls when the props are empty strings', () => {
+			const { queryAllByText, queryByText } = render(
+				<Pagination
+					currentPage={2}
+					totalPages={3}
+					newest=""
+					newer=""
+					renderingTarget="Web"
+				/>,
+			);
+
+			expect(queryAllByText('Newest').length).toBeGreaterThan(0);
+			expect(queryByText('Previous')).not.toBeNull();
+		});
+	});
+
+	describe('older and oldest', () => {
+		it('does not render the older/oldest controls when the props are undefined', () => {
+			const { queryAllByText, queryByText } = render(
+				<Pagination
+					currentPage={2}
+					totalPages={3}
+					renderingTarget="Web"
+				/>,
+			);
+
+			expect(queryAllByText('Oldest').length).toBe(0);
+			expect(queryByText('Next')).toBeNull();
+		});
+
+		it('renders the older/oldest controls when the props are empty strings', () => {
+			const { queryAllByText, queryByText } = render(
+				<Pagination
+					currentPage={2}
+					totalPages={3}
+					oldest=""
+					older=""
+					renderingTarget="Web"
+				/>,
+			);
+
+			expect(queryAllByText('Oldest').length).toBeGreaterThan(0);
+			expect(queryByText('Next')).not.toBeNull();
+		});
+	});
+});

--- a/dotcom-rendering/src/components/Pagination.test.tsx
+++ b/dotcom-rendering/src/components/Pagination.test.tsx
@@ -30,6 +30,26 @@ describe('Pagination', () => {
 			expect(queryAllByText('Newest').length).toBeGreaterThan(0);
 			expect(queryByText('Previous')).not.toBeNull();
 		});
+
+		it('does not add an empty query string when there are no params to render', () => {
+			const { getAllByRole } = render(
+				<Pagination
+					currentPage={2}
+					totalPages={3}
+					newest=""
+					newer=""
+					renderingTarget="Web"
+				/>,
+			);
+
+			expect(
+				getAllByRole('link').map((a) => (a as HTMLAnchorElement).href),
+			).toEqual([
+				'http://localhost/#maincontent',
+				'http://localhost/#maincontent',
+				'http://localhost/#liveblog-navigation',
+			]);
+		});
 	});
 
 	describe('older and oldest', () => {

--- a/dotcom-rendering/src/components/Pagination.test.tsx
+++ b/dotcom-rendering/src/components/Pagination.test.tsx
@@ -51,8 +51,8 @@ describe('Pagination', () => {
 				<Pagination
 					currentPage={2}
 					totalPages={3}
-					oldest=""
-					older=""
+					oldest="?page=with:block-6a2b00d18f0881a067713ae5"
+					older="?page=with:block-6a2b00d18f0881a067713ae5"
 					renderingTarget="Web"
 				/>,
 			);

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -93,7 +93,7 @@ export const Pagination = ({
 					style={{ gridArea: 'newer', justifySelf: 'start' }}
 					css={flexSection}
 				>
-					{!!newest && (
+					{newest !== undefined && (
 						<>
 							<Hide from="phablet">
 								<LinkButton
@@ -132,7 +132,7 @@ export const Pagination = ({
 							</Hide>
 						</>
 					)}
-					{!!newer && (
+					{newer !== undefined && (
 						<LinkButton
 							size="small"
 							priority="tertiary"
@@ -165,7 +165,7 @@ export const Pagination = ({
 					style={{ gridArea: 'older', justifySelf: 'end' }}
 					css={flexSection}
 				>
-					{!!older && (
+					{older !== undefined && (
 						<LinkButton
 							size="small"
 							priority="tertiary"
@@ -181,7 +181,7 @@ export const Pagination = ({
 							Next
 						</LinkButton>
 					)}
-					{!!oldest && (
+					{oldest !== undefined && (
 						<>
 							<Hide from="phablet">
 								<LinkButton

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -72,6 +72,12 @@ const getPagePath = ({
 		searchParams.append('dcr', 'apps');
 	}
 
+	const fragmentPart = `#${fragment}`;
+
+	if (!searchParams.size) {
+		return fragmentPart;
+	}
+
 	return `?${searchParams.toString()}#${fragment}`;
 };
 


### PR DESCRIPTION
## What does this change?

Render pagination links when the destinations are empty strings.

## Why?

AFAICS this is causing a problem because of a change upstream in frontend (https://github.com/guardian/frontend/pull/28825). https://github.com/guardian/frontend/pull/28825/changes/12355aa4c66294632353139fd0b110082ee03ebf removed a query param which was populating pagination strings:

| Before      | After      |
| ----------- | ---------- |
| <img width="526" height="139" alt="Screenshot 2026-06-14 at 21 09 53" src="https://github.com/user-attachments/assets/7d269f17-74ea-4aeb-904a-0668f7e3da18" /> | <img width="526" height="139" alt="Screenshot 2026-06-14 at 21 10 05" src="https://github.com/user-attachments/assets/07a98205-aaa0-4e7b-9ba5-f54a42b22dfc" /> |

My understanding is that this is reasonable, as the string is intended to be a query string, and an empty query string in this case just means 'latest', i.e. there's no preceding block to mention.

Downstream in DCR, the check to see whether pagination strings are present is ... you guessed it:

https://github.com/guardian/dotcom-rendering/blob/648a9d809939a5d29bad7681ae4d6f1b2084272f/dotcom-rendering/src/components/Pagination.tsx#L96

... which will ignore empty strings. (The linter currently warns, but does not error, on this line.)

This PR makes this check an explicit comparison to `undefined`, and adds unit tests. The tests were added prior to the fix to verify red/green. If this'd be better verified with a story, super happy to add!

~Finally, do we need the tests for Next/Oldest? I can't imagine a scenario where they'd be empty strings (they have to reference a preceding block to be paginated, no?) Perhaps replacing the empty strings in those cases would be more representative.~ I've done that in [579cda9](https://github.com/guardian/dotcom-rendering/pull/16153/commits/579cda92fd68bb6767207b3ec62be0e848bdf0d4).

NB: The investigation and the fix was manual. The tests were written with Claude Opus 4.8, and reviewed manually.

## Screenshots

From [this piece](https://www.theguardian.com/australia-news/live/2026/jun/14/australia-news-live-jonathon-duniam-senator-retire-liberal-national-coalition-labor-albanese-taylor-one-nation-sydney-nsw-victoria-high-court-ntwnfb?page=with%3Ablock-6a2e04868f0881a06771523f#liveblog-navigation), local DCAR pointing at CODE CAPI:

| Before      | After      |
| ----------- | ---------- |
| <img width="589" height="308" alt="Screenshot 2026-06-14 at 21 30 54" src="https://github.com/user-attachments/assets/ced9b46f-c685-47e6-a7d4-d4aeae956580" /> | <img width="589" height="308" alt="Screenshot 2026-06-14 at 21 30 40" src="https://github.com/user-attachments/assets/cf4054bc-c0e0-40a5-86d8-775ab053303e" /> |




<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
