### PR TITLE
Remove superfluous custom resource logging

### DIFF
--- a/ab-testing/deploy-lambda/src/lib/custom-resource-response.ts
+++ b/ab-testing/deploy-lambda/src/lib/custom-resource-response.ts
@@ -35,9 +35,6 @@ const send = async (
 		Data: responseData,
 	});
 
-	console.log("Response body:\n", responseBody);
-	console.log("Sending response to:", event.ResponseURL);
-
 	try {
 		await fetch(event.ResponseURL, {
 			method: "PUT",


### PR DESCRIPTION
## Why?
We don't need to log this
