### PR TITLE
Spike: support atoms on fronts

### DIFF
--- a/dotcom-rendering/src/components/Card/Card.tsx
+++ b/dotcom-rendering/src/components/Card/Card.tsx
@@ -35,6 +35,7 @@ import { CardCommentCount } from '../CardCommentCount.island';
 import { CardHeadline, type ResponsiveFontSize } from '../CardHeadline';
 import type { Loading } from '../CardPicture';
 import { CardPicture } from '../CardPicture';
+import { CardSnapAtom } from '../CardSnapAtom';
 import { Island } from '../Island';
 import { LatestLinks } from '../LatestLinks.island';
 import { Pill } from '../Pill';
@@ -506,6 +507,12 @@ export const Card = ({
 				<Snap snapData={snapData} dataLinkName={dataLinkName} />
 			</SnapCssSandbox>
 		);
+	}
+
+	// SPIKE: render an atom (guide, Q&A, profile, timeline, audio, explainer or
+	// CTA) that arrived on a front as a `LinkSnap`.
+	if (snapData?.atoms) {
+		return <CardSnapAtom atoms={snapData.atoms} />;
 	}
 
 	// Determine if the card is used within a gallery article

--- a/dotcom-rendering/src/components/CardSnapAtom.tsx
+++ b/dotcom-rendering/src/components/CardSnapAtom.tsx
@@ -1,0 +1,117 @@
+import type { SnapAtoms } from '../types/front';
+import { AudioAtomWrapper } from './AudioAtomWrapper.island';
+import { CallToActionAtom } from './CallToActionAtom';
+import { ExplainerAtom } from './ExplainerAtom';
+import { GuideAtomWrapper } from './GuideAtomWrapper.island';
+import { Island } from './Island';
+import { ProfileAtomWrapper } from './ProfileAtomWrapper.island';
+import { QandaAtom } from './QandaAtom.island';
+import { TimelineAtom } from './TimelineAtom.island';
+
+type Props = {
+	atoms: SnapAtoms;
+};
+
+/**
+ * Renders an atom (guide, Q&A, profile, timeline, audio, explainer or CTA) that
+ * has been placed on a front as a snap and pre-fetched by facia-press.
+ *
+ * Mirrors the equivalent atom cases in `renderElement`, keeping the conditional
+ * atom logic out of `Card`.
+ */
+export const CardSnapAtom = ({ atoms }: Props) => {
+	if (atoms.guide) {
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<GuideAtomWrapper
+					id={atoms.guide.id}
+					title={atoms.guide.title}
+					html={atoms.guide.html}
+					image={atoms.guide.img}
+					credit={atoms.guide.credit}
+				/>
+			</Island>
+		);
+	}
+
+	if (atoms.qanda) {
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<QandaAtom
+					id={atoms.qanda.id}
+					title={atoms.qanda.title}
+					html={atoms.qanda.html}
+					image={atoms.qanda.img}
+					credit={atoms.qanda.credit}
+				/>
+			</Island>
+		);
+	}
+
+	if (atoms.profile) {
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<ProfileAtomWrapper
+					id={atoms.profile.id}
+					title={atoms.profile.title}
+					html={atoms.profile.html}
+					image={atoms.profile.img}
+					credit={atoms.profile.credit}
+				/>
+			</Island>
+		);
+	}
+
+	if (atoms.timeline) {
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<TimelineAtom
+					id={atoms.timeline.id}
+					title={atoms.timeline.title}
+					events={atoms.timeline.events}
+					description={atoms.timeline.description}
+				/>
+			</Island>
+		);
+	}
+
+	if (atoms.audio) {
+		return (
+			<Island priority="critical" defer={{ until: 'visible' }}>
+				<AudioAtomWrapper
+					id={atoms.audio.id}
+					trackUrl={atoms.audio.trackUrl}
+					kicker={atoms.audio.kicker}
+					title={atoms.audio.title}
+					duration={atoms.audio.duration}
+					contentIsNotSensitive={true}
+					aCastisEnabled={false}
+					readerCanBeShownAds={false}
+				/>
+			</Island>
+		);
+	}
+
+	if (atoms.explainer) {
+		return (
+			<ExplainerAtom
+				id={atoms.explainer.id}
+				title={atoms.explainer.title}
+				html={atoms.explainer.body}
+			/>
+		);
+	}
+
+	if (atoms.cta) {
+		return (
+			<CallToActionAtom
+				linkUrl={atoms.cta.url}
+				backgroundImage={atoms.cta.image}
+				text={atoms.cta.label}
+				buttonText={atoms.cta.btnText}
+			/>
+		);
+	}
+
+	return null;
+};

--- a/dotcom-rendering/src/components/CardSnapAtom.tsx
+++ b/dotcom-rendering/src/components/CardSnapAtom.tsx
@@ -2,10 +2,11 @@ import type { SnapAtoms } from '../types/front';
 import { AudioAtomWrapper } from './AudioAtomWrapper.island';
 import { CallToActionAtom } from './CallToActionAtom';
 import { ExplainerAtom } from './ExplainerAtom';
+import { FootballCompetitionAtom } from './FootballCompetitionAtom.island';
 import { GuideAtomWrapper } from './GuideAtomWrapper.island';
 import { Island } from './Island';
 import { ProfileAtomWrapper } from './ProfileAtomWrapper.island';
