### PR TITLE
Rename headline AB test to support other editorial AB tests (eg articles)

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -196,8 +196,8 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
-		name: "fronts-and-curation-editorial-headline-test",
-		description: "Allow editorial headline A/B tests to run on web",
+		name: "fronts-and-curation-editorial-test",
+		description: "Allow editorial A/B tests to run on web",
 		owners: [
 			"fronts.and.curation@guardian.co.uk",
 			"ab.test.mission@guardian.co.uk",

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -678,7 +678,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithNoEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -691,7 +691,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'invalid-test-front',
@@ -704,7 +704,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					false,
 					'test-front',
@@ -717,7 +717,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -730,7 +730,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'b',
+						'fronts-and-curation-editorial-test': 'b',
 					},
 					true,
 					'test-front',
@@ -743,7 +743,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'c',
+						'fronts-and-curation-editorial-test': 'c',
 					},
 					true,
 					'test-front',
@@ -756,7 +756,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithEditorialTestWithUndefinedVariantMeta,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -769,7 +769,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithExpiredEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',
@@ -782,7 +782,7 @@ describe('Enhance Cards', () => {
 				decideHeadline(
 					cardWithManuallyEndedEditorialTest,
 					{
-						'fronts-and-curation-editorial-headline-test': 'a',
+						'fronts-and-curation-editorial-test': 'a',
 					},
 					true,
 					'test-front',

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -216,8 +216,7 @@ export const decideHeadline = (
 ): string => {
 	const defaultHeadline = faciaCard.header.headline;
 
-	const testBucket =
-		serverSideABTests['fronts-and-curation-editorial-headline-test'];
+	const testBucket = serverSideABTests['fronts-and-curation-editorial-test'];
 
 	const activeEditorialTest = findActiveEditorialTest(
 		faciaCard.properties.tests,


### PR DESCRIPTION
## What does this change?
We're now going to use this same test to cover article AB tests, as creating a new one would take up even more test space, and they are functionally equivalent in segmenting the audience into a 50/50 test (used to drive editorial 'sub-tests').

I was originally planning to rename in https://github.com/guardian/dotcom-rendering/pull/16673 but I think it's best we rename in a separate PR to unlink the rollout of the test to the renaming (downstream applications like Ophan might care about the renaming, and we don't want to break that dependency at the same time we release).