### PR TITLE
Let spacefinder know about self-hosted video

### DIFF
--- a/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
+++ b/dotcom-rendering/src/components/SelfHostedVideoInArticle.tsx
@@ -49,7 +49,7 @@ export const SelfHostedVideoInArticle = ({
 	}
 
 	return (
-		<div css={containerStyles}>
+		<div css={containerStyles} data-spacefinder-role="inline">
 			<Island priority="critical" defer={{ until: 'visible' }}>
 				<SelfHostedVideo
 					atomId={element.id}


### PR DESCRIPTION
## What does this change?

Adds a data-attribute to self-hosted video in article elements to inform spacefinder of their existence.

## Why?

Spacefinder needs to know about content in the body in which it needs to avoid placing an advert directly above or below. By adding this attribute, we will no longer see ads immediately above/below a self-hosted video.

## How has this change been tested?

Locally

## Screenshots

Screenshots are taken from [this article](https://www.theguardian.com/us-news/2026/aug/10/trump-secret-flight-nato-return?sfdebug) with the `?sfdebug` parameter appended to the URL to enable Spacefinder debug mode. 

| <img width=100/> | Before | After |
| - | - | - |
| mobile | ![mobile-before] | ![mobile-after] |
| desktop | ![desktop-before] | ![desktop-after] |

[mobile-before]: https://github.com/user-attachments/assets/90ef332e-1aaf-40b1-bf95-ae963695d423
[desktop-before]: https://github.com/user-attachments/assets/10017bb9-6b10-4101-a3a7-d703bdd67936
[mobile-after]: https://github.com/user-attachments/assets/e182595f-877b-4211-84f5-06a4c8ddc5de
[desktop-after]: https://github.com/user-attachments/assets/aa4ebdbe-da16-48b6-b1ff-5dcc837d88b8