### PR TITLE
adding error text to the email failure logs

### DIFF
--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -21,6 +21,10 @@ import { useEffect, useRef, useState } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import {
+	getErrorType,
+	getResponseErrorDescription,
+} from '../lib/newsletterSignupFailureDetails';
+import {
 	getEffectiveMarketingOptIn,
 	getMarketingOptInType,
 } from '../lib/newsletter-marketing-opt-in';
@@ -245,19 +249,6 @@ const postFormData = async (
 		},
 	});
 };
-
-const getErrorType = (error: unknown): string => {
-	if (error instanceof TypeError) {
-		return 'network-or-fetch';
-	}
-
-	if (error instanceof Error) {
-		return error.name || 'error';
-	}
-
-	return 'unknown';
-};
-
 const sendTracking = (
 	newsletterId: string,
 	eventDescription: NewsletterEventDescription,
@@ -403,6 +394,11 @@ export const SecureSignup = ({
 
 		if (!response.ok) {
 			trackingDetails.responseStatus = response.status;
+			const errorDescription =
+				await getResponseErrorDescription(response);
+			if (errorDescription) {
+				trackingDetails.errorDescription = errorDescription;
+			}
 		}
 
 		sendTracking(

--- a/dotcom-rendering/src/components/SecureSignup.island.tsx
+++ b/dotcom-rendering/src/components/SecureSignup.island.tsx
@@ -21,13 +21,13 @@ import { useEffect, useRef, useState } from 'react';
 import ReactGoogleRecaptcha from 'react-google-recaptcha';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import {
-	getErrorType,
-	getResponseErrorDescription,
-} from '../lib/newsletterSignupFailureDetails';
-import {
 	getEffectiveMarketingOptIn,
 	getMarketingOptInType,
 } from '../lib/newsletter-marketing-opt-in';
+import {
+	getErrorType,
+	getResponseErrorDescription,
+} from '../lib/newsletterSignupFailureDetails';
 import {
 	EVENT_DESCRIPTION_TO_ACTION,
 	NEWSLETTER_SIGNUP_COMPONENT_ID,

--- a/dotcom-rendering/src/lib/newsletterSignupFailureDetails.test.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupFailureDetails.test.ts
@@ -1,0 +1,72 @@
+import {
+	getErrorType,
+	getResponseErrorDescription,
+} from './newsletterSignupFailureDetails';
+
+const mockResponse = (text: string): Response =>
+	({
+		text: jest.fn().mockResolvedValue(text),
+	}) as unknown as Response;
+
+describe('newsletterSignupFailureDetails', () => {
+	describe('getResponseErrorDescription', () => {
+		it('returns undefined for an empty response body', async () => {
+			const response = mockResponse('   ');
+
+			await expect(getResponseErrorDescription(response)).resolves.toBe(
+				undefined,
+			);
+		});
+
+		it('trims and collapses whitespace in the response body', async () => {
+			const response = mockResponse('  too\n\n many\t spaces  ');
+
+			await expect(getResponseErrorDescription(response)).resolves.toBe(
+				'too many spaces',
+			);
+		});
+
+		it('truncates the response body to 120 characters', async () => {
+			const longMessage = 'a'.repeat(130);
+			const response = mockResponse(longMessage);
+
+			await expect(getResponseErrorDescription(response)).resolves.toBe(
+				'a'.repeat(120),
+			);
+		});
+
+		it('returns undefined when reading the response body throws', async () => {
+			const response = {
+				text: jest.fn().mockRejectedValue(new Error('read failed')),
+			} as unknown as Response;
+
+			await expect(getResponseErrorDescription(response)).resolves.toBe(
+				undefined,
+			);
+		});
+	});
+
+	describe('getErrorType', () => {
+		it('returns network-or-fetch for TypeError instances', () => {
+			expect(getErrorType(new TypeError('Failed to fetch'))).toBe(
+				'network-or-fetch',
+			);
+		});
+
+		it('returns the error name for other Error instances', () => {
+			class CustomError extends Error {
+				constructor(message: string) {
+					super(message);
+					this.name = 'CustomError';
+				}
+			}
+
+			expect(getErrorType(new CustomError('boom'))).toBe('CustomError');
+		});
+
+		it('returns unknown for non-Error values', () => {
+			expect(getErrorType('boom')).toBe('unknown');
+			expect(getErrorType({ message: 'boom' })).toBe('unknown');
+		});
+	});
+});

--- a/dotcom-rendering/src/lib/newsletterSignupFailureDetails.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupFailureDetails.ts
@@ -1,0 +1,23 @@
+export const getResponseErrorDescription = async (
+	response: Response,
+): Promise<string | undefined> => {
+	try {
+		const responseText = (await response.text()).trim();
+		if (!responseText) return;
+		return responseText.replace(/\s+/g, ' ').substring(0, 120);
+	} catch {
+		return;
+	}
+};
+
+export const getErrorType = (error: unknown): string => {
+	if (error instanceof TypeError) {
+		return 'network-or-fetch';
+	}
+
+	if (error instanceof Error) {
+		return error.name || 'error';
+	}
+
+	return 'unknown';
+};

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -11,6 +11,10 @@ import {
 	getMarketingOptInType,
 } from './newsletter-marketing-opt-in';
 import {
+	getErrorType,
+	getResponseErrorDescription,
+} from './newsletterSignupFailureDetails';
+import {
 	EVENT_DESCRIPTION_TO_ACTION,
 	type NewsletterEventDescription,
 	sendNewsletterSignupEvent,
@@ -108,19 +112,6 @@ const postFormData = async (
 		},
 	});
 };
-
-const getErrorType = (error: unknown): string => {
-	if (error instanceof TypeError) {
-		return 'network-or-fetch';
-	}
-
-	if (error instanceof Error) {
-		return error.name || 'error';
-	}
-
-	return 'unknown';
-};
-
 const sendTracking = (
 	newsletterId: string,
 	componentId: string,
@@ -388,6 +379,11 @@ export const useNewsletterSignupForm = (
 
 			if (!response.ok) {
 				trackingDetails.responseStatus = response.status;
+				const errorDescription =
+					await getResponseErrorDescription(response);
+				if (errorDescription) {
+					trackingDetails.errorDescription = errorDescription;
+				}
 			}
 
 			sendTracking(


### PR DESCRIPTION
## What does this change?
This change adds error description to newsletter signup failure tracking.

## Why?
To further help investigate high signup failure rates.

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
