### PR TITLE
Turn off growth-holdback-group audience targeting

### DIFF
--- a/.windsurf/rules/minimal-impact.md
+++ b/.windsurf/rules/minimal-impact.md
@@ -1,0 +1,12 @@
+# Minimal-impact changes
+
+When modifying code in this codebase:
+
+1. Understand the full context and dependencies first.
+2. Analyze the impact of changes across the codebase.
+3. Consider edge cases and downstream effects.
+4. Prefer minimal, targeted fixes over wholesale refactoring.
+5. Preserve existing behavior unless there is a clear reason to change it.
+6. Think like a senior engineer: understand first, then act.
+
+Avoid creating new issues or side-effects; make the least changes possible.

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -51,7 +51,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2027-01-01",
 		type: "client",
 		status: "ON",
-		audienceSize: 5 / 100,
+		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
Sets `audienceSize` for `growth-holdback-group` from `5/100` to `0/100`, disabling the 5% holdback group. All other test fields unchanged.