### PR TITLE
Fix banner e2e test

### DIFF
--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -178,7 +178,7 @@ test.describe('Banner browserId targeting', function () {
 	});
 
 	// Skip this test because it doesn't work in the github actions run. It does however work locally
-	test.skip('does not send browserId when user has not consented, even if in the auxia variant', async ({
+	test('does not send browserId when user has not consented, even if in the auxia variant', async ({
 		page,
 		context,
 	}) => {

--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -16,6 +16,50 @@ const ARTICLE_PATH =
 	'/Article/https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people';
 const RR_BANNER_URL = 'https://contributions.guardianapis.com/banner';
 
+const isCmpReady = async (page: Page, timeoutMs = 5000): Promise<boolean> => {
+	const result = await page
+		.evaluate(
+			({ timeoutMs: timeout }) =>
+				new Promise<boolean>((resolve) => {
+					const start = Date.now();
+					type TcfApi = (
+						command: string,
+						version: number,
+						callback: (ping: unknown, success: boolean) => void,
+					) => void;
+
+					const check = () => {
+						const tcfApi = (
+							window as unknown as Record<string, unknown>
+						)['__tcfapi'];
+
+						if (typeof tcfApi !== 'function') {
+							if (Date.now() - start >= timeout) {
+								resolve(false);
+								return;
+							}
+							setTimeout(check, 100);
+							return;
+						}
+
+						(tcfApi as TcfApi)(
+							'ping',
+							2,
+							(_ping: unknown, pingSuccess: boolean) => {
+								resolve(pingSuccess);
+							},
+						);
+					};
+
+					check();
+				}),
+			{ timeoutMs },
+		)
+		.catch(() => false);
+
+	return result;
+};
+
 const requestBodyHasProperties = (
 	request: Request,
 	url: string | RegExp,
@@ -149,6 +193,12 @@ test.describe('Banner browserId targeting', function () {
 			preventSupportBanner: false,
 		});
 
+		const cmpReady = await isCmpReady(page);
+		expect(
+			cmpReady,
+			'CMP should be ready before running banner consent assertions.',
+		).toBe(true);
+
 		if (acceptConsent) {
 			await cmpAcceptAll(page);
 		} else {
@@ -177,7 +227,6 @@ test.describe('Banner browserId targeting', function () {
 		expect(browserId).toBe('test-browser-id');
 	});
 
-	// Skip this test because it doesn't work in the github actions run. It does however work locally
 	test('does not send browserId when user has not consented, even if in the auxia variant', async ({
 		page,
 		context,

--- a/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
+++ b/dotcom-rendering/playwright/tests/banner.e2e.spec.ts
@@ -16,50 +16,6 @@ const ARTICLE_PATH =
 	'/Article/https://www.theguardian.com/politics/2019/nov/20/jeremy-corbyn-boris-johnson-tv-debate-watched-by-67-million-people';
 const RR_BANNER_URL = 'https://contributions.guardianapis.com/banner';
 
-const isCmpReady = async (page: Page, timeoutMs = 5000): Promise<boolean> => {
-	const result = await page
-		.evaluate(
-			({ timeoutMs: timeout }) =>
-				new Promise<boolean>((resolve) => {
-					const start = Date.now();
-					type TcfApi = (
-						command: string,
-						version: number,
-						callback: (ping: unknown, success: boolean) => void,
-					) => void;
-
-					const check = () => {
-						const tcfApi = (
-							window as unknown as Record<string, unknown>
-						)['__tcfapi'];
-
-						if (typeof tcfApi !== 'function') {
-							if (Date.now() - start >= timeout) {
-								resolve(false);
-								return;
-							}
-							setTimeout(check, 100);
-							return;
-						}
-
-						(tcfApi as TcfApi)(
-							'ping',
-							2,
-							(_ping: unknown, pingSuccess: boolean) => {
-								resolve(pingSuccess);
-							},
-						);
-					};
-
-					check();
-				}),
-			{ timeoutMs },
-		)
-		.catch(() => false);
-
-	return result;
-};
-
 const requestBodyHasProperties = (
 	request: Request,
 	url: string | RegExp,
@@ -102,6 +58,11 @@ test.describe('The banner', function () {
 			waitUntil: 'domcontentloaded',
 			region: 'GB',
 			preventSupportBanner: false,
+			overrides: {
+				switchOverrides: {
+					consentManagement: true,
+				},
+			},
 		});
 		await cmpAcceptAll(page);
 
@@ -191,13 +152,14 @@ test.describe('Banner browserId targeting', function () {
 			waitUntil: 'domcontentloaded',
 			region: 'GB',
 			preventSupportBanner: false,
+			overrides: {
+				switchOverrides: {
+					consentManagement: true,
+				},
+			},
+			queryParamsOn: true,
+			queryParams: { _sp_geo_override: 'GB-XX' },
 		});
-
-		const cmpReady = await isCmpReady(page);
-		expect(
-			cmpReady,
-			'CMP should be ready before running banner consent assertions.',
-		).toBe(true);
 
 		if (acceptConsent) {
 			await cmpAcceptAll(page);
@@ -237,6 +199,12 @@ test.describe('Banner browserId targeting', function () {
 			acceptConsent: false,
 			inAuxiaVariant: true,
 		});
+
+		// CI/CD runs these tests with US geolocation, and fixing the origin to GB in loadPage is not enough for CMP initialization to conclude that the country is GDPR-applied.
+		// If gdprApplies is false, TCData is allowed to be minimal. If GDPR does not apply to this user in this context then only gdprApplies, tcfPolicyVersion, cmpId and cmpVersion shall exist in the object. (If GDPR does not apply to this user in this context then only gdprApplies, tcfPolicyVersion, cmpId and cmpVersion shall exist in the object.)
+		// @Guardian/content-management-platform uses the _sp_geo_override query parameter to override geo location in non-production environments.
+		const currentUrl = new URL(page.url());
+		expect(currentUrl.searchParams.get('_sp_geo_override')).toBe('GB-XX');
 
 		const browserId = getBannerRequestField(
 			bannerRequest,


### PR DESCRIPTION
## What does this change?
This change fixes the banner e2e test, which passed successfully in PROD environment, but failed when running in CI/CD or locally.
The cause of failure was the error, which could be seen in browser console.log:
`Cannot read properties of undefined (reading 'consents')`
It prevented the script execution to continue. The reason for this was in the way the cmp was initialised in CI/CD environment. The loadPage call was setting region to 'GB' explicitly, but CI runs in the US. Apparently setting region to "GB" in loadPage was not enough for cmp initialisation to correctly determine geo-location and during debugging by pinging window.__tsfapi it was detected that gdprApplies was false. According to [this document](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata) 

> If GDPR does not apply to this user in this context then only gdprApplies, tcfPolicyVersion, cmpId and cmpVersion shall exist in the object
>
This is why consents was null, which caused the error.
In @guardian/consent-manager platform there is an opportunity to force geo-location in non-prod environment with query parameter https://github.com/guardian/csnx/blob/a3a7bbe55e74811d79c943381eb31c4d8520313a/libs/%40guardian/consent-manager/src/export.ts#L67
With this query parameters in place the test successfully passes.
Also explicit override `overrides: {
				switchOverrides: {
					consentManagement: true,
				},
			},` was added to guaranty that the switch is on.

## Why?
e2e test for banner failed

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
