### PR TITLE
Election trackers `USCongress`

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/StackedProgress.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/StackedProgress.tsx
@@ -255,6 +255,7 @@ const SectionDiv = (props: {
 	<div
 		css={{
 			display: 'flex',
+			overflow: 'hidden',
 			'::before': {
 				...textSans12Object,
 				backgroundColor: palette(

--- a/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
@@ -108,9 +108,11 @@ export const Empty = meta.story({
 		);
 
 		// Link
-		const link = canvas.getByRole('link');
-		await expect(link.textContent).toBe(args.linkText);
-		await expect(link).toHaveAttribute('href', args.link.href);
+		const links = canvas.getAllByRole('link');
+		for (const link of links) {
+			await expect(link.textContent).toBe(args.linkText);
+			await expect(link).toHaveAttribute('href', args.link.href);
+		}
 	},
 });
 
@@ -197,8 +199,10 @@ export const Final = Empty.extend({
 		);
 
 		// Link
-		const link = canvas.getByRole('link');
-		await expect(link.textContent).toBe(args.linkText);
-		await expect(link).toHaveAttribute('href', args.link.href);
+		const links = canvas.getAllByRole('link');
+		for (const link of links) {
+			await expect(link.textContent).toBe(args.linkText);
+			await expect(link).toHaveAttribute('href', args.link.href);
+		}
 	},
 });

--- a/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
@@ -1,3 +1,4 @@
+import { expect, within } from 'storybook/test';
 import { allModes } from '../../../.storybook/modes';
 import preview from '../../../.storybook/preview';
 import { palette } from '../../palette';
@@ -81,6 +82,36 @@ export const Empty = meta.story({
 		link: new URL('https://www.theguardian.com'),
 		linkText: 'Full results',
 	},
+	async play({ args, canvasElement }) {
+		const canvas = within(canvasElement);
+
+		// Numbers
+		const p = canvas.getAllByRole('paragraph');
+		await expect(p[0]?.textContent).toBe('DemocratsDemocrats280');
+		await expect(p[1]?.textContent).toBe('RepublicansRepublicans380');
+		await expect(p[2]?.textContent).toBe('0/34 races called');
+		await expect(p[3]?.textContent).toBe('DemocratsDemocrats00');
+		await expect(p[4]?.textContent).toBe('RepublicansRepublicans00');
+		await expect(p[5]?.textContent).toBe('0/435 races called');
+
+		// Progress bars
+		const bars = canvas.getAllByRole('progressbar');
+		await expect(bars[0]).toHaveValue(0);
+		await expect(bars[0]).toHaveAttribute(
+			'aria-valuemax',
+			args.senate.total.toString(),
+		);
+		await expect(bars[1]).toHaveValue(0);
+		await expect(bars[1]).toHaveAttribute(
+			'aria-valuemax',
+			args.house.total.toString(),
+		);
+
+		// Link
+		const link = canvas.getByRole('link');
+		await expect(link.textContent).toBe(args.linkText);
+		await expect(link).toHaveAttribute('href', args.link.href);
+	},
 });
 
 export const Final = Empty.extend({
@@ -138,5 +169,36 @@ export const Final = Empty.extend({
 				holdovers: Empty.composed.args.senate.others.holdovers,
 			},
 		},
+	},
+	async play({ args, canvasElement }) {
+		const canvas = within(canvasElement);
+
+		// Numbers
+		const p = canvas.getAllByRole('paragraph');
+		await expect(p[0]?.textContent).toBe('Democrats*Democrats*47-4');
+		await expect(p[1]?.textContent).toBe('RepublicansRepublicans53+4');
+		await expect(p[2]?.textContent).toBe('*includes independents');
+		await expect(p[3]?.textContent).toBe('34/34 races called');
+		await expect(p[4]?.textContent).toBe('DemocratsDemocrats215+1');
+		await expect(p[5]?.textContent).toBe('RepublicansRepublicans220-1');
+		await expect(p[6]?.textContent).toBe('435/435 races called');
+
+		// Progress bars
+		const bars = canvas.getAllByRole('progressbar');
+		await expect(bars[0]).toHaveValue(args.senate.total);
+		await expect(bars[0]).toHaveAttribute(
+			'aria-valuemax',
+			args.senate.total.toString(),
+		);
+		await expect(bars[1]).toHaveValue(args.house.total);
+		await expect(bars[1]).toHaveAttribute(
+			'aria-valuemax',
+			args.house.total.toString(),
+		);
+
+		// Link
+		const link = canvas.getByRole('link');
+		await expect(link.textContent).toBe(args.linkText);
+		await expect(link).toHaveAttribute('href', args.link.href);
 	},
 });

