### PR TITLE
`Versus` change number alignment

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/Versus.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/Versus.tsx
@@ -7,6 +7,7 @@ import {
 	headlineMedium20Object,
 	headlineMedium24Object,
 	headlineMedium34Object,
+	space,
 	textSans12Object,
 } from '@guardian/source/foundations';
 import { generateImageURL } from '../../lib/image';
@@ -166,24 +167,19 @@ const GroupComponent = (props: {
 					: textColour(props.faded)
 			}
 		/>
-		<Value
-			value={props.group.value}
-			colour={
-				props.colour === 'value'
-					? props.group.colour
-					: textColour(props.faded)
-			}
+		<ValueWithChange
+			align={props.align}
+			colour={props.colour}
 			faded={props.faded}
+			group={props.group}
 		/>
-		{'change' in props.group ? (
-			<Change change={props.group.change} />
-		) : (
+		{'description' in props.group ? (
 			<Description
 				description={props.group.description}
 				align={props.align}
 				faded={props.faded}
 			/>
-		)}
+		) : null}
 	</p>
 );
 
@@ -229,6 +225,53 @@ const Name = ({
 		</span>
 	</span>
 );
+
+const ValueWithChange = (props: {
+	align: 'left' | 'right';
+	colour: Props['colour'];
+	faded: Props['faded'];
+	group: Group;
+}) => {
+	const value = (
+		<Value
+			value={props.group.value}
+			colour={
+				props.colour === 'value'
+					? props.group.colour
+					: textColour(props.faded)
+			}
+			faded={props.faded}
+		/>
+	);
+
+	const change =
+		'change' in props.group ? <Change change={props.group.change} /> : null;
+
+	if (props.group.image !== undefined) {
+		return (
+			<>
+				{value}
+				{change}
+			</>
+		);
+	}
+
+	return (
+		<span
+			css={{
+				display: 'flex',
+				alignItems: 'end',
+				gap: space[1],
+			}}
+			style={{
+				flexDirection: props.align === 'right' ? 'row-reverse' : 'row',
+			}}
+		>
+			{value}
+			{change}
+		</span>
+	);
+};
 
 const Value = (props: {
 	value: Group['value'];


### PR DESCRIPTION
At the moment, in the `Versus` component, if there is a change number it always appears below the main value number. This alters that behaviour, so that this is now only the case when there are images in the `Versus` component. If there aren't images, the change number moves alongside the value number, as there's more horizontal space available.

## Screenshots

| | Before | After |
|--------|--------|--------|
| US House | <img width="1206" height="342" alt="house-before" src="https://github.com/user-attachments/assets/f3dc0980-c02f-469f-82dd-9c31283e2eee" /> | <img width="1206" height="255" alt="house-after" src="https://github.com/user-attachments/assets/35bf3aa6-4c0e-4d99-85e4-ecd0b3560fbe" /> |
| Parliament | <img width="1206" height="342" alt="parliament-before" src="https://github.com/user-attachments/assets/73cf2ced-77da-4c8f-a876-3f6b6f82a859" /> | <img width="1206" height="342" alt="parliament-after" src="https://github.com/user-attachments/assets/6f7bfbc7-2a80-49e4-85f5-a6bf4bd6f87f" /> | 
