### PR TITLE
chore(deps): Update GuCDK from 64.2.0 to 64.3.0

### DIFF
--- a/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
@@ -2,7 +2,7 @@ exports[`The ID5 Baton Lambda stack > matches the CODE snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Parameters": {
     "BuildId": {
@@ -46,7 +46,7 @@ exports[`The ID5 Baton Lambda stack > matches the PROD snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Parameters": {
     "BuildId": {

--- a/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -55,7 +55,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -294,7 +294,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -327,7 +327,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -377,7 +377,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -616,7 +616,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -10,7 +10,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -24,7 +24,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -113,7 +113,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -166,7 +166,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -340,7 +340,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -452,7 +452,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -494,7 +494,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.2.0"
+    "gu:cdk:version": "64.3.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -508,7 +508,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -597,7 +597,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -660,7 +660,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -834,7 +834,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -869,7 +869,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",
@@ -1006,7 +1006,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.2.0"
+            "Value": "64.3.0"
           },
           {
             "Key": "gu:repo",

--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -1991,7 +1991,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
             "ContainerName": "tag-page-rendering",
             "ContainerPort": 9000,
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupTagpagerendering06213654",
+              "Ref": "TagpagerenderingEcsTargetGroupTagpagerendering0976D2E5",
             },
           },
         ],
@@ -2096,55 +2096,6 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
         "ServiceNamespace": "ecs",
       },
       "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
