### PR TITLE
Fixes an issue where End events can be sent without preceding milestones

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1117,9 +1117,11 @@ export const SelfHostedVideo = ({
 	};
 
 	const handleEnded = () => {
-		trackMilestones({ ended: true });
-		resetMilestones();
-		setPlayerState('ENDED');
+		if (playerState === 'PLAYING') {
+			trackMilestones({ ended: true });
+			resetMilestones();
+			setPlayerState('ENDED');
+		}
 	};
 
 	/**

--- a/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
+++ b/dotcom-rendering/src/lib/useVideoMilestoneTracking.ts
@@ -56,6 +56,7 @@ export const useVideoMilestoneTracking = (
 
 			if ('ended' in progress) {
 				reachedEnd = true;
+				percent = 100;
 			} else if ('duration' in progress && progress.duration > 0) {
 				percent = (progress.currentTime / progress.duration) * 100;
 
@@ -65,6 +66,7 @@ export const useVideoMilestoneTracking = (
 				 */
 				if (Math.abs(progress.duration - progress.currentTime) < 0.5) {
 					reachedEnd = true;
+					percent = 100;
 				}
 			}
 


### PR DESCRIPTION
## What does this change?

This PR addresses an issue where `END` events were found for video playback without the expected preceding milestones e.g. percentage 25/50/75. 

In investigating the issue, we were able to identify the problem as Safari related. I have now identified the cause as videos being scrubbed whilst paused. If a user on Safari pauses a video a scrubs to the end, they would have only sent the end milestone and no others.

The difference between browsers, causing this to be a Safari specific issue, is when the `ended` event is triggered. For Chrome, if a video is paused and scrubbed to the end, the event is NOT fired. For safari, in the same situation, the event will be fired. 

>[!Warning]
> Investigate this bug highlighted that Safari may is likely to over counting PLAY and END events. Scrubbing the video to the end and back, whilst in a paused state, would result in multiple PLAY and END events to be triggered. 

In order to resolve the issue, this PR makes two changes:

1. Sending all preceding milestones if an END milestone is triggered.
2. Discarding END event handling if the video is not in a playing state.

>[!Note]
> This also uncovered a bug in the transition between PAUSE-ENDED state, where pressing the play button does not start the video.

## Why?

We expect all milestones to have been sent if a user reaches the end.


## Test cases

To confirm the behaviour works as expected, I tried the following scenarios:

Example: https://www.theguardian.com/football/video/2026/jun/10/the-most-inclusive-world-cup-ever-doesnt-look-like-it

| Case | Browser | Result |
|--------|--------|--------|
| Video play uninterrupted (all milestones fire) | Chrome | ✅ |
| | Firefox | ✅ |
| | Safari | ✅ |
| Video scrubbed to end whilst playing (all milestones fire)  | Chrome | ✅ |
| | Firefox | ✅ | 
| | Safari | ✅ | 
| Video scrubbed to end whilst paused (milestones do not fire) | Chrome | ✅ |
| | Firefox | ✅ | 
| | Safari | ✅ | 