### PR TITLE
Stacked product card - wording "show fewer" instead of "show less" products

### DIFF
--- a/dotcom-rendering/src/components/StackedProducts.island.tsx
+++ b/dotcom-rendering/src/components/StackedProducts.island.tsx
@@ -113,7 +113,9 @@ export const StackedProducts = ({
 					theme={theme}
 					data-ignore="global-link-styling"
 				>
-					{isExpanded ? 'Show less' : `Show all (${products.length})`}
+					{isExpanded
+						? 'Show fewer'
+						: `Show all (${products.length})`}
 				</LinkButton>
 			)}
 		</div>


### PR DESCRIPTION
## What does this change?

The wording on the product stacked card expander button from "Show less" to "Show fewer"

## Why?

A production editor noted the grammar

## How has this change been tested?

Storybook

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="661" height="343" alt="image" src="https://github.com/user-attachments/assets/3be02aa6-a889-4bd1-9e47-9584fd72926b" /> | <img width="658" height="346" alt="image" src="https://github.com/user-attachments/assets/09ea6008-197d-4717-bea5-c7522a7beb61" /> |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
