### PR TITLE
Add A/B EditorialTest model types to FEFrontCard

### DIFF
--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -9,6 +9,7 @@ import type {
 	StarRating,
 } from '../types/content';
 import type { FooterType } from '../types/footer';
+import type { Test } from '../types/front';
 import type { FENavType } from '../types/frontend';
 import type { FETagType } from '../types/tag';
 import type { Territory } from '../types/territory';
@@ -205,6 +206,7 @@ export type FEFrontCard = {
 		href?: string;
 		embedUri?: string;
 		newsletterData?: Newsletter;
+		tests?: Test[];
 	};
 	header: {
 		isVideo: boolean;

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -9,7 +9,7 @@ import type {
 	StarRating,
 } from '../types/content';
 import type { FooterType } from '../types/footer';
-import type { Test } from '../types/front';
+import type { EditorialTest } from '../types/front';
 import type { FENavType } from '../types/frontend';
 import type { FETagType } from '../types/tag';
 import type { Territory } from '../types/territory';
@@ -206,7 +206,7 @@ export type FEFrontCard = {
 		href?: string;
 		embedUri?: string;
 		newsletterData?: Newsletter;
-		tests?: Test[];
+		tests?: EditorialTest[];
 	};
 	header: {
 		isVideo: boolean;

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -3397,11 +3397,11 @@
             ]
         },
         "VariantId": {
-            "type": "number",
             "enum": [
-                0,
-                1
-            ]
+                "A",
+                "B"
+            ],
+            "type": "string"
         },
         "FEFrontCardStyle": {
             "enum": [

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -634,6 +634,71 @@
                                                         "successDescription",
                                                         "theme"
                                                     ]
+                                                },
+                                                "tests": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "testUuid": {
+                                                                "type": "string"
+                                                            },
+                                                            "variantMeta": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "$ref": "#/definitions/VariantId"
+                                                                        },
+                                                                        "meta": {
+                                                                            "type": "object",
+                                                                            "additionalProperties": {}
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "meta"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "createdByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "createdByEmail": {
+                                                                "type": "string"
+                                                            },
+                                                            "startDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "expiryDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "frontsThisTestCanRunOn": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "hasManuallyEndedOnThisTrail": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByEmail": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "createdByEmail",
+                                                            "createdByName",
+                                                            "frontsThisTestCanRunOn",
+                                                            "hasManuallyEndedOnThisTrail",
+                                                            "testUuid",
+                                                            "variantMeta"
+                                                        ]
+                                                    }
                                                 }
                                             },
                                             "required": [
@@ -1469,6 +1534,71 @@
                                                         "successDescription",
                                                         "theme"
                                                     ]
+                                                },
+                                                "tests": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "testUuid": {
+                                                                "type": "string"
+                                                            },
+                                                            "variantMeta": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "$ref": "#/definitions/VariantId"
+                                                                        },
+                                                                        "meta": {
+                                                                            "type": "object",
+                                                                            "additionalProperties": {}
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "meta"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "createdByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "createdByEmail": {
+                                                                "type": "string"
+                                                            },
+                                                            "startDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "expiryDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "frontsThisTestCanRunOn": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "hasManuallyEndedOnThisTrail": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByEmail": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "createdByEmail",
+                                                            "createdByName",
+                                                            "frontsThisTestCanRunOn",
+                                                            "hasManuallyEndedOnThisTrail",
+                                                            "testUuid",
+                                                            "variantMeta"
+                                                        ]
+                                                    }
                                                 }
                                             },
                                             "required": [
@@ -2304,6 +2434,71 @@
                                                         "successDescription",
                                                         "theme"
                                                     ]
