### PR TITLE
Speed up CI: slim E2E image and cache Playwright browsers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,12 @@ jobs:
           sudo mv /usr/bin/mandb /usr/bin/mandb-OFF
           sudo cp -p /bin/true /usr/bin/mandb
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright Browsers
         run: pnpm playwright install --with-deps chromium
         working-directory: ./dotcom-rendering

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Most commands are run from within the dotcom-rendering project but the following
 ### Storybook
 
 `pnpm storybook` - Runs Storybook for all projects
+
 `pnpm build-storybook` - Builds Storybook for all projects

--- a/dotcom-rendering/Containerfile
+++ b/dotcom-rendering/Containerfile
@@ -1,6 +1,6 @@
 # This container is used in our CICD pipelines for running E2E and regression tests.
 # Keep the Node version in sync with `.nvmrc`
-FROM node:24
+FROM node:24-slim
 
 WORKDIR /opt/app/dotcom-rendering/dotcom-rendering
 


### PR DESCRIPTION
## What does this change?

Speeds up CI by switching the E2E container to a slim base image and caching Playwright browser binaries between runs.

## How has this change been tested?

## Have we considered potential risks?

