### PR TITLE
Add zero percent test for ozone hashed email support

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -108,6 +108,18 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
+		name: "commercial-ozone-hashed-email",
+		description:
+			"Pass hashed email to Ozone via pubProvidedId for audience matching",
+		owners: ["commercial.dev@guardian.co.uk"],
+		status: "ON",
+		expirationDate: "2026-09-30",
+		type: "client",
+		audienceSize: 0,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+	},
+	{
 		name: "fronts-and-curation-loop-click-through",
 		description:
 			"Test impact of click to article via loop videos on fronts",


### PR DESCRIPTION
## What does this change?

Adds the commercial-ozone-hashed-email AB test at 0 percent audience for QA.

See companion [commercial pr](https://github.com/guardian/commercial/pull/2688)