--- a/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
@@ -1,0 +1,86 @@
+import { allModes } from '../../../.storybook/modes';
+import preview from '../../../.storybook/preview';
+import { palette } from '../../palette';
+import { USCongress } from './USCongress';
+
+/**
+ * Results from 2024:
+ * https://www.theguardian.com/us-news/ng-interactive/2024/nov/14/us-house-senate-and-governor-elections-2024-results-from-all-50-states
+ */
+const meta = preview.meta({
+	title: 'Components/Election Trackers/US Congress',
+	component: USCongress,
+	parameters: {
+		colourSchemeBackground: {
+			light: palette('--article-background'),
+			dark: palette('--article-background'),
+		},
+		chromatic: {
+			modes: {
+				'vertical mobile': allModes['vertical mobileMedium'],
+				'vertical tablet': allModes['vertical tablet'],
+				'vertical wide': allModes['vertical tablet'],
+			},
+		},
+	},
+});
+
+export const Empty = meta.story({
+	args: {
+		house: {
+			total: 435,
+			democrats: {
+				value: 0,
+				change: 0,
+			},
+			republicans: {
+				value: 0,
+				change: 0,
+			},
+		},
+		senate: {
+			total: 34,
+			democrats: {
+				value: 0,
+				change: 0,
+				holdovers: 28,
+			},
+			republicans: {
+				value: 0,
+				change: 0,
+				holdovers: 38,
+			},
+		},
+		link: new URL('https://www.theguardian.com'),
+		linkText: 'Full results',
+	},
+});
+
+export const Final = Empty.extend({
+	args: {
+		house: {
+			total: Empty.composed.args.house.total,
+			democrats: {
+				value: 215,
+				change: 1,
+			},
+			republicans: {
+				value: 220,
+				change: -1,
+			},
+		},
+		senate: {
+			total: Empty.composed.args.senate.total,
+			democrats: {
+				value: 19,
+				change: -4,
+				holdovers: Empty.composed.args.senate.democrats.holdovers,
+			},
+			republicans: {
+				value: 15,
+				change: 4,
+				holdovers: Empty.composed.args.senate.republicans.holdovers,
+			},
+		},
+	},
+});

--- a/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USCongress.stories.tsx
@@ -33,7 +33,19 @@ export const Empty = meta.story({
 				value: 0,
 				change: 0,
 			},
+			caucusWithDemocrats: {
+				value: 0,
+				change: 0,
+			},
 			republicans: {
+				value: 0,
+				change: 0,
+			},
+			caucusWithRepublicans: {
+				value: 0,
+				change: 0,
+			},
+			others: {
 				value: 0,
 				change: 0,
 			},
@@ -45,10 +57,25 @@ export const Empty = meta.story({
 				change: 0,
 				holdovers: 28,
 			},
+			caucusWithDemocrats: {
+				value: 0,
+				change: 0,
+				holdovers: 0,
+			},
 			republicans: {
 				value: 0,
 				change: 0,
 				holdovers: 38,
+			},
+			caucusWithRepublicans: {
+				value: 0,
+				change: 0,
+				holdovers: 0,
+			},
+			others: {
+				value: 0,
+				change: 0,
+				holdovers: 0,
 			},
 		},
 		link: new URL('https://www.theguardian.com'),
@@ -64,22 +91,51 @@ export const Final = Empty.extend({
 				value: 215,
 				change: 1,
 			},
+			caucusWithDemocrats: {
+				value: 0,
+				change: 0,
+			},
 			republicans: {
 				value: 220,
 				change: -1,
+			},
+			caucusWithRepublicans: {
+				value: 0,
+				change: 0,
+			},
+			others: {
+				value: 0,
+				change: 0,
 			},
 		},
 		senate: {
 			total: Empty.composed.args.senate.total,
 			democrats: {
-				value: 19,
-				change: -4,
+				value: 17,
+				change: -2,
 				holdovers: Empty.composed.args.senate.democrats.holdovers,
+			},
+			caucusWithDemocrats: {
+				value: 2,
+				change: -2,
+				holdovers:
+					Empty.composed.args.senate.caucusWithDemocrats.holdovers,
 			},
 			republicans: {
 				value: 15,
 				change: 4,
 				holdovers: Empty.composed.args.senate.republicans.holdovers,
+			},
+			caucusWithRepublicans: {
+				value: 0,
+				change: 0,
+				holdovers:
+					Empty.composed.args.senate.caucusWithRepublicans.holdovers,
+			},
+			others: {
+				value: 0,
+				change: 0,
+				holdovers: Empty.composed.args.senate.others.holdovers,
 			},
 		},
 	},