-import { QandaAtom } from './QandaAtom.island';
+// import { QandaAtom } from './QandaAtom.island';
 import { TimelineAtom } from './TimelineAtom.island';
 
 type Props = {
@@ -20,6 +21,7 @@ type Props = {
  * atom logic out of `Card`.
  */
 export const CardSnapAtom = ({ atoms }: Props) => {
+	console.log('test');
 	if (atoms.guide) {
 		return (
 			<Island priority="feature" defer={{ until: 'visible' }}>
@@ -35,17 +37,33 @@ export const CardSnapAtom = ({ atoms }: Props) => {
 	}
 
 	if (atoms.qanda) {
-		return (
-			<Island priority="feature" defer={{ until: 'visible' }}>
-				<QandaAtom
-					id={atoms.qanda.id}
-					title={atoms.qanda.title}
-					html={atoms.qanda.html}
-					image={atoms.qanda.img}
-					credit={atoms.qanda.credit}
-				/>
-			</Island>
-		);
+		const mockData = {
+			competitionId: '700',
+			footballCompetitionComponentType: 'match-day',
+		};
+
+		// for testing until the capi flow is setup
+		if (mockData) {
+			return (
+				<Island priority="feature" defer={{ until: 'visible' }}>
+					<FootballCompetitionAtom
+						footballCompetitionData={mockData}
+					/>
+				</Island>
+			);
+		}
+
+		//  // return (
+		//  //  <Island priority="feature" defer={{ until: 'visible' }}>
+		//  //      <QandaAtom
+		//  //          id={atoms.qanda.id}
+		//  //          title={atoms.qanda.title}
+		//  //          html={atoms.qanda.html}
+		//  //          image={atoms.qanda.img}
+		//  //          credit={atoms.qanda.credit}
+		//  //      />
+		//  //  </Island>
+		//  // );
 	}
 
 	if (atoms.profile) {
@@ -112,6 +130,14 @@ export const CardSnapAtom = ({ atoms }: Props) => {
 			/>
 		);
 	}
+
+	// if (atoms.footballcompetition) {
+	// 	return (
+	// 		<FootballCompetitionAtom
+	// 			footballCompetitionData={atoms.footballcompetition}
+	// 		/>
+	// 	);
+	// }
 
 	return null;
 };

--- a/dotcom-rendering/src/components/CardSnapAtom.tsx
+++ b/dotcom-rendering/src/components/CardSnapAtom.tsx
@@ -6,7 +6,7 @@ import { FootballCompetitionAtom } from './FootballCompetitionAtom.island';
 import { GuideAtomWrapper } from './GuideAtomWrapper.island';
 import { Island } from './Island';
 import { ProfileAtomWrapper } from './ProfileAtomWrapper.island';
-// import { QandaAtom } from './QandaAtom.island';
+import { QandaAtom } from './QandaAtom.island';
 import { TimelineAtom } from './TimelineAtom.island';
 
 type Props = {
@@ -37,33 +37,17 @@ export const CardSnapAtom = ({ atoms }: Props) => {
 	}
 
 	if (atoms.qanda) {
-		const mockData = {
-			competitionId: '700',
-			footballCompetitionComponentType: 'match-day',
-		};
-
-		// for testing until the capi flow is setup
-		if (mockData) {
-			return (
-				<Island priority="feature" defer={{ until: 'visible' }}>
-					<FootballCompetitionAtom
-						footballCompetitionData={mockData}
-					/>
-				</Island>
-			);
-		}
-
-		//  // return (
-		//  //  <Island priority="feature" defer={{ until: 'visible' }}>
-		//  //      <QandaAtom
-		//  //          id={atoms.qanda.id}
-		//  //          title={atoms.qanda.title}
-		//  //          html={atoms.qanda.html}
-		//  //          image={atoms.qanda.img}
-		//  //          credit={atoms.qanda.credit}
-		//  //      />
-		//  //  </Island>
-		//  // );
+		return (
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<QandaAtom
+					id={atoms.qanda.id}
+					title={atoms.qanda.title}
+					html={atoms.qanda.html}
+					image={atoms.qanda.img}
+					credit={atoms.qanda.credit}
+				/>
+			</Island>
+		);
 	}
 
 	if (atoms.profile) {
@@ -131,13 +115,13 @@ export const CardSnapAtom = ({ atoms }: Props) => {
 		);
 	}
 
-	// if (atoms.footballcompetition) {
-	// 	return (
-	// 		<FootballCompetitionAtom
-	// 			footballCompetitionData={atoms.footballcompetition}
-	// 		/>
-	// 	);
-	// }
+	if (atoms.tempfootballcompetition) {
+		return (
+			<FootballCompetitionAtom
+				footballCompetitionData={atoms.tempfootballcompetition}
+			/>
+		);
+	}
 
 	return null;
 };

--- a/dotcom-rendering/src/components/CardSnapAtom.tsx
+++ b/dotcom-rendering/src/components/CardSnapAtom.tsx
@@ -21,7 +21,6 @@ type Props = {
  * atom logic out of `Card`.
  */
 export const CardSnapAtom = ({ atoms }: Props) => {
-	console.log('test');
 	if (atoms.guide) {
 		return (
 			<Island priority="feature" defer={{ until: 'visible' }}>
@@ -117,9 +116,11 @@ export const CardSnapAtom = ({ atoms }: Props) => {
 
 	if (atoms.tempfootballcompetition) {
 		return (
-			<FootballCompetitionAtom
-				footballCompetitionData={atoms.tempfootballcompetition}
-			/>
+			<Island priority="feature" defer={{ until: 'visible' }}>
+				<FootballCompetitionAtom
+					footballCompetitionData={atoms.tempfootballcompetition}
+				/>
+			</Island>
 		);
 	}
 

--- a/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
@@ -1,0 +1,84 @@
+import useSWR from 'swr';
+import { omit, safeParse } from 'valibot';
+import { parse as parseFootballMatches } from '../footballMatches';
+import { feFootballMatchDaySchema } from '../frontend/feFootballMatchDay';
+import { FootballMatchDay } from './FootballMatchDay';
+
+type Props = {
+	footballCompetitionData: {
+		competitionId: string;
+		footballCompetitionComponentType: string;
+	};
+};
+
+// The public match-day JSON endpoint returns the full DCR page payload, which
+// does not include the `competitionTag` field that the embed endpoint provides.
+// We therefore validate the fields we actually receive and derive the tag from
+// the first competition's URL below.
+const matchDayResponseSchema = omit(feFootballMatchDaySchema, [
+	'competitionTag',
+]);
+
+const fetcher = (url: string): Promise<unknown> =>
+	fetch(url).then((res) => res.json());
+
+export const FootballCompetitionAtom = ({
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- retained for the eventual production mapping of competition id to endpoint URL
+	footballCompetitionData,
+}: Props) => {
+	// competition id is e.g. 700, so need to map to a competition name, e.g. Premier League, La Liga, etc.
+	// the endpoint is hardcoded and irrespective of the competition, so we can comment the below out
+	// production use of this component would imply using the map to adjust the fetched url with the relevant competition name
+	// const competitionIdToNameMap: Record<string, string> = {
+	//  700: 'world-cup-2026',
+	//  100: 'premier-league',
+	// };
+
+	const { data, error } = useSWR<unknown, Error>(
+		///
+		// `https://api.nextgen.guardianapps.co.uk/football/${footballCompetitionData.competitionId}/embed?season=2023`,
+		// https://www.theguardian.com/football/world-cup-2026/live.json?dcr=true
+		// production use of this component would likely require using the live endpoint, but this will only return data if there's an actual match on the day
+		// for testing purposes, we can hardcode a match day endpoint to return data for a specific date, e.g. 2026-07-09, which provides at least one result
+		'https://api.nextgen.guardianapps.co.uk/football/match-day/2026/jul/09.json?dcr=true',
+		fetcher,
+	);
+
+	if (error) {
+		return <div>Failed to load football data</div>;
+	}
+
+	// SWR returns `undefined` for `data` until the request resolves.
+	if (data === undefined) {
+		return <div>Loading…</div>;
+	}
+
+	const validated = safeParse(matchDayResponseSchema, data);
+	if (!validated.success) {
+		return <div>Unexpected football data shape</div>;
+	}
+
+	const { matchesList, editionId, guardianBaseURL } = validated.output;
+
+	const parsedMatches = parseFootballMatches(matchesList);
+	if (!parsedMatches.ok) {
+		return <div>Could not parse football matches</div>;
+	}
+
+	// Derive the competition tag (e.g. "world-cup-2026") from the first
+	// competition's URL (e.g. "/football/world-cup-2026").
+	const competitionTag =
+		matchesList[0]?.competitionMatches[0]?.competitionSummary.url.replace(
+			'/football/',
+			'',
+		) ?? '';
+
+	return (
+		<FootballMatchDay
+			competitionTag={competitionTag}
+			matches={parsedMatches.value}
+			guardianBaseUrl={guardianBaseURL}
+			edition={editionId}
+		/>
+	);
+};

--- a/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
@@ -7,7 +7,7 @@ import { FootballMatchDay } from './FootballMatchDay';
 type Props = {
 	footballCompetitionData: {
 		competitionId: string;
-		footballCompetitionComponentType: string;
+		componentType: string;
 	};
 };
 

--- a/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
@@ -22,25 +22,26 @@ const matchDayResponseSchema = omit(feFootballMatchDaySchema, [
 const fetcher = (url: string): Promise<unknown> =>
 	fetch(url).then((res) => res.json());
 
-export const FootballCompetitionAtom = ({
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- retained for the eventual production mapping of competition id to endpoint URL
-	footballCompetitionData,
-}: Props) => {
+export const FootballCompetitionAtom = ({ footballCompetitionData }: Props) => {
 	// competition id is e.g. 700, so need to map to a competition name, e.g. Premier League, La Liga, etc.
 	// the endpoint is hardcoded and irrespective of the competition, so we can comment the below out
 	// production use of this component would imply using the map to adjust the fetched url with the relevant competition name
-	// const competitionIdToNameMap: Record<string, string> = {
-	//  700: 'world-cup-2026',
-	//  100: 'premier-league',
-	// };
+	const competitionIdToNameMap: Record<string, string> = {
+		700: 'world-cup-2026',
+		100: 'premier-league',
+	};
+
+	const competitionName =
+		competitionIdToNameMap[footballCompetitionData.competitionId];
 
 	const { data, error } = useSWR<unknown, Error>(
 		///
-		// `https://api.nextgen.guardianapps.co.uk/football/${footballCompetitionData.competitionId}/embed?season=2023`,
+		// `https://api.nextgen.guardianapps.co.uk/football/${footballCompetitionData.competitionId}/embed
 		// https://www.theguardian.com/football/world-cup-2026/live.json?dcr=true
 		// production use of this component would likely require using the live endpoint, but this will only return data if there's an actual match on the day
 		// for testing purposes, we can hardcode a match day endpoint to return data for a specific date, e.g. 2026-07-09, which provides at least one result
-		'https://api.nextgen.guardianapps.co.uk/football/match-day/2026/jul/09.json?dcr=true',
+		// 'https://api.nextgen.guardianapps.co.uk/football/match-day/2026/jul/09.json?dcr=true',
+		`https://api.nextgen.guardianapps.co.uk/football/${competitionName}/live.json?dcr=true`,
 		fetcher,
 	);
 
@@ -48,7 +49,6 @@ export const FootballCompetitionAtom = ({
 		return <div>Failed to load football data</div>;
 	}
 
-	// SWR returns `undefined` for `data` until the request resolves.
 	if (data === undefined) {
 		return <div>Loading…</div>;
 	}

--- a/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
+++ b/dotcom-rendering/src/components/FootballCompetitionAtom.island.tsx
@@ -29,6 +29,7 @@ export const FootballCompetitionAtom = ({ footballCompetitionData }: Props) => {
 	const competitionIdToNameMap: Record<string, string> = {
 		700: 'world-cup-2026',
 		100: 'premier-league',
+		501: 'champions-league-qualifying',
 	};
 
 	const competitionName =

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -294,9 +294,9 @@ export type FESnap = {
 	AudioAtom?: AudioAtomBlockElement;
 	ExplainerAtom?: ExplainerAtomBlockElement;
 	CtaAtom?: CallToActionAtomBlockElement;
-	FootballCompetitionAtom?: {
+	TempFootballCompetitionAtom?: {
 		competitionId: string;
-		footballCompetitionComponentType: string;
+		componentType: string;
 	};
 };
 

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -3,10 +3,17 @@ import type { EditionId } from '../lib/edition';
 import type { EditionBranding } from '../types/branding';
 import type { StageType, Switches } from '../types/config';
 import type {
+	AudioAtomBlockElement,
 	BoostLevel,
+	CallToActionAtomBlockElement,
+	ExplainerAtomBlockElement,
+	GuideAtomBlockElement,
 	Image,
 	Newsletter,
+	ProfileAtomBlockElement,
+	QABlockElement,
 	StarRating,
+	TimelineAtomBlockElement,
 } from '../types/content';
 import type { FooterType } from '../types/footer';
 import type { FENavType } from '../types/frontend';
@@ -275,6 +282,18 @@ export type FESnap = {
 	embedHtml?: string;
 	embedCss?: string;
 	embedJs?: string;
+	/**
+	 * Atom block elements pre-fetched by facia-press so that atoms placed on
+	 * fronts (as snaps) can be rendered server-side. Each field mirrors the
+	 * equivalent DCR block element for that atom type.
+	 */
+	GuideAtom?: GuideAtomBlockElement;
+	QandaAtom?: QABlockElement;
+	ProfileAtom?: ProfileAtomBlockElement;
+	TimelineAtom?: TimelineAtomBlockElement;
+	AudioAtom?: AudioAtomBlockElement;
+	ExplainerAtom?: ExplainerAtomBlockElement;
+	CtaAtom?: CallToActionAtomBlockElement;
 };
 
 export type FEAspectRatio = '5:3' | '5:4' | '4:5' | '1:1';

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -294,6 +294,10 @@ export type FESnap = {
 	AudioAtom?: AudioAtomBlockElement;
 	ExplainerAtom?: ExplainerAtomBlockElement;
 	CtaAtom?: CallToActionAtomBlockElement;
+	FootballCompetitionAtom?: {
+		competitionId: string;
+		footballCompetitionComponentType: string;
+	};
 };
 
 export type FEAspectRatio = '5:3' | '5:4' | '4:5' | '1:1';

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5879,6 +5879,21 @@
                                 },
                                 "cta": {
                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                },
+                                "tempfootballcompetition": {
+                                    "type": "object",
+                                    "properties": {
+                                        "competitionId": {
+                                            "type": "string"
+                                        },
+                                        "footballCompetitionComponentType": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "competitionId",
+                                        "footballCompetitionComponentType"
+                                    ]
                                 }
                             }
                         }

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5854,6 +5854,33 @@
                         },
                         "embedJs": {
                             "type": "string"
+                        },
+                        "atoms": {
+                            "description": "Atom block elements that have been placed on a front as a snap and\npre-fetched by facia-press so they can be rendered server-side. Each field\nmirrors the equivalent DCR block element for that atom type.",
+                            "type": "object",
+                            "properties": {
+                                "guide": {
+                                    "$ref": "#/definitions/GuideAtomBlockElement"
+                                },
+                                "qanda": {
+                                    "$ref": "#/definitions/QABlockElement"
+                                },
+                                "profile": {
+                                    "$ref": "#/definitions/ProfileAtomBlockElement"
+                                },
+                                "timeline": {
+                                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                                },
+                                "audio": {
+                                    "$ref": "#/definitions/AudioAtomBlockElement"
+                                },
+                                "explainer": {
+                                    "$ref": "#/definitions/ExplainerAtomBlockElement"
+                                },
+                                "cta": {
+                                    "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                }
+                            }
                         }
                     }
                 },

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -5886,13 +5886,13 @@
                                         "competitionId": {
                                             "type": "string"
                                         },
-                                        "footballCompetitionComponentType": {
+                                        "componentType": {
                                             "type": "string"
                                         }
                                     },
                                     "required": [
                                         "competitionId",
-                                        "footballCompetitionComponentType"
+                                        "componentType"
                                     ]
                                 }
                             }

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -880,6 +880,28 @@
                                                 },
                                                 "embedJs": {
                                                     "type": "string"
+                                                },
+                                                "GuideAtom": {
+                                                    "$ref": "#/definitions/GuideAtomBlockElement",
+                                                    "description": "Atom block elements pre-fetched by facia-press so that atoms placed on\nfronts (as snaps) can be rendered server-side. Each field mirrors the\nequivalent DCR block element for that atom type."
+                                                },
+                                                "QandaAtom": {
+                                                    "$ref": "#/definitions/QABlockElement"
+                                                },
+                                                "ProfileAtom": {
+                                                    "$ref": "#/definitions/ProfileAtomBlockElement"
+                                                },
+                                                "TimelineAtom": {
+                                                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                                                },
+                                                "AudioAtom": {
+                                                    "$ref": "#/definitions/AudioAtomBlockElement"
+                                                },
+                                                "ExplainerAtom": {
+                                                    "$ref": "#/definitions/ExplainerAtomBlockElement"
+                                                },
+                                                "CtaAtom": {
+                                                    "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 }
                                             }
                                         },
@@ -1715,6 +1737,28 @@
                                                 },
                                                 "embedJs": {
                                                     "type": "string"
+                                                },
+                                                "GuideAtom": {
+                                                    "$ref": "#/definitions/GuideAtomBlockElement",
+                                                    "description": "Atom block elements pre-fetched by facia-press so that atoms placed on\nfronts (as snaps) can be rendered server-side. Each field mirrors the\nequivalent DCR block element for that atom type."
+                                                },
+                                                "QandaAtom": {
+                                                    "$ref": "#/definitions/QABlockElement"
+                                                },
+                                                "ProfileAtom": {
+                                                    "$ref": "#/definitions/ProfileAtomBlockElement"
+                                                },
+                                                "TimelineAtom": {
+                                                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                                                },
+                                                "AudioAtom": {
+                                                    "$ref": "#/definitions/AudioAtomBlockElement"
+                                                },
+                                                "ExplainerAtom": {
+                                                    "$ref": "#/definitions/ExplainerAtomBlockElement"
+                                                },
+                                                "CtaAtom": {
+                                                    "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 }
                                             }
                                         },
@@ -2550,6 +2594,28 @@
                                                 },
                                                 "embedJs": {
                                                     "type": "string"
+                                                },
+                                                "GuideAtom": {
+                                                    "$ref": "#/definitions/GuideAtomBlockElement",
+                                                    "description": "Atom block elements pre-fetched by facia-press so that atoms placed on\nfronts (as snaps) can be rendered server-side. Each field mirrors the\nequivalent DCR block element for that atom type."
+                                                },
+                                                "QandaAtom": {
+                                                    "$ref": "#/definitions/QABlockElement"
+                                                },
+                                                "ProfileAtom": {
+                                                    "$ref": "#/definitions/ProfileAtomBlockElement"
+                                                },
+                                                "TimelineAtom": {
+                                                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                                                },
+                                                "AudioAtom": {
+                                                    "$ref": "#/definitions/AudioAtomBlockElement"
+                                                },
+                                                "ExplainerAtom": {
+                                                    "$ref": "#/definitions/ExplainerAtomBlockElement"
+                                                },
+                                                "CtaAtom": {
+                                                    "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 }
                                             }
                                         },
@@ -3238,6 +3304,318 @@
                 "megaboost"
             ],
             "type": "string"
+        },
+        "GuideAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.GuideAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
+        },
+        "RoleType": {
+            "description": "Affects how an image is placed.\n\nAlso known as “weighting” in Composer, but we respect the CAPI naming.",
+            "enum": [
+                "halfWidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "QABlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.QABlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "title"
+            ]
+        },
+        "ProfileAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.ProfileAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
+        },
+        "TimelineAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.TimelineAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineAtomEvent"
+                    }
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "events",
+                "id",
+                "title"
+            ]
+        },
+        "TimelineAtomEvent": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "unixDate": {
+                    "type": "number"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "toDate": {
+                    "type": "string"
+                },
+                "toUnixDate": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "date",
+                "title",
+                "unixDate"
+            ]
+        },
+        "AudioAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kicker": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trackUrl": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
+                },
+                "coverUrl": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "coverUrl",
+                "duration",
+                "elementId",
+                "id",
+                "kicker",
+                "trackUrl"
+            ]
+        },
+        "ExplainerAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.ExplainerAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "body",
+                "elementId",
+                "id",
+                "title"
+            ]
+        },
+        "CallToActionAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.CallToActionAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "trackingCode": {
+                    "type": "string"
+                },
+                "btnText": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "id",
+                "title",
+                "url"
+            ]
         },
         "FEContainer": {
             "enum": [
@@ -3966,6 +4344,33 @@
                         },
                         "embedJs": {
                             "type": "string"
+                        },
+                        "atoms": {
+                            "description": "Atom block elements that have been placed on a front as a snap and\npre-fetched by facia-press so they can be rendered server-side. Each field\nmirrors the equivalent DCR block element for that atom type.",
+                            "type": "object",
+                            "properties": {
+                                "guide": {
+                                    "$ref": "#/definitions/GuideAtomBlockElement"
+                                },
+                                "qanda": {
+                                    "$ref": "#/definitions/QABlockElement"
+                                },
+                                "profile": {
+                                    "$ref": "#/definitions/ProfileAtomBlockElement"
+                                },
+                                "timeline": {
+                                    "$ref": "#/definitions/TimelineAtomBlockElement"
+                                },
+                                "audio": {
+                                    "$ref": "#/definitions/AudioAtomBlockElement"
+                                },
+                                "explainer": {
+                                    "$ref": "#/definitions/ExplainerAtomBlockElement"
+                                },
+                                "cta": {
+                                    "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                }
+                            }
                         }
                     }
                 },

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -903,19 +903,19 @@
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 },
-                                                "FootballCompetitionAtom": {
+                                                "TempFootballCompetitionAtom": {
                                                     "type": "object",
                                                     "properties": {
                                                         "competitionId": {
                                                             "type": "string"
                                                         },
-                                                        "footballCompetitionComponentType": {
+                                                        "componentType": {
                                                             "type": "string"
                                                         }
                                                     },
                                                     "required": [
                                                         "competitionId",
-                                                        "footballCompetitionComponentType"
+                                                        "componentType"
                                                     ]
                                                 }
                                             }
@@ -1775,19 +1775,19 @@
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 },
-                                                "FootballCompetitionAtom": {
+                                                "TempFootballCompetitionAtom": {
                                                     "type": "object",
                                                     "properties": {
                                                         "competitionId": {
                                                             "type": "string"
                                                         },
-                                                        "footballCompetitionComponentType": {
+                                                        "componentType": {
                                                             "type": "string"
                                                         }
                                                     },
                                                     "required": [
                                                         "competitionId",
-                                                        "footballCompetitionComponentType"
+                                                        "componentType"
                                                     ]
                                                 }
                                             }
@@ -2647,19 +2647,19 @@
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
                                                 },
