### PR TITLE
Fix: forward `preview-*` query parameter to SDC requests

### DIFF
--- a/dotcom-rendering/src/lib/sdcRequests.test.ts
+++ b/dotcom-rendering/src/lib/sdcRequests.test.ts
@@ -144,6 +144,31 @@ describe('sdcRequests', () => {
 			);
 		});
 
+		it('appends preview parameter when present in URL', async () => {
+			Object.defineProperty(window, 'location', {
+				value: {
+					search: '?preview-epic=control',
+				},
+				writable: true,
+			});
+
+			const { getEpic } = await import('./sdcRequests');
+			await getEpic('https://contributions.guardianapis.com', {
+				targeting: {},
+			} as never);
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://contributions.guardianapis.com/epic?preview=control',
+				{
+					method: 'post',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: '{"targeting":{}}',
+				},
+			);
+		});
+
 		it('does not append force when neither is present', async () => {
 			const { getEpic } = await import('./sdcRequests');
 			await getEpic('https://contributions.guardianapis.com', {

--- a/dotcom-rendering/src/lib/sdcRequests.ts
+++ b/dotcom-rendering/src/lib/sdcRequests.ts
@@ -35,11 +35,17 @@ const getForcedVariant = (type: ModuleType): string | null => {
 	return params.get(`force-${type}`);
 };
 
+const getPreviewVariant = (type: ModuleType): string | null => {
+	const params = new URLSearchParams(window.location.search);
+	return params.get(`preview-${type}`);
+};
+
 type Payload = EpicPayload | BannerPayload | HeaderPayload | GutterPayload;
 
 const buildSDCUrl = (baseUrl: string, type: ModuleType): string => {
 	const deviceClass = getDeviceClass();
 	const forcedVariant = getForcedVariant(type);
+	const previewVariant = getPreviewVariant(type);
 
 	const queryParams = new URLSearchParams();
 	if (deviceClass) {
@@ -47,6 +53,9 @@ const buildSDCUrl = (baseUrl: string, type: ModuleType): string => {
 	}
 	if (forcedVariant) {
 		queryParams.set('force', forcedVariant);
+	}
+	if (previewVariant) {
+		queryParams.set('preview', previewVariant);
 	}
 
 	const queryString = queryParams.toString();


### PR DESCRIPTION
The `preview-*` URL parameter was not being forwarded to SDC — only `force-*` was. 

This adds [getPreviewVariant](cci:1://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/lib/sdcRequests.ts:37:0-40:2) to [sdcRequests.ts](cci:7://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/lib/sdcRequests.ts:0:0-0:0) and wires it into [buildSDCUrl](cci:1://file:///Users/admin.juarez.mota/code/dotcom-rendering/dotcom-rendering/src/lib/sdcRequests.ts:44:0-64:2), so `preview-banner` / `preview-epic` etc. are sent as `?preview=<value>` to SDC, matching the existing `force-*` pattern.