+                                                },
+                                                "tests": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "testUuid": {
+                                                                "type": "string"
+                                                            },
+                                                            "variantMeta": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "$ref": "#/definitions/VariantId"
+                                                                        },
+                                                                        "meta": {
+                                                                            "type": "object",
+                                                                            "additionalProperties": {}
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "meta"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "createdByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "createdByEmail": {
+                                                                "type": "string"
+                                                            },
+                                                            "startDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "expiryDate": {
+                                                                "type": "number"
+                                                            },
+                                                            "frontsThisTestCanRunOn": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "hasManuallyEndedOnThisTrail": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByName": {
+                                                                "type": "string"
+                                                            },
+                                                            "manuallyEndedOnThisTrailByEmail": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "createdByEmail",
+                                                            "createdByName",
+                                                            "frontsThisTestCanRunOn",
+                                                            "hasManuallyEndedOnThisTrail",
+                                                            "testUuid",
+                                                            "variantMeta"
+                                                        ]
+                                                    }
                                                 }
                                             },
                                             "required": [
@@ -3199,6 +3394,13 @@
                 "index",
                 "mediaType",
                 "url"
+            ]
+        },
+        "VariantId": {
+            "type": "number",
+            "enum": [
+                0,
+                1
             ]
         },
         "FEFrontCardStyle": {

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -662,12 +662,6 @@
                                                                     ]
                                                                 }
                                                             },
-                                                            "createdByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "createdByEmail": {
-                                                                "type": "string"
-                                                            },
                                                             "startDate": {
                                                                 "type": "number"
                                                             },
@@ -682,17 +676,9 @@
                                                             },
                                                             "hasManuallyEndedOnThisTrail": {
                                                                 "type": "boolean"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByEmail": {
-                                                                "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "createdByEmail",
-                                                            "createdByName",
                                                             "frontsThisTestCanRunOn",
                                                             "hasManuallyEndedOnThisTrail",
                                                             "testUuid",
@@ -1562,12 +1548,6 @@
                                                                     ]
                                                                 }
                                                             },
-                                                            "createdByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "createdByEmail": {
-                                                                "type": "string"
-                                                            },
                                                             "startDate": {
                                                                 "type": "number"
                                                             },
@@ -1582,17 +1562,9 @@
                                                             },
                                                             "hasManuallyEndedOnThisTrail": {
                                                                 "type": "boolean"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByEmail": {
-                                                                "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "createdByEmail",
-                                                            "createdByName",
                                                             "frontsThisTestCanRunOn",
                                                             "hasManuallyEndedOnThisTrail",
                                                             "testUuid",
@@ -2462,12 +2434,6 @@
                                                                     ]
                                                                 }
                                                             },
-                                                            "createdByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "createdByEmail": {
-                                                                "type": "string"
-                                                            },
                                                             "startDate": {
                                                                 "type": "number"
                                                             },
@@ -2482,17 +2448,9 @@
                                                             },
                                                             "hasManuallyEndedOnThisTrail": {
                                                                 "type": "boolean"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByName": {
-                                                                "type": "string"
-                                                            },
-                                                            "manuallyEndedOnThisTrailByEmail": {
-                                                                "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "createdByEmail",
-                                                            "createdByName",
                                                             "frontsThisTestCanRunOn",
                                                             "hasManuallyEndedOnThisTrail",
                                                             "testUuid",

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -505,12 +505,6 @@
                                                 ]
                                             }
                                         },
-                                        "createdByName": {
-                                            "type": "string"
-                                        },
-                                        "createdByEmail": {
-                                            "type": "string"
-                                        },
                                         "startDate": {
                                             "type": "number"
                                         },
