### PR TITLE
Remove figure wrapper for interactive atoms

### DIFF
--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -15,7 +15,7 @@ import { DocumentBlockComponent } from '../components/DocumentBlockComponent.isl
 import { EmailSignUpWrapper } from '../components/EmailSignUpWrapper.island';
 import { EmbedBlockComponent } from '../components/EmbedBlockComponent.island';
 import { ExplainerAtom } from '../components/ExplainerAtom';
-import { Figure } from '../components/Figure';
+import { defaultRoleStyles, Figure } from '../components/Figure';
 import { GuideAtomWrapper } from '../components/GuideAtomWrapper.island';
 import { GuVideoBlockComponent } from '../components/GuVideoBlockComponent';
 import { HighlightBlockComponent } from '../components/HighlightBlockComponent';
@@ -1082,7 +1082,12 @@ export const RenderArticleElement = ({
 		idApiUrl,
 	});
 
-	const needsFigure = !bareElements.has(element._type);
+	const isInteractiveLayoutAtom =
+		element._type ===
+		'model.dotcomrendering.pageElements.InteractiveAtomBlockElement';
+
+	const needsFigure =
+		!bareElements.has(element._type) && !isInteractiveLayoutAtom;
 
 	const role =
 		'role' in element
@@ -1106,6 +1111,17 @@ export const RenderArticleElement = ({
 		>
 			{el}
 		</Figure>
+	) : isInteractiveLayoutAtom ? (
+		<section
+			key={'elementId' in element ? element.elementId : index}
+			id={'elementId' in element ? element.elementId : undefined}
+			css={defaultRoleStyles(role ?? 'inline', format, isTimeline)}
+			data-spacefinder-role={role}
+			data-spacefinder-type={element._type}
+			className={interactiveLegacyFigureClasses(element._type, role)}
+		>
+			{el}
+		</section>
 	) : (
 		el
 	);


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
