### PR TITLE
Add A/B test for in-article newsletter signup with no preview variant

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -134,6 +134,19 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
+		name: "newsletters-in-article-signup-preview",
+		description:
+			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",
+		owners: ["newsletters.dev@guardian.co.uk"],
+		expirationDate: "2026-07-21",
+		type: "client",
+		status: "ON",
+		audienceSize: 50 / 100,
+		audienceSpace: "A",
+		groups: ["illustrated", "without-preview"],
+		shouldForceMetricsCollection: false,
+	},
+	{
 		name: "fronts-and-curation-loop-click-through",
 		description:
 			"Test impact of click to article via loop videos on fronts",

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
@@ -219,25 +219,28 @@ describe('EmailSignUpWrapper', () => {
 
 		it('still fires the VIEW event without AB metadata if the AB framework never resolves', () => {
 			jest.useFakeTimers();
-			(useAB as jest.Mock).mockReturnValue(undefined);
 
-			renderWrapper();
+			try {
+				(useAB as jest.Mock).mockReturnValue(undefined);
 
-			// The VIEW event is deferred while waiting for the AB framework.
-			expect(submitComponentEvent).not.toHaveBeenCalled();
+				renderWrapper();
 
-			jest.runOnlyPendingTimers();
+				// The VIEW event is deferred while waiting for the AB framework.
+				expect(submitComponentEvent).not.toHaveBeenCalled();
 
-			expect(submitComponentEvent).toHaveBeenCalledTimes(1);
-			expect(submitComponentEvent).toHaveBeenCalledWith(
-				expect.objectContaining({
-					action: 'VIEW',
-					abTest: undefined,
-				}),
-				'Web',
-			);
+				jest.advanceTimersByTime(2000);
 
-			jest.useRealTimers();
+				expect(submitComponentEvent).toHaveBeenCalledTimes(1);
+				expect(submitComponentEvent).toHaveBeenCalledWith(
+					expect.objectContaining({
+						action: 'VIEW',
+						abTest: undefined,
+					}),
+					'Web',
+				);
+			} finally {
+				jest.useRealTimers();
+			}
 		});
 	});
 });

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.test.tsx
@@ -1,7 +1,12 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import {
+	NEWSLETTER_PREVIEW_AB_TEST_NAME,
+	NEWSLETTER_PREVIEW_VARIANT,
+} from '../lib/newsletterSignupAbTest';
 import { NEWSLETTER_SIGNUP_COMPONENT_ID } from '../lib/newsletterSignupTracking';