-    },
-    "EcsTargetGroupTagpagerendering06213654": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/_healthcheck",
-        "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 9000,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "tag-page-rendering",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/dotcom-rendering",
-          },
-          {
-            "Key": "Stack",
-            "Value": "frontend",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "deregistration_delay.timeout_seconds",
-            "Value": "30",
-          },
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "ip",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "EcsTaskDefinition63157ED3": {
       "Properties": {
@@ -2884,7 +2835,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
                 },
                 {
                   "TargetGroupArn": {
-                    "Ref": "EcsTargetGroupTagpagerendering06213654",
+                    "Ref": "TagpagerenderingEcsTargetGroupTagpagerendering0976D2E5",
                   },
                   "Weight": 0,
                 },
@@ -2957,7 +2908,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
         "Actions": [
           {
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupTagpagerendering06213654",
+              "Ref": "TagpagerenderingEcsTargetGroupTagpagerendering0976D2E5",
             },
             "Type": "forward",
           },
@@ -3274,6 +3225,55 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "TagpagerenderingEcsTargetGroupTagpagerendering0976D2E5": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/_healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "tag-page-rendering",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/dotcom-rendering",
+          },
+          {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "TargetGroupTagpagerendering42E428EE": {
       "Properties": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.995.0
       version: 3.995.0
     '@guardian/cdk':
-      specifier: 64.2.0
-      version: 64.2.0
+      specifier: 64.3.0
+      version: 64.3.0
     '@guardian/eslint-config':
       specifier: 14.0.1
       version: 14.0.1
@@ -37,14 +37,14 @@ catalogs:
       specifier: 24.12.4
       version: 24.12.4
     aws-cdk:
-      specifier: 2.1134.0
-      version: 2.1134.0
+      specifier: 2.1135.0
+      version: 2.1135.0
     aws-cdk-lib:
-      specifier: 2.262.2
-      version: 2.262.2
+      specifier: 2.263.0
+      version: 2.263.0
     constructs:
-      specifier: 10.7.2
-      version: 10.7.2
+      specifier: 10.8.1
+      version: 10.8.1
     esbuild:
       specifier: 0.28.1
       version: 0.28.1
@@ -121,7 +121,7 @@ importers:
         version: 3.995.0
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.2.0(aws-cdk-lib@2.262.2(constructs@10.7.2))(aws-cdk@2.1134.0)(constructs@10.7.2)
+        version: 64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/tsconfig':
         specifier: 'catalog:'
         version: 1.0.1
@@ -130,13 +130,13 @@ importers:
         version: 24.12.4
       aws-cdk:
         specifier: 'catalog:'
-        version: 2.1134.0
+        version: 2.1135.0
       aws-cdk-lib:
         specifier: 'catalog:'
-        version: 2.262.2(constructs@10.7.2)
+        version: 2.263.0(constructs@10.8.1)
       constructs:
         specifier: 'catalog:'
-        version: 10.7.2
+        version: 10.8.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -325,7 +325,7 @@ importers:
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.2.0(aws-cdk-lib@2.262.2(constructs@10.7.2))(aws-cdk@2.1134.0)(constructs@10.7.2)
+        version: 64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/commercial-core':
         specifier: 34.0.0
         version: 34.0.0(@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))
@@ -508,10 +508,10 @@ importers:
         version: 2.1.1(ajv@8.18.0)
       aws-cdk:
         specifier: 'catalog:'
-        version: 2.1134.0
+        version: 2.1135.0
       aws-cdk-lib:
         specifier: 'catalog:'
-        version: 2.262.2(constructs@10.7.2)
+        version: 2.263.0(constructs@10.8.1)
       browserslist:
         specifier: 4.24.4
         version: 4.24.4
@@ -529,7 +529,7 @@ importers:
         version: 1.7.4
       constructs:
         specifier: 'catalog:'
-        version: 10.7.2
+        version: 10.8.1
       cpy:
         specifier: 11.0.0
         version: 11.0.0
@@ -852,6 +852,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.0':
     resolution: {integrity: sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==}
@@ -2574,13 +2577,13 @@ packages:
       browserslist: ^4.22.2
       tslib: ^2.6.2
 
-  '@guardian/cdk@64.2.0':
-    resolution: {integrity: sha512-L8KHxaThC/c1841PtniqBqhxv9zKywCqnhdtWNITemRxlfbWN3TCFcVoLRRu7ebS+AlTU+/UJR7q0Wo+xzxUAg==}
+  '@guardian/cdk@64.3.0':
+    resolution: {integrity: sha512-Lfkac9pqB0meaVLLyg26c4+imgCyXeAaCJcWSUgm450REsn3xXkREsD4D7NqsPjGk7J0T9QrwljQZ93hTeNYow==}
     hasBin: true
     peerDependencies:
-      aws-cdk: ^2.1110.0
-      aws-cdk-lib: ^2.241.0
-      constructs: ^10.5.1
+      aws-cdk: ^2.1135.0
+      aws-cdk-lib: ^2.263.0
+      constructs: ^10.8.1
 
   '@guardian/commercial-core@34.0.0':
     resolution: {integrity: sha512-Uq1fIk6jaHPNfk5Y1E2hgwYTNegOH1iILeOG3oRY6aVJ2LDCZtiXwVqClaXaZLD+xdRFQJYCOZse+xKOnUQvBA==}
@@ -4931,8 +4934,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.262.2:
-    resolution: {integrity: sha512-lWQRW/AHxB4gMgkRmfYQIKWqiJLD4whkl7sQF3c26eK1DVt1Jw9rNBSFvVQ+DZddxxnifNGan/i97YgsNpgOeQ==}
+  aws-cdk-lib@2.263.0:
+    resolution: {integrity: sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       constructs: ^10.5.0
@@ -4950,8 +4953,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.1134.0:
-    resolution: {integrity: sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==}
+  aws-cdk@2.1135.0:
+    resolution: {integrity: sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -5388,8 +5391,8 @@ packages:
     resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
     engines: {node: '>=4'}
 
-  constructs@10.7.2:
-    resolution: {integrity: sha512-vA7JOqvO/xwq2HBCuq3qc6V2R9mHZCxJ8HPoucUcUWJY88YULe7bzMcsdBy27/gJJIphZi73U1oIXDY2Eqg6nA==}
+  constructs@10.8.1:
+    resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -10186,11 +10189,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.72':
@@ -10573,13 +10576,13 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.977.4
       '@aws-sdk/signature-v4-multi-region': 3.996.28
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.39':
@@ -10612,10 +10615,10 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.43':
@@ -10627,21 +10630,21 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1014.0':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1052.0':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1100.0':
@@ -12061,16 +12064,16 @@ snapshots:
       browserslist: 4.24.4
       tslib: 2.6.2
 
-  '@guardian/cdk@64.2.0(aws-cdk-lib@2.262.2(constructs@10.7.2))(aws-cdk@2.1134.0)(constructs@10.7.2)':
+  '@guardian/cdk@64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)':
     dependencies:
       '@aws-sdk/client-ec2': 3.1101.0
       '@aws-sdk/client-ssm': 3.1101.0
       '@aws-sdk/credential-providers': 3.1101.0
-      aws-cdk: 2.1134.0
-      aws-cdk-lib: 2.262.2(constructs@10.7.2)
+      aws-cdk: 2.1135.0
+      aws-cdk-lib: 2.263.0(constructs@10.8.1)
       chalk: 4.1.2
       codemaker: 1.139.0
-      constructs: 10.7.2
+      constructs: 10.8.1
       git-url-parse: 16.1.0
       js-yaml: 4.3.1
       read-pkg-up: 7.0.1
@@ -13088,7 +13091,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.8':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -14769,14 +14772,14 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-cdk-lib@2.262.2(constructs@10.7.2):
+  aws-cdk-lib@2.263.0(constructs@10.8.1):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.282
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
       '@aws-cdk/cloud-assembly-schema': 54.15.0
-      constructs: 10.7.2
+      constructs: 10.8.1
 
-  aws-cdk@2.1134.0: {}
+  aws-cdk@2.1135.0: {}
 
   axe-core@4.11.1: {}
 
@@ -15214,7 +15217,7 @@ snapshots:
 
   console-clear@1.1.1: {}
 
-  constructs@10.7.2: {}
+  constructs@10.8.1: {}
 
   content-disposition@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ blockExoticSubdeps: true
 catalog:
   '@aws-sdk/client-s3': 3.995.0
   '@aws-sdk/client-ssm': 3.995.0
-  '@guardian/cdk': 64.2.0
+  '@guardian/cdk': 64.3.0
   '@guardian/eslint-config': 14.0.1
   '@guardian/tsconfig': 1.0.1
   '@rollup/plugin-commonjs': 29.0.0
@@ -19,9 +19,9 @@ catalog:
   '@rollup/plugin-node-resolve': 16.0.3
   '@types/aws-lambda': 8.10.158
   '@types/node': 24.12.4
-  aws-cdk: 2.1134.0
-  aws-cdk-lib: 2.262.2
-  constructs: 10.7.2
+  aws-cdk: 2.1135.0
+  aws-cdk-lib: 2.263.0
+  constructs: 10.8.1
   esbuild: 0.28.1
   eslint: 9.39.1
   rollup: 4.59.0


### PR DESCRIPTION
## What does this change?
This update recreates the `AWS::ElasticLoadBalancingV2::TargetGroup` resource for the ECS infrastructure. We currently only provision ECS infrastructure for `tag-page-rendering` CODE. No ECS infrastructure currently serves production traffic. That is, whilst destructive, this change is safe.

See https://github.com/guardian/cdk/pull/2949 for more information.

## How has this change been tested?
See updated snapshots.

---

Closes https://github.com/guardian/dotcom-rendering/pull/16512.