### PR TITLE
Set prebid failsafe timeout to 10%

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -216,7 +216,7 @@ const ABTests: ABTest[] = [
 		expirationDate: "2026-09-30",
 		type: "client",
 		status: "ON",
-		audienceSize: 1 / 100,
+		audienceSize: 10 / 100,
 		audienceSpace: "B",
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,


### PR DESCRIPTION
## What does this change?

Sets the commercial-prebid-failsafe-timeout AB test to 10%.

## Why?

No detrimental effects were found whilst at 1%.

Follows the PR to set this test to 1%: https://github.com/guardian/dotcom-rendering/pull/16662