### PR TITLE
update AB test contamination test name

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -145,12 +145,12 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
-		name: "webx-monitor-group-contamination",
+		name: "webx-monitor-group-contamination-v2",
 		description:
-			"Test to measure the impact of contamination between groups in ab tests",
+			"V2 of test to measure the impact of contamination between groups in ab tests",
 		owners: ["dotcom.platform@theguardian.com"],
 		status: "ON",
-		expirationDate: "2026-08-31",
+		expirationDate: "2026-09-30",
 		type: "client",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",

--- a/dotcom-rendering/src/components/Metrics.island.tsx
+++ b/dotcom-rendering/src/components/Metrics.island.tsx
@@ -112,7 +112,7 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 	);
 
 	const isInMonitoringTest = abTests?.isUserInTest(
-		'webx-monitor-group-contamination',
+		'webx-monitor-group-contamination-v2',
 	);
 
 	useEffect(


### PR DESCRIPTION
## What does this change?

We'd like to test whether https://github.com/guardian/fastly-edge-cache/pull/1209 has helped with the reported AB test contamination issue. The analysts advised we set-up a new test to track the impact of this change. This change updates the test name, and updates the logger logic.

