### PR TITLE
Sets fullscreen using Bridget if player is found to be compatible

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -172,15 +172,19 @@ const displayFullscreenStyle = css`
 	}
 `;
 
+const fullscreenGlobalHiddenOverflow = (hideOverflow: boolean) =>
+	hideOverflow &&
+	css`
+		html {
+			overflow: hidden;
+		}
+	`;
+
 const fullscreenStyles = (bridgetFullscreen: boolean) => css`
 	${bridgetFullscreen && displayFullscreenStyle}
 
 	${bridgetFullscreen &&
 	css`
-		html {
-			overflow: hidden;
-		}
-
 		position: fixed;
 		top: 0;
 		z-index: ${getZIndex('selfHostedFullscreen')};
@@ -1258,7 +1262,11 @@ export const SelfHostedVideo = ({
 				]}
 			>
 				{isBridgetFullscreen && (
-					<Global styles={fullscreenStyles(isBridgetFullscreen)} />
+					<Global
+						styles={fullscreenGlobalHiddenOverflow(
+							isBridgetFullscreen,
+						)}
+					/>
 				)}
 				<div
 					ref={playerContainerRef}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, Global } from '@emotion/react';
 import { isUndefined, log, storage } from '@guardian/libs';
 import { from, space, until } from '@guardian/source/foundations';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -174,6 +174,22 @@ const displayFullscreenStyle = css`
 
 const fullscreenStyles = (bridgetFullscreen: boolean) => css`
 	${bridgetFullscreen && displayFullscreenStyle}
