### PR TITLE
Roll variant headlines out to 50% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 25 / 100,
+		audienceSize: 50 / 100,
 		audienceSpace: "E",
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
Stage 2 of rolling out variant headlines rendered through the platform test `fronts-and-curation-editorial-headline-test`: https://github.com/guardian/dotcom-rendering/pull/16554.