### PR TITLE
Update the actions-publish-image step to allow for the publish of the…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write # Required by guardian/actions-publish-image to comment on PRs
     uses: ./.github/workflows/container-production.yml
     secrets:
-      GU_RIFF_RAFF_ROLE_ARN: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+      GU_ARTIFACTS_ROLE_ARN: ${{ secrets.GU_ARTIFACTS_ROLE_ARN }}
 
   container:
     permissions:

--- a/.github/workflows/container-production.yml
+++ b/.github/workflows/container-production.yml
@@ -2,7 +2,7 @@ name: Production container
 on:
   workflow_call:
     secrets:
-      GU_RIFF_RAFF_ROLE_ARN:
+      GU_ARTIFACTS_ROLE_ARN:
         required: true
     outputs:
       imageDigest:
@@ -39,10 +39,10 @@ jobs:
       - name: Build image
         run: docker buildx build --platform linux/arm64 -f Production.dockerfile -t ${{ github.repository }}:latest .
       - name: Publish Image
-        uses: guardian/actions-publish-image@v0.0.3
+        uses: guardian/actions-publish-image@v0.0.4
         id: publish-image
         with:
-          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          roleArn: ${{ secrets.GU_ARTIFACTS_ROLE_ARN }}
           branchName: ${{ needs.facts.outputs.branchName }}
           buildNumber: ${{ needs.facts.outputs.buildNumber }}
           commitSha: ${{ needs.facts.outputs.commitSha }}

--- a/.github/workflows/container-production.yml
+++ b/.github/workflows/container-production.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build image
         run: docker buildx build --platform linux/arm64 -f Production.dockerfile -t ${{ github.repository }}:latest .
       - name: Publish Image
-        uses: guardian/actions-publish-image@v0.0.4
+        uses: guardian/actions-publish-image@v0.0.7
         id: publish-image
         with:
           roleArn: ${{ secrets.GU_ARTIFACTS_ROLE_ARN }}

--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -1693,8 +1693,8 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
       "Description": "S3 bucket to store your access logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "DeployToolsAccountIdParameter": {
-      "Default": "/organisation/accounts/deployTools",
+    "ArtifactAccountIdParameter": {
+      "Default": "/organisation/accounts/artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
@@ -2188,7 +2188,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
                 "",
                 [
                   {
-                    "Ref": "DeployToolsAccountIdParameter",
+                    "Ref": "ArtifactAccountIdParameter",
                   },
                   ".dkr.ecr.eu-west-1.",
                   {
@@ -2413,7 +2413,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering CODE 
                     },
                     ":ecr:eu-west-1:",
                     {
-                      "Ref": "DeployToolsAccountIdParameter",
+                      "Ref": "ArtifactAccountIdParameter",
                     },
                     ":repository/guardian/dotcom-rendering",
                   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.995.0
       version: 3.995.0
     '@guardian/cdk':
-      specifier: 64.5.1
-      version: 64.5.1
+      specifier: 64.6.0
+      version: 64.6.0
     '@guardian/eslint-config':
       specifier: 14.0.1
       version: 14.0.1
@@ -121,7 +121,7 @@ importers:
         version: 3.995.0
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.5.1(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)
+        version: 64.6.0(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)
       '@guardian/tsconfig':
         specifier: 'catalog:'
         version: 1.0.1
@@ -325,7 +325,7 @@ importers:
         version: 6.1.0(browserslist@4.28.8)(tslib@2.6.2)
       '@guardian/cdk':
         specifier: 'catalog:'
-        version: 64.5.1(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)
+        version: 64.6.0(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)
       '@guardian/commercial-core':
         specifier: 34.0.0
         version: 34.0.0(@guardian/consent-manager@2.1.0(@guardian/ophan-tracker-js@5.1.1)(tslib@2.6.2)(typescript@6.0.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.1.1)(tslib@2.6.2)(typescript@6.0.3))
@@ -2615,8 +2615,8 @@ packages:
       browserslist: ^4.22.2
       tslib: ^2.6.2
 
-  '@guardian/cdk@64.5.1':
-    resolution: {integrity: sha512-5CxYfYhaAAz47OD+qWYqMycjPij+ewj5g7lNyK1mmMm7CICB9yTB8TNV5byFyBkXdCnWlvQlLmmg/XtsA8o1wQ==}
+  '@guardian/cdk@64.6.0':
+    resolution: {integrity: sha512-tTeCPVvRECwpwpG/UuHtlsUXjUruDBqrYN3HEvU4M9NISt1mrQ/9yriEBl/d2ECfTahGej9mzBGW2NyPRKFWag==}
     hasBin: true
     peerDependencies:
       aws-cdk: ^2.1135.0
@@ -12502,7 +12502,7 @@ snapshots:
       browserslist: 4.28.8
       tslib: 2.6.2
 
-  '@guardian/cdk@64.5.1(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)':
+  '@guardian/cdk@64.6.0(aws-cdk-lib@2.267.0(constructs@10.8.1))(aws-cdk@2.1139.0)(constructs@10.8.1)':
     dependencies:
       '@aws-sdk/client-ec2': 3.1101.0
       '@aws-sdk/client-ssm': 3.1101.0
@@ -14396,7 +14396,7 @@ snapshots:
       flat-cache: 3.2.0
       micromatch: 4.0.8
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      tslib: 2.6.2
+      tslib: 2.8.1
       typescript: 6.0.3
       webpack: 5.110.2(@swc/core@1.16.1)(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(postcss@8.5.26)(webpack-cli@7.2.3)
     transitivePeerDependencies:
@@ -16373,7 +16373,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:
@@ -19134,7 +19134,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   path-equal@1.2.5: {}
 
@@ -19951,7 +19951,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   sort-keys-length@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ blockExoticSubdeps: true
 catalog:
   '@aws-sdk/client-s3': 3.995.0
   '@aws-sdk/client-ssm': 3.995.0
-  '@guardian/cdk': 64.5.1
+  '@guardian/cdk': 64.6.0
   '@guardian/eslint-config': 14.0.1
   '@guardian/tsconfig': 1.0.1
   '@rollup/plugin-commonjs': 29.0.0


### PR DESCRIPTION
… tag in the artifacts account

## What does this change?

The objective of this PR is to enable the `tag-page-rendering` service, which is part of the `dotcom-rendering` application, to publish the docker image that is produced and deployed, to be published in the AWS ECR under the `Artifacts` account. This involved enabling the `actions-publish-image` action to assume the correct role associated with the correct AWS account i.e. the `Artifacts` account 


## Why?

## How has this change been tested?

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
