### PR TITLE
Add "Back to top" button to Hosted Gallery

### DIFF
--- a/dotcom-rendering/src/components/BackToTop.tsx
+++ b/dotcom-rendering/src/components/BackToTop.tsx
@@ -2,9 +2,12 @@ import { css } from '@emotion/react';
 import {
 	brandBackground,
 	brandText,
+	calculateHoverColour,
 	palette,
+	palette as sourcePalette,
 	textSansBold15,
 } from '@guardian/source/foundations';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 
 const iconHeight = '42px';
 
@@ -33,6 +36,18 @@ const link = css`
 	}
 `;
 
+const hostedGalleryLink = css`
+	:hover {
+		color: ${calculateHoverColour(sourcePalette.neutral[100])};
+
+		.icon-container {
+			background-color: ${calculateHoverColour(
+				sourcePalette.neutral[100],
+			)};
+		}
+	}
+`;
+
 const icon = css`
 	::before {
 		position: absolute;
@@ -56,11 +71,18 @@ const textStyles = css`
 	padding-right: 5px;
 `;
 
-export const BackToTop = () => (
-	<a css={link} href="#top" data-link-name="back to top">
-		<span css={textStyles}>Back to top</span>
-		<span css={iconContainer} className="icon-container">
-			<i css={icon} />
-		</span>
-	</a>
-);
+export const BackToTop = ({ format }: { format?: ArticleFormat }) => {
+	const isHostedGallery = format?.design === ArticleDesign.HostedGallery;
+	return (
+		<a
+			css={[link, isHostedGallery && hostedGalleryLink]}
+			href="#top"
+			data-link-name="back to top"
+		>
+			<span css={textStyles}>Back to top</span>
+			<span css={iconContainer} className="icon-container">
+				<i css={icon} />
+			</span>
+		</a>
+	);
+};

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -3,6 +3,7 @@ import {
 	from,
 	palette as sourcePalette,
 	space,
+	textSansBold15,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { CallToActionButton } from '../components/CallToActionAtom';
@@ -75,6 +76,64 @@ const metaStyles = css`
 	& > * {
 		margin-top: ${space[4]}px;
 	}
+`;
+
+const bttPosition = css`
+	background-color: ${palette('--article-inner-background')};
+	padding: 0 5px;
+	position: absolute;
+	bottom: ${space[5]}px;
+	right: ${space[5]}px;
+`;
+
+const iconHeight = '42px';
+
+const iconContainer = css`
+	position: relative;
+	float: right;
+	border-radius: 100%;
+	background-color: ${sourcePalette.neutral[100]};
+	cursor: pointer;
+	height: ${iconHeight};
+	min-width: ${iconHeight};
+`;
+
+const link = css`
+	text-decoration: none;
+	color: ${sourcePalette.neutral[100]};
+	font-weight: bold;
+	line-height: ${iconHeight};
+
+	:hover {
+		color: ${sourcePalette.neutral[86]};
+
+		.icon-container {
+			background-color: ${sourcePalette.neutral[86]};
+		}
+	}
+`;
+
+const icon = css`
+	::before {
+		position: absolute;
+		top: 6px;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		margin: auto;
+		border: 2px solid ${sourcePalette.neutral[7]};
+		border-bottom: 0;
+		border-right: 0;
+		content: '';
+		height: 12px;
+		width: 12px;
+		transform: rotate(45deg);
+	}
+`;
+
+const textStyles = css`
+	${textSansBold15};
+	padding-right: 5px;
 `;
 
 const ctaButtonStyles = css`
@@ -174,6 +233,9 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					pageId={frontendData.pageId}
 					webTitle={frontendData.webTitle}
 				/>
+				<div css={bttPosition}>
+					<BackToTop />
+				</div>
 			</main>
 			<Island priority="feature" defer={{ until: 'visible' }}>
 				<OnwardsUpper
