### PR TITLE
Pass article to cricket header so fallback works

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -6,6 +6,8 @@ import type {
 	FECricketInnings,
 	FECricketMatch,
 } from '../../frontend/feCricketMatchPage';
+import type { ArticleFormat } from '../../lib/articleFormat';
+import type { ArticleDeprecated } from '../../types/article';
 import { CricketMatchHeader } from './CricketMatchHeader';
 
 const meta = {
@@ -130,6 +132,8 @@ const baseArgs = {
 	refreshInterval: 3_000,
 	tabContentId: 'cricket-tab-content',
 	getHeaderData: () => getMockData(headerData(baseMatch)),
+	article: {} as ArticleDeprecated,
+	format: {} as ArticleFormat,
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 
 const getMockData = (data: FECricketMatchHeader) =>

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -52,13 +52,13 @@ export type CricketMatchHeaderProps = {
 	edition: EditionId;
 	selectedTab: 'info' | 'live' | 'report';
 	tabContentId: string;
+	format: ArticleFormat;
+	article: ArticleDeprecated;
 };
 
 type Props = CricketMatchHeaderProps & {
 	getHeaderData: (url: string) => Promise<unknown>;
 	refreshInterval: number;
-	format?: ArticleFormat;
-	article?: ArticleDeprecated;
 };
 
 export const CricketMatchHeader = (props: Props) => {

--- a/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
@@ -5,6 +5,8 @@ import { allModes } from '../../.storybook/modes';
 import preview from '../../.storybook/preview';
 import { liveMatch, resultMatch } from '../../fixtures/manual/cricketMatch';
 import type { FECricketMatchHeader } from '../frontend/feCricketMatchHeader';
+import type { ArticleFormat } from '../lib/articleFormat';
+import type { ArticleDeprecated } from '../types/article';
 import { CricketMatchHeader } from './CricketMatchHeader/CricketMatchHeader';
 
 const meta = preview.meta({
@@ -48,6 +50,8 @@ const baseArgs = {
 			liveURL:
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
 		}),
+	article: {} as ArticleDeprecated,
+	format: {} as ArticleFormat,
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 
 const liveArgs = {

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1200,6 +1200,8 @@ const Header = (props: {
 						selectedTab={'live'}
 						edition={props.article.editionId}
 						matchHeaderURL={cricketMatchHeaderUrl}
+						article={props.article}
+						format={props.format}
 					/>
 				</Island>
 			</>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -241,6 +241,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 			/>
 
 			<MatchHeaderContainer
+				article={article}
+				format={format}
 				isMatchReport={isMatchReport}
 				footballMatchHeaderUrl={footballMatchHeaderUrl}
 				leagueName={footballMatchLeagueName}
@@ -834,6 +836,8 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 };
 
 const MatchHeaderContainer = ({
+	article,
+	format,
 	isMatchReport,
 	footballMatchHeaderUrl,
 	leagueName,
@@ -841,6 +845,8 @@ const MatchHeaderContainer = ({
 	editionId,
 	renderingTarget,
 }: {
+	article: ArticleDeprecated;
+	format: ArticleFormat;
 	isMatchReport: boolean;
 	footballMatchHeaderUrl: string | undefined;
 	leagueName: string;
@@ -869,6 +875,8 @@ const MatchHeaderContainer = ({
 					edition={editionId}
 					matchHeaderURL={footballMatchHeaderUrl}
 					renderingTarget={renderingTarget}
+					article={article}
+					format={format}
 				/>
 			</Island>
 		);


### PR DESCRIPTION
## What does this change?
Ensure article is passed to the header component. Make them required for cricket header, we will always have an article on the liveblog and match report pages where it's used.

## Why?
Noticed this with a match that was about to start, where the pa data wasn't available yet.

The fallback header needs these to work, otherwise the placeholder shows indefinitely.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/371faa22-cd8a-4e10-a253-92bdffa744bb
[after]: https://github.com/user-attachments/assets/e247e110-763a-4b6d-a1be-a8a4359c9ed4

