### PR TITLE
remove intentIQ ab test configs

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -95,32 +95,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-user-module-intentIq",
-		description:
-			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module.",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-16",
-		type: "client",
-		status: "ON",
-		audienceSize: 10 / 100,
-		audienceSpace: "A",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: true,
-	},
-	{
-		name: "commercial-user-module-intentIq-us",
-		description:
-			"Holdback test to measure the impact of adding intentIq as an ID partner in the user module for users in the US",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-16",
-		type: "client",
-		status: "ON",
-		audienceSize: 10 / 100,
-		audienceSpace: "A",
-		groups: ["control", "holdback"],
-		shouldForceMetricsCollection: true,
-	},
-	{
 		name: "commercial-mobile-sticky-liveblog-us",
 		description:
 			"Holdback test, where variant is the 'holdback' group, to measure uplift in adding the mobile-sticky slot for Liveblogs articles in the US.",


### PR DESCRIPTION
## What does this change?
Removes IntentIQ test configs:
- commercial-user-module-intentIq
- commercial-user-module-intentIq-us
## Why?
The IntentIQ integration has been validated end-to-end with IntentIQ.
We now want to make IntentIQ available to all users in supported regions and therefore do not need the test configs for intentIQ.
