### PR TITLE
Roll variant headlines out to 100% of users

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -205,7 +205,7 @@ const ABTests: ABTest[] = [
 		status: "ON",
 		expirationDate: "2036-08-12",
 		type: "server",
-		audienceSize: 50 / 100,
+		audienceSize: 100 / 100,
 		audienceSpace: "E",
 		groups: ["a", "b"],
 		shouldForceMetricsCollection: false,


### PR DESCRIPTION
Finishes rolling out variant headlines rendered through the platform test fronts-and-curation-editorial-test (renamed from fronts-and-curation-editorial-headline-test to future-proof for when we test articles using same test): https://github.com/guardian/dotcom-rendering/pull/16554.

This test is a 50/50 test, we have reached this threshold in stages to avoid overloading the cache.