### PR TITLE
Update valibot to 0.42.1

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.38.0",
+		"valibot": "0.39.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.40.0",
+		"valibot": "0.41.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.39.0",
+		"valibot": "0.40.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.41.0",
+		"valibot": "0.42.1",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.40.0
-        version: 0.40.0(typescript@6.0.3)
+        specifier: 0.41.0
+        version: 0.41.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.40.0:
-    resolution: {integrity: sha512-XHKnaVtwHqxPwnGOsLrwka9CEaL7yNeLNp707OKv/bmT29GnPVdl6PxBOZ6BW7hF66/6QT6iVbOlnW7qVPmoKw==}
+  valibot@0.41.0:
+    resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.40.0(typescript@6.0.3):
+  valibot@0.41.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.41.0
-        version: 0.41.0(typescript@6.0.3)
+        specifier: 0.42.1
+        version: 0.42.1(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.41.0:
-    resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
+  valibot@0.42.1:
+    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.41.0(typescript@6.0.3):
+  valibot@0.42.1(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.39.0
-        version: 0.39.0(typescript@6.0.3)
+        specifier: 0.40.0
+        version: 0.40.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.39.0:
-    resolution: {integrity: sha512-d+vE8SDRNy9zKg6No5MHz2tdz8H6CW8X3OdqYdmlhnoqQmEoM6Hu0hJUrZv3tPSVrzZkIIMCtdCQtMzcM6NCWw==}
+  valibot@0.40.0:
+    resolution: {integrity: sha512-XHKnaVtwHqxPwnGOsLrwka9CEaL7yNeLNp707OKv/bmT29GnPVdl6PxBOZ6BW7hF66/6QT6iVbOlnW7qVPmoKw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.39.0(typescript@6.0.3):
+  valibot@0.40.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.38.0
-        version: 0.38.0(typescript@6.0.3)
+        specifier: 0.39.0
+        version: 0.39.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.38.0:
-    resolution: {integrity: sha512-RCJa0fetnzp+h+KN9BdgYOgtsMAG9bfoJ9JSjIhFHobKWVWyzM3jjaeNTdpFK9tQtf3q1sguXeERJ/LcmdFE7w==}
+  valibot@0.39.0:
+    resolution: {integrity: sha512-d+vE8SDRNy9zKg6No5MHz2tdz8H6CW8X3OdqYdmlhnoqQmEoM6Hu0hJUrZv3tPSVrzZkIIMCtdCQtMzcM6NCWw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.38.0(typescript@6.0.3):
+  valibot@0.39.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
Continuing the upgrade started in #16630, this updates to 0.42.1. Similar to #16632, other than updating the dependency, no other changes are required. This is the last version before v1.0.0, which will come with a number of changes. Release notes:

- https://github.com/open-circle/valibot/releases/tag/v0.39.0
- https://github.com/open-circle/valibot/releases/tag/v0.40.0
- https://github.com/open-circle/valibot/releases/tag/v0.41.0
- https://github.com/open-circle/valibot/releases/tag/v0.42.0
- https://github.com/open-circle/valibot/releases/tag/v0.42.1
