### PR TITLE
Add click event and split form tracking for HighlightsNewsletterCard

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
@@ -11,6 +11,7 @@ jest.mock('../../../lib/newsletterSignupTracking', () => ({
 	sendNewsletterSignupEvent: jest.fn(),
 	NEWSLETTER_SIGNUP_COMPONENT_ID: {
 		highlightsCard: (id: string) => `highlights-card-${id}`,
+		highlightsCardForm: (id: string) => `highlights-card-form-${id}`,
 	},
 }));
 
@@ -109,6 +110,16 @@ describe('HighlightsNewsletterCard', () => {
 
 		expect(sendNewsletterSignupEvent).toHaveBeenCalledWith(
 			expect.objectContaining({
+				action: 'CLICK',
+				identityName: defaultProps.newsletter.identityName,
+				componentId: `highlights-card-${defaultProps.newsletter.identityName}`,
+				renderingTarget: defaultProps.renderingTarget,
+				value: { eventDescription: 'highlights-card-clicked' },
+			}),
+		);
+
+		expect(sendNewsletterSignupEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
 				action: 'EXPAND',
 				identityName: defaultProps.newsletter.identityName,
 				componentId: `highlights-card-${defaultProps.newsletter.identityName}`,
@@ -175,6 +186,10 @@ describe('HighlightsNewsletterCard', () => {
 		expect(
 			screen.queryByTestId('highlights-newsletter-signup-modal'),
 		).not.toBeInTheDocument();
+
+		expect(sendNewsletterSignupEvent).not.toHaveBeenCalledWith(
+			expect.objectContaining({ action: 'CLICK' }),
+		);
 
 		expect(sendNewsletterSignupEvent).not.toHaveBeenCalledWith(
 			expect.objectContaining({ action: 'EXPAND' }),

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
@@ -163,6 +163,15 @@ export const HighlightsNewsletterCard = ({
 	const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		if (renderingTarget === 'Web') {
 			event.preventDefault();
+
+			sendNewsletterSignupEvent({
+				action: 'CLICK',
+				identityName: newsletter.identityName,
+				componentId,
+				renderingTarget,
+				value: { eventDescription: 'highlights-card-clicked' },
+			});
+
 			setIsModalOpen(true);
 
 			sendNewsletterSignupEvent({

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.tsx
@@ -144,7 +144,7 @@ const HighlightsNewsletterSignupModalContent = ({
 					frequency={newsletter.frequency}
 					isModal={true}
 					isAlreadySubscribed={isSubscribed === true}
-					componentId={NEWSLETTER_SIGNUP_COMPONENT_ID.highlightsCard(
+					componentId={NEWSLETTER_SIGNUP_COMPONENT_ID.highlightsCardForm(
 						newsletter.identityName,
 					)}
 				/>

--- a/dotcom-rendering/src/lib/newsletterSignupTracking.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupTracking.ts
@@ -14,6 +14,7 @@ export type NewsletterEventDescription =
 	| 'captcha-not-passed'
 	| 'captcha-passed'
 	| 'highlights-card-viewed'
+	| 'highlights-card-clicked'
 	| 'highlights-card-modal-opened'
 	| 'highlights-card-modal-closed';
 
@@ -29,6 +30,7 @@ export const EVENT_DESCRIPTION_TO_ACTION = {
 	'submission-failed': 'CLOSE',
 	'open-captcha': 'EXPAND',
 	'highlights-card-viewed': 'VIEW',
+	'highlights-card-clicked': 'CLICK',
 	'highlights-card-modal-opened': 'EXPAND',
 	'highlights-card-modal-closed': 'CLOSE',
 } as const satisfies Record<NewsletterEventDescription, string>;
@@ -45,6 +47,8 @@ export const NEWSLETTER_SIGNUP_COMPONENT_ID = {
 		`AR NewsletterSignupForm ${identityName}`,
 	highlightsCard: (identityName: string) =>
 		`HighlightsNewsletterCard ${identityName}`,
+	highlightsCardForm: (identityName: string) =>
+		`HighlightsNewsletterCardForm ${identityName}`,
 } as const;
 
 /**


### PR DESCRIPTION
## What does this change?

Adds a `CLICK` event to `HighlightsNewsletterCard` and splits form tracking onto a new `HighlightsNewsletterCardForm` component ID.

**Full event table:**

| Event | Action | componentId |
|---|---|---|
| Card scrolls into view | `VIEW` | `HighlightsNewsletterCard {id}` |
| Card clicked | `CLICK` | `HighlightsNewsletterCard {id}` |
| Card clicked → modal opens | `EXPAND` | `HighlightsNewsletterCard {id}` |
| Modal closed | `CLOSE` | `HighlightsNewsletterCard {id}` |
| Email focused, captcha opens | `EXPAND` | `HighlightsNewsletterCardForm {id}` |
| Form submitted, captcha passed/failed | `ANSWER` | `HighlightsNewsletterCardForm {id}` |
| Submission failed | `CLOSE` | `HighlightsNewsletterCardForm {id}` |
| Subscribed | `SUBSCRIBE` | `HighlightsNewsletterCardForm {id}` |

## Why?

Previously all events shared a single `componentId`, making it impossible to distinguish card interactions from form interactions in Ophan. Needed so Ophan can surface highlights card click counts in Heatphan.

`CLICK` and `EXPAND` both fire in sequence on the same card click — `CLICK` fires immediately, `EXPAND` fires once the modal is opening. A gap between them in Ophan would indicate the modal failed to open.

## Screenshots

No visual changes.