### PR TITLE
Election trackers `OnwardLink`

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/OnwardLink.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/OnwardLink.stories.tsx
@@ -1,0 +1,22 @@
+import { allModes } from '../../../.storybook/modes';
+import preview from '../../../.storybook/preview';
+import { OnwardLink as OnwardLinkComponent } from './OnwardLink';
+
+const meta = preview.meta({
+	title: 'Components/Election Trackers/Onward Link',
+	component: OnwardLinkComponent,
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+			},
+		},
+	},
+});
+
+export const OnwardLink = meta.story({
+	args: {
+		link: new URL('https://www.theguardian.com'),
+		text: 'Full results',
+	},
+});

--- a/dotcom-rendering/src/components/ElectionTrackers/OnwardLink.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/OnwardLink.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/source/foundations';
+import {
+	LinkButton,
+	SvgArrowRightStraight,
+} from '@guardian/source/react-components';
+import { palette } from '../../palette';
+
+type Props = {
+	link: URL;
+	text: string;
+};
+
+/**
+ * An instance of a Source `LinkButton` for linking to a full results page from
+ * an election tracker.
+ */
+export const OnwardLink = (props: Props) => (
+	<LinkButton
+		icon={<SvgArrowRightStraight />}
+		iconSide="right"
+		theme={{
+			backgroundPrimary: palette('--election-tracker-button-background'),
+			textPrimary: palette('--election-tracker-button-text'),
+		}}
+		cssOverrides={css({
+			marginTop: space[4],
+		})}
+		href={props.link.href}
+	>
+		{props.text}
+	</LinkButton>
+);

--- a/dotcom-rendering/src/components/ElectionTrackers/SideBySide.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/SideBySide.stories.tsx
@@ -1,0 +1,39 @@
+import { textEgyptian17Object } from '@guardian/source/foundations';
+import { allModes } from '../../../.storybook/modes';
+import preview from '../../../.storybook/preview';
+import { SideBySide as SideBySideComponent } from './SideBySide';
+
+const meta = preview.meta({
+	title: 'Components/Election Trackers/Side By Side',
+	component: SideBySideComponent,
+	parameters: {
+		chromatic: {
+			modes: {
+				'vertical mobileMedium': allModes['vertical mobileMedium'],
+				'vertical tablet': allModes['vertical tablet'],
+			},
+		},
+	},
+});
+
+export const SideBySide = meta.story({
+	args: {
+		from: 'tablet',
+		left: {
+			heading: 'Senate',
+			children: (
+				<p css={textEgyptian17Object}>
+					Some components on the left from the "tablet" breakpoint.
+				</p>
+			),
+		},
+		right: {
+			heading: 'House',
+			children: (
+				<p css={textEgyptian17Object}>
+					Some components on the right from the "tablet" breakpoint.
+				</p>
+			),
+		},
+	},
+});

--- a/dotcom-rendering/src/components/ElectionTrackers/SideBySide.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/SideBySide.tsx
@@ -1,0 +1,80 @@
+import {
+	type Breakpoint,
+	from,
+	headlineBold20Object,
+	headlineBold24Object,
+	space,
+} from '@guardian/source/foundations';
+import type { ReactNode } from 'react';
+import { palette } from '../../palette';
+
+type Props = {
+	/**
+	 * The breakpoint from which to place the components side-by-side.
+	 */
+	from: Breakpoint;
+	left: {
+		heading: string;
+		children: ReactNode;
+	};
+	right: {
+		heading: string;
+		children: ReactNode;
+	};
+};
+
+/**
+ * Handles a common design pattern, where components are placed above one
+ * another at narrower breakpoints and side-by-side at wider ones.
+ */
+export const SideBySide = (props: Props) => (
+	<div
+		css={{
+			[from[props.from]]: {
+				display: 'flex',
+			},
+		}}
+	>
+		<div
+			css={{
+				[from[props.from]]: {
+					flexBasis: '50%',
+					paddingRight: space[2],
+				},
+			}}
+		>
+			<Heading from={props.from}>{props.left.heading}</Heading>
+			{props.left.children}
+		</div>
+		<div
+			css={{
+				[from[props.from]]: {
+					flexBasis: '50%',
+					paddingLeft: space[2],
+					borderLeftStyle: 'solid',
+					borderLeftColor: palette('--election-tracker-border'),
+					borderLeftWidth: 1,
+				},
+			}}
+		>
+			<Heading from={props.from}>{props.right.heading}</Heading>
+			{props.right.children}
+		</div>
+	</div>
+);
+
+const Heading = (props: { children: string; from: Breakpoint }) => (
+	<h3
+		css={{
+			...headlineBold20Object,
+			paddingBottom: space[2],
+			paddingTop: space[4],
+			[from[props.from]]: {
+				...headlineBold24Object,
+				paddingTop: 0,
+			},
+		}}
+	>
+		{props.children}
+	</h3>
+);

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7153,6 +7153,10 @@ const paletteColours = {
 		light: editorialButtonText,
 		dark: editorialButtonTextDark,
 	},
+	'--election-tracker-border': {
+		light: () => sourcePalette.neutral[86],
+		dark: () => sourcePalette.neutral[20],
+	},
 	'--email-signup-button-background': {
 		light: emailSignupButtonBackgroundLight,
 		dark: emailSignupButtonBackgroundDark,

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7157,6 +7157,14 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[86],
 		dark: () => sourcePalette.neutral[20],
 	},
+	'--election-tracker-button-background': {
+		light: () => sourcePalette.neutral[7],
+		dark: () => sourcePalette.neutral[100],
+	},
+	'--election-tracker-button-text': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[7],
+	},
 	'--email-signup-button-background': {
 		light: emailSignupButtonBackgroundLight,
 		dark: emailSignupButtonBackgroundDark,


### PR DESCRIPTION
An `OnwardLink` component for linking to a full results page from an election tracker.

| Header | Header |
|--------|--------|
| <img width="564" height="240" alt="onward-light" src="https://github.com/user-attachments/assets/446bcabc-890c-4fe8-a06b-42c476bf2710" /> | <img width="564" height="186" alt="onward-dark" src="https://github.com/user-attachments/assets/44881dce-4ea3-4f27-b339-896af2730998" /> | 
