### PR TITLE
Add AB test for header bidder timeouts

### DIFF
--- a/ab-testing/config/abTests.ts
+++ b/ab-testing/config/abTests.ts
@@ -231,6 +231,26 @@ const ABTests: ABTest[] = [
 		groups: ["control", "variant"],
 		shouldForceMetricsCollection: true,
 	},
+	{
+		name: "commercial-header-bidder-timeouts",
+		description:
+			"Test to measure the impact of changing the Prebid and APS timeout value.",
+		owners: ["commercial.dev@guardian.co.uk"],
+		expirationDate: "2026-10-28",
+		type: "client",
+		status: "ON",
+		audienceSize: 0 / 100,
+		audienceSpace: "A",
+		groups: [
+			"variant-500",
+			"variant-750",
+			"variant-1000",
+			"variant-1250",
+			"control", // 1500ms timeout
+			"variant-1650",
+		],
+		shouldForceMetricsCollection: true,
+	},
 ];
 
 const activeABtests = ABTests.filter((test) => test.status === "ON");


### PR DESCRIPTION
## What does this change?

Adds an AB test to measure the impact of changing the Prebid and APS timeout value.

## Why?

We want to see if there can be revenue gains by altering the default timeout value for header bidders.

## Opt-in links

- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:variant-500
- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:variant-750
- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:variant-1000
- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:variant-1250
- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:control
- https://theguardian.com/ab-tests/opt-in/commercial-header-bidder-timeouts:variant-1650