### PR TITLE
Extend auxia banner test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -48,7 +48,7 @@ const ABTests: ABTest[] = [
 		name: "growth-auxia-banner",
 		description: "Use Auxia API for deciding when to show a RR banner",
 		owners: ["growth.dev@guardian.co.uk"],
-		expirationDate: "2026-09-01",
+		expirationDate: "2026-12-01",
 		type: "client",
 		status: "ON",
 		audienceSize: 1,


### PR DESCRIPTION
we want to continue running this test, which explores using Auxia (a 3rd party API) to decide when RR banners are displayed