### PR TITLE
epic colors updated to match BAU colors

### DIFF
--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -1,4 +1,4 @@
-import { from, palette } from '@guardian/source/foundations';
+import { from } from '@guardian/source/foundations';
 import type { ChoiceCard } from '@guardian/support-dotcom-components/dist/shared/types/props/choiceCards';
 import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types/props/epic';
 import { useState } from 'react';
@@ -49,11 +49,6 @@ export const ContributionsEpicCtasContainer: ReactComponent<EpicProps> = ({
 					choices={choiceCards}
 					id={'epic'}
 					submitComponentEvent={submitComponentEvent}
-					choiceCardDesignSettings={{
-						pillBackgroundColour: palette.brand[500],
-						pillTextColour: palette.neutral[100],
-						buttonSelectBorderColour: palette.brand[400],
-					}}
 				/>
 			)}
 			<ContributionsEpicButtons

--- a/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
+++ b/dotcom-rendering/src/components/marketing/epics/ctas/ContributionsEpicCtasContainer.tsx
@@ -1,4 +1,4 @@
-import { from } from '@guardian/source/foundations';
+import { from, palette } from '@guardian/source/foundations';
 import type { ChoiceCard } from '@guardian/support-dotcom-components/dist/shared/types/props/choiceCards';
 import type { EpicProps } from '@guardian/support-dotcom-components/dist/shared/types/props/epic';
 import { useState } from 'react';
@@ -49,6 +49,11 @@ export const ContributionsEpicCtasContainer: ReactComponent<EpicProps> = ({
 					choices={choiceCards}
 					id={'epic'}
 					submitComponentEvent={submitComponentEvent}
+					choiceCardDesignSettings={{
+						pillBackgroundColour: palette.brand[500],
+						pillTextColour: palette.neutral[100],
+						buttonSelectBorderColour: palette.brand[400],
+					}}
 				/>
 			)}
 			<ContributionsEpicButtons

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -144,7 +144,7 @@ export const ThreeTierChoiceCards = ({
 		border: ${selected
 			? `2px solid ${
 					choiceCardDesignSettings?.buttonSelectBorderColour ??
-					palette.brand['500']
+					palette.brand['400']
 				}`
 			: `1px solid ${
 					choiceCardDesignSettings?.buttonBorderColour ??
@@ -180,12 +180,12 @@ export const ThreeTierChoiceCards = ({
 		...themeRadio,
 		borderSelected:
 			choiceCardDesignSettings?.buttonSelectBorderColour ??
-			palette.brandAlt[400],
+			palette.brand[400],
 		borderUnselected:
 			choiceCardDesignSettings?.buttonBorderColour ?? palette.neutral[46],
 		borderHover:
 			choiceCardDesignSettings?.buttonSelectBorderColour ??
-			palette.brandAlt[400],
+			palette.brand[400],
 		fillSelected:
 			choiceCardDesignSettings?.buttonSelectMarkerColour ??
 			palette.brand[400],
@@ -200,7 +200,7 @@ export const ThreeTierChoiceCards = ({
 		if (pill.backgroundColour) {
 			return hexColourToString(pill.backgroundColour as HexColour);
 		}
-		return palette.brandAlt[400];
+		return palette.brand[500];
 	};
 
 	const pillStyles = (pill: NonNullable<ChoiceCard['pill']>) => {
@@ -211,7 +211,7 @@ export const ThreeTierChoiceCards = ({
 			if (pill.textColour) {
 				return hexColourToString(pill.textColour as HexColour);
 			}
-			return palette.neutral[7];
+			return palette.neutral[100];
 		};
 
 		return css`


### PR DESCRIPTION
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1216599525115758)
## What does this change?
This change updates radio button and ☑️ icons on epic and live blog epic choice cards to match the colours on BAU banner choice cards
## Why?

## How has this change been tested?
Deployed to CODE environment
<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

Before:
<img width="633" height="564" alt="before" src="https://github.com/user-attachments/assets/fc79ccfd-f444-4601-a460-2e7fdf7a8b00" />

After:
<img width="674" height="493" alt="Screenshot 2026-07-16 at 13 43 48" src="https://github.com/user-attachments/assets/f521412d-a9cf-4aa6-8c28-9be2503e7d74" />

The choice cards with promotion applied remain unchanged:
<img width="664" height="440" alt="Screenshot 2026-07-16 at 14 12 26" src="https://github.com/user-attachments/assets/072df301-cf2b-4240-aac8-d137dc615322" />


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
