### PR TITLE
Fix product summary order

### DIFF
--- a/dotcom-rendering/src/model/enhance-product-summary.test.ts
+++ b/dotcom-rendering/src/model/enhance-product-summary.test.ts
@@ -47,8 +47,8 @@ describe('enhanceProductSummary', () => {
 
 	it('enhances product summary elements with the correct CTA indices', () => {
 		const summaryProducts = [
-			{ productId: '1', ctaIndex: 0 },
 			{ productId: '3', ctaIndex: 1 },
+			{ productId: '1', ctaIndex: 0 },
 		];
 		const input = [
 			productElement(
@@ -82,6 +82,11 @@ describe('enhanceProductSummary', () => {
 			enhancedProductSummaryElement?.products.map(
 				(mapping) => mapping.ctaIndex,
 			),
-		).toEqual([0, 1]);
+		).toEqual([1, 0]);
+		expect(
+			enhancedProductSummaryElement?.products.map(
+				(mapping) => mapping.productBlock.id,
+			),
+		).toEqual(['3', '1']);
 	});
 });

--- a/dotcom-rendering/src/model/enhance-product-summary.ts
+++ b/dotcom-rendering/src/model/enhance-product-summary.ts
@@ -8,27 +8,22 @@ const getSummaryProducts = (
 	pageElements: FEElement[],
 	summaryProducts: SummaryProductRef[],
 ): SummaryProduct[] =>
-	pageElements.reduce<SummaryProduct[]>((acc, element) => {
+	summaryProducts.reduce<SummaryProduct[]>((acc, summaryProduct) => {
+		const matchingPageElement = pageElements.find(
+			(pageElement) =>
+				pageElement._type ===
+					'model.dotcomrendering.pageElements.ProductBlockElement' &&
+				summaryProduct.productId === pageElement.id,
+		);
 		if (
-			element._type !==
+			matchingPageElement?._type ===
 			'model.dotcomrendering.pageElements.ProductBlockElement'
 		) {
-			return acc;
+			acc.push({
+				productBlock: matchingPageElement,
+				ctaIndex: summaryProduct.ctaIndex,
+			});
 		}
-
-		const matchingSummaryProduct = summaryProducts.find(
-			(summaryProduct) => summaryProduct.productId === element.id,
-		);
-
-		if (!matchingSummaryProduct) {
-			return acc;
-		}
-
-		acc.push({
-			productBlock: element,
-			ctaIndex: matchingSummaryProduct.ctaIndex,
-		});
-
 		return acc;
 	}, []);
 


### PR DESCRIPTION

## What does this change?

Fix the product summary order, added in https://github.com/guardian/dotcom-rendering/pull/16202

## Why?

The order should be based on the summary element's list of products, not the order they appear in the article

## How has this change been tested?

Updated the unit test, and running frontend + DCAR against CODE CAPI

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

Config
<img width="673" height="349" alt="image" src="https://github.com/user-attachments/assets/8316685e-fa68-4b59-b091-103ff14ba27b" />

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b76fa555-a820-43b4-b360-ebab38115722
[after]: https://github.com/user-attachments/assets/908e7b40-0b87-4a33-bb29-d58762b15367

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
