### PR TITLE
Fix external link check

### DIFF
--- a/dotcom-rendering/src/components/Button/utils.test.tsx
+++ b/dotcom-rendering/src/components/Button/utils.test.tsx
@@ -5,6 +5,7 @@ describe('isExternalLink', () => {
 		expect(isExternalLink('https://www.theguardian.com/a/path')).toBe(
 			false,
 		);
+		expect(isExternalLink('https://theguardian.com/a/path')).toBe(false);
 		expect(isExternalLink('https://code.dev-theguardian.com/dsa')).toBe(
 			false,
 		);

--- a/dotcom-rendering/src/components/Button/utils.tsx
+++ b/dotcom-rendering/src/components/Button/utils.tsx
@@ -5,6 +5,7 @@ const platformHostnames = [
 	'code.dev-theguardian.com',
 	'm.code.dev-theguardian.com',
 	// PROD
+	'theguardian.com',
 	'www.theguardian.com',
 ];
 


### PR DESCRIPTION
## What does this change?

Previously, editorial buttons linking to `theguardian.com` (as opposed to `www.theguardian.com`) displayed an external-link arrow.

This PR adds `theguardian.com` to the list of platform host names to prevent this.

## Screenshots

| Before | After |
|--------|--------|
| <img width="180" height="74" alt="Screenshot 2026-07-31 at 11 37 55" src="https://github.com/user-attachments/assets/daf32446-ea24-4733-82a0-117fb53bdcc1" /> | <img width="144" height="74" alt="Screenshot 2026-07-31 at 11 37 58" src="https://github.com/user-attachments/assets/e86d92b8-5bcb-45eb-a9c9-732aaa0145c6" /> | 


