### PR TITLE
add test for mobile-sticky slot in liveblogs us and turn off pricefloors

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -101,7 +101,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-07-16",
 		type: "client",
-		status: "ON",
+		status: "OFF",
 		audienceSize: 5 / 100,
 		audienceSpace: "A",
 		groups: ["holdback"],
@@ -136,14 +136,14 @@ const ABTests: ABTest[] = [
 	{
 		name: "commercial-mobile-sticky-liveblog-us",
 		description:
-			"Holdback test to measure uplift in adding the mobile-sticky slot for Liveblogs articles in Us.",
+			"Holdback test, where variant is the 'holdback' group, to measure uplift in adding the mobile-sticky slot for Liveblogs articles in the US.",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-06-25",
+		expirationDate: "2026-07-02",
 		type: "client",
-		status: "OFF",
-		audienceSize: 10 / 100,
+		status: "ON",
+		audienceSize: 5 / 100,
 		audienceSpace: "A",
-		groups: ["control", "holdback"],
+		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
 	{

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -134,6 +134,19 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-mobile-sticky-liveblog-us",
+		description:
+			"Holdback test to measure uplift in adding the mobile-sticky slot for Liveblogs articles in Us.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-06-25",
+		type: "client",
+		status: "OFF",
+		audienceSize: 10 / 100,
+		audienceSpace: "A",
+		groups: ["control", "holdback"],
+		shouldForceMetricsCollection: true,
+	},
+	{
 		name: "commercial-teads-prebid",
 		description:
 			"Test to measure the impact of adding Teads as a bidder in prebid .",


### PR DESCRIPTION
## What does this change?
We'd like to measure the impact of adding the mobile-sticky ad to all Liveblog articles in the US region
This PR introduces a new AB test for US Liveblog articles to measure the impact of the mobile-sticky ad.

Creates a new test in audience space A `commercial-mobile-sticky-liveblog-us`

Splits users into:
- 2.5% **variant** (do not get the feature)
- 2.5% **control** (get the feature)

- All users who are not in the test will also get the feature

**note**: this PR also turns the `commercial-prebid-price-floor-holdback` test to OFF, to free up space in grp A.
## Why?
We want to measure the impact of enabling the mobile-sticky ad on all Liveblog articles in the US region.

Related PR: https://github.com/guardian/commercial/pull/2588