### PR TITLE
Change shouldForceMetricsCollection to true

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -181,7 +181,7 @@ const ABTests: ABTest[] = [
 		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant-1", "variant-2"],
-		shouldForceMetricsCollection: false,
+		shouldForceMetricsCollection: true,
 	},
 	{
 		name: "fronts-and-curation-editorial-headline-test",


### PR DESCRIPTION
## What does this change?
Updates shouldForceMetricsCollection value for `identity-and-trust-consent-rr-banner-us` ab test 
## Why?
Mistakenly set it to false.
## How has this change been tested?

<!--

