### PR TITLE
Reserve 90px space for `top-above-nav` advert on tablet

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -91,8 +91,11 @@ type Props = DefaultProps &
 
 const halfPageAdHeight = adSizes.halfPage.height;
 
-/** Calculates the minimum height for an ad slot. Used to avoid CLS */
-const getMinHeight = (adHeight: number, padding?: number): number =>
+/**
+ * Calculates the minimum height for an ad slot. Assumes an ad label of
+ * fixed height will be present above the advert. Used to avoid CLS.
+ */
+const getMinHeightOfAdSlot = (adHeight: number, padding?: number): number =>
 	adHeight + labelHeight + (padding ?? 0);
 
 const outOfPageStyles = css`
@@ -105,7 +108,7 @@ const hideBelowDesktop = css`
 	}
 `;
 
-const containerMinHeight = getMinHeight(250, space[5]);
+const containerMinHeight = getMinHeightOfAdSlot(250, space[5]);
 
 const topAboveNavContainerStyles = css`
 	padding-bottom: ${space[5]}px;
@@ -126,8 +129,8 @@ const topAboveNavContainerStyles = css`
 		::before {
 			content: '';
 			position: absolute;
-			height: 250px;
-			width: 728px;
+			height: ${adSizes.billboard.height}px;
+			width: ${adSizes.leaderboard.width}px;
 			top: ${labelHeight}px;
 			left: 50%;
 			transform: translateX(-50%);
@@ -135,7 +138,7 @@ const topAboveNavContainerStyles = css`
 		}
 		${from.desktop} {
 			::before {
-				width: 970px;
+				width: ${adSizes.billboard.width}px;
 			}
 		}
 	}
@@ -148,7 +151,7 @@ const topAboveNavContainerStyles = css`
  * render first, we need to reserve space for the ad to avoid CLS.
  */
 const showcaseRightColumnContainerStyles = css`
-	min-height: ${getMinHeight(halfPageAdHeight)}px;
+	min-height: ${getMinHeightOfAdSlot(halfPageAdHeight)}px;
 `;
 
 const showcaseRightColumnStyles = css`
@@ -178,7 +181,7 @@ const allowFullWidthAdContainerStyles = css`
 
 const merchandisingAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.billboard.height, space[3])}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.billboard.height, space[3])}px;
 	margin: ${space[3]}px auto;
 	max-width: ${breakpoints['wide']}px;
 	overflow: hidden;
@@ -187,7 +190,10 @@ const merchandisingAdStyles = css`
 	${from.desktop} {
 		margin: 0;
 		padding-bottom: ${space[5]}px;
-		min-height: ${getMinHeight(adSizes.billboard.height, space[5])}px;
+		min-height: ${getMinHeightOfAdSlot(
+			adSizes.billboard.height,
+			space[5],
+		)}px;
 	}
 
 	&:not(.ad-slot--fluid).ad-slot--rendered {
@@ -220,7 +226,7 @@ const liveblogInlineContainerStyles = css`
 
 const liveblogInlineAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height)}px;
 	background-color: ${schemedPalette('--ad-background-article-inner')};
 
 	${until.tablet} {
@@ -230,7 +236,7 @@ const liveblogInlineAdStyles = css`
 
 const liveblogInlineMobileAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.outstreamMobile.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.outstreamMobile.height)}px;
 
 	${from.tablet} {
 		display: none;
@@ -239,7 +245,7 @@ const liveblogInlineMobileAdStyles = css`
 
 const mobileFrontAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.mpu.height, space[3])}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height, space[3])}px;
 	min-width: 300px;
 	width: 300px;
 	margin: ${space[3]}px auto;
@@ -255,11 +261,17 @@ const frontsBannerAdTopContainerStyles = css`
 	${from.tablet} {
 		display: flex;
 		justify-content: center;
-		min-height: ${getMinHeight(adSizes.leaderboard.height, space[6])}px;
+		min-height: ${getMinHeightOfAdSlot(
+			adSizes.leaderboard.height,
+			space[6],
+		)}px;
 		background-color: ${schemedPalette('--ad-background')};
 	}
 	${from.desktop} {
-		min-height: ${getMinHeight(adSizes.billboard.height, space[6])}px;
+		min-height: ${getMinHeightOfAdSlot(
+			adSizes.billboard.height,
+			space[6],
+		)}px;
 	}
 `;
 
@@ -277,7 +289,7 @@ const frontsBannerCollapseStyles = css`
 
 const frontsBannerAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.leaderboard.height, space[6])}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.leaderboard.height, space[6])}px;
 	max-width: ${adSizes.leaderboard.width}px;
 	overflow: hidden;
 	padding-bottom: ${space[6]}px;
