### PR TITLE
Add image number above caption in Hosted Gallery

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -22,8 +22,8 @@ type Props = {
 	webTitle: string;
 	/** Position of the image in the gallery used to build share fragment */
 	position?: number;
+	// Pass the total number of images from Hosted Gallery to include in the image caption (e.g. 1/5, 2/5, etc.)
 	imagesLength?: number;
-	imageIndex?: number;
 };
 
 const styles = css`
@@ -55,7 +55,6 @@ export const GalleryCaption = ({
 	webTitle,
 	position,
 	imagesLength,
-	imageIndex,
 }: Props) => {
 	const emptyCaption = captionHtml === undefined || captionHtml.trim() === '';
 	const hideCredit =
@@ -69,7 +68,7 @@ export const GalleryCaption = ({
 	return (
 		<figcaption css={styles}>
 			{isHostedGallery &&
-			imageIndex !== undefined &&
+			typeof position === 'number' &&
 			imagesLength !== undefined ? (
 				<small
 					css={css`
@@ -78,7 +77,7 @@ export const GalleryCaption = ({
 						padding: ${space[2]}px 0 ${space[1]}px;
 					`}
 				>
-					{imageIndex + 1}&#47;{imagesLength}
+					{position}&#47;{imagesLength}
 				</small>
 			) : null}
 			{emptyCaption ? null : <CaptionText html={captionHtml} />}

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -69,7 +69,7 @@ export const GalleryCaption = ({
 		<figcaption css={styles}>
 			{isHostedGallery &&
 			typeof position === 'number' &&
-			imagesLength !== undefined ? (
+			!!imagesLength ? (
 				<small
 					css={css`
 						${textSans15}

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -76,6 +76,7 @@ export const GalleryCaption = ({
 						padding: ${space[2]}px 0 ${space[1]}px;
 					`}
 				>
+					{/* Gallery caption hashes use a 1-offset position (first image maps to "img-2"), so subtract 1 to show the expected hosted gallery index. */}
 					{position - 1}&#47;{imagesLength}
 				</small>
 			) : null}

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -23,6 +23,7 @@ type Props = {
 	/** Position of the image in the gallery used to build share fragment */
 	position?: number;
 	imagesLength?: number;
+	imageIndex?: number;
 };
 
 const styles = css`
@@ -54,6 +55,7 @@ export const GalleryCaption = ({
 	webTitle,
 	position,
 	imagesLength,
+	imageIndex,
 }: Props) => {
 	const emptyCaption = captionHtml === undefined || captionHtml.trim() === '';
 	const hideCredit =
@@ -67,7 +69,7 @@ export const GalleryCaption = ({
 	return (
 		<figcaption css={styles}>
 			{isHostedGallery &&
-			typeof position === 'number' &&
+			imageIndex !== undefined &&
 			imagesLength !== undefined ? (
 				<small
 					css={css`
@@ -76,8 +78,7 @@ export const GalleryCaption = ({
 						padding: ${space[2]}px 0 ${space[1]}px;
 					`}
 				>
-					{/* Gallery caption hashes use a 1-offset position (first image maps to "img-2"), so subtract 1 to show the expected hosted gallery index. */}
-					{position - 1}&#47;{imagesLength}
+					{imageIndex + 1}&#47;{imagesLength}
 				</small>
 			) : null}
 			{emptyCaption ? null : <CaptionText html={captionHtml} />}

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -1,5 +1,11 @@
 import { css } from '@emotion/react';
-import { between, from, space, textSans14 } from '@guardian/source/foundations';
+import {
+	between,
+	from,
+	space,
+	textSans14,
+	textSans15,
+} from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
@@ -16,6 +22,7 @@ type Props = {
 	webTitle: string;
 	/** Position of the image in the gallery used to build share fragment */
 	position?: number;
+	imagesLength?: number;
 };
 
 const styles = css`
@@ -46,12 +53,12 @@ export const GalleryCaption = ({
 	pageId,
 	webTitle,
 	position,
+	imagesLength,
 }: Props) => {
 	const emptyCaption = captionHtml === undefined || captionHtml.trim() === '';
 	const hideCredit =
 		displayCredit === false || credit === undefined || credit === '';
-	const shouldIncludeShareButton =
-		format.design !== ArticleDesign.HostedGallery;
+	const isHostedGallery = format.design === ArticleDesign.HostedGallery;
 
 	if (emptyCaption && hideCredit) {
 		return null;
@@ -59,6 +66,19 @@ export const GalleryCaption = ({
 
 	return (
 		<figcaption css={styles}>
+			{isHostedGallery &&
+			typeof position === 'number' &&
+			imagesLength !== undefined ? (
+				<small
+					css={css`
+						${textSans15}
+						display: block;
+						padding: ${space[2]}px 0 ${space[1]}px;
+					`}
+				>
+					{position - 1}&#47;{imagesLength}
+				</small>
+			) : null}
 			{emptyCaption ? null : <CaptionText html={captionHtml} />}
 			{hideCredit ? null : (
 				<small
@@ -71,7 +91,7 @@ export const GalleryCaption = ({
 				</small>
 			)}
 
-			{shouldIncludeShareButton && (
+			{!isHostedGallery && (
 				<div
 					css={css`
 						padding-top: ${space[2]}px;

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -19,6 +19,7 @@ type Props = {
 	pageId: string;
 	webTitle: string;
 	renderingTarget: RenderingTarget;
+	imagesLength?: number;
 };
 
 const styles = css`
@@ -70,6 +71,7 @@ export const GalleryImage = ({
 	pageId,
 	webTitle,
 	renderingTarget,
+	imagesLength,
 }: Props) => {
 	const asset = getImage(image.media.allImages);
 
@@ -138,6 +140,7 @@ export const GalleryImage = ({
 				pageId={pageId}
 				webTitle={webTitle}
 				position={image.position}
+				imagesLength={imagesLength}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -5,10 +5,7 @@ import { grid } from '../grid';
 import { type ArticleFormat } from '../lib/articleFormat';
 import { getImage } from '../lib/image';
 import { palette } from '../palette';
-import type {
-	AdPlaceholderBlockElement,
-	ImageBlockElement,
-} from '../types/content';
+import type { ImageBlockElement } from '../types/content';
 import { type RenderingTarget } from '../types/renderingTarget';
 import { AppsLightboxImage } from './AppsLightboxImage.island';
 import { GalleryCaption } from './GalleryCaption';
@@ -22,7 +19,7 @@ type Props = {
 	pageId: string;
 	webTitle: string;
 	renderingTarget: RenderingTarget;
-	images?: (ImageBlockElement | AdPlaceholderBlockElement)[];
+	imagesLength?: number;
 };
 
 const styles = css`
@@ -74,7 +71,7 @@ export const GalleryImage = ({
 	pageId,
 	webTitle,
 	renderingTarget,
-	images,
+	imagesLength,
 }: Props) => {
 	const asset = getImage(image.media.allImages);
 
@@ -88,8 +85,6 @@ export const GalleryImage = ({
 	if (isNaN(width) || isNaN(height)) {
 		return null;
 	}
-
-	const imageIndex = images?.indexOf(image);
 
 	return (
 		<figure css={styles}>
@@ -145,8 +140,7 @@ export const GalleryImage = ({
 				pageId={pageId}
 				webTitle={webTitle}
 				position={image.position}
-				imagesLength={images?.length}
-				imageIndex={imageIndex}
+				imagesLength={imagesLength}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -5,7 +5,10 @@ import { grid } from '../grid';
 import { type ArticleFormat } from '../lib/articleFormat';
 import { getImage } from '../lib/image';
 import { palette } from '../palette';
-import { type ImageBlockElement } from '../types/content';
+import type {
+	AdPlaceholderBlockElement,
+	ImageBlockElement,
+} from '../types/content';
 import { type RenderingTarget } from '../types/renderingTarget';
 import { AppsLightboxImage } from './AppsLightboxImage.island';
 import { GalleryCaption } from './GalleryCaption';
@@ -19,7 +22,7 @@ type Props = {
 	pageId: string;
 	webTitle: string;
 	renderingTarget: RenderingTarget;
-	imagesLength?: number;
+	images?: (ImageBlockElement | AdPlaceholderBlockElement)[];
 };
 
 const styles = css`
@@ -71,7 +74,7 @@ export const GalleryImage = ({
 	pageId,
 	webTitle,
 	renderingTarget,
-	imagesLength,
+	images,
 }: Props) => {
 	const asset = getImage(image.media.allImages);
 
@@ -85,6 +88,8 @@ export const GalleryImage = ({
 	if (isNaN(width) || isNaN(height)) {
 		return null;
 	}
+
+	const imageIndex = images?.indexOf(image);
 
 	return (
 		<figure css={styles}>
@@ -140,7 +145,8 @@ export const GalleryImage = ({
 				pageId={pageId}
 				webTitle={webTitle}
 				position={image.position}
-				imagesLength={imagesLength}
+				imagesLength={images?.length}
+				imageIndex={imageIndex}
 			/>
 		</figure>
 	);

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -222,6 +222,7 @@ const GalleryBody = (props: {
 						webTitle={props.webTitle}
 						renderingTarget={props.renderingTarget}
 						key={element.elementId}
+						imagesLength={props.bodyElements.length}
 					/>
 				);
 			} else {

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -222,7 +222,8 @@ const GalleryBody = (props: {
 						webTitle={props.webTitle}
 						renderingTarget={props.renderingTarget}
 						key={element.elementId}
-						images={props.bodyElements}
+						// Pass the total number of images to include in the image caption (e.g. 1/5, 2/5, etc.)
+						imagesLength={props.bodyElements.length}
 					/>
 				);
 			} else {

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -222,7 +222,7 @@ const GalleryBody = (props: {
 						webTitle={props.webTitle}
 						renderingTarget={props.renderingTarget}
 						key={element.elementId}
-						imagesLength={props.bodyElements.length}
+						images={props.bodyElements}
 					/>
 				);
 			} else {


### PR DESCRIPTION
## What does this change?

This PR adds the image number above the caption in Hosted Content Gallery.  

Tested locally and in CODE with multiple Hosted Galleries and it works as expected. 

## Why?

Migrating Hosted Content to DCAR and Hosted Gallery is the last page to migrate. The new designs require this change. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/e0fc8a94-27d7-44eb-8e35-60ad66574db0
[after]: https://github.com/user-attachments/assets/07662a27-1b82-40b4-bf5e-e397ba02c8cf

[before2]: https://github.com/user-attachments/assets/238a564d-8c0f-43a5-887e-581e39c82cfc
[after2]: https://github.com/user-attachments/assets/396a2021-00ca-4337-b343-d486efe81fde

[before3]: https://github.com/user-attachments/assets/ac17d706-3412-4f35-9545-6e94736ec3e3
[after3]: https://github.com/user-attachments/assets/89a2c06e-73b5-4e54-8eac-4761e567cc51

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215810866963288