### PR TITLE
chore: Keep Docker resources up-to-date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,3 +71,15 @@ updates:
     schedule:
       interval: 'daily'
     rebase-strategy: 'disabled'
+
+  # Keeps Production.dockerfile at repo root up-to-date
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+
+  # Keeps docker-compose.yaml at repo root up-to-date
+  - package-ecosystem: 'docker-compose'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## What does this change?
Configures Dependabot to update the Dockerfile at a daily interval. This interval [matches others](https://github.com/search?q=repo%3Aguardian%2Fdotcom-rendering+path%3A.github%2Fdependabot.yml+interval&type=code). See also https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#docker.

## Why?
Keeping the image used in production up-to-date.

## How has this change been tested?
I don't think it's possible, without merging. With that said, we currently [reference images via tags](https://github.com/guardian/dotcom-rendering/blob/7fc064b1ff5c2e173703aa57fa6cc4bd26ba29dd/Production.dockerfile#L1). It looks like these tags are mutable, so we're already up-to-date.