### PR TITLE
Update valibot to 1.0.0

### DIFF
--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "0.42.1",
+		"valibot": "1.0.0",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchInfoPage.json
@@ -46,21 +46,21 @@
             "type": "object",
             "properties": {
                 "matchStats": {
-                    "$ref": "#/definitions/{id:string;homeTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}"
+                    "$ref": "#/definitions/{id:string;homeTeam:{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;};awayTeam:{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;};status:string;comments?:string;}"
                 },
                 "matchInfo": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
+                            "$ref": "#/definitions/{type:\"Fixture\";competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                         },
                         {
-                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}"
+                            "$ref": "#/definitions/{type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;attendance?:string;referee?:{id:string;name:string;};competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                         },
                         {
-                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                            "$ref": "#/definitions/{type:\"Result\";reportAvailable:boolean;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                         },
                         {
-                            "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                            "$ref": "#/definitions/{type:\"LiveMatch\";status:string;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                         }
                     ]
                 },
@@ -939,17 +939,17 @@
                 "url"
             ]
         },
-        "{id:string;homeTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};awayTeam:{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;};status:string;comments?:string;}": {
+        "{id:string;homeTeam:{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;};awayTeam:{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;};status:string;comments?:string;}": {
             "type": "object",
             "properties": {
                 "id": {
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
+                    "$ref": "#/definitions/{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}"
+                    "$ref": "#/definitions/{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;}"
                 },
                 "status": {
                     "type": "string"
@@ -965,29 +965,32 @@
                 "status"
             ]
         },
-        "{name:string;id:string;scorers:string[];players:{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}[];codename:string;possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;score?:number;}": {
+        "{id:string;name:string;codename:string;players:{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}[];score?:number;scorers:string[];possession:number;shotsOn:number;shotsOff:number;corners:number;fouls:number;colours:string;crest:string;}": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
-                "id": {
+                "codename": {
                     "type": "string"
+                },
+                "players": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}"
+                    }
+                },
+                "score": {
+                    "type": "number"
                 },
                 "scorers": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "players": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}"
-                    }
-                },
-                "codename": {
-                    "type": "string"
                 },
                 "possession": {
                     "type": "number"
@@ -1009,9 +1012,6 @@
                 },
                 "crest": {
                     "type": "string"
-                },
-                "score": {
-                    "type": "number"
                 }
             },
             "required": [
@@ -1029,26 +1029,14 @@
                 "shotsOn"
             ]
         },
-        "{name:string;id:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventType:string;eventId:string;normalTime:string;addedTime:string;}[];position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;}": {
+        "{id:string;name:string;position:string;lastName:string;substitute:boolean;timeOnPitch:string;shirtNumber:string;events:{eventTime:string;eventType:string;}[];enhancedEvents:{eventId:string;eventType:string;normalTime:string;addedTime:string;}[];}": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "string"
                 },
-                "events": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/{eventTime:string;eventType:string;}"
-                    }
-                },
-                "enhancedEvents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/{eventType:string;eventId:string;normalTime:string;addedTime:string;}"
-                    }
+                "name": {
+                    "type": "string"
                 },
                 "position": {
                     "type": "string"
@@ -1064,6 +1052,18 @@
                 },
                 "shirtNumber": {
                     "type": "string"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{eventTime:string;eventType:string;}"
+                    }
+                },
+                "enhancedEvents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/{eventId:string;eventType:string;normalTime:string;addedTime:string;}"
+                    }
                 }
             },
             "required": [
@@ -1093,13 +1093,13 @@
                 "eventType"
             ]
         },
