### PR TITLE
Update valibot to 0.38.0

### DIFF
--- a/dotcom-rendering/fixtures/manual/comment.ts
+++ b/dotcom-rendering/fixtures/manual/comment.ts
@@ -27,6 +27,7 @@ export const comment = {
 		isClosedForComments: true,
 		isClosedForRecommendation: true,
 	},
+	responseTo: undefined,
 	responses: [
 		{
 			id: '138809396',
@@ -38,6 +39,7 @@ export const comment = {
 			apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/138809396',
 			numRecommends: 0,
 			isHighlighted: false,
+			responses: undefined,
 			responseTo: {
 				displayName: 'blipvert',
 				commentApiUrl:
@@ -68,6 +70,7 @@ export const comment = {
 			apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/138809487',
 			numRecommends: 30,
 			isHighlighted: false,
+			responses: undefined,
 			responseTo: {
 				displayName: 'blipvert',
 				commentApiUrl:
@@ -98,6 +101,7 @@ export const comment = {
 			apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/138809896',
 			numRecommends: 9,
 			isHighlighted: false,
+			responses: undefined,
 			responseTo: {
 				displayName: 'blipvert',
 				commentApiUrl:
@@ -128,6 +132,7 @@ export const comment = {
 			apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/138810191',
 			numRecommends: 20,
 			isHighlighted: false,
+			responses: undefined,
 			responseTo: {
 				displayName: 'AJVC1991',
 				commentApiUrl:

--- a/dotcom-rendering/fixtures/manual/legacyDiscussionWithoutThreading.ts
+++ b/dotcom-rendering/fixtures/manual/legacyDiscussionWithoutThreading.ts
@@ -28,6 +28,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 13,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2479941',
 					displayName: 'madmonty',
@@ -50,6 +51,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 5,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2870517',
 					displayName: 'GSC82',
@@ -72,6 +74,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 12,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '794075',
 					displayName: 'Alasdairca',
@@ -94,6 +97,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3111076',
 					displayName: 'philstyle',
@@ -116,6 +120,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 9,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '1331497',
 					displayName: 'DoctorDark',
@@ -138,6 +143,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 5,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4279254',
 					displayName: 'bordighera1',
@@ -160,6 +166,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 0,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4530494',
 					displayName: 'jobrian',
@@ -182,6 +189,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 11,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '1954291',
 					displayName: 'drabacus',
@@ -204,6 +212,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 12,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -226,6 +235,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 8,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '1301439',
 					displayName: 'WaitForPete',
@@ -248,6 +258,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3596779',
 					displayName: 'Ecoboy1980',
@@ -270,6 +281,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 4,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4387033',
 					displayName: 'Atomant77',
@@ -292,6 +304,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '1268926',
 					displayName: 'kvms',
@@ -314,6 +327,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 5,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3874929',
 					displayName: 'carnaptious99',
@@ -336,6 +350,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4568262',
 					displayName: 'JimmerInManila',
@@ -358,6 +373,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 5,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2427181',
 					displayName: 'CharlesArthur',
@@ -384,6 +400,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4188282',
 					displayName: 'sparclear',
@@ -406,6 +423,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4573193',
 					displayName: 'PanYanPickle',
@@ -428,6 +446,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -450,6 +469,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4368868',
 					displayName: 'kitenet',
@@ -472,6 +492,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3699054',
 					displayName: 'NeverMindTheBollocks',
@@ -494,6 +515,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4212243',
 					displayName: 'grumpygrowlygirlie',
@@ -516,6 +538,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -538,6 +561,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 6,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4741862',
 					displayName: 'EstherHegt',
@@ -560,6 +584,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 4,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -582,6 +607,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4641408',
 					displayName: 'MrRatfan1976',
@@ -604,6 +630,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 0,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4487660',
 					displayName: 'MrPiggles',
@@ -626,6 +653,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2411079',
 					displayName: 'antipodean1',
@@ -648,6 +676,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 4,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4741862',
 					displayName: 'EstherHegt',
@@ -670,6 +699,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 4,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4323663',
 					displayName: 'thepoisongarden',
@@ -692,6 +722,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4742115',
 					displayName: 'NickAltena',
@@ -714,6 +745,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4741862',
 					displayName: 'EstherHegt',
@@ -736,6 +768,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -758,6 +791,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 0,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4641408',
 					displayName: 'MrRatfan1976',
@@ -780,6 +814,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4311896',
 					displayName: 'SteB1',
@@ -802,6 +837,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4641408',
 					displayName: 'MrRatfan1976',
@@ -824,6 +860,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 3,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4741862',
 					displayName: 'EstherHegt',
@@ -846,6 +883,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4742115',
 					displayName: 'NickAltena',
@@ -868,6 +906,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2411079',
 					displayName: 'antipodean1',
@@ -890,6 +929,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3237256',
 					displayName: 'PizzaRe',
@@ -912,6 +952,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 1,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4323663',
 					displayName: 'thepoisongarden',
@@ -934,6 +975,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 0,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '2456210',
 					displayName: 'paulhs',
@@ -956,6 +998,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 0,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3699054',
 					displayName: 'NeverMindTheBollocks',
@@ -978,6 +1021,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '3938636',
 					displayName: 'lxy001',
@@ -1000,6 +1044,7 @@ export const legacyDiscussionWithoutThreading = {
 				numResponses: 0,
 				numRecommends: 2,
 				isHighlighted: false,
+				responseTo: undefined,
 				userProfile: {
 					userId: '4741862',
 					displayName: 'EstherHegt',

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.37.0",
+		"valibot": "0.38.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/src/components/Discussion.test.tsx
+++ b/dotcom-rendering/src/components/Discussion.test.tsx
@@ -29,6 +29,7 @@ const createComment = (
 	isoDateTime: '2024-01-01T00:00:01Z',
 	numRecommends: 0,
 	status: 'visible',
+	responseTo: undefined,
 });
 
 const createReply = (id: string, body: string): ReplyType => ({
@@ -42,6 +43,7 @@ const createReply = (id: string, body: string): ReplyType => ({
 	isoDateTime: '2024-01-01T00:00:01Z',
 	numRecommends: 0,
 	status: 'visible',
+	responses: undefined,
 	responseTo: {
 		date: '',
 		isoDateTime: '',

--- a/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/Comment.stories.tsx
@@ -31,6 +31,7 @@ const commentData: CommentType = {
 		badge: [],
 	},
 	responses: [],
+	responseTo: undefined,
 	metaData: {
 		commentCount: 2,
 		staffCommenterCount: 1,

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.stories.tsx
@@ -26,6 +26,7 @@ const commentData: CommentType = {
 		badge: [],
 	},
 	responses: [],
+	responseTo: undefined,
 	metaData: {
 		commentCount: 2,
 		staffCommenterCount: 1,
@@ -45,6 +46,7 @@ const threadComment: ReplyType = {
 	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25488498',
 	numRecommends: 0,
 	isHighlighted: false,
+	responses: undefined,
 	responseTo: {
 		displayName: 'FrankDeFord',
 		commentApiUrl:
@@ -80,6 +82,7 @@ const threadCommentWithLongUsernames: ReplyType = {
 	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25488498',
 	numRecommends: 0,
 	isHighlighted: false,
+	responses: undefined,
 	responseTo: {
 		displayName: 'FrankDeFord',
 		commentApiUrl:
@@ -115,6 +118,7 @@ const commentDataWithLongThread: CommentType = {
 	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25487686',
 	numRecommends: 0,
 	isHighlighted: false,
+	responseTo: undefined,
 	userProfile: {
 		userId: '2762428',
 		displayName: 'FrankDeFord',

--- a/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentContainer.tsx
@@ -230,7 +230,7 @@ export const CommentContainer = ({
 							<CommentForm
 								shortUrl={shortUrl}
 								onAddComment={(response) => {
-									if ('responses' in response) {
+									if (response.responses !== undefined) {
 										return;
 									}
 									onAddReply(comment.id, response);

--- a/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.stories.tsx
@@ -64,6 +64,7 @@ const aComment: CommentType = {
 		badge: [],
 	},
 	responses: [],
+	responseTo: undefined,
 	metaData: {
 		commentCount: 2,
 		staffCommenterCount: 1,

--- a/dotcom-rendering/src/components/Discussion/CommentForm.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentForm.tsx
@@ -182,6 +182,7 @@ const simulateNewComment = (
 	isHighlighted: false,
 	userProfile,
 	responses: [],
+	responseTo: undefined,
 });
 
 const simulateNewReply = (
@@ -200,6 +201,7 @@ const simulateNewReply = (
 	numRecommends: 0,
 	isHighlighted: false,
 	userProfile,
+	responses: undefined,
 	responseTo: {
 		displayName: commentBeingRepliedTo.userProfile.displayName,
 		commentApiUrl: `https://discussion.guardianapis.com/discussion-api/comment/${commentBeingRepliedTo.id}`,

--- a/dotcom-rendering/src/components/Discussion/CommentReplyPreview.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/CommentReplyPreview.stories.tsx
@@ -44,6 +44,7 @@ const commentBeingRepliedTo: CommentType = {
 		badge: [],
 	},
 	responses: [],
+	responseTo: undefined,
 	metaData: {
 		commentCount: 2,
 		staffCommenterCount: 1,

--- a/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPick.stories.tsx
@@ -23,6 +23,7 @@ const comment: ReplyType = {
 	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25488498',
 	numRecommends: 0,
 	isHighlighted: false,
+	responses: undefined,
 	responseTo: {
 		displayName: 'FrankDeFord',
 		commentApiUrl:

--- a/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
+++ b/dotcom-rendering/src/components/Discussion/TopPicks.stories.tsx
@@ -22,6 +22,7 @@ const comment: ReplyType = {
 	apiUrl: 'https://discussion.guardianapis.com/discussion-api/comment/25488498',
 	numRecommends: 0,
 	isHighlighted: false,
+	responses: undefined,
 	responseTo: {
 		displayName: 'FrankDeFord',
 		commentApiUrl:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.37.0
-        version: 0.37.0(typescript@6.0.3)
+        specifier: 0.38.0
+        version: 0.38.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.37.0:
-    resolution: {integrity: sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==}
+  valibot@0.38.0:
+    resolution: {integrity: sha512-RCJa0fetnzp+h+KN9BdgYOgtsMAG9bfoJ9JSjIhFHobKWVWyzM3jjaeNTdpFK9tQtf3q1sguXeERJ/LcmdFE7w==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.37.0(typescript@6.0.3):
+  valibot@0.38.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
Continuing the upgrade started in #16630, this updates to 0.38.0:

https://github.com/open-circle/valibot/releases/tag/v0.38.0

This version of valibot includes a change to the way `optional` works. Previously, this schema:

```ts
const schema = object({
    field: optional(undefined_(), undefined),
});
```

would have resulted in this type:

```ts
type Schema = {
    field?: undefined;
};
```

But the presence of the default parameter means this field will always contain a value. In v0.38.0 the types have been updated so that `field` in this situation will no longer be optional in the `Schema` type.

## Comments and replies

This has an impact on the discussion code, as it contains schemas that look like this:

```ts
const comment = object({
    responses: optional(array(replySchema), []),
    responseTo: optional(undefined_(), undefined),
});

const reply = object({
    responses: optional(undefined_(), undefined),
    responseTo: object({}),
});
```

This is used to differentiate top-level comments from replies. The former may contain a `responses` array, but will not contain a `responseTo` object. The latter will contain a `responseTo` object but will not contain a `responses` array. This is important because the two kinds of comments are handled and presented in different ways, and these two fields are used to distinguish between them in several places within the code[^1][^2].

These schema would previously have resulted in these types:

```ts
type Comment = {
    responses?: ReplySchema[];
    responseTo?: undefined;
};

type Reply = {
    responses?: undefined;
    responseTo: {};
};
```

but now results in these types:

```ts
type Comment = {
    responses: ReplySchema[];
    responseTo: undefined;
};

type Reply = {
    responses: undefined;
    responseTo: {};
};
```

which means that everywhere these types are used, these field must be present. It also means the `in` operator can no longer be used to check which kind of comment an object is, because both fields will always be present. The values must be checked directly instead.

## Changes

Anywhere a comment object is created by the valibot parser it should have the same value as before, because `undefined` or `[]` will be used as the fallback values whenever the relevant fields are missing. Therefore the objects that have to be updated are largely in test/story code, because that's where comment objects are being created manually, and previously the compiler did not require these fields to be present.

The exception to this is the `CommentForm`. This creates both comment and reply objects manually, without going via the parser, because it displays a new comment to the user when they submit it. This also results in a change to the `CommentContainer`, because it was relying on an `in` operator to examine the `CommentForm` comments.

## An alternative

It may be preferable to use `never` for this instead:

```ts
const comment = object({
    responses: optional(array(replySchema), []),
    responseTo: optional(never()),
});

const reply = object({
    responses: optional(never()),
    responseTo: object({}),
});
```

This will likely result in fewer code changes, as the type of this field will remain optional.

[^1]: https://github.com/guardian/dotcom-rendering/pull/10599
[^2]: https://github.com/guardian/dotcom-rendering/pull/10563#pullrequestreview-1878472187
