### PR TITLE
Dynamic data attribute for self hosted video, remove wrapper

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -319,6 +319,7 @@ type Props = {
 		isExternalLink: boolean;
 	};
 	isInLoopClickTestVariant?: boolean;
+	isInArticle?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -351,6 +352,7 @@ export const SelfHostedVideo = ({
 	restrictHeightOnDesktop = false,
 	cardLink,
 	isInLoopClickTestVariant,
+	isInArticle = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1075,9 +1077,13 @@ export const SelfHostedVideo = ({
 
 	return (
 		<figure
-			css={css`
-				margin-bottom: ${space[3]}px;
-			`}
+			css={
+				isInArticle
+					? css`
+							margin-bottom: ${space[3]}px;
+						`
+					: undefined
+			}
 			ref={videoContainerRef}
 			className={`video-container ${videoStyleFormat} ${
 				role === 'immersive' ? 'element-video-immersive' : ''

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -1071,13 +1071,18 @@ export const SelfHostedVideo = ({
 		}
 	}
 
+	const videoStyleFormat = videoStyle.toLocaleLowerCase();
+
 	return (
 		<figure
+			css={css`
+				margin-bottom: ${space[3]}px;
+			`}
 			ref={videoContainerRef}
-			className={`video-container ${videoStyle.toLocaleLowerCase()} ${
+			className={`video-container ${videoStyleFormat} ${
 				role === 'immersive' ? 'element-video-immersive' : ''
 			}`}
-			data-component="gu-video-loop"
+			data-component={`gu-video-${videoStyleFormat}`}
 		>
 			<div
 				ref={setNode}

--- a/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideo.island.tsx
@@ -319,7 +319,7 @@ type Props = {
 		isExternalLink: boolean;
 	};
 	isInLoopClickTestVariant?: boolean;
-	isInArticle?: boolean;
+	hasBottomMargin?: boolean;
 };
 
 export const SelfHostedVideo = ({
@@ -352,7 +352,7 @@ export const SelfHostedVideo = ({
 	restrictHeightOnDesktop = false,
 	cardLink,
 	isInLoopClickTestVariant,
-	isInArticle = false,
+	hasBottomMargin = false,
 }: Props) => {
 	const adapted = useShouldAdapt();
 	const { renderingTarget } = useConfig();
@@ -1075,20 +1075,19 @@ export const SelfHostedVideo = ({
 
 	const videoStyleFormat = videoStyle.toLocaleLowerCase();
 
+	const bottomMarginStyles = css`
+		margin-bottom: ${space[3]}px;
+	`;
+
 	return (
 		<figure
-			css={
-				isInArticle
-					? css`
-							margin-bottom: ${space[3]}px;
-						`
-					: undefined
-			}
+			css={hasBottomMargin && bottomMarginStyles}
 			ref={videoContainerRef}
 			className={`video-container ${videoStyleFormat} ${
 				role === 'immersive' ? 'element-video-immersive' : ''
 			}`}
 			data-component={`gu-video-${videoStyleFormat}`}
+			data-spacefinder-role="inline"
 		>
 			<div
 				ref={setNode}

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -70,6 +70,7 @@ export const SelfHostedVideoInArticle = ({
 				restrictHeightOnDesktop={
 					isVerticalVideo && !isInteractive(format.design)
 				}
+				isInArticle={true}
 			/>
 		</Island>
 	);

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
 import type { FEAspectRatio } from '../frontend/feFront';
 import { isInteractive } from '../layouts/lib/interactiveLegacyStyling';
 import type { ArticleFormat } from '../lib/articleFormat';
@@ -12,10 +10,6 @@ import type { MediaAtomBlockElement, RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.island';
-
-const containerStyles = css`
-	margin-bottom: ${space[3]}px;
-`;
 
 type SelfHostedVideoInArticleProps = {
 	element: MediaAtomBlockElement;
@@ -49,39 +43,34 @@ export const SelfHostedVideoInArticle = ({
 	}
 
 	return (
-		<div css={containerStyles}>
-			<Island priority="critical" defer={{ until: 'visible' }}>
-				<SelfHostedVideo
-					atomId={element.id}
-					fallbackImage={posterImageUrl}
-					fallbackImageAlt={caption}
-					fallbackImageAspectRatio={
-						(firstVideoSource?.aspectRatio ??
-							'5:4') as FEAspectRatio
-					}
-					fallbackImageLoading="lazy"
-					fallbackImageSize="small"
-					aspectRatio={aspectRatio}
-					linkTo="Article-embed-MediaAtomBlockElement"
-					posterImage={posterImageUrl}
-					posterImageAspectRatio={
-						firstVideoSource?.aspectRatio ?? '5:4'
-					}
-					sources={sources}
-					subtitleSize="medium"
-					subtitleSource={getSubtitleAsset(element.assets)}
-					videoStyle={videoStyle}
-					uniqueId={element.id}
-					caption={caption}
-					format={format}
-					isMainMedia={isMainMedia}
-					role={role}
-					preventAutoplay={videoStyle === 'Default'}
-					restrictHeightOnDesktop={
-						isVerticalVideo && !isInteractive(format.design)
-					}
-				/>
-			</Island>
-		</div>
+		<Island priority="critical" defer={{ until: 'visible' }}>
+			<SelfHostedVideo
+				atomId={element.id}
+				fallbackImage={posterImageUrl}
+				fallbackImageAlt={caption}
+				fallbackImageAspectRatio={
+					(firstVideoSource?.aspectRatio ?? '5:4') as FEAspectRatio
+				}
+				fallbackImageLoading="lazy"
+				fallbackImageSize="small"
+				aspectRatio={aspectRatio}
+				linkTo="Article-embed-MediaAtomBlockElement"
+				posterImage={posterImageUrl}
+				posterImageAspectRatio={firstVideoSource?.aspectRatio ?? '5:4'}
+				sources={sources}
+				subtitleSize="medium"
+				subtitleSource={getSubtitleAsset(element.assets)}
+				videoStyle={videoStyle}
+				uniqueId={element.id}
+				caption={caption}
+				format={format}
+				isMainMedia={isMainMedia}
+				role={role}
+				preventAutoplay={videoStyle === 'Default'}
+				restrictHeightOnDesktop={
+					isVerticalVideo && !isInteractive(format.design)
+				}
+			/>
+		</Island>
 	);
 };

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-import { space } from '@guardian/source/foundations';
 import type { FEAspectRatio } from '../frontend/feFront';
 import { isInteractive } from '../layouts/lib/interactiveLegacyStyling';
 import type { ArticleFormat } from '../lib/articleFormat';
@@ -12,10 +10,6 @@ import type { MediaAtomBlockElement, RoleType } from '../types/content';
 import type { VideoPlayerFormat } from '../types/mainMedia';
 import { Island } from './Island';
 import { SelfHostedVideo } from './SelfHostedVideo.island';
-
-const containerStyles = css`
-	margin-bottom: ${space[3]}px;
-`;
 
 type SelfHostedVideoInArticleProps = {
 	element: MediaAtomBlockElement;
@@ -49,39 +43,34 @@ export const SelfHostedVideoInArticle = ({
 	}
 
 	return (
-		<div css={containerStyles} data-spacefinder-role="inline">
-			<Island priority="critical" defer={{ until: 'visible' }}>
-				<SelfHostedVideo
-					atomId={element.id}
-					fallbackImage={posterImageUrl}
-					fallbackImageAlt={caption}
-					fallbackImageAspectRatio={
-						(firstVideoSource?.aspectRatio ??
-							'5:4') as FEAspectRatio
-					}
-					fallbackImageLoading="lazy"
-					fallbackImageSize="small"
-					aspectRatio={aspectRatio}
-					linkTo="Article-embed-MediaAtomBlockElement"
-					posterImage={posterImageUrl}
-					posterImageAspectRatio={
-						firstVideoSource?.aspectRatio ?? '5:4'
-					}
-					sources={sources}
-					subtitleSize="medium"
-					subtitleSource={getSubtitleAsset(element.assets)}
-					videoStyle={videoStyle}
-					uniqueId={element.id}
-					caption={caption}
-					format={format}
-					isMainMedia={isMainMedia}
-					role={role}
-					preventAutoplay={videoStyle === 'Default'}
-					restrictHeightOnDesktop={
-						isVerticalVideo && !isInteractive(format.design)
-					}
-				/>
-			</Island>
-		</div>
+		<Island priority="critical" defer={{ until: 'visible' }}>
+			<SelfHostedVideo
+				atomId={element.id}
+				fallbackImage={posterImageUrl}
+				fallbackImageAlt={caption}
+				fallbackImageAspectRatio={
+					(firstVideoSource?.aspectRatio ?? '5:4') as FEAspectRatio
+				}
+				fallbackImageLoading="lazy"
+				fallbackImageSize="small"
+				aspectRatio={aspectRatio}
+				linkTo="Article-embed-MediaAtomBlockElement"
+				posterImage={posterImageUrl}
+				posterImageAspectRatio={firstVideoSource?.aspectRatio ?? '5:4'}
+				sources={sources}
+				subtitleSize="medium"
+				subtitleSource={getSubtitleAsset(element.assets)}
+				videoStyle={videoStyle}
+				uniqueId={element.id}
+				caption={caption}
+				format={format}
+				isMainMedia={isMainMedia}
+				role={role}
+				preventAutoplay={videoStyle === 'Default'}
+				restrictHeightOnDesktop={
+					isVerticalVideo && !isInteractive(format.design)
+				}
+			/>
+		</Island>
 	);
 };

--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -70,7 +70,7 @@ export const SelfHostedVideoInArticle = ({
 				restrictHeightOnDesktop={
 					isVerticalVideo && !isInteractive(format.design)
 				}
-				isInArticle={true}
+				hasBottomMargin={true}
 			/>
 		</Island>
 	);


### PR DESCRIPTION
A bit of tidying around self hosted videos, this adjusts the figure's `gu` data element to be dynamic like the class name is and also removes an unnecessary wrapper `<div>` element by moving some bottom padding to the `figure` element inside the island, where it probably belongs anyway. 