### PR TITLE
remove AB test config for mobile sticky in us liveblogs

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -70,31 +70,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-mobile-sticky-liveblog-us",
-		description:
-			"Holdback test, where variant is the 'holdback' group, to measure uplift in adding the mobile-sticky slot for Liveblogs articles in the US.",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-07-22",
-		type: "client",
-		status: "ON",
-		audienceSize: 5 / 100,
-		audienceSpace: "A",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: true,
-	},
-	{
-		name: "commercial-ozone-outstream",
-		description: "A test to ensure correct integration of Ozone outstream.",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-09-23",
-		type: "client",
-		status: "ON",
-		audienceSize: 0 / 100,
-		audienceSpace: "A",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: false,
-	},
-	{
 		name: "newsletters-in-article-signup-preview",
 		description:
 			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",


### PR DESCRIPTION
What does this change?
Removes the `commercial-mobile-sticky-liveblog-us` test configuration.

Why?
This test is now redundant since we have completed the A/B experiment and are not using it as a test gate in the commercial code.