### PR TITLE
Revert "ci: Use `guardian/actions-build-facts` to correctly reference commit sha"

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,22 +4,10 @@ on:
   push:
 
 jobs:
-  facts:
-    runs-on: ubuntu-slim
-    permissions: {}
-    outputs:
-      commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
-    steps:
-      - uses: guardian/actions-build-facts@v0.0.1
-        id: get-build-facts
-
   container:
     permissions:
       packages: write
     uses: ./.github/workflows/container.yml
-    needs: [facts]
-    with:
-      commitSha: ${{ needs.facts.outputs.commitSha }}
 
   prettier:
     uses: ./.github/workflows/prettier.yml

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,11 +2,6 @@
 # Commercial rely on a container image built from the main branch with the tag 'main'
 on:
   workflow_call:
-    inputs:
-      commitSha:
-        description: 'The SHA of the commit being built. Will be used as an image tag.'
-        required: true
-        type: string
     outputs:
       container-image:
         description: 'The generated container image path'
@@ -32,7 +27,7 @@ jobs:
       - name: Add commit hash for PRout
         working-directory: dotcom-rendering
         run: |
-          echo 'export const GIT_COMMIT_HASH = "${{ inputs.commitSha }}";' > src/server/prout.ts
+          echo 'export const GIT_COMMIT_HASH = "${{ github.sha }}";' > src/server/prout.ts
 
       - name: Generate production bundle
         run: make riffraff-bundle
@@ -44,7 +39,7 @@ jobs:
         with:
           image: dotcom-rendering
           # Commercial rely on a container image built from the main branch with the tag 'main'
-          tags: ${{ inputs.commitSha }} ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
+          tags: ${{ github.sha }} ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
           context: ./
           containerfiles: ./dotcom-rendering/Containerfile
 

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -7,15 +7,6 @@ on:
     types: [opened, labeled, synchronize]
 
 jobs:
-  facts:
-    runs-on: ubuntu-slim
-    permissions: {}
-    outputs:
-      commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
-    steps:
-      - uses: guardian/actions-build-facts@v0.0.1
-        id: get-build-facts
-
   check-paths:
     name: Check changed paths
     uses: ./.github/workflows/check-chromatic-paths.yml
@@ -23,7 +14,7 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
-    needs: [facts, check-paths]
+    needs: check-paths
     # Always run so the required "UI Tests: dotcom_rendering" status check is always
     # reported. When skipping, Chromatic posts a passing status without building Storybook.
     steps:
@@ -32,7 +23,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request'}}
         with:
           fetch-depth: 0
-          ref: ${{ needs.facts.outputs.commitSha }}
+          # By default the pull_request event will run on a ephermeral merge commit which simulates a merge between the pull request
+          # and the target branch. This can cause issues with Chromatic https://www.chromatic.com/docs/turbosnap#github-pullrequest-triggers
+          # Hopefully by checking out the HEAD commit of a PR instead of the merge commit we can avoid some of those issues.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout - On Push Event
         uses: actions/checkout@v6
         if: ${{ github.event_name == 'push'}}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#16158

We have noticed issues with Chromatic not diffing correctly

@Jakeii 