### PR TITLE
Add Ozone outstream 0% AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -134,6 +134,18 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-ozone-outstream",
+		description: "A test to ensure correct integration of Ozone outstream.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-09-23",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
+	},
+	{
 		name: "fronts-and-curation-loop-click-through",
 		description:
 			"Test impact of click to article via loop videos on fronts",


### PR DESCRIPTION
## What does this change?

Adds a new 0% AB test: `commercial-ozone-outstream`

## Why?

So that we can test a new Ozone outstream integration before sending the feature live.

Related Commercial PR: https://github.com/guardian/commercial/pull/2611

## Opt in links:
- LOCAL suffix ?ab-commercial-ozone-outstream=variant
- CODE http://code.dev-theguardian.com/ab-tests/opt-in/commercial-ozone-outstream:variant
- PROD http://theguardian.com/ab-tests/opt-in/commercial-ozone-outstream:variant