### PR TITLE
Remove some gallery-specific styling from section link

### DIFF
--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -86,9 +86,13 @@ const invertedStyle = css`
 	/* Handle text wrapping onto a new line */
 	white-space: pre-wrap;
 	box-decoration-break: clone;
-	padding-right: ${space[2]}px;
+	line-height: 28px;
+	padding-right: ${space[1]}px;
 	padding-top: ${space[1]}px;
 	padding-bottom: ${space[2]}px;
+	${from.wide} {
+		line-height: 28px;
+	}
 `;
 
 const fontStyles = (format: ArticleFormat) => {
@@ -180,7 +184,7 @@ const sectionPadding = css`
 		padding-left: 18px;
 	}
 	${from.tablet} {
-		padding-left: ${space[3]}px;
+		padding-left: ${space[1]}px;
 	}
 `;
 

--- a/dotcom-rendering/src/components/SeriesSectionLink.tsx
+++ b/dotcom-rendering/src/components/SeriesSectionLink.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-	between,
 	from,
 	headlineBold17,
 	headlineBold20,
@@ -83,23 +82,14 @@ const marginRight = css`
 	}
 `;
 
-const invertedStyle = (design: ArticleDesign) => {
-	if (design === ArticleDesign.Gallery) {
-		return '';
-	}
-	return css`
-		/* Handle text wrapping onto a new line */
-		white-space: pre-wrap;
-		box-decoration-break: clone;
-		line-height: 28px;
-		${from.leftCol} {
-			line-height: 28px;
-		}
-		padding-right: ${space[1]}px;
-		padding-top: ${space[1]}px;
-		padding-bottom: ${space[3]}px;
-	`;
-};
+const invertedStyle = css`
+	/* Handle text wrapping onto a new line */
+	white-space: pre-wrap;
+	box-decoration-break: clone;
+	padding-right: ${space[2]}px;
+	padding-top: ${space[1]}px;
+	padding-bottom: ${space[2]}px;
+`;
 
 const fontStyles = (format: ArticleFormat) => {
 	switch (format.design) {
@@ -184,26 +174,15 @@ const breakWord = css`
 	word-break: break-word;
 `;
 
-const sectionPadding = (design: ArticleDesign) => {
-	if (design === ArticleDesign.Gallery) {
-		return css`
-			padding: 0 ${space[2]}px 0 ${space[3]}px;
-
-			${between.mobileLandscape.and.tablet} {
-				padding-left: ${space[5]}px;
-			}
-		`;
+const sectionPadding = css`
+	padding-left: 10px;
+	${from.mobileLandscape} {
+		padding-left: 18px;
 	}
-	return css`
-		padding-left: 10px;
-		${from.mobileLandscape} {
-			padding-left: 18px;
-		}
-		${from.tablet} {
-			padding-left: ${space[1]}px;
-		}
-	`;
-};
+	${from.tablet} {
+		padding-left: ${space[3]}px;
+	}
+`;
 
 export const SeriesSectionLink = ({
 	format,
@@ -358,9 +337,9 @@ export const SeriesSectionLink = ({
 						css={[
 							sectionLabelLink,
 							fontStyles(format),
-							invertedStyle(format.design),
+							invertedStyle,
 							breakWord,
-							sectionPadding(format.design),
+							sectionPadding,
 							css`
 								color: ${titleColour};
 								background-color: ${themePalette(
@@ -369,7 +348,6 @@ export const SeriesSectionLink = ({
 							`,
 							format.design === ArticleDesign.Gallery &&
 								css`
-									display: inline-block;
 									position: relative;
 								`,
 							format.display === ArticleDisplay.Immersive &&


### PR DESCRIPTION
## What does this change?

Removes some gallery-specific styling from the section link, bringing it into line with other content types. Ostensibly we want the background of the section link to only appear behind the text, not to take up the full width of the header.

## Why?

The gallery-specific styles were introduced when gallery series were migrated to DCAR in #14060. It's possible we didn't test with long series titles ([example](https://www.theguardian.com/environment/gallery/2026/jul/03/brazil-ruined-utopias-afterlife-amazon-forgotten-company-towns)).

Alternative to #16315

## Screenshots

### Mobile

| Before      | After      |
| ----------- | ---------- |
| ![before-mobile][] | ![after-mobile][] |

[before-mobile]: https://github.com/user-attachments/assets/e5b07609-ba86-4dbc-a70d-f171f4cc3e8d
[after-mobile]: https://github.com/user-attachments/assets/9a765604-939c-4f12-9fbb-e438643ee4f8

### Tablet

| Before      | After      |
| ----------- | ---------- |
| ![before-tablet][] | ![after-tablet][] |

[before-tablet]: https://github.com/user-attachments/assets/2a0f9c1e-b761-4d29-b738-040d11d6e292
[after-tablet]: https://github.com/user-attachments/assets/016f9119-e470-4ab8-b11b-921c5bfac064

### Desktop

| Before      | After      |
| ----------- | ---------- |
| ![before-desktop][] | ![after-desktop][] |

[before-desktop]: https://github.com/user-attachments/assets/3fec2b1c-8dc7-4ee1-9985-2a844a4a8dea
[after-desktop]: https://github.com/user-attachments/assets/b32de128-a415-401a-a625-9c514433b5eb

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

