### PR TITLE
Update NewsletterSignupCard styling for better responsiveness on small devices

### DIFF
--- a/dotcom-rendering/src/components/NewsletterSignupCard.stories.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.stories.tsx
@@ -39,3 +39,25 @@ export const Default = meta.story({
 		children: <></>,
 	},
 });
+
+/**
+ * Demonstrates a longer frequency string in a narrow container, to show that
+ * the text breaks after the "|" divider rather than wrapping mid-word.
+ */
+export const LongFrequencyNarrow = meta.story({
+	args: {
+		name: 'Breaking News US',
+		description: 'Get the most important news as it breaks.',
+		frequency: 'Around 2-3 times a day',
+		illustrationSquare:
+			'https://media.guim.co.uk/10b4e02333ee97ecf51d5e814fd324a88832fb17/1177_0_2998_3000/2998.jpg',
+		children: <></>,
+	},
+	decorators: [
+		(Story) => (
+			<div css={{ maxWidth: 300 }}>
+				<Story />
+			</div>
+		),
+	],
+});

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -4,7 +4,7 @@ import {
 	headlineMedium20,
 	space,
 	textSans14,
-	textSans15,
+	textSansBold15,
 } from '@guardian/source/foundations';
 import { SvgNewsletterFilled } from '@guardian/source/react-components';
 import { palette as themePalette } from '../palette';
@@ -55,23 +55,48 @@ const titleStyles = css`
 const frequencyTagStyles = css`
 	display: flex;
 	align-items: center;
+	gap: 6px;
 	color: ${themePalette('--newsletter-card-frequency-tag')};
-	${textSans15};
-	margin-left: -1px;
-	margin-top: -1px;
-	margin-bottom: ${space[1]}px;
+	${textSansBold15};
+	margin-bottom: ${space[2]}px;
+`;
+
+const frequencyTextStyles = css`
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: ${space[1]}px;
+`;
+
+const frequencyLabelStyles = css`
+	white-space: nowrap;
+`;
+
+const badgeStyles = css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	background-color: ${themePalette('--newsletter-card-badge-background')};
 
 	svg {
-		fill: currentColor;
-		height: 20px;
-		width: 20px;
+		fill: ${themePalette('--newsletter-card-badge-icon')};
+		height: 18px;
+		width: 18px;
 	}
+`;
+
+const innerDividerStyles = css`
+	border: none;
+	border-top: 1px solid ${themePalette('--newsletter-card-divider')};
+	margin: 0 0 ${space[2]}px;
 `;
 
 const descriptionStyles = css`
 	${textSans14};
 	line-height: 1.15;
-	margin-bottom: ${space[2]}px;
 	clear: both;
 	color: ${themePalette('--newsletter-card-description')};
 `;
