### PR TITLE
Fallback to current url if on that tab on the cricket header

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -132,7 +132,10 @@ const baseArgs = {
 	refreshInterval: 3_000,
 	tabContentId: 'cricket-tab-content',
 	getHeaderData: () => getMockData(headerData(baseMatch)),
-	article: {} as ArticleDeprecated,
+	article: {
+		pageId: 'sport/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+		guardianBaseURL: 'https://www.theguardian.com',
+	} as ArticleDeprecated,
 	format: {} as ArticleFormat,
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -65,10 +65,13 @@ type Props = CricketMatchHeaderProps & {
 export const CricketMatchHeader = (props: Props) => {
 	const scorecardHashbang = '#scorecard';
 	const locationHash = useLocationHash();
+	const currentUrl = new URL(
+		`${props.article.guardianBaseURL}${props.article.pageId}`,
+	);
 
 	const { data, error } = useSWR<CricketHeaderData, Error>(
 		props.matchHeaderURL,
-		fetcher(props.getHeaderData),
+		fetcher(props.getHeaderData, props.selectedTab, currentUrl),
 		swrOptions(props.refreshInterval),
 	);
 
@@ -193,10 +196,14 @@ const swrOptions = (
 });
 
 const fetcher =
-	(getHeaderData: Props['getHeaderData']) =>
+	(
+		getHeaderData: Props['getHeaderData'],
+		selectedTab: 'info' | 'live' | 'report',
+		currentUrl: URL,
+	) =>
 	(url: string): Promise<CricketHeaderData> =>
 		getHeaderData(url)
-			.then(parseHeaderData)
+			.then(parseHeaderData(selectedTab, currentUrl))
 			.then((result) => {
 				if (!result.ok) {
 					log('dotcom', result.error);

--- a/dotcom-rendering/src/components/CricketMatchHeader/headerData.ts
+++ b/dotcom-rendering/src/components/CricketMatchHeader/headerData.ts
@@ -13,59 +13,95 @@ export type CricketHeaderData = {
 	match: CricketMatch;
 };
 
-export const parse = (json: unknown): Result<string, CricketHeaderData> => {
-	const feData = fromValibot(safeParse(feCricketMatchHeaderSchema, json));
+export const parse =
+	(selectedTab: 'live' | 'info' | 'report', currentUrl: URL) =>
+	(json: unknown): Result<string, CricketHeaderData> => {
+		const feData = fromValibot(safeParse(feCricketMatchHeaderSchema, json));
 
-	if (!feData.ok) {
-		return error('Failed to validate match header json');
-	}
+		if (!feData.ok) {
+			return error('Failed to validate match header json');
+		}
 
-	const parsedMatch = parseCricketMatchV2(feData.value.cricketMatch);
+		const parsedMatch = parseCricketMatchV2(feData.value.cricketMatch);
 
-	if (!parsedMatch.ok) {
-		return error('Failed to parse the match from the header json');
-	}
+		if (!parsedMatch.ok) {
+			return error('Failed to parse the match from the header json');
+		}
 
-	const maybeTabs = createTabs(feData.value, parsedMatch.value.kind);
-
-	if (!maybeTabs.ok) {
-		return error(
-			`The match header data contained an invalid ${maybeTabs.error.kind} URL`,
+		const maybeTabs = createTabs(
+			feData.value,
+			parsedMatch.value.kind,
+			selectedTab,
+			currentUrl,
 		);
-	}
 
-	return ok({
-		match: parsedMatch.value,
-		tabs: maybeTabs.value,
-	});
-};
+		if (!maybeTabs.ok) {
+			return error(
+				`The match header data contained an invalid ${maybeTabs.error.kind} URL`,
+			);
+		}
+
+		return ok({
+			match: parsedMatch.value,
+			tabs: maybeTabs.value,
+		});
+	};
 
 type MatchURLError = {
 	kind: 'live' | 'report';
 };
 
+/**
+ * Returns the URL for a given tab if we have it, if we don't have it and we are on that tab we can fallback to the current URL, there are some edge cases where live/report tabs urls aren't found by the API e.g the article is not tagged correctly.
+ */
+const getTabURL = (
+	kind: 'live' | 'report',
+	url: string | undefined,
+	selectedTab: 'live' | 'info' | 'report',
+	currentUrl: URL,
+): Result<MatchURLError, URL | undefined> => {
+	if (url === undefined) {
+		if (selectedTab === kind) {
+			return ok(currentUrl);
+		}
+		return ok(undefined);
+	}
+
+	const parsedURL = safeParseURL(url);
+
+	if (!parsedURL.ok) {
+		return error({ kind });
+	}
+
+	return ok(parsedURL.value);
+};
+
 const createTabs = (
 	feData: FECricketMatchHeader,
 	matchKind: CricketMatch['kind'],
+	selectedTab: 'live' | 'info' | 'report',
+	currentUrl: URL,
 ): Result<MatchURLError, CricketHeaderData['tabs']> => {
-	const reportURL =
-		feData.reportURL !== undefined
-			? safeParseURL(feData.reportURL)
-			: undefined;
-	const liveURL =
-		feData.liveURL !== undefined ? safeParseURL(feData.liveURL) : undefined;
-	if (reportURL !== undefined && !reportURL.ok) {
-		return error({ kind: 'report' });
+	const reportURL = getTabURL(
+		'report',
+		feData.reportURL,
+		selectedTab,
+		currentUrl,
+	);
+	const liveURL = getTabURL('live', feData.liveURL, selectedTab, currentUrl);
+
+	if (!reportURL.ok) {
+		return error(reportURL.error);
 	}
 
-	if (liveURL !== undefined && !liveURL.ok) {
-		return error({ kind: 'live' });
+	if (!liveURL.ok) {
+		return error(liveURL.error);
 	}
 
 	return ok({
 		matchKind,
 		sportKind: 'cricket',
-		reportURL: reportURL?.value,
-		liveURL: liveURL?.value,
+		reportURL: reportURL.value,
+		liveURL: liveURL.value,
 	});
 };

--- a/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
@@ -50,7 +50,10 @@ const baseArgs = {
 			liveURL:
 				'https://www.theguardian.com/sport/live/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
 		}),
-	article: {} as ArticleDeprecated,
+	article: {
+		pageId: 'sport/2026/jan/27/australia-v-england-second-test-day-two-live-cricket',
+		guardianBaseURL: 'https://www.theguardian.com',
+	} as ArticleDeprecated,
 	format: {} as ArticleFormat,
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 


### PR DESCRIPTION
## What does this change?
Get the current page url and use it as a fallback for the `liveURL`/`reportURL`

## Why?
There are some edge cases where we get the header, but the header API response can't find the liveURL/reportURL, usually due to an article tagging issue.

If you're on the liveblog and the matchURL is missing (or vice versa) that's fine, that tab just won't appear.

but if you're on the liveblog and the liveURL is missing, when you switch to the scorecard the liveblog tab disappears!