### PR TITLE
Suppress CMP dialog for RRCP web preview

### DIFF
--- a/dotcom-rendering/src/components/StickyBottomBanner.island.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.island.tsx
@@ -371,13 +371,18 @@ export const StickyBottomBanner = ({
 
 		const hasForceBannerParam =
 			window.location.search.includes('force-banner');
+		// rrcp=1 is appended by the RRCP tool's "web preview" button alongside
+		// force-banner. It skips CMP and sign-in gate so the banner is always visible.
+		const isRRCPPreview = window.location.search.includes('rrcp=1');
 		const hasForceBrazeMessageParam = window.location.hash.includes(
 			'force-braze-message',
 		);
 
 		let candidates: SlotConfig['candidates'];
 
-		if (hasForceBannerParam) {
+		if (hasForceBannerParam && isRRCPPreview) {
+			candidates = [readerRevenue];
+		} else if (hasForceBannerParam) {
 			candidates = [CMP, readerRevenue];
 		} else if (hasForceBrazeMessageParam) {
 			candidates = [CMP, brazeBannersSystem, brazeBanner];


### PR DESCRIPTION
## What does this change?
This change adds check for rrcp=1 search param. If it is presented, then the page was loaded from "web preview" button in RRCP tool and CMP dialog can be suppressed to enable banner preview
## Why?
Sometimes when user tried to see the banner variant by clicking "web preview" from RRCP they saw a CMP consent dialog instead which was confusing.
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| 
<img width="804" height="559" alt="Screenshot 2026-06-22 at 15 00 18" src="https://github.com/user-attachments/assets/0705fdef-746a-437f-9a66-af45da894688" />
 | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
