### PR TITLE
Move conditional rendering logic for the `share` button to remove styling

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -70,12 +70,12 @@ export const GalleryCaption = ({
 					{credit}
 				</small>
 			)}
-			<div
-				css={css`
-					padding-top: ${space[2]}px;
-				`}
-			>
-				{shouldIncludeShareButton && (
+			{shouldIncludeShareButton && (
+				<div
+					css={css`
+						padding-top: ${space[2]}px;
+					`}
+				>
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<ShareButton
 							format={format}
@@ -89,8 +89,8 @@ export const GalleryCaption = ({
 							}
 						/>
 					</Island>
-				)}
-			</div>
+				</div>
+			)}
 		</figcaption>
 	);
 };


### PR DESCRIPTION
## What does this change?
Moves the share-button conditional rendering logic outside the parent container so the container is not rendered when the share button is omitted.
This prevents the unused top padding from being applied when no share button is shown.

## Why?
A related PR introduced conditional rendering for the share button: https://github.com/guardian/dotcom-rendering/pull/16139/
In the current implementation, when the share button is not rendered, the parent container still renders and applies padding-top, leaving unnecessary spacing.
This is a small cleanup that avoids that layout side effect.