--- a/dotcom-rendering/src/components/ElectionTrackers/USCongress.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USCongress.tsx
@@ -1,0 +1,49 @@
+import type { ComponentProps } from 'react';
+import { OnwardLink } from './OnwardLink';
+import { SideBySide } from './SideBySide';
+import { USHouse } from './USHouse';
+import { USSenate } from './USSenate';
+
+type Props = {
+	/**
+	 * Results for the US Senate. See {@linkcode USSenate} for more details.
+	 */
+	senate: ComponentProps<typeof USSenate>;
+	/**
+	 * Results for the US House of Representatives. See {@linkcode USSenate} for
+	 * more details.
+	 */
+	house: ComponentProps<typeof USHouse>;
+	/**
+	 * Text to be shown on the onward link to the full results page. For
+	 * example, "Full results".
+	 */
+	linkText: string;
+	/**
+	 * Onward link to the full results page.
+	 */
+	link: URL;
+};
+
+/**
+ * Represents results from elections to the US Congress, and includes a summary
+ * for both the Senate and the House of Representatives. Each can also be
+ * represented individually using the {@linkcode USSenate} or
+ * {@linkcode USHouse} components.
+ */
+export const USCongress = (props: Props) => (
+	<>
+		<SideBySide
+			from="tablet"
+			left={{
+				heading: 'Senate',
+				children: <USSenate {...props.senate} />,
+			}}
+			right={{
+				heading: 'House',
+				children: <USHouse {...props.house} />,
+			}}
+		/>
+		<OnwardLink link={props.link} text={props.linkText} />
+	</>
+);

--- a/dotcom-rendering/src/components/ElectionTrackers/USHouse.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USHouse.tsx
@@ -1,0 +1,94 @@
+import { space } from '@guardian/source/foundations';
+import { palette } from '../../palette';
+import { ProgressNumber } from './ProgressNumber';
+import { StackedProgress } from './StackedProgress';
+import { Versus } from './Versus';
+
+type Props = {
+	/**
+	 * The total number of seats up for election.
+	 */
+	total: number;
+	democrats: {
+		/**
+		 * The number of races called for the Democrats so far.
+		 */
+		value: number;
+		/**
+		 * The net change in seats for the Democrats so far.
+		 */
+		change: number;
+	};
+	republicans: {
+		/**
+		 * The number of races called for the Republicans so far.
+		 */
+		value: number;
+		/**
+		 * The net change in seats for the Republicans so far.
+		 */
+		change: number;
+	};
+};
+
+/**
+ * Represents results from elections to the US House of Representatives. It can
+ * be used on its own, or as part of the `USCongress` component, which also
+ * includes the Senate.
+ */
+export const USHouse = (props: Props) => (
+	<>
+		<Versus
+			left={{
+				name: 'Democrats',
+				abbreviation: 'Democrats',
+				value: props.democrats.value,
+				change: props.democrats.change,
+				image: undefined,
+				colour: palette('--us-elections-democrats'),
+			}}
+			right={{
+				name: 'Republicans',
+				abbreviation: 'Republicans',
+				value: props.republicans.value,
+				change: props.republicans.change,
+				image: undefined,
+				colour: palette('--us-elections-republicans'),
+			}}
+			colour="none"
+			faded={false}
+			banner={undefined}
+		/>
+		<StackedProgress
+			total={props.total}
+			label="to win"
+			calculateWinner={true}
+			excludedCopy={undefined}
+			sections={[
+				{
+					name: 'Democrats',
+					colour: palette('--us-elections-democrats'),
+					value: props.democrats.value,
+					align: 'left',
+					exclude: false,
+				},
+				{
+					name: 'Republicans',
+					colour: palette('--us-elections-republicans'),
+					value: props.republicans.value,
+					align: 'right',
+					exclude: false,
+				},
+			]}
+			css={{
+				paddingTop: space[2],
+			}}
+		/>
+		<ProgressNumber
+			progress={props.democrats.value + props.republicans.value}
+			total={props.total}
+			copy="races called"
+			additionalCopy={undefined}
+		/>
+	</>
+);

