### PR TITLE
Pillar specific backgrounds for immersive headlines

### DIFF
--- a/dotcom-rendering/src/components/ArticleHeadline.tsx
+++ b/dotcom-rendering/src/components/ArticleHeadline.tsx
@@ -270,6 +270,10 @@ const darkBackground = css`
 	background-color: ${themePalette('--headline-background')};
 `;
 
+const immersiveDarkBackground = css`
+	background-color: ${themePalette('--headline-background-immersive')};
+`;
+
 const invertedText = css`
 	color: white;
 	background-color: black;
@@ -299,7 +303,7 @@ const gridHeadlineTextBelowDesktop = css`
 
 	${until.desktop} {
 		color: white;
-		background-color: ${themePalette('--headline-background')};
+		background-color: ${themePalette('--headline-background-immersive')};
 		white-space: pre-wrap;
 		padding-bottom: ${space[1]}px;
 		padding-left: 12px;
@@ -322,7 +326,7 @@ const immersiveHeadlineStyles = (
 	}
 
 	if (layoutType === 'immersiveLandscape') {
-		return [invertedText, darkBackground];
+		return [invertedText, immersiveDarkBackground];
 	}
 
 	return gridHeadlineTextBelowDesktop;
@@ -560,7 +564,10 @@ export const ArticleHeadline = ({
 													`,
 												]
 											: isInverted
-												? [invertedText, darkBackground]
+												? [
+														invertedText,
+														immersiveDarkBackground,
+													]
 												: gridHeadlineText,
 									]}
 								>

--- a/dotcom-rendering/src/layouts/StandardLayoutArticleGrid.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayoutArticleGrid.tsx
@@ -173,7 +173,9 @@ export const StandardLayoutArticleGrid = ({
 	const isShowcase = format.display === ArticleDisplay.Showcase;
 	const isImmersive = format.display === ArticleDisplay.Immersive;
 	const isFeature = format.design === ArticleDesign.Feature;
-	const headlineBackground = themePalette('--headline-background-immersive');
+	const headlineBackgroundImmersive = themePalette(
+		'--headline-background-immersive',
+	);
 
 	const isFootballMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchStatsUrl;
@@ -275,7 +277,7 @@ export const StandardLayoutArticleGrid = ({
 								}
 
 								${immersiveMediaBelowDesktop(
-									headlineBackground,
+									headlineBackgroundImmersive,
 									isMainMediaImage,
 								)}
 							`
@@ -353,7 +355,7 @@ export const StandardLayoutArticleGrid = ({
 
 							${until.desktop} {
 								margin-top: -1px;
-								background-color: ${headlineBackground};
+								background-color: ${headlineBackgroundImmersive};
 								padding-top: 1px;
 								padding-bottom: ${space[8]}px;
 							}

--- a/dotcom-rendering/src/layouts/StandardLayoutArticleGrid.tsx
+++ b/dotcom-rendering/src/layouts/StandardLayoutArticleGrid.tsx
@@ -173,7 +173,7 @@ export const StandardLayoutArticleGrid = ({
 	const isShowcase = format.display === ArticleDisplay.Showcase;
 	const isImmersive = format.display === ArticleDisplay.Immersive;
 	const isFeature = format.design === ArticleDesign.Feature;
-	const headlineBackground = themePalette('--headline-background');
+	const headlineBackground = themePalette('--headline-background-immersive');
 
 	const isFootballMatchReport =
 		format.design === ArticleDesign.MatchReport && !!footballMatchStatsUrl;
@@ -220,12 +220,22 @@ export const StandardLayoutArticleGrid = ({
 				`,
 				grid.container,
 				grid.outerRules(),
-				isImmersive &&
+				isLabs &&
+					isImmersive &&
 					css`
-						&::before,
-						&::after {
-							z-index: ${getZIndex('immersiveGridOuterRules')};
+						${from.desktop} {
+							&::before,
+							&::after {
+								z-index: ${getZIndex(
+									'immersiveGridOuterRules',
+								)};
+							}
 						}
+						/* Anchor the title consistently while wrapped text extends the media below it. */
+						grid-template-rows: ${immersiveMediaRowHeight} repeat(
+								6,
+								auto
+							);
 					`,
 				!isLabs &&
 					css`
@@ -245,16 +255,6 @@ export const StandardLayoutArticleGrid = ({
 							grid-template-rows: auto auto ${ageWarning != null
 									? '130px'
 									: '90px'} auto auto auto auto auto;
-						}
-					`,
-				isImmersive &&
-					css`
-						${until.desktop} {
-							/* Anchor the title consistently while wrapped text extends the media below it. */
-							grid-template-rows: ${immersiveMediaRowHeight} repeat(
-									6,
-									auto
-								);
 						}
 					`,
 			]}
@@ -358,6 +358,12 @@ export const StandardLayoutArticleGrid = ({
 								padding-bottom: ${space[8]}px;
 							}
 						`,
+					layoutType === 'immersiveLandscape' &&
+						css`
+							${from.desktop} {
+								padding-bottom: ${space[8]}px;
+							}
+						`,
 					layoutType === 'immersivePortrait' &&
 						css`
 							${from.desktop} {
@@ -365,12 +371,6 @@ export const StandardLayoutArticleGrid = ({
 									${themePalette('--article-border')};
 								border-top: 1px solid
 									${themePalette('--article-border')};
-							}
-						`,
-					layoutType === 'immersiveLandscape' &&
-						css`
-							${from.desktop} {
-								padding-bottom: ${space[8]}px;
 							}
 						`,
 				]}

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -298,6 +298,28 @@ const headlineBackgroundDark: PaletteFunction = ({
 	}
 };
 
+// Merge this with the above functions once the new immersive grid layouts
+// are fully rolled out and the old layout removed
+const headlineBackgroundImmersiveLight: PaletteFunction = ({ theme }) => {
+	switch (theme) {
+		case Pillar.Lifestyle:
+			return '#310028';
+		case Pillar.Culture:
+			return '#251F15';
+		case Pillar.Sport:
+			return '#00243A';
+		case Pillar.Opinion:
+			return '#3E1302';
+		case Pillar.News:
+			return sourcePalette.neutral[10];
+		default:
+			return sourcePalette.neutral[7];
+	}
+};
+
+const headlineBackgroundImmersiveDark: PaletteFunction = () =>
+	sourcePalette.neutral[10];
+
 const headlineBlogBackgroundLight: PaletteFunction = ({
 	design,
 	display,
@@ -7602,6 +7624,10 @@ const paletteColours = {
 	'--headline-background': {
 		light: headlineBackgroundLight,
 		dark: headlineBackgroundDark,
+	},
+	'--headline-background-immersive': {
+		light: headlineBackgroundImmersiveLight,
+		dark: headlineBackgroundImmersiveDark,
 	},
 	'--headline-blog-background': {
 		light: headlineBlogBackgroundLight,


### PR DESCRIPTION
This updates the upcoming immersive layout revamp to use bespoke background colours for inverted headlines depending on the pillar.

<img width="649" height="168" alt="image" src="https://github.com/user-attachments/assets/122d0a22-ab12-4c02-8d8f-10a1135f0896" />

### Before

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d1c7c65b-8e54-4a47-b615-42e6f1e2e8fd" />

### After

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3b9f18b7-231e-437e-be06-435274d837d5" />
