### PR TITLE
Always publish artifact, even on merge queue

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,7 +46,6 @@ jobs:
       contents: read
       pull-requests: write # required by riff-raff action
     needs: [container, islands, prettier, jest, lint, playwright]
-    if: github.event_name == 'push' # We don't need a riff-raff deployment for merge_group events
     uses: ./.github/workflows/publish.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}


### PR DESCRIPTION
## Why?
As we want to keep this a required check on main, we have to run it in the merge queue
