### PR TITLE
Extend click through test by a month

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -165,7 +165,7 @@ const ABTests: ABTest[] = [
 			"Test impact of click to article via loop videos on fronts",
 		owners: ["fronts.and.curation@guardian.co.uk"],
 		status: "ON",
-		expirationDate: "2026-06-19",
+		expirationDate: "2026-07-19",
 		type: "server",
 		audienceSize: 0 / 100,
 		groups: ["control", "variant"],


### PR DESCRIPTION
## What does this change?
Extends the duration of the loop click through test by a month 

## Why?
This launch for this test is delayed due to current resourcing limitations.  