+
+	${bridgetFullscreen &&
+	css`
+		html {
+			overflow: hidden;
+		}
+
+		position: fixed;
+		top: 0;
+		z-index: ${getZIndex('selfHostedFullscreen')};
+		/* override vw and vh with svw and svh if supported */
+		/* stylelint-disable declaration-block-no-duplicate-properties */
+		width: 100svw;
+		height: 100svh;
+		/* stylelint-enable declaration-block-no-duplicate-properties */
+	`}
 
 	&:fullscreen {
 		${displayFullscreenStyle};
@@ -1048,9 +1064,7 @@ export const SelfHostedVideo = ({
 			void videoClient
 				.setFullscreen(fullscreen)
 				.then(() => setIsBridgetFullscreen(fullscreen));
-		}
-
-		if (document.fullscreenElement) {
+		} else if (document.fullscreenElement) {
 			void document.exitFullscreen();
 		} else if (playerContainerRef.current) {
 			void playerContainerRef.current.requestFullscreen();
@@ -1243,6 +1257,9 @@ export const SelfHostedVideo = ({
 					restrictHeightOnDesktop && maxHeightStyles,
 				]}
 			>
+				{isBridgetFullscreen && (
+					<Global styles={fullscreenStyles(isBridgetFullscreen)} />
+				)}
 				<div
 					ref={playerContainerRef}
 					css={[

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -151,26 +151,32 @@ const videoContainerStyles = (
 	`}
 `;
 
-const fullscreenStyles = css`
+const displayFullscreenStyle = css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: ${palette('--video-fullscreen-background')};
+	width: 100vw;
+	height: 100vh;
+
+	/* Override the fixed aspect-ratio + width:100% on the video so it
+   fits within the screen while preserving its aspect ratio. */
+
+	video {
+		width: 100%;
+		height: 100%;
+		max-width: 100vw;
+		max-height: 100vh;
+		aspect-ratio: auto;
+		object-fit: contain;
+	}
+`;
+
+const fullscreenStyles = (bridgetFullscreen: boolean) => css`
+	${bridgetFullscreen && displayFullscreenStyle}
+
 	&:fullscreen {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background-color: ${palette('--video-fullscreen-background')};
-		width: 100vw;
-		height: 100vh;
-
-		/* Override the fixed aspect-ratio + width:100% on the video so it
-		   fits within the screen while preserving its aspect ratio. */
-
-		video {
-			width: 100%;
-			height: 100%;
-			max-width: 100vw;
-			max-height: 100vh;
-			aspect-ratio: auto;
-			object-fit: contain;
-		}
+		${displayFullscreenStyle};
 	}
 `;
 
@@ -786,12 +792,35 @@ export const SelfHostedVideo = ({
 			);
 	}, [positionCues]);
 
+	const doesBridgetSupportFullscreen = async () => {
+		const isBridgetCompatible = await hasMinimumBridgetVersion('8.8.0');
+
+		if (!isBridgetCompatible) {
+			return false;
+		}
+
+		try {
+			const videoClient = getVideoClient();
+			return await videoClient.setFullscreen(false);
+		} catch (error) {
+			if (error instanceof Error) {
+				window.guardian.modules.sentry.reportError(
+					error,
+					'self-hosted-video',
+				);
+			}
+			log('dotcom', 'Failed to set app autoplay user preference:', error);
+			return false;
+		}
+	};
+
 	useEffect(() => {
-		const videoClient = getVideoClient();
-		void videoClient
-			.setFullscreen(false)
-			.then(setShouldUseBridgetFullscreen);
-	}, []);
+		if (isApps) {
+			void doesBridgetSupportFullscreen().then(
+				setShouldUseBridgetFullscreen,
+			);
+		}
+	}, [isApps]);
 
 	/**
 	 * Track the first time the video comes into view.
@@ -1226,7 +1255,7 @@ export const SelfHostedVideo = ({
 							isVideoCroppedAtLeftRight,
 							containerAspectRatioDesktop,
 						),
-						fullscreenStyles,
+						fullscreenStyles(isBridgetFullscreen),
 						fadeableControlsStyles,
 					]}
 					onMouseMove={showFadeableControlsAndStartTimer}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -13,11 +13,11 @@ import { generateImageURL } from '../lib/image';
 import { useFadeableControls } from '../lib/useFadeableControls';
 import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
-import { useVideoFullscreen } from '../lib/useVideoFullscreen';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
 import { useVideoAttentionTracking } from '../lib/useVideoAttentionTracking';
+import { useVideoFullscreen } from '../lib/useVideoFullscreen';
 import { useVideoMilestoneTracking } from '../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail, Source } from '../lib/video';
 import {

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -821,6 +821,13 @@ export const SelfHostedVideo = ({
 
 		try {
 			const videoClient = getVideoClient();
+
+			/**
+			 * We request to set the video to fullscreen to determine if the Bridget function is supported.
+			 * > On Android, this method will return true if the operation was successful, false otherwise
+			 * > On iOS, this method will always return false
+			 * – taken from comments on the Bridget thrift interface.
+			 */
 			return await videoClient.setFullscreen(false);
 		} catch (error) {
 			if (error instanceof Error) {
@@ -829,7 +836,7 @@ export const SelfHostedVideo = ({
 					'self-hosted-video',
 				);
 			}
-			log('dotcom', 'Failed to set app autoplay user preference:', error);
+			log('dotcom', 'Failed to check Bridget fullscreen support:', error);
 			return false;
 		}
 	};

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -13,6 +13,7 @@ import { generateImageURL } from '../lib/image';
 import { useFadeableControls } from '../lib/useFadeableControls';
 import { hasMinimumBridgetVersion } from '../lib/useIsBridgetCompatible';
 import { useIsInView } from '../lib/useIsInView';
+import { useVideoFullscreen } from '../lib/useVideoFullscreen';
 import { useOnce } from '../lib/useOnce';
 import { useShouldAdapt } from '../lib/useShouldAdapt';
 import { useSubtitles } from '../lib/useSubtitles';
@@ -151,55 +152,6 @@ const videoContainerStyles = (
 	`}
 `;
 
-const displayFullscreenStyle = css`
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background-color: ${palette('--video-fullscreen-background')};
-	width: 100vw;
-	height: 100vh;
-
-	/* Override the fixed aspect-ratio + width:100% on the video so it
-   fits within the screen while preserving its aspect ratio. */
-
-	video {
-		width: 100%;
-		height: 100%;
-		max-width: 100vw;
-		max-height: 100vh;
-		aspect-ratio: auto;
-		object-fit: contain;
-	}
-`;
-
-const fullscreenGlobalHiddenOverflow = (hideOverflow: boolean) =>
-	hideOverflow &&
-	css`
-		html {
-			overflow: hidden;
-		}
-	`;
-
-const fullscreenStyles = (bridgetFullscreen: boolean) => css`
-	${bridgetFullscreen && displayFullscreenStyle}
-
-	${bridgetFullscreen &&
-	css`
-		position: fixed;
-		top: 0;
-		z-index: ${getZIndex('selfHostedFullscreen')};
-		/* override vw and vh with svw and svh if supported */
-		/* stylelint-disable declaration-block-no-duplicate-properties */
-		width: 100svw;
-		height: 100svh;
-		/* stylelint-enable declaration-block-no-duplicate-properties */
-	`}
-
-	&:fullscreen {
-		${displayFullscreenStyle};
-	}
-`;
-
 /**
  * Dispatches a custom play audio event so that other videos listening for this event will be muted.
  */
@@ -240,28 +192,6 @@ const getOptimisedPosterImage = (
 		aspectRatio,
 	});
 };
-
-/**
- * 	The Fullscreen api is not supported by Safari mobile,
- * 	so we need to check if we have access to the webkit api we can use instead.
- * */
-const shouldUseWebkitFullscreen = (video: HTMLVideoElement): boolean => {
-	return (
-		'webkitDisplayingFullscreen' in video &&
-		'webkitEnterFullscreen' in video &&
-		'webkitExitFullscreen' in video
-	);
-};
-
-/**
- * 	The events we need to respond to for fullscreen tracking
- * */
-const fullscreenChangeEvents = [
-	'fullscreenchange',
-	'webkitfullscreenchange',
-	'webkitbeginfullscreen',
-	'webkitendfullscreen',
-];
 
 /**
  * Ensures the aspect ratio falls between the minimum and maximum allowed aspect ratios, if specified.
@@ -428,13 +358,7 @@ export const SelfHostedVideo = ({
 	const [width, setWidth] = useState<number | undefined>();
 	const [height, setHeight] = useState<number | undefined>();
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
-	const [isFullscreen, setIsFullscreen] = useState(false);
-	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
-	const [isBridgetFullscreen, setIsBridgetFullscreen] = useState(false);
 	const [isProgressBarSeeking, setIsProgressBarSeeking] = useState(false);
-
-	const [shouldUseBridgetFullscreen, setShouldUseBridgetFullscreen] =
-		useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -793,62 +717,6 @@ export const SelfHostedVideo = ({
 		};
 	}, [setMutedState, uniqueId, sources, renderingTarget, pauseVideo]);
 
-	/* Creates video-specific event listeners to handle fullscreen behaviour */
-	useEffect(() => {
-		const video = vidRef.current;
-		if (!video) return;
-
-		const handleEndFullscreen = () => {
-			setIsWebKitFullscreen(false);
-			positionCues(video);
-		};
-
-		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
-
-		return () =>
-			video.removeEventListener(
-				'webkitendfullscreen',
-				handleEndFullscreen,
-			);
-	}, [positionCues]);
-
-	const doesBridgetSupportFullscreen = async () => {
-		const isBridgetCompatible = await hasMinimumBridgetVersion('8.8.0');
-
-		if (!isBridgetCompatible) {
-			return false;
-		}
-
-		try {
-			const videoClient = getVideoClient();
-
-			/**
-			 * We request to set the video to fullscreen to determine if the Bridget function is supported.
-			 * > On Android, this method will return true if the operation was successful, false otherwise
-			 * > On iOS, this method will always return false
-			 * – taken from comments on the Bridget thrift interface.
-			 */
-			return await videoClient.setFullscreen(false);
-		} catch (error) {
-			if (error instanceof Error) {
-				window.guardian.modules.sentry.reportError(
-					error,
-					'self-hosted-video',
-				);
-			}
-			log('dotcom', 'Failed to check Bridget fullscreen support:', error);
-			return false;
-		}
-	};
-
-	useEffect(() => {
-		if (isApps) {
-			void doesBridgetSupportFullscreen().then(
-				setShouldUseBridgetFullscreen,
-			);
-		}
-	}, [isApps]);
-
 	/**
 	 * Track the first time the video comes into view.
 	 */
@@ -890,73 +758,20 @@ export const SelfHostedVideo = ({
 		}
 	}, [shouldAutoplay, isInView, playerState]);
 
