### PR TITLE
fix: Make root filesystem read-only for OTEL container

### DIFF
--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -2297,6 +2297,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
             },
             "Memory": 512,
             "Name": "aws-otel-collector",
+            "ReadonlyRootFilesystem": true,
           },
         ],
         "Cpu": "1024",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -359,6 +359,7 @@ export class RenderingCDKStack extends CDKStack {
 						// If resources are constrained this container can be
 						// taken down to give room to the main app
 						essential: false,
+						readonlyRootFilesystem: true,
 					},
 				);
 


### PR DESCRIPTION
## What does this change?
Updates the OTEL container added in https://github.com/guardian/dotcom-rendering/pull/16594 with a read-only root filesystem as required by [FSBP ECS.5](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5).

## Why?
See above.

## How has this change been tested?
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/27f472fb-94a0-4819-90a1-d770ce5702c6), I've issued some requests and can see the resulting traces in the AWS console:

<img width="766" height="301" alt="image" src="https://github.com/user-attachments/assets/fbb00e83-ae33-43aa-a3b7-a994fb98715d" />