--- a/dotcom-rendering/src/components/ElectionTrackers/USHouse.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USHouse.tsx
@@ -9,26 +9,22 @@ type Props = {
 	 * The total number of seats up for election.
 	 */
 	total: number;
-	democrats: {
-		/**
-		 * The number of races called for the Democrats so far.
-		 */
-		value: number;
-		/**
-		 * The net change in seats for the Democrats so far.
-		 */
-		change: number;
-	};
-	republicans: {
-		/**
-		 * The number of races called for the Republicans so far.
-		 */
-		value: number;
-		/**
-		 * The net change in seats for the Republicans so far.
-		 */
-		change: number;
-	};
+	democrats: Group;
+	caucusWithDemocrats: Group;
+	republicans: Group;
+	caucusWithRepublicans: Group;
+	others: Group;
+};
+
+type Group = {
+	/**
+	 * The number of races called for this group so far.
+	 */
+	value: number;
+	/**
+	 * The net change in seats for this group so far.
+	 */
+	change: number;
 };
 
 /**
@@ -40,18 +36,22 @@ export const USHouse = (props: Props) => (
 	<>
 		<Versus
 			left={{
-				name: 'Democrats',
-				abbreviation: 'Democrats',
-				value: props.democrats.value,
-				change: props.democrats.change,
+				name: `Democrats${democratIndependents(props) ? '*' : ''}`,
+				abbreviation: `Democrats${democratIndependents(props) ? '*' : ''}`,
+				value: props.democrats.value + props.caucusWithDemocrats.value,
+				change:
+					props.democrats.change + props.caucusWithDemocrats.change,
 				image: undefined,
 				colour: palette('--us-elections-democrats'),
 			}}
 			right={{
-				name: 'Republicans',
-				abbreviation: 'Republicans',
-				value: props.republicans.value,
-				change: props.republicans.change,
+				name: `Republicans${republicanIndependents(props) ? '*' : ''}`,
+				abbreviation: `Republicans${republicanIndependents(props) ? '*' : ''}`,
+				value:
+					props.republicans.value + props.caucusWithRepublicans.value,
+				change:
+					props.republicans.change +
+					props.caucusWithRepublicans.change,
 				image: undefined,
 				colour: palette('--us-elections-republicans'),
 			}}
@@ -68,14 +68,24 @@ export const USHouse = (props: Props) => (
 				{
 					name: 'Democrats',
 					colour: palette('--us-elections-democrats'),
-					value: props.democrats.value,
+					value:
+						props.democrats.value + props.caucusWithDemocrats.value,
+					align: 'left',
+					exclude: false,
+				},
+				{
+					name: 'Others',
+					colour: palette('--us-elections-others'),
+					value: props.others.value,
 					align: 'left',
 					exclude: false,
 				},
 				{
 					name: 'Republicans',
 					colour: palette('--us-elections-republicans'),
-					value: props.republicans.value,
+					value:
+						props.republicans.value +
+						props.caucusWithRepublicans.value,
 					align: 'right',
 					exclude: false,
 				},
@@ -85,10 +95,26 @@ export const USHouse = (props: Props) => (
 			}}
 		/>
 		<ProgressNumber
-			progress={props.democrats.value + props.republicans.value}
+			progress={
+				props.democrats.value +
+				props.caucusWithDemocrats.value +
+				props.republicans.value +
+				props.caucusWithRepublicans.value +
+				props.others.value
+			}
 			total={props.total}
 			copy="races called"
-			additionalCopy={undefined}
+			additionalCopy={
+				democratIndependents(props) || republicanIndependents(props)
+					? '*includes independents'
+					: undefined
+			}
 		/>
 	</>
 );
+
+const democratIndependents = (props: Props) =>
+	props.caucusWithDemocrats.value > 0;
+
+const republicanIndependents = (props: Props) =>
+	props.caucusWithRepublicans.value > 0;

--- a/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
@@ -1,0 +1,117 @@
+import { space } from '@guardian/source/foundations';
+import { palette } from '../../palette';
+import { ProgressNumber } from './ProgressNumber';
+import { StackedProgress } from './StackedProgress';
+import { Versus } from './Versus';
+
+type Props = {
+	/**
+	 * The total number of seats up for election, excluding holdovers.
+	 */
+	total: number;
+	democrats: {
+		/**
+		 * The number of races called for the Democrats so far.
+		 */
+		value: number;
+		/**
+		 * The net change in seats for the Democrats so far.
+		 */
+		change: number;
+		/**
+		 * The number of seats held by the Democrats that are not up for
+		 * election this time.
+		 */
+		holdovers: number;
+	};
+	republicans: {
+		/**
+		 * The number of races called for the Republicans so far.
+		 */
+		value: number;
+		/**
+		 * The net change in seats for the Republicans so far.
+		 */
+		change: number;
+		/**
+		 * The number of seats held by the Republicans that are not up for
+		 * election this time.
+		 */
+		holdovers: number;
+	};
+};
+
+/**
+ * Represents results from elections to the US Senate. It can be used on its
+ * own, or as part of the `USCongress` component, which also includes the House.
+ */
+export const USSenate = (props: Props) => (
+	<>
+		<Versus
+			left={{
+				name: 'Democrats*',
+				abbreviation: 'Democrats*',
+				value: props.democrats.value + props.democrats.holdovers,
+				change: props.democrats.change,
+				image: undefined,
+				colour: palette('--us-elections-democrats'),
+			}}
+			right={{
+				name: 'Republicans',
+				abbreviation: 'Republicans',
+				value: props.republicans.value + props.republicans.holdovers,
+				change: props.republicans.change,
+				image: undefined,
+				colour: palette('--us-elections-republicans'),
+			}}
+			colour="none"
+			faded={false}
+			banner={undefined}
+		/>
+		<StackedProgress
+			total={props.total}
+			label="50"
+			calculateWinner={false}
+			excludedCopy="No election"
+			sections={[
+				{
+					name: 'Democrats',
+					colour: palette('--us-elections-democrats-alt'),
+					value: props.democrats.holdovers,
+					align: 'left',
+					exclude: true,
+				},
+				{
+					name: 'Democrats',
+					colour: palette('--us-elections-democrats'),
+					value: props.democrats.value,
+					align: 'left',
+					exclude: false,
+				},
+				{
+					name: 'Republicans',
+					colour: palette('--us-elections-republicans-alt'),
+					value: props.republicans.holdovers,
+					align: 'right',
+					exclude: true,
+				},
+				{
+					name: 'Republicans',
+					colour: palette('--us-elections-republicans'),
+					value: props.republicans.value,
+					align: 'right',
+					exclude: false,
+				},
+			]}
+			css={{
+				paddingTop: space[2],
+			}}
+		/>
+		<ProgressNumber
+			progress={props.democrats.value + props.republicans.value}
+			total={props.total}
+			copy="races called"
+			additionalCopy="*includes independents"
+		/>
+	</>
+);

