### PR TITLE
Add css via class name to support introduction of super billboard ads

### DIFF
--- a/dotcom-rendering/src/lib/adStyles.ts
+++ b/dotcom-rendering/src/lib/adStyles.ts
@@ -112,6 +112,10 @@ const adSlotStyles = css`
 			&[data-label-show='true'] {
 				min-height: calc(250px + ${labelHeight}px);
 			}
+
+			&.ad-slot--reset-height {
+				min-height: auto;
+			}
 		}
 	}
 `;


### PR DESCRIPTION
## What does this change?

Adds styling to fluid ad slots to remove the `min-height` by setting it to `auto` when the `ad-slot--reset-height` class is present.

The `ad-slot--reset-height` class is added by commercial (see https://github.com/guardian/commercial/pull/2664) in response to a message sent from inside the iframe of the advert to the top layer of the page

**Demo of how this works (without the postMessage handler):**

https://github.com/user-attachments/assets/9fadc414-d6be-44e1-9700-8b076e401935

Notice how when the ad collapses, the ad slot does not resize properly until the class has been added. When the class is removed it reverts back to the original behaviour.

- The part in the commercial repo is responsible for handling the postMessage and adding the class name 
- The part in the dotcom-rendering repo is responsible for adding the ad slot styling (the CSS which corresponds to the class being present)

## Why?

There's a new type of "super billboard" ad we want to support which allows expanding and collapsing the ad within the ad slot. This is being created as a fabric custom ad which uses the "fluid" size. Fluid ads have a minimum height set on them in the code.
This, along with [the companion PR in commercial](https://github.com/guardian/commercial/pull/2664), allow a fabric custom advert to be created which posts a message to the top layer asking for the slot to resize according to the dimensions of the ad it contains, rather than setting a minimum height as a constant.