### PR TITLE
Add 0%  editorial-headline-test to test definitions

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -186,7 +186,10 @@ const ABTests: ABTest[] = [
 	{
 		name: "fronts-and-curation-editorial-headline-test",
 		description: "Allow editorial headline A/B tests to run on web",
-		owners: ["fronts.and.curation@guardian.co.uk"],
+		owners: [
+			"fronts.and.curation@guardian.co.uk",
+			"ab.test.mission@guardian.co.uk",
+		],
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -183,6 +183,17 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant-1", "variant-2"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "fronts-and-curation-editorial-headline-test",
+		description: "Allow editorial headline A/B tests to run on web",
+		owners: ["fronts.and.curation@guardian.co.uk"],
+		status: "ON",
+		expirationDate: "2036-08-12",
+		type: "server",
+		audienceSize: 0 / 100,
+		groups: ["a", "b"],
+		shouldForceMetricsCollection: false,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION


## What does this change?
Adds "fronts-and-curation-editorial-headline-test" as a 0% test.

This test is the parent / platform test for Editorial headline A/B tests. Its responsibility is to manage user bucket participation as well as over all the global test on/off status, rather than managing individual editorial a/b test lifecycles which is managed by config in the fronts tool.

This has been set up as a 0% test for testing. Once this feature is ready for production, it will be slowly ramped up to a 50/50 test. 

This test framework is being developed by the A/B test mission. As such, there is no long life team to associate with this test. Given that these tests will run on fronts cards only (at least in the immediate), this test has been assoiciated with the `Fronts and Curation` team. 

## How has this change been tested?


## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
