### PR TITLE
Fix Current URL on Cricket Match Header

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -69,7 +69,7 @@ export const CricketMatchHeader = (props: Props) => {
 	const scorecardHashbang = '#scorecard';
 	const locationHash = useLocationHash();
 	const currentUrl = new URL(
-		`${props.article.guardianBaseURL}${props.article.pageId}`,
+		`${props.article.guardianBaseURL}/${props.article.pageId}`,
 	);
 
 	const { data, error } = useSWR<CricketHeaderData, Error>(


### PR DESCRIPTION
## What does this change?

Adds a forward slash to the currentUrl stored by the Cricket Match Header.

## Why?

https://github.com/guardian/dotcom-rendering/pull/16358 introduced a fallback URL which seems to be missing a forward slash.