### PR TITLE
Create apps version of newsletter signup page

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -34,7 +34,6 @@ interface WebProps extends BaseProps {
 export type Props = WebProps | AppProps;
 
 const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
-	const notSupported = <pre>Not supported</pre>;
 	const format = {
 		design: article.design,
 		display: article.display,
@@ -155,8 +154,14 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 						/>
 					);
 				case ArticleDesign.NewsletterSignup:
-					// Should be NewsletterSignup once implemented for apps
-					return notSupported;
+					return (
+						<NewsletterSignupLayout
+							article={article.frontendData}
+							format={format}
+							renderingTarget={renderingTarget}
+							serverTime={serverTime}
+						/>
+					);
 				case ArticleDesign.Gallery:
 					return (
 						<GalleryLayout

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -40,16 +40,22 @@ import { decideStoryPackageTrails } from '../lib/decideTrail';
 import { isValidUrl } from '../lib/isValidUrl';
 import type { NavType } from '../model/extract-nav';
 import type { ArticleDeprecated } from '../types/article';
-import type { RenderingTarget } from '../types/renderingTarget';
 import { BannerWrapper, Stuck } from './lib/stickiness';
 
-type Props = {
+type BaseProps = {
 	article: ArticleDeprecated;
-	NAV: NavType;
 	format: ArticleFormat;
-	renderingTarget: RenderingTarget;
 	serverTime?: number;
 };
+
+type WebProps = {
+	NAV: NavType;
+	renderingTarget: 'Web';
+} & BaseProps;
+
+type AppsProps = {
+	renderingTarget: 'Apps';
+} & BaseProps;
 
 const mainColWrapperStyle = css`
 	display: flex;
@@ -186,13 +192,8 @@ const getMainMediaCaptions = (
 			: undefined,
 	);
 
-export const NewsletterSignupLayout = ({
-	article,
-	NAV,
-	format,
-	renderingTarget,
-	serverTime,
-}: Props) => {
+export const NewsletterSignupLayout = (props: WebProps | AppsProps) => {
+	const { article, format, renderingTarget, serverTime } = props;
 	const {
 		promotedNewsletter,
 		config: { host, hasSurveyAd },
@@ -217,39 +218,43 @@ export const NewsletterSignupLayout = ({
 
 	return (
 		<>
-			<div data-print-layout="hide" id="bannerandheader">
-				{isWeb && renderAds && (
-					<Stuck>
-						<Section
-							fullWidth={true}
-							showTopBorder={false}
-							showSideBorders={false}
-							padSides={false}
-							shouldCenter={false}
-						>
-							<HeaderAdSlot />
-						</Section>
-					</Stuck>
-				)}
+			{isWeb && (
+				<div data-print-layout="hide" id="bannerandheader">
+					{renderAds && (
+						<Stuck>
+							<Section
+								fullWidth={true}
+								showTopBorder={false}
+								showSideBorders={false}
+								padSides={false}
+								shouldCenter={false}
+							>
+								<HeaderAdSlot />
+							</Section>
+						</Stuck>
+					)}
 
-				<Masthead
-					nav={NAV}
-					editionId={article.editionId}
-					idUrl={article.config.idUrl}
-					mmaUrl={article.config.mmaUrl}
-					discussionApiUrl={article.config.discussionApiUrl}
-					idApiUrl={article.config.idApiUrl}
-					contributionsServiceUrl={contributionsServiceUrl}
-					showSubNav={true}
-					showSlimNav={format.display === ArticleDisplay.Immersive}
-					hasPageSkin={false}
-					hasPageSkinContentSelfConstrain={false}
-					pageId={article.pageId}
-					tagIds={article.tags.map((tag) => tag.id)}
-					sectionId={article.config.section}
-					contentType={article.contentType}
-				/>
-			</div>
+					<Masthead
+						nav={props.NAV}
+						editionId={article.editionId}
+						idUrl={article.config.idUrl}
+						mmaUrl={article.config.mmaUrl}
+						discussionApiUrl={article.config.discussionApiUrl}
+						idApiUrl={article.config.idApiUrl}
+						contributionsServiceUrl={contributionsServiceUrl}
+						showSubNav={true}
+						showSlimNav={
+							format.display === ArticleDisplay.Immersive
+						}
+						hasPageSkin={false}
+						hasPageSkinContentSelfConstrain={false}
+						pageId={article.pageId}
+						tagIds={article.tags.map((tag) => tag.id)}
+						sectionId={article.config.section}
+						contentType={article.contentType}
+					/>
+				</div>
+			)}
 
 			{isWeb && renderAds && hasSurveyAd && (
 				<AdSlot position="survey" display={format.display} />
@@ -469,23 +474,25 @@ export const NewsletterSignupLayout = ({
 				</Island>
 			</main>
 
-			<Section
-				fullWidth={true}
-				padSides={false}
-				showTopBorder={false}
-				backgroundColour={sourcePalette.brand[400]}
-				borderColour={sourcePalette.brand[600]}
-				showSideBorders={false}
-				element="footer"
-			>
-				<Footer
-					pageFooter={article.pageFooter}
-					selectedPillar={NAV.selectedPillar}
-					pillars={NAV.pillars}
-					urls={article.nav.readerRevenueLinks.footer}
-					editionId={article.editionId}
-				/>
-			</Section>
+			{isWeb && (
+				<Section
+					fullWidth={true}
+					padSides={false}
+					showTopBorder={false}
+					backgroundColour={sourcePalette.brand[400]}
+					borderColour={sourcePalette.brand[600]}
+					showSideBorders={false}
+					element="footer"
+				>
+					<Footer
+						pageFooter={article.pageFooter}
+						selectedPillar={props.NAV.selectedPillar}
+						pillars={props.NAV.pillars}
+						urls={article.nav.readerRevenueLinks.footer}
+						editionId={article.editionId}
+					/>
+				</Section>
+			)}
 
 			<BannerWrapper data-print-layout="hide" />
 			{renderAds && <MobileStickyContainer data-print-layout="hide" />}

--- a/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
+++ b/dotcom-rendering/src/layouts/NewsletterSignupLayout.tsx
@@ -495,7 +495,9 @@ export const NewsletterSignupLayout = (props: WebProps | AppsProps) => {
 			)}
 
 			<BannerWrapper data-print-layout="hide" />
-			{renderAds && <MobileStickyContainer data-print-layout="hide" />}
+			{isWeb && renderAds && (
+				<MobileStickyContainer data-print-layout="hide" />
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
## Why?
So we can render these pages with DCAR in the app rather than apps templates

## How has this change been tested?
Tested that it renders in the app on CODE, the signup button and share button work as expected


## Screenshots

<img width="350" height="750" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-24 at 11 52 59" src="https://github.com/user-attachments/assets/a44e1b83-1775-4b1d-b450-2c0a51ebd510" />
