### PR TITLE
Hide native Feast recipe nudge from signed-in users with no Braze banner

### DIFF
--- a/dotcom-rendering/src/components/FeastContextualNudge.island.test.tsx
+++ b/dotcom-rendering/src/components/FeastContextualNudge.island.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { isPlacementStale } from '../lib/braze/BrazeBannersSystem';
 import type { BrazeInstance } from '../lib/braze/initialiseBraze';
+import * as savedFromWeb from '../lib/feast/savedFromWeb';
 import { useAB } from '../lib/useAB';
+import { useAuthStatus } from '../lib/useAuthStatus';
 import { useBraze } from '../lib/useBraze';
 import type { RecipeBlockElement } from '../types/content';
 import { ConfigProvider } from './ConfigContext';
@@ -10,8 +12,9 @@ import { FeastContextualNudge } from './FeastContextualNudge.island';
 jest.mock('../lib/useAB');
 jest.mock('../lib/useBraze');
 jest.mock('../lib/useAuthStatus', () => ({
-	useAuthStatus: jest.fn().mockReturnValue({ kind: 'SignedOut' }),
+	useAuthStatus: jest.fn(),
 }));
+jest.mock('../lib/feast/savedFromWeb');
 jest.mock('../lib/braze/BrazeBannersSystem', () => ({
 	BrazeBannersSystemPlacementId: {
 		FeastContextualNudge1: 'dotcom-rendering_feast-contextual-nudge-1',
@@ -73,6 +76,7 @@ describe('FeastContextualNudge Braze fallback', () => {
 		});
 		jest.mocked(isPlacementStale).mockReturnValue(false);
 		jest.mocked(braze.getBanner).mockReset();
+		jest.mocked(useAuthStatus).mockReturnValue({ kind: 'SignedOut' });
 	});
 
 	it('renders the Braze banner for a fresh eligible placement', () => {
@@ -113,5 +117,24 @@ describe('FeastContextualNudge Braze fallback', () => {
 
 		expect(screen.getByText('Download the app')).toBeInTheDocument();
 		expect(braze.getBanner).not.toHaveBeenCalled();
+	});
+
+	it('renders nothing for a signed-in reader with no Braze banner eligible', async () => {
+		jest.mocked(useAuthStatus).mockReturnValue({
+			kind: 'SignedIn',
+			accessToken: { accessToken: 'token' } as never,
+			idToken: { claims: { sub: 'user-id' } } as never,
+		});
+		jest.mocked(
+			savedFromWeb.getFeastSavedFromTheWebRecipes,
+		).mockResolvedValue(new Set());
+		jest.mocked(braze.getBanner).mockReturnValue(null);
+
+		const { container } = renderNudge('https://id.test');
+
+		await waitFor(() => {
+			expect(container).toBeEmptyDOMElement();
+		});
+		expect(screen.queryByText('Download the app')).not.toBeInTheDocument();
 	});
 });

--- a/dotcom-rendering/src/components/FeastContextualNudge.island.tsx
+++ b/dotcom-rendering/src/components/FeastContextualNudge.island.tsx
@@ -373,6 +373,17 @@ export const FeastContextualNudge = ({
 				</div>
 			);
 		}
+
+		// A signed-in reader with no Braze banner for this placement is (by
+		// definition) not part of any Canvas targeting this nudge. Rather
+		// than falling back to the generic native "Download the app" card —
+		// which isn't personalised and could be shown to a reader who has
+		// been deliberately excluded from Feast messaging — show nothing.
+		// Signed-out/pending readers aren't Braze-targetable at all, so they
+		// still fall through to the native nudge below.
+		if (authStatus.kind === 'SignedIn') {
+			return null;
+		}
 	}
 
 	return (


### PR DESCRIPTION
## What does this change?

For the Feast contextual recipe nudge (`FeastContextualNudge`), signed-in readers who are not targeted by any Braze Canvas for that placement now see nothing, instead of falling back to the generic native "Download the app" card.

Signed-out/pending readers are unaffected: since Braze targeting doesn't apply to them at all, they continue to see the native fallback card as before.

## Why?

The native fallback card was originally meant as a generic "Braze isn't available/loaded yet" safety net. However, for signed-in readers, having no eligible Braze banner for a placement means Braze itself has decided (via Canvas targeting) that this reader shouldn't see the nudge. Showing the generic native card in that case undermines that targeting decision and shows a non-personalised nudge to readers who were deliberately excluded.

## How has this change been tested?

- Updated unit tests in `FeastContextualNudge.island.test.tsx`, including a new test asserting that a signed-in reader with no eligible Braze banner renders nothing.
- Existing tests covering the Braze banner render path, stale-placement fallback, and signed-out fallback behaviour still pass unchanged.