@@ -92,27 +117,35 @@ const illustrationStyles = css`
 const NewsletterSignupHeader = (
 	props: Omit<NewsletterSignupCardProps, 'children'>,
 ) => (
-	<div css={headerStyles}>
-		<div css={titleAndMetaStyles}>
-			<div css={frequencyTagStyles}>
+	<>
+		<div css={frequencyTagStyles}>
+			<span css={badgeStyles}>
 				<SvgNewsletterFilled />
-				Free newsletter | {props.frequency}
-			</div>
-			<p css={titleStyles}>
-				Sign up to <span>{props.name}</span>
-			</p>
-			<p css={descriptionStyles}>{props.description}</p>
+			</span>
+			<span css={frequencyTextStyles}>
+				<span css={frequencyLabelStyles}>Free newsletter |</span>
+				<span css={frequencyLabelStyles}>{props.frequency}</span>
+			</span>
 		</div>
-		{!!props.illustrationSquare && (
-			<img
-				css={illustrationStyles}
-				src={props.illustrationSquare}
-				alt=""
-				loading="lazy"
-				decoding="async"
-			/>
-		)}
-	</div>
+		<hr css={innerDividerStyles} />
+		<div css={headerStyles}>
+			<div css={titleAndMetaStyles}>
+				<p css={titleStyles}>
+					Sign up to <span>{props.name}</span>
+				</p>
+				<p css={descriptionStyles}>{props.description}</p>
+			</div>
+			{!!props.illustrationSquare && (
+				<img
+					css={illustrationStyles}
+					src={props.illustrationSquare}
+					alt=""
+					loading="lazy"
+					decoding="async"
+				/>
+			)}
+		</div>
+	</>
 );
 
 export const NewsletterSignupCard = ({

--- a/dotcom-rendering/src/components/NewsletterSignupCard.tsx
+++ b/dotcom-rendering/src/components/NewsletterSignupCard.tsx
@@ -91,7 +91,7 @@ const badgeStyles = css`
 const innerDividerStyles = css`
 	border: none;
 	border-top: 1px solid ${themePalette('--newsletter-card-divider')};
-	margin: 0 0 ${space[2]}px;
+	margin: 0 -${space[3]}px ${space[2]}px;
 `;
 
 const descriptionStyles = css`
@@ -103,10 +103,15 @@ const descriptionStyles = css`
 
 const illustrationStyles = css`
 	flex-shrink: 0;
-	width: 90px;
-	height: 90px;
+	width: 70px;
+	height: 70px;
 	border-radius: 50%;
 	object-fit: cover;
+
+	${from.mobileMedium} {
+		width: 90px;
+		height: 90px;
+	}
 
 	${from.tablet} {
 		width: 100px;

--- a/dotcom-rendering/src/paletteDeclarations.ts
+++ b/dotcom-rendering/src/paletteDeclarations.ts
@@ -7965,6 +7965,14 @@ const paletteColours = {
 		light: () => '#F3F7FF',
 		dark: () => sourcePalette.brand[100],
 	},
+	'--newsletter-card-badge-background': {
+		light: () => sourcePalette.brand[400],
+		dark: () => sourcePalette.brand[600],
+	},
+	'--newsletter-card-badge-icon': {
+		light: () => sourcePalette.neutral[100],
+		dark: () => sourcePalette.neutral[100],
+	},
 	'--newsletter-card-description': {
 		light: () => sourcePalette.neutral[20],
 		dark: () => sourcePalette.neutral[86],
@@ -7974,8 +7982,8 @@ const paletteColours = {
 		dark: () => sourcePalette.neutral[46],
 	},
 	'--newsletter-card-frequency-tag': {
-		light: () => sourcePalette.neutral[38],
-		dark: () => sourcePalette.neutral[73],
+		light: () => sourcePalette.brand[400],
+		dark: () => sourcePalette.neutral[100],
 	},
 	'--newsletter-card-title': {
 		light: () => sourcePalette.neutral[7],


### PR DESCRIPTION
## What does this change?

Updates the styling of the `NewsletterSignupCard` header to match the latest design

## Why?

On small/narrow devices the frequency text ("Free newsletter | Around 2-3 times a day") could wrap awkwardly, and Dani created a new visual design (circular icon badge, bold frequency text, and a divider between the badge row and the heading).

## How has this change been tested?

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

Styling-only change — verified manually in Storybook (`Default` and new `LongFrequencyNarrow` stories) across mobile/wide viewports and in light/dark mode. Existing Storybook stories can be used for Chromatic visual regression testing.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/fec16d6c-0d7e-4d10-b5e2-a35d91f3ec24
[after]: https://github.com/user-attachments/assets/b9afc5fe-e1fa-40e4-87a4-fa1ff2be3cb9
[before2]: https://github.com/user-attachments/assets/51839746-9d2e-4295-ba3f-1601e551b805
[after2]: https://github.com/user-attachments/assets/7e22ec17-df4c-4e04-b9e6-c3cb9aa8963e

New `LongFrequencyNarrow` story, showing the text wrapping after the "|" divider with the icon centred against the two-line block:

![long-frequency-narrow](https://github.com/user-attachments/assets/401960ba-216b-4cb1-8fb6-6c47554df61f)

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->

