### PR TITLE
Replace `superstruct` with `valibot`

### DIFF
--- a/ab-testing/config/lib/config.ts
+++ b/ab-testing/config/lib/config.ts
@@ -1,4 +1,4 @@
-import { assert, object, string } from "superstruct";
+import { assert, strictObject, string } from "valibot";
 
 const getEnv = (key: string): string => {
 	const value = process.env[key];
@@ -8,7 +8,7 @@ const getEnv = (key: string): string => {
 	return value;
 };
 
-const configStruct = object({
+const configStruct = strictObject({
 	serviceName: string(),
 	serviceId: string(),
 	mvtDictionaryId: string(),
@@ -19,7 +19,7 @@ const configStruct = object({
 
 const getConfigFromEnv = () => {
 	const config = JSON.parse(getEnv("FASTLY_AB_TESTING_CONFIG")) as unknown;
-	assert(config, configStruct);
+	assert(configStruct, config);
 
 	return config;
 };

--- a/ab-testing/config/lib/fastly/client.ts
+++ b/ab-testing/config/lib/fastly/client.ts
@@ -2,16 +2,16 @@ import {
 	array,
 	assert,
 	boolean,
-	type Infer,
+	type InferOutput,
+	looseObject,
 	nullable,
 	number,
-	object,
+	strictObject,
 	string,
-	type,
-} from "superstruct";
+} from "valibot";
 import { FastlyService } from "./service.ts";
 
-const fastlyDictionaryItemStruct = object({
+const fastlyDictionaryItemStruct = strictObject({
 	service_id: string(),
 	item_key: string(),
 	item_value: string(),
@@ -21,7 +21,9 @@ const fastlyDictionaryItemStruct = object({
 	deleted_at: nullable(string()),
 });
 
-export type FastlyDictionaryItem = Infer<typeof fastlyDictionaryItemStruct>;
+export type FastlyDictionaryItem = InferOutput<
+	typeof fastlyDictionaryItemStruct
+>;
 
 export type UpdateDictionaryItemRequest =
 	| {
@@ -87,17 +89,17 @@ export class FastlyClient {
 		const serviceConfig = await this.fetch(`service/${serviceId}`);
 
 		assert(
-			serviceConfig,
-			type({
+			looseObject({
 				id: string(),
 				name: string(),
 				versions: array(
-					type({
+					looseObject({
 						active: boolean(),
 						number: number(),
 					}),
 				),
 			}),
+			serviceConfig,
 		);
 
 		if (serviceConfig.name !== serviceName) {
@@ -135,7 +137,7 @@ export class FastlyClient {
 		const dictionary = await this.fetch(
 			`service/${serviceId}/version/${activeVersion}/dictionary/${dictionaryName}`,
 		);
-		assert(dictionary, type({ id: string(), name: string() }));
+		assert(looseObject({ id: string(), name: string() }), dictionary);
 
 		return dictionary;
 	}
@@ -151,7 +153,7 @@ export class FastlyClient {
 			`service/${serviceId}/dictionary/${dictionaryId}/items?per_page=1000`,
 		);
 
-		assert(dictionary, array(fastlyDictionaryItemStruct));
+		assert(array(fastlyDictionaryItemStruct), dictionary);
 
 		return dictionary;
 	}
@@ -180,7 +182,7 @@ export class FastlyClient {
 			},
 		);
 
-		assert(dictionary, object({ status: string() }));
+		assert(strictObject({ status: string() }), dictionary);
 		if (dictionary.status !== "ok") {
 			throw new Error(
 				`Failed to update dictionary: ${dictionary.status}`,

--- a/ab-testing/config/package.json
+++ b/ab-testing/config/package.json
@@ -15,7 +15,7 @@
 		"test": "node --test --test-reporter spec './**/*.test.ts'"
 	},
 	"dependencies": {
-		"superstruct": "catalog:"
+		"valibot": "catalog:"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-s3": "catalog:",

--- a/ab-testing/deploy-lambda/package.json
+++ b/ab-testing/deploy-lambda/package.json
@@ -12,7 +12,7 @@
 		"@aws-sdk/client-s3": "catalog:",
 		"@aws-sdk/client-ssm": "catalog:",
 		"@guardian/ab-testing-config": "workspace:ab-testing-config",
-		"superstruct": "catalog:"
+		"valibot": "catalog:"
 	},
 	"devDependencies": {
 		"@guardian/tsconfig": "catalog:",

--- a/ab-testing/deploy-lambda/src/lib/fastly-config.ts
+++ b/ab-testing/deploy-lambda/src/lib/fastly-config.ts
@@ -1,6 +1,6 @@
 import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import { configStruct } from "@guardian/ab-testing-config/lib/config.ts";
-import { assert } from "superstruct";
+import { assert } from "valibot";
 import { REGION } from "./constants.ts";
 
 const getSecureString = async (name: string) => {
@@ -34,7 +34,7 @@ export const getFastlyConfig = async () => {
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string is invalid JSON too
 	const json = JSON.parse(stringParam || "{}") as unknown;
 
-	assert(json, configStruct);
+	assert(configStruct, json);
 
 	return json;
 };

--- a/ab-testing/deploy-lambda/src/lib/fetch-artifact.ts
+++ b/ab-testing/deploy-lambda/src/lib/fetch-artifact.ts
@@ -1,14 +1,14 @@
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import type { Infer } from "superstruct";
-import { array, create, object, string } from "superstruct";
+import type { InferOutput } from "valibot";
+import { array, parse, strictObject, string } from "valibot";
 import { REGION } from "./constants.ts";
 
-const fastlyKVStruct = object({
+const fastlyKVStruct = strictObject({
 	item_key: string(),
 	item_value: string(),
 });
 
-type KeyValue = Infer<typeof fastlyKVStruct>;
+type KeyValue = InferOutput<typeof fastlyKVStruct>;
 
 /**
  * Fetches the dictionary artifact from the given s3 location, using the AWS SDK.
@@ -37,7 +37,7 @@ const fetchDictionaryArtifact = async (
 		const bodyString = await response.Body.transformToString();
 		const parsed = JSON.parse(bodyString) as unknown;
 
-		const result = create(parsed, array(fastlyKVStruct));
+		const result = parse(array(fastlyKVStruct), parsed);
 
 		return result;
 	} catch (error) {

--- a/dotcom-rendering/package.json
+++ b/dotcom-rendering/package.json
@@ -164,7 +164,7 @@
 		"typescript-json-schema": "0.64.0",
 		"unified": "11.0.5",
 		"url": "0.11.4",
-		"valibot": "1.4.2",
+		"valibot": "catalog:",
 		"web-vitals": "4.2.3",
 		"webpack": "5.109.2",
 		"webpack-assets-manifest": "6.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ catalogs:
     rollup-plugin-esbuild:
       specifier: 6.2.1
       version: 6.2.1
-    superstruct:
-      specifier: 2.0.2
-      version: 2.0.2
     tslib:
       specifier: 2.6.2
       version: 2.6.2
@@ -69,6 +66,9 @@ catalogs:
     typescript:
       specifier: 6.0.3
       version: 6.0.3
+    valibot:
+      specifier: 1.4.2
+      version: 1.4.2
 
 importers:
 
@@ -143,9 +143,9 @@ importers:
 
   ab-testing/config:
     dependencies:
-      superstruct:
+      valibot:
         specifier: 'catalog:'
-        version: 2.0.2
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: 'catalog:'
@@ -174,9 +174,9 @@ importers:
       '@guardian/ab-testing-config':
         specifier: workspace:ab-testing-config
         version: link:../config
-      superstruct:
+      valibot:
         specifier: 'catalog:'
-        version: 2.0.2
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@guardian/tsconfig':
         specifier: 'catalog:'
@@ -723,7 +723,7 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       valibot:
-        specifier: 1.4.2
+        specifier: 'catalog:'
         version: 1.4.2(typescript@6.0.3)
       web-vitals:
         specifier: 4.2.3
@@ -9212,10 +9212,6 @@ packages:
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
-
-  superstruct@2.0.2:
-    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
-    engines: {node: '>=14.0.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -20256,8 +20252,6 @@ snapshots:
       function-timeout: 1.0.2
       make-asynchronous: 1.1.0
       time-span: 5.1.0
-
-  superstruct@2.0.2: {}
 
   supports-color@5.5.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,10 +27,10 @@ catalog:
   eslint: 9.39.1
   rollup: 4.59.0
   rollup-plugin-esbuild: 6.2.1
-  superstruct: 2.0.2
   tslib: 2.6.2
   type-fest: 4.21.0
   typescript: 6.0.3
+  valibot: 1.4.2
 minimumReleaseAge: 2880 # 2 day minimum package version age
 minimumReleaseAgeExclude:
   - '@guardian/*'


### PR DESCRIPTION
`ab-testing` currently uses `superstruct`, DCAR uses `valibot`. They perform similar roles, so consolidating on one reduces the number of packages we depend on and the number of APIs developers have to work with. We're using valibot more widely, both in this project and elsewhere, so that's the one this change migrates to.

The APIs are similar, so some functions retain the same name[^1]. Changes relevant to this project are as follows:

- `object` becomes `strictObject`
- `assert` has its argument order swapped, schema first and then input
- `Infer` becomes `InferOutput`
- `type` becomes `looseObject`
- `create` becomes `parse`, and has its argument order swapped, schema first and then input

`ab-testing` also used pnpm's catalog feature[^2], as `superstruct` was used across two sub-projects. `valibot` is now used across three, so it's moved into the catalog as part of this change.

[^1]: https://valibot.dev/guides/migrate-from-superstruct/
[^2]: https://pnpm.io/catalogs
