### PR TITLE
Strip main media from hosted gallery page data before rendering

### DIFF
--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -93,8 +93,14 @@ export const enhanceArticleType = (
 
 	const serverTime = Date.now();
 
+	const mainMediaElementsData =
+		// Hosted Gallery pages do not display main media
+		format.design === ArticleDesign.HostedGallery
+			? []
+			: data.mainMediaElements;
+
 	const imagesForLightbox = data.config.switches.lightbox
-		? buildLightboxImages(data.format, data.blocks, data.mainMediaElements)
+		? buildLightboxImages(data.format, data.blocks, mainMediaElementsData)
 		: [];
 
 	const enhancedBlocks = enhanceBlocks(data.blocks, format, {
@@ -120,7 +126,7 @@ export const enhanceArticleType = (
 		imagesForLightbox,
 		true,
 		data.main,
-	)(data.mainMediaElements);
+	)(mainMediaElementsData);
 
 	const isGalleryPage = (design: ArticleDesign): design is GalleryDesign =>
 		design === ArticleDesign.Gallery ||


### PR DESCRIPTION
## What does this change?

Strips out the main media elements at the enhance stage of the process for hosted gallery pages

## Why?

We don't display main media for hosted gallery pages. Some hosted gallery articles in Composer have main media present and some don't. Given the need to support older pages, and that the existing designs don't accommodate main media explicitly, we need to prevent main media displaying.

This was previously done at the rendering stage by simply not including the `MainMedia` component, but this doesn't take Lightbox into account or image indexing in general.

To solve this more thoroughly and explicitly, we need to strip the main media elements out from the data at an earlier stage for consistency throughout the rendering process

## Screenshots

_The screenshots below show the result of clicking the first image in the gallery to launch the lightbox. The before image shows `2/9`, the after image shows `1/8`_
| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/65ff49c7-3a2a-46db-9ae4-2e3f2b92195b
[after]: https://github.com/user-attachments/assets/370820a5-eb46-4a82-8175-ad487b9f6efe
