### PR TITLE
Use `posterImage` for Hosted Content Video

### DIFF
--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -141,7 +141,7 @@ describe('YoutubeAtom', () => {
 
 		expect(
 			container.querySelector('source')?.getAttribute('srcset'),
-		).toContain('width=1140&dpr=2');
+		).toContain('width=980&dpr=2');
 	});
 
 	it('player div has correct title', () => {

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -105,6 +105,46 @@ describe('YoutubeAtom', () => {
 		expect(playerDiv).toBeInTheDocument();
 	});
 
+	it('uses high-resolution HostedVideo image sources', () => {
+		const { container } = render(
+			<ConfigProvider
+				value={{
+					renderingTarget: 'Web',
+					darkModeAvailable: false,
+					assetOrigin: '/',
+					editionId: 'UK',
+				}}
+			>
+				<YoutubeAtom
+					atomId="2e9e138b-0a23-4b96-a7f6-0258c0bacc8f"
+					videoId="c_xtiZNDgGc"
+					uniqueId="c_xtiZNDgGc-1"
+					title="My Youtube video!"
+					alt=""
+					adTargeting={{ disableAds: true }}
+					eventEmitters={[]}
+					format={{
+						theme: Pillar.News,
+						design: ArticleDesign.HostedVideo,
+						display: ArticleDisplay.Standard,
+					}}
+					consentState={consentStateCanTarget}
+					image={overlayImage}
+					shouldStick={false}
+					isMainMedia={true}
+					abTestParticipations={{}}
+					hidePillOnMobile={false}
+					renderingTarget="Web"
+					isHosted={true}
+				/>
+			</ConfigProvider>,
+		);
+
+		expect(
+			container.querySelector('source')?.getAttribute('srcset'),
+		).toContain('width=1140&dpr=2');
+	});
+
 	it('player div has correct title', () => {
 		const title = 'My Youtube video!';
 

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -135,7 +135,6 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					hidePillOnMobile={false}
 					renderingTarget="Web"
-					isHostedContent={true}
 				/>
 			</ConfigProvider>,
 		);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.test.tsx
@@ -135,7 +135,7 @@ describe('YoutubeAtom', () => {
 					abTestParticipations={{}}
 					hidePillOnMobile={false}
 					renderingTarget="Web"
-					isHosted={true}
+					isHostedContent={true}
 				/>
 			</ConfigProvider>,
 		);

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -68,7 +68,7 @@ export type Props = {
 	showByline?: boolean;
 	isLive?: boolean;
 	articleMedia?: ArticleMedia;
-	isHosted?: boolean;
+	isHostedContent?: boolean;
 };
 
 /**
@@ -123,7 +123,7 @@ export const YoutubeAtom = ({
 	showByline,
 	isLive,
 	articleMedia,
-	isHosted,
+	isHostedContent,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -299,7 +299,7 @@ export const YoutubeAtom = ({
 								hidePillOnMobile={hidePillOnMobile}
 								aspectRatio={aspectRatio}
 								isLive={isLive}
-								isHosted={isHosted}
+								isHostedContent={isHostedContent}
 							/>
 						))}
 					{showPlaceholder && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -68,6 +68,7 @@ export type Props = {
 	showByline?: boolean;
 	isLive?: boolean;
 	articleMedia?: ArticleMedia;
+	isHosted?: boolean;
 };
 
 /**
@@ -122,6 +123,7 @@ export const YoutubeAtom = ({
 	showByline,
 	isLive,
 	articleMedia,
+	isHosted,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -297,6 +299,7 @@ export const YoutubeAtom = ({
 								hidePillOnMobile={hidePillOnMobile}
 								aspectRatio={aspectRatio}
 								isLive={isLive}
+								isHosted={isHosted}
 							/>
 						))}
 					{showPlaceholder && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx
@@ -68,7 +68,6 @@ export type Props = {
 	showByline?: boolean;
 	isLive?: boolean;
 	articleMedia?: ArticleMedia;
-	isHostedContent?: boolean;
 };
 
 /**
@@ -123,7 +122,6 @@ export const YoutubeAtom = ({
 	showByline,
 	isLive,
 	articleMedia,
-	isHostedContent,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -299,7 +297,6 @@ export const YoutubeAtom = ({
 								hidePillOnMobile={hidePillOnMobile}
 								aspectRatio={aspectRatio}
 								isLive={isLive}
-								isHostedContent={isHostedContent}
 							/>
 						))}
 					{showPlaceholder && (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -85,7 +85,7 @@ export const YoutubeAtomOverlay = ({
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
-	const isHostedContent = format.design === ArticleDesign.HostedVideo;
+	const isHostedVideo = format.design === ArticleDesign.HostedVideo;
 
 	return (
 		<FormatBoundary format={format}>
@@ -103,7 +103,7 @@ export const YoutubeAtomOverlay = ({
 						height={height}
 						width={width}
 						aspectRatio={aspectRatio}
-						isHostedContent={isHostedContent}
+						isHostedVideo={isHostedVideo}
 					/>
 				)}
 				{isLive ? (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
-import { type ArticleFormat } from '../../lib/articleFormat';
+import { ArticleDesign, type ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
 import type { AspectRatio } from '../../types/front';
@@ -67,7 +67,6 @@ type Props = {
 	duration?: number; // in seconds
 	aspectRatio?: AspectRatio;
 	isLive?: boolean;
-	isHostedContent?: boolean;
 };
 
 export const YoutubeAtomOverlay = ({
@@ -83,10 +82,10 @@ export const YoutubeAtomOverlay = ({
 	duration,
 	aspectRatio,
 	isLive,
-	isHostedContent,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
+	const isHostedContent = format.design === ArticleDesign.HostedVideo;
 
 	return (
 		<FormatBoundary format={format}>

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { space } from '@guardian/source/foundations';
-import type { ArticleFormat } from '../../lib/articleFormat';
+import { type ArticleFormat } from '../../lib/articleFormat';
 import { secondsToDuration } from '../../lib/formatTime';
 import { palette } from '../../palette';
 import type { AspectRatio } from '../../types/front';
@@ -67,6 +67,7 @@ type Props = {
 	duration?: number; // in seconds
 	aspectRatio?: AspectRatio;
 	isLive?: boolean;
+	isHosted?: boolean;
 };
 
 export const YoutubeAtomOverlay = ({
@@ -82,6 +83,7 @@ export const YoutubeAtomOverlay = ({
 	duration,
 	aspectRatio,
 	isLive,
+	isHosted,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -102,6 +104,7 @@ export const YoutubeAtomOverlay = ({
 						height={height}
 						width={width}
 						aspectRatio={aspectRatio}
+						isHosted={isHosted}
 					/>
 				)}
 				{isLive ? (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomOverlay.tsx
@@ -67,7 +67,7 @@ type Props = {
 	duration?: number; // in seconds
 	aspectRatio?: AspectRatio;
 	isLive?: boolean;
-	isHosted?: boolean;
+	isHostedContent?: boolean;
 };
 
 export const YoutubeAtomOverlay = ({
@@ -83,7 +83,7 @@ export const YoutubeAtomOverlay = ({
 	duration,
 	aspectRatio,
 	isLive,
-	isHosted,
+	isHostedContent,
 }: Props) => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = !isUndefined(duration) && duration > 0;
@@ -104,7 +104,7 @@ export const YoutubeAtomOverlay = ({
 						height={height}
 						width={width}
 						aspectRatio={aspectRatio}
-						isHosted={isHosted}
+						isHostedContent={isHostedContent}
 					/>
 				)}
 				{isLive ? (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -12,7 +12,7 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
 	isImmersive?: boolean;
-	isHostedContent?: boolean;
+	isHostedVideo?: boolean;
 };
 
 export const YoutubeAtomPicture = ({
@@ -23,34 +23,34 @@ export const YoutubeAtomPicture = ({
 	aspectRatio,
 	mobileAspectRatio,
 	isImmersive = false,
-	isHostedContent = false,
+	isHostedVideo = false,
 }: Props) => {
 	const mobileAspect = mobileAspectRatio ?? aspectRatio;
 	const sources = generateSources(getSourceImageUrl(image), [
 		{
 			breakpoint: breakpoints.mobile,
-			width: isHostedContent ? breakpoints.mobileLandscape : 465,
+			width: isHostedVideo ? breakpoints.mobileLandscape : 465,
 			aspectRatio: mobileAspect,
 		},
 		{
 			breakpoint: breakpoints.mobileLandscape,
-			width: isHostedContent ? breakpoints.phablet : 645,
+			width: isHostedVideo ? breakpoints.phablet : 645,
 			aspectRatio: mobileAspect,
 		},
 		{
 			breakpoint: breakpoints.phablet,
-			width: isHostedContent ? breakpoints.tablet : 620,
+			width: isHostedVideo ? breakpoints.tablet : 620,
 			aspectRatio: mobileAspect,
 		},
 		{
 			breakpoint: breakpoints.tablet,
-			width: isHostedContent ? breakpoints.desktop : 700,
+			width: isHostedVideo ? breakpoints.desktop : 700,
 			aspectRatio,
 			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
 		},
 		{
 			breakpoint: breakpoints.desktop,
-			width: isHostedContent ? breakpoints.leftCol : 620,
+			width: isHostedVideo ? breakpoints.desktop : 620,
 			aspectRatio,
 			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
 		},

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -17,7 +17,7 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
 	isImmersive?: boolean;
-	isHosted?: boolean;
+	isHostedContent?: boolean;
 };
 
 export const YoutubeAtomPicture = ({
@@ -28,10 +28,10 @@ export const YoutubeAtomPicture = ({
 	aspectRatio,
 	mobileAspectRatio,
 	isImmersive = false,
-	isHosted = false,
+	isHostedContent = false,
 }: Props) => {
 	const mobileAspect = mobileAspectRatio ?? aspectRatio;
-	const imageWidths: [ImageWidthType, ...ImageWidthType[]] = isHosted
+	const imageWidths: [ImageWidthType, ...ImageWidthType[]] = isHostedContent
 		? [
 				{
 					breakpoint: breakpoints.mobile,

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -2,7 +2,12 @@ import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source/foundations';
 import { getSourceImageUrl } from '../../lib/getSourceImageUrl_temp_fix';
 import type { AspectRatio } from '../../types/front';
-import { generateSources, getFallbackSource, Sources } from '../Picture';
+import {
+	generateSources,
+	getFallbackSource,
+	type ImageWidthType,
+	Sources,
+} from '../Picture';
 
 type Props = {
 	image: string;
@@ -12,6 +17,7 @@ type Props = {
 	aspectRatio?: AspectRatio;
 	mobileAspectRatio?: AspectRatio;
 	isImmersive?: boolean;
+	isHosted?: boolean;
 };
 
 export const YoutubeAtomPicture = ({
@@ -22,37 +28,67 @@ export const YoutubeAtomPicture = ({
 	aspectRatio,
 	mobileAspectRatio,
 	isImmersive = false,
+	isHosted = false,
 }: Props) => {
 	const mobileAspect = mobileAspectRatio ?? aspectRatio;
-	const sources = generateSources(getSourceImageUrl(image), [
-		{
-			breakpoint: breakpoints.mobile,
-			width: 465,
-			aspectRatio: mobileAspect,
-		},
-		{
-			breakpoint: breakpoints.mobileLandscape,
-			width: 645,
-			aspectRatio: mobileAspect,
-		},
-		{
-			breakpoint: breakpoints.phablet,
-			width: 620,
-			aspectRatio: mobileAspect,
-		},
-		{
-			breakpoint: breakpoints.tablet,
-			width: 700,
-			aspectRatio,
-			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
-		},
-		{
-			breakpoint: breakpoints.desktop,
-			width: 620,
-			aspectRatio,
-			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
-		},
-	]);
+	const imageWidths: [ImageWidthType, ...ImageWidthType[]] = isHosted
+		? [
+				{
+					breakpoint: breakpoints.mobile,
+					width: breakpoints.mobileLandscape,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.mobileLandscape,
+					width: breakpoints.phablet,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.phablet,
+					width: breakpoints.tablet,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.tablet,
+					width: breakpoints.desktop,
+					aspectRatio,
+				},
+				{
+					breakpoint: breakpoints.desktop,
+					width: breakpoints.leftCol,
+					aspectRatio,
+				},
+			]
+		: [
+				{
+					breakpoint: breakpoints.mobile,
+					width: 465,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.mobileLandscape,
+					width: 645,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.phablet,
+					width: 620,
+					aspectRatio: mobileAspect,
+				},
+				{
+					breakpoint: breakpoints.tablet,
+					width: 700,
+					aspectRatio,
+					cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+				},
+				{
+					breakpoint: breakpoints.desktop,
+					width: 620,
+					aspectRatio,
+					cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+				},
+			];
+	const sources = generateSources(getSourceImageUrl(image), [...imageWidths]);
 	const fallbackSource = getFallbackSource(sources);
 
 	return (

--- a/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
+++ b/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtomPicture.tsx
@@ -2,12 +2,7 @@ import { css } from '@emotion/react';
 import { breakpoints } from '@guardian/source/foundations';
 import { getSourceImageUrl } from '../../lib/getSourceImageUrl_temp_fix';
 import type { AspectRatio } from '../../types/front';
-import {
-	generateSources,
-	getFallbackSource,
-	type ImageWidthType,
-	Sources,
-} from '../Picture';
+import { generateSources, getFallbackSource, Sources } from '../Picture';
 
 type Props = {
 	image: string;
@@ -31,64 +26,35 @@ export const YoutubeAtomPicture = ({
 	isHostedContent = false,
 }: Props) => {
 	const mobileAspect = mobileAspectRatio ?? aspectRatio;
-	const imageWidths: [ImageWidthType, ...ImageWidthType[]] = isHostedContent
-		? [
-				{
-					breakpoint: breakpoints.mobile,
-					width: breakpoints.mobileLandscape,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.mobileLandscape,
-					width: breakpoints.phablet,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.phablet,
-					width: breakpoints.tablet,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.tablet,
-					width: breakpoints.desktop,
-					aspectRatio,
-				},
-				{
-					breakpoint: breakpoints.desktop,
-					width: breakpoints.leftCol,
-					aspectRatio,
-				},
-			]
-		: [
-				{
-					breakpoint: breakpoints.mobile,
-					width: 465,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.mobileLandscape,
-					width: 645,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.phablet,
-					width: 620,
-					aspectRatio: mobileAspect,
-				},
-				{
-					breakpoint: breakpoints.tablet,
-					width: 700,
-					aspectRatio,
-					cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
-				},
-				{
-					breakpoint: breakpoints.desktop,
-					width: 620,
-					aspectRatio,
-					cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
-				},
-			];
-	const sources = generateSources(getSourceImageUrl(image), [...imageWidths]);
+	const sources = generateSources(getSourceImageUrl(image), [
+		{
+			breakpoint: breakpoints.mobile,
+			width: isHostedContent ? breakpoints.mobileLandscape : 465,
+			aspectRatio: mobileAspect,
+		},
+		{
+			breakpoint: breakpoints.mobileLandscape,
+			width: isHostedContent ? breakpoints.phablet : 645,
+			aspectRatio: mobileAspect,
+		},
+		{
+			breakpoint: breakpoints.phablet,
+			width: isHostedContent ? breakpoints.tablet : 620,
+			aspectRatio: mobileAspect,
+		},
+		{
+			breakpoint: breakpoints.tablet,
+			width: isHostedContent ? breakpoints.desktop : 700,
+			aspectRatio,
+			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+		},
+		{
+			breakpoint: breakpoints.desktop,
+			width: isHostedContent ? breakpoints.leftCol : 620,
+			aspectRatio,
+			cropOffset: isImmersive ? { x: 50, y: 0 } : undefined,
+		},
+	]);
 	const fallbackSource = getFallbackSource(sources);
 
 	return (

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
@@ -124,18 +124,13 @@ export const YoutubeBlockComponent = ({
 			return posterImage;
 		}
 
-		// For Standard Articles and Liveblog Articles with a Video atom for
+		// For Standard Articles, Liveblog Articles and Hosted Video Articles with a Video atom for
 		// their main media we need to display the poster image.
 		if (
 			contentLayout?.toLowerCase() === 'standardlayout' ||
-			contentLayout?.toLowerCase() === 'livebloglayout'
+			contentLayout?.toLowerCase() === 'livebloglayout' ||
+			contentLayout?.toLowerCase() === 'hostedvideolayout'
 		) {
-			return posterImage;
-		}
-
-		// For Hosted Video Articles with a Video atom for
-		// their main media we need to display the poster image.
-		if (contentLayout?.toLowerCase() === 'hostedvideolayout') {
 			return posterImage;
 		}
 

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
@@ -1,6 +1,9 @@
 import type { ConsentState } from '@guardian/consent-manager';
 import { useEffect, useState } from 'react';
-import type { ArticleFormat } from '../lib/articleFormat';
+import {
+	type ArticleFormat,
+	isHostedContentDesign,
+} from '../lib/articleFormat';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import type { AdTargeting } from '../types/commercial';
@@ -229,6 +232,7 @@ export const YoutubeBlockComponent = ({
 				showByline={showByline}
 				isLive={isLive}
 				articleMedia={articleMedia}
+				isHosted={isHostedContentDesign(format.design)}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
@@ -130,6 +130,12 @@ export const YoutubeBlockComponent = ({
 			return posterImage;
 		}
 
+		// For Hosted Video Articles with a Video atom for
+		// their main media we need to display the poster image.
+		if (contentLayout?.toLowerCase() === 'hostedvideolayout') {
+			return posterImage;
+		}
+
 		// Default behaviour is to use the override image, if supplied
 		// otherwise use the poster image
 		return overrideImage ?? posterImage;

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
@@ -1,9 +1,6 @@
 import type { ConsentState } from '@guardian/consent-manager';
 import { useEffect, useState } from 'react';
-import {
-	type ArticleFormat,
-	isHostedContentDesign,
-} from '../lib/articleFormat';
+import { type ArticleFormat } from '../lib/articleFormat';
 import { useAB } from '../lib/useAB';
 import { useAdTargeting } from '../lib/useAdTargeting';
 import type { AdTargeting } from '../types/commercial';
@@ -227,7 +224,6 @@ export const YoutubeBlockComponent = ({
 				showByline={showByline}
 				isLive={isLive}
 				articleMedia={articleMedia}
-				isHostedContent={isHostedContentDesign(format.design)}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
+++ b/dotcom-rendering/src/components/YoutubeBlockComponent.island.tsx
@@ -227,7 +227,7 @@ export const YoutubeBlockComponent = ({
 				showByline={showByline}
 				isLive={isLive}
 				articleMedia={articleMedia}
-				isHosted={isHostedContentDesign(format.design)}
+				isHostedContent={isHostedContentDesign(format.design)}
 			/>
 			{!hideCaption && (
 				<Caption

--- a/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
+++ b/dotcom-rendering/src/layouts/HostedVideoLayout.tsx
@@ -222,6 +222,7 @@ export const HostedVideoLayout = (props: WebProps | AppProps) => {
 							hideCaption={true}
 							shouldHideAds={true}
 							contentType={frontendData.contentType}
+							contentLayout="HostedVideoLayout"
 						/>
 					</div>
 


### PR DESCRIPTION
## What does this change?

This PR uses the correct image for Hosted Video Articles when provided in the data. The fix is to use `posterImage` instead of `overrideImage`.

I also noticed the image resolution is not good enough to be in Hosted Video Articles and this is due to the image is wider compared to the normal video articles. I created a check if `isHostedVideo` to add different Image widths.

## Why?

The Hosted Video image used in DCAR is incorrect compared to non-DCAR rendering which probably was one of the few fixes left after the migration. 

## How has this change been tested?

It has been tested locally

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots
The first row is the main PR change and the second row is the fix for image width to improve the quality/resolution.

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/c31bad29-09ff-4841-afa0-c991a459e0e9
[after]: https://github.com/user-attachments/assets/331402e8-0701-4f85-b01b-0a94ecd86771

[before2]: https://github.com/user-attachments/assets/331402e8-0701-4f85-b01b-0a94ecd86771
[after2]: https://github.com/user-attachments/assets/6e48b64f-c2d1-4804-8886-ba23d07bccf0

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217165334040828