### PR TITLE
Add election trackers `Refresh` component

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/Refresh.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/Refresh.stories.tsx
@@ -1,0 +1,52 @@
+import preview from '../../../.storybook/preview';
+import { palette } from '../../palette';
+import { Refresh } from './Refresh';
+import { useCountdown } from './useCountdown';
+
+const meta = preview.meta({
+	component: Refresh,
+	title: 'Components/Election Trackers/Refresh',
+	parameters: {
+		colourSchemeBackground: {
+			light: palette('--front-container-background'),
+			dark: palette('--front-container-background'),
+		},
+	},
+});
+
+/**
+ * Not used for snapshots, just for documentation purposes in storybook, to
+ * demonstrate how `reset` works.
+ */
+export const Countdown = meta.story({
+	args: {
+		remaining: 20,
+	},
+	render: function Render(props) {
+		const [remaining, reset] = useCountdown(props.remaining);
+
+		return (
+			<>
+				<Refresh remaining={remaining} />
+				<button onClick={reset}>Reset</button>
+			</>
+		);
+	},
+	parameters: {
+		chromatic: {
+			disable: true,
+		},
+	},
+});
+
+export const Remaining = meta.story({
+	args: {
+		remaining: 5,
+	},
+});
+
+export const Refreshing = meta.story({
+	args: {
+		remaining: 0,
+	},
+});

--- a/dotcom-rendering/src/components/ElectionTrackers/Refresh.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/Refresh.tsx
@@ -1,0 +1,35 @@
+import {
+	space,
+	textSans14Object,
+	textSansBold14Object,
+} from '@guardian/source/foundations';
+import { palette } from '../../palette';
+import { PulsingDot } from '../PulsingDot.island';
+
+type Props = {
+	/**
+	 * The number of seconds remaining until refresh.
+	 */
+	remaining: number;
+};
+
+export const Refresh = (props: Props) => {
+	const refreshing =
+		props.remaining === 0
+			? 'refreshing...'
+			: `next refresh in ${props.remaining}s`;
+
+	return (
+		<p
+			css={{
+				...textSans14Object,
+				paddingBottom: space[3],
+				color: palette('--election-tracker-refresh'),
+			}}
+			role="timer"
+		>
+			<PulsingDot />
+			<b css={textSansBold14Object}>LIVE</b> {refreshing}
+		</p>
+	);
+};

--- a/dotcom-rendering/src/components/ElectionTrackers/useCountdown.ts
+++ b/dotcom-rendering/src/components/ElectionTrackers/useCountdown.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Count down from a provided number of seconds to zero, emitting a new value
+ * every second, and then stay at zero. Calling `reset` will start the countdown
+ * again.
+ *
+ * Note that calling reset will only restart the countdown to within about a
+ * second of its original value. E.g. if the countdown is from 60, it will
+ * reset to somewhere between 59-60 seconds. If greater accuracy is required,
+ * this hook is not suitable.
+ *
+ * @param from The number of seconds to count down from.
+ */
+export const useCountdown = (from: number): [number, () => void] => {
+	const [remaining, setRemaining] = useState(from);
+
+	const reset = () => setRemaining(from);
+
+	useEffect(() => {
+		const id = setInterval(() => {
+			setRemaining((r) => (r <= 0 ? 0 : r - 1));
+		}, 1_000);
+
+		return () => clearInterval(id);
+	}, []);
+
+	return [remaining, reset];
+};

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7330,6 +7330,10 @@ const paletteColours = {
 		light: () => sourcePalette.neutral[100],
 		dark: () => sourcePalette.neutral[7],
 	},
+	'--election-tracker-refresh': {
+		light: () => sourcePalette.neutral[38],
+		dark: () => sourcePalette.neutral[86],
+	},
 	'--email-signup-button-background': {
 		light: emailSignupButtonBackgroundLight,
 		dark: emailSignupButtonBackgroundDark,


### PR DESCRIPTION
Election trackers will typically poll client-side for new data. This component shows a countdown until the next poll.

| | Light | Dark |
|--------|--------|--------|
| Remaining | <img width="498" height="69" alt="remaining-light" src="https://github.com/user-attachments/assets/2af1923c-0a2f-4881-9a84-72d8f65ef859" /> | <img width="490" height="69" alt="remaining-dark" src="https://github.com/user-attachments/assets/2eef1eed-e913-4122-bec3-c6b59ca28333" /> |
| Refreshing | <img width="410" height="70" alt="refreshing-light" src="https://github.com/user-attachments/assets/de86eb08-cff2-4bc7-9db0-d7aa52e12441" /> | <img width="401" height="66" alt="refreshing-dark" src="https://github.com/user-attachments/assets/4a6447bf-a806-4080-88fa-7c5a7bdc2f97" /> | 
