### PR TITLE
Turn off growth-holdback-group audience targeting

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -51,7 +51,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2027-01-01",
 		type: "client",
 		status: "ON",
-		audienceSize: 5 / 100,
+		audienceSize: 0 / 100,
 		audienceSpace: "A",
 		groups: ["control"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
Sets `audienceSize` for `growth-holdback-group` from `5/100` to `0/100`, disabling the 5% holdback group. All other test fields unchanged.