@@ -525,17 +519,9 @@
                                         },
                                         "hasManuallyEndedOnThisTrail": {
                                             "type": "boolean"
-                                        },
-                                        "manuallyEndedOnThisTrailByName": {
-                                            "type": "string"
-                                        },
-                                        "manuallyEndedOnThisTrailByEmail": {
-                                            "type": "string"
                                         }
                                     },
                                     "required": [
-                                        "createdByEmail",
-                                        "createdByName",
                                         "frontsThisTestCanRunOn",
                                         "hasManuallyEndedOnThisTrail",
                                         "testUuid",

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -1495,11 +1495,11 @@
             ]
         },
         "VariantId": {
-            "type": "number",
             "enum": [
-                0,
-                1
-            ]
+                "A",
+                "B"
+            ],
+            "type": "string"
         },
         "FEFrontCardStyle": {
             "enum": [

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -477,6 +477,71 @@
                                     "successDescription",
                                     "theme"
                                 ]
+                            },
+                            "tests": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "testUuid": {
+                                            "type": "string"
+                                        },
+                                        "variantMeta": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "$ref": "#/definitions/VariantId"
+                                                    },
+                                                    "meta": {
+                                                        "type": "object",
+                                                        "additionalProperties": {}
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "meta"
+                                                ]
+                                            }
+                                        },
+                                        "createdByName": {
+                                            "type": "string"
+                                        },
+                                        "createdByEmail": {
+                                            "type": "string"
+                                        },
+                                        "startDate": {
+                                            "type": "number"
+                                        },
+                                        "expiryDate": {
+                                            "type": "number"
+                                        },
+                                        "frontsThisTestCanRunOn": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "hasManuallyEndedOnThisTrail": {
+                                            "type": "boolean"
+                                        },
+                                        "manuallyEndedOnThisTrailByName": {
+                                            "type": "string"
+                                        },
+                                        "manuallyEndedOnThisTrailByEmail": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "createdByEmail",
+                                        "createdByName",
+                                        "frontsThisTestCanRunOn",
+                                        "hasManuallyEndedOnThisTrail",
+                                        "testUuid",
+                                        "variantMeta"
+                                    ]
+                                }
                             }
                         },
                         "required": [
@@ -1427,6 +1492,13 @@
                         "name"
                     ]
                 }
+            ]
+        },
+        "VariantId": {
+            "type": "number",
+            "enum": [
+                0,
+                1
             ]
         },
         "FEFrontCardStyle": {

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -180,7 +180,7 @@ export type VariantMeta = {
 	};
 };
 
-export type Test = {
+export type EditorialTest = {
 	testUuid: string;
 	variantMeta: VariantMeta[];
 	createdByName: string;

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -183,12 +183,8 @@ export type VariantMeta = {
 export type EditorialTest = {
 	testUuid: string;
 	variantMeta: VariantMeta[];
-	createdByName: string;
-	createdByEmail: string;
 	startDate?: number;
 	expiryDate?: number;
 	frontsThisTestCanRunOn: string[];
 	hasManuallyEndedOnThisTrail: boolean;
-	manuallyEndedOnThisTrailByName?: string;
-	manuallyEndedOnThisTrailByEmail?: string;
 };

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -170,3 +170,28 @@ export type TreatType = {
 	 */
 	pageId?: string;
 };
+
+enum VariantId {
+	A,
+	B,
+}
+
+export type VariantMeta = {
+	id: VariantId;
+	meta: {
+		[key: string]: unknown;
+	};
+};
+
+export type Test = {
+	testUuid: string;
+	variantMeta: VariantMeta[];
+	createdByName: string;
+	createdByEmail: string;
+	startDate?: number;
+	expiryDate?: number;
+	frontsThisTestCanRunOn: string[];
+	hasManuallyEndedOnThisTrail: boolean;
+	manuallyEndedOnThisTrailByName?: string;
+	manuallyEndedOnThisTrailByEmail?: string;
+};

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -171,10 +171,7 @@ export type TreatType = {
 	pageId?: string;
 };
 
-enum VariantId {
-	A,
-	B,
-}
+export type VariantId = 'A' | 'B';
 
 export type VariantMeta = {
 	id: VariantId;


### PR DESCRIPTION
## What does this change?
Plumbs the front card Test model, by introducing the an optional `tests` field on FEFrontCard model. As the `tests` field is optional, this change is backwards compatible. The `EditorialTest` model removes any PII data fields so these are ignored by DCR. At the moment, these are still sent from Frontend but there is a PR in progress to full remove these fields before they are sent to DCR.

This PR does not implement editorial testing. This will be achieved in a follow up PR.

Schemas have also been freshly generated to account for these model changes.

## Why?
This is required to send editorial a/b test information from frontend to DCR.

## How has this change been tested?
Deployed branch to CODE and tested on fronts with and without a tests field. Fronts rendered without issue.
