### PR TITLE
Handle product summary missing heading edge case

### DIFF
--- a/dotcom-rendering/src/components/ProductCtaList.tsx
+++ b/dotcom-rendering/src/components/ProductCtaList.tsx
@@ -45,8 +45,12 @@ const ListItem = ({ product }: { product: SummaryProduct }) => {
 	return (
 		<li key={product.productBlock.id}>
 			<p>
-				<strong>{productBlock.primaryHeadingText}</strong>
-				<br />
+				{(productBlock.primaryHeadingText ?? '') && (
+					<>
+						<strong>{productBlock.primaryHeadingText}</strong>
+						<br />
+					</>
+				)}
 				{productBlock.brandName} {productBlock.productName}
 			</p>
 			{cta && (


### PR DESCRIPTION
## What does this change?

Check the heading in a product summary CTA list is there before rendering a new line.

## Why?
It's an optional field, although conventionally filled in

Before
<img width="287" height="126" alt="image" src="https://github.com/user-attachments/assets/ac89b672-e78c-46e1-ae20-aac1076668db" />

After
<img width="448" height="219" alt="image" src="https://github.com/user-attachments/assets/b81cad1d-eb51-4b2f-b810-9c0ca63b34de" />

## How has this change been tested?
Storybook
<!--
