### PR TITLE
Improvements to cricket scorecard & hash handling

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -30,6 +30,7 @@ import {
 	getTimeZoneFromEdition,
 } from '../../lib/edition';
 import { generateImageURL } from '../../lib/image';
+import { useLocationHash } from '../../lib/useLocationHash';
 import { palette } from '../../palette';
 import type { ColourName } from '../../paletteDeclarations';
 import type { ArticleDeprecated } from '../../types/article';
@@ -63,6 +64,7 @@ type Props = CricketMatchHeaderProps & {
 
 export const CricketMatchHeader = (props: Props) => {
 	const scorecardHashbang = '#scorecard';
+	const locationHash = useLocationHash();
 
 	const { data, error } = useSWR<CricketHeaderData, Error>(
 		props.matchHeaderURL,
@@ -78,11 +80,11 @@ export const CricketMatchHeader = (props: Props) => {
 		useState<HTMLElement | null>(null);
 
 	useEffect(() => {
-		if (window.location.hash === scorecardHashbang) {
+		if (locationHash === scorecardHashbang) {
 			// eslint-disable-next-line react-hooks/set-state-in-effect -- we want to set the selected tab based on the hashbang in the URL
 			setSelectedTab('info');
 		}
-	}, []);
+	}, [locationHash]);
 
 	useEffect(() => {
 		const el = document.getElementById(props.tabContentId);

--- a/dotcom-rendering/src/components/CricketScorecardTab.tsx
+++ b/dotcom-rendering/src/components/CricketScorecardTab.tsx
@@ -11,6 +11,14 @@ export type CricketScorecardTabProps = Pick<
 	'innings' | 'officials' | 'homeTeam' | 'awayTeam' | 'result'
 >;
 
+// this is needed to override global style
+// html:not(.src-focus-disabled) *:focus
+const disableFocusShadow = css({
+	'&&:focus': {
+		boxShadow: 'none',
+	},
+});
+
 export const CricketScorecardTab = ({
 	innings,
 	officials,
@@ -30,7 +38,7 @@ export const CricketScorecardTab = ({
 	return (
 		<div
 			ref={regionRef}
-			css={bodyGridStyles}
+			css={[bodyGridStyles, disableFocusShadow]}
 			aria-label="Cricket scorecard"
 			role="region"
 			tabIndex={-1}

--- a/dotcom-rendering/src/lib/useLocationHash.ts
+++ b/dotcom-rendering/src/lib/useLocationHash.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export const useLocationHash = (): string => {
+	const [hash, setHash] = useState('');
+
+	useEffect(() => {
+		function onHashChange() {
+			setHash(window.location.hash);
+		}
+
+		// Set the initial hash value
+		onHashChange();
+
+		const event = 'hashchange';
+		window.addEventListener(event, onHashChange);
+		return () => window.removeEventListener(event, onHashChange);
+	}, []);
+
+	return hash;
+};


### PR DESCRIPTION
## What does this change?
Actually monitor the location hash to switch to the scorecard.

Remove the focus shadow added by a global style, it's focused exclusively for screen readers so we don't need the visual cue. 

## Why?
If there are links in the liveblog/elsewhere on the page with the same url but just `#scorecard` appended the browser won't do a full navigation when clicked, so we need to subscribe to the `hashchange` event and keep track of the hash for these links to work properly.