### PR TITLE
Revert "Release Labs immersives"

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -32,6 +32,18 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
+		name: "commercial-labs-immersive-grid",
+		description:
+			"New grid-based immersive layout for Guardian Labs articles",
+		owners: ["commercial.dev@guardian.co.uk"],
+		status: "ON",
+		expirationDate: "2026-08-31",
+		type: "server",
+		audienceSize: 0 / 100,
+		groups: ["enable"],
+		shouldForceMetricsCollection: false,
+	},
+	{
 		name: "growth-holdback-group",
 		description:
 			"Test for 5% holdback group that does not qualify for any testing so long as the test is live in the RRCP",

--- a/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.stories.tsx
@@ -32,7 +32,11 @@ import { getCurrentPillar } from '../lib/layoutHelpers';
 import { extractNAV } from '../model/extract-nav';
 import { type Article, enhanceArticleType } from '../types/article';
 import type { ImageBlockElement } from '../types/content';
-import { DecideLayout, type Props as DecideLayoutProps } from './DecideLayout';
+import {
+	DecideLayout,
+	type Props as DecideLayoutProps,
+	LABS_IMMERSIVE_GRID_AB_TEST,
+} from './DecideLayout';
 
 export type HydratedLayoutDecoratorArgs = {
 	colourScheme?: 'light' | 'dark';
@@ -263,6 +267,24 @@ const photoEssayImmersiveLabsPortraitArticle = enhanceArticleType(
 	'Web',
 );
 
+/**
+ * Opts an article into the new grid layout regardless of the 0% production
+ * rollout.
+ */
+const enableLabsImmersiveGridTest = (article: Article): Article => ({
+	...article,
+	frontendData: {
+		...article.frontendData,
+		config: {
+			...article.frontendData.config,
+			serverSideABTests: {
+				...article.frontendData.config.serverSideABTests,
+				[LABS_IMMERSIVE_GRID_AB_TEST]: 'enable',
+			},
+		},
+	},
+});
+
 const labsImmersiveArticle = ({
 	orientation,
 	design,
@@ -274,7 +296,7 @@ const labsImmersiveArticle = ({
 		orientation === 'portrait'
 			? photoEssayImmersiveLabsPortraitArticle
 			: photoEssayImmersiveLabsArticle;
-	return { ...base, design };
+	return enableLabsImmersiveGridTest({ ...base, design });
 };
 
 const immersiveLabsParameters = {
@@ -398,28 +420,36 @@ export const WebFeatureImmersiveLabsPortraitDark: Story = {
  */
 export const WebImmersiveLabsRealParrtjima: Story = {
 	args: {
-		article: enhanceArticleType(LabsImmersiveParrtjimaFixture, 'Web'),
+		article: enableLabsImmersiveGridTest(
+			enhanceArticleType(LabsImmersiveParrtjimaFixture, 'Web'),
+		),
 	},
 	parameters: immersiveLabsMobileParameters,
 };
 
 export const WebImmersiveLabsRealVictorianWater: Story = {
 	args: {
-		article: enhanceArticleType(LabsImmersiveVictorianWaterFixture, 'Web'),
+		article: enableLabsImmersiveGridTest(
+			enhanceArticleType(LabsImmersiveVictorianWaterFixture, 'Web'),
+		),
 	},
 	parameters: immersiveLabsMobileParameters,
 };
 
 export const WebImmersiveLabsRealGlobalX: Story = {
 	args: {
-		article: enhanceArticleType(LabsImmersiveGlobalXFixture, 'Web'),
+		article: enableLabsImmersiveGridTest(
+			enhanceArticleType(LabsImmersiveGlobalXFixture, 'Web'),
+		),
 	},
 	parameters: immersiveLabsMobileParameters,
 };
 
 export const WebImmersiveLabsRealFakeSpielberg: Story = {
 	args: {
-		article: enhanceArticleType(stableFakeSpielbergFixture, 'Web'),
+		article: enableLabsImmersiveGridTest(
+			enhanceArticleType(stableFakeSpielbergFixture, 'Web'),
+		),
 	},
 	parameters: immersiveLabsMobileParameters,
 };

--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -36,6 +36,17 @@ interface WebProps extends BaseProps {
 
 export type Props = WebProps | AppProps;
 
+/**
+ * Guards the new grid-based immersive layout for Guardian Labs articles
+ * behind a 0% a/b test
+ */
+export const LABS_IMMERSIVE_GRID_AB_TEST = 'commercial-labs-immersive-grid';
+
+const isInLabsImmersiveGridTest = (article: Article): boolean =>
+	article.frontendData.config.serverSideABTests[
+		LABS_IMMERSIVE_GRID_AB_TEST
+	] === 'enable';
+
 const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 	const format = {
 		design: article.design,
@@ -58,7 +69,8 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 					);
 				}
 				default: {
-					return article.theme === ArticleSpecial.Labs ? (
+					return article.theme === ArticleSpecial.Labs &&
+						isInLabsImmersiveGridTest(article) ? (
 						<StandardLayout
 							article={article.frontendData}
 							format={format}
@@ -241,7 +253,8 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 					);
 				}
 				default: {
-					return article.theme === ArticleSpecial.Labs ? (
+					return article.theme === ArticleSpecial.Labs &&
+						isInLabsImmersiveGridTest(article) ? (
 						<StandardLayout
 							article={article.frontendData}
 							format={format}


### PR DESCRIPTION
Reverts guardian/dotcom-rendering#16608, some of the design changes unexpectedly leaked into a Labs Photo Essay template.