### PR TITLE
`ElectionTracker` polling

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.stories.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.stories.tsx
@@ -1,18 +1,14 @@
+import { parse } from 'valibot';
 import preview from '../../../.storybook/preview';
+import { euParliament } from '../../../fixtures/manual/electionTrackers/euParliament';
+import { ukGeneralExitPoll } from '../../../fixtures/manual/electionTrackers/ukGeneralExitPoll';
+import { ukGeneralFinal } from '../../../fixtures/manual/electionTrackers/ukGeneralFinal';
+import { ukLocal } from '../../../fixtures/manual/electionTrackers/ukLocal';
+import { usCongressEmpty } from '../../../fixtures/manual/electionTrackers/usCongressEmpty';
+import { usPresidential } from '../../../fixtures/manual/electionTrackers/usPresidential';
 import { palette } from '../../palette';
-import { UKLocal as ChangeBarsUKLocal } from './ChangeBars.stories';
+import { ElectionComponents } from './electionComponent';
 import { ElectionTracker } from './ElectionTracker';
-import {
-	UKGeneral as StackedProgressUKGeneral,
-	USPresidential as StackedProgressUSPresidential,
-} from './StackedProgress.stories';
-import { EUParliament as StackedProgressEUParliament } from './StackedProgress.stories';
-import { EUParliament as ValuesWithChangeEUParliament } from './ValuesWithChange.stories';
-import {
-	UKExitPoll as VersusUKExitPoll,
-	UKGeneral as VersusUKGeneral,
-	USPresidential as VersusUSPresidential,
-} from './Versus.stories';
 
 const meta = preview.meta({
 	title: 'Components/Election Trackers/Election Tracker',
@@ -21,330 +17,61 @@ const meta = preview.meta({
 
 export const USCongressEmpty = meta.story({
 	args: {
-		components: [
-			{
-				kind: 'sideBySide',
-				from: 'tablet',
-				left: {
-					heading: 'Senate',
-					children: [
-						{
-							kind: 'versus',
-							props: {
-								left: {
-									name: 'Democrats',
-									abbreviation: 'Democrats',
-									value: 28,
-									change: 0,
-									colour: palette('--us-elections-democrats'),
-									image: undefined,
-								},
-								right: {
-									name: 'Republicans',
-									abbreviation: 'Republicans',
-									value: 38,
-									change: 0,
-									colour: palette(
-										'--us-elections-republicans',
-									),
-									image: undefined,
-								},
-								colour: 'none',
-								faded: false,
-								banner: undefined,
-							},
-						},
-						{
-							kind: 'stackedProgress',
-							props: {
-								total: 34,
-								label: '50',
-								calculateWinner: false,
-								excludedCopy: 'No election',
-								sections: [
-									{
-										name: 'Democrats',
-										colour: palette(
-											'--us-elections-democrats-alt',
-										),
-										value: 28,
-										align: 'left',
-										exclude: true,
-									},
-									{
-										name: 'Democrats',
-										colour: palette(
-											'--us-elections-democrats',
-										),
-										value: 0,
-										align: 'left',
-										exclude: false,
-									},
-									{
-										name: 'Others',
-										colour: palette(
-											'--us-elections-others',
-										),
-										value: 0,
-										align: 'left',
-										exclude: true,
-									},
-									{
-										name: 'Others',
-										colour: palette(
-											'--us-elections-others',
-										),
-										value: 0,
-										align: 'left',
-										exclude: false,
-									},
-									{
-										name: 'Republicans',
-										colour: palette(
-											'--us-elections-republicans-alt',
-										),
-										value: 38,
-										align: 'right',
-										exclude: true,
-									},
-									{
-										name: 'Republicans',
-										colour: palette(
-											'--us-elections-republicans',
-										),
-										value: 0,
-										align: 'right',
-										exclude: false,
-									},
-								],
-							},
-						},
-						{
-							kind: 'progressNumber',
-							props: {
-								additionalCopy: undefined,
-								copy: 'races called',
-								progress: 0,
-								total: 34,
-							},
-						},
-					],
-				},
-				right: {
-					heading: 'House',
-					children: [
-						{
-							kind: 'versus',
-							props: {
-								left: {
-									name: 'Democrats',
-									abbreviation: 'Democrats',
-									value: 0,
-									change: 0,
-									colour: palette('--us-elections-democrats'),
-									image: undefined,
-								},
-								right: {
-									name: 'Republicans',
-									abbreviation: 'Republicans',
-									value: 0,
-									change: 0,
-									colour: palette(
-										'--us-elections-republicans',
-									),
-									image: undefined,
-								},
-								colour: 'none',
-								faded: false,
-								banner: undefined,
-							},
-						},
-						{
-							kind: 'stackedProgress',
-							props: {
-								total: 435,
-								label: 'to win',
-								calculateWinner: true,
-								excludedCopy: undefined,
-								sections: [
-									{
-										name: 'Democrats',
-										colour: palette(
-											'--us-elections-democrats',
-										),
-										value: 0,
-										align: 'left',
-										exclude: false,
-									},
-									{
-										name: 'Others',
-										colour: palette(
-											'--us-elections-others',
-										),
-										value: 0,
-										align: 'left',
-										exclude: false,
-									},
-									{
-										name: 'Republicans',
-										colour: palette(
-											'--us-elections-republicans',
-										),
-										value: 0,
-										align: 'right',
-										exclude: false,
-									},
-								],
-							},
-						},
-						{
-							kind: 'progressNumber',
-							props: {
-								additionalCopy: undefined,
-								copy: 'races called',
-								progress: 0,
-								total: 435,
-							},
-						},
-					],
-				},
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'Full results',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		initialData: parse(ElectionComponents, usCongressEmpty).components,
+		electionDataUrl: new URL(
+			'https://www.theguardian.com/us-congress-empty',
+		),
+		getElectionData: () => Promise.resolve(usCongressEmpty),
+		refreshInterval: 5,
+	},
+	parameters: {
+		colourSchemeBackground: {
+			light: palette('--front-container-background'),
+			dark: palette('--front-container-background'),
+		},
 	},
 });
 
-export const UKGeneralFinal = meta.story({
+export const UKGeneralFinal = USCongressEmpty.extend({
 	args: {
-		components: [
-			{
-				kind: 'versus',
-				props: VersusUKGeneral.composed.args,
-			},
-			{
-				kind: 'stackedProgress',
-				props: StackedProgressUKGeneral.composed.args,
-			},
-			{
-				kind: 'progressNumber',
-				props: {
-					progress: 650,
-					total: 650,
-					copy: 'seats declared',
-					additionalCopy: undefined,
-				},
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'See full results',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		electionDataUrl: new URL(
+			'https://www.theguardian.com/uk-general-final',
+		),
+		initialData: parse(ElectionComponents, ukGeneralFinal).components,
+		getElectionData: () => Promise.resolve(ukGeneralFinal),
 	},
 });
 
-export const UKGeneralExitPoll = meta.story({
+export const UKGeneralExitPoll = USCongressEmpty.extend({
 	args: {
-		components: [
-			{
-				kind: 'versus',
-				props: VersusUKExitPoll.composed.args,
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'View results page',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		electionDataUrl: new URL(
+			'https://www.theguardian.com/uk-general-exit-poll',
+		),
+		initialData: parse(ElectionComponents, ukGeneralExitPoll).components,
+		getElectionData: () => Promise.resolve(ukGeneralExitPoll),
 	},
 });
 
-export const UKLocal = meta.story({
+export const UKLocal = USCongressEmpty.extend({
 	args: {
-		components: [
-			{
-				kind: 'changeBars',
-				props: ChangeBarsUKLocal.args,
-			},
-			{
-				kind: 'progressNumber',
-				props: {
-					progress: 200,
-					total: 200,
-					copy: 'councils declared',
-					additionalCopy: undefined,
-				},
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'See full results',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		electionDataUrl: new URL('https://www.theguardian.com/uk-local'),
+		initialData: parse(ElectionComponents, ukLocal).components,
+		getElectionData: () => Promise.resolve(ukLocal),
 	},
 });
 
-export const USPresidential = meta.story({
+export const USPresidential = USCongressEmpty.extend({
 	args: {
-		components: [
-			{
-				kind: 'progressNumber',
-				props: {
-					progress: 51,
-					total: 51,
-					copy: 'states called (includes DC)',
-					additionalCopy: 'Latest results',
-				},
-			},
-			{
-				kind: 'versus',
-				props: VersusUSPresidential.composed.args,
-			},
-			{
-				kind: 'stackedProgress',
-				props: StackedProgressUSPresidential.composed.args,
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'Full US election results',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		electionDataUrl: new URL('https://www.theguardian.com/us-presidential'),
+		initialData: parse(ElectionComponents, usPresidential).components,
+		getElectionData: () => Promise.resolve(usPresidential),
 	},
 });
 
-export const EUParliament = meta.story({
+export const EUParliament = USCongressEmpty.extend({
 	args: {
-		components: [
-			{
-				kind: 'stackedProgress',
-				props: StackedProgressEUParliament.composed.args,
-			},
-			{
-				kind: 'valuesWithChange',
-				props: ValuesWithChangeEUParliament.args,
-			},
-			{
-				kind: 'onwardLink',
-				props: {
-					text: 'See full results',
-					link: new URL('https://www.theguardian.com'),
-				},
-			},
-		],
+		electionDataUrl: new URL('https://www.theguardian.com/eu-parliament'),
+		initialData: parse(ElectionComponents, euParliament).components,
+		getElectionData: () => Promise.resolve(euParliament),
 	},
 });

--- a/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.tsx
@@ -1,86 +1,112 @@
-import type { Breakpoint } from '@guardian/source/foundations';
-import type { ComponentProps } from 'react';
+import { log } from '@guardian/libs';
+import useSWR from 'swr';
+import { safeParse, summarize } from 'valibot';
+import { fromValibot } from '../../lib/result';
 import { ChangeBars } from './ChangeBars';
+import {
+	type ElectionComponent,
+	ElectionComponents,
+} from './electionComponent';
 import { OnwardLink } from './OnwardLink';
 import { ProgressNumber } from './ProgressNumber';
+import { Refresh } from './Refresh';
 import { SideBySide } from './SideBySide';
 import { StackedProgress } from './StackedProgress';
+import { useCountdown } from './useCountdown';
 import { ValuesWithChange } from './ValuesWithChange';
 import { Versus } from './Versus';
 
 type Props = {
-	components: Component[];
+	/**
+	 * The URL from which to retrieve the election data via
+	 * {@linkcode Props.getElectionData|getElectionData}.
+	 */
+	electionDataUrl: URL;
+	/**
+	 * A potentially side-effectful function used to retrieve election data from
+	 * the given URL. The result is a JS object of unknown shape.
+	 */
+	getElectionData: (url: string) => Promise<unknown>;
+	/**
+	 * The initial election data, available on the server before client-side
+	 * polling begins.
+	 */
+	initialData: ElectionComponent[];
+	/**
+	 * How often to update the data, in seconds.
+	 */
+	refreshInterval: number;
 };
 
-type Component = Layout | ElectionElement;
+export const ElectionTracker = (props: Props) => {
+	const [remaining, reset] = useCountdown(props.refreshInterval);
+	const { data, error } = useSWR<ElectionComponent[], Error>(
+		props.electionDataUrl.toString(),
+		fetcher(props.getElectionData),
+		{
+			errorRetryCount: 1,
+			refreshInterval: props.refreshInterval * 1_000,
+			fallbackData: props.initialData,
+			onSuccess: reset,
+		},
+	);
 
-type Layout = {
-	kind: 'sideBySide';
-	from: Breakpoint;
-	left: {
-		heading: string;
-		children: ElectionElement[];
-	};
-	right: {
-		heading: string;
-		children: ElectionElement[];
-	};
+	const components =
+		error !== undefined || data === undefined ? props.initialData : data;
+
+	return (
+		<>
+			<Refresh remaining={remaining} />
+			<Components components={components} />
+		</>
+	);
 };
 
-type ElectionElement =
-	| {
-			kind: 'changeBars';
-			props: ComponentProps<typeof ChangeBars>;
-	  }
-	| {
-			kind: 'onwardLink';
-			props: ComponentProps<typeof OnwardLink>;
-	  }
-	| {
-			kind: 'progressNumber';
-			props: ComponentProps<typeof ProgressNumber>;
-	  }
-	| {
-			kind: 'stackedProgress';
-			props: ComponentProps<typeof StackedProgress>;
-	  }
-	| {
-			kind: 'valuesWithChange';
-			props: ComponentProps<typeof ValuesWithChange>;
-	  }
-	| {
-			kind: 'versus';
-			props: ComponentProps<typeof Versus>;
-	  };
+const fetcher = (getElectionData: Props['getElectionData']) => (url: string) =>
+	getElectionData(url)
+		.then(parseElectionData)
+		.then((result) => {
+			if (!result.ok) {
+				log('dotcom', result.error);
+				throw new Error(summarize(result.error));
+			} else {
+				return result.value;
+			}
+		})
+		.catch(() => {
+			log('dotcom', 'Failed to fetch election data json');
+			throw new Error();
+		});
 
-export const ElectionTracker = (props: Props) => (
+const parseElectionData = (data: unknown) =>
+	fromValibot(safeParse(ElectionComponents, data)).map(
+		(value) => value.components,
+	);
+
+const Components = ({ components }: { components: ElectionComponent[] }) => (
 	<>
-		{props.components.map((component) => (
-			<ElectionComponent key={component.kind} component={component} />
+		{components.map((component) => (
+			<Component key={component.kind} component={component} />
 		))}
 	</>
 );
 
-const ElectionComponent = ({ component }: { component: Component }) => {
+const Component = ({ component }: { component: ElectionComponent }) => {
 	switch (component.kind) {
 		case 'sideBySide':
 			return (
 				<SideBySide
-					from={component.from}
+					from="tablet"
 					left={{
 						heading: component.left.heading,
 						children: (
-							<ElectionTracker
-								components={component.left.children}
-							/>
+							<Components components={component.left.children} />
 						),
 					}}
 					right={{
 						heading: component.right.heading,
 						children: (
-							<ElectionTracker
-								components={component.right.children}
-							/>
+							<Components components={component.right.children} />
 						),
 					}}
 				/>

--- a/dotcom-rendering/src/components/ElectionTrackers/SideBySide.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/SideBySide.tsx
@@ -68,7 +68,6 @@ const Heading = (props: { children: string; from: Breakpoint }) => (
 		css={{
 			...headlineBold20Object,
 			paddingBottom: space[2],
-			paddingTop: space[4],
 			[from[props.from]]: {
 				...headlineBold24Object,
 				paddingTop: 0,

--- a/dotcom-rendering/src/lib/result.test.ts
+++ b/dotcom-rendering/src/lib/result.test.ts
@@ -180,6 +180,6 @@ describe('fromValibot', () => {
 		const result = fromValibot(valibotResult);
 		const err = result.getErrorOrThrow('Expected an Err');
 
-		expect(err[0]!.expected).toBe('"string literal"');
+		expect(err[0].expected).toBe('"string literal"');
 	});
 });

--- a/dotcom-rendering/src/lib/result.ts
+++ b/dotcom-rendering/src/lib/result.ts
@@ -185,7 +185,9 @@ const error = <E, A>(err: E): Result<E, A> => new Err(err);
  */
 export const fromValibot = <Schema extends GenericSchema | GenericSchemaAsync>(
 	result: SafeParseResult<Schema>,
-): Result<InferIssue<Schema>[], InferOutput<Schema>> =>
-	result.success ? ok(result.output) : error(result.issues);
+): Result<
+	[InferIssue<Schema>, ...InferIssue<Schema>[]],
+	InferOutput<Schema>
+> => (result.success ? ok(result.output) : error(result.issues));
 
 export { Result, ok, error };


### PR DESCRIPTION
Add polling to the `ElectionTracker` component with SWR, using a pattern similar to that of the `FootballMatchHeader` component. A side-effectful function is passed to the component for use in SWR's fetcher function, which allows different effects to be passed in different environments, e.g. production vs storybook. The `ElectionComponents` valibot schema is then used to parse the data, and the type of `fromValibot` in the `Result` module is updated to better reflect what `safeParse` returns.

The `Refresh` component and the `useCountdown` hook are added to provide a countdown until the next refresh. For the `SideBySide` layout, the data from the server does not provide a breakpoint, and leaves this up to the client implementation. Finally, the stories are updated to use new fixtures that were recently added for the tests.
