### PR TITLE
Update to latest cdk version - switch ECS tasks and build to arm64

### DIFF
--- a/.github/workflows/container-production.yml
+++ b/.github/workflows/container-production.yml
@@ -21,7 +21,7 @@ jobs:
         id: get-build-facts
 
   build-production-image:
-    # ARM runner so the arm64 image builds natively rather than under QEMU emulation
+    # ECS tasks run on ARM, so we use the arm runner to natively build the containaer image (rather than rely on emulation)
     runs-on: ubuntu-24.04-arm
     needs:
       - facts

--- a/.github/workflows/container-production.yml
+++ b/.github/workflows/container-production.yml
@@ -21,7 +21,8 @@ jobs:
         id: get-build-facts
 
   build-production-image:
-    runs-on: ubuntu-latest
+    # ARM runner so the arm64 image builds natively rather than under QEMU emulation
+    runs-on: ubuntu-24.04-arm
     needs:
       - facts
     permissions:
@@ -35,7 +36,7 @@ jobs:
         working-directory: dotcom-rendering
         run: echo 'export const GIT_COMMIT_HASH = "${{ needs.facts.outputs.commitSha }}";' > src/server/prout.ts
       - name: Build image
-        run: docker buildx build -f Production.dockerfile -t ${{ github.repository }}:latest .
+        run: docker buildx build --platform linux/arm64 -f Production.dockerfile -t ${{ github.repository }}:latest .
       - name: Publish Image
         uses: guardian/actions-publish-image@v0.0.2
         id: publish-image

--- a/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
@@ -2,7 +2,7 @@ exports[`The ID5 Baton Lambda stack > matches the CODE snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Parameters": {
     "BuildId": {
@@ -46,7 +46,7 @@ exports[`The ID5 Baton Lambda stack > matches the PROD snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Parameters": {
     "BuildId": {

--- a/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -55,7 +55,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -294,7 +294,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -327,7 +327,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -377,7 +377,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -616,7 +616,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -10,7 +10,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -24,7 +24,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -113,7 +113,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -166,7 +166,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -340,7 +340,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -452,7 +452,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -494,7 +494,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.3.0"
+    "gu:cdk:version": "64.4.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -508,7 +508,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -597,7 +597,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -660,7 +660,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -834,7 +834,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -869,7 +869,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",
@@ -1006,7 +1006,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.3.0"
+            "Value": "64.4.0"
           },
           {
             "Key": "gu:repo",

--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -2244,6 +2244,10 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.995.0
       version: 3.995.0
     '@guardian/cdk':
-      specifier: 64.3.0
-      version: 64.3.0
+      specifier: 64.4.0
+      version: 64.4.0
     '@guardian/eslint-config':
       specifier: 14.0.1
       version: 14.0.1
@@ -121,7 +121,7 @@ importers:
         version: 3.995.0
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
+        version: 64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/tsconfig':
         specifier: 'catalog:'
         version: 1.0.1
@@ -325,7 +325,7 @@ importers:
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
+        version: 64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/commercial-core':
         specifier: 34.0.0
         version: 34.0.0(@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.6.2)(typescript@6.0.3))
@@ -2577,8 +2577,8 @@ packages:
       browserslist: ^4.22.2
       tslib: ^2.6.2
 
-  '@guardian/cdk@64.3.0':
-    resolution: {integrity: sha512-Lfkac9pqB0meaVLLyg26c4+imgCyXeAaCJcWSUgm450REsn3xXkREsD4D7NqsPjGk7J0T9QrwljQZ93hTeNYow==}
+  '@guardian/cdk@64.4.0':
+    resolution: {integrity: sha512-0FeaWGMqIAc+KnQczWt92vpUWQig+uwCa8RtJSewfGjg0PkIg3YoUCjZ7MBgnbtpy4V2ReABfXn26v9ZsiXGdg==}
     hasBin: true
     peerDependencies:
       aws-cdk: ^2.1135.0
@@ -12060,7 +12060,7 @@ snapshots:
       browserslist: 4.24.4
       tslib: 2.6.2
 
-  '@guardian/cdk@64.3.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)':
+  '@guardian/cdk@64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)':
     dependencies:
       '@aws-sdk/client-ec2': 3.1101.0
       '@aws-sdk/client-ssm': 3.1101.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ blockExoticSubdeps: true
 catalog:
   '@aws-sdk/client-s3': 3.995.0
   '@aws-sdk/client-ssm': 3.995.0
-  '@guardian/cdk': 64.3.0
+  '@guardian/cdk': 64.4.0
   '@guardian/eslint-config': 14.0.1
   '@guardian/tsconfig': 1.0.1
   '@rollup/plugin-commonjs': 29.0.0


### PR DESCRIPTION
## What does this change?

This version of GuCDK switches `GuLoadBalancedAppExperimental` to use ARM64 ECS tasks. We can see this in the diff for the renderingStack snapshot. `RuntimePlatform` was previously unspecified, so the tasks ran on x86 as its the default.
```diff
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
```

Running an ARM64 task requires an ARM64 container, so this PR also patches the build pipeline to use an arm runner and specify the platform argument.

## Why?

The `GuLoadBalancedAppExperimental`  was meant to be on ARM64 already, but wasn't due to oversight!


## How has this change been tested?

The build change only impacts the ECS container build, which is currently unused in prod, and the ECS task, which is also not used in prod.