### PR TITLE
Comment out all other US states apart from South Carolina

### DIFF
--- a/dotcom-rendering/src/components/marketing/lib/consentBannerTest.ts
+++ b/dotcom-rendering/src/components/marketing/lib/consentBannerTest.ts
@@ -2,18 +2,18 @@ import { getCookie } from '@guardian/libs';
 
 const AB_TEST_GEO_REGION_COOKIE = 'GU_geo_country_region';
 const AB_TEST_US_STATES = [
-	'WA', // Washington
-	'NC', // North Carolina
-	'OH', // Ohio
 	'SC', // South Carolina
-	'MI', // Michigan
-	'AZ', // Arizona
-	'MO', // Missouri
-	'WI', // Wisconsin
-	'DC', // District of Columbia
-	'KS', // Kansas
-	'NM', // New Mexico
-	'ME', // Maine
+	// 'WA', // Washington
+	// 'NC', // North Carolina
+	// 'OH', // Ohio
+	// 'MI', // Michigan
+	// 'AZ', // Arizona
+	// 'MO', // Missouri
+	// 'WI', // Wisconsin
+	// 'DC', // District of Columbia
+	// 'KS', // Kansas
+	// 'NM', // New Mexico
+	// 'ME', // Maine
 ];
 
 export const isInUsStateForAbTest = (): boolean => {


### PR DESCRIPTION
## What are you changing?

- This PR comments out other US states for the US AB (Reader Revenue) banner test.

## Why?

- This will be rolled out the one state for testing before rolling out to other 11 states.
