### PR TITLE
AB test monitoring: log GU_mvt_id

### DIFF
--- a/dotcom-rendering/src/components/Metrics.island.tsx
+++ b/dotcom-rendering/src/components/Metrics.island.tsx
@@ -51,7 +51,11 @@ const useDev = () => {
 	return isDev;
 };
 
-const logMvt = (mvtId: string | null, abTestCookie: string | null) => {
+const logMvt = (
+	mvtId: string | null,
+	oldMvtId: string | null,
+	abTestCookie: string | null,
+) => {
 	const logsEndpoint = window.guardian.config.page.isDev
 		? '//logs.code.dev-guardianapis.com/log'
 		: '//logs.guardianapis.com/log';
@@ -62,6 +66,7 @@ const logMvt = (mvtId: string | null, abTestCookie: string | null) => {
 			label: 'webx.ab-testing',
 			properties: [
 				{ name: 'mvtId', value: mvtId },
+				{ name: 'oldMvtId', value: oldMvtId },
 				{
 					name: 'pageviewId',
 					value: window.guardian.config.ophan.pageViewId,
@@ -222,12 +227,17 @@ export const Metrics = ({ commercialMetricsEnabled }: Props) => {
 				shouldMemoize: true,
 			});
 
+			const oldMvtId = getCookie({
+				name: 'GU_mvt_id',
+				shouldMemoize: true,
+			});
+
 			const rawClientABTests = getCookie({
 				name: 'gu_client_ab_tests',
 				shouldMemoize: true,
 			});
 
-			logMvt(mvtId, rawClientABTests);
+			logMvt(mvtId, oldMvtId, rawClientABTests);
 		},
 		[isInMonitoringTest],
 	);


### PR DESCRIPTION
## What does this change?

I'd like to update the logging we've put in place to monitor an "AB test contamination" issue to also include the older `GU_mvt_id` cookie, this will help us track the frequency the new `gu_v2_mvt_id` changes compared to the old, which could help narrow our investigation.