### PR TITLE
Update CODEOWNERS for ab-testing project 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,4 +26,4 @@
 /dotcom-rendering/src/lib/braze/                @guardian/martech
 /dotcom-rendering/webpack/                      @guardian/dotcom-platform
 /scripts/                                       @guardian/dotcom-platform
-/ab-testing/                                    @guardian/commercial-dev
+/ab-testing/                                    @guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

This PR updates the CODEOWNERS for the [ab-testing](https://github.com/guardian/dotcom-rendering/tree/main/ab-testing) project to `@guardian/dotcom-platfrom` instead of `@guardian/commercial-dev` as agreed between CommDev and WebX.

## Why?

CommDev has done the dev work for this project and the removal of the ab-testing code in Frontend. WebX are now the new owners for "ab-testing" and we are officially handing over the ownership to WebX. 


<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216723350558851