### PR TITLE
Update makefile

### DIFF
--- a/dotcom-rendering/makefile
+++ b/dotcom-rendering/makefile
@@ -146,7 +146,7 @@ clean-dist:
 
 clean-deps:
 	$(call log, "trashing dependencies")
-	@rm -rf node_modules
+	@pnpm clean
 
 install: check-env
 	$(call log, "refreshing dependencies")


### PR DESCRIPTION
## What does this change?
Updates the `clean-deps` task to run [`pnpm clean`](https://pnpm.io/cli/clean) to:

> Safely remove node_modules contents from all workspace projects.

Previously only `root/dotcom-rendering/node_modules` was removed. `root/node_modules` also needs to be removed in this task.

Example output:

```console
❯ pnpm clean
Removing ../ab-testing/node_modules
Removing ../node_modules
Removing ../ab-testing/cdk/node_modules
Removing ../ab-testing/config/node_modules
Removing ../ab-testing/frontend/node_modules
Removing ../ab-testing/deploy-lambda/node_modules
Removing ../ab-testing/notification-lambda/node_modules
Removing node_modules
```

I'm not sure how useful the `clean-deps` task actually is; see also https://github.com/guardian/dotcom-rendering/issues/16265.

## Why?
See above.

## How has this change been tested?
See above.