-                                                "FootballCompetitionAtom": {
+                                                "TempFootballCompetitionAtom": {
                                                     "type": "object",
                                                     "properties": {
                                                         "competitionId": {
                                                             "type": "string"
                                                         },
-                                                        "footballCompetitionComponentType": {
+                                                        "componentType": {
                                                             "type": "string"
                                                         }
                                                     },
                                                     "required": [
                                                         "competitionId",
-                                                        "footballCompetitionComponentType"
+                                                        "componentType"
                                                     ]
                                                 }
                                             }
@@ -4421,13 +4421,13 @@
                                         "competitionId": {
                                             "type": "string"
                                         },
-                                        "footballCompetitionComponentType": {
+                                        "componentType": {
                                             "type": "string"
                                         }
                                     },
                                     "required": [
                                         "competitionId",
-                                        "footballCompetitionComponentType"
+                                        "componentType"
                                     ]
                                 }
                             }

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -902,6 +902,21 @@
                                                 },
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                                },
+                                                "FootballCompetitionAtom": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "competitionId": {
+                                                            "type": "string"
+                                                        },
+                                                        "footballCompetitionComponentType": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "competitionId",
+                                                        "footballCompetitionComponentType"
+                                                    ]
                                                 }
                                             }
                                         },
@@ -1759,6 +1774,21 @@
                                                 },
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                                },
+                                                "FootballCompetitionAtom": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "competitionId": {
+                                                            "type": "string"
+                                                        },
+                                                        "footballCompetitionComponentType": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "competitionId",
+                                                        "footballCompetitionComponentType"
+                                                    ]
                                                 }
                                             }
                                         },
