### PR TITLE
feat: Enable enhanced container insights

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -3416,6 +3416,12 @@ systemctl start tag-page-rendering",
     },
     "tagpagerenderingEcsClusterE7696595": {
       "Properties": {
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "enhanced",
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -17,6 +17,7 @@ import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
+import { ClusterSettings } from 'aws-cdk-lib/aws-ecs/mixins';
 import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
@@ -309,6 +310,13 @@ export class RenderingCDKStack extends CDKStack {
 					value,
 				);
 			}
+
+			// TODO enable this at the pattern level in GuCDK
+			app.ecsService?.cluster.with(
+				new ClusterSettings([
+					{ name: 'containerInsights', value: 'enhanced' },
+				]),
+			);
 		}
 
 		/**


### PR DESCRIPTION
## What does this change?
Follows https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.mixins.ClusterSettings.html to enable [enhanced container insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html). We'll use these to understand if the container has enough resources when under load.