### PR TITLE
Revert "Use USE_LOCAL_ASSETS env var to determine path for assets"

### DIFF
--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -11,6 +11,5 @@ EXPOSE 9000
 
 ENV DISABLE_LOGGING_AND_METRICS=true
 ENV NODE_ENV=production
-ENV USE_LOCAL_ASSETS=true
 
 ENTRYPOINT ["node", "article-rendering/dist/server.js"]

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -43,12 +43,10 @@ prod:
 	NODE_ENV=production node dist/server.js
 
 prod-local: export DISABLE_LOGGING_AND_METRICS = true
-prod-local: export USE_LOCAL_ASSETS = true
 prod-local: prod
 
 # dev #########################################
 
-dev: export USE_LOCAL_ASSETS = true
 dev: clear clean-dist install
 	$(call log, "starting DEV server")
 	@NODE_ENV=development webpack serve --config ./webpack/webpack.config.js

--- a/dotcom-rendering/src/client/decidePublicPath.test.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.test.ts
@@ -1,5 +1,14 @@
 import { decidePublicPath } from './decidePublicPath';
 
+const mockHostname = (hostname: string | undefined) => {
+	Object.defineProperty(window, 'location', {
+		value: {
+			hostname,
+		},
+		writable: true,
+	});
+};
+
 const mockFrontendAssetsFullURL = (frontendAssetsFullURL: string) => {
 	Object.defineProperty(window, 'guardian', {
 		value: {
@@ -15,13 +24,26 @@ describe('decidePublicPath', () => {
 	beforeEach(() => {
 		jest.resetModules();
 
+		mockHostname(undefined);
+
 		mockFrontendAssetsFullURL('https://assets.guim.co.uk/');
 
-		process.env = { USE_LOCAL_ASSETS: undefined };
+		process.env = { NODE_ENV: undefined, HOSTNAME: undefined };
 	});
 
-	it('with USE_LOCAL_ASSETS flag', () => {
-		process.env.USE_LOCAL_ASSETS = 'true';
+	it('with development flag', () => {
+		process.env.NODE_ENV = 'development';
+		expect(decidePublicPath()).toEqual('/assets/');
+	});
+
+	it('with production flag', () => {
+		process.env.NODE_ENV = 'production';
+		expect(decidePublicPath()).toEqual('https://assets.guim.co.uk/assets/');
+	});
+
+	it('with production flag and localhost', () => {
+		process.env.NODE_ENV = 'production';
+		mockHostname('localhost');
 		expect(decidePublicPath()).toEqual('/assets/');
 	});
 

--- a/dotcom-rendering/src/client/decidePublicPath.ts
+++ b/dotcom-rendering/src/client/decidePublicPath.ts
@@ -4,9 +4,10 @@
  * @returns The webpack public path to use
  */
 export const decidePublicPath = (): string => {
-	const useLocalAssets = process.env.USE_LOCAL_ASSETS === 'true';
-
-	return useLocalAssets
+	const isDev = process.env.NODE_ENV === 'development';
+	const isLocalHost = window.location.hostname === 'localhost';
+	// Use relative path if running locally or in CI
+	return isDev || isLocalHost
 		? '/assets/'
 		: `${window.guardian.config.frontendAssetsFullURL}assets/`;
 };

--- a/dotcom-rendering/webpack/webpack.config.js
+++ b/dotcom-rendering/webpack/webpack.config.js
@@ -60,9 +60,6 @@ const commonConfigs = ({ platform }) => ({
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 			'process.env.HOSTNAME': JSON.stringify(process.env.HOSTNAME),
-			'process.env.USE_LOCAL_ASSETS': JSON.stringify(
-				process.env.USE_LOCAL_ASSETS,
-			),
 		}),
 		// Matching modules specified in this regex will not be imported during the webpack build
 		// We use this if there are optional dependencies (e.g in jsdom, ws) to remove uneccesary warnings in our builds / console outpouts.


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#16256, as it's causing playwright tests to flake for reasons I do not yet understand.