### PR TITLE
Include Product Element content images in Lightbox

### DIFF
--- a/dotcom-rendering/src/model/buildLightboxImages.ts
+++ b/dotcom-rendering/src/model/buildLightboxImages.ts
@@ -92,6 +92,8 @@ const getImages = (
 					event.body.flatMap(getImages),
 				),
 			);
+		case 'model.dotcomrendering.pageElements.ProductBlockElement':
+			return element.content.flatMap(getImages);
 
 		default:
 			return [];


### PR DESCRIPTION
## What does this change?

Adds a Lightbox to images contained in the Product element main nested content.

## Why?

Currently Filter articles written using Product elements (for product cards) do not have the a lightbox on the main content images. As far as editorial know, this is unexpected behaviour. I checked with the old team who built the element and it seems to be an oversight. The product card images still render as links.

[e.g. article
](https://www.theguardian.com/thefilter/2026/jul/02/jess-cartner-morleys-july-style-essentials-2026)
## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/3be15959-874d-41b6-b3f9-ecfb6caf905c
[after]: https://github.com/user-attachments/assets/852ac803-edce-45b3-a9a6-b39c90418486

### Fullscreen
<img width="2554" height="1430" alt="image" src="https://github.com/user-attachments/assets/4615c891-5f92-4d6b-902e-48c8fc2c393f" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