@@ -2616,6 +2646,21 @@
                                                 },
                                                 "CtaAtom": {
                                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                                },
+                                                "FootballCompetitionAtom": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "competitionId": {
+                                                            "type": "string"
+                                                        },
+                                                        "footballCompetitionComponentType": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "competitionId",
+                                                        "footballCompetitionComponentType"
+                                                    ]
                                                 }
                                             }
                                         },
@@ -4369,6 +4414,21 @@
                                 },
                                 "cta": {
                                     "$ref": "#/definitions/CallToActionAtomBlockElement"
+                                },
+                                "tempfootballcompetition": {
+                                    "type": "object",
+                                    "properties": {
+                                        "competitionId": {
+                                            "type": "string"
+                                        },
+                                        "footballCompetitionComponentType": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "competitionId",
+                                        "footballCompetitionComponentType"
+                                    ]
                                 }
                             }
                         }

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -746,19 +746,19 @@
                             "CtaAtom": {
                                 "$ref": "#/definitions/CallToActionAtomBlockElement"
                             },
-                            "FootballCompetitionAtom": {
+                            "TempFootballCompetitionAtom": {
                                 "type": "object",
                                 "properties": {
                                     "competitionId": {
                                         "type": "string"
                                     },
-                                    "footballCompetitionComponentType": {
+                                    "componentType": {
                                         "type": "string"
                                     }
                                 },
                                 "required": [
                                     "competitionId",
-                                    "footballCompetitionComponentType"
+                                    "componentType"
                                 ]
                             }
                         }

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -723,6 +723,28 @@
                             },
                             "embedJs": {
                                 "type": "string"
+                            },
+                            "GuideAtom": {
+                                "$ref": "#/definitions/GuideAtomBlockElement",
+                                "description": "Atom block elements pre-fetched by facia-press so that atoms placed on\nfronts (as snaps) can be rendered server-side. Each field mirrors the\nequivalent DCR block element for that atom type."
+                            },
+                            "QandaAtom": {
+                                "$ref": "#/definitions/QABlockElement"
+                            },
+                            "ProfileAtom": {
+                                "$ref": "#/definitions/ProfileAtomBlockElement"
+                            },
+                            "TimelineAtom": {
+                                "$ref": "#/definitions/TimelineAtomBlockElement"
+                            },
+                            "AudioAtom": {
+                                "$ref": "#/definitions/AudioAtomBlockElement"
+                            },
+                            "ExplainerAtom": {
+                                "$ref": "#/definitions/ExplainerAtomBlockElement"
+                            },
+                            "CtaAtom": {
+                                "$ref": "#/definitions/CallToActionAtomBlockElement"
                             }
                         }
                     },
