### PR TITLE
Fix floating point error with ab test space validator

### DIFF
--- a/ab-testing/config/scripts/validation/enoughSpace.ts
+++ b/ab-testing/config/scripts/validation/enoughSpace.ts
@@ -5,14 +5,14 @@ export function enoughSpace(allTests: ABTest[]) {
 		(acc, test) => {
 			const space = test.audienceSpace ?? "A";
 
-			acc[space] += test.audienceSize;
+			acc[space] += test.audienceSize * 100;
 			return acc;
 		},
 		{ A: 0, B: 0, C: 0 },
 	);
 
 	Object.entries(spaceTotalSize).forEach(([space, size]) => {
-		if (size > 1) {
+		if (size > 100) {
 			throw new Error(`Audience sizes in space ${space} exceeds 100%`);
 		}
 	});


### PR DESCRIPTION
## What does this change?
Multiply by 100 tests to avoid floating point errors

## Why?
the decimal test sizes when combined can lead to floating point errors, for example at the moment if you add a 10% test making audience space A total 100%, the calculated total is `1.0000000000000002`
