### PR TITLE
Wire up cricket header in live blog

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -197,6 +197,17 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant-1"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "webx-cricket-redesign",
+		description: "Redesign of the cricket header and scorecard on web",
+		owners: ["dotcom.platform@theguardian.com"],
+		status: "ON",
+		expirationDate: "2026-08-01",
+		type: "server",
+		audienceSize: 0 / 100,
+		groups: ["enable"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -89,7 +89,7 @@ const defaultInnings = {
 
 const baseArgs = {
 	edition: 'UK' as EditionId,
-	match: {
+	initialData: {
 		kind: 'Fixture' as CricketMatch['kind'],
 		series: 'Ashes 2025–2026',
 		competition: 'Second Test Match',
@@ -112,6 +112,10 @@ const baseArgs = {
 	infoURL: new URL(
 		'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket#scorecard',
 	),
+	matchHeaderURL:
+		'https://api.nextgen.guardianapps.co.uk/sport/cricket/match-header/2026-06-13/australia-women-s-cricket-team.json',
+	refreshInterval: 3_000,
+	getHeaderData: () => Promise.resolve(undefined),
 };
 
 export const Fixture = {
@@ -121,8 +125,8 @@ export const Fixture = {
 export const Live = {
 	args: {
 		...baseArgs,
-		match: {
-			...Fixture.args.match,
+		initialData: {
+			...Fixture.args.initialData,
 			kind: 'Live' as CricketMatch['kind'],
 			day: 2,
 			innings: [
@@ -167,8 +171,8 @@ export const LiveYetToBat = {
 	args: {
 		...baseArgs,
 		edition: 'UK' as EditionId,
-		match: {
-			...Fixture.args.match,
+		initialData: {
+			...Fixture.args.initialData,
 			kind: 'Live',
 			day: 2,
 			innings: [
@@ -200,8 +204,8 @@ export const Result = {
 	args: {
 		...baseArgs,
 		edition: 'UK' as EditionId,
-		match: {
-			...Fixture.args.match,
+		initialData: {
+			...Fixture.args.initialData,
 			kind: 'Result',
 			day: 4,
 			innings: [
@@ -270,8 +274,8 @@ export const ResultWinByWickets = {
 	args: {
 		...baseArgs,
 		edition: 'UK' as EditionId,
-		match: {
-			...Fixture.args.match,
+		initialData: {
+			...Fixture.args.initialData,
 			kind: 'Result',
 			innings: [
 				{
@@ -321,8 +325,8 @@ export const ResultDrawn = {
 	args: {
 		...baseArgs,
 		edition: 'UK' as EditionId,
-		match: {
-			...Fixture.args.match,
+		initialData: {
+			...Fixture.args.initialData,
 			kind: 'Result',
 			day: 4,
 			innings: [

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, within } from 'storybook/test';
 import type { CricketMatch } from '../../cricketMatchV2';
 import type { EditionId } from '../../lib/edition';
 import { CricketMatchHeader } from './CricketMatchHeader';
@@ -120,6 +121,35 @@ const baseArgs = {
 
 export const Fixture = {
 	args: baseArgs,
+	play: async ({ canvas, canvasElement, step }) => {
+		const nav = canvas.getByRole('navigation');
+
+		await step(
+			'Placeholder not shown as we have initial data and can render header',
+			async () => {
+				void expect(
+					canvasElement.querySelector('[data-name="placeholder"]'),
+				).toBeNull();
+
+				const initialTabs = within(nav).getAllByRole('listitem');
+
+				void expect(initialTabs.length).toBe(1);
+				void expect(initialTabs[0]).toHaveTextContent('Scorecard');
+			},
+		);
+
+		await step('Fetch updated match header data', async () => {
+			// Wait for 'Ashes 2025–2026' to appear which indicates match header
+			// data has been fetched and the UI updated on the client
+			await canvas.findByText('Ashes 2025–2026');
+			void canvas.findByText('England');
+			void canvas.findByText('Australia');
+
+			const updatedTabs = within(nav).getAllByRole('listitem');
+			void expect(updatedTabs.length).toBe(1);
+			void expect(updatedTabs[0]).toHaveTextContent('Scorecard');
+		});
+	},
 } satisfies Story;
 
 export const Live = {
@@ -163,6 +193,29 @@ export const Live = {
 		liveURL: new URL(
 			'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
 		),
+	},
+	play: async ({ canvas, step }) => {
+		await step('Fetch match header data and render UI', async () => {
+			// Wait for 'Ashes 2025–2026' to appear which signals match header
+			// data has been fetched and the UI rendered on the client
+			await canvas.findByText('Ashes 2025–2026');
+			void canvas.findByText('England');
+			void canvas.findByText('Australia');
+
+			void expect(
+				canvas.getByLabelText('169 runs, 0 wickets fallen'),
+			).toBeInTheDocument();
+			void expect(
+				canvas.getByLabelText('173 runs, 3 wickets fallen'),
+			).toBeInTheDocument();
+
+			const nav = canvas.getByRole('navigation');
+			const tabs = within(nav).getAllByRole('listitem');
+
+			void expect(tabs.length).toBe(2);
+			void expect(tabs[0]).toHaveTextContent('Live feed');
+			void expect(tabs[1]).toHaveTextContent('Scorecard');
+		});
 	},
 } satisfies Story;
 
@@ -267,6 +320,22 @@ export const Result = {
 		liveURL: new URL(
 			'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
 		),
+	},
+	play: async ({ canvas, step }) => {
+		await step('Fetch match header data and render UI', async () => {
+			// Wait for 'Ashes 2025–2026' to appear which signals match header
+			// data has been fetched and the UI rendered on the client
+			await canvas.findByText('Ashes 2025–2026');
+			void canvas.findByText('England');
+			void canvas.findByText('Australia');
+
+			const nav = canvas.getByRole('navigation');
+			const tabs = within(nav).getAllByRole('listitem');
+
+			void expect(tabs.length).toBe(2);
+			void expect(tabs[0]).toHaveTextContent('Live feed');
+			void expect(tabs[1]).toHaveTextContent('Scorecard');
+		});
 	},
 } satisfies Story;
 

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { log } from '@guardian/libs';
 import {
 	from,
 	headlineBold20Object,
@@ -14,6 +15,8 @@ import {
 	until,
 } from '@guardian/source/foundations';
 import { Fragment, type ReactNode, useMemo } from 'react';
+import type { SWRConfiguration } from 'swr';
+import useSWR from 'swr';
 import type {
 	CricketMatch,
 	CricketResult,
@@ -35,19 +38,47 @@ import {
 	primaryText,
 	secondaryText,
 } from '../FootballMatchHeader/colours';
+import type { TabName } from '../FootballMatchHeader/Tabs';
 import { Tabs } from '../FootballMatchHeader/Tabs';
+import { Placeholder } from '../Placeholder';
+import type { CricketHeaderData } from './headerData';
+import { parse as parseHeaderData } from './headerData';
 
-type Props = {
+export type CricketMatchHeaderProps = {
+	initialData?: CricketMatch;
+	matchHeaderURL: string;
 	edition: EditionId;
-	match: CricketMatch;
 	selectedTab: 'info' | 'live' | 'report';
 	reportURL?: URL;
 	liveURL?: URL;
 	infoURL?: URL;
 };
 
+type Props = CricketMatchHeaderProps & {
+	getHeaderData: (url: string) => Promise<unknown>;
+	refreshInterval: number;
+};
+
 export const CricketMatchHeader = (props: Props) => {
-	const match = props.match;
+	const { data } = useSWR<CricketHeaderData, Error>(
+		props.matchHeaderURL,
+		fetcher(props.selectedTab, props.getHeaderData),
+		swrOptions(props.refreshInterval),
+	);
+	const match = data?.match ?? props.initialData;
+
+	if (match === undefined) {
+		return (
+			<Placeholder
+				heights={
+					new Map([
+						['mobile', 182],
+						['leftCol', 172],
+					])
+				}
+			/>
+		);
+	}
 
 	return (
 		<section
@@ -90,6 +121,36 @@ export const CricketMatchHeader = (props: Props) => {
 		</section>
 	);
 };
+
+const swrOptions = (
+	refreshInterval: number,
+): SWRConfiguration<CricketHeaderData> => ({
+	errorRetryCount: 1,
+	refreshInterval: (latestData: CricketHeaderData | undefined) => {
+		return latestData?.match.kind === 'Live' ||
+			latestData?.match.kind === 'Fixture'
+			? refreshInterval
+			: 0;
+	},
+});
+
+const fetcher =
+	(selected: TabName, getHeaderData: Props['getHeaderData']) =>
+	(url: string): Promise<CricketHeaderData> =>
+		getHeaderData(url)
+			.then(parseHeaderData(selected))
+			.then((result) => {
+				if (!result.ok) {
+					log('dotcom', result.error);
+					throw new Error();
+				} else {
+					return result.value;
+				}
+			})
+			.catch(() => {
+				log('dotcom', 'Failed to fetch match header json');
+				throw new Error();
+			});
 
 const StatusLine = (props: { match: CricketMatch; edition: EditionId }) => (
 	<p

--- a/dotcom-rendering/src/components/CricketMatchHeader/headerData.ts
+++ b/dotcom-rendering/src/components/CricketMatchHeader/headerData.ts
@@ -1,0 +1,95 @@
+import type { ComponentProps } from 'react';
+import { safeParse } from 'valibot';
+import { type CricketMatch, parseCricketMatchV2 } from '../../cricketMatchV2';
+import type { FECricketMatchHeader } from '../../frontend/feCricketMatchHeader';
+import { feCricketMatchHeaderSchema } from '../../frontend/feCricketMatchHeader';
+import { safeParseURL } from '../../lib/parse';
+import { error, fromValibot, ok, type Result } from '../../lib/result';
+import type { Tabs } from '../FootballMatchHeader/Tabs';
+
+export type CricketHeaderData = {
+	tabs: ComponentProps<typeof Tabs>;
+	match: CricketMatch;
+};
+
+export const parse =
+	(selected: CricketHeaderData['tabs']['selected']) =>
+	(json: unknown): Result<string, CricketHeaderData> => {
+		const feData = fromValibot(safeParse(feCricketMatchHeaderSchema, json));
+
+		if (!feData.ok) {
+			return error('Failed to validate match header json');
+		}
+
+		const parsedMatch = parseCricketMatchV2(feData.value.cricketMatch);
+
+		if (!parsedMatch.ok) {
+			return error('Failed to parse the match from the header json');
+		}
+
+		const maybeTabs = createTabs(
+			selected,
+			feData.value,
+			parsedMatch.value.kind,
+		);
+
+		if (!maybeTabs.ok) {
+			return error(
+				`The match header data contained an invalid ${maybeTabs.error.kind} URL`,
+			);
+		}
+
+		return ok({
+			match: parsedMatch.value,
+			tabs: maybeTabs.value,
+		});
+	};
+
+type MatchURLError = {
+	kind: 'live' | 'report';
+};
+
+const createTabs = (
+	selected: CricketHeaderData['tabs']['selected'],
+	feData: FECricketMatchHeader,
+	matchKind: CricketMatch['kind'],
+): Result<MatchURLError, CricketHeaderData['tabs']> => {
+	const reportURL =
+		feData.reportURL !== undefined
+			? safeParseURL(feData.reportURL)
+			: undefined;
+	const liveURL =
+		feData.liveURL !== undefined ? safeParseURL(feData.liveURL) : undefined;
+	if (reportURL !== undefined && !reportURL.ok) {
+		return error({ kind: 'report' });
+	}
+
+	if (liveURL !== undefined && !liveURL.ok) {
+		return error({ kind: 'live' });
+	}
+
+	switch (selected) {
+		case 'info':
+			return ok({
+				matchKind,
+				sportKind: 'cricket',
+				selected,
+				reportURL: reportURL?.value,
+				liveURL: liveURL?.value,
+			});
+		case 'live':
+			return ok({
+				matchKind,
+				sportKind: 'cricket',
+				selected,
+				reportURL: reportURL?.value,
+			});
+		case 'report':
+			return ok({
+				matchKind,
+				sportKind: 'cricket',
+				selected,
+				liveURL: liveURL?.value,
+			});
+	}
+};

--- a/dotcom-rendering/src/components/CricketMatchHeaderWrapper.island.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeaderWrapper.island.tsx
@@ -1,0 +1,32 @@
+import type { CricketMatch } from '../cricketMatchV2';
+import type { CricketMatchHeaderProps } from './CricketMatchHeader/CricketMatchHeader';
+import { CricketMatchHeader } from './CricketMatchHeader/CricketMatchHeader';
+
+type Props =
+	| (CricketMatchHeaderProps & {
+			selectedTab: 'info';
+			initialData: CricketMatch;
+	  })
+	| (CricketMatchHeaderProps & {
+			selectedTab: 'live' | 'report';
+			initialData?: never;
+	  });
+
+export const CricketMatchHeaderWrapper = (props: Props) => (
+	<CricketMatchHeader
+		{...props}
+		initialData={
+			props.initialData ? fixHydration(props.initialData) : undefined
+		}
+		refreshInterval={60_000}
+		getHeaderData={getHeaderData}
+	/>
+);
+
+const fixHydration = (initialData: CricketMatch): CricketMatch => ({
+	...initialData,
+	matchDate: new Date(initialData.matchDate),
+});
+
+const getHeaderData = (url: string): Promise<unknown> =>
+	fetch(url).then((res) => res.json());

--- a/dotcom-rendering/src/components/CricketScorecardPageNew.stories.tsx
+++ b/dotcom-rendering/src/components/CricketScorecardPageNew.stories.tsx
@@ -65,10 +65,11 @@ const baseArgs = {
 			'R S Madugalle',
 		],
 	},
-	selectedTab: 'info' as 'info' | 'live' | 'report',
 	infoURL: new URL(
 		'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket#scorecard',
 	),
+	matchHeaderURL:
+		'https://api.nextgen.guardianapps.co.uk/sport/cricket/match-header/2026-06-13/australia-women-s-cricket-team.json',
 	edition: 'UK',
 } satisfies ComponentProps<typeof CricketScorecardPageNewComponent>;
 
@@ -81,7 +82,6 @@ export const CricketScorecardPageNewLive = meta.story({
 	name: 'Cricket Scorecard Page Live (New)',
 	args: {
 		...baseArgs,
-		selectedTab: 'info',
 
 		liveURL: new URL(
 			'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',

--- a/dotcom-rendering/src/components/CricketScorecardPageNew.tsx
+++ b/dotcom-rendering/src/components/CricketScorecardPageNew.tsx
@@ -4,31 +4,31 @@ import type { CricketMatch } from '../cricketMatchV2';
 import { grid } from '../grid';
 import { type EditionId } from '../lib/edition';
 import { palette } from '../palette';
-import { CricketMatchHeader } from './CricketMatchHeader/CricketMatchHeader';
+import { CricketMatchHeaderWrapper } from './CricketMatchHeaderWrapper.island';
 import { CricketScorecardNew } from './CricketScorecardNew';
-import type { TabName } from './FootballMatchHeader/Tabs';
 
 export const CricketScorecardPageNew = ({
 	match,
 	edition,
-	selectedTab,
+	matchHeaderURL,
 	infoURL,
 	liveURL,
 	reportURL,
 }: {
 	match: CricketMatch;
 	edition: EditionId;
-	selectedTab: TabName;
+	matchHeaderURL: string;
 	infoURL?: URL;
 	liveURL?: URL;
 	reportURL?: URL;
 }) => {
 	return (
 		<main id="maincontent">
-			<CricketMatchHeader
-				match={match}
+			<CricketMatchHeaderWrapper
+				initialData={match}
 				edition={edition}
-				selectedTab={selectedTab}
+				selectedTab={'info'}
+				matchHeaderURL={matchHeaderURL}
 				infoURL={infoURL}
 				liveURL={liveURL}
 				reportURL={reportURL}

--- a/dotcom-rendering/src/frontend/feCricketMatchHeader.ts
+++ b/dotcom-rendering/src/frontend/feCricketMatchHeader.ts
@@ -3,10 +3,8 @@ import { feCricketMatchSchema } from './feCricketMatchPage';
 
 export const feCricketMatchHeaderSchema = object({
 	cricketMatch: feCricketMatchSchema,
-	competitionName: string(),
 	liveURL: optional(string()),
 	reportURL: optional(string()),
-	infoURL: string(),
 });
 
 export type FECricketMatchHeader = Output<typeof feCricketMatchHeaderSchema>;

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -283,16 +283,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const { branding } = article.commercialProperties[article.editionId];
 
-	const ab = useAB();
-	const isCricketRedesignEnabled = Boolean(
-		ab?.isUserInTestGroup('webx-cricket-redesign', 'enable'),
-	);
-
-	const footballMatchUrl =
-		article.matchType === 'FootballMatchType'
-			? article.matchUrl
-			: undefined;
-
 	const footballMatchHeaderUrl =
 		article.matchType === 'FootballMatchType'
 			? article.matchHeaderUrl
@@ -303,16 +293,8 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			? article.matchStatsUrl
 			: undefined;
 
-	const footballMatchLeagueName = article.sectionLabel;
-	const footballMatchLeagueUrl = `${article.guardianBaseURL}/${article.sectionUrl}`;
-
 	const cricketMatchUrl =
 		article.matchType === 'CricketMatchType' ? article.matchUrl : undefined;
-
-	const cricketMatchHeaderUrl =
-		article.matchType === 'CricketMatchType'
-			? article.matchHeaderUrl
-			: undefined;
 
 	const hasKeyEvents = !!article.keyEvents.length;
 
@@ -396,16 +378,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 					</Island>
 				)}
 				<Header
-					football={{
-						footballMatchLeagueName,
-						footballMatchLeagueUrl,
-						footballMatchHeaderUrl,
-						footballMatchUrl,
-					}}
-					cricket={{
-						cricketMatchHeaderUrl,
-						isCricketRedesignEnabled,
-					}}
 					renderingTarget={renderingTarget}
 					format={format}
 					article={article}
@@ -705,7 +677,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 									id="maincontent"
 									css={[
 										bodyWrapper,
-										!!footballMatchUrl &&
+										!!footballMatchHeaderUrl &&
 											footballMatchBodyWrapper,
 									]}
 								>
@@ -1111,24 +1083,27 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 };
 
 const Header = (props: {
-	football: {
-		footballMatchLeagueName: string;
-		footballMatchLeagueUrl: string;
-		footballMatchHeaderUrl?: string;
-		footballMatchUrl?: string;
-	};
-	cricket: {
-		cricketMatchHeaderUrl?: string;
-		isCricketRedesignEnabled: boolean;
-	};
 	renderingTarget: RenderingTarget;
 	format: ArticleFormat;
 	article: ArticleDeprecated;
 }) => {
-	if (
-		props.football.footballMatchUrl &&
-		props.football.footballMatchHeaderUrl
-	) {
+	const footballMatchLeagueName = props.article.sectionLabel;
+	const footballMatchLeagueUrl = `${props.article.guardianBaseURL}/${props.article.sectionUrl}`;
+	const footballMatchHeaderUrl =
+		props.article.matchType === 'FootballMatchType'
+			? props.article.matchHeaderUrl
+			: undefined;
+	const cricketMatchHeaderUrl =
+		props.article.matchType === 'CricketMatchType'
+			? props.article.matchHeaderUrl
+			: undefined;
+
+	const ab = useAB();
+	const isCricketRedesignEnabled = Boolean(
+		ab?.isUserInTestGroup('webx-cricket-redesign', 'enable'),
+	);
+
+	if (footballMatchHeaderUrl) {
 		return (
 			<>
 				<noscript>
@@ -1140,10 +1115,10 @@ const Header = (props: {
 				<Island priority="feature" defer={{ until: 'visible' }}>
 					<FootballMatchHeaderWrapper
 						initialTab="live"
-						leagueName={props.football.footballMatchLeagueName}
-						leagueURL={props.football.footballMatchLeagueUrl}
+						leagueName={footballMatchLeagueName}
+						leagueURL={footballMatchLeagueUrl}
 						edition={props.article.editionId}
-						matchHeaderURL={props.football.footballMatchHeaderUrl}
+						matchHeaderURL={footballMatchHeaderUrl}
 						renderingTarget={props.renderingTarget}
 						article={props.article}
 						format={props.format}
@@ -1153,17 +1128,14 @@ const Header = (props: {
 		);
 	}
 
-	if (
-		props.cricket.cricketMatchHeaderUrl &&
-		props.cricket.isCricketRedesignEnabled
-	) {
+	if (cricketMatchHeaderUrl && isCricketRedesignEnabled) {
 		return (
 			<Island priority="feature" defer={{ until: 'visible' }}>
 				<CricketMatchHeaderWrapper
 					initialData={undefined}
 					selectedTab={'live'}
 					edition={props.article.editionId}
-					matchHeaderURL={props.cricket.cricketMatchHeaderUrl}
+					matchHeaderURL={cricketMatchHeaderUrl}
 				/>
 			</Island>
 		);
@@ -1188,7 +1160,7 @@ const Header = (props: {
 				</GridItem>
 				<GridItem area="headline">
 					<div css={maxWidth}>
-						{!props.football.footballMatchUrl && (
+						{!footballMatchHeaderUrl && (
 							<ArticleHeadline
 								format={props.format}
 								headlineString={props.article.headline}

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -19,6 +19,7 @@ import { ArticleMetaApps } from '../components/ArticleMeta.apps';
 import { ArticleMeta } from '../components/ArticleMeta.web';
 import { ArticleTitle } from '../components/ArticleTitle';
 import { Carousel } from '../components/Carousel.island';
+import { CricketMatchHeaderWrapper } from '../components/CricketMatchHeaderWrapper.island';
 import { DecideLines } from '../components/DecideLines';
 import { DirectoryPageNavIsland } from '../components/DirectoryPageNavIsland';
 import { DiscussionLayout } from '../components/DiscussionLayout';
@@ -50,6 +51,7 @@ import { canRenderAds } from '../lib/canRenderAds';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { getZIndex } from '../lib/getZIndex';
+import { useAB } from '../lib/useAB';
 import { worldCupTagId } from '../lib/worldCup2026';
 import type { NavType } from '../model/extract-nav';
 import { palette as themePalette } from '../palette';
@@ -281,6 +283,15 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const { branding } = article.commercialProperties[article.editionId];
 
+	const ab = useAB();
+	const isCricketRedesignEnabled = Boolean(
+		ab?.isUserInTestGroup('webx-cricket-redesign', 'enable'),
+	);
+
+	const isSportsMatch =
+		article.matchType === 'FootballMatchType' ||
+		article.matchType === 'CricketMatchType';
+
 	const footballMatchUrl =
 		article.matchType === 'FootballMatchType'
 			? article.matchUrl
@@ -301,6 +312,11 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 
 	const cricketMatchUrl =
 		article.matchType === 'CricketMatchType' ? article.matchUrl : undefined;
+
+	const cricketMatchHeaderUrl =
+		article.matchType === 'CricketMatchType'
+			? article.matchHeaderUrl
+			: undefined;
 
 	const hasKeyEvents = !!article.keyEvents.length;
 
@@ -383,32 +399,22 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						<AdPortals rightAlignFrom="wide" />
 					</Island>
 				)}
-				{footballMatchUrl ? (
-					footballMatchHeaderUrl && (
-						<>
-							<noscript>
-								<FootballMatchHeaderFallback
-									format={format}
-									article={article}
-								/>
-							</noscript>
-							<Island
-								priority="feature"
-								defer={{ until: 'visible' }}
-							>
-								<FootballMatchHeaderWrapper
-									initialTab="live"
-									leagueName={footballMatchLeagueName}
-									leagueURL={footballMatchLeagueUrl}
-									edition={article.editionId}
-									matchHeaderURL={footballMatchHeaderUrl}
-									renderingTarget={renderingTarget}
-									article={article}
-									format={format}
-								/>
-							</Island>
-						</>
-					)
+				{isSportsMatch ? (
+					<MatchHeader
+						football={{
+							footballMatchLeagueName,
+							footballMatchLeagueUrl,
+							footballMatchHeaderUrl,
+							footballMatchUrl,
+						}}
+						cricket={{
+							cricketMatchHeaderUrl,
+							isCricketRedesignEnabled,
+						}}
+						renderingTarget={renderingTarget}
+						format={format}
+						article={article}
+					/>
 				) : (
 					<Section
 						fullWidth={true}
@@ -1146,4 +1152,66 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 			)}
 		</>
 	);
+};
+
+const MatchHeader = (props: {
+	football: {
+		footballMatchLeagueName: string;
+		footballMatchLeagueUrl: string;
+		footballMatchHeaderUrl?: string;
+		footballMatchUrl?: string;
+	};
+	cricket: {
+		cricketMatchHeaderUrl?: string;
+		isCricketRedesignEnabled: boolean;
+	};
+	renderingTarget: RenderingTarget;
+	format: ArticleFormat;
+	article: ArticleDeprecated;
+}) => {
+	if (
+		props.football.footballMatchUrl &&
+		props.football.footballMatchHeaderUrl
+	) {
+		return (
+			<>
+				<noscript>
+					<FootballMatchHeaderFallback
+						format={props.format}
+						article={props.article}
+					/>
+				</noscript>
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<FootballMatchHeaderWrapper
+						initialTab="live"
+						leagueName={props.football.footballMatchLeagueName}
+						leagueURL={props.football.footballMatchLeagueUrl}
+						edition={props.article.editionId}
+						matchHeaderURL={props.football.footballMatchHeaderUrl}
+						renderingTarget={props.renderingTarget}
+						article={props.article}
+						format={props.format}
+					/>
+				</Island>
+			</>
+		);
+	}
+
+	if (
+		props.cricket.cricketMatchHeaderUrl &&
+		props.cricket.isCricketRedesignEnabled
+	) {
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<CricketMatchHeaderWrapper
+					initialData={undefined}
+					selectedTab={'live'}
+					edition={props.article.editionId}
+					matchHeaderURL={props.cricket.cricketMatchHeaderUrl}
+				/>
+			</Island>
+		);
+	}
+
+	return null;
 };

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1103,6 +1103,8 @@ const Header = (props: {
 		ab?.isUserInTestGroup('webx-cricket-redesign', 'enable'),
 	);
 
+	const isApps = props.renderingTarget === 'Apps';
+
 	if (footballMatchHeaderUrl) {
 		return (
 			<>
@@ -1128,7 +1130,7 @@ const Header = (props: {
 		);
 	}
 
-	if (cricketMatchHeaderUrl && isCricketRedesignEnabled) {
+	if (!isApps && cricketMatchHeaderUrl && isCricketRedesignEnabled) {
 		return (
 			<Island priority="feature" defer={{ until: 'visible' }}>
 				<CricketMatchHeaderWrapper

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -288,10 +288,6 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 		ab?.isUserInTestGroup('webx-cricket-redesign', 'enable'),
 	);
 
-	const isSportsMatch =
-		article.matchType === 'FootballMatchType' ||
-		article.matchType === 'CricketMatchType';
-
 	const footballMatchUrl =
 		article.matchType === 'FootballMatchType'
 			? article.matchUrl
@@ -399,61 +395,21 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 						<AdPortals rightAlignFrom="wide" />
 					</Island>
 				)}
-				{isSportsMatch ? (
-					<MatchHeader
-						football={{
-							footballMatchLeagueName,
-							footballMatchLeagueUrl,
-							footballMatchHeaderUrl,
-							footballMatchUrl,
-						}}
-						cricket={{
-							cricketMatchHeaderUrl,
-							isCricketRedesignEnabled,
-						}}
-						renderingTarget={renderingTarget}
-						format={format}
-						article={article}
-					/>
-				) : (
-					<Section
-						fullWidth={true}
-						showTopBorder={false}
-						backgroundColour={themePalette(
-							'--headline-blog-background',
-						)}
-						borderColour={themePalette('--headline-border')}
-					>
-						<HeadlineGrid>
-							<GridItem area="title">
-								<ArticleTitle
-									format={format}
-									tags={article.tags}
-									sectionLabel={article.sectionLabel}
-									sectionUrl={article.sectionUrl}
-									guardianBaseURL={article.guardianBaseURL}
-								/>
-							</GridItem>
-							<GridItem area="headline">
-								<div css={maxWidth}>
-									{!footballMatchUrl && (
-										<ArticleHeadline
-											format={format}
-											headlineString={article.headline}
-											tags={article.tags}
-											byline={article.byline}
-											webPublicationDateDeprecated={
-												article.webPublicationDateDeprecated
-											}
-											starRating={article.starRating}
-										/>
-									)}
-								</div>
-							</GridItem>
-						</HeadlineGrid>
-					</Section>
-				)}
-
+				<Header
+					football={{
+						footballMatchLeagueName,
+						footballMatchLeagueUrl,
+						footballMatchHeaderUrl,
+						footballMatchUrl,
+					}}
+					cricket={{
+						cricketMatchHeaderUrl,
+						isCricketRedesignEnabled,
+					}}
+					renderingTarget={renderingTarget}
+					format={format}
+					article={article}
+				/>
 				<Section
 					fullWidth={true}
 					showTopBorder={false}
@@ -1154,7 +1110,7 @@ export const LiveLayout = (props: WebProps | AppsProps) => {
 	);
 };
 
-const MatchHeader = (props: {
+const Header = (props: {
 	football: {
 		footballMatchLeagueName: string;
 		footballMatchLeagueUrl: string;
@@ -1213,5 +1169,40 @@ const MatchHeader = (props: {
 		);
 	}
 
-	return null;
+	return (
+		<Section
+			fullWidth={true}
+			showTopBorder={false}
+			backgroundColour={themePalette('--headline-blog-background')}
+			borderColour={themePalette('--headline-border')}
+		>
+			<HeadlineGrid>
+				<GridItem area="title">
+					<ArticleTitle
+						format={props.format}
+						tags={props.article.tags}
+						sectionLabel={props.article.sectionLabel}
+						sectionUrl={props.article.sectionUrl}
+						guardianBaseURL={props.article.guardianBaseURL}
+					/>
+				</GridItem>
+				<GridItem area="headline">
+					<div css={maxWidth}>
+						{!props.football.footballMatchUrl && (
+							<ArticleHeadline
+								format={props.format}
+								headlineString={props.article.headline}
+								tags={props.article.tags}
+								byline={props.article.byline}
+								webPublicationDateDeprecated={
+									props.article.webPublicationDateDeprecated
+								}
+								starRating={props.article.starRating}
+							/>
+						)}
+					</div>
+				</GridItem>
+			</HeadlineGrid>
+		</Section>
+	);
 };


### PR DESCRIPTION
## What does this change?
Wiring up cricket header into cricket live blog

This PR adds a new `CricketMatchHeaderWrapper` component that wraps the `CricketMatchHeader`. The purpose of having this component is for testing. This way we can easily add storybook interaction tests using the play function since the logic for `getHeaderData` can be passed to the component as a prop, so the consumer decides how to get the data. 

The `CricketMatchHeaderWrapper` is used in the `LiveLayout` when the live blog is for a cricket match. This is now behind a feature flag and you'd need to opt-in in order to see it (https://m.code.dev-theguardian.com/ab-tests/opt-in/webx-cricket-redesign:enable). 

**Note:** Currently I have added some interaction tests in CricketMatchHeader storybook, but the tests need to get expanded and improved after we have the tab logic for the scorecard. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/e84f2e88-ec81-4cbc-bb8f-63880b98706a
[after]: https://github.com/user-attachments/assets/a4817254-6434-4db9-8b08-4d237d2a234e


Tested in CODE. 


Fixes https://github.com/guardian/dotcom-rendering/issues/16144