### PR TITLE
Fix duplicate banner tracking

### DIFF
--- a/dotcom-rendering/src/components/marketing/banners/designableBanner/components/BannerChoiceCards.tsx
+++ b/dotcom-rendering/src/components/marketing/banners/designableBanner/components/BannerChoiceCards.tsx
@@ -161,9 +161,9 @@ export const BannerChoiceCards = ({
 			>
 				<LinkButton
 					href={enrichSupportUrl({
-						baseUrl: bannerData.selectedChoiceCard
-							? getChoiceCardUrl(bannerData.selectedChoiceCard)
-							: (copyForViewport.primaryCta?.ctaUrl ?? ''),
+						baseUrl: getChoiceCardUrl(
+							bannerData.selectedChoiceCard,
+						),
 						tracking: bannerData.tracking,
 						promoCodes: bannerData.promoCodes ?? [],
 						countryCode: bannerData.countryCode,

--- a/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.test.ts
@@ -59,6 +59,11 @@ describe('enrichSupportUrl', () => {
 });
 
 describe('getChoiceCardUrl', () => {
+	it('returns the landing page url when choiceCard is undefined', () => {
+		const url = getChoiceCardUrl(undefined);
+		expect(url).toEqual('https://support.theguardian.com/contribute');
+	});
+
 	// One-time
 	it('builds landing page url for one-time choice', () => {
 		const url = getChoiceCardUrl({

--- a/dotcom-rendering/src/components/marketing/lib/tracking.ts
+++ b/dotcom-rendering/src/components/marketing/lib/tracking.ts
@@ -298,7 +298,11 @@ export const addTrackingParamsToProfileUrl = (
 
 const SupportUrl = 'https://support.theguardian.com';
 
-export const getChoiceCardUrl = (choiceCard: ChoiceCard): string => {
+export const getChoiceCardUrl = (choiceCard?: ChoiceCard): string => {
+	if (!choiceCard) {
+		// No choice selected, send to landing page
+		return `${SupportUrl}/contribute`;
+	}
 	const { product } = choiceCard;
 	const destination = choiceCard.destination ?? 'LandingPage';
 	const { destinationTest } = choiceCard;


### PR DESCRIPTION
## What does this change?
Fixes a bug in the banner where the tracking params on the CTA are added twice.
This happens only if no choice card is selected. This is an experimental feature that MRR have been testing, where by default no choice is selected, but users can still click the CTA.

Currently, in the case where no choice is selected the banner CTA falls back on the `primaryCta.ctaUrl` field. However, this field already has all the tracking, and is only meant to be used when the choice cards are not displayed. This is then wrapped in `enrichSupportUrl`, causing the tracking to be added again.
The solution is to change the `getChoiceCardUrl` function to also handle the case where no choice is selected.

Tested in CODE to confirm that the tracking is no longer duplicated when no choice is selected.