### PR TITLE
Update valibot to 0.31.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -160,7 +160,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.29.0",
+		"valibot": "0.30.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -160,7 +160,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.28.1",
+		"valibot": "0.29.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -160,7 +160,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.30.0",
+		"valibot": "0.31.1",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/src/components/InteractiveAtomMessenger.island.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtomMessenger.island.tsx
@@ -1,13 +1,13 @@
 import { log } from '@guardian/libs';
 import { useCallback, useEffect, useState } from 'react';
-import type { Output } from 'valibot';
+import type { InferOutput } from 'valibot';
 import { literal, number, object, safeParse, variant } from 'valibot';
 
 type Props = {
 	id: string;
 };
 
-type InteractiveMessage = Output<typeof interactiveMessageSchema>;
+type InteractiveMessage = InferOutput<typeof interactiveMessageSchema>;
 const interactiveMessageSchema = variant('kind', [
 	object({
 		kind: literal('interactive:scroll'),

--- a/dotcom-rendering/src/cricketMatch.ts
+++ b/dotcom-rendering/src/cricketMatch.ts
@@ -1,5 +1,5 @@
 import { isUndefined } from '@guardian/libs';
-import type { Output } from 'valibot';
+import type { InferOutput } from 'valibot';
 import { is, picklist } from 'valibot';
 import type {
 	FECricketMatch,
@@ -80,7 +80,7 @@ const winnerTypesSchema = picklist([
 	'forfeit',
 	'run-rate',
 ] as const);
-type WinnerType = Output<typeof winnerTypesSchema>;
+type WinnerType = InferOutput<typeof winnerTypesSchema>;
 
 const parseWinnerType = (type: string): Result<ParserError, WinnerType> => {
 	if (is(winnerTypesSchema, type)) {

--- a/dotcom-rendering/src/frontend/feCricketMatchData.ts
+++ b/dotcom-rendering/src/frontend/feCricketMatchData.ts
@@ -1,4 +1,4 @@
-import type { Output } from 'valibot';
+import type { InferOutput } from 'valibot';
 import { array, boolean, number, object, optional, string } from 'valibot';
 
 const feCricketTeamSchema = object({
@@ -9,7 +9,7 @@ const feCricketTeamSchema = object({
 	teamTagId: optional(string()),
 });
 
-export type FECricketTeam = Output<typeof feCricketTeamSchema>;
+export type FECricketTeam = InferOutput<typeof feCricketTeamSchema>;
 
 const feCricketBatterSchema = object({
 	name: string(),
@@ -60,7 +60,7 @@ const feCricketInningsSchema = object({
 	extras: number(),
 });
 
-export type FECricketInnings = Output<typeof feCricketInningsSchema>;
+export type FECricketInnings = InferOutput<typeof feCricketInningsSchema>;
 
 const matchWinnerStatusSchema = object({
 	winType: string(),
@@ -68,7 +68,7 @@ const matchWinnerStatusSchema = object({
 	team: string(),
 });
 
-export type FECricketMatchResultWinnerStatus = Output<
+export type FECricketMatchResultWinnerStatus = InferOutput<
 	typeof matchWinnerStatusSchema
 >;
 
@@ -78,7 +78,7 @@ const matchResultSchema = object({
 	winner: optional(matchWinnerStatusSchema),
 });
 
-export type FECricketMatchResult = Output<typeof matchResultSchema>;
+export type FECricketMatchResult = InferOutput<typeof matchResultSchema>;
 
 export const feCricketMatchSchema = object({
 	teams: array(feCricketTeamSchema),
@@ -95,7 +95,7 @@ export const feCricketMatchSchema = object({
 	fullResult: optional(matchResultSchema),
 });
 
-export type FECricketMatch = Output<typeof feCricketMatchSchema>;
+export type FECricketMatch = InferOutput<typeof feCricketMatchSchema>;
 
 export const feCricketMatchStatsSummarySchema = object({
 	status: string(),
@@ -103,6 +103,6 @@ export const feCricketMatchStatsSummarySchema = object({
 	notOutBatters: optional(array(feCricketBatterSchema)),
 });
 
-export type FECricketMatchStatsSummary = Output<
+export type FECricketMatchStatsSummary = InferOutput<
 	typeof feCricketMatchStatsSummarySchema
 >;

--- a/dotcom-rendering/src/frontend/feCricketMatchHeader.ts
+++ b/dotcom-rendering/src/frontend/feCricketMatchHeader.ts
@@ -1,4 +1,4 @@
-import { object, optional, type Output, string } from 'valibot';
+import { type InferOutput, object, optional, string } from 'valibot';
 import { feCricketMatchSchema } from './feCricketMatchData';
 
 export const feCricketMatchHeaderSchema = object({
@@ -7,4 +7,6 @@ export const feCricketMatchHeaderSchema = object({
 	reportURL: optional(string()),
 });
 
-export type FECricketMatchHeader = Output<typeof feCricketMatchHeaderSchema>;
+export type FECricketMatchHeader = InferOutput<
+	typeof feCricketMatchHeaderSchema
+>;

--- a/dotcom-rendering/src/frontend/feFootballMatchDay.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchDay.ts
@@ -1,9 +1,9 @@
 import {
 	array,
+	type InferOutput,
 	literal,
 	number,
 	object,
-	type Output,
 	string,
 	union,
 } from 'valibot';
@@ -42,4 +42,4 @@ export const feFootballMatchDaySchema = object({
 	guardianBaseURL: string(),
 });
 
-export type FEFootballMatchDay = Output<typeof feFootballMatchDaySchema>;
+export type FEFootballMatchDay = InferOutput<typeof feFootballMatchDaySchema>;

--- a/dotcom-rendering/src/frontend/feFootballMatchHeader.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchHeader.ts
@@ -1,4 +1,4 @@
-import { object, optional, type Output, string } from 'valibot';
+import { type InferOutput, object, optional, string } from 'valibot';
 import { feFootballMatchSchema } from './feFootballMatchListPage';
 
 export const feFootballMatchHeaderSchema = object({
@@ -9,4 +9,6 @@ export const feFootballMatchHeaderSchema = object({
 	infoURL: string(),
 });
 
-export type FEFootballMatchHeader = Output<typeof feFootballMatchHeaderSchema>;
+export type FEFootballMatchHeader = InferOutput<
+	typeof feFootballMatchHeaderSchema
+>;

--- a/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchInfoPage.ts
@@ -1,10 +1,10 @@
 import {
 	array,
 	boolean,
+	type InferOutput,
 	number,
 	object,
 	optional,
-	type Output,
 	string,
 } from 'valibot';
 import type { FEFootballDataPage } from './feFootballDataPage';
@@ -23,9 +23,11 @@ const feFootballPlayerEventEnhancedSchema = object({
 	addedTime: string(),
 });
 
-export type FEFootballPlayerEvent = Output<typeof feFootballPlayerEventSchema>;
+export type FEFootballPlayerEvent = InferOutput<
+	typeof feFootballPlayerEventSchema
+>;
 
-export type FEFootballPlayerEventEnhanced = Output<
+export type FEFootballPlayerEventEnhanced = InferOutput<
 	typeof feFootballPlayerEventEnhancedSchema
 >;
 
@@ -41,7 +43,7 @@ const feFootballPlayerSchema = object({
 	enhancedEvents: array(feFootballPlayerEventEnhancedSchema),
 });
 
-export type FEFootballPlayer = Output<typeof feFootballPlayerSchema>;
+export type FEFootballPlayer = InferOutput<typeof feFootballPlayerSchema>;
 
 const feFootballTeamSchema = object({
 	id: string(),
@@ -59,7 +61,7 @@ const feFootballTeamSchema = object({
 	crest: string(),
 });
 
-export type FEFootballTeam = Output<typeof feFootballTeamSchema>;
+export type FEFootballTeam = InferOutput<typeof feFootballTeamSchema>;
 
 export const feFootballMatchStatsSchema = object({
 	id: string(),
@@ -69,7 +71,9 @@ export const feFootballMatchStatsSchema = object({
 	comments: optional(string()),
 });
 
-export type FEFootballMatchStats = Output<typeof feFootballMatchStatsSchema>;
+export type FEFootballMatchStats = InferOutput<
+	typeof feFootballMatchStatsSchema
+>;
 
 export type FEFootballMatchInfoPage = FEFootballDataPage & {
 	matchStats: FEFootballMatchStats;
@@ -88,7 +92,9 @@ export const feFootballTeamSummarySchema = object({
 	colours: string(),
 });
 
-export type FEFootballTeamSummary = Output<typeof feFootballTeamSummarySchema>;
+export type FEFootballTeamSummary = InferOutput<
+	typeof feFootballTeamSummarySchema
+>;
 
 export const feFootballMatchStatsSummarySchema = object({
 	id: string(),
@@ -98,6 +104,6 @@ export const feFootballMatchStatsSummarySchema = object({
 	infoURL: string(),
 });
 
-export type FEFootballMatchStatsSummary = Output<
+export type FEFootballMatchStatsSummary = InferOutput<
 	typeof feFootballMatchStatsSummarySchema
 >;

--- a/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
+++ b/dotcom-rendering/src/frontend/feFootballMatchListPage.ts
@@ -1,10 +1,10 @@
 import {
 	boolean,
+	type InferOutput,
 	literal,
 	number,
 	object,
 	optional,
-	type Output,
 	string,
 	variant,
 } from 'valibot';
@@ -103,12 +103,12 @@ export const feFootballMatchSchema = variant('type', [
 	liveSchema,
 ]);
 
-export type FELive = Output<typeof liveSchema>;
-export type FEFixture = Output<typeof fixtureSchema>;
-export type FEMatchDay = Output<typeof matchDaySchema>;
-export type FEResult = Output<typeof resultSchema>;
-export type FEFootballMatch = Output<typeof feFootballMatchSchema>;
-export type FEMatchDayTeam = Output<typeof matchDayTeamSchema>;
+export type FELive = InferOutput<typeof liveSchema>;
+export type FEFixture = InferOutput<typeof fixtureSchema>;
+export type FEMatchDay = InferOutput<typeof matchDaySchema>;
+export type FEResult = InferOutput<typeof resultSchema>;
+export type FEFootballMatch = InferOutput<typeof feFootballMatchSchema>;
+export type FEMatchDayTeam = InferOutput<typeof matchDayTeamSchema>;
 
 export type FECompetitionMatch = {
 	competitionSummary: FECompetitionSummary;

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
@@ -46,13 +46,10 @@
             "type": "object",
             "properties": {
                 "matchStats": {
-                    "$ref": "#/definitions/{id:string;homeTeam:{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}"
+                    "$ref": "#/definitions/{id:string;homeTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}"
                 },
                 "matchInfo": {
                     "anyOf": [
-                        {
-                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
-                        },
                         {
                             "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
                         },
@@ -61,6 +58,9 @@
                         },
                         {
                             "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                        },
+                        {
+                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
                         }
                     ]
                 },
@@ -939,17 +939,17 @@
                 "url"
             ]
         },
-        "{id:string;homeTeam:{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}": {
+        "{id:string;homeTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}": {
             "type": "object",
             "properties": {
                 "id": {
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
+                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
+                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
                 },
                 "status": {
                     "type": "string"
@@ -965,7 +965,7 @@
                 "status"
             ]
         },
-        "{name:string;id:string;scorers:string[];codename:string;players:{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}": {
+        "{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}": {
             "type": "object",
             "properties": {
                 "name": {
@@ -980,14 +980,14 @@
                         "type": "string"
                     }
                 },
-                "codename": {
-                    "type": "string"
-                },
                 "players": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}"
+                        "$ref": "#/definitions/{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}"
                     }
+                },
+                "codename": {
+                    "type": "string"
                 },
                 "possession": {
                     "type": "number"
@@ -1029,7 +1029,7 @@
                 "shotsOn"
             ]
         },
-        "{name:string;id:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];}": {
+        "{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}": {
             "type": "object",
             "properties": {
                 "name": {
@@ -1037,6 +1037,18 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{eventTime:string;eventType:string;}"
+                    }
+                },
+                "enhancedEvents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{eventType:string;eventId:string;normalTime:string;addedTime:string;}"
+                    }
                 },
                 "position": {
                     "type": "string"
@@ -1052,18 +1064,6 @@
                 },
                 "shirtNumber": {
                     "type": "string"
-                },
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/{eventTime:string;eventType:string;}"
-                    }
-                },
-                "enhancedEvents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/{eventType:string;eventId:string;normalTime:string;addedTime:string;}"
-                    }
                 }
             },
             "required": [
@@ -1116,7 +1116,7 @@
                 "normalTime"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
             "type": "object",
             "properties": {
                 "stage": {
@@ -1127,7 +1127,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "const": "LiveMatch"
+                    "const": "Fixture"
                 },
                 "date": {
                     "type": "string"
@@ -1144,19 +1144,13 @@
                 "awayTeam": {
                     "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
-                "status": {
-                    "type": "string"
-                },
                 "venue": {
                     "$ref": "#/definitions/{name:string;id:string;}"
                 },
                 "comments": {
                     "type": "string"
                 },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
+                "competition": {
                     "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
@@ -1168,7 +1162,6 @@
                 "leg",
                 "round",
                 "stage",
-                "status",
                 "type"
             ]
         },
@@ -1257,70 +1250,6 @@
                 "name"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
-            "type": "object",
-            "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "const": "Fixture"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "round": {
-                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
-                },
-                "leg": {
-                    "type": "string"
-                },
-                "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
-                },
-                "comments": {
-                    "type": "string"
-                },
-                "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
-                }
-            },
-            "required": [
-                "awayTeam",
-                "date",
-                "homeTeam",
-                "id",
-                "leg",
-                "round",
-                "stage",
-                "type"
-            ]
-        },
-        "{name:string;id:string;}_2": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "name"
-            ]
-        },
         "{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
             "type": "object",
             "properties": {
@@ -1377,10 +1306,10 @@
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 },
                 "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
             "required": [
@@ -1398,6 +1327,21 @@
                 "round",
                 "stage",
                 "type"
+            ]
+        },
+        "{name:string;id:string;}_2": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
         "{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
@@ -1441,7 +1385,7 @@
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [
@@ -1453,6 +1397,62 @@
                 "reportAvailable",
                 "round",
                 "stage",
+                "type"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "LiveMatch"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "status",
                 "type"
             ]
         }

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
@@ -96,9 +96,6 @@
                                             "items": {
                                                 "anyOf": [
                                                     {
-                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
-                                                    },
-                                                    {
                                                         "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
                                                     },
                                                     {
@@ -106,6 +103,9 @@
                                                     },
                                                     {
                                                         "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                                                    },
+                                                    {
+                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
                                                     }
                                                 ]
                                             }
@@ -824,7 +824,7 @@
         "Record<string,FEFootballCompetition[]>": {
             "type": "object"
         },
-        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
             "type": "object",
             "properties": {
                 "stage": {
@@ -835,7 +835,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "const": "LiveMatch"
+                    "const": "Fixture"
                 },
                 "date": {
                     "type": "string"
@@ -852,19 +852,13 @@
                 "awayTeam": {
                     "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
-                "status": {
-                    "type": "string"
-                },
                 "venue": {
                     "$ref": "#/definitions/{name:string;id:string;}"
                 },
                 "comments": {
                     "type": "string"
                 },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
+                "competition": {
                     "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
@@ -876,7 +870,6 @@
                 "leg",
                 "round",
                 "stage",
-                "status",
                 "type"
             ]
         },
@@ -965,70 +958,6 @@
                 "name"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
-            "type": "object",
-            "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "const": "Fixture"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "round": {
-                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
-                },
-                "leg": {
-                    "type": "string"
-                },
-                "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
-                },
-                "comments": {
-                    "type": "string"
-                },
-                "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
-                }
-            },
-            "required": [
-                "awayTeam",
-                "date",
-                "homeTeam",
-                "id",
-                "leg",
-                "round",
-                "stage",
-                "type"
-            ]
-        },
-        "{name:string;id:string;}_2": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "name"
-            ]
-        },
         "{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
             "type": "object",
             "properties": {
@@ -1085,10 +1014,10 @@
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 },
                 "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
             "required": [
@@ -1106,6 +1035,21 @@
                 "round",
                 "stage",
                 "type"
+            ]
+        },
+        "{name:string;id:string;}_2": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
         "{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
@@ -1149,7 +1093,7 @@
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [
@@ -1161,6 +1105,62 @@
                 "reportAvailable",
                 "round",
                 "stage",
+                "type"
+            ]
+        },
+        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+            "type": "object",
+            "properties": {
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "const": "LiveMatch"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{name:string;id:string;}"
+                },
+                "comments": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                }
+            },
+            "required": [
+                "awayTeam",
+                "date",
+                "homeTeam",
+                "id",
+                "leg",
+                "round",
+                "stage",
+                "status",
                 "type"
             ]
         }

--- a/dotcom-rendering/src/lib/discussion.ts
+++ b/dotcom-rendering/src/lib/discussion.ts
@@ -1,15 +1,15 @@
 import { isOneOf } from '@guardian/libs';
-import type { BaseSchema, Input, Output } from 'valibot';
+import type { GenericSchema, InferInput, InferOutput } from 'valibot';
 import {
 	array,
 	boolean,
 	literal,
-	merge,
 	minLength,
 	number,
 	object,
 	optional,
 	picklist,
+	pipe,
 	safeParse,
 	string,
 	transform,
@@ -36,7 +36,7 @@ export type CAPIPillar =
 	| 'lifestyle'
 	| 'labs';
 
-const userProfile: BaseSchema<UserProfile> = object({
+const userProfile: GenericSchema<UserProfile> = object({
 	userId: string(),
 	displayName: string(),
 	webUrl: string(),
@@ -86,7 +86,10 @@ export const parseUserProfile = (
 };
 
 const baseCommentSchema = object({
-	id: transform(union([number(), string()]), (id) => id.toString()),
+	id: pipe(
+		union([number(), string()]),
+		transform((id) => id.toString()),
+	),
 	body: string(),
 	date: string(),
 	isoDateTime: string(),
@@ -118,32 +121,28 @@ const baseCommentSchema = object({
 	),
 });
 
-export type ReplyType = Output<typeof replySchema>;
+export type ReplyType = InferOutput<typeof replySchema>;
 
-const replySchema = merge([
-	baseCommentSchema,
-	object({
-		responses: optional(undefined_(), undefined),
-		responseTo: object({
-			displayName: string(),
-			commentApiUrl: string(),
-			isoDateTime: string(),
-			date: string(),
-			commentId: string(),
-			commentWebUrl: string(),
-		}),
+const replySchema = object({
+	...baseCommentSchema.entries,
+	responses: optional(undefined_(), undefined),
+	responseTo: object({
+		displayName: string(),
+		commentApiUrl: string(),
+		isoDateTime: string(),
+		date: string(),
+		commentId: string(),
+		commentWebUrl: string(),
 	}),
-]);
+});
 
-export type CommentType = Output<typeof commentSchema>;
+export type CommentType = InferOutput<typeof commentSchema>;
 
-const commentSchema = merge([
-	baseCommentSchema,
-	object({
-		responses: optional(array(replySchema), []),
-		responseTo: optional(undefined_(), undefined),
-	}),
-]);
+const commentSchema = object({
+	...baseCommentSchema.entries,
+	responses: optional(array(replySchema), []),
+	responseTo: optional(undefined_(), undefined),
+});
 
 const commentRepliesResponseSchema = variant('status', [
 	object({
@@ -267,12 +266,7 @@ export const parseAbuseResponse = (data: unknown): Result<string, true> => {
 export const postUsernameResponseSchema = variant('status', [
 	object({
 		status: literal('error'),
-		errors: array(
-			object({
-				message: string(),
-			}),
-			[minLength(1)],
-		),
+		errors: pipe(array(object({ message: string() })), minLength(1)),
 	}),
 	object({
 		status: literal('ok'),
@@ -324,7 +318,9 @@ const discussionApiErrorSchema = object({
 	errorCode: optional(string()),
 });
 
-export type GetDiscussionSuccess = Output<typeof discussionApiSuccessSchema>;
+export type GetDiscussionSuccess = InferOutput<
+	typeof discussionApiSuccessSchema
+>;
 
 const discussionApiSuccessSchema = object({
 	status: literal('ok'),
@@ -351,7 +347,9 @@ export const discussionApiResponseSchema = variant('status', [
 	discussionApiSuccessSchema,
 ]);
 
-export type GetDiscussionResponse = Input<typeof discussionApiResponseSchema>;
+export type GetDiscussionResponse = InferInput<
+	typeof discussionApiResponseSchema
+>;
 
 export interface DiscussionOptions {
 	orderBy: string;

--- a/dotcom-rendering/src/lib/result.test.ts
+++ b/dotcom-rendering/src/lib/result.test.ts
@@ -180,7 +180,6 @@ describe('fromValibot', () => {
 		const result = fromValibot(valibotResult);
 		const err = result.getErrorOrThrow('Expected an Err');
 
-		expect(err[0].reason).toBe('type');
-		expect(err[0].context).toBe('literal');
+		expect(err[0]!.expected).toBe('"string literal"');
 	});
 });

--- a/dotcom-rendering/src/lib/result.ts
+++ b/dotcom-rendering/src/lib/result.ts
@@ -1,9 +1,9 @@
 import type {
-	BaseSchema,
-	BaseSchemaAsync,
-	Output,
+	GenericSchema,
+	GenericSchemaAsync,
+	InferIssue,
+	InferOutput,
 	SafeParseResult,
-	SchemaIssues,
 } from 'valibot';
 
 /**
@@ -183,9 +183,9 @@ const error = <E, A>(err: E): Result<E, A> => new Err(err);
  * const valibotResult = safeParse(schema, input);
  * const result = fromValibot(valibotResult);
  */
-export const fromValibot = <Schema extends BaseSchema | BaseSchemaAsync>(
+export const fromValibot = <Schema extends GenericSchema | GenericSchemaAsync>(
 	result: SafeParseResult<Schema>,
-): Result<SchemaIssues, Output<Schema>> =>
+): Result<InferIssue<Schema>[], InferOutput<Schema>> =>
 	result.success ? ok(result.output) : error(result.issues);
 
 export { Result, ok, error };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.30.0
-        version: 0.30.0
+        specifier: 0.31.1
+        version: 0.31.1
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9570,8 +9570,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.30.0:
-    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
+  valibot@0.31.1:
+    resolution: {integrity: sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20425,7 +20425,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.30.0: {}
+  valibot@0.31.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.29.0
-        version: 0.29.0
+        specifier: 0.30.0
+        version: 0.30.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9570,8 +9570,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.29.0:
-    resolution: {integrity: sha512-JhZn08lwZPhAamOCfBwBkv/btQt4KeQhekULPH8crH053zUCLSOGEF2zKExu3bFf245tsj6J1dY0ysd/jUiMIQ==}
+  valibot@0.30.0:
+    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20425,7 +20425,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.29.0: {}
+  valibot@0.30.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.28.1
-        version: 0.28.1
+        specifier: 0.29.0
+        version: 0.29.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9570,8 +9570,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.28.1:
-    resolution: {integrity: sha512-zQnjwNJuXk6362Leu0+4eFa/SMwRom3/hEvH6s1EGf3oXIPbo2WFKDra9ymnbVh3clLRvd8hw4sKF5ruI2Lyvw==}
+  valibot@0.29.0:
+    resolution: {integrity: sha512-JhZn08lwZPhAamOCfBwBkv/btQt4KeQhekULPH8crH053zUCLSOGEF2zKExu3bFf245tsj6J1dY0ysd/jUiMIQ==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20425,7 +20425,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.28.1: {}
+  valibot@0.29.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
We're using a more recent version of valibot for the events service, and we're likely to want to share types and schemas, so it would be helpful to bring the version of valibot in DCAR up to date. This is the first part of that upgrade, bringing us to v0.31.1, as several breaking changes were made in 0.31.0[^1].

**Note:** Some of the types in the JSON schema files are inferred by valibot, and the upgrade has changed the order of some of the object fields, so the schemas have been re-generated.

[^1]: https://valibot.dev/blog/valibot-v0.31.0-is-finally-available/

## Versions

This branch contains one commit per major version change.

### 0.29.0

https://github.com/open-circle/valibot/releases/tag/v0.29.0

The only change to an API we use is `transform`, and the specific change should not affect our one usage.

### 0.30.0

https://github.com/open-circle/valibot/releases/tag/v0.30.0

### 0.31.1

https://github.com/open-circle/valibot/releases/tag/v0.31.0
https://github.com/open-circle/valibot/releases/tag/v0.31.1
https://valibot.dev/guides/migrate-to-v0.31.0/

The updates that affect us, and therefore result in changes:

- Renamed `Output` to `InferOutput`
- Renamed `Input` to `InferInput`
- Renamed `BaseSchema` to `GenericSchema`
- Renamed `BaseSchemaAsync` to `GenericSchemaAsync`
- Issue types are now more specific, e.g. `LiteralIssue`
- `transform` is now an action to be used with the `pipe` method
- `merge` has been replaced by spreading with an object schema's `.entries` method
- Schemas no longer take validation actions as arguments, the schema and actions are now passed to `pipe`
