### PR TITLE
Fix cricket overs font and colour

### DIFF
--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -43,6 +43,7 @@ import {
 	border,
 	primaryText,
 	scoreSecondaryText,
+	secondaryText,
 } from '../FootballMatchHeader/colours';
 import { Tabs } from '../FootballMatchHeader/Tabs';
 import { MatchHeaderFallback } from '../MatchHeaderFallback';
@@ -251,7 +252,7 @@ const StatusLine = (props: { match: CricketMatch; edition: EditionId }) => (
 			},
 		}}
 		style={{
-			color: palette(scoreSecondaryText(props.match.kind)),
+			color: palette(secondaryText(props.match.kind)),
 		}}
 	>
 		<SeriesName matchKind={props.match.kind}>

--- a/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
+++ b/dotcom-rendering/src/components/CricketMatchHeader/CricketMatchHeader.tsx
@@ -5,9 +5,9 @@ import {
 	headlineBold20Object,
 	headlineBold24Object,
 	space,
-	textSans12Object,
 	textSans14Object,
 	textSans15Object,
+	textSansBold12Object,
 	textSansBold14Object,
 	textSansBold17Object,
 	textSansItalic14Object,
@@ -42,7 +42,7 @@ import {
 	background,
 	border,
 	primaryText,
-	secondaryText,
+	scoreSecondaryText,
 } from '../FootballMatchHeader/colours';
 import { Tabs } from '../FootballMatchHeader/Tabs';
 import { MatchHeaderFallback } from '../MatchHeaderFallback';
@@ -251,7 +251,7 @@ const StatusLine = (props: { match: CricketMatch; edition: EditionId }) => (
 			},
 		}}
 		style={{
-			color: palette(secondaryText(props.match.kind)),
+			color: palette(scoreSecondaryText(props.match.kind)),
 		}}
 	>
 		<SeriesName matchKind={props.match.kind}>
@@ -458,14 +458,14 @@ const Team = (props: { team: CricketTeam; match: CricketMatch }) => {
 										/>
 										<span
 											css={{
-												...textSans12Object,
+												...textSansBold12Object,
 												display: 'inline-block',
 												marginTop: space[2],
 												padding: `0 ${space[1]}px 1px ${space[1]}px`,
-												border: '1px solid',
+												border: `1px solid ${palette(border(props.match.kind))}`,
 												borderRadius: 30,
 												color: palette(
-													secondaryText(
+													scoreSecondaryText(
 														props.match.kind,
 													),
 												),


### PR DESCRIPTION
## What does this change?
Followup to #16610, ensure the cricket overs text is aligned with the design.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/0f19e00b-752e-4a00-88c1-d53a8ddf06ab
[after]: https://github.com/user-attachments/assets/17df6700-72e9-4445-9845-4be944a65ad4
