### PR TITLE
set paramKey to force-landing-page for recurring contributions

### DIFF
--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -261,6 +261,7 @@ const addChoiceCardDestinationTestParam = (
 	url: string,
 	destination: ChoiceCard['destination'],
 	destinationTest: ChoiceCard['destinationTest'],
+	isRecurringProduct: boolean,
 ): string => {
 	if (!destinationTest || typeof destinationTest !== 'object') {
 		return url;
@@ -275,7 +276,7 @@ const addChoiceCardDestinationTestParam = (
 
 	const { testName, variantName } = parsedDestinationTest;
 	const paramKey =
-		destination === 'LandingPage'
+		isRecurringProduct || destination === 'LandingPage'
 			? 'force-landing-page'
 			: 'force-one-time-checkout';
 	const newParam = `${paramKey}=${testName}:${variantName}`;
@@ -308,12 +309,14 @@ export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
 				addChoiceCardsOneTimeParams(`${SupportUrl}/contribute`),
 				destination,
 				destinationTest,
+				false,
 			);
 		} else {
 			return addChoiceCardDestinationTestParam(
 				`${SupportUrl}/one-time-checkout`,
 				destination,
 				destinationTest,
+				false,
 			);
 		}
 	} else {
@@ -326,6 +329,7 @@ export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
 			),
 			destination,
 			destinationTest,
+			true,
 		);
 	}
 };


### PR DESCRIPTION
## What does this change?
This change updated pathKey for recurring products (products except OneOff) to be 'force-landing-page' for any 'destination' option in order to fix the variant where destination is set to 'checkout' but the test journey should continue (for weekly prices for example).

## Why?
Previously when destination was set to 'checkout', 'force-one-time-checkout' was set for any product, but it should be set only for OneOff product.
## Screenshots


[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
