### PR TITLE
Remove newsletter highlights signup card AB test and related props from components

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -160,19 +160,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "newsletters-highlights-signup-card",
-		description:
-			"Test a new newsletter signup card design in the scrollable/highlights container. Only users in the enabled group see the newsletter card; for all other users, newsletter trails are hidden during this rollout phase.",
-		owners: ["newsletters.dev@guardian.co.uk"],
-		status: "ON",
-		expirationDate: "2026-12-31",
-		type: "server",
-		audienceSize: 0,
-		audienceSpace: "C",
-		groups: ["enable"],
-		shouldForceMetricsCollection: true,
-	},
-	{
 		name: "fronts-and-curation-loop-click-through",
 		description:
 			"Test impact of click to article via loop videos on fronts",

--- a/dotcom-rendering/src/components/DecideContainer.tsx
+++ b/dotcom-rendering/src/components/DecideContainer.tsx
@@ -31,7 +31,6 @@ type Props = {
 	frontId?: string;
 	collectionId: number;
 	containerLevel?: DCRContainerLevel;
-	isNewsletterSignupCardEnabled?: boolean;
 };
 
 export const DecideContainer = ({
@@ -47,7 +46,6 @@ export const DecideContainer = ({
 	frontId,
 	collectionId,
 	containerLevel,
-	isNewsletterSignupCardEnabled = false,
 }: Props) => {
 	switch (containerType) {
 		case 'nav/list':
@@ -57,13 +55,7 @@ export const DecideContainer = ({
 		case 'scrollable/highlights':
 			return (
 				<Island priority="critical" defer={{ until: 'visible' }}>
-					<ScrollableHighlights
-						trails={trails}
-						frontId={frontId}
-						isNewsletterSignupCardEnabled={
-							isNewsletterSignupCardEnabled
-						}
-					/>
+					<ScrollableHighlights trails={trails} frontId={frontId} />
 				</Island>
 			);
 		case 'flexible/special':

--- a/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.island.test.tsx
@@ -17,7 +17,6 @@ jest.mock('../lib/newsletterSignupTracking', () => ({
 
 const renderHighlights = (
 	trailList: React.ComponentProps<typeof ScrollableHighlights>['trails'],
-	isNewsletterSignupCardEnabled: boolean,
 ) =>
 	render(
 		<ConfigProvider
@@ -28,14 +27,11 @@ const renderHighlights = (
 				editionId: 'UK',
 			}}
 		>
-			<ScrollableHighlights
-				trails={trailList}
-				isNewsletterSignupCardEnabled={isNewsletterSignupCardEnabled}
-			/>
+			<ScrollableHighlights trails={trailList} />
 		</ConfigProvider>,
 	);
 
-/** A signup card where newsletterData is missing — should still be hidden when the switch is off. */
+/** A signup card where newsletterData is missing — should be hidden. */
 const newsletterSignupCardWithoutData = {
 	...newsletterSignupCard,
 	newsletterData: undefined,
@@ -49,110 +45,57 @@ const newsletterTaggedArticle = {
 	newsletterData: undefined,
 };
 
-describe('ScrollableHighlights — newsletter card AB test', () => {
+describe('ScrollableHighlights', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
-	describe('when user is in the "enable" group', () => {
-		it('renders the HighlightsNewsletterCard for a newsletter trail', () => {
-			renderHighlights([newsletterSignupCard], true);
+	it('renders the HighlightsNewsletterCard for a newsletter signup trail', () => {
+		renderHighlights([newsletterSignupCard]);
 
-			expect(
-				screen.getByRole('link', {
-					name: newsletterSignupCard.headline,
-				}),
-			).toBeInTheDocument();
-		});
-
-		it('does not render a newsletter signup card when newsletterData is missing', () => {
-			renderHighlights([newsletterSignupCardWithoutData], true);
-
-			expect(
-				screen.queryByRole('link', {
-					name: newsletterSignupCardWithoutData.headline,
-				}),
-			).not.toBeInTheDocument();
-		});
-
-		it('renders a newsletter-tagged article (isNewsletter) even when newsletterData is missing', () => {
-			renderHighlights([newsletterTaggedArticle], true);
-
-			expect(
-				screen.getByRole('link', {
-					name: newsletterTaggedArticle.headline,
-				}),
-			).toBeInTheDocument();
-		});
-
-		it('still renders regular cards alongside the newsletter card', () => {
-			renderHighlights([newsletterSignupCard, defaultCard], true);
-
-			expect(
-				screen.getByRole('link', {
-					name: `${newsletterSignupCard.headline}`,
-				}),
-			).toBeInTheDocument();
-			expect(screen.getByText(defaultCard.headline)).toBeInTheDocument();
-		});
+		expect(
+			screen.getByRole('link', {
+				name: newsletterSignupCard.headline,
+			}),
+		).toBeInTheDocument();
 	});
 
-	describe('when user is NOT in the "enable" group', () => {
-		it('does not render a newsletter signup card when newsletterData is missing', () => {
-			renderHighlights([newsletterSignupCardWithoutData], false);
+	it('does not render a newsletter signup card when newsletterData is missing', () => {
+		renderHighlights([newsletterSignupCardWithoutData]);
 
-			expect(
-				screen.queryByRole('link', {
-					name: newsletterSignupCardWithoutData.headline,
-				}),
-			).not.toBeInTheDocument();
-		});
+		expect(
+			screen.queryByRole('link', {
+				name: newsletterSignupCardWithoutData.headline,
+			}),
+		).not.toBeInTheDocument();
+	});
 
-		it('renders a newsletter-tagged article (isNewsletter) even when newsletterData is missing', () => {
-			renderHighlights([newsletterTaggedArticle], false);
+	it('renders a newsletter-tagged article (isNewsletter) even when newsletterData is missing', () => {
+		renderHighlights([newsletterTaggedArticle]);
 
-			expect(
-				screen.getByRole('link', {
-					name: newsletterTaggedArticle.headline,
-				}),
-			).toBeInTheDocument();
-		});
+		expect(
+			screen.getByRole('link', {
+				name: newsletterTaggedArticle.headline,
+			}),
+		).toBeInTheDocument();
+	});
 
-		it('does not render a newsletter card at all', () => {
-			renderHighlights([newsletterSignupCard], false);
+	it('still renders regular cards alongside the newsletter card', () => {
+		renderHighlights([newsletterSignupCard, defaultCard]);
 
-			expect(
-				screen.queryByRole('link', {
-					name: newsletterSignupCard.headline,
-				}),
-			).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('link', {
+				name: newsletterSignupCard.headline,
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText(defaultCard.headline)).toBeInTheDocument();
+	});
 
-			expect(screen.queryByText('Newsletter')).not.toBeInTheDocument();
-		});
+	it('renders all regular trails correctly', () => {
+		renderHighlights(trails.slice(0, 3));
 
-		it('does not render a newsletter trail when newsletterData is missing', () => {
-			renderHighlights([newsletterSignupCardWithoutData], false);
-
-			expect(
-				screen.queryByRole('link', {
-					name: newsletterSignupCardWithoutData.headline,
-				}),
-			).not.toBeInTheDocument();
-			expect(screen.queryByText('Newsletter')).not.toBeInTheDocument();
-		});
-
-		it('still renders non-newsletter cards normally', () => {
-			renderHighlights([newsletterSignupCard, defaultCard], false);
-
-			expect(screen.getByText(defaultCard.headline)).toBeInTheDocument();
-		});
-
-		it('renders all regular trails unaffected', () => {
-			renderHighlights(trails.slice(0, 3), false);
-
-			expect(screen.getByText(trails[0]!.headline)).toBeInTheDocument();
-			expect(screen.getByText(trails[1]!.headline)).toBeInTheDocument();
-			expect(screen.getByText(trails[2]!.headline)).toBeInTheDocument();
-		});
+		expect(screen.getByText(trails[0]!.headline)).toBeInTheDocument();
+		expect(screen.getByText(trails[1]!.headline)).toBeInTheDocument();
+		expect(screen.getByText(trails[2]!.headline)).toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/ScrollableHighlights.island.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.island.tsx
@@ -18,7 +18,6 @@ import { HighlightsNewsletterCard } from './Masthead/Newsletter/HighlightsNewsle
 type Props = {
 	trails: DCRFrontCard[];
 	frontId?: string;
-	isNewsletterSignupCardEnabled: boolean;
 };
 
 const containerStyles = css`
@@ -212,16 +211,12 @@ const getOphanInfo = (frontId?: string) => {
 	};
 };
 
-export const ScrollableHighlights = ({
-	trails,
-	frontId,
-	isNewsletterSignupCardEnabled,
-}: Props) => {
+export const ScrollableHighlights = ({ trails, frontId }: Props) => {
 	const carouselRef = useRef<HTMLOListElement | null>(null);
 
 	const visibleTrails = trails.filter((trail) => {
 		if (trail.isNewsletterSignup !== true) return true;
-		return isNewsletterSignupCardEnabled && Boolean(trail.newsletterData);
+		return Boolean(trail.newsletterData);
 	});
 	const carouselLength = visibleTrails.length;
 	const imageLoading = 'eager';

--- a/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
+++ b/dotcom-rendering/src/components/ScrollableHighlights.stories.tsx
@@ -39,7 +39,6 @@ const meta = preview.meta({
 export const Default = meta.story({
 	args: {
 		trails: trails.slice(0, 6),
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
@@ -47,7 +46,6 @@ export const withEightCards = meta.story({
 	name: 'With Eight Cards',
 	args: {
 		trails: trails.slice(0, 8),
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
@@ -62,7 +60,6 @@ export const withTwoLineKicker = meta.story({
 			},
 			...Default.input.args.trails,
 		],
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
@@ -78,7 +75,6 @@ export const withLiveKicker = meta.story({
 			},
 			...Default.input.args.trails,
 		],
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
@@ -94,7 +90,6 @@ export const withFourLineHeadline = meta.story({
 			},
 			...Default.input.args.trails,
 		],
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
@@ -110,15 +105,13 @@ export const withExcessivleyLongHeadline = meta.story({
 			},
 			...Default.input.args.trails,
 		],
-		isNewsletterSignupCardEnabled: false,
 	},
 });
 
 export const withNewsletterCardVariant = meta.story({
 	...Default.input,
-	name: 'With Newsletter Signup Card (AB enabled)',
+	name: 'With Newsletter Signup Card',
 	args: {
 		trails: [newsletterSignupCard, ...Default.input.args.trails],
-		isNewsletterSignupCardEnabled: true,
 	},
 });

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -118,10 +118,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	} = front;
 
 	const serverTime = front.serverTime;
-	const isNewsletterSignupCardEnabled =
-		front.config.isPreview ||
-		front.config.serverSideABTests['newsletters-highlights-signup-card'] ===
-			'enable';
 
 	const renderAds = canRenderAds(front);
 
@@ -191,9 +187,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					)}
 					frontId={front.pressedPage.id}
 					collectionId={0}
-					isNewsletterSignupCardEnabled={
-						isNewsletterSignupCardEnabled
-					}
 				/>
 			)
 		);


### PR DESCRIPTION
## What does this change?

Removes the A/B test from hiding the newsletter signup highlights card

## Why?

Allows it to be shown to all users

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
