### PR TITLE
Use guardian ckd version that does cluster setting and monitoring setting in the pattern

### DIFF
--- a/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
@@ -2,7 +2,7 @@ exports[`The ID5 Baton Lambda stack > matches the CODE snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Parameters": {
     "BuildId": {
@@ -46,7 +46,7 @@ exports[`The ID5 Baton Lambda stack > matches the PROD snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Parameters": {
     "BuildId": {

--- a/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -55,7 +55,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -294,7 +294,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -327,7 +327,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -377,7 +377,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -616,7 +616,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -10,7 +10,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -24,7 +24,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -113,7 +113,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -166,7 +166,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -340,7 +340,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -452,7 +452,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -494,7 +494,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.4.0"
+    "gu:cdk:version": "64.5.0"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -508,7 +508,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -597,7 +597,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -660,7 +660,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -834,7 +834,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -869,7 +869,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",
@@ -1006,7 +1006,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.4.0"
+            "Value": "64.5.0"
           },
           {
             "Key": "gu:repo",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -312,28 +312,6 @@ export class RenderingCDKStack extends CDKStack {
 				);
 			}
 
-			// TODO make these changes at the pattern level in GuCDK
-			if (app.ecsService) {
-				app.ecsService.cluster.with(
-					new ClusterSettings([
-						{ name: 'containerInsights', value: 'enhanced' },
-					]),
-				);
-
-				const cfnService = app.ecsService.node
-					.defaultChild as CfnService;
-				cfnService.addPropertyOverride('Monitoring', {
-					MetricConfigurations: [
-						{
-							MetricNames: [
-								'CPUUtilization',
-								'MemoryUtilization',
-							],
-							ResolutionSeconds: 20,
-						},
-					],
-				});
-			}
 		}
 
 		/**

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -17,8 +17,6 @@ import { Metric, Unit } from 'aws-cdk-lib/aws-cloudwatch';
 import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer } from 'aws-cdk-lib/aws-ec2';
-import type { CfnService } from 'aws-cdk-lib/aws-ecs';
-import { ClusterSettings } from 'aws-cdk-lib/aws-ecs/mixins';
 import { Subscription, SubscriptionProtocol, Topic } from 'aws-cdk-lib/aws-sns';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { getUserData } from './userData';
@@ -311,7 +309,6 @@ export class RenderingCDKStack extends CDKStack {
 					value,
 				);
 			}
-
 		}
 
 		/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.995.0
       version: 3.995.0
     '@guardian/cdk':
-      specifier: 64.4.0
-      version: 64.4.0
+      specifier: 64.5.0
+      version: 64.5.0
     '@guardian/eslint-config':
       specifier: 14.0.1
       version: 14.0.1
@@ -121,7 +121,7 @@ importers:
         version: 3.995.0
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
+        version: 64.5.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/tsconfig':
         specifier: 'catalog:'
         version: 1.0.1
@@ -325,7 +325,7 @@ importers:
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
+        version: 64.5.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)
       '@guardian/commercial-core':
         specifier: 34.0.0
         version: 34.0.0(@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@5.1.1)(tslib@2.6.2)(typescript@6.0.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.1.1)(tslib@2.6.2)(typescript@6.0.3))
@@ -908,10 +908,6 @@ packages:
     resolution: {integrity: sha512-OmE/pSkbMM3dCj1HdOnZ5kXnKK+R/Yz+kbBugraBecp0pGAs21eEURfQRz+1N2gzIHLVyGIP1MEjk/uSrFsngg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.43':
-    resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.72':
     resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
     engines: {node: '>=20.0.0'}
@@ -1024,10 +1020,6 @@ packages:
     resolution: {integrity: sha512-ptZ1HF4yYHNJX8cgFF+8NdYO69XJKZn7ft0/ynV3c0hCbN+89fAbrLS+fqniU2tW8o9Kfqhj8FUh+IPXb2Qsuw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.11':
-    resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.997.39':
     resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
     engines: {node: '>=20.0.0'}
@@ -1038,10 +1030,6 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.995.0':
     resolution: {integrity: sha512-9Qx5JcAucnxnomREPb2D6L8K8GLG0rknt3+VK/BU3qTUynAcV4W21DQ04Z2RKDw+DYpW88lsZpXbVetWST2WUg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.28':
-    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.43':
@@ -2650,8 +2638,8 @@ packages:
       browserslist: ^4.22.2
       tslib: ^2.6.2
 
-  '@guardian/cdk@64.4.0':
-    resolution: {integrity: sha512-0FeaWGMqIAc+KnQczWt92vpUWQig+uwCa8RtJSewfGjg0PkIg3YoUCjZ7MBgnbtpy4V2ReABfXn26v9ZsiXGdg==}
+  '@guardian/cdk@64.5.0':
+    resolution: {integrity: sha512-XZIcMBbRpT4uFDrEWTXY9+PNd3kdSdA9JtfELMdYSj50KEEZ9yiPaZx/nEGRSUtJ2JLwxZaY3Iyi2opPaTy9PQ==}
     hasBin: true
     peerDependencies:
       aws-cdk: ^2.1135.0
@@ -10092,13 +10080,13 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.974.2
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.974.2
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -10132,7 +10120,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.974.2
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -10439,7 +10427,7 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.0':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.16':
@@ -10470,10 +10458,10 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.65':
@@ -10499,12 +10487,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.67':
@@ -10538,18 +10526,18 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/credential-provider-env': 3.972.39
-      '@aws-sdk/credential-provider-http': 3.972.41
-      '@aws-sdk/credential-provider-login': 3.972.43
-      '@aws-sdk/credential-provider-process': 3.972.39
-      '@aws-sdk/credential-provider-sso': 3.972.43
-      '@aws-sdk/credential-provider-web-identity': 3.972.43
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/credential-provider-imds': 4.3.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.10':
@@ -10580,15 +10568,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.43':
-    dependencies:
-      '@aws-sdk/core': 3.977.4
-      '@aws-sdk/nested-clients': 3.997.39
-      '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.72':
     dependencies:
@@ -10655,10 +10634,10 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.65':
@@ -10684,12 +10663,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
       '@aws-sdk/token-providers': 3.1052.0
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.9':
@@ -10716,11 +10695,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.71':
@@ -10927,19 +10906,19 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.977.4
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.8
       '@aws-sdk/middleware-user-agent': 3.972.24
       '@aws-sdk/region-config-resolver': 3.972.9
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.974.2
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
       '@aws-sdk/util-user-agent-node': 3.973.10
       '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
       '@smithy/middleware-content-length': 4.2.12
@@ -10948,10 +10927,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.15
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/node-http-handler': 4.9.13
       '@smithy/protocol-http': 5.3.12
       '@smithy/smithy-client': 4.12.7
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -10965,19 +10944,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-
-  '@aws-sdk/nested-clients@3.997.11':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.977.4
-      '@aws-sdk/signature-v4-multi-region': 3.996.28
-      '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.39':
     dependencies:
@@ -11005,14 +10971,6 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.4.4
       '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.28':
-    dependencies:
-      '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.31.1
-      '@smithy/signature-v4': 5.6.12
-      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.43':
@@ -11079,8 +11037,8 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.996.5':
     dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/types': 4.16.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
@@ -11107,14 +11065,14 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.15':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.25':
     dependencies:
       '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -12578,7 +12536,7 @@ snapshots:
       browserslist: 4.24.4
       tslib: 2.6.2
 
-  '@guardian/cdk@64.4.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)':
+  '@guardian/cdk@64.5.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(aws-cdk@2.1135.0)(constructs@10.8.1)':
     dependencies:
       '@aws-sdk/client-ec2': 3.1101.0
       '@aws-sdk/client-ssm': 3.1101.0
@@ -13678,7 +13636,7 @@ snapshots:
 
   '@smithy/abort-controller@4.2.12':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.1':
@@ -13733,8 +13691,8 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.4.16':
@@ -13770,7 +13728,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.8':
     dependencies:
       '@smithy/eventstream-codec': 4.2.8
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.15':
@@ -13925,29 +13883,29 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.12':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.12':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.12':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
 
   '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.12':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
@@ -13956,8 +13914,8 @@ snapshots:
 
   '@smithy/signature-v4@5.4.4':
     dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.12':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ blockExoticSubdeps: true
 catalog:
   '@aws-sdk/client-s3': 3.995.0
   '@aws-sdk/client-ssm': 3.995.0
-  '@guardian/cdk': 64.4.0
+  '@guardian/cdk': 64.5.0
   '@guardian/eslint-config': 14.0.1
   '@guardian/tsconfig': 1.0.1
   '@rollup/plugin-commonjs': 29.0.0


### PR DESCRIPTION
## What does this change?
Remove cluster setting and monitoring setting for ECS 

## Why?
[They are now set in the pattern itself.](https://github.com/guardian/cdk/pull/2954) as of v64.5.0

