### PR TITLE
Pass customData into iframe for interactive atoms

### DIFF
--- a/dotcom-rendering/src/components/InteractiveAtom.tsx
+++ b/dotcom-rendering/src/components/InteractiveAtom.tsx
@@ -53,7 +53,6 @@ export const InteractiveAtom = ({
 			css={[containerStyles, !!isMainMedia && fullHeightStyles]}
 			data-atom-id={id}
 			data-atom-type="interactive"
-			{...(customData ? { 'data-atom-custom-data': customData } : {})}
 		>
 			<Island
 				priority="feature"
@@ -70,6 +69,7 @@ export const InteractiveAtom = ({
 					elementCss,
 					elementHtml,
 					renderingTarget,
+					customData,
 				})}
 				frameBorder="0"
 			/>

--- a/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
+++ b/dotcom-rendering/src/lib/interactiveAtoms.test.tsx
@@ -6,7 +6,7 @@ import { InteractiveLayoutAtom } from '../components/InteractiveLayoutAtom';
 const mockCustomData = JSON.stringify({ key: 'value' });
 
 describe('Interactive atom custom data attributes', () => {
-	it('should add custom data attribute to InteractiveAtom on web', () => {
+	it('should inject custom data into srcDoc for InteractiveAtom on web', () => {
 		const { container } = render(
 			<ConfigProvider
 				value={{
@@ -23,13 +23,13 @@ describe('Interactive atom custom data attributes', () => {
 				/>
 			</ConfigProvider>,
 		);
-		const el = container.querySelector(
-			`[data-atom-custom-data='${mockCustomData}']`,
+		const iframe = container.querySelector('iframe');
+		expect(iframe?.srcdoc).toContain(
+			`window.__atomCustomData = ${mockCustomData}`,
 		);
-		expect(el).toBeInTheDocument();
 	});
 
-	it('should add custom data attribute to InteractiveAtom on apps', () => {
+	it('should inject custom data into srcDoc for InteractiveAtom on apps', () => {
 		const { container } = render(
 			<ConfigProvider
 				value={{
@@ -46,10 +46,10 @@ describe('Interactive atom custom data attributes', () => {
 				/>
 			</ConfigProvider>,
 		);
-		const el = container.querySelector(
-			`[data-atom-custom-data='${mockCustomData}']`,
+		const iframe = container.querySelector('iframe');
+		expect(iframe?.srcdoc).toContain(
+			`window.__atomCustomData = ${mockCustomData}`,
 		);
-		expect(el).toBeInTheDocument();
 	});
 
 	it('should add custom data attribute to InteractiveLayoutAtom', () => {

--- a/dotcom-rendering/src/lib/unifyPageContent.tsx
+++ b/dotcom-rendering/src/lib/unifyPageContent.tsx
@@ -6,11 +6,13 @@ export const unifyPageContent = ({
 	elementJs,
 	elementHtml,
 	renderingTarget,
+	customData,
 }: {
 	elementCss?: string;
 	elementJs?: string;
 	elementHtml?: string;
 	renderingTarget: RenderingTarget;
+	customData?: string;
 }): string =>
 	renderToString(
 		<html lang="en">
@@ -29,6 +31,13 @@ export const unifyPageContent = ({
 					<div dangerouslySetInnerHTML={{ __html: elementHtml }} />
 				)}
 			</body>
+			{!!customData && (
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `window.__atomCustomData = ${customData};`,
+					}}
+				/>
+			)}
 			{/* JS need to load on body render */}
 			{!!elementJs && (
 				<script dangerouslySetInnerHTML={{ __html: elementJs }} />


### PR DESCRIPTION
Following on from #16612, this adjusts a silly mistake I made for interactive atoms on non interactive pages. Before the custom data was being attached to the element outside of the iframe, rendering it useless to atoms inside. Here we pass the data _into_ the iframe so the atom can use it.

The helper function on the interactive atom side would then shift to something like this:

```typescript
export const getAtomCustomData = <T>(): T | null => {
    // Inside an iframe — data injected as a global
    if ('__atomCustomData' in window) {
        return window.__atomCustomData as T;
    }
    // Outside an iframe — data on the DOM element
    const container = document.querySelector(`[data-atom-custom-data]`);
    if (!container) return null;
    const raw = container.getAttribute('data-atom-custom-data');
    if (!raw) return null;
    try {
        return JSON.parse(raw) as T;
    } catch {
        console.warn('Failed to parse data-atom-custom-data');
        return null;
    }
};
```