### PR TITLE
Add AB test for prebid failsafe timeout

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -209,6 +209,20 @@ const ABTests: ABTest[] = [
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},
+
+	{
+		name: "commercial-prebid-failsafe-timeout",
+		description:
+			"Test to measure the impact of the Prebid failsafe timeout",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-09-30",
+		type: "client",
+		status: "OFF",
+		audienceSize: 0 / 100,
+		audienceSpace: "B",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?

Adds a new AB test: `commercial-prebid-failsafe-timeout`

## Why?

To allow testing a new failsafe timeout around Prebid.
