### PR TITLE
feat(cdk): Enable high resolution metrics for ECS

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -1995,6 +1995,17 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
             },
           },
         ],
+        "Monitoring": {
+          "MetricConfigurations": [
+            {
+              "MetricNames": [
+                "CPUUtilization",
+                "MemoryUtilization",
+              ],
+              "ResolutionSeconds": 20,
+            },
+          ],
+        },
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "DISABLED",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -17,6 +17,7 @@ import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
+import type { CfnService } from 'aws-cdk-lib/aws-ecs';
 import { ClusterSettings } from 'aws-cdk-lib/aws-ecs/mixins';
 import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
@@ -311,12 +312,28 @@ export class RenderingCDKStack extends CDKStack {
 				);
 			}
 
-			// TODO enable this at the pattern level in GuCDK
-			app.ecsService?.cluster.with(
-				new ClusterSettings([
-					{ name: 'containerInsights', value: 'enhanced' },
-				]),
-			);
+			// TODO make these changes at the pattern level in GuCDK
+			if (app.ecsService) {
+				app.ecsService.cluster.with(
+					new ClusterSettings([
+						{ name: 'containerInsights', value: 'enhanced' },
+					]),
+				);
+
+				const cfnService = app.ecsService.node
+					.defaultChild as CfnService;
+				cfnService.addPropertyOverride('Monitoring', {
+					MetricConfigurations: [
+						{
+							MetricNames: [
+								'CPUUtilization',
+								'MemoryUtilization',
+							],
+							ResolutionSeconds: 20,
+						},
+					],
+				});
+			}
 		}
 
 		/**


### PR DESCRIPTION
> [!NOTE]
> This is different from https://github.com/guardian/dotcom-rendering/pull/16392. I can't immediately say if we need both!

## What does this change?
This change enables high resolution metrics for CPU and memory for the ECS infrastructure, which should allow for faster service auto scaling.

See https://aws.amazon.com/blogs/aws/amazon-ecs-introduces-new-high-resolution-metrics-for-faster-service-auto-scaling/.

## How has this change been tested?
After [deploying](https://riffraff.gutools.co.uk/deployment/view/a89e6240-2857-4fe5-9572-f0be5edab1ce) we can see the high resolution metrics are enabled for the only ECS service we have (tag-page-rendering CODE):

<img width="560" height="110" alt="image" src="https://github.com/user-attachments/assets/4e450e6f-0270-44ac-9733-2978e9cd61dd" />

Note the timestamp of this datapoint:

<img width="1153" height="684" alt="image" src="https://github.com/user-attachments/assets/dd4a1085-3c0a-42d9-8354-648c1bd2beac" />