### PR TITLE
Update "Golden Boot" casing on the World Cup subnav

### DIFF
--- a/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
+++ b/dotcom-rendering/src/components/DirectoryPageNav.island.tsx
@@ -86,7 +86,7 @@ const worldCup2026Links = [
 		id: 'football/ng-interactive/2026/jun/04/bracketology-predict-a-path-to-world-cup-victory',
 	},
 	{
-		label: 'Golden boot',
+		label: 'Golden Boot',
 		id: 'football/ng-interactive/2026/jun/04/golden-boot-world-cup-2026-top-goalscorers-winner',
 	},
 	{


### PR DESCRIPTION
## What does this change?

Update "Golden Boot" casing on the World Cup subnav

Closes: https://github.com/guardian/dotcom-rendering/issues/16173
