### PR TITLE
Newsletter sign ups - use bridget to fill in logged in user email in native apps

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -29,7 +29,7 @@
 		"@emotion/server": "11.11.0",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
 		"@guardian/braze-components": "23.0.2",
-		"@guardian/bridget": "8.13.1",
+		"@guardian/bridget": "8.14.0",
 		"@guardian/browserslist-config": "6.1.0",
 		"@guardian/cdk": "catalog:",
 		"@guardian/commercial-core": "34.0.0",

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -5,6 +5,7 @@ import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type ReactGoogleRecaptcha from 'react-google-recaptcha';
 import type { RenderingTarget } from '../types/renderingTarget';
+import { getNewslettersClient } from './bridgetApi';
 import { lazyFetchEmailWithTimeout } from './fetchEmail';
 import {
 	getEffectiveMarketingOptIn,
@@ -22,7 +23,6 @@ import {
 import { clearSubscriptionCache } from './newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from './useAuthStatus';
 import { useBrowserId } from './useBrowserId';
-import { getNewslettersClient } from './bridgetApi';
 
 // ---------------------------------------------------------------------------
 // Helpers (kept local — not part of the public API)
@@ -336,7 +336,7 @@ export const useNewsletterSignupForm = (
 				setIsInteracted(true);
 			});
 		}
-	}, [isSignedIn]);
+	}, [isSignedIn, renderingTarget]);
 
 	const submitForm = useCallback(
 		async (emailAddress: string, token: string): Promise<void> => {

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -308,13 +308,11 @@ export const useNewsletterSignupForm = (
 	}, []);
 
 	useEffect(() => {
-		console.log('after useEffect fill in email');
 		if (renderingTarget === 'Apps') {
 			// Fill in email using apps bridget API
 			void getNewslettersClient()
 				.getLoggedInUserEmail()
 				.then((maybeEmail) => {
-					console.log('after getLoggedInUserEmail ', maybeEmail);
 					const email = maybeEmail.emailAddress;
 					if (!email) return;
 					setUserEmail(email);
@@ -322,7 +320,10 @@ export const useNewsletterSignupForm = (
 					setIsInteracted(true);
 				})
 				.catch((reason) => {
-					console.log('after getLoggedInUserEmail catch ', reason);
+					console.log(
+						'Failed to getLoggedInUserEmail from bridget ',
+						reason,
+					);
 				});
 		} else {
 			if (emailFetchStartedRef.current) return;

--- a/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
+++ b/dotcom-rendering/src/lib/useNewsletterSignupForm.ts
@@ -22,6 +22,7 @@ import {
 import { clearSubscriptionCache } from './newsletterSubscriptionCache';
 import { useAuthStatus, useIsSignedIn } from './useAuthStatus';
 import { useBrowserId } from './useBrowserId';
+import { getNewslettersClient } from './bridgetApi';
 
 // ---------------------------------------------------------------------------
 // Helpers (kept local — not part of the public API)
@@ -305,17 +306,36 @@ export const useNewsletterSignupForm = (
 	useEffect(() => {
 		setCaptchaSiteKey(window.guardian.config.page.googleRecaptchaSiteKey);
 	}, []);
-	useEffect(() => {
-		if (emailFetchStartedRef.current) return;
-		if (isSignedIn === 'Pending') return;
-		emailFetchStartedRef.current = true;
 
-		void resolveUserEmail(isSignedIn).then((email) => {
-			if (!isString(email)) return;
-			setUserEmail(email);
-			setHasPrefilledEmail(true);
-			setIsInteracted(true);
-		});
+	useEffect(() => {
+		console.log('after useEffect fill in email');
+		if (renderingTarget === 'Apps') {
+			// Fill in email using apps bridget API
+			void getNewslettersClient()
+				.getLoggedInUserEmail()
+				.then((maybeEmail) => {
+					console.log('after getLoggedInUserEmail ', maybeEmail);
+					const email = maybeEmail.emailAddress;
+					if (!email) return;
+					setUserEmail(email);
+					setHasPrefilledEmail(true);
+					setIsInteracted(true);
+				})
+				.catch((reason) => {
+					console.log('after getLoggedInUserEmail catch ', reason);
+				});
+		} else {
+			if (emailFetchStartedRef.current) return;
+			if (isSignedIn === 'Pending') return;
+			emailFetchStartedRef.current = true;
+
+			void resolveUserEmail(isSignedIn).then((email) => {
+				if (!isString(email)) return;
+				setUserEmail(email);
+				setHasPrefilledEmail(true);
+				setIsInteracted(true);
+			});
+		}
 	}, [isSignedIn]);
 
 	const submitForm = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: 23.0.2
         version: 23.0.2(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.1.1)(tslib@2.6.2)(typescript@6.0.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@6.0.3))(react@18.3.1)
       '@guardian/bridget':
-        specifier: 8.13.1
-        version: 8.13.1
+        specifier: 8.14.0
+        version: 8.14.0
       '@guardian/browserslist-config':
         specifier: 6.1.0
         version: 6.1.0(browserslist@4.24.4)(tslib@2.6.2)
@@ -2641,8 +2641,8 @@ packages:
       '@guardian/source': 12.2.0
       react: 17.0.2 || 18.2.0
 
-  '@guardian/bridget@8.13.1':
-    resolution: {integrity: sha512-aSza9vG5hPqB0x3mX0ZUTBWbT1vB3k567KWGy6tVoWPw7vSolFD82qo03YcUYqE7AJbe/XHwJp74PaSMsG//Ow==}
+  '@guardian/bridget@8.14.0':
+    resolution: {integrity: sha512-0ZYPSGaevgaVBceFHC21nFhy0SIaMb8eaVy4xQwBJN6UYc5oucexvY/X4v3BDu4+huQ0SjcLddQBwVrHYRJltw==}
 
   '@guardian/browserslist-config@6.1.0':
     resolution: {integrity: sha512-qM0QxAv6E5IHXny5Okli6AZXEio0mpXzzEzz38qrb4IwO91R6eWVKyihdj0qW2k7TVxMFVOSfNmBZ1H5EiJhgw==}
@@ -12571,7 +12571,7 @@ snapshots:
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@types/react@18.3.1)(react@18.3.1))(@types/react@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@6.0.3)
       react: 18.3.1
 
-  '@guardian/bridget@8.13.1': {}
+  '@guardian/bridget@8.14.0': {}
 
   '@guardian/browserslist-config@6.1.0(browserslist@4.24.4)(tslib@2.6.2)':
     dependencies:


### PR DESCRIPTION

## What does this change?
- Update bridget to 8.14.0
- Attempt to fill in email in newsletters sign up using bridget function (if apps)

Paired with @rBangay 

## Why?
To try to increase newsletter sign ups in apps by making it easier.

## How has this change been tested?
Tested in Android emulator locally by deploying to CODE and integrating against this PR https://github.com/guardian/android-news-app/pull/13461

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| <img width="1080" height="2092" alt="before_Screenshot_20260818_085502" src="https://github.com/user-attachments/assets/79626afe-4cf4-4b33-aa79-5fd238fc1820" /> | <img width="1080" height="2092" alt="after_Screenshot_20260817_170941" src="https://github.com/user-attachments/assets/5bf364df-ed5e-4a70-a9c2-b68c2b9cd4d7" /> |

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
