### PR TITLE
Turn off commercial-spacefinder-highvalue-section AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -89,7 +89,7 @@ const ABTests: ABTest[] = [
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-09-01",
 		type: "client",
-		status: "ON",
+		status: "OFF",
 		audienceSize: 10 / 100,
 		audienceSpace: "A",
 		groups: ["control", "variant"],


### PR DESCRIPTION
## What does this change?

Turn off `commercial-spacefinder-highvalue-section` AB test. Awaiting results for next step.