### PR TITLE
Update ECS instance resources to recommended values

### DIFF
--- a/dotcom-rendering/cdk/bin/cdk.ts
+++ b/dotcom-rendering/cdk/bin/cdk.ts
@@ -111,7 +111,11 @@ export const TagPageRenderingPropsCODE: RenderingCDKStackProps = {
 	domainName: 'tag-page-rendering.code.dev-guardianapis.com',
 	scaling: { minimumInstances: 1, maximumInstances: 3 },
 	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
-	imageIdentifier: getImageIdentifier(),
+	ecsProps: {
+		imageIdentifier: getImageIdentifier(),
+		taskCpu: 1024,
+		taskMemoryLimitMiB: 2048,
+	},
 };
 
 new RenderingCDKStack(
@@ -150,7 +154,11 @@ export const TagPageRenderingPropsPROD: RenderingCDKStackProps = {
 		},
 	},
 	instanceType: InstanceType.of(InstanceClass.C8G, InstanceSize.MEDIUM),
-	imageIdentifier: getImageIdentifier(),
+	ecsProps: {
+		imageIdentifier: getImageIdentifier(),
+		taskCpu: 2048,
+		taskMemoryLimitMiB: 4096,
+	},
 };
 
 new RenderingCDKStack(

--- a/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
+++ b/dotcom-rendering/cdk/lib/__snapshots__/renderingStack.test.ts.snap
@@ -4442,7 +4442,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering PROD 
             "ReadonlyRootFilesystem": true,
           },
         ],
-        "Cpu": "1024",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "EcsTaskDefinitionExecutionRoleBE450C73",
@@ -4450,7 +4450,7 @@ exports[`The RenderingCDKStack matches the snapshot for Tag Page Rendering PROD 
           ],
         },
         "Family": "TagPageRenderingPRODEcsTaskDefinition12224835",
-        "Memory": "2048",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/dotcom-rendering/cdk/lib/renderingStack.ts
+++ b/dotcom-rendering/cdk/lib/renderingStack.ts
@@ -46,14 +46,28 @@ export interface RenderingCDKStackProps extends Omit<GuStackProps, 'stack'> {
 	};
 
 	/**
-	 * Which image to run.
-	 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
-	 *
-	 * @note Currently optional to control which services run in an EC2-ECS hybrid mode, or EC2-only.
-	 *
-	 * @see https://docs.docker.com/dhi/core-concepts/digests
+	 * ECS configuration including image identifier and instance sizing.
+	 * Optional to control which services run in an EC2-ECS hybrid mode, or EC2-only.
 	 */
-	imageIdentifier?: string;
+	ecsProps?: {
+		/**
+		 * Which image to run.
+		 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
+		 *
+		 * @see https://docs.docker.com/dhi/core-concepts/digests
+		 */
+		imageIdentifier: string;
+
+		/**
+		 * vCPU units for the ECS task
+		 */
+		taskCpu: number;
+
+		/**
+		 * Memory in MB for ECS task
+		 */
+		taskMemoryLimitMiB: number;
+	};
 }
 
 const addCPUStepScalingPolicy = (
@@ -200,14 +214,8 @@ export class RenderingCDKStack extends CDKStack {
 		});
 
 		const { stack: guStack, region, account } = this;
-		const {
-			guApp,
-			stage,
-			instanceType,
-			scaling,
-			domainName,
-			imageIdentifier,
-		} = props;
+		const { guApp, stage, instanceType, scaling, domainName, ecsProps } =
+			props;
 
 		const artifactsBucket =
 			GuDistributionBucketParameter.getInstance(this).valueAsString;
@@ -276,17 +284,16 @@ export class RenderingCDKStack extends CDKStack {
 				}),
 			},
 
-			// Provision ECS resources only when `imageIdentifier` has been provided
-			...(imageIdentifier == null
+			// Provision ECS resources only when `ecsProps` has been provided
+			...(ecsProps == null
 				? {}
 				: {
 						ecsProps: {
 							repositoryName: 'guardian/dotcom-rendering',
-							imageIdentifier,
+							imageIdentifier: ecsProps.imageIdentifier,
 
-							// TODO tune these values
-							memoryLimitMiB: 2048,
-							cpu: 1024,
+							memoryLimitMiB: ecsProps.taskMemoryLimitMiB,
+							cpu: ecsProps.taskCpu,
 							scaling: {
 								minimumTasks: 1,
 								maximumTasks: 2,


### PR DESCRIPTION
Update the ECS instance resources to be in line with the results of our scaling policies research. See https://github.com/guardian/dotcom-rendering/pull/16452.