### PR TITLE
Support headline AB tests on card sublinks

### DIFF
--- a/dotcom-rendering/src/frontend/feFront.ts
+++ b/dotcom-rendering/src/frontend/feFront.ts
@@ -434,6 +434,7 @@ export type FESupportingContent = {
 	properties: {
 		href?: string;
 		webUrl?: string;
+		tests?: EditorialTest[];
 	};
 	header: {
 		kicker?: {

--- a/dotcom-rendering/src/frontend/schemas/feFront.json
+++ b/dotcom-rendering/src/frontend/schemas/feFront.json
@@ -950,6 +950,57 @@
                                                             },
                                                             "webUrl": {
                                                                 "type": "string"
+                                                            },
+                                                            "tests": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "testUuid": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "variantMeta": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "$ref": "#/definitions/VariantId"
+                                                                                    },
+                                                                                    "meta": {
+                                                                                        "type": "object",
+                                                                                        "additionalProperties": {}
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "meta"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "startDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "expiryDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "frontsThisTestCanRunOn": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "hasManuallyEndedOnThisTrail": {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "frontsThisTestCanRunOn",
+                                                                        "hasManuallyEndedOnThisTrail",
+                                                                        "testUuid",
+                                                                        "variantMeta"
+                                                                    ]
+                                                                }
                                                             }
                                                         }
                                                     },
@@ -1836,6 +1887,57 @@
                                                             },
                                                             "webUrl": {
                                                                 "type": "string"
+                                                            },
+                                                            "tests": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "testUuid": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "variantMeta": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "$ref": "#/definitions/VariantId"
+                                                                                    },
+                                                                                    "meta": {
+                                                                                        "type": "object",
+                                                                                        "additionalProperties": {}
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "meta"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "startDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "expiryDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "frontsThisTestCanRunOn": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "hasManuallyEndedOnThisTrail": {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "frontsThisTestCanRunOn",
+                                                                        "hasManuallyEndedOnThisTrail",
+                                                                        "testUuid",
+                                                                        "variantMeta"
+                                                                    ]
+                                                                }
                                                             }
                                                         }
                                                     },
@@ -2722,6 +2824,57 @@
                                                             },
                                                             "webUrl": {
                                                                 "type": "string"
+                                                            },
+                                                            "tests": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "testUuid": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "variantMeta": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "$ref": "#/definitions/VariantId"
+                                                                                    },
+                                                                                    "meta": {
+                                                                                        "type": "object",
+                                                                                        "additionalProperties": {}
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "meta"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "startDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "expiryDate": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "frontsThisTestCanRunOn": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "hasManuallyEndedOnThisTrail": {
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "frontsThisTestCanRunOn",
+                                                                        "hasManuallyEndedOnThisTrail",
+                                                                        "testUuid",
+                                                                        "variantMeta"
+                                                                    ]
+                                                                }
                                                             }
                                                         }
                                                     },

--- a/dotcom-rendering/src/frontend/schemas/feTagPage.json
+++ b/dotcom-rendering/src/frontend/schemas/feTagPage.json
@@ -793,6 +793,57 @@
                                         },
                                         "webUrl": {
                                             "type": "string"
+                                        },
+                                        "tests": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "testUuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "variantMeta": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "$ref": "#/definitions/VariantId"
+                                                                },
+                                                                "meta": {
+                                                                    "type": "object",
+                                                                    "additionalProperties": {}
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id",
+                                                                "meta"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "startDate": {
+                                                        "type": "number"
+                                                    },
+                                                    "expiryDate": {
+                                                        "type": "number"
+                                                    },
+                                                    "frontsThisTestCanRunOn": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "hasManuallyEndedOnThisTrail": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "frontsThisTestCanRunOn",
+                                                    "hasManuallyEndedOnThisTrail",
+                                                    "testUuid",
+                                                    "variantMeta"
+                                                ]
+                                            }
                                         }
                                     }
                                 },

--- a/dotcom-rendering/src/model/enhanceCards.test.ts
+++ b/dotcom-rendering/src/model/enhanceCards.test.ts
@@ -2,6 +2,7 @@ import type {
 	FEFrontCardStyle,
 	FEMediaAsset,
 	FEMediaAtom,
+	FESupportingContent,
 } from '../frontend/feFront';
 import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
 import type { EditorialTest, VariantMeta } from '../types/front';
