### PR TITLE
extend us mobile sticky expiry date

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -125,7 +125,7 @@ const ABTests: ABTest[] = [
 		description:
 			"Holdback test, where variant is the 'holdback' group, to measure uplift in adding the mobile-sticky slot for Liveblogs articles in the US.",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-02",
+		expirationDate: "2026-07-22",
 		type: "client",
 		status: "ON",
 		audienceSize: 5 / 100,


### PR DESCRIPTION
## What does this change?
Extends the `commercial-mobile-sticky-liveblog-us` test till the 22nd July 2026.
## Why?
We would like to continue collating data for mobile-sticky slot in US liveblogs, for more analysis.
