### PR TITLE
Remove the `commercial-fronts-ad-increase-ad-limit` AB test

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -70,19 +70,6 @@ const ABTests: ABTest[] = [
 		shouldForceMetricsCollection: true,
 	},
 	{
-		name: "commercial-fronts-ad-increase-ad-limit",
-		description:
-			"A test to understand the impact of changing page-level ad limit on fronts",
-		owners: ["commercial.dev@guardian.co.uk"],
-		expirationDate: "2026-09-10",
-		type: "server",
-		status: "ON",
-		audienceSize: 10 / 100,
-		audienceSpace: "A",
-		groups: ["control", "variant"],
-		shouldForceMetricsCollection: true,
-	},
-	{
 		name: "commercial-spacefinder-highvalue-section",
 		description:
 			"Test to measure the impact on ad density after adding to high value sections in spacefinder",

--- a/dotcom-rendering/src/layouts/FrontLayout.tsx
+++ b/dotcom-rendering/src/layouts/FrontLayout.tsx
@@ -31,11 +31,14 @@ import { SubNav } from '../components/SubNav.island';
 import { TrendingTopics } from '../components/TrendingTopics';
 import { ArticleDisplay } from '../lib/articleFormat';
 import { canRenderAds } from '../lib/canRenderAds';
+import {
+	MAX_FRONTS_BANNER_ADS as maxDesktopAds,
+	MAX_FRONTS_MOBILE_ADS as maxMobileAds,
+} from '../lib/commercial-constants';
 import { getContributionsServiceUrl } from '../lib/contributions';
 import { editionList } from '../lib/edition';
 import {
 	getDesktopAdPositions,
-	getMaxFrontsAdCounts,
 	getMerchHighPosition,
 	getMobileAdPositions,
 } from '../lib/getFrontsAdPositions';
@@ -117,10 +120,6 @@ export const FrontLayout = ({ front, NAV }: Props) => {
 		},
 		editionId,
 	} = front;
-
-	const { maxDesktopAds, maxMobileAds } = getMaxFrontsAdCounts(
-		front.config.serverSideABTests,
-	);
 
 	const serverTime = front.serverTime;
 

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -412,16 +412,6 @@ const getDesktopAdPositions = (
 	return adPositionsFromReducer;
 };
 
-export const getMaxFrontsAdCounts = (): {
-	maxDesktopAds: number;
-	maxMobileAds: number;
-} => {
-	return {
-		maxDesktopAds: MAX_FRONTS_BANNER_ADS,
-		maxMobileAds: MAX_FRONTS_MOBILE_ADS,
-	};
-};
-
 export {
 	isEvenIndex,
 	getMerchHighPosition,

--- a/dotcom-rendering/src/lib/getFrontsAdPositions.ts
+++ b/dotcom-rendering/src/lib/getFrontsAdPositions.ts
@@ -412,15 +412,13 @@ const getDesktopAdPositions = (
 	return adPositionsFromReducer;
 };
 
-export const getMaxFrontsAdCounts = (
-	serverSideAbTests: Record<string, string>,
-): { maxDesktopAds: number; maxMobileAds: number } => {
-	const shouldIncreaseAdLimit =
-		serverSideAbTests['commercial-fronts-ad-increase-ad-limit'] ===
-		'variant';
+export const getMaxFrontsAdCounts = (): {
+	maxDesktopAds: number;
+	maxMobileAds: number;
+} => {
 	return {
-		maxDesktopAds: shouldIncreaseAdLimit ? 16 : MAX_FRONTS_BANNER_ADS,
-		maxMobileAds: shouldIncreaseAdLimit ? 20 : MAX_FRONTS_MOBILE_ADS,
+		maxDesktopAds: MAX_FRONTS_BANNER_ADS,
+		maxMobileAds: MAX_FRONTS_MOBILE_ADS,
 	};
 };
 


### PR DESCRIPTION
## What does this change?

Removes the `commercial-fronts-ad-increase-ad-limit` AB test and associated code

## Why?

We've finished collecting the data for this so can switch it off and revert back to the original state until analysis has taken place
