### PR TITLE
Do not strip the start of the query string for liveblog pagination links

### DIFF
--- a/dotcom-rendering/src/components/Pagination.test.tsx
+++ b/dotcom-rendering/src/components/Pagination.test.tsx
@@ -30,26 +30,6 @@ describe('Pagination', () => {
 			expect(queryAllByText('Newest').length).toBeGreaterThan(0);
 			expect(queryByText('Previous')).not.toBeNull();
 		});
-
-		it('does not add an empty query string when there are no params to render', () => {
-			const { getAllByRole } = render(
-				<Pagination
-					currentPage={2}
-					totalPages={3}
-					newest=""
-					newer=""
-					renderingTarget="Web"
-				/>,
-			);
-
-			expect(
-				getAllByRole('link').map((a) => (a as HTMLAnchorElement).href),
-			).toEqual([
-				'http://localhost/#maincontent',
-				'http://localhost/#maincontent',
-				'http://localhost/#liveblog-navigation',
-			]);
-		});
 	});
 
 	describe('older and oldest', () => {

--- a/dotcom-rendering/src/components/Pagination.tsx
+++ b/dotcom-rendering/src/components/Pagination.tsx
@@ -72,12 +72,6 @@ const getPagePath = ({
 		searchParams.append('dcr', 'apps');
 	}
 
-	const fragmentPart = `#${fragment}`;
-
-	if (!searchParams.size) {
-		return fragmentPart;
-	}
-
 	return `?${searchParams.toString()}#${fragment}`;
 };
 


### PR DESCRIPTION
## What does this change?

Do not strip the start of the query string for liveblog pagination links: a revert of [1fb47ed](https://github.com/guardian/dotcom-rendering/pull/16153/commits/1fb47ed2b073dea6f92780d1ba9617a25cdf41e5).

## Why?

By stripping the start of the query string, even if it's blank, we leave just the fragment in the href, which the browser interprets as a local page navigation — and the links don't work.