--- a/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
@@ -9,36 +9,27 @@ type Props = {
 	 * The total number of seats up for election, excluding holdovers.
 	 */
 	total: number;
-	democrats: {
-		/**
-		 * The number of races called for the Democrats so far.
-		 */
-		value: number;
-		/**
-		 * The net change in seats for the Democrats so far.
-		 */
-		change: number;
-		/**
-		 * The number of seats held by the Democrats that are not up for
-		 * election this time.
-		 */
-		holdovers: number;
-	};
-	republicans: {
-		/**
-		 * The number of races called for the Republicans so far.
-		 */
-		value: number;
-		/**
-		 * The net change in seats for the Republicans so far.
-		 */
-		change: number;
-		/**
-		 * The number of seats held by the Republicans that are not up for
-		 * election this time.
-		 */
-		holdovers: number;
-	};
+	democrats: Group;
+	caucusWithDemocrats: Group;
+	republicans: Group;
+	caucusWithRepublicans: Group;
+	others: Group;
+};
+
+type Group = {
+	/**
+	 * The number of races called for the this group so far.
+	 */
+	value: number;
+	/**
+	 * The net change in seats for this group so far.
+	 */
+	change: number;
+	/**
+	 * The number of seats held by this group that are not up for election this
+	 * time.
+	 */
+	holdovers: number;
 };
 
 /**
@@ -49,18 +40,29 @@ export const USSenate = (props: Props) => (
 	<>
 		<Versus
 			left={{
-				name: 'Democrats*',
-				abbreviation: 'Democrats*',
-				value: props.democrats.value + props.democrats.holdovers,
-				change: props.democrats.change,
+				name: `Democrats${democratIndependents(props) ? '*' : ''}`,
+				abbreviation: `Democrats${democratIndependents(props) ? '*' : ''}`,
+				value:
+					props.democrats.value +
+					props.caucusWithDemocrats.value +
+					props.democrats.holdovers +
+					props.caucusWithDemocrats.holdovers,
+				change:
+					props.democrats.change + props.caucusWithDemocrats.change,
 				image: undefined,
 				colour: palette('--us-elections-democrats'),
 			}}
 			right={{
-				name: 'Republicans',
-				abbreviation: 'Republicans',
-				value: props.republicans.value + props.republicans.holdovers,
-				change: props.republicans.change,
+				name: `Republicans${republicanIndependents(props) ? '*' : ''}`,
+				abbreviation: `Republicans${republicanIndependents(props) ? '*' : ''}`,
+				value:
+					props.republicans.value +
+					props.caucusWithRepublicans.value +
+					props.republicans.holdovers +
+					props.caucusWithRepublicans.holdovers,
+				change:
+					props.republicans.change +
+					props.caucusWithRepublicans.change,
 				image: undefined,
 				colour: palette('--us-elections-republicans'),
 			}}
@@ -77,28 +79,49 @@ export const USSenate = (props: Props) => (
 				{
 					name: 'Democrats',
 					colour: palette('--us-elections-democrats-alt'),
-					value: props.democrats.holdovers,
+					value:
+						props.democrats.holdovers +
+						props.caucusWithDemocrats.holdovers,
 					align: 'left',
 					exclude: true,
 				},
 				{
 					name: 'Democrats',
 					colour: palette('--us-elections-democrats'),
-					value: props.democrats.value,
+					value:
+						props.democrats.value + props.caucusWithDemocrats.value,
+					align: 'left',
+					exclude: false,
+				},
+				{
+					name: 'Others',
+					colour: palette('--us-elections-others'),
+					value: props.others.holdovers,
+					align: 'left',
+					exclude: true,
+				},
+				{
+					name: 'Others',
+					colour: palette('--us-elections-others'),
+					value: props.others.value,
 					align: 'left',
 					exclude: false,
 				},
 				{
 					name: 'Republicans',
 					colour: palette('--us-elections-republicans-alt'),
-					value: props.republicans.holdovers,
+					value:
+						props.republicans.holdovers +
+						props.caucusWithRepublicans.holdovers,
 					align: 'right',
 					exclude: true,
 				},
 				{
 					name: 'Republicans',
 					colour: palette('--us-elections-republicans'),
-					value: props.republicans.value,
+					value:
+						props.republicans.value +
+						props.caucusWithRepublicans.value,
 					align: 'right',
 					exclude: false,
 				},
@@ -108,10 +131,28 @@ export const USSenate = (props: Props) => (
 			}}
 		/>
 		<ProgressNumber
-			progress={props.democrats.value + props.republicans.value}
+			progress={
+				props.democrats.value +
+				props.caucusWithDemocrats.value +
+				props.republicans.value +
+				props.caucusWithRepublicans.value +
+				props.others.value
+			}
 			total={props.total}
 			copy="races called"
-			additionalCopy="*includes independents"
+			additionalCopy={
+				democratIndependents(props) || republicanIndependents(props)
+					? '*includes independents'
+					: undefined
+			}
 		/>
 	</>
 );
+
+const democratIndependents = (props: Props) =>
+	props.caucusWithDemocrats.holdovers > 0 ||
+	props.caucusWithDemocrats.value > 0;
+
+const republicanIndependents = (props: Props) =>
+	props.caucusWithRepublicans.holdovers > 0 ||
+	props.caucusWithRepublicans.value > 0;

--- a/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/USSenate.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 type Group = {
 	/**
-	 * The number of races called for the this group so far.
+	 * The number of races called for this group so far.
 	 */
 	value: number;
 	/**

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -8615,6 +8615,10 @@ const paletteColours = {
 		light: () => '#DAD7F5',
 		dark: () => '#DAD7F5',
 	},
+	'--us-elections-others': {
+		light: () => '#848484',
+		dark: () => sourcePalette.neutral[46],
+	},
 	'--us-elections-republicans': {
 		light: () => sourcePalette.news[400],
 		dark: () => '#DC2E1C',


### PR DESCRIPTION
A component for displaying results from an election to the US Congress. The `USHouse` and `USSenate` components could also be used to view results separately. This change includes stories with example data from 2024.