-        "{eventType:string;eventId:string;normalTime:string;addedTime:string;}": {
+        "{eventId:string;eventType:string;normalTime:string;addedTime:string;}": {
             "type": "object",
             "properties": {
-                "eventType": {
+                "eventId": {
                     "type": "string"
                 },
-                "eventId": {
+                "eventType": {
                     "type": "string"
                 },
                 "normalTime": {
@@ -1116,21 +1116,24 @@
                 "normalTime"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
+        "{type:\"Fixture\";competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "Fixture"
                 },
+                "competition": {
+                    "$ref": "#/definitions/{id:string;name:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -1139,19 +1142,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
             "required": [
@@ -1163,6 +1163,21 @@
                 "round",
                 "stage",
                 "type"
+            ]
+        },
+        "{id:string;name:string;}": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
         "{stageNumber:string;}": {
@@ -1190,13 +1205,13 @@
                 "roundNumber"
             ]
         },
-        "{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}": {
+        "{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 },
                 "score": {
@@ -1220,13 +1235,13 @@
                 "name"
             ]
         },
-        "{name:string;id:string;}": {
+        "{id:string;name:string;}_1": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 }
             },
@@ -1235,48 +1250,12 @@
                 "name"
             ]
         },
-        "{name:string;id:string;}_1": {
+        "{type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;attendance?:string;referee?:{id:string;name:string;};competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "name"
-            ]
-        },
-        "{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
-            "type": "object",
-            "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "MatchDay"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "round": {
-                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
-                },
-                "leg": {
-                    "type": "string"
-                },
-                "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "liveMatch": {
                     "type": "boolean"
@@ -1296,20 +1275,41 @@
                 "matchStatus": {
                     "type": "string"
                 },
-                "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
-                },
-                "comments": {
-                    "type": "string"
-                },
                 "attendance": {
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
                 },
                 "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{id:string;name:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
+                },
+                "comments": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -1329,13 +1329,13 @@
                 "type"
             ]
         },
-        "{name:string;id:string;}_2": {
+        "{id:string;name:string;}_2": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 }
             },
@@ -1344,21 +1344,30 @@
                 "name"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{type:\"Result\";reportAvailable:boolean;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "Result"
                 },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -1367,25 +1376,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "reportAvailable": {
-                    "type": "boolean"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [
@@ -1400,21 +1400,30 @@
                 "type"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{type:\"LiveMatch\";status:string;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "LiveMatch"
                 },
+                "status": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -1423,25 +1432,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "status": {
-                    "type": "string"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [

--- a/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feFootballMatchListPage.json
@@ -96,16 +96,16 @@
                                             "items": {
                                                 "anyOf": [
                                                     {
-                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}"
+                                                        "$ref": "#/definitions/{type:\"Fixture\";competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                                                     },
                                                     {
-                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}"
+                                                        "$ref": "#/definitions/{type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;attendance?:string;referee?:{id:string;name:string;};competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                                                     },
                                                     {
-                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                                                        "$ref": "#/definitions/{type:\"Result\";reportAvailable:boolean;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                                                     },
                                                     {
-                                                        "$ref": "#/definitions/{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}"
+                                                        "$ref": "#/definitions/{type:\"LiveMatch\";status:string;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}"
                                                     }
                                                 ]
                                             }
@@ -824,21 +824,24 @@
         "Record<string,FEFootballCompetition[]>": {
             "type": "object"
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Fixture\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{name:string;id:string;};comments?:string;competition?:{name:string;id:string;};}": {
+        "{type:\"Fixture\";competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "Fixture"
                 },
+                "competition": {
+                    "$ref": "#/definitions/{id:string;name:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -847,19 +850,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
                 }
             },
             "required": [
@@ -871,6 +871,21 @@
                 "round",
                 "stage",
                 "type"
+            ]
+        },
+        "{id:string;name:string;}": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "name"
             ]
         },
         "{stageNumber:string;}": {
@@ -898,13 +913,13 @@
                 "roundNumber"
             ]
         },
-        "{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}": {
+        "{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 },
                 "score": {
@@ -928,13 +943,13 @@
                 "name"
             ]
         },
-        "{name:string;id:string;}": {
+        "{id:string;name:string;}_1": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 }
             },
@@ -943,48 +958,12 @@
                 "name"
             ]
         },
-        "{name:string;id:string;}_1": {
+        "{type:\"MatchDay\";liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;attendance?:string;referee?:{id:string;name:string;};competition?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "name"
-            ]
-        },
-        "{stage:{stageNumber:string;};id:string;type:\"MatchDay\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};liveMatch:boolean;result:boolean;previewAvailable:boolean;reportAvailable:boolean;lineupsAvailable:boolean;matchStatus:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};competition?:{name:string;id:string;};}": {
-            "type": "object",
-            "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "MatchDay"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "round": {
-                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
-                },
-                "leg": {
-                    "type": "string"
-                },
-                "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "liveMatch": {
                     "type": "boolean"
@@ -1004,20 +983,41 @@
                 "matchStatus": {
                     "type": "string"
                 },
