### PR TITLE
Hide the mostpop ad slot on tablet viewports

### DIFF
--- a/dotcom-rendering/src/components/AdSlot.web.tsx
+++ b/dotcom-rendering/src/components/AdSlot.web.tsx
@@ -9,7 +9,6 @@ import {
 	space,
 	until,
 } from '@guardian/source/foundations';
-import { Hide } from '@guardian/source/react-components';
 import { labelBoxStyles, labelHeight, labelStyles } from '../lib/adStyles';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { center as layoutCenterStyles } from '../lib/center';
@@ -646,25 +645,23 @@ export const AdSlot = ({
 		}
 		case 'mostpop': {
 			return (
-				<Hide until="tablet">
-					<AdSlotWrapper css={mostPopContainerStyles}>
-						<div
-							id="dfp-ad--mostpop"
-							className={[
-								'js-ad-slot',
-								'ad-slot',
-								'ad-slot--mostpop',
-								'ad-slot--mpu-banner-ad',
-								'ad-slot--rendered',
-							].join(' ')}
-							css={[mostPopAdStyles]}
-							data-link-name="ad slot mostpop"
-							data-name="mostpop"
-							data-testid="slot"
-							aria-hidden="true"
-						/>
-					</AdSlotWrapper>
-				</Hide>
+				<AdSlotWrapper css={mostPopContainerStyles}>
+					<div
+						id="dfp-ad--mostpop"
+						className={[
+							'js-ad-slot',
+							'ad-slot',
+							'ad-slot--mostpop',
+							'ad-slot--mpu-banner-ad',
+							'ad-slot--rendered',
+						].join(' ')}
+						css={mostPopAdStyles}
+						data-link-name="ad slot mostpop"
+						data-name="mostpop"
+						data-testid="slot"
+						aria-hidden="true"
+					/>
+				</AdSlotWrapper>
 			);
 		}
 		case 'merchandising-high': {

--- a/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
+++ b/dotcom-rendering/src/components/MostViewedFooterLayout.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import type { Breakpoint } from '@guardian/source/foundations';
 import { between, from, space } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import { AdSlot } from './AdSlot.web';
 
 const stackBelow = (breakpoint: Breakpoint) => css`
@@ -128,16 +129,18 @@ export const MostViewedFooterLayout = ({
 				{children}
 			</div>
 			{renderAds && (
-				<div
-					css={advertMargin(
-						!!isFront,
-						isDeeplyRead,
-						isLiveblog,
-						hasPageSkin,
-					)}
-				>
-					<AdSlot position="mostpop" />
-				</div>
+				<Hide until="desktop">
+					<div
+						css={advertMargin(
+							!!isFront,
+							isDeeplyRead,
+							isLiveblog,
+							hasPageSkin,
+						)}
+					>
+						<AdSlot position="mostpop" />
+					</div>
+				</Hide>
 			)}
 		</div>
 	);


### PR DESCRIPTION
## What does this change?

Hides the `mostpop` ad slot until the desktop viewport, instead of the tablet viewport.

Moves the `<Hide />` up the DOM tree.

## Why?

The Most Viewed section has space to its right for an ad slot from the desktop viewport onwards. We render the `mostpop` ad slot from the tablet viewport, so on tablet the ad slot is rendered underneath this section. Since we have the `merchandising` ad slot below the Most Viewed section, we shouldn't render the `mostpop` ad slot at tablet viewports.

The `<Hide />` has been moved up the tree to remove the spacing around the ad slot when the ad slot is not rendered.

## How has this change been tested?

Locally

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/8fe9fc26-8af3-425b-afaf-b6c6fb15abc7
[after]: https://github.com/user-attachments/assets/bf6aaa54-af39-4bb8-8ef4-24904518a59c