@@ -1466,6 +1488,318 @@
                 "megaboost"
             ],
             "type": "string"
+        },
+        "GuideAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.GuideAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
+        },
+        "RoleType": {
+            "description": "Affects how an image is placed.\n\nAlso known as “weighting” in Composer, but we respect the CAPI naming.",
+            "enum": [
+                "halfWidth",
+                "immersive",
+                "inline",
+                "showcase",
+                "supporting",
+                "thumbnail"
+            ],
+            "type": "string"
+        },
+        "QABlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.QABlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "title"
+            ]
+        },
+        "ProfileAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.ProfileAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "img": {
+                    "type": "string"
+                },
+                "html": {
+                    "type": "string"
+                },
+                "credit": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "credit",
+                "elementId",
+                "html",
+                "id",
+                "label",
+                "title"
+            ]
+        },
+        "TimelineAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.TimelineAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineAtomEvent"
+                    }
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "events",
+                "id",
+                "title"
+            ]
+        },
+        "TimelineAtomEvent": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "unixDate": {
+                    "type": "number"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "toDate": {
+                    "type": "string"
+                },
+                "toUnixDate": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "date",
+                "title",
+                "unixDate"
+            ]
+        },
+        "AudioAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.AudioAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kicker": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trackUrl": {
+                    "type": "string"
+                },
+                "duration": {
+                    "type": "number"
+                },
+                "coverUrl": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "coverUrl",
+                "duration",
+                "elementId",
+                "id",
+                "kicker",
+                "trackUrl"
+            ]
+        },
+        "ExplainerAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.ExplainerAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/RoleType"
+                }
+            },
+            "required": [
+                "_type",
+                "body",
+                "elementId",
+                "id",
+                "title"
+            ]
+        },
+        "CallToActionAtomBlockElement": {
+            "type": "object",
+            "properties": {
+                "_type": {
+                    "type": "string",
+                    "const": "model.dotcomrendering.pageElements.CallToActionAtomBlockElement"
+                },
+                "elementId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "trackingCode": {
+                    "type": "string"
+                },
+                "btnText": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_type",
+                "elementId",
+                "id",
+                "title",
+                "url"
+            ]
         },
         "FENavType": {
             "type": "object",

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -745,6 +745,21 @@
                             },
                             "CtaAtom": {
                                 "$ref": "#/definitions/CallToActionAtomBlockElement"
+                            },
+                            "FootballCompetitionAtom": {
+                                "type": "object",
+                                "properties": {
+                                    "competitionId": {
+                                        "type": "string"
+                                    },
+                                    "footballCompetitionComponentType": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "competitionId",
+                                    "footballCompetitionComponentType"
+                                ]
                             }
                         }
                     },

