### PR TITLE
Update valibot to 0.37.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.33.3",
+		"valibot": "0.34.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.32.0",
+		"valibot": "0.33.3",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.31.1",
+		"valibot": "0.32.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.35.0",
+		"valibot": "0.36.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.36.0",
+		"valibot": "0.37.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.34.0",
+		"valibot": "0.35.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.36.0
-        version: 0.36.0
+        specifier: 0.37.0
+        version: 0.37.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,13 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.36.0:
-    resolution: {integrity: sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==}
+  valibot@0.37.0:
+    resolution: {integrity: sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +21002,9 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.36.0: {}
+  valibot@0.37.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.32.0
-        version: 0.32.0
+        specifier: 0.33.3
+        version: 0.33.3
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.32.0:
-    resolution: {integrity: sha512-FXBnJl4bNOmeg7lQv+jfvo/wADsRBN8e9C3r+O77Re3dEnDma8opp7p4hcIbF7XJJ30h/5SVohdjer17/sHOsQ==}
+  valibot@0.33.3:
+    resolution: {integrity: sha512-/fuY1DlX8uiQ7aphlzrrI2DbG0YJk84JMgvz2qKpUIdXRNsS53varfo4voPjSrjUr5BSV2K0miSEJUOlA5fQFg==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +20997,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.32.0: {}
+  valibot@0.33.3: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.35.0
-        version: 0.35.0
+        specifier: 0.36.0
+        version: 0.36.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.35.0:
-    resolution: {integrity: sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==}
+  valibot@0.36.0:
+    resolution: {integrity: sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +20997,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.35.0: {}
+  valibot@0.36.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.33.3
-        version: 0.33.3
+        specifier: 0.34.0
+        version: 0.34.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.33.3:
-    resolution: {integrity: sha512-/fuY1DlX8uiQ7aphlzrrI2DbG0YJk84JMgvz2qKpUIdXRNsS53varfo4voPjSrjUr5BSV2K0miSEJUOlA5fQFg==}
+  valibot@0.34.0:
+    resolution: {integrity: sha512-TELvxO0hEB1/6XjTS5Jfi4dS0oyawA5flxs4/sK/tSUXnlLMiKTMYE6Atuu0a7kvtP3eqPv3yZ80msfM+qMDHA==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +20997,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.33.3: {}
+  valibot@0.34.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.31.1
-        version: 0.31.1
+        specifier: 0.32.0
+        version: 0.32.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.31.1:
-    resolution: {integrity: sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==}
+  valibot@0.32.0:
+    resolution: {integrity: sha512-FXBnJl4bNOmeg7lQv+jfvo/wADsRBN8e9C3r+O77Re3dEnDma8opp7p4hcIbF7XJJ30h/5SVohdjer17/sHOsQ==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +20997,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.31.1: {}
+  valibot@0.32.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.34.0
-        version: 0.34.0
+        specifier: 0.35.0
+        version: 0.35.0
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.34.0:
-    resolution: {integrity: sha512-TELvxO0hEB1/6XjTS5Jfi4dS0oyawA5flxs4/sK/tSUXnlLMiKTMYE6Atuu0a7kvtP3eqPv3yZ80msfM+qMDHA==}
+  valibot@0.35.0:
+    resolution: {integrity: sha512-+i2aCRkReTrd5KBN/dW2BrPOvFnU5LXTV2xjZnjnqUIO8YUx6P2+MgRrkwF2FhkexgyKq/NIZdPdknhHf5A/Ww==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -20997,7 +20997,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.34.0: {}
+  valibot@0.35.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
Continuing the upgrade started in #16630, this updates to 0.37.0. Other than updating the dependency, no other changes are required. Release notes:

- https://github.com/open-circle/valibot/releases/tag/v0.32.0
- https://github.com/open-circle/valibot/releases/tag/v0.33.0
- https://github.com/open-circle/valibot/releases/tag/v0.33.1
- https://github.com/open-circle/valibot/releases/tag/v0.33.2
- https://github.com/open-circle/valibot/releases/tag/v0.33.3
- https://github.com/open-circle/valibot/releases/tag/v0.34.0
- https://github.com/open-circle/valibot/releases/tag/v0.35.0
- https://github.com/open-circle/valibot/releases/tag/v0.36.0
- https://github.com/open-circle/valibot/releases/tag/v0.37.0
