### PR TITLE
ci: Mock `gu:cdk:version`

### DIFF
--- a/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/abTestingConfig.test.ts.snap
@@ -2,7 +2,7 @@ exports[`The ID5 Baton Lambda stack > matches the CODE snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Parameters": {
     "BuildId": {
@@ -46,7 +46,7 @@ exports[`The ID5 Baton Lambda stack > matches the PROD snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Parameters": {
     "BuildId": {

--- a/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/deploymentLambda.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -55,7 +55,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -294,7 +294,7 @@ exports[`The AB testing deployment lambda stack > matches the CODE snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -327,7 +327,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
       "GuDistributionBucketParameter",
       "GuLambdaFunction"
     ],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Parameters": {
     "SsmParameterValueaccountservicesdotcomstorebucketC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -377,7 +377,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -616,7 +616,7 @@ exports[`The AB testing deployment lambda stack > matches the PROD snapshot 1`] 
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
+++ b/ab-testing/cdk/lib/__snapshots__/notificationLambda.test.ts.snap
@@ -10,7 +10,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -24,7 +24,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -113,7 +113,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -166,7 +166,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -340,7 +340,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -452,7 +452,7 @@ exports[`The AB testing notification lambda stack > matches the CODE snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -494,7 +494,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm"
     ],
-    "gu:cdk:version": "64.5.1"
+    "gu:cdk:version": "TEST"
   },
   "Resources": {
     "EmailIdentityAbtestingnotificationlambdaE053C648": {
@@ -508,7 +508,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -597,7 +597,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -660,7 +660,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -834,7 +834,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -869,7 +869,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
           },
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",
@@ -1006,7 +1006,7 @@ exports[`The AB testing notification lambda stack > matches the PROD snapshot 1`
         "Tags": [
           {
             "Key": "gu:cdk:version",
-            "Value": "64.5.1"
+            "Value": "TEST"
           },
           {
             "Key": "gu:repo",

--- a/ab-testing/cdk/lib/abTestingConfig.test.ts
+++ b/ab-testing/cdk/lib/abTestingConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import { snapshot } from "node:test";
 import { basename } from "path";
+import { TrackingTag } from "@guardian/cdk/lib/constants/tracking-tag.js";
 import { GuRoot } from "@guardian/cdk/lib/constructs/root.js";
 import { Template } from "aws-cdk-lib/assertions";
 import { AbTestingConfig } from "./abTestingConfig.ts";
@@ -13,7 +14,9 @@ snapshot.setResolveSnapshotPath(
 );
 
 void describe("The ID5 Baton Lambda stack", () => {
-	void it("matches the CODE snapshot", ({ assert }) => {
+	void it("matches the CODE snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingConfig(app, "AbTestingConfig", {
 			stack: "frontend",
@@ -26,7 +29,9 @@ void describe("The ID5 Baton Lambda stack", () => {
 		assert.snapshot(template.toJSON());
 	});
 
-	void it("matches the PROD snapshot", ({ assert }) => {
+	void it("matches the PROD snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingConfig(app, "AbTestingConfig", {
 			stack: "frontend",

--- a/ab-testing/cdk/lib/deploymentLambda.test.ts
+++ b/ab-testing/cdk/lib/deploymentLambda.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import { snapshot } from "node:test";
 import { basename } from "path";
+import { TrackingTag } from "@guardian/cdk/lib/constants/tracking-tag.js";
 import { GuRoot } from "@guardian/cdk/lib/constructs/root.js";
 import { Template } from "aws-cdk-lib/assertions";
 import { AbTestingDeploymentLambda } from "./deploymentLambda.ts";
@@ -13,7 +14,9 @@ snapshot.setResolveSnapshotPath(
 );
 
 void describe("The AB testing deployment lambda stack", () => {
-	void it("matches the CODE snapshot", ({ assert }) => {
+	void it("matches the CODE snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingDeploymentLambda(
 			app,
@@ -30,7 +33,9 @@ void describe("The AB testing deployment lambda stack", () => {
 		assert.snapshot(template.toJSON());
 	});
 
-	void it("matches the PROD snapshot", ({ assert }) => {
+	void it("matches the PROD snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingDeploymentLambda(
 			app,

--- a/ab-testing/cdk/lib/notificationLambda.test.ts
+++ b/ab-testing/cdk/lib/notificationLambda.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import { snapshot } from "node:test";
 import { basename } from "path";
+import { TrackingTag } from "@guardian/cdk/lib/constants/tracking-tag.js";
 import { GuRoot } from "@guardian/cdk/lib/constructs/root.js";
 import { Template } from "aws-cdk-lib/assertions";
 import { AbTestingNotificationLambda } from "./notificationLambda.ts";
@@ -13,7 +14,9 @@ snapshot.setResolveSnapshotPath(
 );
 
 void describe("The AB testing notification lambda stack", () => {
-	void it("matches the CODE snapshot", ({ assert }) => {
+	void it("matches the CODE snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingNotificationLambda(
 			app,
@@ -30,7 +33,9 @@ void describe("The AB testing notification lambda stack", () => {
 		assert.snapshot(template.toJSON());
 	});
 
-	void it("matches the PROD snapshot", ({ assert }) => {
+	void it("matches the PROD snapshot", ({ assert, mock }) => {
+		mock.property(TrackingTag, "Value", "TEST");
+
 		const app = new GuRoot();
 		const stack = new AbTestingNotificationLambda(
 			app,


### PR DESCRIPTION
## What does this change?
Implements [mocking of `gu:cdk:version`](https://github.com/guardian/cdk/blob/main/docs/best-practices.md#mocking-gucdkversion) within `ab-testing` to make GuCDK updates easier. The `ab-testing` project uses Node's test runner, rather than [Jest which `dotcom-rendering` uses](https://github.com/guardian/dotcom-rendering/blob/0757a1bfa306466609f3c880006c92ae588b772c/dotcom-rendering/scripts/jest/setup.ts#L133-L134). This change aligns the DX of the two projects.

In theory we could DRY this out and perform the mock once via [global setup](https://nodejs.org/api/test.html#global-setup-and-teardown), however I've not managed to get this working.

## Why?
Improving the DX of updating the version of GuCDK in this repository.

## How has this change been tested?
See updated snapshots and CI results.