### PR TITLE
Spike subnav rendering

### DIFF
--- a/dotcom-rendering/src/components/CustomSubNav.stories.tsx
+++ b/dotcom-rendering/src/components/CustomSubNav.stories.tsx
@@ -1,0 +1,49 @@
+import preview from '../../.storybook/preview';
+import type { CustomSubnav } from '../types/customSubnav';
+import { CustomSubNav as CustomSubNavComponent } from './CustomSubNav';
+
+const links: CustomSubnav['links'] = [
+	{ linkText: 'Wildlife', dotcomPath: '/environment/wildlife' },
+	{ linkText: 'Energy', dotcomPath: '/environment/energy' },
+	{ linkText: 'Pollution', dotcomPath: '/environment/pollution' },
+	{ linkText: 'Climate crisis', dotcomPath: '/environment/climate-crisis' },
+	{ linkText: 'Trees and forests', dotcomPath: '/environment/forests' },
+];
+
+const baseSubnav: CustomSubnav = {
+	id: 'environment-custom-subnav',
+	header: {
+		headerText: 'The age of extinction',
+		dotcomPath: '/environment/age-of-extinction',
+		copy: 'Our reporting on the sixth mass extinction and the fight to protect the natural world.',
+	},
+	format: 'large',
+	links,
+	pages: [{ type: 'front', path: 'environment' }],
+	lastUpdated: 1_700_000_000_000,
+	updatedBy: 'Ada Lovelace',
+	updatedEmail: 'ada.lovelace@theguardian.com',
+};
+
+const meta = preview.meta({
+	component: CustomSubNavComponent,
+	parameters: {},
+	args: {
+		guardianBaseURL: 'https://www.theguardian.com',
+	},
+});
+
+export const Large = meta.story({
+	args: {
+		subnav: baseSubnav,
+	},
+});
+
+export const Compact = meta.story({
+	args: {
+		subnav: {
+			...baseSubnav,
+			format: 'compact',
+		},
+	},
+});

--- a/dotcom-rendering/src/components/CustomSubNav.tsx
+++ b/dotcom-rendering/src/components/CustomSubNav.tsx
@@ -1,0 +1,168 @@
+import { css } from '@emotion/react';
+import {
+	from,
+	headlineBold20,
+	space,
+	textSans15,
+	textSans17,
+} from '@guardian/source/foundations';
+import { nestedOphanComponents } from '../lib/ophan-helpers';
+import { palette } from '../palette';
+import type { CustomSubnav } from '../types/customSubnav';
+
+type Props = {
+	subnav: CustomSubnav;
+	/** Base URL used to resolve site-relative `dotcomPath`s. */
+	guardianBaseURL: string;
+};
+
+/**
+ * Resolves a site-relative `dotcomPath` against the site base URL. Absolute
+ * URLs are returned unchanged.
+ */
+const buildUrl = (dotcomPath: string, guardianBaseURL: string): string => {
+	if (/^https?:\/\//.test(dotcomPath)) {
+		return dotcomPath;
+	}
+	return `${guardianBaseURL}${
+		dotcomPath.startsWith('/') ? '' : '/'
+	}${dotcomPath}`;
+};
+
+const wrapperStyles = css`
+	display: flex;
+	flex-direction: column;
+	gap: ${space[1]}px;
+	padding: ${space[2]}px 10px;
+	color: var(--sub-nav-link-header);
+	border-bottom: 1px solid ${palette('--sub-nav-border')};
+
+	${from.mobileLandscape} {
+		padding: ${space[2]}px 20px;
+	}
+`;
+
+const compactWrapperStyles = css`
+	flex-direction: row;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: ${space[2]}px ${space[4]}px;
+`;
+
+const headerTextStyles = css`
+	${headlineBold20};
+	color: inherit;
+	margin: 0;
+`;
+
+const compactHeaderTextStyles = css`
+	${textSans17};
+	font-weight: 700;
+`;
+
+const headerLinkStyles = css`
+	color: inherit;
+	text-decoration: none;
+
+	:hover {
+		color: ${palette('--sub-nav-link-hover')};
+	}
+`;
+
+const copyStyles = css`
+	${textSans15};
+	color: inherit;
+	margin: 0;
+`;
+
+const linksListStyles = css`
+	${textSans15};
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: ${space[4]}px;
+	row-gap: ${space[1]}px;
+
+	${from.tablet} {
+		${textSans17};
+	}
+`;
+
+const linkStyles = css`
+	color: inherit;
+	text-decoration: none;
+	font-weight: 500;
+
+	:hover {
+		color: ${palette('--sub-nav-link-hover')};
+	}
+`;
+
+/**
+ * Renders a custom subnav targeted at a front. Frontend forwards the already
+ * selected subnav; DCR just renders it.
+ *
+ * For now only the header text and links are rendered. Images and palettes are
+ * intentionally ignored. Unknown `format` values fail safe to `compact`.
+ */
+export const CustomSubNav = ({ subnav, guardianBaseURL }: Props) => {
+	const { header, links, format } = subnav;
+	const isLarge = format === 'large';
+
+	const headerText = header.dotcomPath ? (
+		<a
+			href={buildUrl(header.dotcomPath, guardianBaseURL)}
+			css={headerLinkStyles}
+			data-link-name={nestedOphanComponents(
+				'custom-subnav',
+				'header',
+				header.headerText,
+			)}
+		>
+			{header.headerText}
+		</a>
+	) : (
+		header.headerText
+	);
+
+	return (
+		<nav
+			css={[wrapperStyles, !isLarge && compactWrapperStyles]}
+			data-component="custom-subnav"
+			aria-label="Custom subnavigation"
+		>
+			<h2 css={[headerTextStyles, !isLarge && compactHeaderTextStyles]}>
+				{headerText}
+			</h2>
+
+			{isLarge && header.copy !== '' && (
+				<p css={copyStyles}>{header.copy}</p>
+			)}
+
+			{links.length > 0 && (
+				<ul css={linksListStyles}>
+					{links.map((link) => (
+						<li key={`${link.linkText}-${link.dotcomPath}`}>
+							<a
+								href={buildUrl(
+									link.dotcomPath,
+									guardianBaseURL,
+								)}
+								css={linkStyles}
+								data-link-name={nestedOphanComponents(
+									'custom-subnav',
+									'link',
+									link.linkText,
+								)}
+							>
+								{link.linkText}
+							</a>
+						</li>
+					))}
+				</ul>
+			)}
+		</nav>
+	);
+};

