### PR TITLE
check for cricket match report before showing header

### DIFF
--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -153,6 +153,14 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 	const isFootballMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchUrl;
 
+	const cricketMatchUrl =
+		article.matchType === 'CricketMatchType'
+			? article.matchStatsUrl
+			: undefined;
+
+	const isCricketMatchReport =
+		format.design === ArticleDesign.MatchReport && !!cricketMatchUrl;
+
 	const isMedia =
 		format.design === ArticleDesign.Video ||
 		format.design === ArticleDesign.Audio;
@@ -236,6 +244,7 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 			<MatchHeaderContainer
 				isFootballMatchReport={isFootballMatchReport}
+				isCricketMatchReport={isCricketMatchReport}
 				renderingTarget={renderingTarget}
 				article={article}
 				format={format}
@@ -844,11 +853,13 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 
 const MatchHeaderContainer = ({
 	isFootballMatchReport,
+	isCricketMatchReport,
 	renderingTarget,
 	article,
 	format,
 }: {
 	isFootballMatchReport: boolean;
+	isCricketMatchReport: boolean;
 	renderingTarget: RenderingTarget;
 	article: ArticleDeprecated;
 	format: ArticleFormat;
@@ -895,7 +906,12 @@ const MatchHeaderContainer = ({
 		);
 	}
 
-	if (!isApps && cricketMatchHeaderUrl && isCricketRedesignEnabled) {
+	if (
+		!isApps &&
+		cricketMatchHeaderUrl &&
+		isCricketMatchReport &&
+		isCricketRedesignEnabled
+	) {
 		return (
 			<>
 				<noscript>


### PR DESCRIPTION
## What does this change?

Checks if the page is a cricket match report before showing the cricket header.

## Why?

Similar fix to this:

https://github.com/guardian/dotcom-rendering/pull/16271
