### PR TITLE
Increase the ad limit on fronts to measure impact

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -74,7 +74,7 @@ const ABTests: ABTest[] = [
 		description:
 			"A test to understand the impact of changing page-level ad limit on fronts",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-08-11",
+		expirationDate: "2026-08-27",
 		type: "server",
 		status: "ON",
 		audienceSize: 10 / 100,

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -75,7 +75,7 @@ const ABTests: ABTest[] = [
 			"A test to understand the impact of changing page-level ad limit on fronts",
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-08-11",
-		type: "client",
+		type: "server",
 		status: "ON",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -70,6 +70,19 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-fronts-ad-increase-ad-limit",
+		description:
+			"A test to understand the impact of changing page-level ad limit on fronts",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-08-11",
+		type: "client",
+		status: "ON",
+		audienceSize: 10 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
+	{
 		name: "newsletters-in-article-signup-preview",
 		description:
 			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -121,7 +121,8 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		editionId,
 	} = front;
 
-	const isInVariant =
+    /** Test participation determines whether to increase the maximum number of ads shown on fronts */
+	const shouldIncreaseAdLimit =
 		front.config.serverSideABTests[
 			'commercial-fronts-ad-increase-ad-limit'
 		] === 'variant';

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,14 +31,11 @@ import { SubNav } from '../components/SubNav.island';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
-import {
-	MAX_FRONTS_BANNER_ADS,
-	MAX_FRONTS_MOBILE_ADS,
-} from '../lib/commercial-constants';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
 	getDesktopAdPositions,
+	getMaxFrontsAdCounts,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
@@ -121,14 +118,9 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		editionId,
 	} = front;
 
-    /** Test participation determines whether to increase the maximum number of ads shown on fronts */
-	const shouldIncreaseAdLimit =
-		front.config.serverSideABTests[
-			'commercial-fronts-ad-increase-ad-limit'
-		] === 'variant';
-
-	const maxDesktopAds = isInVariant ? 16 : MAX_FRONTS_BANNER_ADS;
-	const maxMobileAds = isInVariant ? 20 : MAX_FRONTS_MOBILE_ADS;
+	const { maxDesktopAds, maxMobileAds } = getMaxFrontsAdCounts(
+		front.config.serverSideABTests,
+	);
 
 	const serverTime = front.serverTime;
 

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,11 +31,11 @@ import { SubNav } from '../components/SubNav.island';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
-import { getMaxFrontsBannerAds } from '../lib/commercial-constants';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
 	getDesktopAdPositions,
+	getMaxFrontsBannerAds,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,6 +31,7 @@ import { SubNav } from '../components/SubNav.island';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
+import { getMaxFrontsBannerAds } from '../lib/commercial-constants';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
@@ -40,6 +41,7 @@ import {
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import { ophanComponentId } from '../lib/ophan-helpers';
+import { useAB } from '../lib/useAB';
 import { worldCup2026PageIds } from '../lib/worldCup2026';
 import type { NavType } from '../model/extract-nav';
 import { palette as schemePalette } from '../palette';
@@ -117,6 +119,10 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		editionId,
 	} = front;
 
+	const abTests = useAB();
+
+	const maxAds = getMaxFrontsBannerAds(abTests);
+
 	const serverTime = front.serverTime;
 
 	const renderAds = canRenderAds(front);
@@ -136,7 +142,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		: [];
 
 	const desktopAdPositions = renderAds
-		? getDesktopAdPositions(filteredCollections, pageId)
+		? getDesktopAdPositions(filteredCollections, pageId, maxAds)
 		: [];
 
 	const showMostPopular =

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,17 +31,19 @@ import { SubNav } from '../components/SubNav.island';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
+import {
+	MAX_FRONTS_BANNER_ADS,
+	MAX_FRONTS_MOBILE_ADS,
+} from '../lib/commercial-constants';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
 	getDesktopAdPositions,
-	getMaxFrontsBannerAds,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
 import { hideAge } from '../lib/hideAge';
 import { ophanComponentId } from '../lib/ophan-helpers';
-import { useAB } from '../lib/useAB';
 import { worldCup2026PageIds } from '../lib/worldCup2026';
 import type { NavType } from '../model/extract-nav';
 import { palette as schemePalette } from '../palette';
@@ -119,9 +121,13 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		editionId,
 	} = front;
 
