### PR TITLE
remove AB test config for price-floor-holdback

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -57,19 +57,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-prebid-price-floor-holdback",
-		description:
-			"This test will be the 5% holdback group for the prebid price floor",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-16",
-		type: "client",
-		status: "OFF",
-		audienceSize: 5 / 100,
-		audienceSpace: "A",
-		groups: ["holdback"],
-		shouldForceMetricsCollection: true,
-	},
-	{
 		name: "commercial-mobile-sticky-liveblog-us",
 		description:
 			"Holdback test, where variant is the 'holdback' group, to measure uplift in adding the mobile-sticky slot for Liveblogs articles in the US.",


### PR DESCRIPTION
What does this change?
Removes the AB test configuration for: `commercial-prebid-price-floor-holdback`

Why?
This test is now redundant since we have completed the holdback experiment.
Related commercial PR: https://github.com/guardian/commercial/pull/2628