### PR TITLE
Roll variant headlines out to 25% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 5 / 95,
+		audienceSize: 25 / 100,
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -206,6 +206,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2036-08-12",
 		type: "server",
 		audienceSize: 25 / 100,
+		audienceSpace: "E",
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},

--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 0 / 100,
+		audienceSize: 5 / 95,
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,
 	},


### PR DESCRIPTION
Begin rolling out variant headlines rendered through the platform test fronts-and-curation-editorial-test: https://github.com/guardian/dotcom-rendering/pull/16554.

The end goal is a 100% 50/50 test, we are reaching this threshold in stages to avoid overloading the cache.