### PR TITLE
Check if page is match report before showing football header

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -150,7 +150,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 			? article.matchStatsUrl
 			: undefined;
 
-	const isMatchReport =
+	const isFootballMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchUrl;
 
 	const isMedia =
@@ -235,6 +235,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 			/>
 
 			<MatchHeaderContainer
+				isFootballMatchReport={isFootballMatchReport}
 				renderingTarget={renderingTarget}
 				article={article}
 				format={format}
@@ -499,7 +500,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 									idApiUrl={article.config.idApiUrl}
 								/>
 								<MatchInfoContainer
-									isMatchReport={isMatchReport}
+									isMatchReport={isFootballMatchReport}
 									footballMatchStatsUrl={
 										footballMatchStatsUrl
 									}
@@ -844,10 +845,12 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 };
 
 const MatchHeaderContainer = ({
+	isFootballMatchReport,
 	renderingTarget,
 	article,
 	format,
 }: {
+	isFootballMatchReport: boolean;
 	renderingTarget: RenderingTarget;
 	article: ArticleDeprecated;
 	format: ArticleFormat;
@@ -872,7 +875,7 @@ const MatchHeaderContainer = ({
 
 	const isApps = renderingTarget === 'Apps';
 
-	if (footballMatchHeaderUrl) {
+	if (isFootballMatchReport && footballMatchHeaderUrl) {
 		return (
 			<>
 				<noscript>


### PR DESCRIPTION
## What does this change?
Check if page is match report before showing football header

## Why?
Regression introduced in #16252 

We probably need this for the cricket header too, but it's behind a 0% test so we can fix forward