-	const abTests = useAB();
+	const isInVariant =
+		front.config.serverSideABTests[
+			'commercial-fronts-ad-increase-ad-limit'
+		] === 'variant';
 
-	const maxAds = getMaxFrontsBannerAds(abTests);
+	const maxDesktopAds = isInVariant ? 16 : MAX_FRONTS_BANNER_ADS;
+	const maxMobileAds = isInVariant ? 20 : MAX_FRONTS_MOBILE_ADS;
 
 	const serverTime = front.serverTime;
 
@@ -138,11 +144,11 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 	const merchHighAdPosition = getMerchHighPosition(filteredCollections);
 
 	const mobileAdPositions = renderAds
-		? getMobileAdPositions(filteredCollections, pageId)
+		? getMobileAdPositions(filteredCollections, pageId, maxMobileAds)
 		: [];
 
 	const desktopAdPositions = renderAds
-		? getDesktopAdPositions(filteredCollections, pageId, maxAds)
+		? getDesktopAdPositions(filteredCollections, pageId, maxDesktopAds)
 		: [];
 
 	const showMostPopular =

--- a/dotcom-rendering/src/lib/commercial-constants.ts
+++ b/dotcom-rendering/src/lib/commercial-constants.ts
@@ -1,8 +1,22 @@
+import type { ABTestAPI } from '../experiments/lib/ab-tests';
+
 /**
  * The maximum number of fronts-banner ads that can be inserted on any front.
  * fronts-banner ads are inserted from the desktop breakpoint.
  */
 export const MAX_FRONTS_BANNER_ADS = 8;
+
+export const getMaxFrontsBannerAds = (
+	abTests: ABTestAPI | undefined,
+): number => {
+	const isInVariantAdLimitGroup =
+		abTests?.isUserInTestGroup(
+			'commercial-fronts-ad-increase-ad-limit',
+			'variant',
+		) ?? false;
+
+	return isInVariantAdLimitGroup ? 16 : MAX_FRONTS_BANNER_ADS;
+};
 
 /**
  * The maximum number of ads that can be inserted on any mobile front.

--- a/dotcom-rendering/src/lib/commercial-constants.ts
+++ b/dotcom-rendering/src/lib/commercial-constants.ts
@@ -1,22 +1,8 @@
-import type { ABTestAPI } from '../experiments/lib/ab-tests';
-
 /**
  * The maximum number of fronts-banner ads that can be inserted on any front.
  * fronts-banner ads are inserted from the desktop breakpoint.
  */
 export const MAX_FRONTS_BANNER_ADS = 8;
