### PR TITLE
Use Labs 500 for standfirst text for galleries

### DIFF
--- a/dotcom-rendering/src/components/Standfirst.stories.tsx
+++ b/dotcom-rendering/src/components/Standfirst.stories.tsx
@@ -492,3 +492,28 @@ LabsWithLink.decorators = [
 		},
 	]),
 ];
+
+export const LabsGallery: StoryObj = ({
+	format,
+}: {
+	format: ArticleFormat;
+}) => {
+	return (
+		<Section fullWidth={true}>
+			<Standfirst
+				format={format}
+				standfirst="<p>From riding a steampunk elephant in Nantes to exploring a ghost fishing village, you’ll find no shortage of out-of-this-world experiences in Brittany and Normandy</p>"
+			/>
+		</Section>
+	);
+};
+LabsGallery.storyName = 'LabsGallery';
+LabsGallery.decorators = [
+	splitTheme([
+		{
+			display: ArticleDisplay.Standard,
+			design: ArticleDesign.Gallery,
+			theme: ArticleSpecial.Labs,
+		},
+	]),
+];

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2502,19 +2502,17 @@ const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 const standfirstTextLight: PaletteFunction = (format) => {
 	if (
 		format.theme === ArticleSpecial.Labs &&
-		![ArticleDesign.LiveBlog, ...labsHostedDesigns].includes(format.design)
+		![
+			ArticleDesign.LiveBlog,
+			...labsMediaDesigns,
+			...labsHostedDesigns,
+		].includes(format.design)
 	) {
 		if (format.design === ArticleDesign.Gallery) {
 			return sourcePalette.labs[500];
 		}
 
 		return sourcePalette.labs[100];
-	}
-	if (
-		format.theme === ArticleSpecial.Labs &&
-		format.design === ArticleDesign.HostedGallery
-	) {
-		return sourcePalette.labs[500];
 	}
 
 	switch (format.design) {
@@ -2544,7 +2542,14 @@ const standfirstTextLight: PaletteFunction = (format) => {
 };
 
 const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
-	if (theme === ArticleSpecial.Labs && design !== ArticleDesign.LiveBlog) {
+	if (
+		theme === ArticleSpecial.Labs &&
+		![
+			ArticleDesign.LiveBlog,
+			...labsMediaDesigns,
+			...labsHostedDesigns,
+		].includes(design)
+	) {
 		return sourcePalette.labs[500];
 	}
 

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -2502,13 +2502,19 @@ const standfirstLinkTextDark: PaletteFunction = ({ design, theme }) => {
 const standfirstTextLight: PaletteFunction = (format) => {
 	if (
 		format.theme === ArticleSpecial.Labs &&
-		![
-			ArticleDesign.LiveBlog,
-			...labsMediaDesigns,
-			...labsHostedDesigns,
-		].includes(format.design)
+		![ArticleDesign.LiveBlog, ...labsHostedDesigns].includes(format.design)
 	) {
+		if (format.design === ArticleDesign.Gallery) {
+			return sourcePalette.labs[500];
+		}
+
 		return sourcePalette.labs[100];
+	}
+	if (
+		format.theme === ArticleSpecial.Labs &&
+		format.design === ArticleDesign.HostedGallery
+	) {
+		return sourcePalette.labs[500];
 	}
 
 	switch (format.design) {
@@ -2538,10 +2544,7 @@ const standfirstTextLight: PaletteFunction = (format) => {
 };
 
 const standfirstTextDark: PaletteFunction = ({ design, display, theme }) => {
-	if (
-		theme === ArticleSpecial.Labs &&
-		![ArticleDesign.LiveBlog, ...labsHostedDesigns].includes(design)
-	) {
+	if (theme === ArticleSpecial.Labs && design !== ArticleDesign.LiveBlog) {
 		return sourcePalette.labs[500];
 	}
 


### PR DESCRIPTION
## What does this change?

Updates the standfirst text colour logic for light mode Gallery to use `labs[500]` instead of `labs[100]`.

## Why?

Colour contrast to match designs



<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

<img width="980" height="451" alt="image" src="https://github.com/user-attachments/assets/408cba5d-d854-4299-b84a-c4555bb72e46" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217685454221061