### PR TITLE
Allow duplicate products in choice cards

### DIFF
--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
@@ -216,9 +216,9 @@ describe('ThreeTierChoiceCards', () => {
 		// inner Radio label), so labelFors may repeat a valid id.
 		const labels = document.querySelectorAll('label[for]');
 		const labelFors = Array.from(labels).map((l) => l.getAttribute('for'));
-		labelFors.forEach((forAttr) => {
+		for (const forAttr of labelFors) {
 			expect(ids).toContain(forAttr);
-		});
+		}
 		expect(new Set(labelFors)).toEqual(new Set(ids));
 
 		// Only the default (card 1) is checked initially; card 2 is not

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
@@ -350,4 +350,136 @@ describe('ThreeTierChoiceCards', () => {
 
 		consoleErrorSpy.mockRestore();
 	});
+
+	it('selects the default card when selectedChoiceCard is a stale reference from a previous array identity', () => {
+		// Regression: useMatchMedia resolves after mount, so the banner/epic
+		// switches from mobileChoiceCards to choiceCards. The initial default
+		// (captured via useState from the first array) then no longer
+		// reference-matches any card, so reference-only selection leaves
+		// nothing selected. A structurally equal card must still be selected.
+		const staleSelected: ChoiceCard = {
+			product: { supportTier: 'SupporterPlus', ratePlan: 'Monthly' },
+			label: 'Support £12/month',
+			isDefault: true,
+			benefits: [
+				{ copy: 'Unlimited access to the Guardian app' },
+				{ copy: 'Ad-free reading on all your devices' },
+			],
+		};
+
+		render(
+			<ThreeTierChoiceCards
+				selectedChoiceCard={staleSelected}
+				setSelectedChoiceCard={() => {}}
+				choices={mockChoiceCards}
+				id="banner"
+			/>,
+		);
+
+		const radios = screen.getAllByRole('radio');
+		expect(radios[0]).not.toBeChecked(); // Contribution
+		expect(radios[1]).toBeChecked(); // SupporterPlus (value-matches stale ref)
+		expect(radios[2]).not.toBeChecked(); // OneOff
+	});
+
+	it('resolves a stale reference to the correct card when duplicates exist', () => {
+		// With two OneOff cards, a stale selectedChoiceCard must resolve by
+		// value (product + label) to the matching card only — not both.
+		const duplicateOneOffCards: Array<
+			ChoiceCard & { defaultExpanded?: boolean }
+		> = [
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 1',
+				isDefault: true,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 2',
+				isDefault: false,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+		];
+
+		const staleSelected: ChoiceCard = {
+			// Matches the SECOND card by value — product alone cannot
+			// distinguish the duplicates, so this asserts the label
+			// participates in the structural match.
+			product: { supportTier: 'OneOff' },
+			label: 'One-time 2',
+			isDefault: false,
+			benefits: [{ copy: 'We welcome support of any size, any time' }],
+		};
+
+		render(
+			<ThreeTierChoiceCards
+				selectedChoiceCard={staleSelected}
+				setSelectedChoiceCard={() => {}}
+				choices={duplicateOneOffCards}
+				id="banner"
+			/>,
+		);
+
+		const radios = screen.getAllByRole('radio');
+		expect(radios[0]).not.toBeChecked(); // One-time 1
+		expect(radios[1]).toBeChecked(); // One-time 2
+	});
+
+	it('distinguishes cards with identical product and label by reference when clicked', () => {
+		// When duplicates are fully identical (same product AND label), value
+		// comparison cannot tell them apart — selection after a click must
+		// follow the clicked card only.
+		const identicalCards: Array<
+			ChoiceCard & { defaultExpanded?: boolean }
+		> = [
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time',
+				isDefault: true,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time',
+				isDefault: false,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+		];
+
+		const TestComponent = () => {
+			const [selectedChoiceCard, setSelectedChoiceCard] = useState<
+				ChoiceCard | undefined
+			>(identicalCards[0]);
+
+			return (
+				<ThreeTierChoiceCards
+					selectedChoiceCard={selectedChoiceCard}
+					setSelectedChoiceCard={setSelectedChoiceCard}
+					choices={identicalCards}
+					id="banner"
+				/>
+			);
+		};
+
+		render(<TestComponent />);
+
+		const radios = screen.getAllByRole('radio');
+		expect(radios).toHaveLength(2);
+		const [firstRadio, secondRadio] = radios as [HTMLElement, HTMLElement];
+		expect(firstRadio).toBeChecked();
+		expect(secondRadio).not.toBeChecked();
+
+		fireEvent.click(secondRadio);
+		expect(secondRadio).toBeChecked();
+		expect(firstRadio).not.toBeChecked();
+	});
 });

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.test.tsx
@@ -154,11 +154,200 @@ describe('ThreeTierChoiceCards', () => {
 		});
 		expect(checkedRadiosAfter).toHaveLength(1);
 
