### PR TITLE
Deduplicate merge queue/main CI

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -2,7 +2,7 @@ name: DCR Build Check
 on:
   merge_group:
     types: [checks_requested]
-  push:
+  pull_request:
     paths-ignore:
       - 'dotcom-rendering/docs/**'
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,19 +23,24 @@ jobs:
       production-image-digest: ${{ needs.production-container.outputs.imageDigest }}
 
   prettier:
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/prettier.yml
 
   jest:
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/jest.yml
 
   lint:
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/lint.yml
 
   islands:
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/check-islands.yml
 
   playwright:
     needs: [container]
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/playwright.yml
     with:
       container-image: ${{ needs.container.outputs.container-image }}

--- a/.github/workflows/dcr-chromatic.yml
+++ b/.github/workflows/dcr-chromatic.yml
@@ -3,8 +3,6 @@ name: DCR Chromatic 👓
 on:
   merge_group:
     types: [checks_requested]
-  push:
-    branches: [main]
   pull_request:
     types: [opened, labeled, synchronize]
 
@@ -31,14 +29,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout - On Push Event
         uses: actions/checkout@v6
-        if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+        if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0
 
       - name: Set up Node environment
         # Only needed for a full Chromatic run.
         if: |
-          (github.event_name == 'push' || github.event_name == 'merge_group') ||
+          github.event_name == 'merge_group' ||
           (github.event_name == 'pull_request' &&
             contains(github.event.pull_request.labels.*.name, 'run_chromatic'))
         uses: ./.github/actions/setup-node-env
@@ -51,7 +49,7 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
         uses: chromaui/action@v17.4.1
         if: |
-          (github.event_name == 'push' || github.event_name == 'merge_group') ||
+          github.event_name == 'merge_group' ||
           (github.event_name == 'pull_request' &&
             contains(github.event.pull_request.labels.*.name, 'run_chromatic')) ||
           (github.event_name == 'pull_request' && needs.check-paths.outputs.relevant != 'true')

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -2,7 +2,7 @@ name: DCR Schema Check
 on:
   merge_group:
     types: [checks_requested]
-  push:
+  pull_request:
     paths-ignore:
       - 'dotcom-rendering/docs/**'
 

--- a/.github/workflows/stories-check.yml
+++ b/.github/workflows/stories-check.yml
@@ -2,7 +2,7 @@ name: DCR Stories Check
 on:
   merge_group:
     types: [checks_requested]
-  push:
+  pull_request:
     paths-ignore:
       - 'dotcom-rendering/docs/**'
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -2,7 +2,7 @@ name: DCR typescript 🕵‍♀
 on:
   merge_group:
     types: [checks_requested]
-  push:
+  pull_request:
     paths-ignore:
       - 'dotcom-rendering/docs/**'
 


### PR DESCRIPTION
## What does this change?
Refine our workflows so that most checks run either in the merge group or on merge to `main`, as they are run against the exact same commit/code. Demonstrated by the way github shows both push and merge_group results in the PR checks:
<img width="1045" height="621" alt="Screenshot 2026-07-23 at 09 58 21" src="https://github.com/user-attachments/assets/f5479c17-c0fa-4bda-bc6f-5f8a6bdc163b" />

So with these changes, jobs now generally run on `pull_request` and `merge_group` events, no longer the `push` event (which runs on push to main or pushes to PRs), just the `cicd.yml` workflow still runs on `push` (to main) so that it can publish the artifact to riff-raff.

## Why?
Running everything on both is a waste of time/github action compute/chromatic tokens.