@@ -208,7 +270,11 @@ const GalleryBody = (props: {
 	pageId: string;
 	webTitle: string;
 }) => (
-	<>
+	<div
+		css={css`
+			position: relative;
+		`}
+	>
 		{props.bodyElements.map((element) => {
 			if (
 				element._type ===
@@ -230,5 +296,14 @@ const GalleryBody = (props: {
 				return null;
 			}
 		})}
-	</>
+	</div>
+);
+
+const BackToTop = () => (
+	<a css={link} href="#top" data-link-name="back to top">
+		<span css={textStyles}>Back to top</span>
+		<span css={iconContainer} className="icon-container">
+			<i css={icon} />
+		</span>
+	</a>
 );

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -1,13 +1,12 @@
 import { css } from '@emotion/react';
 import {
-	calculateHoverColour,
 	from,
 	palette as sourcePalette,
 	space,
-	textSansBold15,
 	until,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
+import { BackToTop } from '../components/BackToTop';
 import { CallToActionButton } from '../components/CallToActionAtom';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
@@ -114,58 +113,6 @@ const bttPosition = css`
 	}
 `;
 
-const bttIconHeight = '42px';
-
-const bttIconContainer = css`
-	position: relative;
-	float: right;
-	border-radius: 100%;
-	background-color: ${sourcePalette.neutral[100]};
-	cursor: pointer;
-	height: ${bttIconHeight};
-	min-width: ${bttIconHeight};
-`;
-
-const bttLink = css`
-	text-decoration: none;
-	color: ${sourcePalette.neutral[100]};
-	font-weight: bold;
-	line-height: ${bttIconHeight};
-
-	:hover {
-		color: ${calculateHoverColour(sourcePalette.neutral[100])};
-
-		.icon-container {
-			background-color: ${calculateHoverColour(
-				sourcePalette.neutral[100],
-			)};
-		}
-	}
-`;
-
-const bttIcon = css`
-	::before {
-		position: absolute;
-		top: 6px;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		margin: auto;
-		border: 2px solid ${sourcePalette.neutral[7]};
-		border-bottom: 0;
-		border-right: 0;
-		content: '';
-		height: 12px;
-		width: 12px;
-		transform: rotate(45deg);
-	}
-`;
-
-const bttTextStyles = css`
-	${textSansBold15};
-	padding-right: 5px;
-`;
-
 const ctaButtonStyles = css`
 	margin-right: ${space[3]}px;
 `;
@@ -265,7 +212,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 				/>
 				<div css={bttStyles}>
 					<div css={bttPosition}>
-						<BackToTop />
+						<BackToTop format={format} />
 					</div>
 				</div>
 			</main>
@@ -329,17 +276,4 @@ const GalleryBody = (props: {
 			}
 		})}
 	</div>
-);
-
-/** In order to reuse the BackToTop component in the Guardian Footer https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/BackToTop.tsx
- * we need to have access to the format to check if it's Hosted Gallery and then change the Link styling which I think it isn't possible as the Footer is not used in Hosted Content pages.
- * I created a new BackToTop component here but unfortunately we had to duplicate all the styling from the original BackToTop component except some updates in bttLink.
- * */
-const BackToTop = () => (
-	<a css={bttLink} href="#top" data-link-name="back to top">
-		<span css={bttTextStyles}>Back to top</span>
-		<span css={bttIconContainer} className="icon-container">
-			<i css={bttIcon} />
-		</span>
-	</a>
 );

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -331,6 +331,10 @@ const GalleryBody = (props: {
 	</div>
 );
 
+/** In order to reuse the BackToTop component in the Guardian Footer https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/BackToTop.tsx
+ * we need to have access to the format to check if it's Hosted Gallery and then change the Link styling which I think it isn't possible as the Footer is not used in Hosted Content pages.
+ * I created a new BackToTop component here but unfortunately we had to duplicate all the styling from the original BackToTop component except some updates in bttLink.
+ * */
 const BackToTop = () => (
 	<a css={bttLink} href="#top" data-link-name="back to top">
 		<span css={bttTextStyles}>Back to top</span>

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -80,10 +80,21 @@ const metaStyles = css`
 
 const bttPosition = css`
 	background-color: ${palette('--article-inner-background')};
-	padding: 0 5px;
+	padding: ${space[5]}px ${space[3]}px ${space[4]}px;
 	position: absolute;
-	bottom: ${space[5]}px;
-	right: ${space[5]}px;
+	bottom: -21px;
+	right: 0;
+	display: flex;
+	justify-content: flex-end;
+	width: 100%;
+
+	${from.tablet} {
+		padding: ${space[5]}px ${space[8]}px ${space[4]}px;
+	}
+
+	${from.desktop} {
+		padding: ${space[5]}px ${space[5]}px ${space[4]}px;
+	}
 `;
 
 const iconHeight = '42px';
@@ -177,6 +188,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 			<main
 				css={{
 					backgroundColor: palette('--article-background'),
+					position: 'relative',
 				}}
 			>
 				<header css={headerStyles}>

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -83,16 +83,6 @@ const bttStyles = css`
 	${grid.paddedContainer}
 	${grid.outerRules()}
 	background-color: ${palette('--article-inner-background')};
-
-	${until.tablet} {
-		padding-top: ${space[1]}px;
-	}
-
-	${from.desktop} {
-		&:first-of-type > * {
-			padding-top: ${space[3]}px;
-		}
-	}
 `;
 
 const bttPosition = css`
@@ -104,8 +94,7 @@ const bttPosition = css`
 
 	${from.tablet} {
 		${grid.column.centre}
-		padding-right: 0;
-		padding-left: 0;
+		padding: 0 0 ${space[4]}px;
 	}
 
 	${from.desktop} {
@@ -249,11 +238,7 @@ const GalleryBody = (props: {
 	pageId: string;
 	webTitle: string;
 }) => (
-	<div
-		css={css`
-			position: relative;
-		`}
-	>
+	<>
 		{props.bodyElements.map((element) => {
 			if (
 				element._type ===
@@ -275,5 +260,5 @@ const GalleryBody = (props: {
 				return null;
 			}
 		})}
-	</div>
+	</>
 );

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -3,7 +3,6 @@ import {
 	from,
 	palette as sourcePalette,
 	space,
-	until,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { BackToTop } from '../components/BackToTop';

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -80,20 +80,19 @@ const metaStyles = css`
 
 const bttPosition = css`
 	background-color: ${palette('--article-inner-background')};
-	padding: ${space[5]}px ${space[3]}px ${space[4]}px;
+	padding: 0 ${space[3]}px ${space[4]}px;
 	position: absolute;
-	bottom: -21px;
 	right: 0;
 	display: flex;
 	justify-content: flex-end;
 	width: 100%;
 
 	${from.tablet} {
-		padding: ${space[5]}px ${space[8]}px ${space[4]}px;
+		padding: 0 ${space[8]}px ${space[4]}px;
 	}
 
 	${from.desktop} {
-		padding: ${space[5]}px ${space[5]}px ${space[4]}px;
+		padding: 0 ${space[5]}px ${space[4]}px;
 	}
 `;
 

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
 import {
+	calculateHoverColour,
 	from,
 	palette as sourcePalette,
 	space,
 	textSansBold15,
+	until,
 } from '@guardian/source/foundations';
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { CallToActionButton } from '../components/CallToActionAtom';
@@ -78,52 +80,70 @@ const metaStyles = css`
 	}
 `;
 
-const bttPosition = css`
+const bttStyles = css`
+	${grid.paddedContainer}
+	${grid.outerRules()}
 	background-color: ${palette('--article-inner-background')};
-	padding: 0 ${space[3]}px ${space[4]}px;
-	position: absolute;
-	right: 0;
-	display: flex;
-	justify-content: flex-end;
-	width: 100%;
 
-	${from.tablet} {
-		padding: 0 ${space[8]}px ${space[4]}px;
+	${until.tablet} {
+		padding-top: ${space[1]}px;
 	}
 
 	${from.desktop} {
-		padding: 0 ${space[5]}px ${space[4]}px;
+		&:first-of-type > * {
+			padding-top: ${space[3]}px;
+		}
 	}
 `;
 
-const iconHeight = '42px';
+const bttPosition = css`
+	${grid.column.all}
+	display: flex;
+	justify-content: flex-end;
+	position: relative;
+	padding: 0 ${space[3]}px ${space[4]}px;
 
-const iconContainer = css`
+	${from.tablet} {
+		${grid.column.centre}
+		padding-right: 0;
+		padding-left: 0;
+	}
+
+	${from.desktop} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+`;
+
+const bttIconHeight = '42px';
+
+const bttIconContainer = css`
 	position: relative;
 	float: right;
 	border-radius: 100%;
 	background-color: ${sourcePalette.neutral[100]};
 	cursor: pointer;
-	height: ${iconHeight};
-	min-width: ${iconHeight};
+	height: ${bttIconHeight};
+	min-width: ${bttIconHeight};
 `;
 
-const link = css`
+const bttLink = css`
 	text-decoration: none;
 	color: ${sourcePalette.neutral[100]};
 	font-weight: bold;
-	line-height: ${iconHeight};
+	line-height: ${bttIconHeight};
 
 	:hover {
-		color: ${sourcePalette.neutral[86]};
+		color: ${calculateHoverColour(sourcePalette.neutral[100])};
 
 		.icon-container {
-			background-color: ${sourcePalette.neutral[86]};
+			background-color: ${calculateHoverColour(
+				sourcePalette.neutral[100],
+			)};
 		}
 	}
 `;
 
-const icon = css`
+const bttIcon = css`
 	::before {
 		position: absolute;
 		top: 6px;
@@ -141,7 +161,7 @@ const icon = css`
 	}
 `;
 
-const textStyles = css`
+const bttTextStyles = css`
 	${textSansBold15};
 	padding-right: 5px;
 `;
@@ -187,7 +207,6 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 			<main
 				css={{
 					backgroundColor: palette('--article-background'),
-					position: 'relative',
 				}}
 			>
 				<header css={headerStyles}>
@@ -244,8 +263,10 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					pageId={frontendData.pageId}
 					webTitle={frontendData.webTitle}
 				/>
-				<div css={bttPosition}>
-					<BackToTop />
+				<div css={bttStyles}>
+					<div css={bttPosition}>
+						<BackToTop />
+					</div>
 				</div>
 			</main>
 			<Island priority="feature" defer={{ until: 'visible' }}>
@@ -311,10 +332,10 @@ const GalleryBody = (props: {
 );
 
 const BackToTop = () => (
-	<a css={link} href="#top" data-link-name="back to top">
-		<span css={textStyles}>Back to top</span>
-		<span css={iconContainer} className="icon-container">
-			<i css={icon} />
+	<a css={bttLink} href="#top" data-link-name="back to top">
+		<span css={bttTextStyles}>Back to top</span>
+		<span css={bttIconContainer} className="icon-container">
+			<i css={bttIcon} />
 		</span>
 	</a>
 );


### PR DESCRIPTION
## What does this change?

This PR adds a "Back to top" button in the Hosted Gallery pages. There is an existing `BackToTop` component so I made a tiny change to the styling which is basically the hovering color for the anchor tag. 

I tried to align the spacing between the component and the other elements based on the designs but it's a bit hard to do that as the designs suggests `80px` height from the last image or caption (depends on the breakpoint) and the end of the main section including the BackToTop component which has a height of `42px`. 

## Why?

Part of the Hosted Content migration. Hosted Gallery is the last page to migrate as we already migrated Hosted Articles and Videos.

## Screenshots

### Mobile
<img width="318" height="743" alt="image" src="https://github.com/user-attachments/assets/b3673c50-2eea-4b6b-9869-64c2677786d7">

### Tablet
<img width="739" height="743" alt="image" src="https://github.com/user-attachments/assets/31dd4582-f9ba-4000-8d87-3b0fbf2b3313" />

### Desktop
<img width="978" height="743" alt="image" src="https://github.com/user-attachments/assets/3acd2f8e-a860-471c-9722-7864ffe58f7c" />

### LeftCol
<img width="1138" height="743" alt="image" src="https://github.com/user-attachments/assets/4959eeba-d329-4f8d-8d54-1ece0f89d646" />

### Wide
<img width="1490" height="753" alt="image" src="https://github.com/user-attachments/assets/48d06ba7-b3f9-44c6-a0fc-cfc57fc2974d" />

### Hover
<img width="1490" height="753" alt="image" src="https://github.com/user-attachments/assets/10a4bdf5-af9a-4440-a500-abf7b847ea8f" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215810866963290