### PR TITLE
Add onward content to Hosted Gallery pages

### DIFF
--- a/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
+++ b/dotcom-rendering/src/components/FetchHostedOnwards.island.tsx
@@ -6,13 +6,18 @@ import { HostedContentOnwards } from './HostedContentOnwards';
 type Props = {
 	url: string;
 	branding?: Branding;
+	isGalleryPage?: boolean;
 };
 
 type OnwardsResponse = {
 	trails: TrailType[];
 };
 
-export const FetchHostedOnwards = ({ branding, url }: Props) => {
+export const FetchHostedOnwards = ({
+	branding,
+	url,
+	isGalleryPage = false,
+}: Props) => {
 	const { data, error } = useApi<OnwardsResponse>(url);
 
 	if (error) {
@@ -31,6 +36,7 @@ export const FetchHostedOnwards = ({ branding, url }: Props) => {
 		<HostedContentOnwards
 			trails={trails}
 			brandName={branding?.sponsorName ?? ''}
+			isGalleryPage={isGalleryPage}
 		/>
 	);
 };

--- a/dotcom-rendering/src/components/GalleryCaption.tsx
+++ b/dotcom-rendering/src/components/GalleryCaption.tsx
@@ -55,13 +55,13 @@ const hostedGalleryStyles = css`
 	${textSansBold17}
 	align-self: end;
 
+	${from.tablet} {
+		padding-bottom: ${space[10]}px;
+	}
+
 	${between.tablet.and.desktop} {
 		padding-left: 0;
 		padding-right: 0;
-	}
-
-	${from.tablet} {
-		padding-bottom: ${space[10]}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/GalleryImage.tsx
+++ b/dotcom-rendering/src/components/GalleryImage.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { between, from, space, until } from '@guardian/source/foundations';
 import { grid } from '../grid';
-import { type ArticleFormat } from '../lib/articleFormat';
+import { ArticleDesign, type ArticleFormat } from '../lib/articleFormat';
 import { getImage } from '../lib/image';
 import { palette } from '../palette';
 import type { ImageBlockElement } from '../types/content';
@@ -47,6 +47,12 @@ const styles = css`
 	}
 `;
 
+const hostedGalleryOverrides = css`
+	${between.desktop.and.leftCol} {
+		${grid.centreRule(2, 'transparent')}
+	}
+`;
+
 const galleryBodyImageStyles = css`
 	display: inline;
 	position: relative;
@@ -87,7 +93,13 @@ export const GalleryImage = ({
 	}
 
 	return (
-		<figure css={styles}>
+		<figure
+			css={[
+				styles,
+				format.design === ArticleDesign.HostedGallery &&
+					hostedGalleryOverrides,
+			]}
+		>
 			<div
 				css={galleryBodyImageStyles}
 				/**

--- a/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
@@ -9,6 +9,7 @@ const meta = preview.meta({
 	args: {
 		trails: hostedOnwardsTrails,
 		brandName: 'TrendAI',
+		isGalleryPage: false,
 	},
 	render: (args) => <HostedContentOnwards {...args} />,
 });
@@ -16,5 +17,12 @@ const meta = preview.meta({
 export const Default = meta.story({});
 
 export const WithAccentColour = meta.story({
+	decorators: hostedPaletteDecorator('#d90c1f'),
+});
+
+export const HostedGallery = meta.story({
+	args: {
+		isGalleryPage: true,
+	},
 	decorators: hostedPaletteDecorator('#d90c1f'),
 });

--- a/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.stories.tsx
@@ -1,7 +1,21 @@
+import { css } from '@emotion/react';
 import { hostedPaletteDecorator } from '../../.storybook/decorators/themeDecorator';
 import preview from '../../.storybook/preview';
 import { hostedOnwardsTrails } from '../../fixtures/manual/onwardsTrails';
+import type { ArticleFormat } from '../lib/articleFormat';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleSpecial,
+} from '../lib/articleFormat';
+import { palette } from '../palette';
 import { HostedContentOnwards } from './HostedContentOnwards';
+
+const hostedArticleFormat: ArticleFormat = {
+	theme: ArticleSpecial.Labs,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.HostedArticle,
+};
 
 const meta = preview.meta({
 	component: HostedContentOnwards,
@@ -11,7 +25,18 @@ const meta = preview.meta({
 		brandName: 'TrendAI',
 		isGalleryPage: false,
 	},
-	render: (args) => <HostedContentOnwards {...args} />,
+	parameters: {
+		formats: [hostedArticleFormat],
+	},
+	render: (args) => (
+		<div
+			css={css`
+				background-color: ${palette('--article-background')};
+			`}
+		>
+			<HostedContentOnwards {...args} />
+		</div>
+	),
 });
 
 export const Default = meta.story({});
@@ -20,9 +45,16 @@ export const WithAccentColour = meta.story({
 	decorators: hostedPaletteDecorator('#d90c1f'),
 });
 
+const hostedGalleryFormat: ArticleFormat = {
+	...hostedArticleFormat,
+	design: ArticleDesign.HostedGallery,
+};
 export const HostedGallery = meta.story({
 	args: {
 		isGalleryPage: true,
 	},
-	decorators: hostedPaletteDecorator('#d90c1f'),
+	parameters: {
+		formats: [hostedGalleryFormat],
+	},
+	decorators: [hostedPaletteDecorator('#d90c1f')],
 });

--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import {
-	palette as sourcePalette,
+	from,
 	space,
 	textSans17,
 	textSansBold20,
@@ -12,25 +12,29 @@ import { HostedContentOnwardsCard } from './HostedContentOnwardsCard';
 type HostedContentOnwardsProps = {
 	trails: TrailType[];
 	brandName: string;
+	isGalleryPage: boolean;
 };
+
+/**
+ * Override --accent-colour variable at a higher CSS specificity
+ * for hosted gallery articles only, because this only has a dark design
+ */
+const galleryOverrides = css`
+	--accent-colour: ${palette('--onward-text')};
+`;
 
 const headerStyles = css`
 	margin-bottom: ${space[1]}px;
-	border-top: ${space[2]}px solid
-		var(--accent-colour, ${sourcePalette.neutral[86]});
+	border-top: ${space[2]}px solid var(--accent-colour);
 `;
 
 const headingStyles = css`
 	${textSans17}
 	padding-top: ${space[2]}px;
-	color: ${palette('--hosted-content-onwards-heading')};
+	color: ${palette('--onward-text')};
 
 	@media (prefers-color-scheme: dark) {
-		color: ${palette('--hosted-content-onwards-heading')};
-	}
-
-	[data-color-scheme='dark'] & {
-		color: ${palette('--hosted-content-onwards-heading')};
+		color: ${palette('--onward-text')};
 	}
 
 	span {
@@ -47,21 +51,45 @@ const stackedCardsStyles = css`
 
 const stackedCardWrapper = css`
 	width: 100%;
-	border-top: 2px solid ${palette('--onward-content-border')};
-	padding-top: ${space[2]}px;
-	padding-bottom: ${space[2]}px;
+	border-top: 1px solid ${palette('--article-border')};
+	padding: ${space[2]}px 0;
 
 	&:last-of-type {
-		padding-bottom: 0;
+		padding: ${space[2]}px 0 0 0;
+	}
+`;
+
+const rowCardWrapper = css`
+	${stackedCardWrapper}
+	${from.desktop} {
+		width: 100%;
+		border-top: none;
+		border-right: 1px solid ${palette('--article-border')};
+		padding: 0 ${space[2]}px;
+
+		&:first-of-type {
+			padding: 0 ${space[2]}px 0 0;
+		}
+		&:last-of-type {
+			border-right: none;
+			padding: 0 0 0 ${space[2]}px;
+		}
+	}
+`;
+
+const galleryStyles = css`
+	${from.desktop} {
+		flex-direction: row;
 	}
 `;
 
 export const HostedContentOnwards = ({
 	trails,
 	brandName,
+	isGalleryPage = false,
 }: HostedContentOnwardsProps) => {
 	return (
-		<>
+		<div css={isGalleryPage && galleryOverrides}>
 			<header css={headerStyles}>
 				<h2 css={headingStyles}>
 					More from
@@ -69,15 +97,25 @@ export const HostedContentOnwards = ({
 				</h2>
 			</header>
 
-			<ul css={stackedCardsStyles}>
+			<ul css={[stackedCardsStyles, isGalleryPage && galleryStyles]}>
 				{trails.map((trail) => {
 					return (
-						<li key={trail.url} css={stackedCardWrapper}>
-							<HostedContentOnwardsCard trail={trail} />
+						<li
+							key={trail.url}
+							css={
+								isGalleryPage
+									? rowCardWrapper
+									: stackedCardWrapper
+							}
+						>
+							<HostedContentOnwardsCard
+								trail={trail}
+								isGalleryPage={isGalleryPage}
+							/>
 						</li>
 					);
 				})}
 			</ul>
-		</>
+		</div>
 	);
 };

--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -31,6 +31,7 @@ const headerStyles = css`
 const headingStyles = css`
 	${textSans17}
 	padding-top: ${space[2]}px;
+	padding-bottom: ${space[2]}px;
 	color: ${palette('--onward-text')};
 
 	@media (prefers-color-scheme: dark) {

--- a/dotcom-rendering/src/components/HostedContentOnwards.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwards.tsx
@@ -25,7 +25,7 @@ const galleryOverrides = css`
 
 const headerStyles = css`
 	margin-bottom: ${space[1]}px;
-	border-top: ${space[2]}px solid var(--accent-colour);
+	border-top: ${space[2]}px solid var(--accent-colour, var(--onward-text));
 `;
 
 const headingStyles = css`
@@ -33,10 +33,6 @@ const headingStyles = css`
 	padding-top: ${space[2]}px;
 	padding-bottom: ${space[2]}px;
 	color: ${palette('--onward-text')};
-
-	@media (prefers-color-scheme: dark) {
-		color: ${palette('--onward-text')};
-	}
 
 	span {
 		${textSansBold20}

--- a/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space, textSansBold15 } from '@guardian/source/foundations';
 import { getZIndex } from '../lib/getZIndex';
+import { generateImageURL } from '../lib/image';
 import { palette } from '../palette';
 import type { TrailType } from '../types/trails';
 
@@ -65,8 +66,12 @@ export const HostedContentOnwardsCard = ({
 					<picture>
 						<img
 							alt={trail.image.altText}
-							src={trail.image.src}
-							style={{ width: isGalleryPage ? '200px' : '120px' }}
+							src={generateImageURL({
+								mainImage: trail.image.src,
+								imageWidth: isGalleryPage ? 180 : 120,
+								resolution: 'low',
+								aspectRatio: '5:4',
+							})}
 						/>
 					</picture>
 					<div css={mediaOverlayContainerStyles}>

--- a/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
+++ b/dotcom-rendering/src/components/HostedContentOnwardsCard.tsx
@@ -6,16 +6,8 @@ import type { TrailType } from '../types/trails';
 
 type Props = {
 	trail: TrailType;
+	isGalleryPage?: boolean;
 };
-
-type CardPictureProps = {
-	image: string;
-	alt: string;
-};
-
-const imageStyles = css`
-	width: 120px;
-`;
 
 const mediaOverlayContainerStyles = css`
 	position: absolute;
@@ -61,28 +53,26 @@ const headingStyles = css`
 	color: ${palette('--card-headline')};
 `;
 
-const CardPicture = ({ image, alt }: CardPictureProps) => {
-	return (
-		<>
-			<picture>
-				<img alt={alt} src={image} css={imageStyles} />
-			</picture>
-			<div css={mediaOverlayContainerStyles}>
-				<div className="media-overlay" />
-			</div>
-		</>
-	);
-};
-
-export const HostedContentOnwardsCard = ({ trail }: Props) => {
+export const HostedContentOnwardsCard = ({
+	trail,
+	isGalleryPage = false,
+}: Props) => {
 	return (
 		<a href={trail.url} css={linkStyles}>
 			<h3 css={headingStyles}>{trail.headline}</h3>
 			{!!trail.image && (
-				<CardPicture
-					image={trail.image.src}
-					alt={trail.image.altText || ''}
-				/>
+				<>
+					<picture>
+						<img
+							alt={trail.image.altText}
+							src={trail.image.src}
+							style={{ width: isGalleryPage ? '200px' : '120px' }}
+						/>
+					</picture>
+					<div css={mediaOverlayContainerStyles}>
+						<div className="media-overlay" />
+					</div>
+				</>
 			)}
 		</a>
 	);

--- a/dotcom-rendering/src/layouts/HostedArticleLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedArticleLayout.stories.tsx
@@ -30,11 +30,6 @@ const meta = preview.meta({
 	component: HostedArticleLayout,
 	parameters: {
 		config: { darkModeAvailable: true },
-		chromatic: {
-			modes: {
-				'light leftCol': allModes['light leftCol'],
-			},
-		},
 	},
 	render: (args) => {
 		global.fetch = mockOnwardsContentFetch;
@@ -79,6 +74,11 @@ export const Web = meta.story({
 	parameters: {
 		config: {
 			renderingTarget: 'Web',
+		},
+		chromatic: {
+			modes: {
+				'light leftCol': allModes['light leftCol'],
+			},
 		},
 	},
 });
@@ -134,6 +134,11 @@ export const WithoutAccentColour = meta.story({
 		config: {
 			renderingTarget: 'Web',
 		},
+		chromatic: {
+			modes: {
+				'light leftCol': allModes['light leftCol'],
+			},
+		},
 	},
 	decorators: hostedPaletteDecorator(''),
 });
@@ -172,6 +177,11 @@ export const WithoutMainMediaCaption = meta.story({
 	parameters: {
 		config: {
 			renderingTarget: 'Web',
+		},
+		chromatic: {
+			modes: {
+				'light leftCol': allModes['light leftCol'],
+			},
 		},
 	},
 });

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
@@ -2,13 +2,24 @@ import { hostedPaletteDecorator } from '../../.storybook/decorators/themeDecorat
 import { allModes } from '../../.storybook/modes';
 import preview from '../../.storybook/preview';
 import { hostedGallery } from '../../fixtures/manual/hostedGallery';
+import { hostedOnwardsTrails } from '../../fixtures/manual/onwardsTrails';
 import {
 	ArticleDesign,
 	ArticleDisplay,
 	ArticleSpecial,
 } from '../lib/articleFormat';
+import { customMockFetch } from '../lib/mockRESTCalls';
 import { enhanceArticleType } from '../types/article';
 import { HostedGalleryLayout } from './HostedGalleryLayout';
+
+const mockOnwardsContentFetch = customMockFetch([
+	{
+		mockedMethod: 'GET',
+		mockedUrl: `${hostedGallery.config.ajaxUrl}/${hostedGallery.config.pageId}/onward.json`,
+		mockedStatus: 200,
+		mockedBody: { trails: hostedOnwardsTrails },
+	},
+]);
 
 const meta = preview.meta({
 	title: 'Layouts/HostedGallery',
@@ -20,6 +31,10 @@ const meta = preview.meta({
 				'light leftCol': allModes['light leftCol'],
 			},
 		},
+	},
+	render: (args) => {
+		global.fetch = mockOnwardsContentFetch;
+		return <HostedGalleryLayout {...args} />;
 	},
 });
 

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.stories.tsx
@@ -26,11 +26,6 @@ const meta = preview.meta({
 	component: HostedGalleryLayout,
 	parameters: {
 		config: { darkModeAvailable: true },
-		chromatic: {
-			modes: {
-				'light leftCol': allModes['light leftCol'],
-			},
-		},
 	},
 	render: (args) => {
 		global.fetch = mockOnwardsContentFetch;
@@ -83,6 +78,11 @@ export const Web = meta.story({
 	parameters: {
 		config: {
 			renderingTarget: 'Web',
+		},
+		chromatic: {
+			modes: {
+				'light leftCol': allModes['light leftCol'],
+			},
 		},
 	},
 });

--- a/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedGalleryLayout.tsx
@@ -7,11 +7,11 @@ import {
 import { ArticleHeadline } from '../components/ArticleHeadline';
 import { BackToTop } from '../components/BackToTop';
 import { CallToActionButton } from '../components/CallToActionAtom';
+import { FetchHostedOnwards } from '../components/FetchHostedOnwards.island';
 import { GalleryImage } from '../components/GalleryImage';
 import { HostedContentHeader } from '../components/HostedContentHeader.island';
 import { Island } from '../components/Island';
 import { MainMediaGallery } from '../components/MainMediaGallery';
-import { OnwardsUpper } from '../components/OnwardsUpper.island';
 import { Section } from '../components/Section';
 import { ShareButton } from '../components/ShareButton.island';
 import { Standfirst } from '../components/Standfirst';
@@ -78,7 +78,7 @@ const metaStyles = css`
 	}
 `;
 
-const bttStyles = css`
+const paddedContainer = css`
 	${grid.paddedContainer}
 	${grid.outerRules()}
 	background-color: ${palette('--article-inner-background')};
@@ -105,8 +105,17 @@ const ctaButtonStyles = css`
 	margin-right: ${space[3]}px;
 `;
 
+const onwardContentStyles = css`
+	${grid.column.centre}
+	${from.desktop} {
+		${grid.between('centre-column-start', 'right-column-end')}
+	}
+
+	padding-bottom: ${space[5]}px;
+`;
+
 export const HostedGalleryLayout = (props: WebProps | AppProps) => {
-	const { gallery, renderingTarget, format, serverTime } = props;
+	const { gallery, renderingTarget, format } = props;
 	const { frontendData } = gallery;
 	const { commercialProperties, editionId } = frontendData;
 
@@ -149,6 +158,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						format={format}
 						renderingTarget={props.renderingTarget}
 					/>
+
 					<ArticleHeadline
 						format={format}
 						headlineString={frontendData.headline}
@@ -158,6 +168,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 							frontendData.webPublicationDateDeprecated
 						}
 					/>
+
 					<Standfirst
 						format={format}
 						standfirst={frontendData.standfirst}
@@ -188,6 +199,7 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 						)}
 					</div>
 				</header>
+
 				<GalleryBody
 					renderingTarget={renderingTarget}
 					format={format}
@@ -195,34 +207,23 @@ export const HostedGalleryLayout = (props: WebProps | AppProps) => {
 					pageId={frontendData.pageId}
 					webTitle={frontendData.webTitle}
 				/>
-				<div css={bttStyles}>
+
+				<div css={paddedContainer}>
 					<div css={bttPosition}>
 						<BackToTop format={format} />
 					</div>
+
+					<div css={onwardContentStyles}>
+						<Island priority="feature" defer={{ until: 'idle' }}>
+							<FetchHostedOnwards
+								url={`${frontendData.config.ajaxUrl}/${frontendData.config.pageId}/onward.json`}
+								branding={branding}
+								isGalleryPage={true}
+							/>
+						</Island>
+					</div>
 				</div>
 			</main>
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<OnwardsUpper
-					ajaxUrl={frontendData.config.ajaxUrl}
-					hasRelated={frontendData.hasRelated}
-					hasStoryPackage={frontendData.hasStoryPackage}
-					isAdFreeUser={frontendData.isAdFreeUser}
-					pageId={frontendData.pageId}
-					isPaidContent={!!frontendData.config.isPaidContent}
-					showRelatedContent={frontendData.config.showRelatedContent}
-					keywordIds={frontendData.config.keywordIds}
-					contentType={frontendData.contentType}
-					tags={frontendData.tags}
-					format={format}
-					pillar={format.theme}
-					editionId={frontendData.editionId}
-					shortUrlId={frontendData.config.shortUrlId}
-					discussionApiUrl={frontendData.config.discussionApiUrl}
-					serverTime={serverTime}
-					renderingTarget={renderingTarget}
-					webURL={frontendData.webURL}
-				/>
-			</Island>
 		</>
 	);
 };

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.stories.tsx
@@ -29,11 +29,6 @@ const meta = preview.meta({
 	component: HostedVideoLayout,
 	parameters: {
 		config: { darkModeAvailable: true },
-		chromatic: {
-			modes: {
-				'light leftCol': allModes['light leftCol'],
-			},
-		},
 	},
 	render: (args) => {
 		global.fetch = mockOnwardsContentFetch;
@@ -76,6 +71,11 @@ export const Web = meta.story({
 	parameters: {
 		config: {
 			renderingTarget: 'Web',
+		},
+		chromatic: {
+			modes: {
+				'light leftCol': allModes['light leftCol'],
+			},
 		},
 	},
 });

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2571,7 +2571,12 @@ const cardMediaBackgroundDark: PaletteFunction = () =>
 const cardMediaWaveformLight: PaletteFunction = () => sourcePalette.neutral[86];
 const cardMediaWaveformDark: PaletteFunction = () => sourcePalette.neutral[38];
 
-const cardHeadlineTextLight: PaletteFunction = () => sourcePalette.neutral[7];
+const cardHeadlineTextLight: PaletteFunction = (format) => {
+	if (format.design === ArticleDesign.HostedGallery) {
+		return sourcePalette.neutral[97];
+	}
+	return sourcePalette.neutral[7];
+};
 
 const cardTextDark: PaletteFunction = () => sourcePalette.neutral[86];
 
@@ -5795,6 +5800,15 @@ const discussionLoadingShimmerLight: PaletteFunction = () =>
 const discussionLoadingShimmerDark: PaletteFunction = () =>
 	sourcePalette.neutral[46];
 
+const onwardTextLight: PaletteFunction = (format) => {
+	if (format.design === ArticleDesign.HostedGallery) {
+		return sourcePalette.neutral[86];
+	}
+	return sourcePalette.neutral[7];
+};
+
+const onwardTextDark: PaletteFunction = () => sourcePalette.neutral[86];
+
 const paginationTextLight: PaletteFunction = ({ theme }) => {
 	switch (theme) {
 		case Pillar.News:
@@ -7488,10 +7502,6 @@ const paletteColours = {
 		light: highlightContainerStartLight,
 		dark: highlightContainerStartDark,
 	},
-	'--hosted-content-onwards-heading': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[86],
-	},
 	'--image-title-background': {
 		light: imageTitleBackground,
 		dark: imageTitleBackground,
@@ -7841,8 +7851,8 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[20],
 	},
 	'--onward-text': {
-		light: () => sourcePalette.neutral[7],
-		dark: () => sourcePalette.neutral[86],
+		light: onwardTextLight,
+		dark: onwardTextDark,
 	},
 	'--pagination-text': {
 		light: paginationTextLight,


### PR DESCRIPTION
## What does this change?

Adds onward content to Hosted Gallery pages. 

Does this by re-using the existing onward component for hosted content and adapting it slightly for gallery pages by using a larger image size and switching to a row display from desktop upwards

This doesn't strictly follow the designs provided but uses the component that already exists as a step towards the final result. This should allow us to release these pages and iterate on them in the background

### Additional changes

- Fixing storybook theming for hosted content pages
- Updating storybook modes (ie breakpoints) for the hosted layout story variations in web vs apps
- Small CSS fix to remove vertical rule between desktop and leftCol breakpoints by setting it to a transparent colour


## Why?

We're migrating Hosted Gallery pages from frontend to DCR

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |
| ![before3][] | ![after3][] |

[before]: https://github.com/user-attachments/assets/e69f33f8-41aa-47d2-b096-b49f4ffa97c9
[after]: https://github.com/user-attachments/assets/7d15d4ba-025d-4df8-a200-8b191348fbe9

[before2]:https://github.com/user-attachments/assets/08c67aca-1ea4-4685-9472-0007acc723c2
[after2]:https://github.com/user-attachments/assets/9af24508-c094-4315-a4d5-8fe203e56d8f

[before3]:https://github.com/user-attachments/assets/77385aad-c9f1-4ae3-8505-8d0b8b390b3a
[after3]:https://github.com/user-attachments/assets/d49ce21c-3b6d-4e1f-805b-47b68ae75f7d
