### PR TITLE
Make cricket scorecard update interaction test more reliable

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
@@ -121,10 +121,12 @@ export const UpdateScorecardTab = meta.story({
 			).toBeInTheDocument();
 		});
 
-		await expect(
-			canvas.queryByRole('rowheader', { name: /Harry Brook/ })
-				?.nextSibling!.textContent,
-		).toBe('lbw b Henry');
+		await waitFor(() => {
+			void expect(
+				canvas.queryByRole('rowheader', { name: /Harry Brook/ })
+					?.nextSibling!.textContent,
+			).toBe('lbw b Henry');
+		});
 	},
 });
 


### PR DESCRIPTION
## What does this change?
use `waitFor` to make the test more reliable, there's possibly a race condition.

## Why?
There's been some flakiness reported!
