### PR TITLE
Update caption and credit font styling in Hosted Gallery

### DIFF
--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -2,9 +2,11 @@ import { css } from '@emotion/react';
 import {
 	between,
 	from,
+	palette as sourcePalette,
 	space,
 	textSans14,
 	textSans15,
+	textSans17,
 } from '@guardian/source/foundations';
 import { grid } from '../grid';
 import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
@@ -46,6 +48,19 @@ const styles = css`
 	}
 `;
 
+const hostedGalleryStyles = css`
+	${textSans17}
+
+	${between.tablet.and.desktop} {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	${from.tablet} {
+		padding-bottom: ${space[10]}px;
+	}
+`;
+
 export const GalleryCaption = ({
 	captionHtml,
 	credit,
@@ -66,7 +81,7 @@ export const GalleryCaption = ({
 	}
 
 	return (
-		<figcaption css={styles}>
+		<figcaption css={[styles, isHostedGallery && hostedGalleryStyles]}>
 			{isHostedGallery &&
 			typeof position === 'number' &&
 			!!imagesLength ? (
@@ -75,6 +90,10 @@ export const GalleryCaption = ({
 						${textSans15}
 						display: block;
 						padding: ${space[2]}px 0 ${space[1]}px;
+
+						${from.desktop} {
+							padding-top: 0;
+						}
 					`}
 				>
 					{position}&#47;{imagesLength}
@@ -83,10 +102,18 @@ export const GalleryCaption = ({
 			{emptyCaption ? null : <CaptionText html={captionHtml} />}
 			{hideCredit ? null : (
 				<small
-					css={css`
-						display: block;
-						padding: ${space[2]}px 0 ${space[2]}px;
-					`}
+					css={[
+						css`
+							display: block;
+							padding: ${space[2]}px 0 ${space[2]}px;
+						`,
+						isHostedGallery &&
+							css`
+								${textSans15}
+								padding-top: ${space[3]}px;
+								color: ${sourcePalette.neutral[73]};
+							`,
+					]}
 				>
 					{credit}
 				</small>


### PR DESCRIPTION
## What does this change?

This PR updates the caption and credit font styling in Hosted Gallery. I also updated the credit color to align with the new designs. 

## Why?

Part of the Hosted Content migration to DCAR. Hosted Gallery is the last page to migrate as we migrated Hosted Articles and Videos. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |
| ![before4][] | ![after4][] |

[before]: https://github.com/user-attachments/assets/1f9bcf71-e999-4345-82a4-82a94244351c
[after]: https://github.com/user-attachments/assets/3b1fb8ae-d26a-4c3b-b851-06f128bf7345

[before2]: https://github.com/user-attachments/assets/87619c72-e513-4ee5-aa94-9197b8dedf09
[after2]: https://github.com/user-attachments/assets/0e05c7da-d2bf-4d56-aa28-9f5ecaa0ba8a

[before3]: https://github.com/user-attachments/assets/b4139079-3c63-4ed3-ae35-e3e22cd128c8
[after3]: https://github.com/user-attachments/assets/52c2c5ba-46fe-4f9c-b2af-3a980afc9152

[before4]: https://github.com/user-attachments/assets/606630b3-ada3-42f0-a7bf-d2a972d6be3f
[after4]: https://github.com/user-attachments/assets/0dfb9828-94d3-4910-83d5-6fd861345f5d

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215810866963289