### PR TITLE
Use duration when selecting default video format

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -35,7 +35,11 @@ export const SelfHostedVideoInArticle = ({
 	caption,
 }: SelfHostedVideoInArticleProps) => {
 	const posterImageUrl = element.posterImage?.[0]?.url;
-	const sources = extractValidSourcesFromAssets(element.assets, videoStyle);
+	const sources = extractValidSourcesFromAssets(
+		element.assets,
+		videoStyle,
+		element.duration,
+	);
 	const aspectRatio = getAspectRatioFromSources(sources);
 	const firstVideoSource = sources[0];
 

--- a/dotcom-rendering/src/lib/video.test.ts
+++ b/dotcom-rendering/src/lib/video.test.ts
@@ -119,13 +119,22 @@ describe('video', () => {
 			);
 		});
 
-		it('should prefer M3U8 sources with Default video style', () => {
+		it('should prefer M3U8 sources for long videos with Default video style', () => {
 			const assets = [mp4Asset480w, m3u8Asset720h, mp4Asset720h];
 			const expected = [m3u8Src720h, mp4Src480w, mp4Src720h];
 
-			expect(extractValidSourcesFromAssets(assets, 'Default')).toEqual(
-				expected,
-			);
+			expect(
+				extractValidSourcesFromAssets(assets, 'Default', 37),
+			).toEqual(expected);
+		});
+
+		it('should prefer MP4 sources for short videos with Default video style', () => {
+			const assets = [mp4Asset480w, m3u8Asset720h, mp4Asset720h];
+			const expected = [mp4Src480w, mp4Src720h, m3u8Src720h];
+
+			expect(
+				extractValidSourcesFromAssets(assets, 'Default', 12),
+			).toEqual(expected);
 		});
 
 		it('should prefer MP4 sources with Loop video style', () => {

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -49,6 +49,14 @@ export type SupportedVideoFileType =
 	(typeof allSupportedVideoFileTypes)[number];
 
 /**
+ * We use an arbitrary limit or 21 seconds before considering a video "long".
+ * Why 20? This is because we request the video in 10 second chunks.
+ * */
+const isLongVideo = (duration: number): boolean => {
+	const shortVideoMaxDuration = 21; // seconds
+	return duration >= shortVideoMaxDuration;
+};
+/**
  * The looping video player types its `sources` attribute as `Sources`.
  * However, looping videos in articles are delivered as media atoms, which type
  * their `assets` as `VideoAssets`. Which means that we need to alter the shape
@@ -57,12 +65,16 @@ export type SupportedVideoFileType =
 export const extractValidSourcesFromAssets = (
 	assets: VideoAssets[],
 	videoStyle: VideoPlayerFormat,
+	videoDuration?: number,
 ): Source[] => {
 	/**
 	 * Sources are ordered because the browser will use the first source that it supports.
 	 */
 	const orderedMimeTypes =
-		videoStyle === 'Default'
+		/**
+		 * For videos that are 20 seconds or shorter, we prefer mp4 to avoid the overhead of HLS streaming.
+		 * */
+		videoStyle === 'Default' && isLongVideo(videoDuration ?? 0)
 			? supportedFileTypesPreferM3U8
 			: supportedFileTypesPreferMp4;
 

--- a/dotcom-rendering/src/lib/video.ts
+++ b/dotcom-rendering/src/lib/video.ts
@@ -9,6 +9,9 @@ export const DEFAULT_ASPECT_RATIO = 5 / 4;
 
 export const DEFAULT_IMAGE_ASPECT_RATIO = '5:4';
 
+/** * The maximum duration (in seconds) for a video to be considered "short". * Equals two 10-second time segments plus a small buffer. */
+const SHORT_VIDEO_MAX_DURATION = 20;
+
 export const customSelfHostedVideoPlayAudioEventName =
 	'self-hosted-video:play-with-audio';
 export const customYoutubePlayEventName = 'youtube-video:play';
@@ -49,12 +52,11 @@ export type SupportedVideoFileType =
 	(typeof allSupportedVideoFileTypes)[number];
 
 /**
- * We use an arbitrary limit or 21 seconds before considering a video "long".
+ * We use an arbitrary limit or 20 seconds before considering a video "long".
  * Why 20? This is because we request the video in 10 second chunks.
  * */
 const isLongVideo = (duration: number): boolean => {
-	const shortVideoMaxDuration = 21; // seconds
-	return duration >= shortVideoMaxDuration;
+	return duration > SHORT_VIDEO_MAX_DURATION;
 };
 /**
  * The looping video player types its `sources` attribute as `Sources`.

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -240,6 +240,7 @@ export const getActiveMediaAtom = (
 			const sources = extractValidSourcesFromAssets(
 				videoAssets,
 				videoStyle,
+				mediaAtom.duration,
 			);
 
 			const aspectRatio = getAspectRatioFromSources(sources);


### PR DESCRIPTION
## What does this change?
This change considers video duration when selecting the most appropriate format for default self-hosted videos.

Previously, videos using the default style were served as M3U8, as they are typically long-form content. However, some short-form clips also use the default style, where M3U8/HLS introduces unnecessary overhead. For these videos, MP4 is a more appropriate format.

The limit for a video to be considered "short" has been set at 20 seconds. This is because we request in 10 seconds segments.  

## Why?
This change has two main benefits:

1. Reduces the number of requests
M3U8 playback requires upwards of 2 requests(one playlist manifest and one or more segment files) where as MP4 requires a single request, reducing network overhead and potentially improving startup time.

3. Improves video quality in Chrome
Chrome initially selects the lowest-quality stream from an HLS manifest, regardless of the available bandwidth. While this behaviour is generally acceptable for long-form content, short videos may finish before the player has a chance to adapt to a higher-quality stream, resulting in noticeably lower visual quality.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/7fb8b054-2ae5-48d2-8cf2-d333cb1949a9
[after]: https://github.com/user-attachments/assets/3263fcd5-7721-4f26-bbd3-1d3659b169d2

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.


You can then reference the labels and map them to corresponding links.


-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216058085334167