-                "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
-                },
-                "comments": {
-                    "type": "string"
-                },
                 "attendance": {
                     "type": "string"
                 },
                 "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
                 },
                 "competition": {
-                    "$ref": "#/definitions/{name:string;id:string;}_1"
+                    "$ref": "#/definitions/{id:string;name:string;}"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
+                },
+                "round": {
+                    "$ref": "#/definitions/{roundNumber:string;name?:string;}"
+                },
+                "leg": {
+                    "type": "string"
+                },
+                "homeTeam": {
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "awayTeam": {
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                },
+                "venue": {
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
+                },
+                "comments": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -1037,13 +1037,13 @@
                 "type"
             ]
         },
-        "{name:string;id:string;}_2": {
+        "{id:string;name:string;}_2": {
             "type": "object",
             "properties": {
-                "name": {
+                "id": {
                     "type": "string"
                 },
-                "id": {
+                "name": {
                     "type": "string"
                 }
             },
@@ -1052,21 +1052,30 @@
                 "name"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"Result\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};reportAvailable:boolean;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{type:\"Result\";reportAvailable:boolean;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "Result"
                 },
+                "reportAvailable": {
+                    "type": "boolean"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -1075,25 +1084,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "reportAvailable": {
-                    "type": "boolean"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [
@@ -1108,21 +1108,30 @@
                 "type"
             ]
         },
-        "{stage:{stageNumber:string;};id:string;type:\"LiveMatch\";date:string;round:{roundNumber:string;name?:string;};leg:string;homeTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};status:string;venue?:{name:string;id:string;};comments?:string;attendance?:string;referee?:{name:string;id:string;};}": {
+        "{type:\"LiveMatch\";status:string;attendance?:string;referee?:{id:string;name:string;};id:string;date:string;stage:{stageNumber:string;};round:{roundNumber:string;name?:string;};leg:string;homeTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};awayTeam:{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;};venue?:{id:string;name:string;};comments?:string;}": {
             "type": "object",
             "properties": {
-                "stage": {
-                    "$ref": "#/definitions/{stageNumber:string;}"
-                },
-                "id": {
-                    "type": "string"
-                },
                 "type": {
                     "type": "string",
                     "const": "LiveMatch"
                 },
+                "status": {
+                    "type": "string"
+                },
+                "attendance": {
+                    "type": "string"
+                },
+                "referee": {
+                    "$ref": "#/definitions/{id:string;name:string;}_2"
+                },
+                "id": {
+                    "type": "string"
+                },
                 "date": {
                     "type": "string"
+                },
+                "stage": {
+                    "$ref": "#/definitions/{stageNumber:string;}"
                 },
                 "round": {
                     "$ref": "#/definitions/{roundNumber:string;name?:string;}"
@@ -1131,25 +1140,16 @@
                     "type": "string"
                 },
                 "homeTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "awayTeam": {
-                    "$ref": "#/definitions/{name:string;id:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
-                },
-                "status": {
-                    "type": "string"
+                    "$ref": "#/definitions/{id:string;name:string;score?:number;htScore?:number;aggregateScore?:number;scorers?:string;teamUrl?:string;}"
                 },
                 "venue": {
-                    "$ref": "#/definitions/{name:string;id:string;}"
+                    "$ref": "#/definitions/{id:string;name:string;}_1"
                 },
                 "comments": {
                     "type": "string"
-                },
-                "attendance": {
-                    "type": "string"
-                },
-                "referee": {
-                    "$ref": "#/definitions/{name:string;id:string;}_2"
                 }
             },
             "required": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,8 +723,8 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 0.42.1
-        version: 0.42.1(typescript@6.0.3)
+        specifier: 1.0.0
+        version: 1.0.0(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -9822,8 +9822,8 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
 
-  valibot@0.42.1:
-    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -21002,7 +21002,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@0.42.1(typescript@6.0.3):
+  valibot@1.0.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
Continuing the upgrade started in #16630, this updates to 1.0.0:

https://github.com/open-circle/valibot/releases/tag/v1.0.0

There are a large number of updates in this release, but few of them affect DCAR. The only change, other than upgrading the dependency, is to the frontend JSON schemas. Some of the types here are inferred by valibot, and this upgrade has changed the order of some of the object fields. Something similar happened in #16630.
