### PR TITLE
Make centre rule grid line longer

### DIFF
--- a/dotcom-rendering/src/grid.ts
+++ b/dotcom-rendering/src/grid.ts
@@ -116,7 +116,7 @@ const centreRule = (n: number, color?: string): string => `/* CENTRE RULE */
       &::before {
         position: absolute;
         top: 0;
-        bottom: -9999px;
+        bottom: -99999px;
         width: 1px;
         background-color: ${color ?? palette('--article-border')};
         content: '';


### PR DESCRIPTION
Quick fix to address an issue with the grid module's centre rule stopping short on longer articles:

<img width="830" height="380" alt="image" src="https://github.com/user-attachments/assets/d4021e4b-436c-474f-9628-490dbb775e96" />

This bumps up the height a fair bit, which would do the trick for now. Would be nice to have a more elegant solution long term though.