### PR TITLE
Roll variant headlines out to 25% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 5 / 95,
+		audienceSize: 25 / 100,
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -196,8 +196,8 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
-		name: "fronts-and-curation-editorial-headline-test",
-		description: "Allow editorial headline A/B tests to run on web",
+		name: "fronts-and-curation-editorial-test",
+		description: "Allow editorial A/B tests to run on web",
 		owners: [
 			"fronts.and.curation@guardian.co.uk",
 			"ab.test.mission@guardian.co.uk",

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -206,6 +206,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2036-08-12",
 		type: "server",
 		audienceSize: 25 / 100,
+		audienceSpace: "E",
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 0 / 100,
+		audienceSize: 5 / 95,
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -678,7 +678,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithNoEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -691,7 +691,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'invalid-test-front',
@@ -704,7 +704,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					false,
 					'test-front',
@@ -717,7 +717,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -730,7 +730,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'b',
+						'fronts-and-curation-editorial-test': 'b',
 					},
 					true,
 					'test-front',
@@ -743,7 +743,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'c',
+						'fronts-and-curation-editorial-test': 'c',
 					},
 					true,
 					'test-front',
@@ -756,7 +756,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTestWithUndefinedVariantMeta,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -769,7 +769,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithExpiredEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -782,7 +782,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithManuallyEndedEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -216,8 +216,7 @@ export const decideHeadline = (
 ): string => {
 	const defaultHeadline = faciaCard.header.headline;
 
-	const testBucket =
-		serverSideABTests['fronts-and-curation-editorial-headline-test'];
+	const testBucket = serverSideABTests['fronts-and-curation-editorial-test'];
 
 	const activeEditorialTest = findActiveEditorialTest(
 		faciaCard.properties.tests,


### PR DESCRIPTION
Begin rolling out variant headlines rendered through the platform test `fronts-and-curation-editorial-test` (renamed from `fronts-and-curation-editorial-headline-test` to future-proof for when we test articles using same test): https://github.com/guardian/dotcom-rendering/pull/16554.

The end goal is a 100% 50/50 test, we are reaching this threshold in stages to avoid overloading the cache.