### PR TITLE
tests added to prevent banner rendering failures

### DIFF
--- a/dotcom-rendering/src/components/SlotBodyEnd.island.test.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.island.test.tsx
@@ -1,0 +1,165 @@
+import { render, waitFor } from '@testing-library/react';
+import { pickMessage } from '../lib/messagePicker';
+import { useCountryCode } from '../lib/useCountryCode';
+import { ConfigProvider } from './ConfigContext';
+import { SlotBodyEnd } from './SlotBodyEnd.island';
+
+jest.mock('../lib/messagePicker', () => ({
+	pickMessage: jest.fn(),
+}));
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useIsSignedIn: jest.fn().mockReturnValue(false),
+	useAuthStatus: jest.fn().mockReturnValue({ kind: 'SignedOut' }),
+}));
+
+jest.mock('../lib/useCountryCode', () => ({
+	useCountryCode: jest.fn().mockReturnValue('GB'),
+}));
+
+jest.mock('../lib/usePageViewId', () => ({
+	usePageViewId: jest.fn().mockReturnValue('test-page-view-id'),
+}));
+
+jest.mock('../lib/articleCount', () => ({
+	getArticleCounts: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../lib/useBraze', () => ({
+	useBraze: jest.fn().mockReturnValue({
+		brazeMessages: {},
+		brazeCards: undefined,
+		braze: null,
+	}),
+}));
+
+jest.mock('../lib/useAB', () => ({
+	useAB: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('../lib/braze/BrazeBannersSystem', () => ({
+	buildBrazeBannersSystemConfig: jest.fn().mockReturnValue({
+		candidate: {
+			id: 'braze-banners-system',
+			canShow: jest.fn().mockResolvedValue({ show: false }),
+			show: jest.fn(),
+		},
+		timeoutMillis: null,
+	}),
+	BrazeBannersSystemPlacementId: { EndOfArticle: 'EndOfArticle' },
+}));
+
+jest.mock('./SlotBodyEnd/ReaderRevenueEpic', () => ({
+	canShowReaderRevenueEpic: jest.fn().mockResolvedValue({ show: false }),
+	ReaderRevenueEpic: () => null,
+}));
+
+jest.mock('./SlotBodyEnd/BrazeEpic', () => ({
+	canShowBrazeEpic: jest.fn().mockResolvedValue({ show: false }),
+	MaybeBrazeEpic: () => null,
+}));
+
+jest.mock('./AdSlot.web', () => ({
+	AdSlot: () => <div data-testid="ad-slot" />,
+}));
+
+const defaultProps = {
+	contentType: 'Article',
+	sectionId: 'news',
+	shouldHideReaderRevenue: false,
+	isMinuteArticle: false,
+	isPaidContent: false,
+	tags: [],
+	contributionsServiceUrl: 'https://contributions.example.com',
+	idApiUrl: 'https://idapi.example.com',
+	pageId: 'test/article',
+	renderAds: false,
+	isLabs: false,
+	articleEndSlot: false,
+	isSensitive: false,
+};
+
+const renderSlotBodyEnd = (props: Partial<typeof defaultProps> = {}) =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<SlotBodyEnd {...defaultProps} {...props} />
+		</ConfigProvider>,
+	);
+
+const mockPickMessage = jest.mocked(pickMessage);
+const mockUseCountryCode = jest.mocked(useCountryCode);
+
+describe('SlotBodyEnd', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders the SelectedMessage component when pickMessage resolves with MessageSelected', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'MessageSelected',
+			messageId: 'reader-revenue-banner',
+			SelectedMessage: () => (
+				<div data-testid="epic-message">Epic content</div>
+			),
+		});
+
+		const { findByTestId } = renderSlotBodyEnd();
+
+		expect(await findByTestId('epic-message')).toBeInTheDocument();
+	});
+
+	it('renders nothing when pickMessage resolves with NoMessageSelected and no article end slot', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'NoMessageSelected',
+		});
+
+		const { container } = renderSlotBodyEnd();
+
+		await waitFor(() => {
+			expect(mockPickMessage).toHaveBeenCalled();
+		});
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('renders the ad slot when pickMessage resolves with NoMessageSelected and the article end slot is enabled', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'NoMessageSelected',
+		});
+
+		// showPublicGood requires countryCode === 'US'
+		mockUseCountryCode.mockReturnValue('US');
+
+		const { findByTestId } = renderSlotBodyEnd({
+			renderAds: true,
+			articleEndSlot: true,
+		});
+
+		expect(await findByTestId('ad-slot')).toBeInTheDocument();
+	});
+
+	it('dispatches gu.commercial.slot.fill event when no message is selected and article end slot is enabled', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'NoMessageSelected',
+		});
+
+		mockUseCountryCode.mockReturnValue('US');
+
+		const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+
+		renderSlotBodyEnd({ renderAds: true, articleEndSlot: true });
+
+		await waitFor(() => {
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'gu.commercial.slot.fill' }),
+			);
+		});
+	});
+});