-		// The checked radio should be the OneOff card
+		// The checked radio should be the OneOff card. Its value is unique per
+		// card (index-suffixed) so duplicate supportTiers cannot collide.
 		expect(checkedRadiosAfter[0]).toBeChecked();
 		expect(checkedRadiosAfter[0]).toHaveAttribute(
 			'value',
-			'choicecard-banner-OneOff',
+			'choicecard-banner-OneOff-2',
 		);
+	});
+
+	it('renders unique ids/values and selects only the chosen card when two OneOff cards are present', () => {
+		const duplicateOneOffCards: Array<
+			ChoiceCard & { defaultExpanded?: boolean }
+		> = [
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 1',
+				isDefault: true,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 2',
+				isDefault: false,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+		];
+
+		const TestComponent = () => {
+			const [selectedChoiceCard, setSelectedChoiceCard] = useState<
+				ChoiceCard | undefined
+			>(duplicateOneOffCards[0]);
+
+			return (
+				<ThreeTierChoiceCards
+					selectedChoiceCard={selectedChoiceCard}
+					setSelectedChoiceCard={setSelectedChoiceCard}
+					choices={duplicateOneOffCards}
+					id="banner"
+				/>
+			);
+		};
+
+		render(<TestComponent />);
+
+		const radios = screen.getAllByRole('radio');
+
+		// Each radio has a unique id and value
+		const ids = radios.map((r) => r.getAttribute('id'));
+		const values = radios.map((r) => r.getAttribute('value'));
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(new Set(values).size).toBe(values.length);
+
+		// Every label[for] points at a real radio id, and the set of
+		// labels' targets is exactly the set of radio ids (no cross-card
+		// association). Note: each card has two labels (outer card label +
+		// inner Radio label), so labelFors may repeat a valid id.
+		const labels = document.querySelectorAll('label[for]');
+		const labelFors = Array.from(labels).map((l) => l.getAttribute('for'));
+		labelFors.forEach((forAttr) => {
+			expect(ids).toContain(forAttr);
+		});
+		expect(new Set(labelFors)).toEqual(new Set(ids));
+
+		// Only the default (card 1) is checked initially; card 2 is not
+		expect(radios[0]).toBeChecked();
+		expect(radios[1]).not.toBeChecked();
+
+		// Clicking card 2 selects only card 2
+		fireEvent.click(screen.getByText('One-time 2'));
+		expect(radios[1]).toBeChecked();
+		expect(radios[0]).not.toBeChecked();
+	});
+
+	it('applies the same uniqueness/selection guarantees in the epic context (id="epic")', () => {
+		// The component is shared, but the `id` prop seeds
+		// the radio id/name strings, so verify it directly.
+		const duplicateOneOffCards: Array<
+			ChoiceCard & {
+				defaultExpanded?: boolean;
+			}
+		> = [
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 1',
+				isDefault: true,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 2',
+				isDefault: false,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+		];
+
+		const TestComponent = () => {
+			const [selectedChoiceCard, setSelectedChoiceCard] = useState<
+				ChoiceCard | undefined
+			>(duplicateOneOffCards[0]);
+
+			return (
+				<ThreeTierChoiceCards
+					selectedChoiceCard={selectedChoiceCard}
+					setSelectedChoiceCard={setSelectedChoiceCard}
+					choices={duplicateOneOffCards}
+					id="epic"
+				/>
+			);
+		};
+
+		render(<TestComponent />);
+
+		const radios = screen.getAllByRole('radio');
+		const ids = radios.map((r) => r.getAttribute('id'));
+		const values = radios.map((r) => r.getAttribute('value'));
+
+		// (Epic): unique ids and values, seeded with "epic"
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(new Set(values).size).toBe(values.length);
+		expect(ids[0]).toBe('choicecard-epic-OneOff-0');
+		expect(values[0]).toBe('choicecard-epic-OneOff-0');
+
+		// (Epic): only the default card is checked initially
+		expect(radios[0]).toBeChecked();
+		expect(radios[1]).not.toBeChecked();
+
+		fireEvent.click(screen.getByText('One-time 2'));
+		expect(radios[1]).toBeChecked();
+		expect(radios[0]).not.toBeChecked();
+	});
+
+	it('does not emit a duplicate-key warning for duplicate supportTiers', () => {
+		// React keys must be unique per card; a duplicate key only surfaces as
+		// a console.error warning (not DOM breakage), so assert on the warning
+		// to guard the key={radioId} choice against regression.
+		const duplicateOneOffCards: Array<
+			ChoiceCard & {
+				defaultExpanded?: boolean;
+			}
+		> = [
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 1',
+				isDefault: true,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+			{
+				product: { supportTier: 'OneOff' },
+				label: 'One-time 2',
+				isDefault: false,
+				benefits: [
+					{ copy: 'We welcome support of any size, any time' },
+				],
+			},
+		];
+
+		const consoleErrorSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		const TestComponent = () => {
+			const [selectedChoiceCard, setSelectedChoiceCard] = useState<
+				ChoiceCard | undefined
+			>(duplicateOneOffCards[0]);
+
+			return (
+				<ThreeTierChoiceCards
+					selectedChoiceCard={selectedChoiceCard}
+					setSelectedChoiceCard={setSelectedChoiceCard}
+					choices={duplicateOneOffCards}
+					id="banner"
+				/>
+			);
+		};
+
+		render(<TestComponent />);
+
+		const duplicateKeyCalls = consoleErrorSpy.mock.calls.filter((args) =>
+			String(args[0]).includes(
+				'Encountered two children with the same key',
+			),
+		);
+		expect(duplicateKeyCalls).toHaveLength(0);
+
+		consoleErrorSpy.mockRestore();
 	});
 });

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -269,7 +269,7 @@ export const ThreeTierChoiceCards = ({
 				`}
 			>
 				<Stack space={3}>
-					{choices.map((card) => {
+					{choices.map((card, index) => {
 						const {
 							product,
 							label,
@@ -279,37 +279,27 @@ export const ThreeTierChoiceCards = ({
 						} = card;
 						const { supportTier } = product;
 
-						const isSelected = (): boolean => {
-							if (!selectedChoiceCard) {
-								return false;
-							}
-							if (
-								product.supportTier ===
-								selectedChoiceCard.product.supportTier
-							) {
-								if (
-									product.supportTier !== 'OneOff' &&
-									selectedChoiceCard.product.supportTier !==
-										'OneOff'
-								) {
-									return (
-										product.ratePlan ===
-										selectedChoiceCard.product.ratePlan
-									);
-								} else {
-									return true;
-								}
-							} else {
-								return false;
-							}
-						};
-						const selected = isSelected();
+						// Compare by reference: selectedChoiceCard is always a
+						// stable object taken from this choices array (set via
+						// setSelectedChoiceCard(card) / onChoiceCardChange), so
+						// reference equality correctly identifies the chosen
+						// card even when two cards share the same supportTier
+						// (e.g. two OneOff cards). The previous
+						// supportTier/ratePlan comparison returned true for both
+						// duplicate cards.
+						const selected = card === selectedChoiceCard;
 
+						// Suffix with the array index so every radio gets a
+						// unique id and value even when two cards share the
+						// same supportTier (e.g. two OneOff cards). Without
+						// this, both OneOff cards produced
+						// id="choicecard-banner-OneOff", breaking <label
+						// htmlFor> association and React keys.
 						const radioId = `choicecard-${id}-${supportTier}${
 							supportTier !== 'OneOff'
 								? `-${product.ratePlan}`
 								: ''
-						}`;
+						}-${index}`;
 
 						const isExpanded =
 							selected ||
@@ -317,7 +307,7 @@ export const ThreeTierChoiceCards = ({
 
 						return (
 							<div
-								key={supportTier}
+								key={radioId}
 								css={css`
 									position: relative;
 									background-color: inherit;

--- a/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/shared/ThreeTierChoiceCards.tsx
@@ -126,6 +126,20 @@ type ThreeTierChoiceCardsProps = {
 	choiceCardDesignSettings?: ChoiceCardDesignSettings;
 };
 
+/**
+ * Structural equality for choice cards: same product (supportTier and, where
+ * present, ratePlan) and same label. Used to re-resolve a stale
+ * selectedChoiceCard reference — e.g. when useMatchMedia switches the
+ * choices array between mobile and desktop configs after mount, the initial
+ * default (captured via useState from the first array) no longer
+ * reference-matches any card, but is still the same logical card.
+ */
+const isSameCard = (a: ChoiceCard, b: ChoiceCard): boolean =>
+	a.label === b.label &&
+	a.product.supportTier === b.product.supportTier &&
+	('ratePlan' in a.product ? a.product.ratePlan : undefined) ===
+		('ratePlan' in b.product ? b.product.ratePlan : undefined);
+
 export const ThreeTierChoiceCards = ({
 	selectedChoiceCard,
 	setSelectedChoiceCard,
@@ -269,101 +283,116 @@ export const ThreeTierChoiceCards = ({
 				`}
 			>
 				<Stack space={3}>
-					{choices.map((card, index) => {
-						const {
-							product,
-							label,
-							benefitsLabel,
-							benefits,
-							pill,
-						} = card;
-						const { supportTier } = product;
+					{(() => {
+						// Identify the selected card by position so duplicate
+						// cards (e.g. two OneOff cards) can be told apart.
+						// Prefer reference equality — selectedChoiceCard is
+						// normally a stable object from this choices array (set
+						// via setSelectedChoiceCard(card)/onChoiceCardChange).
+						// Fall back to structural equality when the reference
+						// is stale, e.g. the array identity changes when
+						// useMatchMedia switches between mobile and desktop
+						// choice cards after mount.
+						let selectedIndex = -1;
+						if (selectedChoiceCard) {
+							selectedIndex = choices.indexOf(selectedChoiceCard);
+							if (selectedIndex === -1) {
+								selectedIndex = choices.findIndex((choice) =>
+									isSameCard(choice, selectedChoiceCard),
+								);
+							}
+						}
 
-						// Compare by reference: selectedChoiceCard is always a
-						// stable object taken from this choices array (set via
-						// setSelectedChoiceCard(card) / onChoiceCardChange), so
-						// reference equality correctly identifies the chosen
-						// card even when two cards share the same supportTier
-						// (e.g. two OneOff cards). The previous
-						// supportTier/ratePlan comparison returned true for both
-						// duplicate cards.
-						const selected = card === selectedChoiceCard;
+						return choices.map((card, index) => {
+							const {
+								product,
+								label,
+								benefitsLabel,
+								benefits,
+								pill,
+							} = card;
+							const { supportTier } = product;
 
-						// Suffix with the array index so every radio gets a
-						// unique id and value even when two cards share the
-						// same supportTier (e.g. two OneOff cards). Without
-						// this, both OneOff cards produced
-						// id="choicecard-banner-OneOff", breaking <label
-						// htmlFor> association and React keys.
-						const radioId = `choicecard-${id}-${supportTier}${
-							supportTier !== 'OneOff'
-								? `-${product.ratePlan}`
-								: ''
-						}-${index}`;
+							const selected = index === selectedIndex;
 
-						const isExpanded =
-							selected ||
-							(!selectedChoiceCard && card.defaultExpanded);
+							// Suffix with the array index so every radio gets a
+							// unique id and value even when two cards share the
+							// same supportTier (e.g. two OneOff cards). Without
+							// this, both OneOff cards produced
+							// id="choicecard-banner-OneOff", breaking <label
+							// htmlFor> association and React keys.
+							const radioId = `choicecard-${id}-${supportTier}${
+								supportTier !== 'OneOff'
+									? `-${product.ratePlan}`
+									: ''
+							}-${index}`;
 
-						return (
-							<div
-								key={radioId}
-								css={css`
-									position: relative;
-									background-color: inherit;
-								`}
-							>
-								{pill && <ChoiceCardPill pill={pill} />}
-								<label
-									css={supportTierChoiceCardStyles(selected)}
-									htmlFor={radioId}
+							const isExpanded =
+								selected ||
+								(!selectedChoiceCard && card.defaultExpanded);
+
+							return (
+								<div
+									key={radioId}
+									css={css`
+										position: relative;
+										background-color: inherit;
+									`}
 								>
-									<Radio
-										label={
-											<span
-												dangerouslySetInnerHTML={{
-													__html: sanitise(label),
-												}}
-											/>
-										}
-										id={radioId}
-										value={radioId}
-										name={`choice-cards-${id}`}
-										cssOverrides={labelOverrideStyles(
+									{pill && <ChoiceCardPill pill={pill} />}
+									<label
+										css={supportTierChoiceCardStyles(
 											selected,
 										)}
-										supporting={
-											isExpanded && (
-												<SupportingBenefits
-													benefitsLabel={
-														benefitsLabel as
-															| string
-															| undefined
-													}
-													benefits={benefits}
-													benefitsTickColour={
-														pill
-															? getPillBackgroundColour(
-																	pill,
-																)
-															: undefined
-													}
-													choiceCardDesignSettings={
-														choiceCardDesignSettings
-													}
+										htmlFor={radioId}
+									>
+										<Radio
+											label={
+												<span
+													dangerouslySetInnerHTML={{
+														__html: sanitise(label),
+													}}
 												/>
-											)
-										}
-										checked={selected}
-										onChange={() => {
-											setSelectedChoiceCard(card);
-										}}
-										theme={customRadioTheme}
-									/>
-								</label>
-							</div>
-						);
-					})}
+											}
+											id={radioId}
+											value={radioId}
+											name={`choice-cards-${id}`}
+											cssOverrides={labelOverrideStyles(
+												selected,
+											)}
+											supporting={
+												isExpanded && (
+													<SupportingBenefits
+														benefitsLabel={
+															benefitsLabel as
+																| string
+																| undefined
+														}
+														benefits={benefits}
+														benefitsTickColour={
+															pill
+																? getPillBackgroundColour(
+																		pill,
+																	)
+																: undefined
+														}
+														choiceCardDesignSettings={
+															choiceCardDesignSettings
+														}
+													/>
+												)
+											}
+											checked={selected}
+											onChange={() => {
+												setSelectedChoiceCard(card);
+											}}
+											theme={customRadioTheme}
+										/>
+									</label>
+								</div>
+							);
+						});
+					})()}
 				</Stack>
 			</RadioGroup>
 		</div>


### PR DESCRIPTION
Fixes a bug where two choice cards with the same type (e.g. two OneOff cards) produced duplicate radio `id`s, `value`s, and React `key`s, and rendered both radios as `checked` — causing the browser to visually select the wrong card and breaking `<label htmlFor>` association.

- Suffix radio `id`/`value`/`key` with the array index for uniqueness.
- Compare selection by object reference instead of `supportTier`/`ratePlan`.
- Applies to both banner and epic (shared `ThreeTierChoiceCards` component).

## Screenshots

The url of each option is appearing in the screenshots below:

### Landing Page
<img width="1020" height="354" alt="image" src="https://github.com/user-attachments/assets/00742144-f131-4645-9074-d2c82a3264a7" />

### Checkout
<img width="1005" height="355" alt="image" src="https://github.com/user-attachments/assets/f66a0519-2daf-4451-8dcd-a95f88f3e3ca" />

## Generated html
<img width="705" height="367" alt="image" src="https://github.com/user-attachments/assets/124b5766-7283-4919-aa97-8775f55f09f9" />
