### PR TITLE
Assign new AB tests to MVT ids randomly

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -209,7 +209,6 @@ const ABTests: ABTest[] = [
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},
-
 	{
 		name: "commercial-prebid-failsafe-timeout",
 		description:
@@ -222,6 +221,30 @@ const ABTests: ABTest[] = [
 		audienceSpace: "B",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
+	},
+	{
+		name: "webx-test-test",
+		description: "Test for webx test",
+		owners: ["dotcom.platform@theguardian.com"],
+		status: "ON",
+		expirationDate: "2026-08-31",
+		type: "client",
+		audienceSize: 10 / 100,
+		audienceSpace: "D",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
+	},
+	{
+		name: "webx-test-test-2",
+		description: "Test for webx test",
+		owners: ["dotcom.platform@theguardian.com"],
+		status: "ON",
+		expirationDate: "2026-08-31",
+		type: "client",
+		audienceSize: 50 / 100,
+		audienceSpace: "E",
+		groups: ["control", "variant"],
+		shouldForceMetricsCollection: false,
 	},
 ];
 

--- a/ab-testing/config/lib/types.ts
+++ b/ab-testing/config/lib/types.ts
@@ -1,6 +1,6 @@
 type FastlyTestParams = { name: string; type: string; exp: number };
 type AudienceSpace = Map<string, FastlyTestParams>;
 
-type AllSpace = Map<string, FastlyTestParams[]>;
+type AllSpaces = Map<string, FastlyTestParams[]>;
 
-export type { FastlyTestParams, AudienceSpace, AllSpace };
+export type { FastlyTestParams, AudienceSpace, AllSpaces as AllSpace };

--- a/ab-testing/config/scripts/build/calculate-mvt-updates.ts
+++ b/ab-testing/config/scripts/build/calculate-mvt-updates.ts
@@ -104,7 +104,7 @@ const calculateAllSpaceUpdates = (
 	mvtGroups: AllSpace,
 	tests: ABTest[],
 ): AllSpace => {
-	const updatedTestSpace: AudienceSpace[] = AudienceSpaces.map((space, i) => {
+	const updatedTestSpaces: AudienceSpace[] = AudienceSpaces.map((space) => {
 		console.log(`Calculating updates for space: ${space}`);
 		const spaceTests = tests.filter(
 			(test) => (test.audienceSpace ?? "A") === space, // 'A' is the default space
@@ -116,15 +116,24 @@ const calculateAllSpaceUpdates = (
 		}
 
 		const spaceMVTGroups = new Map(
-			mvtGroups
-				.entries()
-				.map(([key, value]) => [key, value[i] as FastlyTestParams]),
+			Array.from(mvtGroups.entries())
+				.map(([mvtId, tests]) => [
+					mvtId,
+					spaceTests.find((test) =>
+						tests.find(
+							(t) => t.name === test.name && t.type === test.type,
+						),
+					),
+				])
+				.filter(([, test]) => test !== undefined) as Array<
+				[string, FastlyTestParams]
+			>,
 		);
 
 		return calculateSpaceUpdates(spaceMVTGroups, spaceTests);
 	});
 
-	return updatedTestSpace.reduce((acc, curr) => {
+	return updatedTestSpaces.reduce((acc, curr) => {
 		curr.forEach((value, key) => {
 			if (!acc.has(key)) {
 				acc.set(key, []);

--- a/ab-testing/config/scripts/build/test-group-mvt-manager.ts
+++ b/ab-testing/config/scripts/build/test-group-mvt-manager.ts
@@ -47,7 +47,10 @@ class TestGroupMVTManager {
 			Array.from(this.testGroups.values()).flat(),
 		);
 
-		// collect all available MVTs that are not currently occupied in a random order
+		/**
+		 * collect all available MVTs that are not currently occupied in a random order
+		 * so that new test mvts are assigned randomly.
+		 */
 		this.availableMVTs = Array.from({ length: MVT_COUNT }, (_, i) => i)
 			.filter((i) => !this.occupiedMVTs.has(i))
 			.sort(() => Math.random() - 0.5);

--- a/ab-testing/config/scripts/build/test-group-mvt-manager.ts
+++ b/ab-testing/config/scripts/build/test-group-mvt-manager.ts
@@ -47,9 +47,10 @@ class TestGroupMVTManager {
 			Array.from(this.testGroups.values()).flat(),
 		);
 
+		// collect all available MVTs that are not currently occupied in a random order
 		this.availableMVTs = Array.from({ length: MVT_COUNT }, (_, i) => i)
 			.filter((i) => !this.occupiedMVTs.has(i))
-			.sort((a, b) => a - b);
+			.sort(() => Math.random() - 0.5);
 
 		console.log(
 			`Initialized TestGroupMVTs with ${this.availableMVTs.length} available MVTs`,
@@ -109,11 +110,14 @@ class TestGroupMVTManager {
 				throw new Error(`Not enough available MVTs for test ${name}`);
 			}
 			for (let i = 0; i < additionalMVTsNeeded; i++) {
-				const mvtIndex = this.availableMVTs.shift();
-				if (mvtIndex !== undefined) {
-					currentMVTs.push(mvtIndex);
-					this.occupiedMVTs.add(mvtIndex);
+				const mvtId = this.availableMVTs.shift();
+				if (mvtId === undefined) {
+					throw new Error(
+						`No available MVTs left to expand test ${name}`,
+					);
 				}
+				currentMVTs.push(mvtId);
+				this.occupiedMVTs.add(mvtId);
 			}
 		} else if (newSize < currentSize) {
 			const removedMVTs = currentMVTs.slice(newSize);
@@ -122,8 +126,6 @@ class TestGroupMVTManager {
 				this.availableMVTs.push(mvt);
 			});
 			currentMVTs.length = newSize;
-			// Keep available MVTs sorted in ascending order
-			this.availableMVTs.sort((a, b) => a - b);
 		}
 		this.testGroups.set(name, currentMVTs);
 	}
@@ -140,8 +142,6 @@ class TestGroupMVTManager {
 				this.availableMVTs.push(mvt);
 			});
 			this.testGroups.delete(name);
-			// Keep available MVTs sorted in ascending order
-			this.availableMVTs.sort((a, b) => a - b);
 		}
 	}
 }


### PR DESCRIPTION
## What does this change?

## Why?

## How has this change been tested?

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
