### PR TITLE
Fullwidth hold back AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -156,7 +156,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		audienceSize: 5 / 100,
 		audienceSpace: "A",
-		groups: ["control", "variant"],
+		groups: ["holdback"],
 		shouldForceMetricsCollection: true,
 	},
 	{

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -147,6 +147,19 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-full-width-hold-back",
+		description:
+			"Test to measure impact of adding full width to spacefinder",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-07-04",
+		type: "client",
+		status: "ON",
+		audienceSize: 5 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
+	{
 		name: "fronts-and-curation-loop-click-through",
 		description:
 			"Test impact of click to article via loop videos on fronts",

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -156,7 +156,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		audienceSize: 5 / 100,
 		audienceSpace: "A",
-		groups: ["holdback"],
+		groups: ["holdback", "control"],
 		shouldForceMetricsCollection: true,
 	},
 	{


### PR DESCRIPTION
## What does this change?

Adds a test to DCR for holding back full width opponent selector

## Why?

For this PR https://github.com/guardian/commercial/pull/2596


I have seen one of these that just has 1 group and one with 2. Trying to find out what is best