### PR TITLE
Affiliate Disclaimer Post Release Changes

### DIFF
--- a/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
+++ b/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
@@ -11,8 +11,8 @@ const AffiliateDisclaimerText = () => (
 			width: 'fit-content',
 		}}
 	>
-		The Guardian’s journalism is independent. We will earn a commission if
-		you buy something through an affiliate link.&nbsp;
+		Guardian journalism is independent. We earn a commission if you buy
+		something through an affiliate link.&nbsp;
 		<a href="https://www.theguardian.com/info/2017/nov/01/reader-information-on-affiliate-links">
 			Learn more
 		</a>

--- a/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
+++ b/dotcom-rendering/src/components/AffiliateDisclaimer.tsx
@@ -9,6 +9,7 @@ const AffiliateDisclaimerText = () => (
 			marginTop: 0,
 			marginBottom: 0,
 			width: 'fit-content',
+			textWrap: 'pretty',
 		}}
 	>
 		Guardian journalism is independent. We earn a commission if you buy
@@ -30,7 +31,7 @@ const AffiliateDisclaimer = ({
 		theme={{
 			backgroundPrimary: palette('--affiliate-disclaimer-background'),
 			textPrimary: palette('--affiliate-disclaimer-text'),
-			linkPrimary: palette('--article-section-title-lifestyle'),
+			linkPrimary: palette('--affiliate-disclaimer-link'),
 		}}
 		cssOverrides={cssOverrides}
 		data-testid={affiliateDisclaimerId}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -4994,33 +4994,51 @@ const richLinkQuoteFillLight: PaletteFunction = ({ design, theme }) => {
 	}
 };
 
-const affiliateDisclaimerBackgroundLight: PaletteFunction = ({ design }) => {
+const affiliateDisclaimerThemes = {
+	light: {
+		bg: sourcePalette.neutral[97],
+		text: sourcePalette.neutral[7],
+		link: sourcePalette.lifestyle[400],
+	},
+	dark: {
+		bg: sourcePalette.neutral[20],
+		text: sourcePalette.neutral[86],
+		link: sourcePalette.lifestyle[450],
+	},
+};
+
+const affiliateDisclaimerLightTheme = ({
+	design,
+}: {
+	design: ArticleDesign;
+}) => {
 	switch (design) {
 		case ArticleDesign.Gallery:
 		case ArticleDesign.Audio:
 		case ArticleDesign.Video:
-			return sourcePalette.neutral[20];
+			return affiliateDisclaimerThemes.dark;
 		default:
-			return sourcePalette.neutral[97];
+			return affiliateDisclaimerThemes.light;
 	}
 };
+
+const affiliateDisclaimerBackgroundLight: PaletteFunction = ({ design }) =>
+	affiliateDisclaimerLightTheme({ design }).bg;
+
 const affiliateDisclaimerBackgroundDark: PaletteFunction = () =>
-	sourcePalette.neutral[20];
+	affiliateDisclaimerThemes.dark.bg;
 
-const affiliateDisclaimerTextLight: PaletteFunction = ({ design }) => {
-	switch (design) {
-		case ArticleDesign.Gallery:
-		case ArticleDesign.Audio:
-		case ArticleDesign.Video:
-			return sourcePalette.neutral[86];
-		default:
-			return sourcePalette.neutral[7];
-	}
-};
+const affiliateDisclaimerTextLight: PaletteFunction = ({ design }) =>
+	affiliateDisclaimerLightTheme({ design }).text;
 
-const affiliateDisclaimerTextDark: PaletteFunction = () => {
-	return sourcePalette.neutral[86];
-};
+const affiliateDisclaimerTextDark: PaletteFunction = () =>
+	affiliateDisclaimerThemes.dark.text;
+
+const affiliateDisclaimerLinkLight: PaletteFunction = ({ design }) =>
+	affiliateDisclaimerLightTheme({ design }).link;
+
+const affiliateDisclaimerLinkDark: PaletteFunction = () =>
+	affiliateDisclaimerThemes.dark.link;
 
 const seriesTitleBackgroundLight: PaletteFunction = ({
 	theme,
@@ -6621,6 +6639,10 @@ const paletteColours = {
 	'--affiliate-disclaimer-background': {
 		light: affiliateDisclaimerBackgroundLight,
 		dark: affiliateDisclaimerBackgroundDark,
+	},
+	'--affiliate-disclaimer-link': {
+		light: affiliateDisclaimerLinkLight,
+		dark: affiliateDisclaimerLinkDark,
 	},
 	'--affiliate-disclaimer-text': {
 		light: affiliateDisclaimerTextLight,


### PR DESCRIPTION
## What does this change?
- Update affiliate disclaimer copy text
  - As requested by design team
- Update affiliate disclaimer text wrapping to `pretty`
  - The text sometimes leaves an ophaned word on a new line, particularly on mobile
- Update affiliate disclaimer link text colour to dark theme on particular layout types
  - The link text colour has been appearing incorrectly when light mode colours are replaced on particular article designs


## How has this change been tested?
Visually inspected

### Manual testing
- Locally ✅ 
- CODE ✅ 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
Copy Change & Pretty Wrapping
<img width="467" height="109" alt="image" src="https://github.com/user-attachments/assets/d4838d00-bb2f-49ee-81f8-49c76b98a288" /> | <img width="466" height="89" alt="image" src="https://github.com/user-attachments/assets/819e3991-9f95-4132-b579-20b7eecbdbc3" />
Dark Mode
<img width="422"  alt="image" src="https://github.com/user-attachments/assets/c7c7529e-0343-487a-b788-6d4336e4d3a6" /> | <img width="640" height="77" alt="image" src="https://github.com/user-attachments/assets/e40dc2b8-269b-4eae-beda-de344d50e7ec" />