### PR TITLE
Change ignore-versions to delete-only-untagged-versions in delete old package versions workflow

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -25,4 +25,4 @@ jobs:
           package-name: 'dotcom-rendering'
           package-type: 'container'
           min-versions-to-keep: ${{ env.NUM_OF_VERSIONS_TO_KEEP }}
-          ignore-versions: main
+          delete-only-untagged-versions: 'true'


### PR DESCRIPTION
## Why?
I don't think the `ignore-versions: main` was working as we still see the `main` image being tidied up sometimes! 