--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -8,6 +8,7 @@ import type {
 	Newsletter,
 	StarRating,
 } from '../types/content';
+import type { CustomSubnav } from '../types/customSubnav';
 import type { FooterType } from '../types/footer';
 import type { EditorialTest } from '../types/front';
 import type { FENavType } from '../types/frontend';
@@ -34,6 +35,11 @@ export interface FEFront {
 	deeplyRead?: FETrailType[];
 	contributionsServiceUrl: string;
 	canonicalUrl?: string;
+	/**
+	 * An optional custom subnav targeted at this front. Omitted entirely when
+	 * no custom subnav targets the front.
+	 */
+	subnav?: CustomSubnav;
 }
 
 interface FEPressedPage {

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -57,6 +57,10 @@
         },
         "canonicalUrl": {
             "type": "string"
+        },
+        "subnav": {
+            "$ref": "#/definitions/CustomSubnav",
+            "description": "An optional custom subnav targeted at this front. Omitted entirely when\nno custom subnav targets the front."
         }
     },
     "required": [
@@ -4456,6 +4460,176 @@
                     ]
                 }
             ]
+        },
+        "CustomSubnav": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "header": {
+                    "$ref": "#/definitions/CustomSubnavHeader"
+                },
+                "format": {
+                    "$ref": "#/definitions/CustomSubnavFormat"
+                },
+                "links": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SubnavLink"
+                    }
+                },
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TargetedPage"
+                    }
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SubnavImage"
+                    }
+                },
+                "palette": {
+                    "$ref": "#/definitions/Palettes"
+                },
+                "lastUpdated": {
+                    "type": "number"
+                },
+                "updatedBy": {
+                    "type": "string"
+                },
+                "updatedEmail": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "format",
+                "header",
+                "id",
+                "lastUpdated",
+                "links",
+                "pages",
+                "updatedBy",
+                "updatedEmail"
+            ]
+        },
+        "CustomSubnavHeader": {
+            "type": "object",
+            "properties": {
+                "headerText": {
+                    "type": "string"
+                },
+                "dotcomPath": {
+                    "type": "string"
+                },
+                "copy": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "copy",
+                "headerText"
+            ]
+        },
+        "CustomSubnavFormat": {
+            "enum": [
+                "compact",
+                "large"
+            ],
+            "type": "string"
+        },
+        "SubnavLink": {
+            "type": "object",
+            "properties": {
+                "linkText": {
+                    "type": "string"
+                },
+                "dotcomPath": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "dotcomPath",
+                "linkText"
+            ]
+        },
+        "TargetedPage": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/TargetedPageType"
+                },
+                "path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path",
+                "type"
+            ]
+        },
+        "TargetedPageType": {
+            "description": "Types for the custom subnav that frontend can target at individual fronts.\n\nFrontend evaluates the targeting rules (`pages`) and forwards the already\nselected subnav in the `/Front` payload. It is omitted entirely when no\ncustom subnav targets the front, so DCR must treat it as optional.\n\nSerialized from the fapi `CustomSubnav` model. Enum values serialize as\nlowercase strings.",
+            "enum": [
+                "article",
+                "front",
+                "hasTag"
+            ],
+            "type": "string"
+        },
+        "SubnavImage": {
+            "type": "object",
+            "properties": {
+                "imageSrc": {
+                    "type": "string"
+                },
+                "breakpoint": {
+                    "$ref": "#/definitions/ImageBreakpoint"
+                }
+            },
+            "required": [
+                "breakpoint",
+                "imageSrc"
+            ]
+        },
+        "ImageBreakpoint": {
+            "enum": [
+                "mobile",
+                "tablet",
+                "web"
+            ],
+            "type": "string"
+        },
+        "Palettes": {
+            "type": "object",
+            "properties": {
+                "light": {
+                    "$ref": "#/definitions/Palette"
+                },
+                "dark": {
+                    "$ref": "#/definitions/Palette"
+                }
+            },
+            "required": [
+                "dark",
+                "light"
+            ]
+        },
+        "Palette": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "header": {
+                    "type": "string"
+                },
+                "link": {
+                    "type": "string"
+                }
+            }
         }
     },
     "$schema": "http://json-schema.org/draft-07/schema#"

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -7,6 +7,7 @@ import {
 import { Fragment } from 'react';
 import { AdSlot } from '../components/AdSlot.web';
 import { CPScottHeader } from '../components/CPScottHeader';
+import { CustomSubNav } from '../components/CustomSubNav';
 import { DecideContainer } from '../components/DecideContainer';
 import { DirectoryPageNavIsland } from '../components/DirectoryPageNavIsland';
 import { EditionSwitcherBanner } from '../components/EditionSwitcherBanner.island';
@@ -246,6 +247,23 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 					sectionId={front.config.section}
 					contentType={front.config.contentType}
 				/>
+
+				{front.subnav && (
+					<Section
+						fullWidth={true}
+						showTopBorder={false}
+						padSides={false}
+						element="nav"
+						backgroundColour={schemePalette(
+							'--front-container-background',
+						)}
+					>
+						<CustomSubNav
+							subnav={front.subnav}
+							guardianBaseURL={front.guardianBaseURL}
+						/>
+					</Section>
+				)}
 
 				{isPaidContent && (
 					<Section

--- a/dotcom-rendering/src/types/customSubnav.ts
+++ b/dotcom-rendering/src/types/customSubnav.ts
@@ -1,0 +1,61 @@
+/**
+ * Types for the custom subnav that frontend can target at individual fronts.
+ *
+ * Frontend evaluates the targeting rules (`pages`) and forwards the already
+ * selected subnav in the `/Front` payload. It is omitted entirely when no
+ * custom subnav targets the front, so DCR must treat it as optional.
+ *
+ * Serialized from the fapi `CustomSubnav` model. Enum values serialize as
+ * lowercase strings.
+ */
+
+export type TargetedPageType = 'front' | 'article' | 'hasTag';
+
+export type CustomSubnavFormat = 'large' | 'compact';
+
+export type ImageBreakpoint = 'mobile' | 'tablet' | 'web';
+
+export interface SubnavLink {
+	linkText: string;
+	dotcomPath: string;
+}
+
+export interface TargetedPage {
+	type: TargetedPageType;
+	path: string;
+}
+
+export interface CustomSubnavHeader {
+	headerText: string;
+	dotcomPath?: string;
+	copy: string;
+}
+
+export interface SubnavImage {
+	imageSrc: string;
+	breakpoint: ImageBreakpoint;
+}
+
+export interface Palette {
+	text?: string;
+	header?: string;
+	link?: string;
+}
+
+export interface Palettes {
+	light: Palette;
+	dark: Palette;
+}
+
+export interface CustomSubnav {
+	id: string;
+	header: CustomSubnavHeader;
+	format: CustomSubnavFormat;
+	links: SubnavLink[];
+	pages: TargetedPage[];
+	images?: SubnavImage[];
+	palette?: Palettes;
+	lastUpdated: number;
+	updatedBy: string;
+	updatedEmail: string;
+}

--- a/dotcom-rendering/src/types/front.ts
+++ b/dotcom-rendering/src/types/front.ts
@@ -14,6 +14,7 @@ import type {
 import type { EditionId } from '../lib/edition';
 import type { Branding, CollectionBranding } from './branding';
 import type { BoostLevel, Newsletter, StarRating } from './content';
+import type { CustomSubnav } from './customSubnav';
 import type { FooterType } from './footer';
 import type { FENavType } from './frontend';
 import type { ArticleMedia, MainMedia } from './mainMedia';
@@ -39,6 +40,11 @@ export interface Front {
 	webURL: string;
 	guardianBaseURL: string;
 	serverTime?: number;
+	/**
+	 * An optional custom subnav targeted at this front. Omitted entirely when
+	 * no custom subnav targets the front.
+	 */
+	subnav?: CustomSubnav;
 }
 
 interface PressedPage {


### PR DESCRIPTION
## What does this change?

Mainly used to test the frontend PR, adds some wiring to show a basic extra subnav on targeted pages

Styling is super basic and not to designs (AI generated for purpose of proof of concept), but the types and relevant wiring can be helpful. 

## Why?

## How has this change been tested?

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
