### PR TITLE
Prevent stopPropagation on product CTA in lightbox

### DIFF
--- a/dotcom-rendering/src/components/LightboxJavascript.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.tsx
@@ -341,8 +341,9 @@ const initialiseLightbox = (
 		lightbox.querySelectorAll<HTMLImageElement>('li img'),
 	);
 
-	const captionLinks =
-		lightbox.querySelectorAll<HTMLAnchorElement>('li aside a');
+	const captionLinks = lightbox.querySelectorAll<HTMLAnchorElement>(
+		'li aside a:not([data-ignore="global-link-styling"])',
+	);
 
 	if (!imageList) {
 		return;

--- a/dotcom-rendering/src/components/LightboxJavascript.tsx
+++ b/dotcom-rendering/src/components/LightboxJavascript.tsx
@@ -341,8 +341,10 @@ const initialiseLightbox = (
 		lightbox.querySelectorAll<HTMLImageElement>('li img'),
 	);
 
-	const captionLinks = lightbox.querySelectorAll<HTMLAnchorElement>(
-		'li aside a:not([data-ignore="global-link-styling"])',
+	const captionLinks = Array.from(
+		lightbox.querySelectorAll<HTMLAnchorElement>('li aside a'),
+	).filter(
+		(link) => !link.closest('[data-component="product-lightbox-link"]'),
 	);
 
 	if (!imageList) {


### PR DESCRIPTION
## What does this change?
Prevents `event.stopPropagation();` from running on CTA product buttons which is preventing Ophan data tracking on the click event.

## Why?
We wish to see performance of click events on CTA product buttons integrated inside of a lightbox element - in this article for example https://www.theguardian.com/thefilter-us/2026/aug/03/bedjet-cooling-bed-review
<img width="915" height="465" alt="image" src="https://github.com/user-attachments/assets/d613b39e-a335-4aaa-b5d0-1db5d9dc2cc0" />


## How has this change been tested?
Manually tested, network requests to Ophan seen for click event after change

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers

You can find examples of each type of test in the repo.

### Manual testing

- run make dev
- visit http://localhost:3030/Article/https://www.theguardian.com/thefilter-us/2026/aug/03/bedjet-cooling-bed-review
- observe Ophan get request upon click of product cta buttons
- deploying to CODE and verifying correct behaviour
