### PR TITLE
Update AB test audience configuration for Feast Web Nudge

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -192,9 +192,9 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2027-01-01",
 		type: "client",
-		audienceSize: 1,
-		audienceSpace: "D",
-		groups: ["control", "variant-1"],
+		audienceSize: 50 / 100,
+		audienceSpace: "A",
+		groups: ["variant-1"],
 		shouldForceMetricsCollection: false,
 	},
 ];

--- a/ab-testing/config/scripts/validation/enoughSpace.ts
+++ b/ab-testing/config/scripts/validation/enoughSpace.ts
@@ -8,7 +8,7 @@ export function enoughSpace(allTests: ABTest[]) {
 			acc[space] += test.audienceSize;
 			return acc;
 		},
-		{ A: 0, B: 0, C: 0, D: 0 },
+		{ A: 0, B: 0, C: 0 },
 	);
 
 	Object.entries(spaceTotalSize).forEach(([space, size]) => {

--- a/ab-testing/config/types.ts
+++ b/ab-testing/config/types.ts
@@ -45,7 +45,7 @@ type ABTest = {
 	 * Having multiple test spaces allows deliberate overlapping of test audiences
 	 * Defaults to A
 	 */
-	audienceSpace?: "A" | "B" | "C" | "D";
+	audienceSpace?: "A" | "B" | "C";
 	/** Test group definition */
 	groups: string[];
 	/**


### PR DESCRIPTION
## What does this change?

Updates the `feast-recipe-nudge` A/B test config from `audienceSize: 1` on a new audience space `D`, to `audienceSize: 50/100` on the existing space `A`, with a single `groups: ["variant-1"]`.

**Original intent:** run the test at 100% audience (50% control, 50% variant-1) in a new space `D`.

**Why it changed:** Fastly only supports spaces A, B, and C out of the box. Adding space `D` would require infrastructure changes outside the scope of this work.

**Compromise:** space A currently has exactly 50% free. We use that allocation for `variant-1` only - 50% of users see the nudge, the other 50% are outside the test and see nothing. The `control` group is dropped because there is no room for it in space A alongside the variant.

The component logic in `FeastContextualNudge.island.tsx` is unchanged - it only checks `isUserInTestGroup('feast-recipe-nudge', 'variant-1')`.

## Why?

Fastly does not support audience spaces beyond A, B, and C without additional infrastructure setup. Space A has 50% available, which is used in full for the variant to maximise the volume of observable Feast opens during the test window.

## Screenshots

No visual change, this is a config-only update to the A/B test definition.

| Before | After |
| ----------- | ---------- |
| N/A | N/A |