### PR TITLE
feat: New logging category for containerised runtime

### DIFF
--- a/Production.dockerfile
+++ b/Production.dockerfile
@@ -23,9 +23,7 @@ FROM dhi.io/node:24-alpine3.23 AS application
 WORKDIR /app
 COPY --from=builder --chown=node:node /app/dotcom-rendering/dist /app
 
-# Disable logging with Log4js as console logs will be forwarded to Central ELK with a sidecar
-# TODO Maintain metrics
-ENV DISABLE_LOGGING_AND_METRICS=true
+ENV GU_CONTAINER=true
 ENV NODE_ENV=production
 
 # Expose the port that the application listens on

--- a/Production.dockerfile
+++ b/Production.dockerfile
@@ -23,7 +23,6 @@ FROM dhi.io/node:24-alpine3.23 AS application
 WORKDIR /app
 COPY --from=builder --chown=node:node /app/dotcom-rendering/dist /app
 
-ENV GU_CONTAINER=true
 ENV NODE_ENV=production
 
 # Expose the port that the application listens on

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -110,6 +110,7 @@ const enableLog4js: Configuration = {
 		production: { appenders: ['out', 'fileAppender'], level: 'info' },
 		code: { appenders: ['out', 'fileAppender'], level: 'debug' },
 		development: { appenders: ['console'], level: 'debug' },
+		container: { appenders: ['out'], level: 'info' },
 	},
 	// log4js cluster mode handling does not work as it prevents
 	// logs from processes other than the main process from
@@ -142,6 +143,9 @@ const getLoggerCategory = (): string => {
 		return 'development';
 	}
 	if (process.env.NODE_ENV === 'production') {
+		if (process.env.GU_CONTAINER === 'true') {
+			return 'container';
+		}
 		return process.env.GU_STAGE === 'CODE' ? 'code' : 'production';
 	}
 	return 'default';

--- a/dotcom-rendering/src/server/lib/logging.ts
+++ b/dotcom-rendering/src/server/lib/logging.ts
@@ -139,13 +139,17 @@ const getLoggerCategory = (): string => {
 	if (process.env.DISABLE_LOGGING_AND_METRICS === 'true') {
 		return 'off';
 	}
+
+	// Are we running in a container?
+	// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
+	if (process.env.AWS_EXECUTION_ENV?.startsWith('AWS_ECS_') === true) {
+		return 'container';
+	}
+
 	if (process.env.NODE_ENV === 'development') {
 		return 'development';
 	}
 	if (process.env.NODE_ENV === 'production') {
-		if (process.env.GU_CONTAINER === 'true') {
-			return 'container';
-		}
 		return process.env.GU_STAGE === 'CODE' ? 'code' : 'production';
 	}
 	return 'default';


### PR DESCRIPTION
## What does this change?
When running in a container, configure log4js to write info logs to stdout. These logs will then be processed by a sidecar, e.g. https://github.com/guardian/devx-logs/tree/main/ecs.

## Why?
Application logs are useful for incident triage.

---

Closes https://github.com/guardian/dotcom-rendering/issues/16264.