### PR TITLE
Roll variant B headlines out to 25% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 5 / 95,
+		audienceSize: 25 / 75,
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},


### PR DESCRIPTION
Continue rolling out variant headlines rendered through the platform test `fronts-and-curation-editorial-headline-test`: https://github.com/guardian/dotcom-rendering/pull/16554.

The end goal is a 50/50 test, we are reaching this threshold in stages to avoid overloading the cache.