### PR TITLE
Remove newsletter signup card AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -82,19 +82,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "newsletters-signup-card-country-illustration",
-		description:
-			"Compare the existing SecureSignup (control) against a slightly modified version of the control (variantNewField) and the new NewsletterSignupCard design (variantIllustratedCard)",
-		owners: ["newsletters.dev@guardian.co.uk"],
-		expirationDate: "2026-07-01",
-		type: "client",
-		status: "ON",
-		audienceSize: 1,
-		audienceSpace: "B",
-		groups: ["variantIllustratedCard"],
-		shouldForceMetricsCollection: false,
-	},
-	{
 		name: "commercial-prebid-price-floor-holdback",
 		description:
 			"This test will be the 5% holdback group for the prebid price floor",

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
@@ -83,9 +83,7 @@ const renderWrapper = (props = {}, renderingTarget: 'Web' | 'Apps' = 'Web') =>
 		</ConfigProvider>,
 	);
 
-const mockAbTests = (
-	variant: 'control' | 'variantIllustratedCard' | 'variantNewField',
-) => {
+const mockAbTests = (variant: 'control' | 'variantIllustratedCard') => {
 	(useAB as jest.Mock).mockReturnValue({
 		getParticipations: () => ({
 			[AB_TEST_NAME]: variant,
@@ -149,12 +147,14 @@ describe('EmailSignUpWrapper', () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('renders the legacy EmailSignup for users in the control group', () => {
+		it('renders NewsletterSignupCardContainer for all web users regardless of AB participation', () => {
 			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: true });
-			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
 			expect(
-				screen.queryByTestId('newsletter-signup-card-container'),
+				screen.getByTestId('newsletter-signup-card-container'),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByTestId('email-signup'),
 			).not.toBeInTheDocument();
 		});
 
@@ -169,16 +169,6 @@ describe('EmailSignUpWrapper', () => {
 			).toBeInTheDocument();
 			expect(
 				screen.queryByTestId('email-signup'),
-			).not.toBeInTheDocument();
-		});
-
-		it('renders the legacy EmailSignup for users in the variantNewField group', () => {
-			mockAbTests('variantNewField');
-			renderWrapper({ showNewNewsletterSignupCard: true });
-			expect(screen.getByTestId('email-signup')).toBeInTheDocument();
-			expect(screen.getByTestId('secure-signup')).toBeInTheDocument();
-			expect(
-				screen.queryByTestId('newsletter-signup-card-container'),
 			).not.toBeInTheDocument();
 		});
 
@@ -219,7 +209,7 @@ describe('EmailSignUpWrapper', () => {
 	});
 
 	describe('VIEW tracking', () => {
-		it('fires a VIEW event with the correct control component id and ab metadata', () => {
+		it('fires a VIEW event with the variantIllustratedCard component id for all web users', () => {
 			mockAbTests('control');
 			renderWrapper({ showNewNewsletterSignupCard: true });
 
@@ -227,10 +217,13 @@ describe('EmailSignUpWrapper', () => {
 				expect.objectContaining({
 					component: {
 						componentType: 'NEWSLETTER_SUBSCRIPTION',
-						id: 'AR SecureSignup the-recap',
+						id: 'AR NewsletterSignupForm the-recap - variantIllustratedCard',
 					},
 					action: 'VIEW',
-					abTest: { name: AB_TEST_NAME, variant: 'control' },
+					abTest: {
+						name: AB_TEST_NAME,
+						variant: 'variantIllustratedCard',
+					},
 				}),
 				'Web',
 			);
@@ -250,26 +243,6 @@ describe('EmailSignUpWrapper', () => {
 					abTest: {
 						name: AB_TEST_NAME,
 						variant: 'variantIllustratedCard',
-					},
-				}),
-				'Web',
-			);
-		});
-
-		it('fires a VIEW event with the correct variantNewField component id and ab metadata', () => {
-			mockAbTests('variantNewField');
-			renderWrapper({ showNewNewsletterSignupCard: true });
-
-			expect(submitComponentEvent).toHaveBeenCalledWith(
-				expect.objectContaining({
-					component: {
-						componentType: 'NEWSLETTER_SUBSCRIPTION',
-						id: 'AR SecureSignup the-recap - variantNewField',
-					},
-					action: 'VIEW',
-					abTest: {
-						name: AB_TEST_NAME,
-						variant: 'variantNewField',
 					},
 				}),
 				'Web',

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -78,18 +78,8 @@ export const EmailSignUpWrapper = ({
 	const abTests = useAB();
 	const abResolved = abTests !== undefined;
 
-	const getVariantName = () => {
-		const currentUserVariant = abTests?.getParticipations()[AB_TEST_NAME];
-		if (
-			currentUserVariant &&
-			['variantNewField', 'variantIllustratedCard'].includes(
-				currentUserVariant,
-			)
-		) {
-			return currentUserVariant;
-		}
-		return 'control';
-	};
+	const getVariantName = () => 'variantIllustratedCard';
+
 	const abVariant = abTestEnabled ? getVariantName() : 'control';
 
 	const isSubscribed = useNewsletterSubscription(


### PR DESCRIPTION
## What does this change?

- Deletes the `newsletters-signup-card-country-illustration` A/B test entry from `abTests.ts`, freeing up space B
- Changes the fallback in `getVariantName()` from `'control'` to `'variantIllustratedCard'`, so all eligible web users now receive the illustrated card regardless of AB participation
- Updates the test suite to reflect the new behaviour — removes the dead `variantNewField` test cases and updates assertions to expect `newsletter-signup-card-container` for all web users with the flag on

The AB framework itself (`useAB`, `abResolved` gating, the placeholder while hydrating) is left untouched, ready for a future test.

## Why?

The `variantIllustratedCard` design has been validated has been set 100% of users. We need to free up the ab test slot for the Feast team. Rather than a large cleanup PR, this is the smallest safe step: delete the test and hardcode the winning variant as the default. A follow-up PR can remove the now-redundant AB resolution logic and dead code.

## Screenshots

No visual change — users who were already in the `variantIllustratedCard` group see no difference, and users previously in `control` will now see the illustrated card for the first time.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
