### PR TITLE
Update Labs theme colours

### DIFF
--- a/dotcom-rendering/src/components/LabsHeader.stories.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.stories.tsx
@@ -12,7 +12,7 @@ export const Default = () => {
 		<Section
 			fullWidth={true}
 			showTopBorder={false}
-			backgroundColour={palette.labs[400]}
+			backgroundColour={palette.labs[100]}
 			borderColour={palette.neutral[60]}
 		>
 			<LabsHeader editionId="UK" />

--- a/dotcom-rendering/src/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.tsx
@@ -17,7 +17,13 @@ import { LABS_HEADER_HEIGHT } from '../lib/labs-constants';
 import LabsLogo from '../static/logos/the-guardian-labs.svg';
 import { Details } from './Details';
 
-const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
+const FlexWrapper = ({
+	children,
+	textColour,
+}: {
+	children: React.ReactNode;
+	textColour: string;
+}) => (
 	<div
 		css={css`
 			position: relative;
@@ -25,7 +31,7 @@ const FlexWrapper = ({ children }: { children: React.ReactNode }) => (
 			display: flex;
 			justify-content: space-between;
 
-			color: ${palette.neutral[7]};
+			color: ${textColour};
 		`}
 	>
 		{children}
@@ -90,11 +96,17 @@ const Title = () => (
 	</div>
 );
 
-const About = () => (
+const About = ({
+	backgroundColour,
+	textColour,
+}: {
+	backgroundColour: string;
+	textColour: string;
+}) => (
 	<div
 		css={css`
 			${textSans15};
-			background-color: ${palette.labs[400]};
+			background-color: ${backgroundColour};
 			border-top: 1px solid ${palette.neutral[60]};
 
 			width: 100vw;
@@ -110,10 +122,6 @@ const About = () => (
 			${from.mobileLandscape} {
 				padding: ${space[3]}px 20px;
 			}
-
-			> a {
-				color: black;
-			}
 		`}
 	>
 		<p>
@@ -125,6 +133,7 @@ const About = () => (
 			iconSide="right"
 			size="xsmall"
 			priority="subdued"
+			theme={{ textSubdued: textColour }}
 			icon={<SvgArrowRightStraight />}
 			href="https://www.theguardian.com/info/2016/jan/25/content-funding"
 		>
@@ -138,13 +147,32 @@ const Logo = ({ editionId }: { editionId: EditionId }) => (
 		href={`https://www.theguardian.com/guardian-labs${getLabsUrlSuffix(
 			editionId,
 		)}`}
+		cssOverrides={css`
+			display: flex;
+			color: inherit;
+			svg {
+				fill: currentColor;
+			}
+
+			&:hover {
+				color: inherit;
+			}
+		`}
 	>
 		<LabsLogo />
 	</Link>
 );
 
-export const LabsHeader = ({ editionId }: { editionId: EditionId }) => (
-	<FlexWrapper>
+export const LabsHeader = ({
+	editionId,
+	textColour = palette.neutral[100],
+	backgroundColour = palette.labs[100],
+}: {
+	editionId: EditionId;
+	textColour?: string;
+	backgroundColour?: string;
+}) => (
+	<FlexWrapper textColour={textColour}>
 		<Left>
 			<HeaderSection isFirst={true}>
 				<Title />
@@ -166,7 +194,10 @@ export const LabsHeader = ({ editionId }: { editionId: EditionId }) => (
 						}
 					`}
 				>
-					<About />
+					<About
+						backgroundColour={backgroundColour}
+						textColour={textColour}
+					/>
 				</Details>
 			</HeaderSection>
 		</Left>

--- a/dotcom-rendering/src/components/LabsHeader.tsx
+++ b/dotcom-rendering/src/components/LabsHeader.tsx
@@ -132,8 +132,8 @@ const About = ({
 		<LinkButton
 			iconSide="right"
 			size="xsmall"
-			priority="subdued"
-			theme={{ textSubdued: textColour }}
+			priority="tertiary"
+			theme={{ textTertiary: textColour, borderTertiary: textColour }}
 			icon={<SvgArrowRightStraight />}
 			href="https://www.theguardian.com/info/2016/jan/25/content-funding"
 		>

--- a/dotcom-rendering/src/components/LabsSectionHeader.tsx
+++ b/dotcom-rendering/src/components/LabsSectionHeader.tsx
@@ -175,11 +175,14 @@ export const LabsSectionHeader = ({
 							<LinkButton
 								iconSide="right"
 								size="xsmall"
-								priority="subdued"
+								priority="tertiary"
 								icon={<SvgArrowRightStraight />}
 								href="https://www.theguardian.com/info/2016/jan/25/content-funding"
 								theme={{
-									textSubdued: schemePalette(
+									textTertiary: schemePalette(
+										'--labs-about-dropdown-link',
+									),
+									borderTertiary: schemePalette(
 										'--labs-about-dropdown-link',
 									),
 								}}

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -251,7 +251,7 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={sourcePalette.labs[400]}
+						backgroundColour={sourcePalette.labs[100]}
 						borderColour={sourcePalette.neutral[60]}
 						sectionId="labs-header"
 					>

--- a/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/FullPageInteractiveLayout.tsx
@@ -234,7 +234,7 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 									fullWidth={true}
 									showTopBorder={false}
 									padSides={true}
-									backgroundColour={sourcePalette.labs[400]}
+									backgroundColour={sourcePalette.labs[100]}
 									borderColour={sourcePalette.neutral[60]}
 									sectionId="labs-header"
 								>
@@ -257,7 +257,7 @@ export const FullPageInteractiveLayout = (props: WebProps | AppsProps) => {
 							fullWidth={true}
 							showTopBorder={false}
 							padSides={true}
-							backgroundColour={sourcePalette.labs[400]}
+							backgroundColour={sourcePalette.labs[100]}
 							borderColour={sourcePalette.neutral[60]}
 							sectionId="labs-header"
 						>

--- a/dotcom-rendering/src/layouts/GalleryLayout.tsx
+++ b/dotcom-rendering/src/layouts/GalleryLayout.tsx
@@ -436,7 +436,7 @@ const GalleryLabsHeader = (props: {
 			<Section
 				fullWidth={true}
 				showTopBorder={false}
-				backgroundColour={sourcePalette.labs[400]}
+				backgroundColour={sourcePalette.labs[100]}
 				borderColour={sourcePalette.neutral[60]}
 				sectionId="labs-header"
 				element="aside"

--- a/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/ImmersiveLayout.tsx
@@ -342,7 +342,7 @@ export const ImmersiveLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={sourcePalette.labs[400]}
+						backgroundColour={sourcePalette.labs[100]}
 						borderColour={sourcePalette.neutral[60]}
 						sectionId="labs-header"
 					>

--- a/dotcom-rendering/src/layouts/InteractiveLayout.tsx
+++ b/dotcom-rendering/src/layouts/InteractiveLayout.tsx
@@ -296,7 +296,7 @@ export const InteractiveLayout = (props: WebProps | AppsProps) => {
 							<Section
 								fullWidth={true}
 								showTopBorder={false}
-								backgroundColour={sourcePalette.labs[400]}
+								backgroundColour={sourcePalette.labs[100]}
 								borderColour={sourcePalette.neutral[60]}
 								sectionId="labs-header"
 							>

--- a/dotcom-rendering/src/layouts/StandardLayout.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayout.tsx
@@ -131,12 +131,16 @@ export const StandardLayout = (props: WebProps | AppProps) => {
 					<Section
 						fullWidth={true}
 						showTopBorder={false}
-						backgroundColour={sourcePalette.labs[400]}
+						backgroundColour={sourcePalette.labs[100]}
 						borderColour={sourcePalette.neutral[60]}
 						sectionId="labs-header"
 						element="aside"
 					>
-						<LabsHeader editionId={editionId} />
+						<LabsHeader
+							editionId={editionId}
+							textColour={sourcePalette.neutral[100]}
+							backgroundColour={sourcePalette.labs[100]}
+						/>
 					</Section>
 				</Stuck>
 			)}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -49,6 +49,25 @@ const pillarPalette = (
 	}
 };
 
+/**
+ * Design groups that keep their pre-existing colours rather than the
+ * Labs theme wide overrides used elsewhere in this file.
+ */
+const labsGalleryDesigns: ArticleDesign[] = [
+	ArticleDesign.Gallery,
+	ArticleDesign.HostedGallery,
+];
+const labsMediaDesigns: ArticleDesign[] = [
+	ArticleDesign.Video,
+	ArticleDesign.Audio,
+	ArticleDesign.Picture,
+];
+const labsHostedDesigns: ArticleDesign[] = [
+	ArticleDesign.HostedArticle,
+	ArticleDesign.HostedVideo,
+	ArticleDesign.HostedGallery,
+];
+
 const textblockBulletLight: PaletteFunction = ({ theme, design }) => {
 	switch (theme) {
 		case Pillar.News: {
@@ -1282,6 +1301,10 @@ const followIconBackgroundLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 const followIconBackgroundDark: PaletteFunction = ({ theme, design }) => {
+	if (theme === ArticleSpecial.Labs && design !== ArticleDesign.LiveBlog) {
+		return sourcePalette.neutral[7];
+	}
+
 	switch (design) {
 		case ArticleDesign.DeadBlog:
 			return sourcePalette.neutral[7];
@@ -1311,6 +1334,10 @@ const followIconBackgroundDark: PaletteFunction = ({ theme, design }) => {
 };
 
 const followIconFillLight: PaletteFunction = ({ design, theme }) => {
+	if (theme === ArticleSpecial.Labs && design !== ArticleDesign.LiveBlog) {
+		return sourcePalette.labs[200];
+	}
+
 	switch (design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.HostedGallery:
@@ -1357,8 +1384,6 @@ const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.culture[400];
 				case Pillar.Lifestyle:
 					return sourcePalette.lifestyle[400];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[300];
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[300];
 				case ArticleSpecial.SpecialReportAlt:
@@ -1389,8 +1414,6 @@ const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 					return sourcePalette.culture[400];
 				case Pillar.Lifestyle:
 					return sourcePalette.lifestyle[400];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[300];
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[300];
 				case ArticleSpecial.SpecialReportAlt:
@@ -1420,13 +1443,15 @@ const followIconFillLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 const followIconFillDark: PaletteFunction = ({ theme, design }) => {
+	if (theme === ArticleSpecial.Labs && design !== ArticleDesign.LiveBlog) {
+		return sourcePalette.labs[500];
+	}
+
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[93];
 		case ArticleDesign.Standard:
 			switch (theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[300];
 				case Pillar.Opinion:
 					return sourcePalette.opinion[500];
 				case Pillar.Sport:
@@ -1464,8 +1489,6 @@ const followIconFillDark: PaletteFunction = ({ theme, design }) => {
 					return sourcePalette.culture[500];
 				case Pillar.Lifestyle:
 					return sourcePalette.lifestyle[500];
-				case ArticleSpecial.Labs:
-					return sourcePalette.labs[400];
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[700];
 				case ArticleSpecial.SpecialReportAlt:
@@ -2470,6 +2493,17 @@ const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 };
 
 const standfirstTextLight: PaletteFunction = (format) => {
+	if (
+		format.theme === ArticleSpecial.Labs &&
+		![
+			ArticleDesign.LiveBlog,
+			...labsMediaDesigns,
+			...labsHostedDesigns,
+		].includes(format.design)
+	) {
+		return sourcePalette.labs[100];
+	}
+
 	switch (format.design) {
 		case ArticleDesign.LiveBlog:
 			return sourcePalette.neutral[100];
@@ -2497,6 +2531,13 @@ const standfirstTextLight: PaletteFunction = (format) => {
 };
 
 const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
+	if (
+		theme === ArticleSpecial.Labs &&
+		![ArticleDesign.LiveBlog, ...labsHostedDesigns].includes(design)
+	) {
+		return sourcePalette.labs[500];
+	}
+
 	switch (design) {
 		case ArticleDesign.LiveBlog:
 		case ArticleDesign.DeadBlog:
@@ -2507,12 +2548,7 @@ const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
 		case ArticleDesign.Picture:
 		case ArticleDesign.Video:
 		case ArticleDesign.Audio:
-			switch (theme) {
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
-				default:
-					return sourcePalette.neutral[86];
-			}
+			return sourcePalette.neutral[86];
 		case ArticleDesign.Standard:
 		case ArticleDesign.Review:
 		case ArticleDesign.Explainer:
@@ -3923,6 +3959,19 @@ const shareButtonCopiedLight: PaletteFunction = ({ design }) => {
 const shareButtonCopiedDark: PaletteFunction = () => sourcePalette.neutral[86];
 
 const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
+	if (
+		theme === ArticleSpecial.Labs &&
+		![
+			ArticleDesign.LiveBlog,
+			...labsGalleryDesigns,
+			...labsMediaDesigns,
+			ArticleDesign.HostedArticle,
+			ArticleDesign.HostedVideo,
+		].includes(design)
+	) {
+		return sourcePalette.labs[200];
+	}
+
 	switch (design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.HostedGallery:
@@ -3953,12 +4002,12 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 			switch (theme) {
 				case Pillar.News:
 					return sourcePalette.news[300];
-				case ArticleSpecial.Labs:
-					return sourcePalette.neutral[7];
 				case ArticleSpecial.SpecialReport:
 					return sourcePalette.specialReport[300];
 				case ArticleSpecial.SpecialReportAlt:
 					return sourcePalette.specialReportAlt[100];
+				case ArticleSpecial.Labs:
+					return sourcePalette.neutral[7];
 				default:
 					return pillarPalette(theme, 400);
 			}
@@ -3990,6 +4039,19 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 };
 
 const shareButtonDark: PaletteFunction = ({ design, theme }) => {
+	if (
+		theme === ArticleSpecial.Labs &&
+		![
+			ArticleDesign.LiveBlog,
+			...labsGalleryDesigns,
+			...labsMediaDesigns,
+			ArticleDesign.HostedArticle,
+			ArticleDesign.HostedVideo,
+		].includes(design)
+	) {
+		return sourcePalette.labs[500];
+	}
+
 	switch (design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.HostedArticle:

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -53,10 +53,6 @@ const pillarPalette = (
  * Design groups that keep their pre-existing colours rather than the
  * Labs theme wide overrides used elsewhere in this file.
  */
-const labsGalleryDesigns: ArticleDesign[] = [
-	ArticleDesign.Gallery,
-	ArticleDesign.HostedGallery,
-];
 const labsMediaDesigns: ArticleDesign[] = [
 	ArticleDesign.Video,
 	ArticleDesign.Audio,
@@ -3963,10 +3959,9 @@ const shareButtonLight: PaletteFunction = ({ design, theme, display }) => {
 		theme === ArticleSpecial.Labs &&
 		![
 			ArticleDesign.LiveBlog,
-			...labsGalleryDesigns,
+			ArticleDesign.Gallery,
 			...labsMediaDesigns,
-			ArticleDesign.HostedArticle,
-			ArticleDesign.HostedVideo,
+			...labsHostedDesigns,
 		].includes(design)
 	) {
 		return sourcePalette.labs[200];
@@ -4043,10 +4038,9 @@ const shareButtonDark: PaletteFunction = ({ design, theme }) => {
 		theme === ArticleSpecial.Labs &&
 		![
 			ArticleDesign.LiveBlog,
-			...labsGalleryDesigns,
+			ArticleDesign.Gallery,
 			...labsMediaDesigns,
-			ArticleDesign.HostedArticle,
-			ArticleDesign.HostedVideo,
+			...labsHostedDesigns,
 		].includes(design)
 	) {
 		return sourcePalette.labs[500];


### PR DESCRIPTION
## What does this change?
Updates Labs theme colours, specifically for the header, standfirst, share button & listen-to-article button.

[See figma design here ](https://www.figma.com/design/EKAebPFSCP6uCe11gP19X7/Formats-%E2%80%94-Display-Hinting?node-id=1088-3571&t=urh9VeuUOa4blweq-0)


## Before / After
<img width="1290" height="604" alt="image" src="https://github.com/user-attachments/assets/8c97abe9-4f7f-49dd-99fc-4c72f8e6864f" />
<img width="968" height="604" alt="image" src="https://github.com/user-attachments/assets/8871bea5-9a34-4bfe-9d1c-d37a51eeac4e" />
<img width="1290" height="558" alt="image" src="https://github.com/user-attachments/assets/9a09e841-5b4b-4b78-8066-90ddac3bfa38" />
<img width="970" height="603" alt="image" src="https://github.com/user-attachments/assets/c3ef91c0-c3d1-4bef-a571-13c46981bd90" />
<img width="1290" height="603" alt="image" src="https://github.com/user-attachments/assets/e6bb0595-86f6-4c00-8843-6b5caf0c9666" />

## Dropdown
<img width="546" height="215" alt="image" src="https://github.com/user-attachments/assets/60b6db83-6c78-4e6c-b5a6-9594a2916df4" />
<img width="652" height="168" alt="image" src="https://github.com/user-attachments/assets/ff27fcbf-db54-4b78-af19-97e610e777c7" />










---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217376431307205