### PR TITLE
Limit new Labs immersive layout to standard articles

### DIFF
--- a/dotcom-rendering/src/layouts/DecideLayout.tsx
+++ b/dotcom-rendering/src/layouts/DecideLayout.tsx
@@ -58,7 +58,8 @@ const DecideLayoutApps = ({ article, renderingTarget }: AppProps) => {
 					);
 				}
 				default: {
-					return article.theme === ArticleSpecial.Labs ? (
+					return article.theme === ArticleSpecial.Labs &&
+						article.design === ArticleDesign.Standard ? (
 						<StandardLayout
 							article={article.frontendData}
 							format={format}
@@ -241,7 +242,8 @@ const DecideLayoutWeb = ({ article, NAV, renderingTarget }: WebProps) => {
 					);
 				}
 				default: {
-					return article.theme === ArticleSpecial.Labs ? (
+					return article.theme === ArticleSpecial.Labs &&
+						article.design === ArticleDesign.Standard ? (
 						<StandardLayout
 							article={article.frontendData}
 							format={format}


### PR DESCRIPTION
## What does this change?

We want to limit the news labs immersive layout to standard article design only