### PR TITLE
`ElectionComponent` model

### DIFF
--- a/dotcom-rendering/fixtures/manual/electionTrackers/euParliament.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/euParliament.ts
@@ -1,0 +1,148 @@
+export const euParliament = {
+	components: [
+		{
+			kind: 'stackedProgress',
+			props: {
+				total: 720,
+				label: null,
+				calculateWinner: false,
+				excludedCopy: null,
+				sections: [
+					{
+						colour: { name: '--eu-parliament-theleft' },
+						name: 'Left',
+						value: 40,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'S&D',
+						colour: { name: '--eu-parliament-sd' },
+						value: 100,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'Grn/EFA',
+						colour: { name: '--eu-parliament-greensefa' },
+						value: 40,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'Renew',
+						colour: { name: '--eu-parliament-renew' },
+						value: 60,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'EPP',
+						colour: { name: '--eu-parliament-epp' },
+						value: 150,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'ECR',
+						colour: { name: '--eu-parliament-ecr' },
+						value: 60,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'NI',
+						colour: { name: '--eu-parliament-ni' },
+						value: 30,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'PfE',
+						colour: { name: '--eu-parliament-unknown' },
+						value: 70,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'ESN',
+						colour: { name: '--eu-parliament-unknown' },
+						value: 20,
+						align: 'left',
+						exclude: false,
+					},
+				],
+			},
+		},
+		{
+			kind: 'valuesWithChange',
+			props: {
+				valueDescription: 'Seats',
+				changeDescription: 'Change in seats',
+				values: [
+					{
+						name: 'Left',
+						value: 46,
+						change: 9,
+						colour: { name: '--eu-parliament-theleft' },
+					},
+					{
+						name: 'S&D',
+						value: 100,
+						change: -3,
+						colour: { name: '--eu-parliament-sd' },
+					},
+					{
+						name: 'Grn/EFA',
+						value: 40,
+						change: -19,
+						colour: { name: '--eu-parliament-greensefa' },
+					},
+					{
+						name: 'Renew',
+						value: 60,
+						change: -25,
+						colour: { name: '--eu-parliament-renew' },
+					},
+					{
+						name: 'EPP',
+						value: 150,
+						change: 12,
+						colour: { name: '--eu-parliament-epp' },
+					},
+					{
+						name: 'ECR',
+						value: 60,
+						change: 9,
+						colour: { name: '--eu-parliament-ecr' },
+					},
+					{
+						name: 'NI',
+						value: 30,
+						change: 0,
+						colour: { name: '--eu-parliament-ni' },
+					},
+					{
+						name: 'PfE',
+						value: 70,
+						change: 0,
+						colour: { name: '--eu-parliament-unknown' },
+					},
+					{
+						name: 'ESN',
+						value: 20,
+						change: 0,
+						colour: { name: '--eu-parliament-unknown' },
+					},
+				],
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'See full results',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/fixtures/manual/electionTrackers/ukGeneralExitPoll.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/ukGeneralExitPoll.ts
@@ -1,0 +1,41 @@
+export const ukGeneralExitPoll = {
+	components: [
+		{
+			kind: 'versus',
+			props: {
+				left: {
+					name: 'Labour',
+					abbreviation: 'Lab',
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/06/24/Starmer.png',
+						alt: 'Watercolour portrait of Sir Keir Starmer',
+					},
+					colour: { name: '--uk-elections-labour' },
+					value: 0,
+					description: 'seats declared',
+				},
+				right: {
+					name: 'Conservatives',
+					abbreviation: 'Con',
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/06/24/Sunak.png',
+						alt: 'Watercolour portrait of Rishi Sunak',
+					},
+					colour: { name: '--uk-elections-conservative' },
+					value: 0,
+					description: 'seats declared',
+				},
+				colour: 'name',
+				faded: true,
+				banner: 'Exit poll',
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'View results page',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/fixtures/manual/electionTrackers/ukGeneralFinal.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/ukGeneralFinal.ts
@@ -1,0 +1,98 @@
+export const ukGeneralFinal = {
+	components: [
+		{
+			kind: 'versus',
+			props: {
+				left: {
+					name: 'Labour',
+					abbreviation: 'Lab',
+					value: 412,
+					change: 214,
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/06/24/Starmer.png',
+						alt: 'Watercolour portrait of Sir Keir Starmer',
+					},
+					colour: { name: '--uk-elections-labour' },
+				},
+				right: {
+					name: 'Conservatives',
+					abbreviation: 'Con',
+					value: 121,
+					change: -252,
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/06/24/Sunak.png',
+						alt: 'Watercolour portrait of Rishi Sunak',
+					},
+					colour: { name: '--uk-elections-conservative' },
+				},
+				colour: 'name',
+				faded: false,
+				banner: null,
+			},
+		},
+		{
+			kind: 'stackedProgress',
+			props: {
+				total: 650,
+				label: 'for majority',
+				calculateWinner: true,
+				excludedCopy: null,
+				sections: [
+					{
+						name: 'Labour',
+						colour: { name: '--uk-elections-labour' },
+						value: 400,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'Conservative',
+						colour: { name: '--uk-elections-conservative' },
+						value: 100,
+						align: 'right',
+						exclude: false,
+					},
+					{
+						name: 'Lib Dem',
+						colour: { name: '--uk-elections-liberal-democrat' },
+						value: 70,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'SNP',
+						colour: {
+							name: '--uk-elections-scottish-national-party',
+						},
+						value: 10,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'Reform',
+						colour: { name: '--uk-elections-reform-uk' },
+						value: 5,
+						align: 'right',
+						exclude: false,
+					},
+				],
+			},
+		},
+		{
+			kind: 'progressNumber',
+			props: {
+				progress: 650,
+				total: 650,
+				copy: 'seats declared',
+				additionalCopy: null,
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'See full results',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/fixtures/manual/electionTrackers/ukLocal.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/ukLocal.ts
@@ -1,0 +1,57 @@
+export const ukLocal = {
+	components: [
+		{
+			kind: 'changeBars',
+			props: {
+				changes: [
+					{
+						name: 'Conservative',
+						abbreviation: 'Con',
+						change: -635,
+						colour: { name: '--uk-elections-conservative' },
+					},
+					{
+						name: 'Labour',
+						abbreviation: 'Lab',
+						change: -198,
+						colour: { name: '--uk-elections-labour' },
+					},
+					{
+						name: 'Liberal Democrat',
+						abbreviation: 'Lib Dem',
+						change: 146,
+						colour: { name: '--uk-elections-liberal-democrat' },
+					},
+					{
+						name: 'Reform UK',
+						abbreviation: 'Reform',
+						change: 648,
+						colour: { name: '--uk-elections-reform-uk' },
+					},
+					{
+						name: 'Other',
+						abbreviation: 'Other',
+						change: -56,
+						colour: { name: '--uk-elections-others' },
+					},
+				],
+			},
+		},
+		{
+			kind: 'progressNumber',
+			props: {
+				progress: 200,
+				total: 200,
+				copy: 'councils declared',
+				additionalCopy: null,
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'See full results',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/fixtures/manual/electionTrackers/usCongressEmpty.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/usCongressEmpty.ts
@@ -1,0 +1,201 @@
+export const usCongressEmpty = {
+	components: [
+		{
+			kind: 'sideBySide',
+			left: {
+				heading: 'Senate',
+				children: [
+					{
+						kind: 'versus',
+						props: {
+							left: {
+								name: 'Democrats',
+								abbreviation: 'Democrats',
+								value: 28,
+								change: 0,
+								colour: {
+									name: '--us-elections-democrats',
+								},
+								image: null,
+							},
+							right: {
+								name: 'Republicans',
+								abbreviation: 'Republicans',
+								value: 38,
+								change: 0,
+								colour: {
+									name: '--us-elections-republicans',
+								},
+								image: null,
+							},
+							colour: 'none',
+							faded: false,
+							banner: null,
+						},
+					},
+					{
+						kind: 'stackedProgress',
+						props: {
+							total: 34,
+							label: '50',
+							calculateWinner: false,
+							excludedCopy: 'No election',
+							sections: [
+								{
+									name: 'Democrats',
+									colour: {
+										name: '--us-elections-democrats-alt',
+									},
+									value: 28,
+									align: 'left',
+									exclude: true,
+								},
+								{
+									name: 'Democrats',
+									colour: {
+										name: '--us-elections-democrats',
+									},
+									value: 0,
+									align: 'left',
+									exclude: false,
+								},
+								{
+									name: 'Others',
+									colour: {
+										name: '--us-elections-others',
+									},
+									value: 0,
+									align: 'left',
+									exclude: true,
+								},
+								{
+									name: 'Others',
+									colour: {
+										name: '--us-elections-others',
+									},
+									value: 0,
+									align: 'left',
+									exclude: false,
+								},
+								{
+									name: 'Republicans',
+									colour: {
+										name: '--us-elections-republicans-alt',
+									},
+									value: 38,
+									align: 'right',
+									exclude: true,
+								},
+								{
+									name: 'Republicans',
+									colour: {
+										name: '--us-elections-republicans',
+									},
+									value: 0,
+									align: 'right',
+									exclude: false,
+								},
+							],
+						},
+					},
+					{
+						kind: 'progressNumber',
+						props: {
+							additionalCopy: null,
+							copy: 'races called',
+							progress: 0,
+							total: 34,
+						},
+					},
+				],
+			},
+			right: {
+				heading: 'House',
+				children: [
+					{
+						kind: 'versus',
+						props: {
+							left: {
+								name: 'Democrats',
+								abbreviation: 'Democrats',
+								value: 0,
+								change: 0,
+								colour: {
+									name: '--us-elections-democrats',
+								},
+								image: null,
+							},
+							right: {
+								name: 'Republicans',
+								abbreviation: 'Republicans',
+								value: 0,
+								change: 0,
+								colour: {
+									name: '--us-elections-republicans',
+								},
+								image: null,
+							},
+							colour: 'none',
+							faded: false,
+							banner: null,
+						},
+					},
+					{
+						kind: 'stackedProgress',
+						props: {
+							total: 435,
+							label: 'to win',
+							calculateWinner: true,
+							excludedCopy: null,
+							sections: [
+								{
+									name: 'Democrats',
+									colour: {
+										name: '--us-elections-democrats',
+									},
+									value: 0,
+									align: 'left',
+									exclude: false,
+								},
+								{
+									name: 'Others',
+									colour: {
+										name: '--us-elections-others',
+									},
+									value: 0,
+									align: 'left',
+									exclude: false,
+								},
+								{
+									name: 'Republicans',
+									colour: {
+										name: '--us-elections-republicans',
+									},
+									value: 0,
+									align: 'right',
+									exclude: false,
+								},
+							],
+						},
+					},
+					{
+						kind: 'progressNumber',
+						props: {
+							additionalCopy: null,
+							copy: 'races called',
+							progress: 0,
+							total: 435,
+						},
+					},
+				],
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'Full results',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/fixtures/manual/electionTrackers/usPresidential.ts
+++ b/dotcom-rendering/fixtures/manual/electionTrackers/usPresidential.ts
@@ -1,0 +1,75 @@
+export const usPresidential = {
+	components: [
+		{
+			kind: 'progressNumber',
+			props: {
+				progress: 51,
+				total: 51,
+				copy: 'states called (includes DC)',
+				additionalCopy: 'Latest results',
+			},
+		},
+		{
+			kind: 'versus',
+			props: {
+				left: {
+					name: 'Kamala Harris',
+					abbreviation: 'Harris',
+					value: 226,
+					description: 'Electoral college votes',
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/08/27/kamala-harris-watercolour.png',
+						alt: 'Watercolour portrait of Kamala Harris',
+					},
+					colour: { name: '--us-elections-democrats' },
+				},
+				right: {
+					name: 'Donald Trump',
+					abbreviation: 'Trump',
+					value: 312,
+					description: 'Electoral college votes',
+					image: {
+						url: 'https://uploads.guim.co.uk/2024/08/27/donald-trump-watercolour.png',
+						alt: 'Watercolour portrait of Donald Trump',
+					},
+					colour: { name: '--us-elections-republicans' },
+				},
+				colour: 'value',
+				faded: false,
+				banner: null,
+			},
+		},
+		{
+			kind: 'stackedProgress',
+			props: {
+				total: 538,
+				label: 'to win',
+				calculateWinner: true,
+				excludedCopy: null,
+				sections: [
+					{
+						name: 'Harris',
+						colour: { name: '--us-elections-democrats' },
+						value: 200,
+						align: 'left',
+						exclude: false,
+					},
+					{
+						name: 'Trump',
+						colour: { name: '--us-elections-republicans' },
+						value: 200,
+						align: 'right',
+						exclude: false,
+					},
+				],
+			},
+		},
+		{
+			kind: 'onwardLink',
+			props: {
+				text: 'Full US election results',
+				link: 'https://www.theguardian.com',
+			},
+		},
+	],
+};

--- a/dotcom-rendering/src/components/ElectionTrackers/electionComponent.test.ts
+++ b/dotcom-rendering/src/components/ElectionTrackers/electionComponent.test.ts
@@ -1,0 +1,32 @@
+import { parse } from 'valibot';
+import { euParliament } from '../../../fixtures/manual/electionTrackers/euParliament';
+import { ukGeneralExitPoll } from '../../../fixtures/manual/electionTrackers/ukGeneralExitPoll';
+import { ukGeneralFinal } from '../../../fixtures/manual/electionTrackers/ukGeneralFinal';
+import { ukLocal } from '../../../fixtures/manual/electionTrackers/ukLocal';
+import { usCongressEmpty } from '../../../fixtures/manual/electionTrackers/usCongressEmpty';
+import { usPresidential } from '../../../fixtures/manual/electionTrackers/usPresidential';
+import { ElectionComponents } from './electionComponent';
+
+it('validates US Congress data', () => {
+	parse(ElectionComponents, usCongressEmpty);
+});
+
+it('validates UK General data', () => {
+	parse(ElectionComponents, ukGeneralFinal);
+});
+
+it('validates UK General Exit Poll data', () => {
+	parse(ElectionComponents, ukGeneralExitPoll);
+});
+
+it('validates UK Local data', () => {
+	parse(ElectionComponents, ukLocal);
+});
+
+it('validates US Presidential data', () => {
+	parse(ElectionComponents, usPresidential);
+});
+
+it('validates EU Parliament data', () => {
+	parse(ElectionComponents, euParliament);
+});

--- a/dotcom-rendering/src/components/ElectionTrackers/electionComponent.ts
+++ b/dotcom-rendering/src/components/ElectionTrackers/electionComponent.ts
@@ -1,0 +1,180 @@
+import * as v from 'valibot';
+import { palette } from '../../palette';
+import { type ColourName, isColourName } from '../../paletteDeclarations';
+
+/**
+ * We use `undefined` rather than `null` in DCAR.
+ */
+const nullableToUndefined = <Schema extends v.GenericSchema>(s: Schema) =>
+	v.pipe(
+		v.nullable(s),
+		v.transform((i) => (i === null ? undefined : i)),
+	);
+
+const colour = v.pipe(
+	v.object({ name: v.string() }),
+	v.transform((o) => o['name']),
+	v.custom<ColourName>(
+		(c) => typeof c === 'string' && isColourName(c),
+		'Not a valid palette colour',
+	),
+	v.transform((c) => palette(c)),
+);
+
+const Change = v.object({
+	name: v.string(),
+	abbreviation: v.string(),
+	change: v.number(),
+	colour,
+});
+
+const ChangeBars = v.object({
+	changes: v.array(Change),
+});
+
+const OnwardLink = v.object({
+	link: v.pipe(
+		v.string(),
+		v.transform((l) => new URL(l)),
+	),
+	text: v.string(),
+});
+
+const ProgressNumber = v.object({
+	progress: v.number(),
+	total: v.number(),
+	copy: v.string(),
+	additionalCopy: nullableToUndefined(v.string()),
+});
+
+const Section = v.object({
+	colour,
+	value: v.number(),
+	name: v.string(),
+	align: v.picklist(['left', 'right']),
+	exclude: v.boolean(),
+});
+
+const StackedProgress = v.object({
+	sections: v.array(Section),
+	total: v.number(),
+	label: nullableToUndefined(v.string()),
+	calculateWinner: v.boolean(),
+	excludedCopy: nullableToUndefined(v.string()),
+});
+
+const ValueWithChange = v.object({
+	name: v.string(),
+	value: v.number(),
+	change: v.number(),
+	colour,
+});
+
+const ValuesWithChange = v.object({
+	values: v.array(ValueWithChange),
+	valueDescription: v.string(),
+	changeDescription: v.string(),
+});
+
+const Image = v.object({
+	url: v.pipe(
+		v.string(),
+		v.transform((l) => new URL(l)),
+	),
+	alt: v.string(),
+});
+
+const Group = v.intersect([
+	v.object({
+		name: v.string(),
+		abbreviation: v.string(),
+		value: v.number(),
+		image: nullableToUndefined(Image),
+		colour,
+	}),
+	v.union([
+		v.object({ change: v.number() }, 'Group does not contain "change"'),
+		v.object(
+			{ description: v.string() },
+			'Group does not contain "description"',
+		),
+	]),
+]);
+
+const Versus = v.object({
+	left: Group,
+	right: Group,
+	colour: v.picklist(['name', 'value', 'none']),
+	faded: v.boolean(),
+	banner: nullableToUndefined(v.string()),
+});
+
+const ElectionElement = v.variant('kind', [
+	v.object(
+		{
+			kind: v.literal('changeBars'),
+			props: ChangeBars,
+		},
+		'Not a ChangeBars element',
+	),
+	v.object(
+		{
+			kind: v.literal('onwardLink'),
+			props: OnwardLink,
+		},
+		'Not an OnwardLink element',
+	),
+	v.object(
+		{
+			kind: v.literal('progressNumber'),
+			props: ProgressNumber,
+		},
+		'Not a ProgressNumber element',
+	),
+	v.object(
+		{
+			kind: v.literal('stackedProgress'),
+			props: StackedProgress,
+		},
+		'Not a StackedProgress element',
+	),
+	v.object(
+		{
+			kind: v.literal('valuesWithChange'),
+			props: ValuesWithChange,
+		},
+		'Not a ValuesWithChange element',
+	),
+	v.object(
+		{
+			kind: v.literal('versus'),
+			props: Versus,
+		},
+		'Not a Versus element',
+	),
+]);
+
+export const Layout = v.variant('kind', [
+	v.object(
+		{
+			kind: v.literal('sideBySide'),
+			left: v.object({
+				heading: v.string(),
+				children: v.array(ElectionElement),
+			}),
+			right: v.object({
+				heading: v.string(),
+				children: v.array(ElectionElement),
+			}),
+		},
+		'Not a SideBySide layout',
+	),
+]);
+
+export const ElectionComponent = v.variant('kind', [Layout, ElectionElement]);
+
+export const ElectionComponents = v.object({
+	components: v.array(ElectionComponent),
+});
+
+export type ElectionComponent = v.InferOutput<typeof ElectionComponent>;

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -8884,4 +8884,7 @@ const paletteDeclarations = (
 			`${colourName}: ${colour[colourScheme](format)};`,
 	);
 
-export { type ColourName, paletteDeclarations };
+const isColourName = (s: string): s is ColourName =>
+	Object.prototype.hasOwnProperty.call(paletteColours, s);
+
+export { type ColourName, paletteDeclarations, isColourName };


### PR DESCRIPTION
The main content of an election tracker is a list of components displaying information about the election. For example, a `Versus` or `StackedProgress` component. For a given election tracker, e.g. for a general election, the specific list of components to display and what information they contain will be defined by the events service.

DCAR will receive an initial payload of data from the events service via frontend, and will then poll for fresh data periodically client-side. The events service responds with JSON, so DCAR will need a way to parse that JSON.

This change adds a valibot schema for the JSON payload, and derives TypeScript types from that schema. It also adds a series of fixtures, consolidating test data that was already being used for the `ElectionTracker` stories and putting it in the format we expect to receive from the events service. These fixtures allow us to write tests verifying the valibot schemas, and will be reused for those same stories in an upcoming change.
