### PR TITLE
remove full width hold back test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -109,19 +109,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-full-width-hold-back",
-		description:
-			"Test to measure impact of adding full width to spacefinder",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-14",
-		type: "client",
-		status: "ON",
-		audienceSize: 5 / 100,
-		audienceSpace: "A",
-		groups: ["holdback", "control"],
-		shouldForceMetricsCollection: true,
-	},
-	{
 		name: "commercial-ozone-outstream",
 		description: "A test to ensure correct integration of Ozone outstream.",
 		owners: ["commercial.dev@guardian.co.uk"],


### PR DESCRIPTION
Remove full width hold back test

## What does this change?

This test is expired. This removes the config for full width hold back test.

corresponding commercial PR https://github.com/guardian/commercial/pull/2625

