### PR TITLE
Add Commercial Rich Link AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -221,7 +221,6 @@ const ABTests: ABTest[] = [
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},
-
 	{
 		name: "commercial-prebid-failsafe-timeout",
 		description:
@@ -233,6 +232,19 @@ const ABTests: ABTest[] = [
 		audienceSize: 0 / 100,
 		audienceSpace: "B",
 		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
+	{
+		name: "commercial-rich-links",
+		description:
+			"Test to measure the impact of fixing rich links insert behaviour and reduced restrictions on ad insertion around rich links.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-09-30",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant-fix", "variant-uplift"],
 		shouldForceMetricsCollection: true,
 	},
 ];

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -206,6 +206,19 @@ const ABTests: ABTest[] = [
 		groups: ["enable"],
 		shouldForceMetricsCollection: false,
 	},
+	{
+		name: "commercial-rich-links",
+		description:
+			"Test to measure the impact of fixing rich links insert behaviour and reduced restrictions on ad insertion around rich links.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-10-28",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?

Adds a new AB test: `commercial-rich-links`. Set to ON at 0%.

## Why?

See this commercial PR for details: https://github.com/guardian/commercial/pull/2713