### PR TITLE
add substitution-injury event type

### DIFF
--- a/dotcom-rendering/src/components/Lineups.tsx
+++ b/dotcom-rendering/src/components/Lineups.tsx
@@ -84,7 +84,7 @@ const Event = ({
 	isSubstitute,
 }: {
 	eventId: string;
-	type: 'substitution' | 'dismissal' | 'booking';
+	type: 'substitution' | 'substitution-injury' | 'dismissal' | 'booking';
 	time: string;
 	substitutions: Substitution[];
 	isSubstitute: boolean;
@@ -106,7 +106,8 @@ const Event = ({
 					aria-label="Yellow Card"
 				/>
 			);
-		case 'substitution': {
+		case 'substitution':
+		case 'substitution-injury': {
 			const substitutionEvent = substitutions.find(
 				(substitution) => substitution.eventId === eventId,
 			);

--- a/dotcom-rendering/src/footballMatch.ts
+++ b/dotcom-rendering/src/footballMatch.ts
@@ -10,7 +10,12 @@ import type { Result } from './lib/result';
 import { error, ok } from './lib/result';
 import { cleanTeamName } from './sportDataPage';
 
-const eventTypes = ['substitution', 'dismissal', 'booking'] as const;
+const eventTypes = [
+	'substitution',
+	'substitution-injury',
+	'dismissal',
+	'booking',
+] as const;
 const isEventType = isOneOf(eventTypes);
 
 export type PlayerEvent = {

--- a/dotcom-rendering/src/footballMatchStats.ts
+++ b/dotcom-rendering/src/footballMatchStats.ts
@@ -69,7 +69,12 @@ type FootballPlayer = {
 	events: PlayerEvent[];
 };
 
-const eventTypes = ['substitution', 'dismissal', 'booking'] as const;
+const eventTypes = [
+	'substitution',
+	'substitution-injury',
+	'dismissal',
+	'booking',
+] as const;
 const isEventType = isOneOf(eventTypes);
 
 /**
@@ -141,7 +146,11 @@ const parseSubstitution = (
 	feFootballMatchSubstitution: FEFootballPlayer,
 ): Substitution[] => {
 	const substitutions = feFootballMatchSubstitution.enhancedEvents
-		.filter((event) => event.eventType === 'substitution')
+		.filter(
+			(event) =>
+				event.eventType === 'substitution' ||
+				event.eventType === 'substitution-injury',
+		)
 		.map((event) => ({
 			eventId: event.eventId,
 			name: feFootballMatchSubstitution.name,


### PR DESCRIPTION
## What does this change?

When this PR (https://github.com/guardian/frontend/pull/29093) is merged, substitution events can either be of type "substitution" or "substitution-injury". This PR adds "substitution-injury" to our lists of eventTypes and parses the corresponding events in the same way we parse events of type "substitution". 

I considered combining "substitution" and "substitution-injury" into one generic substitution type, but I thought as I can't find other types of substitution event, in this case it's better to keep the specificity in case we ever want to differentiate between the different kinds of substitution in the future.

## Why?

Events of type "substitution-injury" were being ignored and so occasionally our lineups wouldn't show a player was subbed off. In the "Before" screenshot below you can see Grealish came on in the 46th minute, but you can't see who he replaced. This fixes that as can be seen in the "after" screenshot where you can see that Doku was replaced.

Fixes https://github.com/guardian/dotcom-rendering/issues/16566

## How has this change been tested?

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/b7455666-7dc3-46e0-bf66-015c0c038323
[after]: https://github.com/user-attachments/assets/b59041ea-cdc1-421e-9cff-91a9d5e791c2