@@ -656,6 +657,16 @@ describe('Enhance Cards', () => {
 			},
 		};
 
+		const cardWithSublinkWithEditorialTest = {
+			...cardWithNoEditorialTest,
+			supportingContent: [cardWithEditorialTest],
+		};
+
+		const cardWithSublinkWithExpiredEditorialTest = {
+			...cardWithNoEditorialTest,
+			supportingContent: [cardWithExpiredEditorialTest],
+		};
+
 		it('returns the default headline if no editorial test exists on the card, page is not in allowed fronts list, and user is not in a test bucket', () => {
 			expect(
 				decideHeadline(
@@ -781,6 +792,34 @@ describe('Enhance Cards', () => {
 			expect(
 				decideHeadline(
 					cardWithManuallyEndedEditorialTest,
+					{
+						'fronts-and-curation-editorial-test': 'a',
+					},
+					true,
+					'test-front',
+				),
+			).toEqual('Headline');
+		});
+
+		it('returns the variant headline if an editorial test is present on a sublink', () => {
+			expect(
+				decideHeadline(
+					cardWithSublinkWithEditorialTest
+						.supportingContent[0] as FESupportingContent,
+					{
+						'fronts-and-curation-editorial-test': 'a',
+					},
+					true,
+					'test-front',
+				),
+			).toEqual('Headline A');
+		});
+
+		it('returns the default headline for a sublink if an editorial test is expired on a sublink', () => {
+			expect(
+				decideHeadline(
+					cardWithSublinkWithExpiredEditorialTest
+						.supportingContent[0] as FESupportingContent,
 					{
 						'fronts-and-curation-editorial-test': 'a',
 					},

--- a/dotcom-rendering/src/model/enhanceCards.ts
+++ b/dotcom-rendering/src/model/enhanceCards.ts
@@ -36,6 +36,9 @@ import { enhanceTags } from './enhanceTags';
 const enhanceSupportingContent = (
 	supportingContent: FESupportingContent[],
 	parentFormat: ArticleFormat,
+	serverSideABTests: Record<string, string>,
+	isEditorialABTestingEnabled: boolean,
+	pageId?: string,
 ): DCRSupportingContent[] => {
 	return supportingContent.map((subLink) => {
 		/** Use link format where available and fallback to parent otherwise */
@@ -50,7 +53,12 @@ const enhanceSupportingContent = (
 
 		return {
 			format: linkFormat,
-			headline: subLink.header.headline,
+			headline: decideHeadline(
+				subLink,
+				serverSideABTests,
+				isEditorialABTestingEnabled,
+				pageId,
+			),
 			url: decideUrl(subLink),
 			kickerText:
 				!kickerText && supportingContentIsLive ? 'Live' : kickerText,
@@ -209,7 +217,7 @@ const findActiveEditorialTest = (
  * return the variant headline matching the user test group. Otherwise, return the default headline
  */
 export const decideHeadline = (
-	faciaCard: FEFrontCard,
+	faciaCard: FEFrontCard | FESupportingContent,
 	serverSideABTests: Record<string, string>,
 	isEditorialABTestingEnabled: boolean,
 	pageId?: string,
@@ -535,7 +543,13 @@ export const enhanceCards = (
 				: undefined,
 			kickerText: decideKicker(faciaCard, cardInTagPage, pageId),
 			supportingContent: faciaCard.supportingContent
-				? enhanceSupportingContent(faciaCard.supportingContent, format)
+				? enhanceSupportingContent(
+						faciaCard.supportingContent,
+						format,
+						serverSideABTests,
+						isEditorialABTestingEnabled,
+						pageId,
+					)
 				: undefined,
 			discussionApiUrl,
 			discussionId: faciaCard.discussion.isCommentable


### PR DESCRIPTION
## What does this change?
Uses variant headlines in headline AB tests for sublinks. 

## Why?
This follows on from [this change](https://github.com/guardian/facia-tool/pull/2063), which now means we support tests in sublinks in the fronts tool.

## How has this change been tested?
Tested locally against a CODE front with an active headline test in a sublink