-
-export const getMaxFrontsBannerAds = (
-	abTests: ABTestAPI | undefined,
-): number => {
-	const isInVariantAdLimitGroup =
-		abTests?.isUserInTestGroup(
-			'commercial-fronts-ad-increase-ad-limit',
-			'variant',
-		) ?? false;
-
-	return isInVariantAdLimitGroup ? 16 : MAX_FRONTS_BANNER_ADS;
-};
 
 /**
  * The maximum number of ads that can be inserted on any mobile front.

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -359,9 +359,8 @@ const canInsertDesktopAd = (
 const getDesktopAdPositions = (
 	collections: AdCandidate[],
 	pageId: string,
+	maxAdsAllowed = MAX_FRONTS_BANNER_ADS,
 ): number[] => {
-	const maxAdsAllowed = MAX_FRONTS_BANNER_ADS;
-
 	const adPositionsFromReducer = collections.reduce<{
 		heightSinceAd: number;
 		adPositions: number[];

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -1,4 +1,5 @@
 import { isUndefined } from '@guardian/libs';
+import type { ABTestAPI } from '../experiments/lib/ab-tests';
 import type { DCRCollectionType, DCRGroupedTrails } from '../types/front';
 import {
 	MAX_FRONTS_BANNER_ADS,
@@ -409,6 +410,17 @@ const getDesktopAdPositions = (
 	).adPositions;
 
 	return adPositionsFromReducer;
+};
+
+export const getMaxFrontsBannerAds = (
+	abTests: ABTestAPI | undefined,
+): number => {
+	const isInVariantAdLimitGroup =
+		abTests?.isUserInTestGroup(
+			'commercial-fronts-ad-increase-ad-limit',
+			'variant',
+		) ?? false;
+	return isInVariantAdLimitGroup ? 16 : MAX_FRONTS_BANNER_ADS;
 };
 
 export {

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -412,6 +412,18 @@ const getDesktopAdPositions = (
 	return adPositionsFromReducer;
 };
 
+export const getMaxFrontsAdCounts = (
+	serverSideAbTests: Record<string, string>,
+): { maxDesktopAds: number; maxMobileAds: number } => {
+	const shouldIncreaseAdLimit =
+		serverSideAbTests['commercial-fronts-ad-increase-ad-limit'] ===
+		'variant';
+	return {
+		maxDesktopAds: shouldIncreaseAdLimit ? 16 : MAX_FRONTS_BANNER_ADS,
+		maxMobileAds: shouldIncreaseAdLimit ? 20 : MAX_FRONTS_MOBILE_ADS,
+	};
+};
+
 export {
 	isEvenIndex,
 	getMerchHighPosition,

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -1,5 +1,4 @@
 import { isUndefined } from '@guardian/libs';
-import type { ABTestAPI } from '../experiments/lib/ab-tests';
 import type { DCRCollectionType, DCRGroupedTrails } from '../types/front';
 import {
 	MAX_FRONTS_BANNER_ADS,
@@ -145,6 +144,7 @@ const isEvenIndex = (_collection: unknown, index: number): boolean =>
 const getMobileAdPositions = (
 	collections: AdCandidate[],
 	pageId: string,
+	maxMobileAds = MAX_FRONTS_MOBILE_ADS,
 ): number[] => {
 	const merchHighPosition = getMerchHighPosition(collections);
 	const hasSecondaryContainers = hasSecondaryLevelContainers(collections);
@@ -168,7 +168,7 @@ const getMobileAdPositions = (
 				: (acc: number[], el: number) => [...acc, el], // returns the original array
 			[],
 		)
-		.slice(0, MAX_FRONTS_MOBILE_ADS);
+		.slice(0, maxMobileAds);
 
 	return adPositions;
 };
@@ -410,17 +410,6 @@ const getDesktopAdPositions = (
 	).adPositions;
 
 	return adPositionsFromReducer;
-};
-
-export const getMaxFrontsBannerAds = (
-	abTests: ABTestAPI | undefined,
-): number => {
-	const isInVariantAdLimitGroup =
-		abTests?.isUserInTestGroup(
-			'commercial-fronts-ad-increase-ad-limit',
-			'variant',
-		) ?? false;
-	return isInVariantAdLimitGroup ? 16 : MAX_FRONTS_BANNER_ADS;
 };
 
 export {


### PR DESCRIPTION
## What does this change?
For users in the variant group of the `commercial-fronts-ad-increase-ad-limit` server-side AB test, increases the effective ad limit on fronts from 8 → 16 (desktop) and 10 → 20 (mobile).

Set behind a server side AB test gate and exposed to the variant group in `commercial-fronts-ad-increase-ad-limit`

## Why?
To measure the impact of increasing the page-level ad limit on impressions, ad ratio, and page performance.


### Testing
Tested with opting using `control` and `variant`:

Locally opting in via: http://localhost:3030/Front/https://www.theguardian.com/international?ab-commercial-fronts-ad-increase-ad-limit=variant