-	/**
-	 * Capture fullscreen tracking events across browsers and devices
-	 * We need to support events across:
-	 * 	- Browsers with fullscreen API support
-	 * 	- OSX Safari
-	 * 	- iOS Safari
-	 */
-	useEffect(() => {
-		const video = vidRef.current;
-		const playerContainer = playerContainerRef.current;
-
-		if (!playerContainer && !video) return;
-
-		const updateStateAndReportFullscreenEvent = () => {
-			const isInFullscreenMode =
-				document.fullscreenElement !== null ||
-				(video !== null &&
-					'webkitDisplayingFullscreen' in video &&
-					Boolean(video.webkitDisplayingFullscreen));
-
-			if (isInFullscreenMode) {
-				setIsFullscreen(true);
-			} else {
-				setIsFullscreen(false);
-			}
-
-			const event = isInFullscreenMode
-				? 'enter_fullscreen'
-				: 'exit_fullscreen';
-
-			sendOphanTrackingEvent(event);
-		};
-
-		for (const event of fullscreenChangeEvents) {
-			if (video) {
-				video.addEventListener(
-					event,
-					updateStateAndReportFullscreenEvent,
-				);
-			}
-
-			if (playerContainer) {
-				playerContainer.addEventListener(
-					event,
-					updateStateAndReportFullscreenEvent,
-				);
-			}
-		}
-
-		return () => {
-			for (const event of fullscreenChangeEvents) {
-				if (video) {
-					video.removeEventListener(
-						event,
-						updateStateAndReportFullscreenEvent,
-					);
-				}
-
-				if (playerContainer) {
-					playerContainer.removeEventListener(
-						event,
-						updateStateAndReportFullscreenEvent,
-					);
-				}
-			}
-		};
-	}, [sendOphanTrackingEvent]);
+	const {
+		isFullscreen,
+		isWebKitFullscreen,
+		handleFullscreenClick,
+		fullscreenStyles,
+		globalFullscreenStyles,
+	} = useVideoFullscreen({
+		videoRef: vidRef,
+		playerContainerRef,
+		renderingTarget,
+		sendOphanTrackingEvent,
+		positionCues,
+		showFadeableControlsAndStartTimer,
+	});
 
 	if (adapted) {
 		return FallbackImageComponent;
@@ -1033,52 +848,6 @@ export const SelfHostedVideo = ({
 			setMutedState({ value: false });
 		} else {
 			setMutedState({ value: true });
-		}
-	};
-
-	const handleFullscreenClick = (event: React.SyntheticEvent) => {
-		void submitClickComponentEvent(event.currentTarget, renderingTarget);
-		event.stopPropagation(); // Don't pause the video
-
-		showFadeableControlsAndStartTimer(); // Show controls when a button is clicked
-
-		const video = vidRef.current;
-		if (!video) {
-			return;
-		}
-
-		if (shouldUseWebkitFullscreen(video)) {
-			/***
-			 * webkit fullscreen methods are not part of the standard HTMLVideoElement
-			 * type definition as they are iOS only.
-			 * We need to extend the type expect these handlers when we're on iOS to keep TS happy.
-			 * @see https://developer.apple.com/documentation/webkitjs/htmlvideoelement/1633500-webkitenterfullscreen
-			 */
-			const webkitVideo = video as HTMLVideoElement & {
-				webkitDisplayingFullscreen: boolean;
-				webkitEnterFullscreen: () => void;
-				webkitExitFullscreen: () => void;
-			};
-
-			if (webkitVideo.webkitDisplayingFullscreen) {
-				setIsWebKitFullscreen(false);
-				return webkitVideo.webkitExitFullscreen();
-			} else {
-				setIsWebKitFullscreen(true);
-				return webkitVideo.webkitEnterFullscreen();
-			}
-		}
-
-		if (shouldUseBridgetFullscreen) {
-			const videoClient = getVideoClient();
-			const fullscreen = !isBridgetFullscreen;
-			void videoClient
-				.setFullscreen(fullscreen)
-				.then(() => setIsBridgetFullscreen(fullscreen));
-		} else if (document.fullscreenElement) {
-			void document.exitFullscreen();
-		} else if (playerContainerRef.current) {
-			void playerContainerRef.current.requestFullscreen();
 		}
 	};
 
@@ -1268,12 +1037,8 @@ export const SelfHostedVideo = ({
 					restrictHeightOnDesktop && maxHeightStyles,
 				]}
 			>
-				{isBridgetFullscreen && (
-					<Global
-						styles={fullscreenGlobalHiddenOverflow(
-							isBridgetFullscreen,
-						)}
-					/>
+				{globalFullscreenStyles && (
+					<Global styles={globalFullscreenStyles} />
 				)}
 				<div
 					ref={playerContainerRef}
@@ -1287,7 +1052,7 @@ export const SelfHostedVideo = ({
 							isVideoCroppedAtLeftRight,
 							containerAspectRatioDesktop,
 						),
-						fullscreenStyles(isBridgetFullscreen),
+						fullscreenStyles,
 						fadeableControlsStyles,
 					]}
 					onMouseMove={showFadeableControlsAndStartTimer}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1013,7 +1013,11 @@ export const SelfHostedVideo = ({
 				setHasPageBecomeActive(false);
 			}
 			void playVideo();
-		} else if (playerState === 'PLAYING' && isInView === false) {
+		} else if (
+			playerState === 'PLAYING' &&
+			isInView === false &&
+			!isFullscreen
+		) {
 			void pauseVideo('PAUSED_BY_INTERSECTION_OBSERVER');
 		}
 	}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -404,7 +404,11 @@ export const SelfHostedVideo = ({
 	const [optimisedSources, setOptimisedSources] = useState<Source[]>([]);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
+	const [isBridgetFullscreen, setIsBridgetFullscreen] = useState(false);
 	const [isProgressBarSeeking, setIsProgressBarSeeking] = useState(false);
+
+	const [shouldUseBridgetFullscreen, setShouldUseBridgetFullscreen] =
+		useState(false);
 
 	const isWeb = renderingTarget === 'Web';
 	const isApps = renderingTarget === 'Apps';
@@ -782,6 +786,13 @@ export const SelfHostedVideo = ({
 			);
 	}, [positionCues]);
 
+	useEffect(() => {
+		const videoClient = getVideoClient();
+		void videoClient
+			.setFullscreen(false)
+			.then(setShouldUseBridgetFullscreen);
+	}, []);
+
 	/**
 	 * Track the first time the video comes into view.
 	 */
@@ -1000,6 +1011,14 @@ export const SelfHostedVideo = ({
 				setIsWebKitFullscreen(true);
 				return webkitVideo.webkitEnterFullscreen();
 			}
+		}
+
+		if (shouldUseBridgetFullscreen) {
+			const videoClient = getVideoClient();
+			const fullscreen = !isBridgetFullscreen;
+			void videoClient
+				.setFullscreen(fullscreen)
+				.then(() => setIsBridgetFullscreen(fullscreen));
 		}
 
 		if (document.fullscreenElement) {

--- a/dotcom-rendering/src/lib/getZIndex.ts
+++ b/dotcom-rendering/src/lib/getZIndex.ts
@@ -26,6 +26,7 @@ const indices = [
 	'sign-in-gate',
 	'lightbox',
 	'youTubeFullscreen',
+	'selfHostedFullscreen',
 
 	// Sticky video and button need to be above everything
 	'sticky-video-button',

--- a/dotcom-rendering/src/lib/useVideoFullscreen.ts
+++ b/dotcom-rendering/src/lib/useVideoFullscreen.ts
@@ -1,13 +1,14 @@
 import { css } from '@emotion/react';
 import { log } from '@guardian/libs';
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 import { submitClickComponentEvent } from '../client/ophan/ophan';
+import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
+import { palette } from '../palette';
+import type { RenderingTarget } from '../types/renderingTarget';
 import { getVideoClient } from './bridgetApi';
 import { getZIndex } from './getZIndex';
 import { hasMinimumBridgetVersion } from './useIsBridgetCompatible';
-import { palette } from '../palette';
-import type { RenderingTarget } from '../types/renderingTarget';
-import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
 
 /**
  * The Fullscreen API is not supported by Safari mobile,
@@ -56,13 +57,14 @@ const displayFullscreenStyle = css`
  * Returns a global style that hides overflow on the html element when the
  * video is in bridget fullscreen mode.
  */
-export const getFullscreenGlobalHiddenOverflow = (hideOverflow: boolean) =>
-	hideOverflow &&
-	css`
-		html {
-			overflow: hidden;
-		}
-	`;
+const getFullscreenGlobalHiddenOverflow = (hideOverflow: boolean) =>
+	(hideOverflow &&
+		css`
+			html {
+				overflow: hidden;
+			}
+		`) ||
+	css``;
 
 const buildFullscreenStyles = (bridgetFullscreen: boolean) => css`
 	${bridgetFullscreen && displayFullscreenStyle}
@@ -125,7 +127,6 @@ type Props = {
 type ReturnValue = {
 	isFullscreen: boolean;
 	isWebKitFullscreen: boolean;
-	isBridgetFullscreen: boolean;
 	handleFullscreenClick: (event: React.SyntheticEvent) => void;
 	/**
 	 * Styles for the player container element. Applies bridget fullscreen
@@ -159,11 +160,11 @@ export const useVideoFullscreen = ({
 }: Props): ReturnValue => {
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
-	const [isBridgetFullscreen, setIsBridgetFullscreen] = useState(false);
 	const [shouldUseBridgetFullscreen, setShouldUseBridgetFullscreen] =
 		useState(false);
 
 	const isApps = renderingTarget === 'Apps';
+	const isBridgetFullscreen = isFullscreen && shouldUseBridgetFullscreen;
 
 	/* Detect whether the apps bridget client supports fullscreen */
 	useEffect(() => {
@@ -296,11 +297,18 @@ export const useVideoFullscreen = ({
 
 		if (shouldUseBridgetFullscreen) {
 			const videoClient = getVideoClient();
-			const fullscreen = !isBridgetFullscreen;
+			const fullscreen = !isFullscreen;
 			void videoClient
 				.setFullscreen(fullscreen)
-				.then(() => setIsBridgetFullscreen(fullscreen));
-		} else if (document.fullscreenElement) {
+				.then(() => setIsFullscreen(fullscreen));
+			const trackingEvent = isFullscreen
+				? 'enter_fullscreen'
+				: 'exit_fullscreen';
+			sendOphanTrackingEvent(trackingEvent);
+			return;
+		}
+
+		if (document.fullscreenElement) {
 			void document.exitFullscreen();
 		} else if (playerContainerRef.current) {
 			void playerContainerRef.current.requestFullscreen();
@@ -310,7 +318,6 @@ export const useVideoFullscreen = ({
 	return {
 		isFullscreen,
 		isWebKitFullscreen,
-		isBridgetFullscreen,
 		handleFullscreenClick,
 		fullscreenStyles: buildFullscreenStyles(isBridgetFullscreen),
 		globalFullscreenStyles:

--- a/dotcom-rendering/src/lib/useVideoFullscreen.ts
+++ b/dotcom-rendering/src/lib/useVideoFullscreen.ts
@@ -301,7 +301,7 @@ export const useVideoFullscreen = ({
 			void videoClient
 				.setFullscreen(fullscreen)
 				.then(() => setIsFullscreen(fullscreen));
-			const trackingEvent = isFullscreen
+			const trackingEvent = fullscreen
 				? 'enter_fullscreen'
 				: 'exit_fullscreen';
 			sendOphanTrackingEvent(trackingEvent);

--- a/dotcom-rendering/src/lib/useVideoFullscreen.ts
+++ b/dotcom-rendering/src/lib/useVideoFullscreen.ts
@@ -1,0 +1,319 @@
+import { css } from '@emotion/react';
+import { log } from '@guardian/libs';
+import React, { useEffect, useState } from 'react';
+import { submitClickComponentEvent } from '../client/ophan/ophan';
+import { getVideoClient } from './bridgetApi';
+import { getZIndex } from './getZIndex';
+import { hasMinimumBridgetVersion } from './useIsBridgetCompatible';
+import { palette } from '../palette';
+import type { RenderingTarget } from '../types/renderingTarget';
+import type { VideoEventKey } from '../components/YoutubeAtom/YoutubeAtom';
+
+/**
+ * The Fullscreen API is not supported by Safari mobile,
+ * so we need to check if we have access to the webkit API we can use instead.
+ */
+const shouldUseWebkitFullscreen = (video: HTMLVideoElement): boolean => {
+	return (
+		'webkitDisplayingFullscreen' in video &&
+		'webkitEnterFullscreen' in video &&
+		'webkitExitFullscreen' in video
+	);
+};
+
+/**
+ * The events we need to respond to for fullscreen tracking.
+ */
+const fullscreenChangeEvents = [
+	'fullscreenchange',
+	'webkitfullscreenchange',
+	'webkitbeginfullscreen',
+	'webkitendfullscreen',
+];
+
+const displayFullscreenStyle = css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: ${palette('--video-fullscreen-background')};
+	width: 100vw;
+	height: 100vh;
+
+	/* Override the fixed aspect-ratio + width:100% on the video so it
+   fits within the screen while preserving its aspect ratio. */
+
+	video {
+		width: 100%;
+		height: 100%;
+		max-width: 100vw;
+		max-height: 100vh;
+		aspect-ratio: auto;
+		object-fit: contain;
+	}
+`;
+
+/**
+ * Returns a global style that hides overflow on the html element when the
+ * video is in bridget fullscreen mode.
+ */
+export const getFullscreenGlobalHiddenOverflow = (hideOverflow: boolean) =>
+	hideOverflow &&
+	css`
+		html {
+			overflow: hidden;
+		}
+	`;
+
+const buildFullscreenStyles = (bridgetFullscreen: boolean) => css`
+	${bridgetFullscreen && displayFullscreenStyle}
+
+	${bridgetFullscreen &&
+	css`
+		position: fixed;
+		top: 0;
+		z-index: ${getZIndex('selfHostedFullscreen')};
+		/* override vw and vh with svw and svh if supported */
+		/* stylelint-disable declaration-block-no-duplicate-properties */
+		width: 100svw;
+		height: 100svh;
+		/* stylelint-enable declaration-block-no-duplicate-properties */
+	`}
+
+	&:fullscreen {
+		${displayFullscreenStyle};
+	}
+`;
+
+const doesBridgetSupportFullscreen = async (): Promise<boolean> => {
+	const isBridgetCompatible = await hasMinimumBridgetVersion('8.8.0');
+
+	if (!isBridgetCompatible) {
+		return false;
+	}
+
+	try {
+		const videoClient = getVideoClient();
+
+		/**
+		 * We request to set the video to fullscreen to determine if the Bridget function is supported.
+		 * > On Android, this method will return true if the operation was successful, false otherwise
+		 * > On iOS, this method will always return false
+		 * – taken from comments on the Bridget thrift interface.
+		 */
+		return await videoClient.setFullscreen(false);
+	} catch (error) {
+		if (error instanceof Error) {
+			window.guardian.modules.sentry.reportError(
+				error,
+				'self-hosted-video',
+			);
+		}
+		log('dotcom', 'Failed to check Bridget fullscreen support:', error);
+		return false;
+	}
+};
+
+type Props = {
+	videoRef: React.RefObject<HTMLVideoElement | null>;
+	playerContainerRef: React.RefObject<HTMLDivElement | null>;
+	renderingTarget: RenderingTarget;
+	sendOphanTrackingEvent: (event: VideoEventKey) => void;
+	positionCues: (video: HTMLVideoElement) => void;
+	showFadeableControlsAndStartTimer: () => void;
+};
+
+type ReturnValue = {
+	isFullscreen: boolean;
+	isWebKitFullscreen: boolean;
+	isBridgetFullscreen: boolean;
+	handleFullscreenClick: (event: React.SyntheticEvent) => void;
+	/**
+	 * Styles for the player container element. Applies bridget fullscreen
+	 * layout and the `:fullscreen` pseudo-class styles.
+	 */
+	fullscreenStyles: ReturnType<typeof css>;
+	/**
+	 * A style value to pass to a `<Global>` component that hides page overflow
+	 * whilst bridget fullscreen is active.
+	 */
+	globalFullscreenStyles: ReturnType<
+		typeof getFullscreenGlobalHiddenOverflow
+	>;
+};
+
+/**
+ * Manages all fullscreen behaviour for self-hosted videos across three
+ * environments: standard browser Fullscreen API, iOS Safari webkit fullscreen,
+ * and the bridget fullscreen API used by Guardian apps.
+ *
+ * Mirrors the shape of `useFadeableControls` by returning computed styles for
+ * the player container alongside the state and event handler.
+ */
+export const useVideoFullscreen = ({
+	videoRef,
+	playerContainerRef,
+	renderingTarget,
+	sendOphanTrackingEvent,
+	positionCues,
+	showFadeableControlsAndStartTimer,
+}: Props): ReturnValue => {
+	const [isFullscreen, setIsFullscreen] = useState(false);
+	const [isWebKitFullscreen, setIsWebKitFullscreen] = useState(false);
+	const [isBridgetFullscreen, setIsBridgetFullscreen] = useState(false);
+	const [shouldUseBridgetFullscreen, setShouldUseBridgetFullscreen] =
+		useState(false);
+
+	const isApps = renderingTarget === 'Apps';
+
+	/* Detect whether the apps bridget client supports fullscreen */
+	useEffect(() => {
+		if (isApps) {
+			void doesBridgetSupportFullscreen().then(
+				setShouldUseBridgetFullscreen,
+			);
+		}
+	}, [isApps]);
+
+	/* Handle webkit (iOS Safari) end-fullscreen events to sync state and reposition cues */
+	useEffect(() => {
+		const video = videoRef.current;
+		if (!video) return;
+
+		const handleEndFullscreen = () => {
+			setIsWebKitFullscreen(false);
+			positionCues(video);
+		};
+
+		video.addEventListener('webkitendfullscreen', handleEndFullscreen);
+
+		return () =>
+			video.removeEventListener(
+				'webkitendfullscreen',
+				handleEndFullscreen,
+			);
+	}, [videoRef, positionCues]);
+
+	/**
+	 * Capture fullscreen tracking events across browsers and devices.
+	 * We need to support events across:
+	 * - Browsers with fullscreen API support
+	 * - OSX Safari
+	 * - iOS Safari
+	 */
+	useEffect(() => {
+		const video = videoRef.current;
+		const playerContainer = playerContainerRef.current;
+
+		if (!playerContainer && !video) return;
+
+		const updateStateAndReportFullscreenEvent = () => {
+			const isInFullscreenMode =
+				document.fullscreenElement !== null ||
+				(video !== null &&
+					'webkitDisplayingFullscreen' in video &&
+					Boolean(video.webkitDisplayingFullscreen));
+
+			if (isInFullscreenMode) {
+				setIsFullscreen(true);
+			} else {
+				setIsFullscreen(false);
+			}
+
+			const event = isInFullscreenMode
+				? 'enter_fullscreen'
+				: 'exit_fullscreen';
+
+			sendOphanTrackingEvent(event);
+		};
+
+		for (const event of fullscreenChangeEvents) {
+			if (video) {
+				video.addEventListener(
+					event,
+					updateStateAndReportFullscreenEvent,
+				);
+			}
+
+			if (playerContainer) {
+				playerContainer.addEventListener(
+					event,
+					updateStateAndReportFullscreenEvent,
+				);
+			}
+		}
+
+		return () => {
+			for (const event of fullscreenChangeEvents) {
+				if (video) {
+					video.removeEventListener(
+						event,
+						updateStateAndReportFullscreenEvent,
+					);
+				}
+
+				if (playerContainer) {
+					playerContainer.removeEventListener(
+						event,
+						updateStateAndReportFullscreenEvent,
+					);
+				}
+			}
+		};
+	}, [videoRef, playerContainerRef, sendOphanTrackingEvent]);
+
+	const handleFullscreenClick = (event: React.SyntheticEvent) => {
+		void submitClickComponentEvent(event.currentTarget, renderingTarget);
+		event.stopPropagation(); // Don't pause the video
+
+		showFadeableControlsAndStartTimer(); // Show controls when a button is clicked
+
+		const video = videoRef.current;
+		if (!video) {
+			return;
+		}
+
+		if (shouldUseWebkitFullscreen(video)) {
+			/**
+			 * webkit fullscreen methods are not part of the standard HTMLVideoElement
+			 * type definition as they are iOS only.
+			 * We need to extend the type to expect these handlers when we're on iOS to keep TS happy.
+			 * @see https://developer.apple.com/documentation/webkitjs/htmlvideoelement/1633500-webkitenterfullscreen
+			 */
+			const webkitVideo = video as HTMLVideoElement & {
+				webkitDisplayingFullscreen: boolean;
+				webkitEnterFullscreen: () => void;
+				webkitExitFullscreen: () => void;
+			};
+
+			if (webkitVideo.webkitDisplayingFullscreen) {
+				setIsWebKitFullscreen(false);
+				return webkitVideo.webkitExitFullscreen();
+			} else {
+				setIsWebKitFullscreen(true);
+				return webkitVideo.webkitEnterFullscreen();
+			}
+		}
+
+		if (shouldUseBridgetFullscreen) {
+			const videoClient = getVideoClient();
+			const fullscreen = !isBridgetFullscreen;
+			void videoClient
+				.setFullscreen(fullscreen)
+				.then(() => setIsBridgetFullscreen(fullscreen));
+		} else if (document.fullscreenElement) {
+			void document.exitFullscreen();
+		} else if (playerContainerRef.current) {
+			void playerContainerRef.current.requestFullscreen();
+		}
+	};
+
+	return {
+		isFullscreen,
+		isWebKitFullscreen,
+		isBridgetFullscreen,
+		handleFullscreenClick,
+		fullscreenStyles: buildFullscreenStyles(isBridgetFullscreen),
+		globalFullscreenStyles:
+			getFullscreenGlobalHiddenOverflow(isBridgetFullscreen),
+	};
+};


### PR DESCRIPTION
## What does this change?
Currently the self-hosted player on Android's fullscreen control does not work. An existing solution for this problem exists in on the YouTube player and should be applicable here: 
https://github.com/guardian/dotcom-rendering/blob/3626d26ca3a3e29a04993cb04da6a81801840324/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx#L671-L675

This change makes use of Bridget to apply fullscreen on DCAR Android. Styling is added to the self hosted video in this situation to make the video appear fullscreen.

## Why?

Android's fullscreen control does not currently work!

## Testing

Testing this change has proven difficult and made the feedback loop painful. Working with the team, I have not found a way to test this successfully locally, therefore it must be deployed to CODE. It would be valuable to have a second opinion to confirm this works and does not break existing fullscreen functionality. 

## Screenshots

| Format      | Video      |
| ----------- | ---------- |
| Vertical (found footage 👻)| <img width="427" height="945" alt="2026-06-17 10 05 01" src="https://github.com/user-attachments/assets/9885829b-3b07-4b9c-b6e5-9c76e6fc2dbf" /> | 
| Horizontal | <img width="427" height="945" alt="2026-06-17 10 04 31" src="https://github.com/user-attachments/assets/126e5f70-6c11-42d7-ad57-07338f0c27a1" /> |