--- a/dotcom-rendering/src/model/enhanceSnaps.ts
+++ b/dotcom-rendering/src/model/enhanceSnaps.ts
@@ -1,5 +1,25 @@
 import type { FESnap } from '../frontend/feFront';
-import type { DCRSnapType } from '../types/front';
+import type { DCRSnapType, SnapAtoms } from '../types/front';
+
+/**
+ * Maps the atom block elements sent on a snap (each as its own optional field)
+ * into a single `SnapAtoms` object, if any are present.
+ */
+const enhanceSnapAtoms = (snap: FESnap): SnapAtoms | undefined => {
+	const atoms: SnapAtoms = {
+		guide: snap.GuideAtom,
+		qanda: snap.QandaAtom,
+		profile: snap.ProfileAtom,
+		timeline: snap.TimelineAtom,
+		audio: snap.AudioAtom,
+		explainer: snap.ExplainerAtom,
+		cta: snap.CtaAtom,
+	};
+
+	const hasAtom = Object.values(atoms).some((atom) => atom !== undefined);
+
+	return hasAtom ? atoms : undefined;
+};
 
 /**
  *
@@ -21,6 +41,13 @@ export const enhanceSnaps = (
 			/body:not\(\.has-active-pageskin\)(?! &)/g,
 			'body:not(.has-active-pageskin) &',
 		);
+	}
+
+	if (dcrSnap) {
+		return {
+			...dcrSnap,
+			atoms: enhanceSnapAtoms(dcrSnap),
+		};
 	}
 
 	return dcrSnap;

--- a/dotcom-rendering/src/model/enhanceSnaps.ts
+++ b/dotcom-rendering/src/model/enhanceSnaps.ts
@@ -14,6 +14,7 @@ const enhanceSnapAtoms = (snap: FESnap): SnapAtoms | undefined => {
 		audio: snap.AudioAtom,
 		explainer: snap.ExplainerAtom,
 		cta: snap.CtaAtom,
+		tempfootballcompetition: snap.TempFootballCompetitionAtom,
 	};
 
 	const hasAtom = Object.values(atoms).some((atom) => atom !== undefined);

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -251,7 +251,7 @@ export interface EmbedBlockElement extends ThirdPartyEmbeddedContent {
 	caption?: string;
 }
 
-interface ExplainerAtomBlockElement {
+export interface ExplainerAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ExplainerAtomBlockElement';
 	elementId: string;
 	id: string;
@@ -271,7 +271,7 @@ interface GenericAtomBlockElement {
 	elementId: string;
 }
 
-interface GuideAtomBlockElement {
+export interface GuideAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.GuideAtomBlockElement';
 	elementId: string;
 	id: string;
@@ -554,7 +554,7 @@ export interface RecipeBlockElement {
 	featuredImage?: RecipeFeaturedImage;
 }
 
-interface ProfileAtomBlockElement {
+export interface ProfileAtomBlockElement {
 	_type: 'model.dotcomrendering.pageElements.ProfileAtomBlockElement';
 	elementId: string;
 	id: string;
@@ -575,7 +575,7 @@ interface PullquoteBlockElement {
 	isThirdPartyTracking?: boolean;
 }
 
-interface QABlockElement {
+export interface QABlockElement {
 	_type: 'model.dotcomrendering.pageElements.QABlockElement';
 	elementId: string;
 	id: string;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -13,7 +13,18 @@ import type {
 } from '../lib/articleFormat';
 import type { EditionId } from '../lib/edition';
 import type { Branding, CollectionBranding } from './branding';
-import type { BoostLevel, Newsletter, StarRating } from './content';
+import type {
+	AudioAtomBlockElement,
+	BoostLevel,
+	CallToActionAtomBlockElement,
+	ExplainerAtomBlockElement,
+	GuideAtomBlockElement,
+	Newsletter,
+	ProfileAtomBlockElement,
+	QABlockElement,
+	StarRating,
+	TimelineAtomBlockElement,
+} from './content';
 import type { FooterType } from './footer';
 import type { FENavType } from './frontend';
 import type { ArticleMedia, MainMedia } from './mainMedia';
@@ -113,10 +124,26 @@ export type DCRSlideshowImage = {
 	imageCaption?: string;
 };
 
+/**
+ * Atom block elements that have been placed on a front as a snap and
+ * pre-fetched by facia-press so they can be rendered server-side. Each field
+ * mirrors the equivalent DCR block element for that atom type.
+ */
+export type SnapAtoms = {
+	guide?: GuideAtomBlockElement;
+	qanda?: QABlockElement;
+	profile?: ProfileAtomBlockElement;
+	timeline?: TimelineAtomBlockElement;
+	audio?: AudioAtomBlockElement;
+	explainer?: ExplainerAtomBlockElement;
+	cta?: CallToActionAtomBlockElement;
+};
+
 export type DCRSnapType = {
 	embedHtml?: string;
 	embedCss?: string;
 	embedJs?: string;
+	atoms?: SnapAtoms;
 };
 
 export type AspectRatio = FEAspectRatio;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -137,6 +137,10 @@ export type SnapAtoms = {
 	audio?: AudioAtomBlockElement;
 	explainer?: ExplainerAtomBlockElement;
 	cta?: CallToActionAtomBlockElement;
+	tempfootballcompetition?: {
+		competitionId: string;
+		footballCompetitionComponentType: string;
+	};
 };
 
 export type DCRSnapType = {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -139,7 +139,7 @@ export type SnapAtoms = {
 	cta?: CallToActionAtomBlockElement;
 	tempfootballcompetition?: {
 		competitionId: string;
-		footballCompetitionComponentType: string;
+		componentType: string;
 	};
 };
 


### PR DESCRIPTION
## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
