### PR TITLE
Remove padding-right from banner heading

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/BannerHeader.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/BannerHeader.tsx
@@ -82,7 +82,6 @@ const getStyles = (
 
 			${from.desktop} {
 				padding-top: ${space[3]}px;
-				padding-right: ${space[5]}px;
 			}
 		`,
 		headerWithImageContainer: css`


### PR DESCRIPTION
## What does this change?
Removes some padding from the RR banner heading at desktop.

## Why?
It causes the banner to be unnecessarily tall

Example from chromatic:

<img width="655" height="268" alt="Screenshot 2026-08-28 at 14 03 44" src="https://github.com/user-attachments/assets/80033bff-c3e5-4037-a871-d720cb7bbc85" />
