### PR TITLE
Add ab test to examine ab test contamination

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -196,6 +196,19 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant-1"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "webx-monitor-group-contamination",
+		description:
+			"Test to measure the impact of contamination between groups in ab tests",
+		owners: ["dotcom.platform@guardian.com"],
+		status: "ON",
+		expirationDate: "2027-01-01",
+		type: "client",
+		audienceSize: 10 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -202,7 +202,7 @@ const ABTests: ABTest[] = [
 			"Test to measure the impact of contamination between groups in ab tests",
 		owners: ["dotcom.platform@guardian.com"],
 		status: "ON",
-		expirationDate: "2027-01-01",
+		expirationDate: "2026-08-31",
 		type: "client",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -200,7 +200,7 @@ const ABTests: ABTest[] = [
 		name: "webx-monitor-group-contamination",
 		description:
 			"Test to measure the impact of contamination between groups in ab tests",
-		owners: ["dotcom.platform@guardian.com"],
+		owners: ["dotcom.platform@theguardian.com"],
 		status: "ON",
 		expirationDate: "2026-08-31",
 		type: "client",

--- a/dotcom-rendering/src/components/Metrics.island.tsx
+++ b/dotcom-rendering/src/components/Metrics.island.tsx
@@ -8,12 +8,13 @@ import {
 	bypassCoreWebVitalsSampling,
 	initCoreWebVitals,
 } from '@guardian/core-web-vitals';
-import { isUndefined } from '@guardian/libs';
+import { getCookie, isUndefined } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
 import { useAB } from '../lib/useAB';
 import { useAdBlockInUse } from '../lib/useAdBlockInUse';
 import { useBrowserId } from '../lib/useBrowserId';
 import { useDetectAdBlock } from '../lib/useDetectAdBlock';
+import { useOnce } from '../lib/useOnce';
 import { usePageViewId } from '../lib/usePageViewId';
 import { useConfig } from './ConfigContext';
 
@@ -48,6 +49,23 @@ const useDev = () => {
 	}, []);
 
 	return isDev;
+};
+
+const logMvt = (mvtId: string | null) => {
+	const logsEndpoint = window.guardian.config.page.isDev
+		? '//logs.code.dev-guardianapis.com/log'
+		: '//logs.guardianapis.com/log';
+
+	void fetch(logsEndpoint, {
+		method: 'POST',
+		body: JSON.stringify({
+			label: 'webx.ab-testing',
+			properties: [{ name: 'mvtId', value: mvtId }],
+		}),
+		keepalive: true,
+		cache: 'no-store',
+		mode: 'no-cors',
+	});
 };
 
 /**
@@ -85,6 +103,9 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 		() => willRecordCoreWebVitals || collectTestMetrics,
 		[collectTestMetrics],
 	);
+
+	const isInMonitoringTest =
+		abTests?.isUserInTest('webx-monitor-group-contamination') ?? false;
 
 	useEffect(
 		function coreWebVitals() {
@@ -182,6 +203,20 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 			pageViewId,
 			shouldBypassSampling,
 		],
+	);
+
+	useOnce(
+		function reportMvtId() {
+			if (isDev || !isInMonitoringTest) return;
+
+			const mvtId = getCookie({
+				name: 'gu_v2_mvt_id',
+				shouldMemoize: true,
+			});
+
+			logMvt(mvtId);
+		},
+		[isDev, isInMonitoringTest],
 	);
 
 	// We don’t render anything

--- a/dotcom-rendering/src/components/Metrics.island.tsx
+++ b/dotcom-rendering/src/components/Metrics.island.tsx
@@ -207,7 +207,7 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 
 	useOnce(
 		function reportMvtId() {
-			if (isDev || !isInMonitoringTest) return;
+			if (!isInMonitoringTest) return;
 
 			const mvtId = getCookie({
 				name: 'gu_v2_mvt_id',
@@ -216,7 +216,7 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 
 			logMvt(mvtId);
 		},
-		[isDev, isInMonitoringTest],
+		[isInMonitoringTest],
 	);
 
 	// We don’t render anything

--- a/dotcom-rendering/src/components/Metrics.island.tsx
+++ b/dotcom-rendering/src/components/Metrics.island.tsx
@@ -60,7 +60,13 @@ const logMvt = (mvtId: string | null) => {
 		method: 'POST',
 		body: JSON.stringify({
 			label: 'webx.ab-testing',
-			properties: [{ name: 'mvtId', value: mvtId }],
+			properties: [
+				{ name: 'mvtId', value: mvtId },
+				{
+					name: 'pageviewId',
+					value: window.guardian.config.ophan.pageViewId,
+				},
+			],
 		}),
 		keepalive: true,
 		cache: 'no-store',


### PR DESCRIPTION
## What does this change?
Add an AB test to monitor the test group contamination issue we've seen lately.

When in this test the content of the pageview's mvt id cookie will also be logged to BigQuery.

## Why?
Hopefully this'll shed some light on the issue!