+import { useAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
 import { ConfigProvider } from './ConfigContext';
@@ -19,27 +24,42 @@ jest.mock('../lib/useNewsletterSubscription', () => ({
 	useNewsletterSubscription: jest.fn(),
 }));
 
+jest.mock('../lib/useAB', () => ({
+	useAB: jest.fn(),
+}));
+
 // Avoid rendering real island children in unit tests
 jest.mock('./Island', () => ({
 	Island: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockNewsletterSignupForm = jest.fn();
+
 jest.mock('./NewsletterSignupForm.island', () => ({
-	NewsletterSignupForm: () => (
-		<div data-testid="newsletter-signup-form">NewsletterSignupForm</div>
-	),
+	NewsletterSignupForm: (props: unknown) => {
+		mockNewsletterSignupForm(props);
+		return (
+			<div data-testid="newsletter-signup-form">NewsletterSignupForm</div>
+		);
+	},
 }));
+
+const mockNewsletterSignupCardContainer = jest.fn();
 
 jest.mock('./NewsletterSignupCardContainer', () => ({
 	NewsletterSignupCardContainer: ({
 		children,
+		...props
 	}: {
 		children: (openPreview: (() => void) | undefined) => React.ReactNode;
-	}) => (
-		<div data-testid="newsletter-signup-card-container">
-			{children(undefined)}
-		</div>
-	),
+	}) => {
+		mockNewsletterSignupCardContainer(props);
+		return (
+			<div data-testid="newsletter-signup-card-container">
+				{children(undefined)}
+			</div>
+		);
+	},
 }));
 
 const defaultProps = {
@@ -72,6 +92,12 @@ describe('EmailSignUpWrapper', () => {
 		jest.resetAllMocks();
 		(useIsSignedIn as jest.Mock).mockReturnValue(false);
 		(useNewsletterSubscription as jest.Mock).mockReturnValue(false);
+		(useAB as jest.Mock).mockReturnValue({
+			getParticipations: () => ({
+				[NEWSLETTER_PREVIEW_AB_TEST_NAME]:
+					NEWSLETTER_PREVIEW_VARIANT.illustrated,
+			}),
+		});
 	});
 
 	describe('rendering', () => {
@@ -125,6 +151,58 @@ describe('EmailSignUpWrapper', () => {
 			expect(submitComponentEvent).toHaveBeenCalledTimes(1);
 		});
 
+		it('passes AB metadata and keeps preview enabled in the illustrated arm', () => {
+			renderWrapper();
+
+			expect(mockNewsletterSignupCardContainer).toHaveBeenCalledWith(
+				expect.objectContaining({
+					enablePreview: true,
+					abTest: {
+						name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+						variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+					},
+				}),
+			);
+			expect(mockNewsletterSignupForm).toHaveBeenCalledWith(
+				expect.objectContaining({
+					abTest: {
+						name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+						variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+					},
+				}),
+			);
+			expect(submitComponentEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					abTest: {
+						name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+						variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+					},
+				}),
+				'Web',
+			);
+		});
+
+		it('disables preview in the without-preview arm', () => {
+			(useAB as jest.Mock).mockReturnValue({
+				getParticipations: () => ({
+					[NEWSLETTER_PREVIEW_AB_TEST_NAME]:
+						NEWSLETTER_PREVIEW_VARIANT.withoutPreview,
+				}),
+			});
+
+			renderWrapper();
+
+			expect(mockNewsletterSignupCardContainer).toHaveBeenCalledWith(
+				expect.objectContaining({
+					enablePreview: false,
+					abTest: {
+						name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+						variant: NEWSLETTER_PREVIEW_VARIANT.withoutPreview,
+					},
+				}),
+			);
+		});
+
 		it('does not fire a VIEW event while subscription status is loading', () => {
 			(useNewsletterSubscription as jest.Mock).mockReturnValue(undefined);
 			renderWrapper();
@@ -137,6 +215,29 @@ describe('EmailSignUpWrapper', () => {
 			renderWrapper();
 
 			expect(submitComponentEvent).not.toHaveBeenCalled();
+		});
+
+		it('still fires the VIEW event without AB metadata if the AB framework never resolves', () => {
+			jest.useFakeTimers();
+			(useAB as jest.Mock).mockReturnValue(undefined);
+
+			renderWrapper();
+
+			// The VIEW event is deferred while waiting for the AB framework.
+			expect(submitComponentEvent).not.toHaveBeenCalled();
+
+			jest.runOnlyPendingTimers();
+
+			expect(submitComponentEvent).toHaveBeenCalledTimes(1);
+			expect(submitComponentEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: 'VIEW',
+					abTest: undefined,
+				}),
+				'Web',
+			);
+
+			jest.useRealTimers();
 		});
 	});
 });

--- a/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
+++ b/dotcom-rendering/src/components/EmailSignUpWrapper.island.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef } from 'react';
 import {
+	isWithoutPreviewVariant,
+	NEWSLETTER_PREVIEW_AB_TEST_NAME,
+	resolveNewsletterPreviewAbTest,
+} from '../lib/newsletterSignupAbTest';
+import {
 	NEWSLETTER_SIGNUP_COMPONENT_ID,
 	sendNewsletterSignupEvent,
 } from '../lib/newsletterSignupTracking';
+import { useAB } from '../lib/useAB';
 import { useIsSignedIn } from '../lib/useAuthStatus';
 import { useNewsletterSubscription } from '../lib/useNewsletterSubscription';
 import { useConfig } from './ConfigContext';
@@ -11,9 +17,13 @@ import { InlineSkipToWrapper } from './InlineSkipToWrapper';
 import { Island } from './Island';
 import { NewsletterSignupCardContainer } from './NewsletterSignupCardContainer';
 import { NewsletterSignupForm } from './NewsletterSignupForm.island';
