### PR TITLE
Clarify `getElectionData`

### DIFF
--- a/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.tsx
+++ b/dotcom-rendering/src/components/ElectionTrackers/ElectionTracker.tsx
@@ -24,7 +24,9 @@ type Props = {
 	electionDataUrl: URL;
 	/**
 	 * A potentially side-effectful function used to retrieve election data from
-	 * the given URL. The result is a JS object of unknown shape.
+	 * the given URL, allowing for different effects to be passed in different
+	 * environments. The result is a JS object of unknown shape, which will be
+	 * parsed here.
 	 */
 	getElectionData: (url: string) => Promise<unknown>;
 	/**


### PR DESCRIPTION
To make it clearer why it's being passed in, and why the type is `unknown`.

Requested by @alexduf https://github.com/guardian/dotcom-rendering/pull/16690#discussion_r3969829095
