### PR TITLE
Remove stray ad from cricket scorecard

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.stories.tsx
@@ -137,6 +137,7 @@ const baseArgs = {
 		guardianBaseURL: 'https://www.theguardian.com',
 	} as ArticleDeprecated,
 	format: {} as ArticleFormat,
+	renderingTarget: 'Web',
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 
 const getMockData = (data: FECricketMatchHeader) =>

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -48,6 +48,7 @@ import { MatchHeaderFallback } from '../MatchHeaderFallback';
 import { Placeholder } from '../Placeholder';
 import type { CricketHeaderData } from './headerData';
 import { parse as parseHeaderData } from './headerData';
+import { RenderingTarget } from '../../types/renderingTarget';
 
 export type CricketMatchHeaderProps = {
 	matchHeaderURL: string;
@@ -56,6 +57,7 @@ export type CricketMatchHeaderProps = {
 	tabContentId: string;
 	format: ArticleFormat;
 	article: ArticleDeprecated;
+	renderingTarget: RenderingTarget;
 };
 
 type Props = CricketMatchHeaderProps & {
@@ -131,8 +133,10 @@ export const CricketMatchHeader = (props: Props) => {
 		setSelectedTab('info');
 		window.location.hash = scorecardHashbang;
 
-		// Remove ads by inserting a list of empty ad slots
-		void getCommercialClient().insertAdverts([]);
+		if (props.renderingTarget == 'Apps') {
+			// Remove ads by inserting a list of empty ad slots
+			void getCommercialClient().insertAdverts([]);
+		}
 	};
 
 	return (

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -35,6 +35,7 @@ import { useLocationHash } from '../../lib/useLocationHash';
 import { palette } from '../../palette';
 import type { ColourName } from '../../paletteDeclarations';
 import type { ArticleDeprecated } from '../../types/article';
+import type { RenderingTarget } from '../../types/renderingTarget';
 import { BigNumber } from '../BigNumber';
 import { CricketScorecardTabRemoteRender } from '../CricketScorecardTabRemoteRender';
 import {
@@ -48,7 +49,6 @@ import { MatchHeaderFallback } from '../MatchHeaderFallback';
 import { Placeholder } from '../Placeholder';
 import type { CricketHeaderData } from './headerData';
 import { parse as parseHeaderData } from './headerData';
-import { RenderingTarget } from '../../types/renderingTarget';
 
 export type CricketMatchHeaderProps = {
 	matchHeaderURL: string;

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -24,6 +24,7 @@ import type {
 } from '../../cricketMatchV2';
 import { grid } from '../../grid';
 import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
+import { getCommercialClient } from '../../lib/bridgetApi';
 import {
 	type EditionId,
 	getLocaleFromEdition,
@@ -129,6 +130,9 @@ export const CricketMatchHeader = (props: Props) => {
 	const onInfoTabClick = () => {
 		setSelectedTab('info');
 		window.location.hash = scorecardHashbang;
+
+		// Remove ads by inserting a list of empty ad slots
+		void getCommercialClient().insertAdverts([]);
 	};
 
 	return (

--- a/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeaderTabsDemo.stories.tsx
@@ -55,6 +55,7 @@ const baseArgs = {
 		guardianBaseURL: 'https://www.theguardian.com',
 	} as ArticleDeprecated,
 	format: {} as ArticleFormat,
+	renderingTarget: 'Web',
 } satisfies ComponentProps<typeof CricketMatchHeader>;
 
 const liveArgs = {

--- a/dotcom-rendering/src/layouts/LiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/LiveLayout.tsx
@@ -1195,6 +1195,7 @@ const Header = (props: {
 						matchHeaderURL={cricketMatchHeaderUrl}
 						article={props.article}
 						format={props.format}
+						renderingTarget={props.renderingTarget}
 					/>
 				</Island>
 			</>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -466,6 +466,7 @@ const MatchHeaderContainer = ({
 						tabContentId={'article'}
 						article={article}
 						format={format}
+						renderingTarget={renderingTarget}
 					/>
 				</Island>
 			</>


### PR DESCRIPTION
## What does this change?

Removes ads from the scorecard tab in iOS. I'm not sure this is the best approach as not only is it unclear that inserting an empty list actually removes ads, but also at some point we might want ads on that scorecard page. However this was the best way I could find to remove the ad whilst only modifying DCAR.

The main fix happens here: https://github.com/guardian/dotcom-rendering/pull/16427/changes#diff-9ed834401923244798201e8f6695ad7bad93dff82001c73ef54d3f36e5afae20R136

The other files just involve adding the RenderingTarget parameter.

Fixes #16413 

## Why?

On iOS (and seemingly not android) I found an ad would float over the top of the cricket scorecard. This removes that ad.

## How has this change been tested?

iOS and Android simulators + ensuring regular web is unaffected. 

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |


[before]: https://github.com/user-attachments/assets/21da5406-4f54-4d3a-8a31-b2a4c45b5a09
[after]: https://github.com/user-attachments/assets/5c8bcf44-fcd7-4d06-9ae4-07d9cf527f31

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