@@ -300,7 +312,7 @@ const articleEndAdStyles = css`
 
 const mostPopAdStyles = css`
 	position: relative;
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	max-width: ${adSizes.mpu.width}px;
 	text-align: center;
@@ -314,7 +326,7 @@ const mostPopAdStyles = css`
 `;
 
 const mostPopContainerStyles = css`
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	width: fit-content;
 	max-width: ${adSizes.mpu.width}px;
@@ -328,7 +340,7 @@ const mostPopContainerStyles = css`
 `;
 
 const liveBlogTopAdStyles = css`
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height)}px;
 	min-width: ${adSizes.mpu.width}px;
 	width: fit-content;
 	max-width: ${adSizes.mpu.width}px;
@@ -409,12 +421,12 @@ const mobileStickyAdStyles = css`
 `;
 
 const crosswordBannerMobileAdStyles = css`
-	min-height: ${getMinHeight(adSizes.mobilesticky.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mobilesticky.height)}px;
 `;
 
 const galleryInlineAdStyles = css`
 	margin: ${space[3]}px auto;
-	min-height: ${getMinHeight(adSizes.mpu.height)}px;
+	min-height: ${getMinHeightOfAdSlot(adSizes.mpu.height)}px;
 
 	&.ad-slot--fluid {
 		margin: ${space[3]}px auto;

--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -108,7 +108,7 @@ const hideBelowDesktop = css`
 	}
 `;
 
-const containerMinHeight = getMinHeightOfAdSlot(250, space[5]);
+const topAboveNavPaddingHeight = space[5];
 
 const topAboveNavContainerStyles = css`
 	padding-bottom: ${space[5]}px;
@@ -117,7 +117,17 @@ const topAboveNavContainerStyles = css`
 	text-align: left;
 	display: block;
 	width: 100%;
-	min-height: ${containerMinHeight}px;
+
+	min-height: ${getMinHeightOfAdSlot(
+		adSizes.leaderboard.height,
+		topAboveNavPaddingHeight,
+	)}px;
+	${from.desktop} {
+		min-height: ${getMinHeightOfAdSlot(
+			adSizes.billboard.height,
+			topAboveNavPaddingHeight,
+		)}px;
+	}
 
 	/* Remove the min-height when the ad has rendered, so that the container can shrink if the ad is smaller */
 	&[top-above-nav-ad-rendered='true'] {
@@ -129,7 +139,7 @@ const topAboveNavContainerStyles = css`
 		::before {
 			content: '';
 			position: absolute;
-			height: ${adSizes.billboard.height}px;
+			height: ${adSizes.leaderboard.height}px;
 			width: ${adSizes.leaderboard.width}px;
 			top: ${labelHeight}px;
 			left: 50%;
@@ -138,6 +148,7 @@ const topAboveNavContainerStyles = css`
 		}
 		${from.desktop} {
 			::before {
+				height: ${adSizes.billboard.height}px;
 				width: ${adSizes.billboard.width}px;
 			}
 		}


### PR DESCRIPTION
## What does this change?

At the tablet breakpoint, between 740px and 980px, reserve 160px less vertical space for the `top-above-nav` advert.

## Why?

We currently reserve enough space for a 970x250 (billboard) advert from the tablet breakpoint onwards. However, we only serve this ad size from the desktop breakpoint onwards. The only fixed ad size we serve on tablet, which is also the most commonly served, is the 728x90 (leaderboard) ad size[^1].

[^1]: https://github.com/guardian/commercial/blob/381fab35ac53d782469671f60b05d3eb7fd18025/core/src/ad-sizes.ts#L269

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/4ca8a710-59a3-4b5c-8d86-5375c9769058
[after]: https://github.com/user-attachments/assets/d762d0a2-35a1-49a9-bbdd-95034d9b0eb5

## Screenshares

### Before

https://github.com/user-attachments/assets/6a03d2ff-7008-4e03-a534-02fcbb7ebfb4

### After

https://github.com/user-attachments/assets/c3fde41f-748d-4ecc-a311-fdf1ab6db9d5


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
