### PR TITLE
Use USE_LOCAL_ASSETS env var to determine path for assets

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,7 +39,8 @@ jobs:
         run: pnpm playwright test --shard=${{ matrix.group }}/8
         working-directory: ./dotcom-rendering
         env:
-          NODE_ENV: production
+          NODE_ENV: 'production'
+          USE_LOCAL_ASSETS: true
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./dotcom-rendering
         env:
           NODE_ENV: 'production'
-          USE_LOCAL_ASSETS: true
+          USE_LOCAL_ASSETS: 'true'
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,8 +39,7 @@ jobs:
         run: pnpm playwright test --shard=${{ matrix.group }}/8
         working-directory: ./dotcom-rendering
         env:
-          NODE_ENV: 'production'
-          USE_LOCAL_ASSETS: 'true'
+          NODE_ENV: production
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -11,5 +11,6 @@ EXPOSE 9000
 
 ENV DISABLE_LOGGING_AND_METRICS=true
 ENV NODE_ENV=production
+ENV USE_LOCAL_ASSETS=true
 
 ENTRYPOINT ["node", "article-rendering/dist/server.js"]

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -43,10 +43,12 @@ prod:
 	NODE_ENV=production node dist/server.js
 
 prod-local: export DISABLE_LOGGING_AND_METRICS = true
+prod-local: export USE_LOCAL_ASSETS = true
 prod-local: prod
 
 # dev #########################################
 
+dev: export USE_LOCAL_ASSETS = true
 dev: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./webpack/webpack.config.js

--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -17,22 +17,11 @@ describe('decidePublicPath', () => {
 
 		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
 
-		process.env = { NODE_ENV: undefined, HOSTNAME: undefined };
+		process.env = { USE_LOCAL_ASSETS: undefined };
 	});
 
-	it('with development flag', () => {
-		process.env.NODE_ENV = 'development';
-		expect(decidePublicPath()).toEqual('/assets/');
-	});
-
-	it('with production flag', () => {
-		process.env.NODE_ENV = 'production';
-		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
-	});
-
-	it('with production flag in CI', () => {
-		process.env.NODE_ENV = 'production';
-		process.env.CI = 'true';
+	it('with USE_LOCAL_ASSETS flag', () => {
+		process.env.USE_LOCAL_ASSETS = 'true';
 		expect(decidePublicPath()).toEqual('/assets/');
 	});
 

--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -1,14 +1,5 @@
 import { decidePublicPath } from './decidePublicPath';
 
-const mockHostname = (hostname: string | undefined) => {
-	Object.defineProperty(window, 'location', {
-		value: {
-			hostname,
-		},
-		writable: true,
-	});
-};
-
 const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
 	Object.defineProperty(window, 'guardian', {
 		value: {
@@ -23,8 +14,6 @@ const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
 describe('decidePublicPath', () => {
 	beforeEach(() => {
 		jest.resetModules();
-
-		mockHostname(undefined);
 
 		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
 
@@ -41,9 +30,9 @@ describe('decidePublicPath', () => {
 		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
 	});
 
-	it('with production flag and localhost', () => {
+	it('with production flag in CI', () => {
 		process.env.NODE_ENV = 'production';
-		mockHostname('localhost');
+		process.env.CI = 'true';
 		expect(decidePublicPath()).toEqual('/assets/');
 	});
 

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -4,10 +4,8 @@
  * @returns The webpack public path to use
  */
 export const decidePublicPath = (): string => {
-	const isDev = process.env.NODE_ENV === 'development';
-	const isCI = process.env.CI === 'true';
+	const useLocalAssets = process.env.USE_LOCAL_ASSETS === 'true';
 
-	const useLocalAssets = isDev || isCI;
 	return useLocalAssets
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -5,9 +5,9 @@
  */
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
-	const isLocalHost = window.location.hostname === 'localhost';
+	const isCI = process.env.CI === 'true';
 	// Use relative path if running locally or in CI
-	return isDev || isLocalHost
+	return isDev || isCI
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -6,8 +6,9 @@
 export const decidePublicPath = (): string => {
 	const isDev = process.env.NODE_ENV === 'development';
 	const isCI = process.env.CI === 'true';
-	// Use relative path if running locally or in CI
-	return isDev || isCI
+
+	const useLocalAssets = isDev || isCI;
+	return useLocalAssets
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -60,6 +60,7 @@ const commonConfigs = ({ platform }) => ({
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 			'process.env.HOSTNAME': JSON.stringify(process.env.HOSTNAME),
+			'process.env.CI': JSON.stringify(process.env.CI),
 		}),
 		// Matching modules specified in this regex will not be imported during the webpack build
 		// We use this if there are optional dependencies (e.g in jsdom, ws) to remove uneccesary warnings in our builds / console outpouts.

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -60,7 +60,9 @@ const commonConfigs = ({ platform }) => ({
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 			'process.env.HOSTNAME': JSON.stringify(process.env.HOSTNAME),
-			'process.env.CI': JSON.stringify(process.env.CI),
+			'process.env.USE_LOCAL_ASSETS': JSON.stringify(
+				process.env.USE_LOCAL_ASSETS,
+			),
 		}),
 		// Matching modules specified in this regex will not be imported during the webpack build
 		// We use this if there are optional dependencies (e.g in jsdom, ws) to remove uneccesary warnings in our builds / console outpouts.


### PR DESCRIPTION
## What does this change?
Amend `decidePublicPath` to use the environment variable `USE_LOCAL_ASSETS` to determine the path for assets, rather than a combination of the `NODE_ENV` variable, and the hostname.

## Why?

The hostname for using live harnesses to work on content atoms locally [(docs)](https://github.com/guardian/interactives#live-harnesses) is always localhost. At the moment, `decidePublicPath` sees that hostname, and makes asset paths relative as a result — but because DCR isn't running locally, those paths don't resolve to assets. The hope is that this change accommodates both the workflows that require local assets (make dev, make prod-local, CI), and the workflows that require hosted assets (code, production, live harnesses).

Here's a table that maps out the old way, the new way, and the result, against all the workflows we know of (I've spoken to @arelra and @Jakeii). If other workflows exist, this PR may impact them, too — so please let me know if there's a row missing.

|            | NODE_ENV (old) | hostname (old)           | USE_LOCAL_ASSETS (new) | Old assets path                       | New assets path |
|------------|----------------|--------------------------|------------------------|-----------------------------------|---|
| local      | development    | localhost                | true                   | `/assets/`                        | `/assets/`                        |
| prod-local | production     | localhost                | true                   | `/assets/`                        | `/assets/`                        |
| ci         | production     | localhost                | true                   | `/assets/`                        | `/assets/`                        |
| code       | production     | code.dev-theguardian.com | _unset_                     | `${frontendAssetsFullURL}assets/` | `${frontendAssetsFullURL}assets/` |
| prod       | production     | theguardian.com          | _unset_                     | `${frontendAssetsFullURL}assets/` | `${frontendAssetsFullURL}assets/` |
| remote-preview | production | localhost | _unset_ | `/assets/`  | `${frontendAssetsFullURL}assets/` |

## How to test

- [x] CI passes
- [x] Running DCR locally (`make dev`) with frontend gives local asset paths
- [x] Running DCR locally (`make prod-local`) with frontend gives local asset paths
- [x] Running DCR in CODE works as expected
- [ ] Running live harnesses with Preview works as expected

## Screenshots

N/A