### PR TITLE
Replace 'Free newsletter' with 'Newsletter' in highlight cards

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
@@ -218,7 +218,7 @@ export const HighlightsNewsletterCard = ({
 					<div css={content}>
 						<span css={kickerStyles}>
 							<SvgNewsletterFilled />
-							Free newsletter
+							Newsletter
 						</span>
 
 						<CardHeadline

--- a/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
@@ -127,9 +127,7 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 				}),
 			).not.toBeInTheDocument();
 
-			expect(
-				screen.queryByText('Free newsletter'),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText('Newsletter')).not.toBeInTheDocument();
 		});
 
 		it('does not render a newsletter trail when newsletterData is missing', () => {
@@ -140,9 +138,7 @@ describe('ScrollableHighlights — newsletter card AB test', () => {
 					name: newsletterSignupCardWithoutData.headline,
 				}),
 			).not.toBeInTheDocument();
-			expect(
-				screen.queryByText('Free newsletter'),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText('Newsletter')).not.toBeInTheDocument();
 		});
 
 		it('still renders non-newsletter cards normally', () => {


### PR DESCRIPTION
## What does this change?

Updates 'Free newsletter' kicker to 'Newsletter' for the newsletter highlights card

## Why?

Although testing for 'Free newsletter' looks ok for the signup card, it suggests that the other content is not free in this context

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/fff1fc6d-6a56-47b6-aac2-092a45a72d71

[after]: https://github.com/user-attachments/assets/51931a74-0500-4129-9041-0e12d2e86207

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
