### PR TITLE
Fix highlights newsletter tracking, expose component IDs for HighlightsNewsletterCard and SignupModal

### DIFF
--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.test.tsx
@@ -27,8 +27,17 @@ jest.mock('../HighlightsCardImage', () => ({
 
 jest.mock('./HighlightsNewsletterSignupModal', () => ({
 	HighlightsNewsletterSignupModal: jest.fn(
-		({ onClose }: { onClose: () => void }) => (
-			<div data-testid="highlights-newsletter-signup-modal">
+		({
+			onClose,
+			componentId,
+		}: {
+			onClose: () => void;
+			componentId: string;
+		}) => (
+			<div
+				data-testid="highlights-newsletter-signup-modal"
+				data-component-id={componentId}
+			>
 				<button type="button" onClick={onClose}>
 					Close signup form
 				</button>
@@ -106,7 +115,10 @@ describe('HighlightsNewsletterCard', () => {
 		fireEvent.click(link);
 		expect(
 			screen.getByTestId('highlights-newsletter-signup-modal'),
-		).toBeInTheDocument();
+		).toHaveAttribute(
+			'data-component-id',
+			`highlights-modal-${defaultProps.newsletter.identityName}`,
+		);
 
 		expect(sendNewsletterSignupEvent).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -238,12 +250,17 @@ describe('HighlightsNewsletterCard', () => {
 		);
 	});
 
-	it('sets data-modal-component-id on the link to match the Ophan modal component ID', () => {
+	it('sets card and modal component IDs on the link to match the Ophan component IDs', () => {
 		renderCard();
 
 		const link = screen.getByRole('link', {
 			name: defaultProps.headlineText,
 		});
+
+		expect(link).toHaveAttribute(
+			'data-card-component-id',
+			`highlights-card-${defaultProps.newsletter.identityName}`,
+		);
 
 		expect(link).toHaveAttribute(
 			'data-modal-component-id',

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterCard.tsx
@@ -196,7 +196,7 @@ export const HighlightsNewsletterCard = ({
 					<HighlightsNewsletterSignupModal
 						newsletter={newsletter}
 						renderingTarget={renderingTarget}
-						componentId={componentId}
+						componentId={modalComponentId}
 						onClose={() => {
 							setIsModalOpen(false);
 							sendNewsletterSignupEvent({
@@ -218,6 +218,7 @@ export const HighlightsNewsletterCard = ({
 						css={linkOverlayStyles}
 						onClick={handleClick}
 						data-link-name={dataLinkName}
+						data-card-component-id={componentId}
 						data-modal-component-id={modalComponentId}
 						aria-label={headlineText}
 					/>

--- a/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.tsx
+++ b/dotcom-rendering/src/components/Masthead/Newsletter/HighlightsNewsletterSignupModal.tsx
@@ -12,10 +12,7 @@ import {
 	Pillar,
 } from '../../../lib/articleFormat';
 import { generateImageURL } from '../../../lib/image';
-import {
-	NEWSLETTER_SIGNUP_COMPONENT_ID,
-	sendNewsletterSignupEvent,
-} from '../../../lib/newsletterSignupTracking';
+import { sendNewsletterSignupEvent } from '../../../lib/newsletterSignupTracking';
 import { useNewsletterSubscription } from '../../../lib/useNewsletterSubscription';
 import type { Newsletter } from '../../../types/content';
 import type { RenderingTarget } from '../../../types/renderingTarget';
@@ -110,10 +107,12 @@ const HighlightsNewsletterSignupModalContent = ({
 	newsletter,
 	titleId,
 	isSubscribed,
+	componentId,
 }: {
 	newsletter: Newsletter;
 	titleId: string;
 	isSubscribed: boolean | undefined;
+	componentId: string;
 }) => {
 	const requestClose = useModalRequestClose();
 
@@ -150,9 +149,7 @@ const HighlightsNewsletterSignupModalContent = ({
 					frequency={newsletter.frequency}
 					isModal={true}
 					isAlreadySubscribed={isSubscribed === true}
-					componentId={NEWSLETTER_SIGNUP_COMPONENT_ID.highlightsModal(
-						newsletter.identityName,
-					)}
+					componentId={componentId}
 				/>
 			</NewsletterSignupCard>
 		</FormatBoundary>
@@ -194,6 +191,7 @@ export const HighlightsNewsletterSignupModal = ({
 				newsletter={newsletter}
 				titleId={titleId}
 				isSubscribed={isSubscribed}
+				componentId={componentId}
 			/>
 		</ModalOverlay>
 	);


### PR DESCRIPTION
## What does this change?

- Corrects the component ID used by the Highlights newsletter modal `VIEW` event.
- Passes the modal component ID to `HighlightsNewsletterSignupModal` instead of the card component ID.
- Exposes both Ophan component IDs on the newsletter card link:
    - `data-card-component-id`
    - `data-modal-component-id`
- Keeps the existing event ownership unchanged:
    - Card `VIEW`, `EXPAND`, and `CLOSE` events use the card component ID.
    - Modal `VIEW`, form, captcha, and `SUBSCRIBE` events use the modal component ID.

## Why?

Highlights newsletter signup tracking spans two components:

- The card component emits the `EXPAND` event when it is clicked to open the modal.
- The modal component emits the modal `VIEW` event and subsequent signup events, including `SUBSCRIBE`.

The modal was previously receiving the card component ID, causing its `VIEW` event to be recorded against the wrong component.

Heatphan also needs both IDs to measure the signup funnel for each card:

- Card component ID + `EXPAND` → opens
- Modal component ID + `SUBSCRIBE` → subscriptions

Exposing both IDs on the card link allows Heatphan to query these events using exact component-ID matching.

## How has this change been tested?

Updated the relevant Jest/React Testing Library tests to verify that:

- The card link exposes both the card and modal component IDs.
- The modal receives the modal component ID.
- The modal-mounted `VIEW` event uses the modal component ID.
- The card `EXPAND` event continues to use the card component ID.
- The newsletter signup form continues to use the modal component ID.

There are no visual or behavioural UI changes.

## Screenshots

Not applicable — this change only affects Ophan tracking metadata and DOM data attributes.