### PR TITLE
updated copy

### DIFF
--- a/dotcom-rendering/src/components/FootballMiniMatchStats.tsx
+++ b/dotcom-rendering/src/components/FootballMiniMatchStats.tsx
@@ -124,8 +124,8 @@ export const FootballMiniMatchStats = (props: Props) => {
 					),
 				}}
 			>
-				<span css={buttonTextCss}>More stats, line-ups and tables</span>
-				<span css={buttonTextShortCss}>Stats and line ups</span>
+				<span css={buttonTextCss}>More match info</span>
+				<span css={buttonTextShortCss}>More match info</span>
 			</LinkButton>
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Changed the call to action copy on the football liveblog mini match component.

## Why?

https://github.com/guardian/dotcom-rendering/issues/16116

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/603be558-a78c-4310-a4b8-83e340086232
[after]: https://github.com/user-attachments/assets/ccca3cbd-0bbf-49cb-bde2-1797af3adc1a

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
