### PR TITLE
Adding details to in article signup logging

### DIFF
--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -102,7 +102,14 @@ const getTrackedEventDescription = (call: unknown[]): string => {
 
 const getTrackedPayloadForEvent = (
 	eventDescription: string,
-): { eventDescription: string; marketingOptInType?: string } | undefined => {
+):
+	| {
+			eventDescription: string;
+			marketingOptInType?: string;
+			responseStatus?: number;
+			errorType?: string;
+	  }
+	| undefined => {
 	const trackingCalls = (submitComponentEvent as jest.Mock).mock
 		.calls as Array<[{ value: string }]>;
 
@@ -110,6 +117,8 @@ const getTrackedPayloadForEvent = (
 		const parsed = JSON.parse(payload.value) as {
 			eventDescription: string;
 			marketingOptInType?: string;
+			responseStatus?: number;
+			errorType?: string;
 		};
 
 		if (parsed.eventDescription === eventDescription) {
@@ -397,7 +406,9 @@ describe('NewsletterSignupForm', () => {
 
 	it('shows failure UI with retry', async () => {
 		const testUser = user.setup();
-		global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+		global.fetch = jest
+			.fn()
+			.mockResolvedValue({ ok: false, status: 500 } as Response);
 
 		renderForm();
 
@@ -416,6 +427,9 @@ describe('NewsletterSignupForm', () => {
 			'form-submission',
 			'submission-failed',
 		]);
+		expect(
+			getTrackedPayloadForEvent('submission-failed')?.responseStatus,
+		).toBe(500);
 
 		await testUser.click(screen.getByRole('button', { name: 'Try again' }));
 
@@ -487,6 +501,36 @@ describe('NewsletterSignupForm', () => {
 		expect(
 			screen.getByRole('button', { name: 'Sign up' }),
 		).toBeInTheDocument();
+	});
+
+	it('tracks an error type when the submit request throws', async () => {
+		const testUser = user.setup();
+		global.fetch = jest
+			.fn()
+			.mockRejectedValue(new TypeError('Failed to fetch'));
+
+		renderForm();
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/there was an error signing you up\./i),
+			).toBeInTheDocument();
+		});
+
+		expectTrackedEventDescriptions([
+			'email-input-focused',
+			'click-button',
+			'open-captcha',
+			'captcha-passed',
+			'form-submission',
+			'form-submit-error',
+		]);
+		expect(getTrackedPayloadForEvent('form-submit-error')?.errorType).toBe(
+			'network-or-fetch',
+		);
 	});
 
 	describe('US hide marketing toggle (usSignupHideMarketingToggle switch)', () => {

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -246,6 +246,18 @@ const postFormData = async (
 	});
 };
 
+const getErrorType = (error: unknown): string => {
+	if (error instanceof TypeError) {
+		return 'network-or-fetch';
+	}
+
+	if (error instanceof Error) {
+		return error.name || 'error';
+	}
+
+	return 'unknown';
+};
+
 const sendTracking = (
 	newsletterId: string,
 	eventDescription: NewsletterEventDescription,
@@ -383,13 +395,25 @@ export const SecureSignup = ({
 			clearSubscriptionCache();
 		}
 
+		const trackingDetails: Record<string, unknown> = {};
+
+		if (marketingOptInType) {
+			trackingDetails.marketingOptInType = marketingOptInType;
+		}
+
+		if (!response.ok) {
+			trackingDetails.responseStatus = response.status;
+		}
+
 		sendTracking(
 			newsletterId,
 			response.ok ? 'submission-confirmed' : 'submission-failed',
 			renderingTarget,
 			isSignedIn,
 			abTest,
-			marketingOptInType ? { marketingOptInType } : undefined,
+			Object.keys(trackingDetails).length > 0
+				? trackingDetails
+				: undefined,
 		);
 	};
 
@@ -438,6 +462,7 @@ export const SecureSignup = ({
 				renderingTarget,
 				isSignedIn,
 				abTest,
+				{ errorType: getErrorType(error) },
 			);
 			setErrorMessage(`Sorry, there was an error signing you up.`);
 			setIsWaitingForResponse(false);

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -41,7 +41,7 @@ import { useConfig } from './ConfigContext';
 // The Google documentation specifies that if the 'recaptcha-badge' is hidden,
 // their T+C's must be displayed instead. While this component hides the
 // badge, its parent must include the T+C along side it.
-// The T+C are not included in this componet directly to reduce layout shift
+// The T+C are not included in this component directly to reduce layout shift
 // from the island hydrating (placeholder height for the text can't
 // be accurately predicated for every breakpoint).
 // https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -109,6 +109,18 @@ const postFormData = async (
 	});
 };
 
+const getErrorType = (error: unknown): string => {
+	if (error instanceof TypeError) {
+		return 'network-or-fetch';
+	}
+
+	if (error instanceof Error) {
+		return error.name || 'error';
+	}
+
+	return 'unknown';
+};
+
 const sendTracking = (
 	newsletterId: string,
 	componentId: string,
@@ -368,6 +380,16 @@ export const useNewsletterSignupForm = (
 
 			setResponseOk(response.ok);
 
+			const trackingDetails: Record<string, unknown> = {};
+
+			if (marketingOptInType) {
+				trackingDetails.marketingOptInType = marketingOptInType;
+			}
+
+			if (!response.ok) {
+				trackingDetails.responseStatus = response.status;
+			}
+
 			sendTracking(
 				newsletterId,
 				componentId,
@@ -375,7 +397,9 @@ export const useNewsletterSignupForm = (
 				renderingTarget,
 				isSignedIn,
 				abTest,
-				marketingOptInType ? { marketingOptInType } : undefined,
+				Object.keys(trackingDetails).length > 0
+					? trackingDetails
+					: undefined,
 			);
 		},
 		[abTest, componentId, isSignedIn, newsletterId, renderingTarget],
@@ -420,6 +444,7 @@ export const useNewsletterSignupForm = (
 						renderingTarget,
 						isSignedIn,
 						abTest,
+						{ errorType: getErrorType(error) },
 					);
 					setIsValidationError(false);
 					setErrorMessage(


### PR DESCRIPTION
## What does this change?

Adds details to logging around in article newsletter signup component.

## Why?

To help investigate high signup failure rates.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
