### PR TITLE
Support strike through in product buttons

### DIFF
--- a/dotcom-rendering/src/components/Button/ProductLinkButton.stories.tsx
+++ b/dotcom-rendering/src/components/Button/ProductLinkButton.stories.tsx
@@ -34,3 +34,9 @@ export const WithLongLabel = {
 		label: '£10.99 for a 5 x 5 x 50cm sheet at Amazon',
 	},
 } satisfies Story;
+
+export const WithStruckThroughLabel = {
+	args: {
+		label: '~£10~ £5 at Amazon',
+	},
+} satisfies Story;

--- a/dotcom-rendering/src/components/Button/ProductLinkButton.tsx
+++ b/dotcom-rendering/src/components/Button/ProductLinkButton.tsx
@@ -7,6 +7,10 @@ import type {
 import { LinkButton } from '@guardian/source/react-components';
 import { SKIMLINK_REL } from '../../lib/affiliateLinksUtils';
 import { palette } from '../../palette';
+import {
+	createAccessibleProductLabel,
+	createStrikeThroughProductLabel,
+} from './productUtils';
 import { heightAutoStyle, wrapButtonTextStyle } from './styles';
 import { getPropsForLinkUrl } from './utils';
 
@@ -34,6 +38,12 @@ const minimisePaddingStyle = css`
 	}
 	> svg {
 		margin-left: -2px;
+	}
+`;
+
+const strikeThroughStyle = css`
+	s {
+		font-weight: normal;
 	}
 `;
 
@@ -67,7 +77,7 @@ export const ProductLinkButton = ({
 
 	return (
 		<LinkButton
-			{...getPropsForLinkUrl(label)}
+			{...getPropsForLinkUrl(createAccessibleProductLabel(label))}
 			href={url}
 			rel={SKIMLINK_REL}
 			priority={priority}
@@ -82,9 +92,9 @@ export const ProductLinkButton = ({
 		>
 			<span
 				style={fullWidthText ? { width: '100%' } : {}}
-				css={wrapButtonTextStyle}
+				css={[wrapButtonTextStyle, strikeThroughStyle]}
 			>
-				{label}
+				{createStrikeThroughProductLabel(label)}
 			</span>
 		</LinkButton>
 	);

--- a/dotcom-rendering/src/components/Button/productUtils.test.tsx
+++ b/dotcom-rendering/src/components/Button/productUtils.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import {
+	createAccessibleProductLabel,
+	createStrikeThroughProductLabel,
+} from './productUtils';
+
+describe('createStrikeThroughProductLabel', () => {
+	it('returns the label unchanged when there is no struck-through text', () => {
+		const { container } = render(
+			<>{createStrikeThroughProductLabel('£5 at Shop')}</>,
+		);
+
+		expect(container.textContent).toBe('£5 at Shop');
+		expect(container.querySelector('s')).toBeNull();
+	});
+
+	it('renders the old price in an s element and preserves the rest', () => {
+		const { container } = render(
+			<>{createStrikeThroughProductLabel('~£10~ £5 at Shop')}</>,
+		);
+
+		expect(container.querySelector('s')).toHaveTextContent('£10');
+		expect(container.textContent).toBe('£10 £5 at Shop');
+	});
+});
+
+describe('createAccessibleProductLabel', () => {
+	it('returns the label unchanged when there is no struck-through text', () => {
+		expect(createAccessibleProductLabel('£5 at Shop')).toBe('£5 at Shop');
+	});
+
+	it('describes the old and new prices accessibly', () => {
+		expect(createAccessibleProductLabel('~£10~ £5 at Shop')).toBe(
+			'Was £10, now  £5 at Shop',
+		);
+	});
+});

--- a/dotcom-rendering/src/components/Button/productUtils.test.tsx
+++ b/dotcom-rendering/src/components/Button/productUtils.test.tsx
@@ -31,7 +31,7 @@ describe('createAccessibleProductLabel', () => {
 
 	it('describes the old and new prices accessibly', () => {
 		expect(createAccessibleProductLabel('~£10~ £5 at Shop')).toBe(
-			'Was £10, now  £5 at Shop',
+			'Was £10, now £5 at Shop',
 		);
 	});
 });

--- a/dotcom-rendering/src/components/Button/productUtils.tsx
+++ b/dotcom-rendering/src/components/Button/productUtils.tsx
@@ -1,0 +1,68 @@
+import { isUndefined } from '@guardian/libs';
+import type { ProductCta } from '../../types/content';
+
+const strikeThroughRegex = /~([^~]+)~(.*)/;
+
+type ParsedProductLabel = {
+	struckThrough: string;
+	restOfLabel: string;
+};
+
+const parseProductLabel = (label: string): ParsedProductLabel | undefined => {
+	const match = label.match(strikeThroughRegex);
+	const struckThrough = match?.[1];
+	const restOfLabel = match?.[2];
+
+	if (isUndefined(struckThrough) || isUndefined(restOfLabel)) {
+		return undefined;
+	}
+
+	return { struckThrough, restOfLabel };
+};
+
+/**
+ * Create a struck through React component from a label
+ * for a product link button or product CTA
+ * that may contain a strikethroughed price
+ * @param label the label text that may contain strikethrough eg '~£10~ £5 at Shop'
+ */
+export const createStrikeThroughProductLabel = (label: string) => {
+	const parsedLabel = parseProductLabel(label);
+
+	if (isUndefined(parsedLabel)) {
+		return label;
+	} else {
+		return (
+			<>
+				<s>{parsedLabel.struckThrough}</s>
+				{parsedLabel.restOfLabel}
+			</>
+		);
+	}
+};
+
+/**
+ * Create accessible label text
+ * for a product link button or product CTA
+ * that may contain a struck through price
+ * @param label the label text that may contain strikethrough eg '~£10~ £5 at Shop'
+ */
+export const createAccessibleProductLabel = (label: string): string => {
+	const parsedLabel = parseProductLabel(label);
+	if (isUndefined(parsedLabel)) {
+		return label;
+	} else {
+		return `Was ${parsedLabel.struckThrough}, now ${parsedLabel.restOfLabel}`;
+	}
+};
+
+export const getProductLinkLabelWithoutPrice = (
+	cardCta: ProductCta,
+): string => {
+	return cardCta.text !== '' ? cardCta.text : `Buy at ${cardCta.retailer}`;
+};
+
+export const getProductLinkLabelWithPrice = (cta: ProductCta): string => {
+	const overrideLabel = cta.text.trim().length > 0;
+	return overrideLabel ? cta.text : `${cta.price} at ${cta.retailer}`;
+};

--- a/dotcom-rendering/src/components/Button/productUtils.tsx
+++ b/dotcom-rendering/src/components/Button/productUtils.tsx
@@ -52,7 +52,7 @@ export const createAccessibleProductLabel = (label: string): string => {
 	if (isUndefined(parsedLabel)) {
 		return label;
 	} else {
-		return `Was ${parsedLabel.struckThrough}, now ${parsedLabel.restOfLabel}`;
+		return `Was ${parsedLabel.struckThrough}, now ${parsedLabel.restOfLabel.trimStart()}`;
 	}
 };
 

--- a/dotcom-rendering/src/components/HorizontalSummaryProductCard.tsx
+++ b/dotcom-rendering/src/components/HorizontalSummaryProductCard.tsx
@@ -8,11 +8,11 @@ import {
 	textSansBold17,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
-import { getProductLinkLabelWithoutPrice } from '../lib/affiliateLinksUtils';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
 import type { SummaryProduct } from '../types/content';
 import { ProductLinkButton } from './Button/ProductLinkButton';
+import { getProductLinkLabelWithoutPrice } from './Button/productUtils';
 import { ProductCardImage } from './ProductCardImage';
 
 const horizontalCard = css`

--- a/dotcom-rendering/src/components/ProductCardButtons.tsx
+++ b/dotcom-rendering/src/components/ProductCardButtons.tsx
@@ -1,7 +1,7 @@
 import type { ThemeButton } from '@guardian/source/react-components';
-import { getProductLinkLabelWithPrice } from '../lib/affiliateLinksUtils';
 import type { ProductCta } from '../types/content';
 import { ProductLinkButton } from './Button/ProductLinkButton';
+import { getProductLinkLabelWithPrice } from './Button/productUtils';
 
 export const ProductCardButtons = ({
 	productCtas,

--- a/dotcom-rendering/src/components/ProductCardInline.stories.tsx
+++ b/dotcom-rendering/src/components/ProductCardInline.stories.tsx
@@ -78,3 +78,18 @@ export const ProductCardOnlyDisplayCredit = meta.story({
 		image: { ...productImage, displayCredit: true },
 	},
 });
+
+export const WithStrikeThroughPrice = meta.story({
+	args: {
+		...meta.input.args,
+		productCtas: [
+			{
+				url: 'https://www.theguardian.com',
+				retailer: 'Amazon',
+				text: '',
+				price: '~£95.99~ £89.99',
+			},
+			...meta.input.args.productCtas.slice(1),
+		],
+	},
+});

--- a/dotcom-rendering/src/components/ProductCarouselCard.tsx
+++ b/dotcom-rendering/src/components/ProductCarouselCard.tsx
@@ -9,11 +9,11 @@ import {
 	textSansBold17,
 } from '@guardian/source/foundations';
 import { Link } from '@guardian/source/react-components';
-import { getProductLinkLabelWithoutPrice } from '../lib/affiliateLinksUtils';
 import type { ArticleFormat } from '../lib/articleFormat';
 import { palette } from '../palette';
 import type { SummaryProduct } from '../types/content';
 import { ProductLinkButton } from './Button/ProductLinkButton';
+import { getProductLinkLabelWithoutPrice } from './Button/productUtils';
 import { ProductCardImage } from './ProductCardImage';
 
 export type ProductCarouselCardProps = {

--- a/dotcom-rendering/src/components/ProductCtaList.tsx
+++ b/dotcom-rendering/src/components/ProductCtaList.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { article17, palette, remSpace } from '@guardian/source/foundations';
-import { getProductLinkLabelWithPrice } from '../lib/affiliateLinksUtils';
 import type { ArticleFormat } from '../lib/articleFormat';
 import type { SummaryProduct } from '../types/content';
 import { ProductLinkButton } from './Button/ProductLinkButton';
+import { getProductLinkLabelWithPrice } from './Button/productUtils';
 import { Subheading } from './Subheading';
 
 const listStyles = css`

--- a/dotcom-rendering/src/lib/affiliateLinksUtils.ts
+++ b/dotcom-rendering/src/lib/affiliateLinksUtils.ts
@@ -1,5 +1,4 @@
 import type { ABParticipations } from '../experiments/lib/ab-tests';
-import type { ProductCta } from '../types/content';
 
 export const SKIMLINK_REL = 'sponsored noreferrer noopener';
 
@@ -137,15 +136,4 @@ export const buildXcustParamForAffiliateLink = ({
 		utmParamsString,
 		xcustComponentId,
 	});
-};
-
-export const getProductLinkLabelWithoutPrice = (
-	cardCta: ProductCta,
-): string => {
-	return cardCta.text !== '' ? cardCta.text : `Buy at ${cardCta.retailer}`;
-};
-
-export const getProductLinkLabelWithPrice = (cta: ProductCta): string => {
-	const overrideLabel = cta.text.trim().length > 0;
-	return overrideLabel ? cta.text : `${cta.price} at ${cta.retailer}`;
 };


### PR DESCRIPTION
## What does this change?

Adds support for ~strike through~ in prices on product buttons, denoted by tildes ~ ~

## Why?

To enable editorial of The Filter to mark sale prices that have been reduced, either manually or later once we have live pricing providing information on discounts.

## How has this change been tested?

Storybook examples added + unit tests

<!--

## Tests

Where applicable please add automated tests.

If you'd like help testing your changes as part of the PR review process then mention that explicitly here.

### Automated tests

- unit tests
  - https://jestjs.io/docs/using-matchers
- component tests
  - https://testing-library.com/docs/react-testing-library/example-intro
- Storybook interaction tests
  - https://storybook.js.org/docs/writing-tests/interaction-testing
- Storybook stories for Chromatic visual regression testing
  - https://storybook.js.org/docs/writing-stories
- Playwright e2e tests
  - https://playwright.dev/docs/writing-tests

You can find examples of each type of test in the repo.

### Manual testing

- running the change locally and verifying correct behaviour
- deploying to CODE and verifying correct behaviour

-->

## Screenshots

Product element product CTA
<img width="630" height="414" alt="image" src="https://github.com/user-attachments/assets/345b7c91-fbcc-4d18-ad54-49f3cf5d45e7" />

Product button element
<img width="259" height="74" alt="image" src="https://github.com/user-attachments/assets/0b85d41e-9aa0-4e47-9791-b6ed6d0cee71" />

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
