### PR TITLE
Set Prebid failsafe timeout AB test to 1%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -209,7 +209,6 @@ const ABTests: ABTest[] = [
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},
-
 	{
 		name: "commercial-prebid-failsafe-timeout",
 		description:
@@ -218,7 +217,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-09-30",
 		type: "client",
 		status: "ON",
-		audienceSize: 0 / 100,
+		audienceSize: 1 / 100,
 		audienceSpace: "B",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -211,8 +211,7 @@ const ABTests: ABTest[] = [
 	},
 	{
 		name: "commercial-prebid-failsafe-timeout",
-		description:
-			"Test to measure the impact of the Prebid failsafe timeout",
+		description: "Gradually roll out the Prebid failsafe timeout feature",
 		owners: ["commercial.dev@guardian.co.uk"],
 		expirationDate: "2026-09-30",
 		type: "client",


### PR DESCRIPTION
## What does this change?

Sets the `commercial-prebid-failsafe-timeout` AB test to 1%.

## Why?

We are conducting a slow rollout of this feature, starting at 1% and monitoring metrics. Our plan is to increase to 10%, then 100%.

## How has this change been tested?

This change has been tested locally, with a modified timeout. It isn't feasible to test this without modifying the timeout rate to something small, as the timeout is extremely unlikely to be reached. More information on the Prebid failsafe timeout can be found here: https://docs.prebid.org/features/timeouts.html
