### PR TITLE
extends prebid pricefloors test expiry date

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -99,7 +99,7 @@ const ABTests: ABTest[] = [
 		description:
 			"This test will be the 5% holdback group for the prebid price floor",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-06-17",
+		expirationDate: "2026-07-16",
 		type: "client",
 		status: "ON",
 		audienceSize: 5 / 100,


### PR DESCRIPTION
## What does this change?
Extends the `commercial-prebid-price-floor-holdback` test by a month.
## Why?
We'd like to gather more data for the Ab Test for prebid price floors