-// When the next A/B experiment is added (e.g. preview-button test), import
-// useAB and AB_TEST_NAME from their respective modules and thread them through
-// sendNewsletterSignupEvent's `abTest` param and NewsletterSignupForm's `abTest` prop.
+
+/**
+ * How long to wait for the AB framework to resolve before firing the VIEW
+ * event without test metadata. Ensures newsletter view tracking still fires
+ * even if the AB framework never initialises.
+ */
+const AB_RESOLUTION_TIMEOUT_MS = 2000;
 
 interface EmailSignUpWrapperProps extends EmailSignUpProps {
 	index: number;
@@ -46,8 +56,14 @@ export const EmailSignUpWrapper = ({
 	theme,
 }: EmailSignUpWrapperProps) => {
 	const { renderingTarget } = useConfig();
+	const abTests = useAB();
 	const isSignedIn = useIsSignedIn();
 	const isSubscribed = useNewsletterSubscription(listId, idApiUrl);
+	const isABResolved = abTests !== undefined;
+	const previewVariant =
+		abTests?.getParticipations()[NEWSLETTER_PREVIEW_AB_TEST_NAME];
+	const abTest = resolveNewsletterPreviewAbTest(previewVariant);
+	const enablePreview = !isWithoutPreviewVariant(previewVariant);
 
 	const componentId =
 		NEWSLETTER_SIGNUP_COMPONENT_ID.inArticleSignupForm(identityName);
@@ -67,17 +83,44 @@ export const EmailSignUpWrapper = ({
 		if (viewFiredRef.current) {
 			return;
 		}
-		viewFiredRef.current = true;
-		sendNewsletterSignupEvent({
-			action: 'VIEW',
-			identityName,
-			componentId,
-			renderingTarget,
-			value: {
-				eventDescription: 'newsletter-signup-viewed',
-			},
-		});
-	}, [componentId, identityName, isSubscribed, renderingTarget]);
+
+		const fireView = () => {
+			if (viewFiredRef.current) {
+				return;
+			}
+			viewFiredRef.current = true;
+			sendNewsletterSignupEvent({
+				action: 'VIEW',
+				identityName,
+				componentId,
+				renderingTarget,
+				abTest,
+				value: {
+					eventDescription: 'newsletter-signup-viewed',
+				},
+			});
+		};
+
+		// When the AB framework has resolved, fire immediately with the test
+		// metadata attached. Otherwise wait briefly for it to resolve so we can
+		// attribute the view to the correct arm — but never block the VIEW event
+		// indefinitely: the AB framework can fail to initialise, and newsletter
+		// tracking must continue to work regardless.
+		if (isABResolved) {
+			fireView();
+			return;
+		}
+
+		const timeoutId = setTimeout(fireView, AB_RESOLUTION_TIMEOUT_MS);
+		return () => clearTimeout(timeoutId);
+	}, [
+		abTest,
+		componentId,
+		identityName,
+		isABResolved,
+		isSubscribed,
+		renderingTarget,
+	]);
 
 	return (
 		<InlineSkipToWrapper
@@ -94,6 +137,8 @@ export const EmailSignUpWrapper = ({
 				category={category}
 				exampleUrl={exampleUrl}
 				renderingTarget={renderingTarget}
+				abTest={abTest}
+				enablePreview={enablePreview}
 				isSignedIn={isSignedIn}
 			>
 				{(previewAction) => (
@@ -104,6 +149,7 @@ export const EmailSignUpWrapper = ({
 							frequency={frequency}
 							previewAction={previewAction}
 							componentId={componentId}
+							abTest={abTest}
 							isAlreadySubscribed={isSubscribed}
 						/>
 					</Island>

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.test.tsx
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import {
+	NEWSLETTER_PREVIEW_AB_TEST_NAME,
+	NEWSLETTER_PREVIEW_VARIANT,
+} from '../lib/newsletterSignupAbTest';
 import { NEWSLETTER_SIGNUP_COMPONENT_ID } from '../lib/newsletterSignupTracking';
 import { NewsletterSignupCardContainer } from './NewsletterSignupCardContainer';
 
@@ -26,18 +30,13 @@ const renderContainer = (props = {}) =>
 			isSignedIn={true}
 			{...props}
 		>
-			{(previewAction) => (
-				<button
-					type="button"
-					onClick={
-						previewAction?.behaviour === 'modal'
-							? previewAction.onClick
-							: undefined
-					}
-				>
-					Preview latest
-				</button>
-			)}
+			{(previewAction) =>
+				previewAction?.behaviour === 'modal' ? (
+					<button type="button" onClick={previewAction.onClick}>
+						Preview latest
+					</button>
+				) : null
+			}
 		</NewsletterSignupCardContainer>,
 	);
 
@@ -63,7 +62,12 @@ describe('NewsletterSignupCardContainer', () => {
 
 	describe('preview tracking', () => {
 		it('fires an EXPAND event with the variant component id when the preview is opened', () => {
-			renderContainer();
+			renderContainer({
+				abTest: {
+					name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+					variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+				},
+			});
 
 			fireEvent.click(
 				screen.getByRole('button', { name: 'Preview latest' }),
@@ -78,6 +82,10 @@ describe('NewsletterSignupCardContainer', () => {
 						),
 					},
 					action: 'EXPAND',
+					abTest: {
+						name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+						variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+					},
 					value: expect.stringContaining(
 						'"eventDescription":"preview-open"',
 					),
@@ -133,6 +141,16 @@ describe('NewsletterSignupCardContainer', () => {
 				firstCallCount,
 			);
 		});
+
+		it('does not render any preview trigger when preview is disabled', () => {
+			renderContainer({ enablePreview: false });
+
+			expect(
+				screen.queryByRole('button', { name: 'Preview latest' }),
+			).not.toBeInTheDocument();
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			expect(submitComponentEvent).not.toHaveBeenCalled();
+		});
 	});
 
 	it('renders a preview link for apps and tracks the open event', () => {
@@ -184,5 +202,38 @@ describe('NewsletterSignupCardContainer', () => {
 			'Apps',
 		);
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	it('does not render a preview link for apps when preview is disabled', () => {
+		render(
+			<NewsletterSignupCardContainer
+				identityName="morning-briefing"
+				category="fronts-based"
+				exampleUrl="/world/newsletters/morning-mail"
+				renderingTarget="Apps"
+				theme="news"
+				name="Morning Briefing"
+				frequency="Every weekday"
+				description="Start your day with top stories."
+				isSignedIn={true}
+				enablePreview={false}
+			>
+				{(previewAction) =>
+					previewAction?.behaviour === 'link' ? (
+						<a
+							href={previewAction.href}
+							onClick={previewAction.onClick}
+						>
+							Preview latest
+						</a>
+					) : null
+				}
+			</NewsletterSignupCardContainer>,
+		);
+
+		expect(
+			screen.queryByRole('link', { name: 'Preview latest' }),
+		).not.toBeInTheDocument();
+		expect(submitComponentEvent).not.toHaveBeenCalled();
 	});
 });

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import type { AbTest } from '@guardian/ophan-tracker-js';
 import { palette as sourcePalette, space } from '@guardian/source/foundations';
 import { useCallback, useState } from 'react';
 import { buildNewsletterPreviewUrl } from '../lib/newsletterPreviewUrl';
@@ -20,12 +21,14 @@ const sendPreviewTracking = ({
 	renderingTarget,
 	renderUrl,
 	isSignedIn,
+	abTest,
 }: {
 	identityName: string;
 	eventDescription: PreviewEventDescription;
 	renderingTarget: RenderingTarget;
 	renderUrl: string;
 	isSignedIn?: boolean | 'Pending';
+	abTest?: AbTest;
 }) => {
 	sendNewsletterSignupEvent({
 		action: eventDescription === 'preview-open' ? 'EXPAND' : 'CLOSE',
@@ -34,6 +37,7 @@ const sendPreviewTracking = ({
 			NEWSLETTER_SIGNUP_COMPONENT_ID.inArticleSignupForm(identityName),
 		renderingTarget,
 		value: { eventDescription, renderUrl, isSignedIn },
+		abTest,
 	});
 };
 
@@ -47,6 +51,8 @@ type Props = Pick<
 	renderingTarget: RenderingTarget;
 	theme: string;
 	isSignedIn?: boolean | 'Pending';
+	abTest?: AbTest;
+	enablePreview?: boolean;
 	children?: (
 		previewAction: NewsletterPreviewAction | undefined,
 	) => React.ReactNode;
@@ -70,6 +76,8 @@ export const NewsletterSignupCardContainer = ({
 	illustrationSquare,
 	children,
 	isSignedIn,
+	abTest,
+	enablePreview = true,
 }: Props) => {
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
@@ -77,10 +85,10 @@ export const NewsletterSignupCardContainer = ({
 		exampleUrl,
 		category,
 	});
-	const hasPreviewUrl = Boolean(renderUrl);
+	const hasPreviewUrl = enablePreview && Boolean(renderUrl);
 
 	const openPreview = useCallback(() => {
-		if (!renderUrl) {
+		if (renderUrl === undefined) {
 			return;
 		}
 
@@ -92,15 +100,16 @@ export const NewsletterSignupCardContainer = ({
 					renderingTarget,
 					renderUrl,
 					isSignedIn,
+					abTest,
 				});
 			}
 
 			return true;
 		});
-	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
+	}, [abTest, identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const trackPreviewLinkOpen = useCallback(() => {
-		if (!renderUrl) {
+		if (renderUrl === undefined) {
 			return;
 		}
 
@@ -110,24 +119,26 @@ export const NewsletterSignupCardContainer = ({
 			renderingTarget,
 			renderUrl,
 			isSignedIn,
+			abTest,
 		});
-	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
+	}, [abTest, identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const closePreview = useCallback(() => {
 		setIsPreviewOpen((isOpen) => {
-			if (isOpen && renderUrl) {
+			if (isOpen && renderUrl !== undefined) {
 				sendPreviewTracking({
 					identityName,
 					eventDescription: 'preview-close',
 					renderingTarget,
 					renderUrl,
 					isSignedIn,
+					abTest,
 				});
 			}
 
 			return false;
 		});
-	}, [identityName, isSignedIn, renderingTarget, renderUrl]);
+	}, [abTest, identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const previewAction = hasPreviewUrl
 		? renderingTarget === 'Apps'
@@ -144,7 +155,7 @@ export const NewsletterSignupCardContainer = ({
 
 	return (
 		<div css={themeColorStyles(theme)}>
-			{isPreviewOpen && hasPreviewUrl && (
+			{enablePreview && isPreviewOpen && hasPreviewUrl && (
 				<NewsletterPreviewModal
 					newsletterName={name}
 					renderUrl={renderUrl ?? ''}

--- a/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCardContainer.tsx
@@ -88,7 +88,7 @@ export const NewsletterSignupCardContainer = ({
 	const hasPreviewUrl = enablePreview && Boolean(renderUrl);
 
 	const openPreview = useCallback(() => {
-		if (renderUrl === undefined) {
+		if (renderUrl === undefined || renderUrl === '') {
 			return;
 		}
 
@@ -109,7 +109,7 @@ export const NewsletterSignupCardContainer = ({
 	}, [abTest, identityName, isSignedIn, renderingTarget, renderUrl]);
 
 	const trackPreviewLinkOpen = useCallback(() => {
-		if (renderUrl === undefined) {
+		if (renderUrl === undefined || renderUrl === '') {
 			return;
 		}
 
@@ -125,7 +125,7 @@ export const NewsletterSignupCardContainer = ({
 
 	const closePreview = useCallback(() => {
 		setIsPreviewOpen((isOpen) => {
-			if (isOpen && renderUrl !== undefined) {
+			if (isOpen && renderUrl !== undefined && renderUrl !== '') {
 				sendPreviewTracking({
 					identityName,
 					eventDescription: 'preview-close',

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -2,11 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { type ComponentProps, forwardRef, useImperativeHandle } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import {
 	NEWSLETTER_PREVIEW_AB_TEST_NAME,
 	NEWSLETTER_PREVIEW_VARIANT,
 } from '../lib/newsletterSignupAbTest';
-import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
 import { useBrowserId } from '../lib/useBrowserId';

--- a/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupForm.island.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { forwardRef, useImperativeHandle } from 'react';
+import { type ComponentProps, forwardRef, useImperativeHandle } from 'react';
 import { submitComponentEvent } from '../client/ophan/ophan';
+import {
+	NEWSLETTER_PREVIEW_AB_TEST_NAME,
+	NEWSLETTER_PREVIEW_VARIANT,
+} from '../lib/newsletterSignupAbTest';
 import { lazyFetchEmailWithTimeout } from '../lib/fetchEmail';
 import { clearSubscriptionCache } from '../lib/newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from '../lib/useAuthStatus';
@@ -75,7 +79,9 @@ jest.mock('react-google-recaptcha', () => ({
 	),
 }));
 
-const renderForm = () =>
+const renderForm = (
+	props?: Partial<ComponentProps<typeof NewsletterSignupForm>>,
+) =>
 	render(
 		<ConfigProvider
 			value={{
@@ -90,6 +96,7 @@ const renderForm = () =>
 				newsletterName="Morning Briefing"
 				frequency="every day"
 				componentId="AR NewsletterSignupForm morning-briefing"
+				{...props}
 			/>
 		</ConfigProvider>,
 	);
@@ -236,6 +243,28 @@ describe('NewsletterSignupForm', () => {
 			getTrackedPayloadForEvent('submission-confirmed')
 				?.marketingOptInType,
 		).toBe('similar-guardian-products-optin');
+	});
+
+	it('forwards AB metadata to tracking events when provided', async () => {
+		const testUser = user.setup();
+		const abTest = {
+			name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+			variant: NEWSLETTER_PREVIEW_VARIANT.illustrated,
+		} as const;
+
+		renderForm({ abTest });
+
+		await typeEmailAddress(testUser);
+		await testUser.click(screen.getByRole('button', { name: 'Sign up' }));
+
+		await waitFor(() => {
+			expect(screen.getByText("You're signed up!")).toBeInTheDocument();
+		});
+
+		const trackingCalls = (submitComponentEvent as jest.Mock).mock
+			.calls as Array<[{ abTest?: { name: string; variant: string } }]>;
+		const [firstEventPayload] = trackingCalls[0] ?? [{}];
+		expect(firstEventPayload.abTest).toEqual(abTest);
 	});
 
 	it('supports tab order from email input to marketing toggle to sign up', async () => {

--- a/dotcom-rendering/src/lib/newsletterSignupAbTest.ts
+++ b/dotcom-rendering/src/lib/newsletterSignupAbTest.ts
@@ -1,0 +1,34 @@
+import type { AbTest } from '@guardian/ophan-tracker-js';
+
+export const NEWSLETTER_PREVIEW_AB_TEST_NAME =
+	'newsletters-in-article-signup-preview';
+
+export const NEWSLETTER_PREVIEW_VARIANT = {
+	illustrated: 'illustrated',
+	withoutPreview: 'without-preview',
+} as const;
+
+export type NewsletterPreviewVariant =
+	(typeof NEWSLETTER_PREVIEW_VARIANT)[keyof typeof NEWSLETTER_PREVIEW_VARIANT];
+
+export const isNewsletterPreviewVariant = (
+	variant: string | undefined,
+): variant is NewsletterPreviewVariant =>
+	variant === NEWSLETTER_PREVIEW_VARIANT.illustrated ||
+	variant === NEWSLETTER_PREVIEW_VARIANT.withoutPreview;
+
+export const isWithoutPreviewVariant = (variant: string | undefined): boolean =>
+	variant === NEWSLETTER_PREVIEW_VARIANT.withoutPreview;
+
+export const resolveNewsletterPreviewAbTest = (
+	variant: string | undefined,
+): AbTest | undefined => {
+	if (!isNewsletterPreviewVariant(variant)) {
+		return;
+	}
+
+	return {
+		name: NEWSLETTER_PREVIEW_AB_TEST_NAME,
+		variant,
+	};
+};


### PR DESCRIPTION
## What does this change?

Introduces a 2-arm A/B test (`newsletters-in-article-signup-preview`) for the in-article newsletter signup component:

- **`illustrated`** – the existing experience, with the "Preview latest" CTA and modal intact
- **`without-preview`** – identical to `illustrated` except the Preview button is removed and the preview modal cannot be opened

The A/B test variant is threaded through to:
- `NewsletterSignupCardContainer` via an `enablePreview` prop (disabling the preview button and modal in `without-preview`)
- `NewsletterSignupForm` and the Ophan `VIEW` event via an `abTest` prop, so all newsletter signup tracking is attributed to the correct arm
- Preview-specific tracking (modal open/close events) only fires in the `illustrated` arm

A small resilience improvement is also included: the `VIEW` event now waits up to 2 seconds for the AB framework to resolve so it can attach test metadata, but will always fire eventually even if the AB framework never initialises.

## Why?

**Hypothesis:** Including the Preview button in the variant is causing people to click it instead of subscribing, reducing conversion.

By running `without-preview` alongside `illustrated` we can measure whether removing the Preview CTA improves newsletter subscription rates.

## Screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!-- before: illustrated arm — Preview CTA visible -->
<!-- after: without-preview arm — Preview CTA removed -->