### PR TITLE
Turn on 0% Prebid failsafe AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -217,7 +217,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-09-30",
 		type: "client",
-		status: "OFF",
+		status: "ON",
 		audienceSize: 0 / 100,
 		audienceSpace: "B",
 		groups: ["control", "variant"],


### PR DESCRIPTION
## What does this change?

Turns on the `commercial-prebid-failsafe-timeout` 0% AB test

## Why?

So we can run some checks before it goes out to users
