### PR TITLE
feat: Add headers to understand who responded

### DIFF
--- a/dotcom-rendering/src/server/lib/header-middleware.ts
+++ b/dotcom-rendering/src/server/lib/header-middleware.ts
@@ -11,8 +11,15 @@ const getTargetGroupHeaderValue = () => {
 	return 'dev';
 };
 
-const backendApp = process.env.GU_APP ?? 'rendering';
-const targetGroup = getTargetGroupHeaderValue();
+const getHeaders: () => Record<string, string> = () => {
+	const backendApp = process.env.GU_APP ?? 'rendering';
+	const targetGroup = getTargetGroupHeaderValue();
+
+	return {
+		'X-Gu-Backend-App': backendApp,
+		'X-Gu-Backend-App-Target-Group': targetGroup,
+	};
+};
 
 /**
  * Middleware to add response headers useful for debugging.
@@ -24,10 +31,7 @@ export const responseHeaderMiddleware: RequestHandler = (
 	res: Response,
 	next: NextFunction,
 ) => {
-	const headers = {
-		'X-Gu-Backend-App': backendApp,
-		'X-Gu-Backend-App-Target-Group': targetGroup,
-	};
+	const headers = getHeaders();
 
 	for (const [key, value] of Object.entries(headers)) {
 		res.setHeader(key, value);

--- a/dotcom-rendering/src/server/lib/header-middleware.ts
+++ b/dotcom-rendering/src/server/lib/header-middleware.ts
@@ -1,0 +1,36 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+const getTargetGroupHeaderValue = () => {
+	if (process.env.NODE_ENV === 'production') {
+		// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
+		return process.env.AWS_EXECUTION_ENV?.startsWith('AWS_ECS_') === true
+			? 'ecs'
+			: 'ec2';
+	}
+
+	return 'dev';
+};
+
+const backendApp = process.env.GU_APP ?? 'dev';
+const targetGroup = getTargetGroupHeaderValue();
+
+/**
+ * Middleware to add response headers useful for debugging.
+ *
+ * @see https://expressjs.com/en/guide/using-middleware
+ */
+export const responseHeaderMiddleware: RequestHandler = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	const headers = {
+		'X-Gu-Backend-App': backendApp,
+		'X-Gu-Backend-App-Target-Group': targetGroup,
+	};
+
+	for (const [key, value] of Object.entries(headers)) {
+		res.setHeader(key, value);
+	}
+	next();
+};

--- a/dotcom-rendering/src/server/lib/header-middleware.ts
+++ b/dotcom-rendering/src/server/lib/header-middleware.ts
@@ -11,7 +11,7 @@ const getTargetGroupHeaderValue = () => {
 	return 'dev';
 };
 
