### PR TITLE
Use `useVideoAttentionTracking` for tracking YouTube player attention time

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -1,6 +1,7 @@
 import type { ConsentState } from '@guardian/consent-manager';
 import { useCallback, useState } from 'react';
 import type { ArticleFormat } from '../../lib/articleFormat';
+import { useIsInView } from '../../lib/useIsInView';
 import type { AdTargeting } from '../../types/commercial';
 import type { AspectRatio } from '../../types/front';
 import type { ArticleMedia } from '../../types/mainMedia';
@@ -128,6 +129,12 @@ export const YoutubeAtom = ({
 	const [isClosed, setIsClosed] = useState<boolean>(false);
 	const [pauseVideo, setPauseVideo] = useState<boolean>(false);
 
+	const [isInView, setRef] = useIsInView({
+		threshold: 0.5,
+		repeat: true,
+		debounce: true,
+	});
+
 	/**
 	 * Consent and ad targeting are initially undefined and set by subsequent re-renders
 	 */
@@ -191,6 +198,7 @@ export const YoutubeAtom = ({
 			data-atom-id={atomId}
 			data-video-id={videoId}
 			data-video-unique-id={uniqueId}
+			ref={setRef}
 		>
 			<YoutubeAtomSticky
 				uniqueId={uniqueId}
@@ -203,6 +211,7 @@ export const YoutubeAtom = ({
 				isClosed={isClosed}
 				setIsClosed={setIsClosed}
 				shouldPauseOutOfView={shouldPauseOutOfView}
+				isIntersecting={isInView}
 			>
 				<MaintainAspectRatio
 					height={height}
@@ -240,6 +249,9 @@ export const YoutubeAtom = ({
 								consentState={consentState}
 								abTestParticipations={abTestParticipations}
 								renderingTarget={renderingTarget}
+								isInView={
+									isInView == true || shouldStick == true
+								}
 							/>
 						)
 					}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -218,6 +218,7 @@ export const YoutubeAtom = ({
 						loadPlayer && consentState && adTargeting && (
 							<YoutubeAtomPlayer
 								videoId={videoId}
+								atomId={atomId}
 								uniqueId={uniqueId}
 								height={height}
 								width={width}

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -12,6 +12,8 @@ import {
 import { getVideoClient } from '../../lib/bridgetApi';
 import { getZIndex } from '../../lib/getZIndex';
 import { getAuthStatus } from '../../lib/identity';
+import { useIsInView } from '../../lib/useIsInView';
+import { useVideoAttentionTracking } from '../../lib/useVideoAttentionTracking';
 import { useVideoMilestoneTracking } from '../../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail } from '../../lib/video';
 import {
@@ -28,6 +30,7 @@ import { YouTubePlayer } from './YoutubePlayer';
 
 type Props = {
 	uniqueId: string;
+	atomId: string;
 	videoId: string;
 	height: number;
 	width: number;
@@ -196,6 +199,7 @@ const createOnStateChangeListener =
 		sendOphanTrackingEvent: (event: VideoEventKey) => void,
 		trackMilestones: ReturnType<typeof useVideoMilestoneTracking>[0],
 		resetMilestones: () => void,
+		setIsPlaying: (value: boolean) => void,
 	): YT.PlayerEventHandler<YT.OnStateChangeEvent> =>
 	(event) => {
 		const loggerFrom = 'YoutubeAtomPlayer onStateChange';
@@ -216,6 +220,7 @@ const createOnStateChangeListener =
 			 * get aware when a video is played
 			 */
 			dispatchCustomPlayEvent(uniqueId);
+			setIsPlaying(true);
 
 			trackMilestones({ started: true });
 			if (playerState.paused) {
@@ -239,6 +244,7 @@ const createOnStateChangeListener =
 
 		if (event.data === YT.PlayerState.PAUSED) {
 			dispatchCustomPauseEvent(uniqueId);
+			setIsPlaying(false);
 
 			log('dotcom', {
 				from: loggerFrom,
@@ -263,6 +269,7 @@ const createOnStateChangeListener =
 
 		if (event.data === YT.PlayerState.ENDED) {
 			dispatchCustomPauseEvent(uniqueId);
+			setIsPlaying(false);
 			clearInterval(playerState.progressIntervalId);
 			trackMilestones({ ended: true });
 			resetMilestones();
@@ -381,6 +388,7 @@ const isSignedIn = async (): Promise<boolean> => {
 
 export const YoutubeAtomPlayer = ({
 	uniqueId,
+	atomId,
 	videoId,
 	height,
 	width,
@@ -411,15 +419,14 @@ export const YoutubeAtomPlayer = ({
 		},
 		[eventEmitters],
 	);
-	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
-		sendOphanTrackingEvent,
-	);
+
 	const playerPauseState = useRef<{
 		paused: boolean;
 		progressIntervalId: ReturnType<typeof setInterval> | undefined;
 	}>({ paused: false, progressIntervalId: undefined });
 
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
+	const [isPlaying, setIsPlaying] = useState<boolean>(false);
 	const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
 	const [applyFullscreenStyles, setApplyFullscreenStyles] =
 		useState<boolean>(false);
@@ -435,6 +442,22 @@ export const YoutubeAtomPlayer = ({
 	const adsManager = useRef<google.ima.AdsManager>();
 
 	const id = `youtube-player-${uniqueId}`;
+
+	const [isInView, setNode] = useIsInView({
+		repeat: true,
+		threshold: 0.5,
+	});
+
+	useVideoAttentionTracking(
+		`gu-video-youtube-${atomId}`,
+		isInView,
+		isPlaying,
+		renderingTarget,
+	);
+
+	const [trackMilestones, resetMilestones] = useVideoMilestoneTracking(
+		sendOphanTrackingEvent,
+	);
 
 	/**
 	 * Initialise player useEffect
@@ -460,6 +483,7 @@ export const YoutubeAtomPlayer = ({
 					sendOphanTrackingEvent,
 					trackMilestones,
 					resetMilestones,
+					setIsPlaying,
 				);
 
 				/**
@@ -726,6 +750,7 @@ export const YoutubeAtomPlayer = ({
 				data-atom-type="youtube"
 				title={title}
 				css={enableAds && imaPlayerStyles}
+				ref={setNode}
 			></div>
 		</>
 	);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -12,7 +12,6 @@ import {
 import { getVideoClient } from '../../lib/bridgetApi';
 import { getZIndex } from '../../lib/getZIndex';
 import { getAuthStatus } from '../../lib/identity';
-import { useIsInView } from '../../lib/useIsInView';
 import { useVideoAttentionTracking } from '../../lib/useVideoAttentionTracking';
 import { useVideoMilestoneTracking } from '../../lib/useVideoMilestoneTracking';
 import type { CustomPlayEventDetail } from '../../lib/video';
@@ -46,6 +45,7 @@ type Props = {
 	consentState: ConsentState;
 	abTestParticipations: Record<string, string>;
 	renderingTarget: RenderingTarget;
+	isInView: boolean;
 };
 
 /**
@@ -404,6 +404,7 @@ export const YoutubeAtomPlayer = ({
 	consentState,
 	abTestParticipations,
 	renderingTarget,
+	isInView,
 }: Props): JSX.Element => {
 	/**
 	 * useRef for player and progressEvents
@@ -442,12 +443,6 @@ export const YoutubeAtomPlayer = ({
 	const adsManager = useRef<google.ima.AdsManager>();
 
 	const id = `youtube-player-${uniqueId}`;
-
-	const [isInView, setNode] = useIsInView({
-		debounce: true,
-		repeat: true,
-		threshold: 0.5,
-	});
 
 	useVideoAttentionTracking(
 		`gu-video-youtube-${atomId}`,
@@ -751,7 +746,6 @@ export const YoutubeAtomPlayer = ({
 				data-atom-type="youtube"
 				title={title}
 				css={enableAds && imaPlayerStyles}
-				ref={setNode}
 			></div>
 		</>
 	);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPlayer.tsx
@@ -444,6 +444,7 @@ export const YoutubeAtomPlayer = ({
 	const id = `youtube-player-${uniqueId}`;
 
 	const [isInView, setNode] = useIsInView({
+		debounce: true,
 		repeat: true,
 		threshold: 0.5,
 	});

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomSticky.tsx
@@ -9,7 +9,6 @@ import { SvgCross } from '@guardian/source/react-components';
 import detectMobile from 'is-mobile';
 import { useEffect, useState } from 'react';
 import { submitComponentEvent } from '../../client/ophan/ophan';
-import { useIsInView } from '../../lib/useIsInView';
 import { useConfig } from '../ConfigContext';
 import type { VideoEventKey } from './YoutubeAtom';
 
@@ -124,6 +123,7 @@ type Props = {
 	isClosed: boolean;
 	setIsClosed: (state: boolean) => void;
 	shouldPauseOutOfView: boolean;
+	isIntersecting: boolean | null;
 };
 
 const isMobile = detectMobile({ tablet: true });
@@ -140,17 +140,12 @@ export const YoutubeAtomSticky = ({
 	isClosed,
 	setIsClosed,
 	shouldPauseOutOfView,
+	isIntersecting,
 }: Props): JSX.Element => {
 	const [isSticky, setIsSticky] = useState<boolean>(false);
 	const [stickEventSent, setStickEventSent] = useState<boolean>(false);
 	const [showOverlay, setShowOverlay] = useState<boolean>(isMobile);
 	const { renderingTarget } = useConfig();
-
-	const [isIntersecting, setRef] = useIsInView({
-		threshold: 0.5,
-		repeat: true,
-		debounce: true,
-	});
 
 	/**
 	 * Click handler for the sticky video close button
@@ -269,7 +264,6 @@ export const YoutubeAtomSticky = ({
 
 	return (
 		<div
-			ref={setRef}
 			css={isSticky && stickyContainerStyles(isMainMedia)}
 			data-testid={`youtube-sticky-${uniqueId}`}
 			data-is-sticky={isSticky}


### PR DESCRIPTION
## What does this change?
As requested by the Ophan team, the current implementation of the YouTube player means attention times under-report as there may be little engagement when a video is playing. The historic mechanism to ensure Ophan continues to tracking attention time for video has long been unused.

This PR adds component attention time and ensures page attention time is captured by using the `useVideoAttentionTracking` hook implemented into the SelfHosted video player. That hook ensure attention time updates continue to be sent by dispatching events the Ophan tracker expects/

Hook:
https://github.com/guardian/dotcom-rendering/blob/9c7620550c38593e27a39a7ea718527ff2332273/dotcom-rendering/src/lib/useVideoAttentionTracking.ts#L54

https://github.com/guardian/dotcom-rendering/blob/9c7620550c38593e27a39a7ea718527ff2332273/dotcom-rendering/src/lib/useVideoAttentionTracking.ts#L62

Ophan
[Ophan Tracker JS - Attention Tracking](https://github.com/guardian/ophan/blob/d1c0f00740825da8038448e8572de92b01806426/tracker-js/src/attention.js#L157-L168)

## Why?

This PR will improve the attention time tracking for YouTube videos as requested by the Ophan team.