### PR TITLE
Remove the outstream ozone AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -83,18 +83,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-ozone-outstream",
-		description: "A test to ensure correct integration of Ozone outstream.",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-09-23",
-		type: "client",
-		status: "ON",
-		audienceSize: 0 / 100,
-		audienceSpace: "A",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: false,
-	},
-	{
 		name: "newsletters-in-article-signup-preview",
 		description:
 			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",


### PR DESCRIPTION
## What does this change?

Removes the `commercial-ozone-outstream` AB test.

## Why?

It is no longer required. See the accompanying Commercial PR for details: https://github.com/guardian/commercial/pull/2641