### PR TITLE
Remove prebid transaction IDs test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -170,19 +170,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: false,
 	},
 	{
-		name: "commercial-prebid-transaction-ids",
-		description:
-			"Test to measure the impact of submitting Prebid transaction IDs",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-09-30",
-		type: "client",
-		status: "ON",
-		audienceSize: 50 / 100,
-		audienceSpace: "B",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: false,
-	},
-	{
 		name: "identity-and-trust-consent-rr-banner-us",
 		description:
 			"Test to measure the impact of not showing the consent RR and banner for US users",


### PR DESCRIPTION
## What does this change?

Remove prebid transaction ids test. We are releasing to 100% [see commercial pr ](https://github.com/guardian/commercial/pull/2718)