### PR TITLE
Hosted Gallery page updates

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -167,6 +167,16 @@ const labsGalleryFont = css`
 	}
 `;
 
+const hostedGalleryFont = css`
+	${textSansBold34};
+	line-height: 2.1875rem;
+
+	${from.desktop} {
+		${textSansBold34};
+		line-height: 3.125rem;
+	}
+`;
+
 const jumboLabsFont = css`
 	${textSansBold34};
 	font-size: 3.125rem;
@@ -888,8 +898,7 @@ export const ArticleHeadline = ({
 							</h1>
 						</div>
 					);
-				case ArticleDesign.Gallery:
-				case ArticleDesign.HostedGallery: {
+				case ArticleDesign.Gallery: {
 					return (
 						<div css={galleryStyles}>
 							<WithAgeWarning
@@ -926,6 +935,34 @@ export const ArticleHeadline = ({
 									</span>
 								</h1>
 							</WithAgeWarning>
+						</div>
+					);
+				}
+				case ArticleDesign.HostedGallery: {
+					return (
+						<div css={galleryStyles}>
+							<h1
+								css={[
+									hostedGalleryFont,
+									css`
+										color: ${themePalette(
+											'--headline-colour',
+										)};
+										${darkBackground};
+										padding-bottom: ${space[6]}px;
+										padding-left: ${space[3]}px;
+										padding-right: ${space[3]}px;
+
+										${between.mobileLandscape.and.tablet} {
+											padding-left: ${space[5]}px;
+										}
+									`,
+								]}
+							>
+								<span css={[displayBlock, maxWidth]}>
+									{headlineString}
+								</span>
+							</h1>
 						</div>
 					);
 				}

--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -172,7 +172,6 @@ const hostedGalleryFont = css`
 	line-height: 2.1875rem;
 
 	${from.desktop} {
-		${textSansBold34};
 		line-height: 3.125rem;
 	}
 `;

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -70,12 +70,13 @@ export const GalleryCaption = ({
 					{credit}
 				</small>
 			)}
-			<div
-				css={css`
-					padding-top: ${space[2]}px;
-				`}
-			>
-				{shouldIncludeShareButton && (
+
+			{shouldIncludeShareButton && (
+				<div
+					css={css`
+						padding-top: ${space[2]}px;
+					`}
+				>
 					<Island priority="feature" defer={{ until: 'visible' }}>
 						<ShareButton
 							format={format}
@@ -89,8 +90,8 @@ export const GalleryCaption = ({
 							}
 						/>
 					</Island>
-				)}
-			</div>
+				</div>
+			)}
 		</figcaption>
 	);
 };

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -175,8 +175,7 @@ const decideImageWidths = ({
 		 */
 		if (
 			format.design === ArticleDesign.HostedArticle ||
-			format.design === ArticleDesign.HostedVideo ||
-			format.design === ArticleDesign.HostedGallery
+			format.design === ArticleDesign.HostedVideo
 		) {
 			return [
 				{
@@ -334,7 +333,10 @@ const decideImageWidths = ({
 					},
 				];
 		}
-	} else if (format.design === ArticleDesign.Gallery) {
+	} else if (
+		format.design === ArticleDesign.Gallery ||
+		format.design === ArticleDesign.HostedGallery
+	) {
 		return [
 			{ breakpoint: breakpoints.mobile, width: 375 },
 			{ breakpoint: breakpoints.mobileMedium, width: 480 },
@@ -544,7 +546,10 @@ export const Sources = ({ sources }: { sources: ImageSource[] }) => {
 };
 
 const styles = ({ design }: ArticleFormat, isLightbox: boolean) => {
-	if (design === ArticleDesign.Gallery) {
+	if (
+		design === ArticleDesign.Gallery ||
+		design === ArticleDesign.HostedGallery
+	) {
 		return css`
 			img {
 				width: 100%;

--- a/dotcom-rendering/src/components/Standfirst.tsx
+++ b/dotcom-rendering/src/components/Standfirst.tsx
@@ -83,7 +83,6 @@ const decideFont = ({ display, design, theme }: ArticleFormat) => {
 	const isLabs = theme === ArticleSpecial.Labs;
 	switch (design) {
 		case ArticleDesign.Gallery:
-		case ArticleDesign.HostedGallery:
 			if (isLabs) {
 				return css`
 					${textSansBold15};
@@ -91,6 +90,10 @@ const decideFont = ({ display, design, theme }: ArticleFormat) => {
 			}
 			return css`
 				${headlineMedium20}
+			`;
+		case ArticleDesign.HostedGallery:
+			return css`
+				${textSans24};
 			`;
 		case ArticleDesign.Obituary:
 		case ArticleDesign.Comment:

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -5,7 +5,6 @@ import {
 	space,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
-import { ArticleTitle } from '../components/ArticleTitle';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
@@ -40,14 +39,38 @@ const headerStyles = css`
 	${grid.container}
 	background-color: ${palette('--article-inner-background')};
 
+	/** Additional padding needed due to no main media pushing the content down */
+	padding-top: ${space[24]}px;
+
 	${from.tablet} {
 		border-bottom: 1px solid ${palette('--article-border')};
+	}
+
+	${from.leftCol} {
+		padding-top: ${space[4]}px;
 	}
 `;
 
 const shareButtonStyles = css`
-	margin-top: ${space[4]}px;
-	padding: ${space[1]}px;
+	${grid.column.centre}
+	padding-bottom: ${space[6]}px;
+	${from.tablet} {
+		position: relative;
+		&::before {
+			content: '';
+			position: absolute;
+			left: -10px;
+			top: 0;
+			bottom: 0;
+			width: 1px;
+			background-color: ${palette('--article-border')};
+		}
+	}
+
+	& button {
+		margin-top: ${space[4]}px;
+		padding: ${space[1]}px;
+	}
 `;
 
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
@@ -67,7 +90,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						showTopBorder={false}
 						shouldCenter={false}
 						backgroundColour={sourcePalette.neutral[7]}
-						padSides={true}
+						padSides={false}
 						element="header"
 					>
 						<Island priority="feature" defer={{ until: 'visible' }}>
@@ -88,13 +111,6 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						format={format}
 						renderingTarget={props.renderingTarget}
 					/>
-					<ArticleTitle
-						format={format}
-						tags={frontendData.tags}
-						sectionLabel={frontendData.sectionLabel}
-						sectionUrl={frontendData.sectionUrl}
-						guardianBaseURL={frontendData.guardianBaseURL}
-					/>
 					<ArticleHeadline
 						format={format}
 						headlineString={frontendData.headline}
@@ -110,39 +126,18 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					/>
 
 					{renderingTarget === 'Web' && (
-						<div
-							data-print-layout="hide"
-							css={{
-								'&': css(grid.column.centre),
-								paddingBottom: space[6],
-								[from.tablet]: {
-									position: 'relative',
-									'&::before': {
-										content: '""',
-										position: 'absolute',
-										left: -10,
-										top: 0,
-										bottom: 0,
-										width: 1,
-										backgroundColor:
-											palette('--article-border'),
-									},
-								},
-							}}
-						>
-							<div css={shareButtonStyles}>
-								<Island
-									priority="feature"
-									defer={{ until: 'visible' }}
-								>
-									<ShareButton
-										pageId={frontendData.pageId}
-										webTitle={frontendData.webTitle}
-										format={format}
-										context="ArticleMeta"
-									/>
-								</Island>
-							</div>
+						<div data-print-layout="hide" css={shareButtonStyles}>
+							<Island
+								priority="feature"
+								defer={{ until: 'visible' }}
+							>
+								<ShareButton
+									pageId={frontendData.pageId}
+									webTitle={frontendData.webTitle}
+									format={format}
+									context="ArticleMeta"
+								/>
+							</Island>
 						</div>
 					)}
 				</header>
@@ -189,20 +184,22 @@ const GalleryBody = (props: {
 }) => (
 	<>
 		{props.bodyElements.map((element) => {
-			switch (element._type) {
-				case 'model.dotcomrendering.pageElements.ImageBlockElement':
-					return (
-						<GalleryImage
-							image={element}
-							format={props.format}
-							pageId={props.pageId}
-							webTitle={props.webTitle}
-							renderingTarget={props.renderingTarget}
-							key={element.elementId}
-						/>
-					);
-				default:
-					return null;
+			if (
+				element._type ===
+				'model.dotcomrendering.pageElements.ImageBlockElement'
+			) {
+				return (
+					<GalleryImage
+						image={element}
+						format={props.format}
+						pageId={props.pageId}
+						webTitle={props.webTitle}
+						renderingTarget={props.renderingTarget}
+						key={element.elementId}
+					/>
+				);
+			} else {
+				return null;
 			}
 		})}
 	</>

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -196,7 +196,7 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 						showTopBorder={false}
 						shouldCenter={false}
 						backgroundColour={sourcePalette.neutral[7]}
-						padSides={true}
+						padSides={false}
 						element="header"
 					>
 						<Island priority="feature" defer={{ until: 'visible' }}>

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -213,7 +213,6 @@ const headlineBackgroundLight: PaletteFunction = ({
 		case ArticleDisplay.Standard:
 			switch (design) {
 				case ArticleDesign.Gallery:
-				case ArticleDesign.HostedGallery:
 					return sourcePalette.neutral[7];
 				case ArticleDesign.Interview:
 					return sourcePalette.neutral[7];
@@ -1939,6 +1938,8 @@ const articleInnerAdBackgroundLight: PaletteFunction = ({ design, theme }) => {
 			return sourcePalette.neutral[93];
 		case ArticleDesign.Gallery:
 			return sourcePalette.neutral[7];
+		case ArticleDesign.HostedGallery:
+			return sourcePalette.neutral[10];
 		default:
 			return sourcePalette.neutral[97];
 	}
@@ -1948,6 +1949,7 @@ const articleInnerAdBackgroundDark: PaletteFunction = ({ design }) => {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[7];
 		case ArticleDesign.Gallery:
+		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[10];
 		default:
 			return sourcePalette.neutral[20];
@@ -2280,7 +2282,6 @@ const standfirstBackgroundLight: PaletteFunction = ({
 					return sourcePalette.neutral[93];
 			}
 		case ArticleDesign.Gallery:
-		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
 		default:
 			return articleBackgroundLight({ design, display, theme });
@@ -3178,8 +3179,9 @@ const articleBackgroundLight: PaletteFunction = ({
 		case ArticleDesign.FullPageInteractive:
 			return 'transparent';
 		case ArticleDesign.Gallery:
-		case ArticleDesign.HostedGallery:
 			return '#0d0d0d';
+		case ArticleDesign.HostedGallery:
+			return sourcePalette.neutral[10];
 		default:
 			switch (theme) {
 				case ArticleSpecial.SpecialReport:
@@ -3241,9 +3243,9 @@ const articleInnerBackgroundLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.neutral[0];
 			}
 		case ArticleDesign.Gallery:
-		case ArticleDesign.HostedGallery:
 			return sourcePalette.neutral[7];
-
+		case ArticleDesign.HostedGallery:
+			return sourcePalette.neutral[10];
 		default:
 			return 'transparent';
 	}
@@ -3549,6 +3551,8 @@ const articleBorderLight: PaletteFunction = ({ design, theme }) => {
 				case ArticleDesign.HostedArticle:
 				case ArticleDesign.HostedVideo:
 					return sourcePalette.neutral[86];
+				case ArticleDesign.HostedGallery:
+					return sourcePalette.neutral[20];
 				default:
 					return sourcePalette.neutral[60];
 			}


### PR DESCRIPTION
## What does this change?

Various improvements for Hosted Gallery pages including:
- Updating border and background colours, setting the background colour as `neutral.10` rather than `neutral.7` for contrast against the sticky top bar
- Allowing the images to take up full width
- Refactoring some css for better readability
- Removing `ArticleTitle` as we don't use that for hosted content pages
- Adjusting font and spacing

## Why?

Creating the Hosted Gallery pages in dotcom-rendering as part of the Hosted Content migration from frontend

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before_m][] | ![after_m][] |

[before]: https://github.com/user-attachments/assets/bf605d8c-a71c-4846-878a-370c36b65583
[after]: https://github.com/user-attachments/assets/05595885-f29e-47ff-bf44-41eee68da08e
[before_m]: https://github.com/user-attachments/assets/69310cf7-43e6-4454-a14e-580f6211cb32
[after_m]: https://github.com/user-attachments/assets/d18b3443-4d7f-4ae1-a1b8-dceecc9f1159