--- a/dotcom-rendering/src/components/StickyBottomBanner.island.test.tsx
+++ b/dotcom-rendering/src/components/StickyBottomBanner.island.test.tsx
@@ -1,0 +1,190 @@
+import { render, waitFor } from '@testing-library/react';
+import { pickMessage } from '../lib/messagePicker';
+import { ConfigProvider } from './ConfigContext';
+import { StickyBottomBanner } from './StickyBottomBanner.island';
+
+jest.mock('../lib/messagePicker', () => ({
+	pickMessage: jest.fn(),
+}));
+
+jest.mock('../lib/useAuthStatus', () => ({
+	useIsSignedIn: jest.fn().mockReturnValue(false),
+	useAuthStatus: jest.fn().mockReturnValue({ kind: 'SignedOut' }),
+}));
+
+jest.mock('../lib/useCountryCode', () => ({
+	useCountryCode: jest.fn().mockReturnValue('GB'),
+}));
+
+jest.mock('../lib/usePageViewId', () => ({
+	usePageViewId: jest.fn().mockReturnValue('test-page-view-id'),
+}));
+
+jest.mock('../lib/articleCount', () => ({
+	getArticleCounts: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../lib/useBraze', () => ({
+	useBraze: jest.fn().mockReturnValue({
+		brazeMessages: {},
+		brazeCards: undefined,
+		braze: null,
+	}),
+}));
+
+jest.mock('../lib/useAB', () => ({
+	useAB: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('../lib/braze/BrazeBannersSystem', () => ({
+	buildBrazeBannersSystemConfig: jest.fn().mockReturnValue({
+		candidate: {
+			id: 'braze-banners-system',
+			canShow: jest.fn().mockResolvedValue({ show: false }),
+			show: jest.fn(),
+		},
+		timeoutMillis: null,
+	}),
+	BrazeBannersSystemPlacementId: { Banner: 'Banner' },
+}));
+
+jest.mock('@guardian/consent-manager', () => ({
+	cmp: {
+		willShowPrivacyMessage: jest.fn().mockResolvedValue(false),
+	},
+}));
+
+jest.mock('./StickyBottomBanner/ReaderRevenueBanner', () => ({
+	canShowRRBanner: jest.fn().mockResolvedValue({ show: false }),
+	ReaderRevenueBanner: () => null,
+}));
+
+jest.mock('./StickyBottomBanner/BrazeBanner', () => ({
+	canShowBrazeBanner: jest.fn().mockResolvedValue({ show: false }),
+	BrazeBanner: () => null,
+}));
+
+jest.mock('./StickyBottomBanner/SignInGatePortal', () => ({
+	canShowSignInGatePortal: jest.fn().mockResolvedValue({ show: false }),
+	SignInGatePortal: () => null,
+}));
+
+const defaultProps = {
+	contentType: 'Article',
+	sectionId: 'news',
+	tags: [],
+	isPaidContent: false,
+	isPreview: false,
+	shouldHideReaderRevenue: false,
+	isMinuteArticle: false,
+	isSensitive: false,
+	contributionsServiceUrl: 'https://contributions.example.com',
+	idApiUrl: 'https://idapi.example.com',
+	pageId: 'test/article',
+	remoteBannerSwitch: true,
+};
+
+const renderStickyBottomBanner = (props: Partial<typeof defaultProps> = {}) =>
+	render(
+		<ConfigProvider
+			value={{
+				renderingTarget: 'Web',
+				darkModeAvailable: false,
+				assetOrigin: '/',
+				editionId: 'UK',
+			}}
+		>
+			<StickyBottomBanner {...defaultProps} {...props} />
+		</ConfigProvider>,
+	);
+
+const mockPickMessage = jest.mocked(pickMessage);
+
+describe('StickyBottomBanner', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders the SelectedMessage component when pickMessage resolves with MessageSelected', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'MessageSelected',
+			messageId: 'reader-revenue-banner',
+			SelectedMessage: () => (
+				<div data-testid="banner-message">Banner content</div>
+			),
+		});
+
+		const { findByTestId } = renderStickyBottomBanner();
+
+		expect(await findByTestId('banner-message')).toBeInTheDocument();
+	});
+
+	it('renders nothing when pickMessage resolves with NoMessageSelected', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'NoMessageSelected',
+		});
+
+		const { container } = renderStickyBottomBanner();
+
+		await waitFor(() => {
+			expect(mockPickMessage).toHaveBeenCalled();
+		});
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('dispatches banner:none event when pickMessage resolves with NoMessageSelected', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'NoMessageSelected',
+		});
+
+		const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+
+		renderStickyBottomBanner();
+
+		await waitFor(() => {
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'banner:none' }),
+			);
+		});
+	});
+
+	it('dispatches banner:sign-in-gate event when the sign-in gate is the selected message', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'MessageSelected',
+			messageId: 'sign-in-gate-portal',
+			SelectedMessage: () => null,
+		});
+
+		const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+
+		renderStickyBottomBanner();
+
+		await waitFor(() => {
+			expect(dispatchEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'banner:sign-in-gate' }),
+			);
+		});
+	});
+
+	it('does not dispatch banner:sign-in-gate for other selected messages', async () => {
+		mockPickMessage.mockResolvedValue({
+			type: 'MessageSelected',
+			messageId: 'reader-revenue-banner',
+			SelectedMessage: () => (
+				<div data-testid="banner-message">Banner</div>
+			),
+		});
+
+		const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+
+		const { findByTestId } = renderStickyBottomBanner();
+
+		await findByTestId('banner-message');
+
+		const signInGateEvents = dispatchEventSpy.mock.calls.filter(
+			([event]) => event.type === 'banner:sign-in-gate',
+		);
+		expect(signInGateEvents).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What does this change?
This change adds unit tests for two banner-related island components:
- SlotBodyEnd.island — the end-of-article slot that renders epics or an ad slot
- StickyBottomBanner.island — the sticky banner at the bottom of the page
## Why?
These components use pickMessage to select and render banners/epics. Without test coverage, regressions in rendering logic (e.g. a selected message not displaying, or the wrong event being dispatched) could silently reach production.
## How has this change been tested?
Deployed to CODE
<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots



<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
