### PR TITLE
Check island locations in CI

### DIFF
--- a/.github/workflows/check-islands.yml
+++ b/.github/workflows/check-islands.yml
@@ -1,0 +1,19 @@
+name: DCR Check Islands
+
+on:
+  workflow_call:
+
+jobs:
+  check_islands:
+    name: DCR Check Islands
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node environment
+        uses: ./.github/actions/setup-node-env
+
+      - name: Validate Islands
+        run: make check-islands
+        working-directory: dotcom-rendering

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,6 +31,9 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  islands:
+    uses: ./.github/workflows/check-islands.yml
+
   playwright:
     needs: [container]
     uses: ./.github/workflows/playwright.yml
@@ -42,7 +45,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write # required by riff-raff action
-    needs: [container, prettier, jest, lint, playwright]
+    needs: [container, islands, prettier, jest, lint, playwright]
     if: github.event_name == 'push' # We don't need a riff-raff deployment for merge_group events
     uses: ./.github/workflows/publish.yml
     with:

--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -88,6 +88,10 @@ buildCheck:
 	$(call log, "checking build files")
 	@node ./scripts/test/build-check.js
 
+check-islands:
+	$(call log, "checking island component locations")
+	@node ./scripts/islands/check-islands.mts
+
 # quality #########################################
 
 tsc: clean-dist install

--- a/dotcom-rendering/scripts/islands/check-islands.mts
+++ b/dotcom-rendering/scripts/islands/check-islands.mts
@@ -1,0 +1,57 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentFilename = fileURLToPath(import.meta.url);
+const currentDirname = path.dirname(currentFilename);
+
+const SRC_DIR = path.resolve(currentDirname, '../../src');
+const COMPONENTS_DIR = path.resolve(SRC_DIR, 'components');
+const ISLAND_FILENAME_FRAGMENT = '.island.tsx';
+
+const normalizePath = (filePath: string): string =>
+	filePath.split(path.sep).join('/');
+
+const run = async (): Promise<void> => {
+	const entries = await readdir(SRC_DIR, { recursive: true });
+
+	const islandFiles = entries.filter((entry) =>
+		path.basename(entry).includes(ISLAND_FILENAME_FRAGMENT),
+	);
+
+	const invalidIslandFiles = islandFiles
+		.filter(
+			(filePath) =>
+				path.resolve(SRC_DIR, path.dirname(filePath)) !==
+				COMPONENTS_DIR,
+		)
+		.map(normalizePath)
+		.sort();
+
+	if (invalidIslandFiles.length === 0) {
+		console.info(
+			`All files containing "${ISLAND_FILENAME_FRAGMENT}" are in src/components.`,
+		);
+		return;
+	}
+
+	console.error(
+		`Islands must live in the root of /components and follow the [MyComponent].island.tsx naming convention 🚨`,
+	);
+
+	console.error(
+		`Found ${invalidIslandFiles.length} file(s) containing "${ISLAND_FILENAME_FRAGMENT}" outside src/components:`,
+	);
+
+	for (const invalidFile of invalidIslandFiles) {
+		console.error(`- ${normalizePath(invalidFile)}`);
+	}
+
+	process.exitCode = 1;
+};
+
+run().catch((error: unknown) => {
+	console.error('Failed to check island component locations.');
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/dotcom-rendering/src/client/islands/doHydration.tsx
+++ b/dotcom-rendering/src/client/islands/doHydration.tsx
@@ -95,7 +95,7 @@ export const doHydration = async (
 			element.dataset.islandStatus = undefined; // remove any island status
 			if (name && error.message.includes(name)) {
 				console.error(
-					`🚨 Error importing ${name}. Components must live in the root of /components and follow the [MyComponent].island.tsx naming convention 🚨`,
+					`🚨 Error importing ${name}. Islands must live in the root of /components and follow the [MyComponent].island.tsx naming convention 🚨`,
 				);
 			}
 			throw error;


### PR DESCRIPTION
Co-authored-by: GPT-5.4 via GitHub Copilot <github-copilot[bot]@users.noreply.github.com>

## What does this change?

Islands must be located in `src/components` to ensure webpack has a known location for asynchronous loading.

If not followed a runtime error is thrown:

<img width="300px" src="https://github.com/user-attachments/assets/68eb6511-1409-419d-a026-e3c299d85c46" />

This PR adds a CI check to ensure all islands are in the `src/components` directory.

## Why?

Earlier feedback.

Fewer errors in production.

## How has this change been tested?

Manually.

CI checks on this PR which has not been rebased with https://github.com/guardian/dotcom-rendering/pull/16401 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| Runtime: ![before][] | CI: ![after][] |

[before]: https://github.com/user-attachments/assets/68eb6511-1409-419d-a026-e3c299d85c46
[after]: https://github.com/user-attachments/assets/7f7c4388-0862-4f18-b44c-9d6a56b65eaa

