### PR TITLE
Add extra data attributes to rich links

### DIFF
--- a/dotcom-rendering/src/components/RichLink.tsx
+++ b/dotcom-rendering/src/components/RichLink.tsx
@@ -218,8 +218,9 @@ export const RichLink = ({
 			data-print-layout="hide"
 			data-link-name={`rich-link-${richLinkIndex} | ${richLinkIndex}`}
 			data-component="rich-link"
-			css={backgroundStyles}
+			data-testid="rich-link"
 			data-name={isPlaceholder ? 'placeholder' : undefined}
+			css={backgroundStyles}
 		>
 			<FormatBoundary format={linkFormat}>
 				<a css={linkStyles} href={url}>
@@ -229,6 +230,8 @@ export const RichLink = ({
 						<div>
 							<img
 								css={imageStyles}
+								data-name="rich-link-image"
+								data-testid="rich-link-image"
 								src={imageData.thumbnailUrl}
 								alt={imageData.altText}
 								width={imageData.width}

--- a/dotcom-rendering/src/components/RichLinkComponent.island.tsx
+++ b/dotcom-rendering/src/components/RichLinkComponent.island.tsx
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import type { FEFormat } from '../frontend/feArticle';
 import { type ArticleFormat, decideFormat } from '../lib/articleFormat';
 import { useApi } from '../lib/useApi';
@@ -56,7 +57,7 @@ const buildUrl = (
 		const path = new URL(element.url).pathname;
 		return `${ajaxUrl}/embed/card${path}.json?dcr=true`;
 	} catch (error) {
-		console.error(`Failed to build a url with "${element.url}"`);
+		log('dotcom', `Failed to build rich link url with "${element.url}"`);
 		return undefined;
 	}
 };


### PR DESCRIPTION
## What does this change?

Adds `data-testid`'s to Rich Link elements so they can be tested by Commercial E2E testing

Adds `data-name` to rich link images so that it can be targeted by commercial code

Relevant Commercial PR: https://github.com/guardian/commercial/pull/2713