### PR TITLE
feat: Route 100% of traffic for tag-page-rendering CODE to ECS

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -2840,13 +2840,13 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
                   "TargetGroupArn": {
                     "Ref": "TargetGroupTagpagerendering42E428EE",
                   },
-                  "Weight": 1,
+                  "Weight": 0,
                 },
                 {
                   "TargetGroupArn": {
                     "Ref": "EcsTargetGroupTagpagerendering06213654",
                   },
-                  "Weight": 0,
+                  "Weight": 1,
                 },
               ],
             },

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -289,10 +289,10 @@ export class RenderingCDKStack extends CDKStack {
 							},
 						},
 
-						// Route all traffic to EC2
+						// Route all traffic to ECS
 						targetGroupWeights: {
-							ec2: 1,
-							ecs: 0,
+							ec2: 0,
+							ecs: 1,
 						},
 					}),
 		});


### PR DESCRIPTION
> [!NOTE]
> This likely requires folk in the WebX team to some understanding of AWS ECS so that they can respond to any queries, debug deployments, etc. https://catalog.us-east-1.prod.workshops.aws/workshops/7eaa1783-1592-4bdc-b579-630e53f00afa/en-US is a good resource for this. Until training is finalised, we can revert this change as an immediate fix to any issues.

## What does this change?
In https://github.com/guardian/dotcom-rendering/pull/16321 we provisioned the infrastructure to run tag-page-rendering CODE on AWS ECS and configured it to receive 0 traffic. To direct traffic to it, we'd set a header (see https://github.com/guardian/cdk/releases/tag/v64.1.0). RelOps have been doing this for load testing to understand the configuration we'd need for PROD. We're confident in the CODE infrastructure.

This change updates tag-page-rendering CODE to serve all requests from the ECS infrastructure 🎉!