### PR TITLE
Adjust series link padding to handle longer titles

### DIFF
--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -187,7 +187,8 @@ const breakWord = css`
 const sectionPadding = (design: ArticleDesign) => {
 	if (design === ArticleDesign.Gallery) {
 		return css`
-			padding: 0 ${space[2]}px 0 ${space[3]}px;
+			line-height: 1.15;
+			padding: ${space[1]}px ${space[2]}px ${space[1]}px ${space[3]}px;
 
 			${between.mobileLandscape.and.tablet} {
 				padding-left: ${space[5]}px;


### PR DESCRIPTION
Adjusts the padding and line height for series section links to sit right when it's long enough to overflow to a new line. Rather than this:

<img width="881" height="588" alt="image" src="https://github.com/user-attachments/assets/a5034acb-44ed-4a61-a694-15a645602c37" />

It looks like this:

<img width="911" height="502" alt="image" src="https://github.com/user-attachments/assets/be9cc75c-21da-4815-aca6-5abfc12e09d2" />

Though it _should_ look like this:

<img width="722" height="282" alt="image" src="https://github.com/user-attachments/assets/702ad7f3-9dc4-453b-aae5-26deafbd7286" />

There's probably a better place to but this tweak as it likely applies beyond galleries. I imagine most series titles aren't long enough for this to be an issue.

A starting point at least.