### PR TITLE
Extend fronts-ad-increase-ad-limit ab test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -86,7 +86,7 @@ const ABTests: ABTest[] = [
 		description:
 			"A test to understand the impact of changing page-level ad limit on fronts",
 		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-08-27",
+		expirationDate: "2026-09-10",
 		type: "server",
 		status: "ON",
 		audienceSize: 10 / 100,


### PR DESCRIPTION
## What does this change?

Extend the `commercial-extend-fronts-ad-increase-ad-limit` test by 2 weeks. 