### PR TITLE
Stop page jumpiness caused by Public Good ad slot

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -289,13 +289,13 @@ const frontsBannerAdStyles = css`
 	}
 `;
 
+/**
+ * The article-end slot is used to display the Public Good advert in the US. However, this advert
+ * is not currently being used. Therefore, there is no minimum height on the slot, so that the
+ * slot does not expand (anticipating an advert) and then collapse (when no advert is served), causing CLS.
+ */
 const articleEndAdStyles = css`
 	position: relative;
-	min-height: 450px;
-
-	&.ad-slot--fluid {
-		min-height: 450px;
-	}
 `;
 
 const mostPopAdStyles = css`

--- a/dotcom-rendering/src/components/SlotBodyEnd.island.tsx
+++ b/dotcom-rendering/src/components/SlotBodyEnd.island.tsx
@@ -3,7 +3,7 @@ import type {
 	BrazeArticleContext,
 	BrazeMessagesInterface,
 } from '@guardian/braze-components/logic';
-import { adSizes, type SizeMapping } from '@guardian/commercial-core';
+import { adSizes } from '@guardian/commercial-core';
 import type { CountryCode } from '@guardian/libs';
 import { isUndefined } from '@guardian/libs';
 import { palette } from '@guardian/source/foundations';
@@ -239,14 +239,11 @@ export const SlotBodyEnd = ({
 			pickMessageResult?.type === 'NoMessageSelected' &&
 			showArticleEndSlot
 		) {
-			const additionalSizes = (): SizeMapping => {
-				return { mobile: [adSizes.fluid] }; // Public Good additional ad slot sizes
-			};
 			document.dispatchEvent(
 				new CustomEvent('gu.commercial.slot.fill', {
 					detail: {
 						slotId: 'dfp-ad--article-end',
-						additionalSizes: additionalSizes(),
+						additionalSizes: { mobile: [adSizes.fluid] }, // Public Good additional ad slot sizes
 					},
 				}),
 			);


### PR DESCRIPTION
## What does this change?

Remove the minimum height for the `article-end` ad slot.

## Why?

This ad slot, which is displayed after the article body and only in the US, is not currently serving. This ad slot is exclusively used by Public Good.

By removing the minimum height, the ad slot will not expand to 450px when the slot is created, then contract to 0px when an advert is not served and the slot is hidden. This will lead to reduced page jumpiness and an improvement in CLS.

Public Good are not currently using this slot. When they were, the min-height was set so that when the SlotBodyEnd island is initiated and the ad slot is created, the slot is expanded to the anticipated advert size, likely in advance of the user scrolling down to the slot. Given it can take a few seconds for the advert to load in the space, setting the min-height early increases the likelihood of a smooth experience for the user.

If Public Good resume using this slot, the slot will expand to fit the advert when the advert loads, instead of when the slot is inserted in the DOM. This means it will be more likely that there will be some CLS for the user. We should revisit this if/when this slot starts to be used again.

## How has this change been tested?

On CODE

## Screenshares

### Before

https://github.com/user-attachments/assets/4ed2a62a-3108-472a-87db-39565b5ca472

### After

https://github.com/user-attachments/assets/21272180-5328-40ef-9e03-f17c7f01a913