-const backendApp = process.env.GU_APP ?? 'dev';
+const backendApp = process.env.GU_APP ?? 'rendering';
 const targetGroup = getTargetGroupHeaderValue();
 
 /**

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -1,4 +1,11 @@
-import { type ErrorRequestHandler, type Handler, Router } from 'express';
+import {
+	type ErrorRequestHandler,
+	type Handler,
+	type NextFunction,
+	type Request,
+	type Response,
+	Router,
+} from 'express';
 import { pages } from '../devServer/routers/pages';
 import { targets } from '../devServer/routers/targets';
 import { handleAllEditorialNewslettersPage } from './handler.allEditorialNewslettersPage.web';
@@ -61,6 +68,8 @@ const editionalisefront = (url: string): string => {
 	return url;
 };
 
+const backendApp = process.env.GU_APP ?? 'dev';
+
 const redirects: Handler = (req, res, next) => {
 	const path = req.path.split('/')[1];
 
@@ -105,6 +114,20 @@ const renderer = Router();
 renderer.use(getContentFromURLMiddleware);
 renderer.use(getABTestsFromQueryParams);
 renderer.use(requestLoggerMiddleware);
+
+renderer.use((req: Request, res: Response, next: NextFunction) => {
+	const headers = {
+		'X-Gu-Backend-App': backendApp,
+		'X-Gu-Backend-App-Target-Group': 'dev',
+	};
+
+	for (const [key, value] of Object.entries(headers)) {
+		res.setHeader(key, value);
+	}
+
+	next();
+});
+
 renderer.get('/Article/*url', handleArticle);
 renderer.get('/Interactive/*url', handleInteractive);
 renderer.get('/Blocks/*url', handleBlocks);

--- a/dotcom-rendering/src/server/server.dev.ts
+++ b/dotcom-rendering/src/server/server.dev.ts
@@ -1,11 +1,4 @@
-import {
-	type ErrorRequestHandler,
-	type Handler,
-	type NextFunction,
-	type Request,
-	type Response,
-	Router,
-} from 'express';
+import { type ErrorRequestHandler, type Handler, Router } from 'express';
 import { pages } from '../devServer/routers/pages';
 import { targets } from '../devServer/routers/targets';
 import { handleAllEditorialNewslettersPage } from './handler.allEditorialNewslettersPage.web';
@@ -35,6 +28,7 @@ import {
 import { handleAppsThrasher } from './handler.thrasher.apps';
 import { getABTestsFromQueryParams } from './lib/get-abtests-from-query-params';
 import { getContentFromURLMiddleware } from './lib/get-content-from-url';
+import { responseHeaderMiddleware } from './lib/header-middleware';
 import { requestLoggerMiddleware } from './lib/logging-middleware';
 import { recordError } from './lib/logging-store';
 
@@ -67,8 +61,6 @@ const editionalisefront = (url: string): string => {
 	}
 	return url;
 };
-
-const backendApp = process.env.GU_APP ?? 'dev';
 
 const redirects: Handler = (req, res, next) => {
 	const path = req.path.split('/')[1];
@@ -114,19 +106,7 @@ const renderer = Router();
 renderer.use(getContentFromURLMiddleware);
 renderer.use(getABTestsFromQueryParams);
 renderer.use(requestLoggerMiddleware);
-
-renderer.use((req: Request, res: Response, next: NextFunction) => {
-	const headers = {
-		'X-Gu-Backend-App': backendApp,
-		'X-Gu-Backend-App-Target-Group': 'dev',
-	};
-
-	for (const [key, value] of Object.entries(headers)) {
-		res.setHeader(key, value);
-	}
-
-	next();
-});
+renderer.use(responseHeaderMiddleware);
 
 renderer.get('/Article/*url', handleArticle);
 renderer.get('/Interactive/*url', handleInteractive);

--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -1,5 +1,10 @@
 import compression from 'compression';
-import type { ErrorRequestHandler, Request, Response } from 'express';
+import type {
+	ErrorRequestHandler,
+	NextFunction,
+	Request,
+	Response,
+} from 'express';
 import express from 'express';
 import { NotRenderableInDCR } from '../lib/errors/not-renderable-in-dcr';
 import { handleAllEditorialNewslettersPage } from './handler.allEditorialNewslettersPage.web';
@@ -32,6 +37,13 @@ import { logger } from './lib/logging';
 import { requestLoggerMiddleware } from './lib/logging-middleware';
 import { recordError } from './lib/logging-store';
 
+// TODO extract this, and other places that read env vars, into a `config` object?
+// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
+const runningInECS =
+	process.env.AWS_EXECUTION_ENV?.startsWith('AWS_ECS_') === true;
+
+const backendApp = process.env.GU_APP ?? 'unknown';
+
 export const prodServer = (): void => {
 	logger.info('dotcom-rendering is GO.');
 
@@ -40,6 +52,19 @@ export const prodServer = (): void => {
 	app.use(express.json({ limit: '50mb' }));
 	app.use(requestLoggerMiddleware);
 	app.use(compression());
+
+	app.use((req: Request, res: Response, next: NextFunction) => {
+		const headers = {
+			'X-Gu-Backend-App': backendApp,
+			'X-Gu-Backend-App-Target-Group': runningInECS ? 'ecs' : 'ec2',
+		};
+
+		for (const [key, value] of Object.entries(headers)) {
+			res.setHeader(key, value);
+		}
+
+		next();
+	});
 
 	app.get('/_healthcheck', (req: Request, res: Response) => {
 		res.status(200).send('OKAY');

--- a/dotcom-rendering/src/server/server.prod.ts
+++ b/dotcom-rendering/src/server/server.prod.ts
@@ -1,10 +1,5 @@
 import compression from 'compression';
-import type {
-	ErrorRequestHandler,
-	NextFunction,
-	Request,
-	Response,
-} from 'express';
+import type { ErrorRequestHandler, Request, Response } from 'express';
 import express from 'express';
 import { NotRenderableInDCR } from '../lib/errors/not-renderable-in-dcr';
 import { handleAllEditorialNewslettersPage } from './handler.allEditorialNewslettersPage.web';
@@ -33,16 +28,10 @@ import {
 } from './handler.sportDataPage';
 import { handleAppsThrasher } from './handler.thrasher.apps';
 import { recordBaselineCloudWatchMetrics } from './lib/aws/metrics-baseline';
+import { responseHeaderMiddleware } from './lib/header-middleware';
 import { logger } from './lib/logging';
 import { requestLoggerMiddleware } from './lib/logging-middleware';
 import { recordError } from './lib/logging-store';
-
-// TODO extract this, and other places that read env vars, into a `config` object?
-// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
-const runningInECS =
-	process.env.AWS_EXECUTION_ENV?.startsWith('AWS_ECS_') === true;
-
-const backendApp = process.env.GU_APP ?? 'unknown';
 
 export const prodServer = (): void => {
 	logger.info('dotcom-rendering is GO.');
@@ -52,19 +41,7 @@ export const prodServer = (): void => {
 	app.use(express.json({ limit: '50mb' }));
 	app.use(requestLoggerMiddleware);
 	app.use(compression());
-
-	app.use((req: Request, res: Response, next: NextFunction) => {
-		const headers = {
-			'X-Gu-Backend-App': backendApp,
-			'X-Gu-Backend-App-Target-Group': runningInECS ? 'ecs' : 'ec2',
-		};
-
-		for (const [key, value] of Object.entries(headers)) {
-			res.setHeader(key, value);
-		}
-
-		next();
-	});
+	app.use(responseHeaderMiddleware);
 
 	app.get('/_healthcheck', (req: Request, res: Response) => {
 		res.status(200).send('OKAY');


### PR DESCRIPTION
## What does this change?
This change adds two headers to each response:
- `X-Gu-Backend-App` which represents which app is running (tag-page-rendering, article-rendering, etc.)
- `X-Gu-Backend-App-Target-Group` which represents which target group served the request (EC2 or ECS)

One use-case for this is in the "run DCR on ECS" project (see also https://github.com/guardian/dotcom-rendering/pull/16321).

This is similar to [guardian/frontend](https://github.com/guardian/frontend/blob/0cbc1c8448d6afb74eab75903b16a224fbcf1114/common/app/http/Filters.scala#L49-L62).

`X-Gu-Backend-App` is already [removed](https://github.com/guardian/fastly-edge-cache/blob/0117ee59aadc9de973b1407eab96f563c5ca10fc/theguardiancom/src/main/resources/varnish21/security.vcl#L43-L53) for reader requests within Fastly. `X-Gu-Backend-App-Target-Group` is removed in https://github.com/guardian/fastly-edge-cache/pull/1199.

## Why?
As part of @guardian/devx-reliability-and-ops's project to run DCR on AWS, we'll be splitting traffic between the current EC2 target group and the new ECS target group. This header helps to distinguish what infrastructure responded.

## How has this change been tested?

After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/2c3cbf83-18c7-4533-aac2-41dccc06be44) and following the steps listed in https://github.com/guardian/dotcom-rendering/pull/16377, we can see the new headers:

```console
curl -s "https://www.theguardian.com/tone/minutebyminute.json?dcr=true" | \
  curl -s -X POST https://tag-page-rendering.code.dev-guardianapis.com/TagPage \
    -H "Content-Type: application/json" \
    -d @- -D - -o /dev/null

HTTP/2 200
date: Wed, 15 Jul 2026 10:13:41 GMT
content-type: text/html; charset=utf-8
content-length: 365212
x-gu-backend-app: tag-page-rendering
x-gu-backend-app-target-group: ec2
x-powered-by: Express
link: <https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6%2Ces7%2Ces2017%2Ces2018%2Ces2019%2Cdefault-3.6%2CHTMLPictureElement%2CIntersectionObserver%2CIntersectionObserverEntry%2CURLSearchParams%2Cfetch%2CNodeList.prototype.forEach%2Cnavigator.sendBeacon%2Cperformance.now%2CPromise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1>; rel=prefetch,<https://assets-code.guim.co.uk/assets/frameworks.client.web.6b19980dfdb962b2f0d0.js>; rel=prefetch,<https://assets-code.guim.co.uk/assets/index.client.web.b98149db4bc4f45b7f3c.js>; rel=prefetch,<https://assets.guim.co.uk/commercial/454fa0f267b7fb516298/graun.standalone.commercial.js>; rel=prefetch,
etag: W/"5929c-f+HFJg+uAM7mWBRL5skzmVOMj+Q"
vary: Accept-Encoding
```