### PR TITLE
Make `customData` available to interactive atoms

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -34,6 +34,7 @@ type InteractiveAtomType = {
 	elementCss?: string;
 	isMainMedia?: boolean;
 	title: string;
+	customData?: string;
 };
 
 export const InteractiveAtom = ({
@@ -43,6 +44,7 @@ export const InteractiveAtom = ({
 	elementCss,
 	isMainMedia,
 	title,
+	customData,
 }: InteractiveAtomType) => {
 	const { renderingTarget } = useConfig();
 
@@ -51,6 +53,7 @@ export const InteractiveAtom = ({
 			css={[containerStyles, !!isMainMedia && fullHeightStyles]}
 			data-atom-id={id}
 			data-atom-type="interactive"
+			{...(customData ? { 'data-atom-custom-data': customData } : {})}
 		>
 			<Island
 				priority="feature"

--- a/dotcom-rendering/src/components/InteractiveLayoutAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveLayoutAtom.tsx
@@ -10,6 +10,7 @@ export type InteractiveLayoutAtomType = {
 	elementHtml?: string;
 	elementJs?: string;
 	elementCss?: string;
+	customData?: string;
 };
 
 export const InteractiveLayoutAtom = ({
@@ -17,12 +18,14 @@ export const InteractiveLayoutAtom = ({
 	elementHtml,
 	elementJs,
 	elementCss,
+	customData,
 }: InteractiveLayoutAtomType) => (
 	<div
 		className="interactive interactive-atom"
 		css={containerStyles}
 		data-atom-id={id}
 		data-atom-type="interactive-layout"
+		{...(customData ? { 'data-atom-custom-data': customData } : {})}
 	>
 		{!!elementCss && (
 			<style

--- a/dotcom-rendering/src/frontend/schemas/feArticle.json
+++ b/dotcom-rendering/src/frontend/schemas/feArticle.json
@@ -2522,6 +2522,9 @@
                         "thumbnail"
                     ],
                     "type": "string"
+                },
+                "customData": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
+++ b/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+import { ConfigProvider } from '../components/ConfigContext';
+import { InteractiveAtom } from '../components/InteractiveAtom';
+import { InteractiveLayoutAtom } from '../components/InteractiveLayoutAtom';
+
+const mockCustomData = JSON.stringify({ key: 'value' });
+
+describe('Interactive atom custom data attributes', () => {
+	it('should add custom data attribute to InteractiveAtom', () => {
+		const { container } = render(
+			<ConfigProvider
+				value={{
+					renderingTarget: 'Apps',
+					darkModeAvailable: true,
+					assetOrigin: '/',
+					editionId: 'UK',
+				}}
+			>
+				<InteractiveAtom
+					id="test-id"
+					title="Test Title"
+					customData={mockCustomData}
+				/>
+			</ConfigProvider>,
+		);
+		const el = container.querySelector(
+			`[data-atom-custom-data='${mockCustomData}']`,
+		);
+		expect(el).toBeInTheDocument();
+	});
+
+	it('should add custom data attribute to InteractiveLayoutAtom', () => {
+		const { container } = render(
+			<InteractiveLayoutAtom id="test-id" customData={mockCustomData} />,
+		);
+		const el = container.querySelector(
+			`[data-atom-custom-data='${mockCustomData}']`,
+		);
+		expect(el).toBeInTheDocument();
+	});
+});

--- a/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
+++ b/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
@@ -6,7 +6,30 @@ import { InteractiveLayoutAtom } from '../components/InteractiveLayoutAtom';
 const mockCustomData = JSON.stringify({ key: 'value' });
 
 describe('Interactive atom custom data attributes', () => {
-	it('should add custom data attribute to InteractiveAtom', () => {
+	it('should add custom data attribute to InteractiveAtom on web', () => {
+		const { container } = render(
+			<ConfigProvider
+				value={{
+					renderingTarget: 'Web',
+					darkModeAvailable: true,
+					assetOrigin: '/',
+					editionId: 'UK',
+				}}
+			>
+				<InteractiveAtom
+					id="test-id"
+					title="Test Title"
+					customData={mockCustomData}
+				/>
+			</ConfigProvider>,
+		);
+		const el = container.querySelector(
+			`[data-atom-custom-data='${mockCustomData}']`,
+		);
+		expect(el).toBeInTheDocument();
+	});
+
+	it('should add custom data attribute to InteractiveAtom on apps', () => {
 		const { container } = render(
 			<ConfigProvider
 				value={{

--- a/dotcom-rendering/src/lib/renderElement.tsx
+++ b/dotcom-rendering/src/lib/renderElement.tsx
@@ -436,6 +436,7 @@ export const renderElement = ({
 						elementHtml={element.html}
 						elementJs={element.js}
 						elementCss={element.css}
+						customData={element.customData}
 					/>
 				);
 			}
@@ -447,6 +448,7 @@ export const renderElement = ({
 					elementJs={element.js}
 					elementCss={element.css}
 					title={element.title}
+					customData={element.customData}
 				/>
 			);
 		case 'model.dotcomrendering.pageElements.InteractiveBlockElement': {

--- a/dotcom-rendering/src/model/block-schema.json
+++ b/dotcom-rendering/src/model/block-schema.json
@@ -1999,6 +1999,9 @@
                         "thumbnail"
                     ],
                     "type": "string"
+                },
+                "customData": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/types/content.ts
+++ b/dotcom-rendering/src/types/content.ts
@@ -347,6 +347,7 @@ export interface InteractiveAtomBlockElement {
 	css?: string;
 	placeholderUrl?: string;
 	role?: RoleType | 'fullWidth';
+	customData?: string;
 }
 
 // Can't guarantee anything in interactiveBlockElement :shrug:


### PR DESCRIPTION
The final domino in the parameterised interactives sequence, this takes the newly available `customData` passed down with interactive atoms and adds a `data-atom-custom-data` attribute to the container if it's there, thereby allowing atoms to access configuration, content, etc. defined in Composer rather than publishing new atoms for even the slightest variation.

Custom data set for interactive atoms in Composer...

<img width="938" height="277" alt="image" src="https://github.com/user-attachments/assets/8714999d-b167-4130-9cda-73d959266864" />

Is now available in Dotcom through a new data attribute:

<img width="1418" height="309" alt="image" src="https://github.com/user-attachments/assets/a1306c75-c91c-4a7f-a934-33bcdfea4875" />

Atoms can then use a snippet like this to get the data:

```typescript
const getAtomCustomData = <T>(id: string): T | null => {
	const getAtomContainer = (id: string): Element | null =>
		document.querySelector(`[data-atom-id="${id}"]`);
	const container = getAtomContainer(id);
	if (!container) return null;
	const raw = container.getAttribute('data-atom-custom-data');
	if (!raw) return null;
	try {
		return JSON.parse(raw) as T;
	} catch {
		console.warn(`Failed to parse data-atom-custom-data for atom "${id}"`);
		return null;
	}
};
```
And do with it as it sees fit.