### PR TITLE
Display CTA button for apps hosted gallery articles

### DIFF
--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -163,19 +163,17 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						standfirst={frontendData.standfirst}
 					/>
 
-					{renderingTarget === 'Web' && (
-						<div data-print-layout="hide" css={metaStyles}>
-							{cta?.url && (
-								<div css={ctaButtonStyles}>
-									<CallToActionButton
-										linkUrl={cta.url}
-										accentColor={
-											branding?.hostedCampaignColour
-										}
-										buttonText={cta.btnText}
-									/>
-								</div>
-							)}
+					<div data-print-layout="hide" css={metaStyles}>
+						{cta?.url && (
+							<div css={ctaButtonStyles}>
+								<CallToActionButton
+									linkUrl={cta.url}
+									accentColor={branding?.hostedCampaignColour}
+									buttonText={cta.btnText}
+								/>
+							</div>
+						)}
+						{renderingTarget === 'Web' && (
 							<Island
 								priority="feature"
 								defer={{ until: 'visible' }}
@@ -187,8 +185,8 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 									context="ArticleMeta"
 								/>
 							</Island>
-						</div>
-					)}
+						)}
+					</div>
 				</header>
 				<GalleryBody
 					renderingTarget={renderingTarget}


### PR DESCRIPTION
## What does this change?

Allows the CTA button to be shown for apps hosted gallery pages

## Why?

It was previously omitted by accident. We only want to omit the share button on apps, not the CTA button as well

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/5c8d1377-146e-456a-bf54-ef08a3a6ce4b
[after]: https://github.com/user-attachments/assets/01221c46-05b8-40ef-b1ad-f9b7177f43b0
