### PR TITLE
100% ON AB Test disabling newsletter signup preview

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -87,12 +87,12 @@ const ABTests: ABTest[] = [
 		description:
 			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",
 		owners: ["newsletters.dev@guardian.co.uk"],
-		expirationDate: "2026-07-21",
+		expirationDate: "2026-09-04",
 		type: "client",
 		status: "ON",
-		audienceSize: 50 / 100,
-		audienceSpace: "A",
-		groups: ["illustrated", "without-preview"],
+		audienceSize: 1,
+		audienceSpace: "B",
+		groups: ["without-preview"],
 		shouldForceMetricsCollection: false,
 	},
 	{

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -85,7 +85,7 @@ const ABTests: ABTest[] = [
 	{
 		name: "newsletters-in-article-signup-preview",
 		description:
-			"Test in-article newsletter signup with illustrated preview CTA vs without preview CTA",
+			"Force disable preview for in-article newsletter signup. 100% audience",
 		owners: ["newsletters.dev@guardian.co.uk"],
 		expirationDate: "2026-09-04",
 		type: "client",


### PR DESCRIPTION
## What does this change?

Updates the existing `newsletters-in-article-signup-preview` a/b test so that it:
* Lives in its own audience space
* Directs 100% of traffic to the 'without-preview' variant.
* Updates the expiry date to 04/09/2026

This effectively disables the newsletter preview functionality for all users. 

## Why?

We want to fully disable the preview functionality in newsletter signups while we work on removing the code entirely. 
We will also use this time to double check the results from our previous AB test, and reinstate the preview if we see signups deteriorate. 

## How has this change been tested?

The AB test has been checked on https://m.code.dev-theguardian.com using links from https://frontend.code.dev-gutools.co.uk/analytics/ab-testing