### PR TITLE
ci: Use `guardian/actions-build-facts` to correctly reference commit sha

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,10 +4,22 @@ on:
   push:
 
 jobs:
+  facts:
+    runs-on: ubuntu-slim
+    permissions: {}
+    outputs:
+      commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
+    steps:
+      - uses: guardian/actions-build-facts@v0.0.1
+        id: get-build-facts
+
   container:
     permissions:
       packages: write
     uses: ./.github/workflows/container.yml
+    needs: [facts]
+    with:
+      commitSha: ${{ needs.facts.outputs.commitSha }}
 
   prettier:
     uses: ./.github/workflows/prettier.yml

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,6 +2,11 @@
 # Commercial rely on a container image built from the main branch with the tag 'main'
 on:
   workflow_call:
+    inputs:
+      commitSha:
+        description: 'The SHA of the commit being built. Will be used as an image tag.'
+        required: true
+        type: string
     outputs:
       container-image:
         description: 'The generated container image path'
@@ -27,7 +32,7 @@ jobs:
       - name: Add commit hash for PRout
         working-directory: dotcom-rendering
         run: |
-          echo 'export const GIT_COMMIT_HASH = "${{ github.sha }}";' > src/server/prout.ts
+          echo 'export const GIT_COMMIT_HASH = "${{ inputs.commitSha }}";' > src/server/prout.ts
 
       - name: Generate production bundle
         run: make riffraff-bundle
@@ -39,7 +44,7 @@ jobs:
         with:
           image: dotcom-rendering
           # Commercial rely on a container image built from the main branch with the tag 'main'
-          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
+          tags: ${{ inputs.commitSha }} ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
           context: ./
           containerfiles: ./dotcom-rendering/Containerfile
 

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -7,6 +7,15 @@ on:
     types: [opened, labeled, synchronize]
 
 jobs:
+  facts:
+    runs-on: ubuntu-slim
+    permissions: {}
+    outputs:
+      commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
+    steps:
+      - uses: guardian/actions-build-facts@v0.0.1
+        id: get-build-facts
+
   check-paths:
     name: Check changed paths
     uses: ./.github/workflows/check-chromatic-paths.yml
@@ -14,7 +23,7 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    needs: check-paths
+    needs: [facts, check-paths]
     # Always run so the required "UI Tests: dotcom_rendering" status check is always
     # reported. When skipping, Chromatic posts a passing status without building Storybook.
     steps:
@@ -23,10 +32,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request'}}
         with:
           fetch-depth: 0
-          # By default the pull_request event will run on a ephermeral merge commit which simulates a merge between the pull request
-          # and the target branch. This can cause issues with Chromatic https://www.chromatic.com/docs/turbosnap#github-pullrequest-triggers
-          # Hopefully by checking out the HEAD commit of a PR instead of the merge commit we can avoid some of those issues.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.facts.outputs.commitSha }}
       - name: Checkout - On Push Event
         uses: actions/checkout@v6
         if: ${{ github.event_name == 'push'}}


### PR DESCRIPTION
## What does this change?
In the context of a GitHub Workflow triggered on `pull_request`, `github.sha` is NOT the sha of the latest commit on the branch. See https://github.com/orgs/community/discussions/26325. This change uses https://github.com/guardian/actions-build-facts to understand the commit sha.

## Why?
Correctness. Although the only place `github.sha` was used was for http://github.com/guardian/prout, which monitors deploys of `main`. The commit sha that PRout sees will be correct, as it's the result of a `merge` event.

This change is also preparation for pushing an image to AWS ECR as part of the trail @guardian/devx-reliability-and-ops are starting to run DCR on AWS ECS; the commit sha will be added as an image tag. See https://github.com/guardian/actions-publish-image.

## Screenshots
N/A.