### PR TITLE
chore(deps): Update GuCDK from 63.6.2 to 64.0.0

### DIFF
--- a/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
@@ -2,7 +2,7 @@ exports[`The ID5 Baton Lambda stack > matches the CODE snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Parameters": {
     "BuildId": {
@@ -46,7 +46,7 @@ exports[`The ID5 Baton Lambda stack > matches the PROD snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Parameters": {
     "BuildId": {

--- a/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -55,7 +55,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -294,7 +294,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -327,7 +327,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -377,7 +377,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -616,7 +616,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -10,7 +10,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -24,7 +24,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -113,7 +113,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -166,7 +166,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -340,7 +340,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -452,7 +452,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -494,7 +494,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "63.6.2"
+    "gu:cdk:version": "64.0.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -508,7 +508,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -597,7 +597,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -660,7 +660,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -834,7 +834,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -869,7 +869,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",
@@ -1006,7 +1006,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "63.6.2"
+            "Value": "64.0.0"
           },
           {
             "Key": "gu:repo",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -216,6 +216,27 @@ export class RenderingCDKStack extends CDKStack {
 			certificateProps: { domainName },
 			healthcheck: { path: '/_healthcheck' },
 			monitoringConfiguration,
+			additionalPolicies: [
+				new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
+					actions: ['cloudwatch:*', 'logs:*'],
+					resources: ['*'],
+				}),
+				new GuAllowPolicy(this, 'AllowPolicyDescribeDecryptKms', {
+					actions: ['kms:Decrypt', 'kms:DescribeKey'],
+					resources: [
+						`arn:aws:kms:${region}:${account}:FrontendConfigKey`,
+					],
+				}),
+				new GuAllowPolicy(this, 'AllowPolicyGetSsmParamsByPath', {
+					actions: ['ssm:GetParametersByPath', 'ssm:GetParameter'],
+					resources: [
+						// This is for backwards compatibility reasons with frontend apps and an old SSM naming system
+						// TODO - ideally we should convert these params to use the newer naming style for consistency
+						`arn:aws:ssm:${region}:${this.account}:parameter/frontend/*`,
+						`arn:aws:ssm:${region}:${this.account}:parameter/dotcom/*`,
+					],
+				}),
+			],
 			ec2Props: {
 				instanceMetricGranularity: '1Minute',
 				applicationLogging: {
@@ -223,40 +244,6 @@ export class RenderingCDKStack extends CDKStack {
 					systemdUnitName: guApp,
 				},
 				instanceType,
-				roleConfiguration: {
-					additionalPolicies: [
-						new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
-							actions: ['cloudwatch:*', 'logs:*'],
-							resources: ['*'],
-						}),
-						new GuAllowPolicy(
-							this,
-							'AllowPolicyDescribeDecryptKms',
-							{
-								actions: ['kms:Decrypt', 'kms:DescribeKey'],
-								resources: [
-									`arn:aws:kms:${region}:${account}:FrontendConfigKey`,
-								],
-							},
-						),
-						new GuAllowPolicy(
-							this,
-							'AllowPolicyGetSsmParamsByPath',
-							{
-								actions: [
-									'ssm:GetParametersByPath',
-									'ssm:GetParameter',
-								],
-								resources: [
-									// This is for backwards compatibility reasons with frontend apps and an old SSM naming system
-									// TODO - ideally we should convert these params to use the newer naming style for consistency
-									`arn:aws:ssm:${region}:${this.account}:parameter/frontend/*`,
-									`arn:aws:ssm:${region}:${this.account}:parameter/dotcom/*`,
-								],
-							},
-						),
-					],
-				},
 				scaling,
 				userData: getUserData({
 					guApp,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.995.0
       version: 3.995.0
     '@guardian/cdk':
-      specifier: 63.6.2
-      version: 63.6.2
+      specifier: 64.0.0
+      version: 64.0.0
     '@guardian/eslint-config':
       specifier: 14.0.1
       version: 14.0.1
@@ -121,7 +121,7 @@ importers:
         version: 3.995.0
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 63.6.2(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)
+        version: 64.0.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)
       '@guardian/tsconfig':
         specifier: 'catalog:'
         version: 1.0.1
@@ -325,7 +325,7 @@ importers:
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 63.6.2(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)
+        version: 64.0.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)
       '@guardian/commercial-core':
         specifier: 34.0.0
         version: 34.0.0(@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))
@@ -2520,8 +2520,8 @@ packages:
       browserslist: ^4.22.2
       tslib: ^2.6.2
 
-  '@guardian/cdk@63.6.2':
-    resolution: {integrity: sha512-1hZW9KwCkV28i38l7aMPPobxFpdq+yv720qCOPi6TKCFz2jZ4/zfS/w1RSurExwccpsiX9PB25AtD8M+kdD2KA==}
+  '@guardian/cdk@64.0.0':
+    resolution: {integrity: sha512-DWDV+P81uRi9kPO4gw+9jmBF3fYsE4LA5Q000Q4aYTG0TM+THOeJMsp49clJRTLkNCDIbXzzw7uMRD0OpAlSqQ==}
     hasBin: true
     peerDependencies:
       aws-cdk: ^2.1110.0
@@ -11958,7 +11958,7 @@ snapshots:
       browserslist: 4.24.4
       tslib: 2.6.2
 
-  '@guardian/cdk@63.6.2(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)':
+  '@guardian/cdk@64.0.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(aws-cdk@2.1128.1)(constructs@10.6.0)':
     dependencies:
       '@aws-sdk/client-ec2': 3.1053.0
       '@aws-sdk/client-ssm': 3.1053.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ blockExoticSubdeps: true
 catalog:
   '@aws-sdk/client-s3': 3.995.0
   '@aws-sdk/client-ssm': 3.995.0
-  '@guardian/cdk': 63.6.2
+  '@guardian/cdk': 64.0.0
   '@guardian/eslint-config': 14.0.1
   '@guardian/tsconfig': 1.0.1
   '@rollup/plugin-commonjs': 29.0.0


### PR DESCRIPTION
## What does this change?
Updates GuCDK to the latest version. See https://github.com/guardian/cdk/releases/tag/v64.0.0.

This change is a no-op, as demonstrated by the lack of changes to the snapshot[^1].

## Why?
This version of GuCDK includes changes that allow the sharing of IAM Policies between EC2 and ECS. This is necessary for the "run DCR on ECS" trial.

[^1]: There are changes to `gu:cdk:version` in the snapshot as we've not setup [mocking](https://github.com/guardian/cdk/blob/main/docs/best-practices.md#snapshot-testing)). These are non-functional changes however.